### PR TITLE
fix: Handle zero-decimal currencies in reward coupons (ENG-639)

### DIFF
--- a/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
+++ b/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
@@ -10,6 +10,7 @@ import {
 	type Reward,
 	RewardType,
 	type UsagePriceConfig,
+	atmnToStripeAmount,
 } from "@autumn/shared";
 import { pricesOnlyOneOff } from "@/internal/products/prices/priceUtils.js";
 import RecaseError from "@/utils/errorUtils.js";
@@ -92,9 +93,10 @@ const couponToStripeValue = ({
 		);
 
 		console.log("amountOff in couponToStripeValue", amountOff);
+		const currency = org.default_currency || "usd";
 		return {
-			amount_off: Math.round(amountOff * 100),
-			currency: org.default_currency || "usd",
+			amount_off: atmnToStripeAmount({ amount: amountOff, currency }),
+			currency,
 		};
 	}
 
@@ -107,9 +109,13 @@ const couponToStripeValue = ({
 		reward.type === RewardType.FixedDiscount ||
 		reward.type === RewardType.InvoiceCredits
 	) {
+		const currency = org.default_currency;
 		return {
-			amount_off: Math.round(discountConfig!.discount_value * 100),
-			currency: org.default_currency,
+			amount_off: atmnToStripeAmount({
+				amount: discountConfig!.discount_value,
+				currency,
+			}),
+			currency,
 		};
 	}
 };


### PR DESCRIPTION
## Summary
- Fixed bug where setting 275 JPY reward resulted in 27,500 JPY
- Replaced manual `* 100` multiplication with `atmnToStripeAmount` utility
- Now correctly handles zero-decimal currencies (JPY, KRW, etc.) without multiplying by 100

## Changes
- Updated `couponToStripeValue` function in `stripeCouponUtils.ts` to use `atmnToStripeAmount` for:
  - Fixed Discount rewards
  - Invoice Credits rewards  
  - Free Product rewards

## Test plan
- [ ] Create a Fixed Discount reward with 275 JPY
- [ ] Verify it displays as 275 JPY (not 27,500 JPY)
- [ ] Test with other zero-decimal currencies (KRW, etc.)
- [ ] Test with regular currencies (USD) to ensure they still work correctly

Fixes ENG-639

🤖 Generated with [Claude Code](https://claude.com/claude-code)