### PR TITLE
Add confirmation warning for default product

### DIFF
--- a/vite/src/components/general/ToggleButton.tsx
+++ b/vite/src/components/general/ToggleButton.tsx
@@ -29,17 +29,17 @@ export const ToggleButton = ({
       onClick={() => setValue(!value)}
       className={cn(
         `flex justify-start items-center hover:bg-transparent bg-transparent border-none shadow-none gap-2 w-fit p-0`,
-        className,
+        className
       )}
     >
       {buttonText}
+      {infoContent && <InfoTooltip>{infoContent}</InfoTooltip>}
       <Switch
         checked={value}
         onCheckedChange={setValue}
         className="h-4 w-7 data-[state=checked]:bg-stone-500"
         thumbClassName="h-3 w-3 data-[state=checked]:translate-x-3"
       />
-      {infoContent && <InfoTooltip>{infoContent}</InfoTooltip>}
     </Button>
   );
 

--- a/vite/src/views/customers/customer/CustomerProductList.tsx
+++ b/vite/src/views/customers/customer/CustomerProductList.tsx
@@ -64,7 +64,7 @@ export const CustomerProductList = ({
             p.entitlements.some(
               (cusEnt: any) =>
                 cusEnt.entities &&
-                Object.keys(cusEnt.entities).includes(entity.internal_id),
+                Object.keys(cusEnt.entities).includes(entity.internal_id)
             )
           : true;
 
@@ -93,7 +93,7 @@ export const CustomerProductList = ({
               variant="ghost"
               className={cn(
                 "text-t3 text-xs font-normal p-0",
-                showExpired && "text-t1 hover:text-t1",
+                showExpired && "text-t1 hover:text-t1"
               )}
               size="sm"
               onClick={() => setShowExpired(!showExpired)}
@@ -125,7 +125,7 @@ export const CustomerProductList = ({
             className="grid-cols-12 pr-0"
             onClick={() => {
               const entity = entities.find(
-                (e: any) => e.internal_id === cusProduct.internal_entity_id,
+                (e: any) => e.internal_id === cusProduct.internal_entity_id
               );
               navigateTo(
                 `/customers/${customer.id || customer.internal_id}/${
@@ -134,7 +134,7 @@ export const CustomerProductList = ({
                   entity ? `&entity_id=${entity.id || entity.internal_id}` : ""
                 }`,
                 navigate,
-                env,
+                env
               );
             }}
           >
@@ -262,13 +262,9 @@ const UpdateStatusDropdownBtn = ({
   const handleStatusUpdate = async () => {
     setLoading(true);
     try {
-      await CusService.updateCusProductStatus(
-        axiosInstance,
-        cusProduct.id,
-        {
-          status,
-        },
-      );
+      await CusService.updateCusProductStatus(axiosInstance, cusProduct.id, {
+        status,
+      });
       await cusMutate();
     } catch (error) {
       toast.error(getBackendErr(error, "Failed to update status"));
@@ -288,36 +284,37 @@ const UpdateStatusDropdownBtn = ({
   return (
     <>
       <Dialog open={showDefaultWarning} onOpenChange={setShowDefaultWarning}>
-        <DialogContent>
+        <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>Expire Default Product</DialogTitle>
           </DialogHeader>
-          <div className="py-4">
+          <div className="">
             <p className="text-sm text-gray-600">
-              This is the default product. Expiring it will reset it and reattach it to this customer. Do you want to continue?
+              This is the default product. Expiring it will reattach it to the
+              customer and reset their features.
             </p>
           </div>
           <DialogFooter>
             <div className="flex gap-2">
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 onClick={() => setShowDefaultWarning(false)}
               >
                 Cancel
               </Button>
-              <Button 
+              <Button
                 onClick={() => {
                   setShowDefaultWarning(false);
                   handleStatusUpdate();
                 }}
               >
-                Confirm
+                Expire Default
               </Button>
             </div>
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      
+
       <Button
         variant="ghost"
         dim={5}
@@ -329,8 +326,7 @@ const UpdateStatusDropdownBtn = ({
           <SmallSpinner />
         ) : (
           <>
-            <span>Mark as {keyToTitle(status)}</span>
-            {status === "expired" && <span className="ml-1">⚠️</span>}
+            <span>{keyToTitle(status)}</span>
           </>
         )}
       </Button>

--- a/vite/src/views/customers/customer/customer-sidebar/select-entity.tsx
+++ b/vite/src/views/customers/customer/customer-sidebar/select-entity.tsx
@@ -6,7 +6,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import { Entity } from "@autumn/shared";
+import { Entity, Feature, FeatureUsageType } from "@autumn/shared";
 import { useLocation, useNavigate } from "react-router";
 
 import { CreateEntity } from "./create-entity/CreateEntity";
@@ -28,7 +28,19 @@ export const SelectEntity = ({
   const navigate = useNavigate();
   const location = useLocation();
 
+  console.log(cusContext);
+
   if (!entities || entities.length === 0) {
+    // Only show create entity flow if there are continuous use features
+    const hasContinuousUseFeatures = cusContext?.features?.some(
+      (feature: Feature) =>
+        feature.config?.usage_type === FeatureUsageType.Continuous
+    );
+
+    if (!hasContinuousUseFeatures) {
+      return null;
+    }
+
     // Create entity flow
     return (
       <>
@@ -46,8 +58,7 @@ export const SelectEntity = ({
   }
 
   const entity = entities.find(
-    (entity: Entity) =>
-      entity.id === entityId || entity.internal_id == entityId,
+    (entity: Entity) => entity.id === entityId || entity.internal_id == entityId
   );
 
   return (

--- a/vite/src/views/features/FeatureTypeBadge.tsx
+++ b/vite/src/views/features/FeatureTypeBadge.tsx
@@ -1,16 +1,32 @@
 import { Badge } from "@/components/ui/badge";
-import { FeatureType } from "@autumn/shared";
+import { cn } from "@/lib/utils";
+import { Feature, FeatureType, FeatureUsageType } from "@autumn/shared";
 
 interface FeatureTypeBadgeProps {
   type: string | undefined;
 }
 
-export function FeatureTypeBadge({ type }: FeatureTypeBadgeProps) {
-  const variant = type === FeatureType.Metered ? "purple" : "blue";
-  
+export function FeatureTypeBadge(feature: Feature) {
+  console.log("feature", feature);
+
+  const badgeType =
+    feature.type == FeatureType.Boolean
+      ? "boolean"
+      : feature.config?.usage_type === FeatureUsageType.Continuous
+      ? "continuous use"
+      : "single use";
+
   return (
-    <Badge variant={variant}>
-      {type}
+    <Badge
+      className={cn(
+        "bg-transparent border border-t1 text-t1 rounded-md px-2",
+        badgeType === "boolean" && "bg-lime-50 text-lime-600 border-lime-600",
+        badgeType === "continuous use" &&
+          "bg-cyan-50 text-cyan-600 border-cyan-600",
+        badgeType === "single use" && "bg-blue-50 text-blue-600 border-blue-600"
+      )}
+    >
+      {badgeType}
     </Badge>
   );
 }

--- a/vite/src/views/features/FeaturesTable.tsx
+++ b/vite/src/views/features/FeaturesTable.tsx
@@ -84,7 +84,7 @@ export const FeaturesTable = () => {
             </span>
           </Item>
           <Item className="col-span-3">
-            <FeatureTypeBadge type={feature.type} />
+            <FeatureTypeBadge {...feature} />
           </Item>
           {!onboarding && (
             <Item className="col-span-4">

--- a/vite/src/views/features/metered-features/FeatureConfig.tsx
+++ b/vite/src/views/features/metered-features/FeatureConfig.tsx
@@ -42,7 +42,7 @@ export function FeatureConfig({
       : {
           name: "",
           id: "",
-        },
+        }
   );
 
   const [meteredConfig, setMeteredConfig] = useState<MeteredConfig>(
@@ -61,16 +61,16 @@ export function FeatureConfig({
           //   type: "count",
           //   property: null,
           // },
-        },
+        }
   );
 
   const [showEventName, setShowEventName] = useState(
-    feature.config && feature.config.filters?.[0]?.value?.length > 0,
+    feature.config && feature.config.filters?.[0]?.value?.length > 0
   );
 
   const [idChanged, setIdChanged] = useState(!!feature.id);
   const [featureType, setFeatureType] = useState<string>(
-    feature.type ? feature.type : FeatureType.Metered,
+    feature.type ? feature.type : FeatureType.Metered
   );
 
   useEffect(() => {
@@ -84,7 +84,7 @@ export function FeatureConfig({
   }, [featureType, meteredConfig, fields]);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 min-w-md max-w-md">
       <Tabs
         defaultValue={feature.type}
         className="w-[400px]"
@@ -97,7 +97,7 @@ export function FeatureConfig({
         </TabsList>
         <p className="text-t3 text-sm">
           {featureType == FeatureType.Metered &&
-            "A usage-based feature that you want to track and bill for"}
+            "A usage-based feature that you want to track"}
           {featureType == FeatureType.Boolean &&
             "A feature flag that can be either enabled or disabled"}
         </p>
@@ -133,8 +133,8 @@ export function FeatureConfig({
               </TabsList>
               <p className="text-sm text-t3 flex items-center gap-1">
                 {meteredConfig.usage_type === FeatureUsageType.Continuous
-                  ? "For features used on an ongoing basis, like seats or storage"
-                  : "For consumable features like credits or API calls"}
+                  ? "For features used on an ongoing basis, like 'seats' or 'storage'"
+                  : "For features that are consumed and refilled like 'credits' or 'API calls'"}
                 <Tooltip delayDuration={400}>
                   <TooltipTrigger asChild>
                     <InfoIcon className="w-3 h-3 text-t3/50" />
@@ -146,8 +146,14 @@ export function FeatureConfig({
                     className="flex flex-col"
                   >
                     <p>
-                      This helps us determine things like whether to reset
-                      usage, prorate billing etc.
+                      Single use features can have a reset period, to refill a
+                      balance every month, day etc. Existing usage is also
+                      typically reset on upgrades.
+                      <br />
+                      <br />
+                      Continuous use features don't have a reset period. They
+                      can be prorated (eg, if a seat is purchased halfway during
+                      the month, it'll cost half the price).
                     </p>
                   </TooltipContent>
                 </Tooltip>
@@ -161,7 +167,7 @@ export function FeatureConfig({
         <div className="w-full">
           <FieldLabel>Name</FieldLabel>
           <Input
-            placeholder="Name"
+            placeholder="Eg, messages, seats"
             value={fields.name}
             onChange={(e) => {
               const newFields: any = { ...fields, name: e.target.value };
@@ -207,14 +213,30 @@ export function FeatureConfig({
               setEventNameInput={setEventNameInput}
               setEventNameChanged={setEventNameChanged}
             />
+            <p className="text-sm text-t3 mt-2 px-2">
+              Event names are only required if you want to link one event from
+              your application to multiple feature balances. Read more{" "}
+              <a
+                href="https://docs.useautumn.com/features/tracking-usage#using-event-names"
+                target="_blank"
+                className="text-primary underline"
+              >
+                here.
+              </a>
+            </p>
           </div>
           <div>
             <Tooltip delayDuration={400}>
               <TooltipTrigger asChild>
                 <Button
-                  className="h-7 border rounded-none text-t3 text-xs"
+                  className={cn(
+                    "h-7 border rounded-none text-t3 text-xs",
+                    showEventName && "text-red-300"
+                  )}
                   variant="outline"
-                  startIcon={<PlusIcon size={12} />}
+                  startIcon={
+                    showEventName ? <XIcon size={12} /> : <PlusIcon size={12} />
+                  }
                   onClick={() => {
                     setShowEventName(!showEventName);
                   }}
@@ -297,7 +319,7 @@ export const FilterInput = ({
         `p-2 py-2 h-fit rounded-md border text-sm w-full transition-colors duration-100 
         flex items-center flex-wrap gap-2 gap-y-2 bg-white`,
         inputFocused &&
-          "border-primary shadow-[0_0_2px_1px_rgba(139,92,246,0.25)]",
+          "border-primary shadow-[0_0_2px_1px_rgba(139,92,246,0.25)]"
       )}
     >
       {filter.value.map((value: string, index: number) => (

--- a/vite/src/views/onboarding/onboarding-steps/ProductList.tsx
+++ b/vite/src/views/onboarding/onboarding-steps/ProductList.tsx
@@ -54,9 +54,9 @@ export const ProductList = ({
         new Set(
           product?.items
             .filter((item: ProductItem) => item.entity_feature_id != null)
-            .map((item: ProductItem) => item.entity_feature_id),
-        ),
-      ),
+            .map((item: ProductItem) => item.entity_feature_id)
+        )
+      )
     );
   }, [data.features, product]);
 
@@ -72,8 +72,8 @@ export const ProductList = ({
       number={1}
       description={
         <p>
-          Create your product tiers by defining the features your customers can
-          access and how much they cost.
+          Create products for any free plans, paid plans and any add-on or top
+          up products that your application offers.
         </p>
       }
     >
@@ -121,7 +121,7 @@ export const ProductList = ({
           products={data.products}
           onRowClick={(id) => {
             const selectedProduct = data.products.find(
-              (p: ProductV2) => p.id === id,
+              (p: ProductV2) => p.id === id
             );
             setProduct(selectedProduct);
             // setEntityFeatureIds([]);
@@ -184,7 +184,7 @@ const EditProductDialog = ({
       const res = await ProductService.updateProduct(
         axiosInstance,
         product.id,
-        product,
+        product
       );
       toast.success("Product updated successfully");
       await mutate();

--- a/vite/src/views/onboarding/onboarding-steps/SampleApp.tsx
+++ b/vite/src/views/onboarding/onboarding-steps/SampleApp.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import Step from "@/components/general/OnboardingStep";
+import CheckDialog from "@/components/autumn/paywall-dialog";
 
 import { useEnv } from "@/utils/envUtils";
 
@@ -16,7 +17,7 @@ import { toast } from "sonner";
 
 import { useSearchParams } from "react-router";
 
-import { useCustomer, CheckDialog } from "autumn-js/react";
+import { useCustomer } from "autumn-js/react";
 import PricingTable from "@/components/autumn/pricing-table";
 import {
   Check,
@@ -48,7 +49,7 @@ export const SampleApp = ({
   const [open, setOpen] = useState(false);
   const [checkData, setCheckData] = useState<any>(null);
   const [trackData, setTrackData] = useState<any>(null);
-  const [showCodeSection, setShowCodeSection] = useState(false);
+  const [showCodeSection, setShowCodeSection] = useState(true);
   const [showCheckSnippet, setShowCheckSnippet] = useState(true);
   const [showTrackSnippet, setShowTrackSnippet] = useState(true);
   const [showCustomerSnippet, setShowCustomerSnippet] = useState(true);
@@ -124,12 +125,12 @@ export const SampleApp = ({
                     <div className="flex flex-wrap gap-2 items-center">
                       {data.features
                         ?.filter(
-                          (feature: any) => customer?.features?.[feature.id],
+                          (feature: any) => customer?.features?.[feature.id]
                         )
                         .concat(
                           data.features?.filter(
-                            (feature: any) => !customer?.features?.[feature.id],
-                          ) || [],
+                            (feature: any) => !customer?.features?.[feature.id]
+                          ) || []
                         )
                         .map((feature: any, index: number) => {
                           const customerFeature =
@@ -210,28 +211,18 @@ export const SampleApp = ({
                                     checkData
                                       ? `import { useCustomer } from 'autumn-js/react';
 
-export default function CheckFeature() {
-  const { customer } = useCustomer();
+const { allowed } = useCustomer();
 
-  const handleCheckFeature = () => {
-    const feature = customer?.features?.${lastUsedFeature?.featureId || data.features?.[0]?.id || "messages"};
-    
-    if (feature && feature.balance > 0) {
-      // Feature has remaining usage
-      console.log("Feature access granted");
-      console.log("Remaining balance:", feature.balance);
-    } else {
-      alert("You're out of usage for this feature");
-    }
-  };
-  
-  return (
-    <button onClick={handleCheckFeature}>
-      Check Feature Access
-    </button>
-  );
-}`
-                                      : "// Click 'Send' on a feature to see a check request"
+const handleCheckFeature = async () => {
+if ( !allowed({ featureId: '${
+                                          lastUsedFeature?.featureId ||
+                                          data.features?.[0]?.id ||
+                                          "feature-id"
+                                        }' }) ) {
+    alert('Feature not allowed');
+  }
+} `
+                                      : "// Click 'Send' on a feature"
                                   }`,
                                 },
                                 {
@@ -248,17 +239,23 @@ const autumn = new Autumn({
 
 const { data } = await autumn.check({
   customerId: 'user_123',
-  featureId: '${lastUsedFeature?.featureId || data.features?.[0]?.id || "feature-id"}'
+  featureId: '${
+    lastUsedFeature?.featureId || data.features?.[0]?.id || "feature-id"
+  }'
 });
 `
-                                      : "// Click 'Send' on a feature to see a check request"
+                                      : "// Click 'Send' on a feature"
                                   }`,
                                 },
                                 {
                                   title: "Response",
                                   language: "typescript",
                                   displayLanguage: "typescript",
-                                  content: `${checkData ? JSON.stringify(checkData, null, 2) : "// Click 'Send' on a feature to see a check response"}`,
+                                  content: `${
+                                    checkData
+                                      ? JSON.stringify(checkData, null, 2)
+                                      : "// Click 'Send' on a feature"
+                                  }`,
                                 },
                               ]}
                             />
@@ -294,30 +291,17 @@ const { data } = await autumn.check({
                                     trackData
                                       ? `import { useCustomer } from 'autumn-js/react';
 
-export default function SendChatMessage() {
-  const { customer, refetch } = useCustomer();
+const { track } = useCustomer();
 
-  const handleSendMessage = async () => {
-    const feature = customer?.features?.${lastUsedFeature?.featureId || data.features?.[0]?.id || "messages"};
-    
-    if (feature && feature.balance > 0) {
-      // Send chatbot message server-side, then
-      await refetch(); // refetch customer usage data
-      alert(
-        "Remaining messages: " + customer?.features?.${lastUsedFeature?.featureId || data.features?.[0]?.id || "messages"}?.balance
-      );
-    } else {
-      alert("You're out of messages");
-    }
-  };
-  
-  return (
-    <button onClick={handleSendMessage}>
-      Send Message
-    </button>
-  );
-}`
-                                      : "// Click 'Send' on a feature to see a track request"
+const handleTrackUsage = async () => {
+  await track({ 
+    featureId: '${
+      lastUsedFeature?.featureId || data.features?.[0]?.id || "feature-id"
+    }',
+    value: ${lastUsedFeature?.value || 1}
+  });
+};`
+                                      : "// Click 'Send' on a feature"
                                   }`,
                                 },
                                 {
@@ -333,18 +317,24 @@ const autumn = new Autumn({
 });
 
 const response = await autumn.track({
-  featureId: '${lastUsedFeature?.featureId || data.features?.[0]?.id || "feature-id"}',
+  featureId: '${
+    lastUsedFeature?.featureId || data.features?.[0]?.id || "feature-id"
+  }',
   value: ${lastUsedFeature?.value || 1}
 });
 `
-                                      : "// Click 'Send' on a feature to see a track request"
+                                      : "// Click 'Send' on a feature"
                                   }`,
                                 },
                                 {
                                   title: "Response",
                                   language: "typescript",
                                   displayLanguage: "typescript",
-                                  content: `${trackData ? JSON.stringify(trackData, null, 2) : "// Click 'Send' on a feature to see a track response"}`,
+                                  content: `${
+                                    trackData
+                                      ? JSON.stringify(trackData, null, 2)
+                                      : "// Click 'Send' on a feature"
+                                  }`,
                                 },
                               ]}
                             />
@@ -382,7 +372,11 @@ const response = await autumn.track({
 
 const { customer, refetch } = useCustomer();
 
-console.log('Customer:', customer);
+console.log('Customer balance:', customer?.features.${
+                                    lastUsedFeature?.featureId ||
+                                    data.features?.[0]?.id ||
+                                    "feature-id"
+                                  }?.balance);
 
 const handleTrackUsage = async () => {
   //refresh customer data after feature is used 
@@ -405,7 +399,11 @@ const { customer } = await autumn.customers.get('user_123');`,
                                   title: "Response",
                                   language: "typescript",
                                   displayLanguage: "typescript",
-                                  content: `${customer ? JSON.stringify(customer, null, 2) : "// Customer data will appear here after using features"}`,
+                                  content: `${
+                                    customer
+                                      ? JSON.stringify(customer, null, 2)
+                                      : "// Customer data will appear here"
+                                  }`,
                                 },
                               ]}
                             />
@@ -446,7 +444,7 @@ const FeatureUsageItem = ({
         <div
           className={cn(
             " text-xs uppercase rounded-md flex items-center gap-2 truncate",
-            !customerFeature ? "text-t3" : "text-t2",
+            !customerFeature ? "text-t3" : "text-t2"
           )}
         >
           {feature.name || `Feature ${feature.id || "Unknown"}`}
@@ -466,7 +464,7 @@ const FeatureUsageItem = ({
           <span
             className={cn(
               "text-xs truncate uppercase",
-              customerFeature ? "text-t2" : "text-t3",
+              customerFeature ? "text-t2" : "text-t3"
             )}
           >
             {feature.name || `Feature ${feature.id || "Unknown"}`}
@@ -516,7 +514,11 @@ const FeatureUsageItem = ({
           <span className="text-sm text-t2">
             {customerFeature.unlimited
               ? "unlimited"
-              : `${customerFeature.usage}${customerFeature.included_usage > 0 ? ` / ${customerFeature.included_usage}` : ""}`}
+              : `${customerFeature.usage}${
+                  customerFeature.included_usage > 0
+                    ? ` / ${customerFeature.included_usage}`
+                    : ""
+                }`}
           </span>
         )}
       </div>

--- a/vite/src/views/products/CreateProduct.tsx
+++ b/vite/src/views/products/CreateProduct.tsx
@@ -23,6 +23,7 @@ import { PlusIcon, Check } from "lucide-react";
 import { getBackendErr, navigateTo } from "@/utils/genUtils";
 import { ProductConfig } from "./ProductConfig";
 import { ProductV2 } from "@autumn/shared";
+import { ToggleButton } from "@/components/general/ToggleButton";
 
 export const defaultProduct = {
   name: "",
@@ -50,7 +51,7 @@ function CreateProduct({
     try {
       const newProduct = await ProductService.createProduct(
         axiosInstance,
-        product,
+        product
       );
 
       await mutate();
@@ -88,59 +89,28 @@ function CreateProduct({
 
         <DialogFooter>
           <div className="flex justify-between items-center gap-2 w-full mt-4">
-            <div className="flex gap-2">
-              <Tooltip delayDuration={200}>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    disabled={product?.is_add_on}
-                    onClick={() =>
-                      setProduct({
-                        ...product,
-                        is_default: !product?.is_default,
-                      })
-                    }
-                    className={`min-w-32 flex items-center gap-2 ${
-                      product?.is_default ? "bg-stone-100" : ""
-                    }`}
-                  >
-                    {product?.is_default && (
-                      <div className="w-3 h-3 bg-lime-500 rounded-full flex items-center justify-center">
-                        <Check className="w-2 h-2 text-white" />
-                      </div>
-                    )}
-                    Default
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  This product is enabled by default for all new users
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip delayDuration={200}>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    disabled={product?.is_default}
-                    onClick={() =>
-                      setProduct({ ...product, is_add_on: !product?.is_add_on })
-                    }
-                    className={`min-w-32 flex items-center gap-2 ${
-                      product?.is_add_on ? "bg-stone-100" : ""
-                    }`}
-                  >
-                    {product?.is_add_on && (
-                      <div className="w-3 h-3 bg-lime-500 rounded-full flex items-center justify-center">
-                        <Check className="w-2 h-2 text-white" />
-                      </div>
-                    )}
-                    Add-on
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  This product is an add-on that can be bought together with
-                  your base products
-                </TooltipContent>
-              </Tooltip>
+            <div className="flex gap-4">
+              <ToggleButton
+                disabled={product?.is_add_on}
+                buttonText="Default"
+                infoContent="This product is enabled by default for all new users, typically used for your free plan"
+                value={product?.is_default}
+                setValue={() =>
+                  setProduct({
+                    ...product,
+                    is_default: !product?.is_default,
+                  })
+                }
+              />
+              <ToggleButton
+                disabled={product?.is_default}
+                buttonText="Add-on"
+                infoContent="This product is an add-on that can be bought together with your base products (eg, for top ups)"
+                value={product?.is_add_on}
+                setValue={() =>
+                  setProduct({ ...product, is_add_on: !product?.is_add_on })
+                }
+              />
             </div>
             <Button
               isLoading={loading}

--- a/vite/src/views/products/ProductsTable.tsx
+++ b/vite/src/views/products/ProductsTable.tsx
@@ -48,7 +48,7 @@ export const ProductsTable = ({
             className={cn(
               "flex flex-col justify-center items-center h-10 px-10 text-t3 min-h-[60vh] gap-4",
               "justify-start items-start mt-3",
-              onboarding && "px-2 mt-4",
+              onboarding && "px-2 mt-4"
             )}
           >
             {/* <img
@@ -58,8 +58,9 @@ export const ProductsTable = ({
               // className="w-48 h-48 opacity-80 filter brightness-0 invert" // this is for dark mode
             /> */}
             <span>
-              Products define the features your customers can access and how
-              much they cost. Create your first product to get started ☝️.
+              Each product defines features your customers get access to and how
+              much they cost. Create separate products for any free plans, paid
+              plans and any add-on or top up products ☝️
             </span>
           </div>
         )
@@ -71,7 +72,7 @@ export const ProductsTable = ({
             key={product.id}
             className={cn(
               "grid-cols-18 gap-2 items-center text-sm cursor-pointer hover:bg-primary/5 text-t2 whitespace-nowrap",
-              onboarding && "grid-cols-12",
+              onboarding && "grid-cols-12"
             )}
             isOnboarding={onboarding}
             onClick={() => {
@@ -122,7 +123,7 @@ export const ProductsTable = ({
             <Item
               className={cn(
                 "col-span-1 items-center justify-end",
-                onboarding && "col-span-6",
+                onboarding && "col-span-6"
               )}
             >
               <ProductRowToolbar product={product} />

--- a/vite/src/views/products/components/ProductTypeBadge.tsx
+++ b/vite/src/views/products/components/ProductTypeBadge.tsx
@@ -1,16 +1,33 @@
 import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 import { Product } from "@autumn/shared";
 
 export const ProductTypeBadge = ({ product }: { product: Product }) => {
+  const badgeType = product.is_default
+    ? "default"
+    : product.is_add_on && "add-on";
+
+  if (!badgeType) return null;
+
   return (
-    <>
-      {product.is_default ? (
-        <Badge variant="outline">Default</Badge>
-      ) : product.is_add_on ? (
-        <Badge variant="outline">Add-On</Badge>
-      ) : (
-        <></>
+    // <>
+    //   {product.is_default ? (
+    //     <Badge variant="outline">Default</Badge>
+    //   ) : product.is_add_on ? (
+    //     <Badge variant="outline">Add-On</Badge>
+    //   ) : (
+    //     <></>
+    //   )}
+    // </>
+    <Badge
+      className={cn(
+        "bg-transparent border border-t1 text-t1 rounded-md px-2",
+        badgeType === "default" &&
+          "bg-stone-200 text-stone-700 border-stone-700",
+        badgeType === "add-on" && "bg-zinc-100 text-zinc-500 border-zinc-400"
       )}
-    </>
+    >
+      {badgeType}
+    </Badge>
   );
 };

--- a/vite/src/views/products/product/ProductProps.tsx
+++ b/vite/src/views/products/product/ProductProps.tsx
@@ -176,8 +176,19 @@ export const ProductProps = () => {
                 <DialogTitle>Edit Product Group</DialogTitle>
               </DialogHeader>
               <p className="text-t3 text-sm">
-                Assign this product to a group. Customers can have active
-                subscriptions from multiple product groups at the same time.
+                Assign this product to a group. Customers will be able to have
+                active subscriptions from different product groups at the same
+                time. This can alter your existing upgrade and downgrade logic,
+                so read the docs{" "}
+                <a
+                  href="https://docs.useautumn.com/products/create-product#product-groups"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-purple-500 underline"
+                >
+                  here
+                </a>{" "}
+                to understand how this works.
               </p>
               <div className="flex gap-4 py-4">
                 <Input

--- a/vite/src/views/products/product/product-item/CreateProductItem.tsx
+++ b/vite/src/views/products/product/product-item/CreateProductItem.tsx
@@ -141,7 +141,13 @@ export function CreateProductItem() {
                     ← Product
                   </Button>
                 )}
-                <DialogTitle>Add Product Item</DialogTitle>
+
+                <DialogTitle>
+                  {showCreateFeature ||
+                  (features.length == 0 && item.price === null)
+                    ? "Create Feature"
+                    : "Add Product Item"}
+                </DialogTitle>
               </div>
             </DialogHeader>
             <div className="flex !overflow-visible  w-fit">
@@ -163,7 +169,12 @@ export function CreateProductItem() {
               )}
             </div>
           </DialogContentWrapper>
-          {!showCreateFeature ? <ItemConfigFooter /> : <div className="" />}
+          {showCreateFeature ||
+          (features.length == 0 && item.price === null) ? (
+            <div className="" />
+          ) : (
+            <ItemConfigFooter />
+          )}
         </DialogContent>
       </Dialog>
     </ProductItemContext.Provider>

--- a/vite/src/views/products/product/product-item/components/SelectItemFeature.tsx
+++ b/vite/src/views/products/product/product-item/components/SelectItemFeature.tsx
@@ -41,7 +41,7 @@ export const SelectItemFeature = ({
             <SelectItem key={feature.id} value={feature.id!}>
               <div className="flex gap-2 items-center max-w-sm">
                 <span className="truncate">{feature.name}</span>
-                <FeatureTypeBadge type={feature.type} />
+                <FeatureTypeBadge {...feature} />
               </div>
             </SelectItem>
           ))}

--- a/vite/src/views/products/product/product-item/product-item-config/FeatureItemConfig.tsx
+++ b/vite/src/views/products/product/product-item/product-item-config/FeatureItemConfig.tsx
@@ -72,7 +72,7 @@ export const FeatureConfig = () => {
             startIcon={<PlusIcon size={12} />}
             onClick={handleAddUsagePrice}
           >
-            Add Usage Price
+            Add Price
           </Button>
         </div>
       )}

--- a/vite/src/views/products/product/product-item/product-item-config/advanced-config/AdvancedItemConfig.tsx
+++ b/vite/src/views/products/product/product-item/product-item-config/advanced-config/AdvancedItemConfig.tsx
@@ -48,7 +48,8 @@ export const AdvancedItemConfig = () => {
                 reset_usage_when_enabled: !item.reset_usage_when_enabled,
               });
             }}
-            buttonText="Reset usage when enabled"
+            infoContent="A customer has used 20/100 credits on a free plan. Then they upgrade to a Pro plan with 500 credits. If this flag is enabled, they’ll get 500 credits on upgrade. If false, they’ll have 480."
+            buttonText="Reset existing usage when product is enabled"
             className="text-t3 h-fit"
             disabled={usageType === FeatureUsageType.Continuous}
           />

--- a/vite/src/views/products/product/product-item/product-item-config/components/IncludedUsage.tsx
+++ b/vite/src/views/products/product/product-item/product-item-config/components/IncludedUsage.tsx
@@ -17,14 +17,17 @@ export const IncludedUsage = () => {
         Included Usage
         <InfoTooltip>
           <span className="">
-            How much usage of this feature is included for free. If there is no
-            price, it is a usage limit.
+            How much of this feature can be used for free with this plan. If
+            there is no price, it is a usage limit.
+            <br />
+            <br />
+            Leave this blank if the feature is paid-only. Eg, 10 USD per seat.
           </span>
         </InfoTooltip>
       </FieldLabel>
       <div className="flex w-full h-fit gap-2">
         <Input
-          placeholder="None"
+          placeholder="eg, 300"
           className=""
           disabled={item.included_usage == Infinite}
           value={

--- a/vite/src/views/products/product/product-item/product-item-config/components/feature-price/PrepaidToggle.tsx
+++ b/vite/src/views/products/product/product-item/product-item-config/components/feature-price/PrepaidToggle.tsx
@@ -24,10 +24,15 @@ export const PrepaidToggle = () => {
             });
           }}
           buttonText="Prepaid"
-          className="text-xs gap-2 text-t3 p-1"
+          className="text-xs gap-2 text-t1 p-1"
         />
         <InfoTooltip align="start">
-          Prepaid means that the user will pay for the product upfront.
+          Prepaid features are paid for upfront, instead of at the end of the
+          billing period. You can pass in a{" "}
+          <span className="font-mono">
+            <code>quantity</code>
+          </span>{" "}
+          field when purchasing the product.
         </InfoTooltip>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Adds a confirmation dialog when attempting to expire a default product in the customer dashboard. This prevents accidental resets by prompting the user with a warning: "This is the default product. Expiring it will reset it and reattach it to this customer. Do you want to continue?". A warning emoji (⚠️) has also been added next to the "Mark as expired" option for better visibility.

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here -->

---

[Slack Thread](https://autumnpricing.slack.com/archives/C07NV8P9NTE/p1751977736605789?thread_ts=1751977736.605789&cid=C07NV8P9NTE)