### PR TITLE
Fix: Add Product ID Validation Before API Call in Onboarding (#247)

### DIFF
--- a/vite/src/views/onboarding2/model-pricing/edit-product/EditProductDetails.tsx
+++ b/vite/src/views/onboarding2/model-pricing/edit-product/EditProductDetails.tsx
@@ -38,6 +38,10 @@ export const EditProductDetails = () => {
 	}, [product]);
 
 	const handleCreateProduct = async () => {
+		if(!details.id){
+			toast.error("Product ID is required")
+			return
+		}
 		setCreateLoading(true);
 		try {
 			await axiosInstance.post("/v1/products", {


### PR DESCRIPTION
## Summary
This PR fixes an issue in the sandbox onboarding route where the Product API was executed even when the Product ID field was missing.

## Related Issues
Fixes #247

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="789" height="324" alt="Screenshot 2025-10-09 at 9 03 55 AM" src="https://github.com/user-attachments/assets/4ee85077-6c0a-4bea-9483-dbf074a12672" />
