### PR TITLE
fix: 'secret key not found in authorization header' error

### DIFF
--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -48,6 +48,7 @@ export const auth = betterAuth({
     "http://localhost:3000",
     "https://app.useautumn.com",
     "https://*.useautumn.com",
+    process.env.CLIENT_URL!,
   ],
   emailAndPassword: {
     enabled: true,

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -16,4 +16,5 @@ export const ADMIN_USER_IDs =
 export const dashboardOrigins = [
   "http://localhost:3000",
   "https://app.useautumn.com",
+  process.env.CLIENT_URL!,
 ];


### PR DESCRIPTION
## Summary
Adds the `CLIENT_URL` environment variable to specific locations to aid self-hosters accessing their instance @ `<their server IP>:<port>`.

![image](https://github.com/user-attachments/assets/e67d93d7-bd0b-4836-9ba4-796124a51df3)

- `server/utils/auth.ts` was originally updated before the error occurred simply because I was unable to login while accessing my instance in the format listed above.
- `server/utils/constants.ts` was updated following the conversation in the support channel to fix the issue this PR is for.

The error occurs when attempting to create a product on a self-hosted instance without the changes made on this PR.

## Related Issues
N/A (though can open a relevant issue for the purposes of logging if requested).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
N/A

## Additional Context
Support Thread: https://discord.com/channels/1362468741945888889/1384994114067759224/1388467758060011601