### PR TITLE
fix: fix plan feature row layout with slide-in buttons

### DIFF
--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -89,8 +89,15 @@ export const PlanFeatureRow = ({
 	const handleRowClicked = () => {
 		if (isDisabled) return;
 		const currentItemId = getItemId({ item, itemIndex: index });
-		setItem(item);
-		setSheet({ type: "edit-feature", itemId: currentItemId });
+
+		if (isSelected) {
+			// If already selected, deselect by going back to edit-plan
+			setSheet({ type: "edit-plan" });
+		} else {
+			// If not selected, select it
+			setItem(item);
+			setSheet({ type: "edit-feature", itemId: currentItemId });
+		}
 	};
 
 	const handleDeleteRow = () => {
@@ -162,7 +169,7 @@ export const PlanFeatureRow = ({
 			{...(isDisabled && { "data-disabled": true })}
 			data-pressed={isPressed}
 			className={cn(
-				"flex w-full group !h-9 group/row select-none outline-none",
+				"flex items-center w-full group !h-9 group/row select-none outline-none",
 				"input-base input-shadow-tiny input-state-open-tiny",
 				isDisabled && "pointer-events-none cursor-default",
 			)}
@@ -189,7 +196,7 @@ export const PlanFeatureRow = ({
 			}}
 		>
 			{/* Left side - Icons and text */}
-			<div className="flex flex-row items-center flex-1 gap-4 min-w-0 relative">
+			<div className="flex flex-row items-center flex-1 gap-2 min-w-0 overflow-hidden">
 				<AdminHover texts={adminHoverText()}>
 					<div className="flex flex-row items-center gap-1 flex-shrink-0">
 						<PlanFeatureIcon item={item} position="left" />
@@ -200,43 +207,43 @@ export const PlanFeatureRow = ({
 					</div>
 				</AdminHover>
 
-				<div className="flex items-center gap-2 flex-1 min-w-0 max-w-[90%] ">
-					<p className="whitespace-nowrap truncate max-w-full">
-						<span className={cn("text-body", !hasFeatureName && "!text-t4")}>
-							{displayText}
-						</span>
+				<p className="whitespace-nowrap truncate flex-1 min-w-0">
+					<span className={cn("text-body", !hasFeatureName && "!text-t4")}>
+						{displayText}
+					</span>
 
-						<span className="text-body-secondary">
-							{" "}
-							{display.secondary_text}
-						</span>
-					</p>
+					<span className="text-body-secondary">
+						{" "}
+						{display.secondary_text}
+					</span>
+				</p>
+
+				<div className={cn(
+					"flex items-center gap-2 max-w-0 opacity-0 overflow-hidden group-hover:max-w-[200px] group-hover:opacity-100 transition-all duration-200 flex-shrink-0",
+					isSelected && "max-w-[200px] opacity-100"
+				)}>
+					<CopyButton
+						text={item.feature_id || ""}
+						disableActive={true}
+						size="sm"
+						variant="skeleton"
+						tabIndex={-1}
+						side="bottom"
+					/>
+					<IconButton
+						icon={<TrashIcon size={16} weight="regular" />}
+						iconOrientation="center"
+						onClick={(e) => {
+							e.stopPropagation();
+							e.preventDefault();
+							handleDeleteRow();
+						}}
+						aria-label="Delete feature"
+						variant="skeleton"
+						disableActive={true}
+						tabIndex={-1}
+					/>
 				</div>
-
-				<CopyButton
-					text={item.feature_id || ""}
-					disableActive={true}
-					size="sm"
-					variant="skeleton"
-					tabIndex={-1}
-					className="absolute right-0 z-20 opacity-0 group-hover:opacity-100 transition-opacity duration-50 bg-hover-primary group-hover:bg-transparent"
-				/>
-			</div>
-
-			<div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity duration-50">
-				<IconButton
-					icon={<TrashIcon size={16} weight="regular" />}
-					iconOrientation="center"
-					onClick={(e) => {
-						e.stopPropagation();
-						e.preventDefault();
-						handleDeleteRow();
-					}}
-					aria-label="Delete feature"
-					variant="skeleton"
-					disableActive={true}
-					tabIndex={-1}
-				/>
 
 				{/* <div className="group/btn cursor-grab active:cursor-grabbing flex items-center justify-center p-1 w-6 h-6">
 					<div className="text-t3 group-hover/btn:text-primary transition-colors">


### PR DESCRIPTION
## Summary
Fixed layout issues in the plan feature row where long feature names caused the copy ID button to overlap with text. Added smooth slide-in animations for action buttons and improved user interactions.

## Related Issues
Fixes https://lindie.app/share/670cc31c69f9ab7d3d1d61e0fb2cc7c3b3ada74b/ENG-742

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Changes Made
- Fixed vertical alignment of buttons with row content
- Fixed text truncation to expand fully and only truncate when hitting action buttons
- Added slide-in animation for copy/delete buttons (collapse to 0 width when hidden, expand on hover)
- Made action buttons stay visible when feature row is selected
- Changed copy button toast to appear below instead of to the right
- Added optional deselectable behavior for feature rows to return to plan details

## Before
Long feature names caused the copy ID button to overlap with text, buttons were always visible taking up space, and clicking a selected row would re-open the same sheet.

## After
Text uses maximum available space and only truncates when necessary, copy and delete buttons smoothly slide in on hover or when selected, toast appears below the button, and clicking a selected row deselects it to return to plan view.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

Originally the idea was to always show the button (but that leads to not always seeing information)
<img width="648" height="291" alt="always-shows" src="https://github.com/user-attachments/assets/842de985-cdf2-4d5f-939a-4e04ff4f9199" />

I decided to make it show when the feature was selected, while others would animate in, and let features be deselected to go back to plan details.

https://github.com/user-attachments/assets/725658bd-bb72-46b4-8f66-867c71589a1d

## Additional Context
The fix uses CSS transitions with `max-w-0` to `max-w-[200px]` to create a smooth collapse/expand animation that allows the text to reclaim space when buttons are hidden, while keeping buttons accessible on hover or when selected.
