### PR TITLE
fix: validate Stripe Secret Key before API call (#245)

### DIFF
--- a/vite/src/views/developer/configure-stripe/ConfigureStripe.tsx
+++ b/vite/src/views/developer/configure-stripe/ConfigureStripe.tsx
@@ -46,6 +46,11 @@ export const ConfigureStripe = () => {
 	};
 
 	const handleConnectStripe = async () => {
+		if(!newStripeConfig.secret_key)	{
+			toast.error("Please provide your stripe secret key");
+			return;
+		}
+
 		if (!newStripeConfig.success_url) {
 			toast.error("Success URL is required");
 			return;


### PR DESCRIPTION
## Summary
This PR fixes a bug where the Stripe API was being called even when the Stripe Secret Key was not provided.

## Related Issues
Fixes #245

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="641" height="428" alt="Screenshot 2025-10-09 at 12 52 43 AM" src="https://github.com/user-attachments/assets/51bf904b-31be-481b-aff2-bf88c89345a9" />
