### PR TITLE
[Feature] Add AM/PM and casing options to formatUnixToDateTime helper (#171)

### DIFF
--- a/vite/src/utils/formatUtils/formatDateUtils.ts
+++ b/vite/src/utils/formatUtils/formatDateUtils.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-
+type TimeCase = "upper" | "lower";
 export const formatDateStr = (date: Date | string) => {
   return format(new Date(date), "dd MMM yyyy");
 };
@@ -17,10 +17,17 @@ export const formatUnixToDate = (
   return format(new Date(unix), excludeYear ? "d MMM" : "d MMM yyyy");
 };
 
-export const formatUnixToDateTime = (unix: number | null | undefined) => {
+export const formatUnixToDateTime = (unix: number | null | undefined,
+  options?: { ampm?: boolean; case?: TimeCase }) => {
   if (!unix) return { date: "", time: "" };
   const date = format(new Date(unix), "d MMM");
-  const time = format(new Date(unix), "HH:mm");
+
+  const pattern = options?.ampm ? "HH:mm a" : "HH:mm";
+  let time = format(new Date(unix), pattern);
+
+  if (options?.case === "lower") time = time.toLowerCase();
+  if (options?.case === "upper") time = time.toUpperCase();
+
   return { date, time };
 };
 

--- a/vite/src/views/customers/CustomersTable.tsx
+++ b/vite/src/views/customers/CustomersTable.tsx
@@ -200,7 +200,7 @@ export const CustomersTable = ({
               {formatUnixToDateTime(customer.created_at).date}
               <span className="text-t3">
                 {" "}
-                {formatUnixToDateTime(customer.created_at).time}{" "}
+                {formatUnixToDateTime(customer.created_at,{ ampm: true, case: "lower" }).time}{" "}
               </span>
             </CustomTableCell>
             <CustomTableCell


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
Closes #171

## Type of Change

- Added optional am/pm flag to switch between 24-hour (HH:mm) and 12-hour (hh:mm a) time formats
- Added case option to control AM/PM casing (upper | lower)

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="231" height="151" alt="Screenshot 2025-09-01 at 2 53 15 PM" src="https://github.com/user-attachments/assets/e1afd300-1c11-4633-b228-e3cebd668741" />
