### PR TITLE
fix: Resolves Issue: #278 update hotkey modifier from 'meta' to 'mod'…

### DIFF
--- a/vite/src/components/v2/buttons/ShortcutButton.tsx
+++ b/vite/src/components/v2/buttons/ShortcutButton.tsx
@@ -24,7 +24,7 @@ export const ShortcutButton = ({
 
 	useHotkeys(
 		metaShortcut
-			? [`meta+${metaShortcut}`]
+			? [`mod+${metaShortcut}`]
 			: singleShortcut
 				? [singleShortcut]
 				: [],


### PR DESCRIPTION
## Summary
This pull request makes a minor update to the keyboard shortcut handling in the `ShortcutButton` component. The change standardizes the modifier key used in the shortcut definition.

* Changed the hotkey modifier from `meta` to `mod` in the `ShortcutButton` component to ensure cross-platform consistency for keyboard shortcuts. (`vite/src/components/v2/buttons/ShortcutButton.tsx`)
* This change needs to be tested on Mac although works fine on windows.
## Related Issues
Fixes #278 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
## Before
![ezgif-2e1b6e76683ecc](https://github.com/user-attachments/assets/29b72b1c-992b-4a31-b0e5-ec556711ad44)

## After
![Screen Recording 2025-10-29 022347(1)](https://github.com/user-attachments/assets/7e308932-8672-4a96-9fbe-a06cbd751ddd)

