### PR TITLE
feat: add max redemptions field to discount configuration

### DIFF
--- a/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
+++ b/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
@@ -136,6 +136,7 @@ export const createStripeCoupon = async ({
 	legacyVersion?: boolean;
 }) => {
 	const discountConfig = reward.discount_config;
+	const maxRedemptions = discountConfig?.max_redemptions;
 
 	const stripeCli = createStripeCli({
 		org,
@@ -185,6 +186,9 @@ export const createStripeCoupon = async ({
 			isOneOffProduct: pricesOnlyOneOff(prices),
 		}) as any),
 		...(couponToStripeValue({ reward, org, prices }) as any),
+		...(maxRedemptions != null
+			? { max_redemptions: maxRedemptions }
+			: {}),
 		name: reward.name,
 		metadata: {
 			autumn_internal_id: reward.internal_id,

--- a/shared/models/rewardModels/rewardModels/rewardModels.ts
+++ b/shared/models/rewardModels/rewardModels/rewardModels.ts
@@ -12,6 +12,7 @@ export const DiscountConfigSchema = z.object({
 	should_rollover: z.boolean().optional(),
 	apply_to_all: z.boolean().optional(),
 	price_ids: z.array(z.string()).optional(),
+	max_redemptions: z.number().optional(),
 });
 
 export const FreeProductConfigSchema = z.object({

--- a/vite/src/views/products/rewards/reward-config/DiscountConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/DiscountConfig.tsx
@@ -57,7 +57,7 @@ export const DiscountConfig = ({
 	return (
 		<div className="flex flex-col gap-4 w-full">
 			<div className="flex items-center gap-2">
-				<div className="w-6/12">
+				<div className="w-4/12">
 					<FieldLabel>Amount</FieldLabel>
 					<Input
 						value={config.discount_value}
@@ -73,7 +73,7 @@ export const DiscountConfig = ({
 						}
 					/>
 				</div>
-				<div className="w-6/12">
+				<div className="w-4/12">
 					<FieldLabel>Duration</FieldLabel>
 					<div className="flex items-center gap-1">
 						{config.duration_type === CouponDurationType.Months && (
@@ -123,6 +123,20 @@ export const DiscountConfig = ({
 					</div>
 				</div>
 			</div>
+		<div className="w-4/12">
+			<FieldLabel>Maximum Redemptions</FieldLabel>
+			<Input
+				type="number"
+				className="no-spinner"
+				value={config.max_redemptions ?? ""}
+				onChange={(e) => {
+					const { value } = e.target;
+					const parsed = value === "" ? undefined : Number(value);
+					setConfig("max_redemptions", parsed);
+				}}
+				placeholder="Unlimited"
+			/>
+		</div>
 
 			<div className="">
 				{/* <p className="text-t2 mb-2 text-t3">Products</p> */}

--- a/vite/src/views/products/rewards/utils/defaultRewardModels.ts
+++ b/vite/src/views/products/rewards/utils/defaultRewardModels.ts
@@ -13,6 +13,7 @@ export const defaultDiscountConfig: DiscountConfig = {
 	should_rollover: true,
 	apply_to_all: false,
 	price_ids: [],
+	max_redemptions: undefined,
 };
 
 export const defaultFreeProductConfig: FreeProductConfig = {


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

Add max redemptions to the coupon, allow maximum redemptions.  https://docs.stripe.com/billing/subscriptions/coupons#redemption-limits

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->
Band-Aid to:

[ENG-608 - coupon code can only be used 1 time per customer](https://linear.app/useautumn/issue/ENG-608/coupon-code-can-only-be-used-1-time-per-customer)

Limit the total redemptions allowed for now

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 