### PR TITLE
fix: fix internal server error when calling autumn from Chrome Extension

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -76,6 +76,8 @@ const init = async () => {
 	const wildcardPatterns = [
 		/^https:\/\/.*\.useautumn\.com$/,
 		/^https:\/\/.*\.alphalog\.ai$/,
+		/^https:\/\/.*\.alphalog\.ai$/,
+		/^chrome-extension:\/\/.*/,
 	];
 
 	app.use(


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

Making a POST request from a chrome-extension page includes the Origin header (set to `chrome-extension://<id>`). Due to origin check (added in https://github.com/useautumn/autumn/commit/c599c88c985a7032e537cb4a377dd7fa63b2a1a0), the request will fail and autumn will return internal server error (see first curl). Removing `origin` header fixed it (see the second curl).

<img width="754" height="377" alt="Ghostty 2025-10-21 2 47 19 PM" src="https://github.com/user-attachments/assets/411c81bd-a14a-4218-bedf-682f4d49f18c" />

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] ~I have added tests where applicable~ (I couldn't find existing test that's relevant, so I'm not adding one)
- [x] I have tested my changes locally
- [ ] ~I have linked relevant issues~ (no relevant issues)
- [ ] ~I have added screenshots for UI changes (if applicable)~