### PR TITLE
feat: add clickable rail to collapsed sidebar

### DIFF
--- a/vite/src/views/main-sidebar/MainSidebar.tsx
+++ b/vite/src/views/main-sidebar/MainSidebar.tsx
@@ -12,13 +12,13 @@ import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 import { useOrg } from "@/hooks/common/useOrg";
 import { cn } from "@/lib/utils";
 import { useEnv } from "@/utils/envUtils";
+import { CollapsibleNavGroup } from "./CollapsibleNavGroup";
 import { DeployToProdButton } from "./components/deploy-button/DeployToProdButton";
 import { OrgDropdown } from "./components/OrgDropdown";
 import { EnvDropdown } from "./EnvDropdown";
 import { NavButton } from "./NavButton";
 import SidebarBottom from "./SidebarBottom";
 import { SidebarContext } from "./SidebarContext";
-import { CollapsibleNavGroup } from "./CollapsibleNavGroup";
 
 export const MainSidebar = () => {
 	const env = useEnv();
@@ -51,88 +51,97 @@ export const MainSidebar = () => {
 	// const expanded = state == "expanded";
 	return (
 		<SidebarContext.Provider value={{ expanded, setExpanded }}>
-			<div
-				className={cn(
-					`h-full bg-stone-100 py-4 flex flex-col justify-between transition-all duration-150`,
-					expanded
-						? "min-w-[200px] max-w-[200px]"
-						: "min-w-[50px] max-w-[50px]",
+			<div className="relative h-full">
+				{!expanded && (
+					<div
+						onClick={() => setExpanded(true)}
+						className="absolute top-[18px] bottom-[18px] right-0 w-px hover:w-1 bg-stone-200 hover:bg-stone-300 transition-all cursor-ew-resize z-10"
+						title="Click to expand sidebar"
+					/>
 				)}
-			>
-				<div className="flex flex-col gap-6 relative">
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() => {
-							setExpanded((prev) => !prev);
-						}}
-						className={cn(
-							"absolute top-1 right-4 text-t3 hover:bg-stone-200 w-5 h-5 p-0 border-none border-0 shadow-none bg-transparent",
-							expanded
-								? "opacity-100 transition-opacity duration-100"
-								: "opacity-0 transition-opacity duration-100",
-						)}
-					>
-						<PanelLeft size={14} />
-					</Button>
-					<OrgDropdown />
-
-					{org?.deployed ? (
-						<EnvDropdown env={env} />
-					) : (
-						<DeployToProdButton expanded={expanded} />
+				<div
+					className={cn(
+						`h-full bg-stone-100 py-4 flex flex-col justify-between transition-all duration-150`,
+						expanded
+							? "min-w-[200px] max-w-[200px]"
+							: "min-w-[50px] max-w-[50px]",
 					)}
-					<div className="flex flex-col px-2 gap-1">
-						<CollapsibleNavGroup
-							value="products"
-							icon={<Package size={14} />}
-							title="Plans"
-							env={env}
-							isOpen={productGroupOpen}
-							onToggle={onProductTabClick}
-							subTabs={[
-								{ title: "Plans", value: "products" },
-								{ title: "Features", value: "features" },
-								{ title: "Rewards", value: "rewards" },
-							]}
-						/>
+				>
+					<div className="flex flex-col gap-6 relative">
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => {
+								setExpanded((prev) => !prev);
+							}}
+							className={cn(
+								"absolute top-1 right-4 text-t3 hover:bg-stone-200 w-5 h-5 p-0 border-none border-0 shadow-none bg-transparent",
+								expanded
+									? "opacity-100 transition-opacity duration-100"
+									: "opacity-0 transition-opacity duration-100",
+							)}
+						>
+							<PanelLeft size={14} />
+						</Button>
+						<OrgDropdown />
 
-						<NavButton
-							value="customers"
-							icon={<CircleUserRound size={14} />}
-							title="Customers"
-							env={env}
-						/>
-						<NavButton
-							value="analytics"
-							icon={<ChartColumnBig size={14} />}
-							title="Analytics"
-							env={env}
-						/>
-						<CollapsibleNavGroup
-							value="dev"
-							icon={<SquareTerminal size={14} />}
-							title="Developer"
-							env={env}
-							isOpen={devGroupOpen}
-							onToggle={() => setDevGroupOpen((prev) => !prev)}
-							subTabs={
-								webhooks
-									? [
-											{ title: "API Keys", value: "api_keys" },
-											{ title: "Stripe", value: "stripe" },
-											{ title: "Webhooks", value: "webhooks" },
-										]
-									: [
-											{ title: "API Keys", value: "api_keys" },
-											{ title: "Stripe", value: "stripe" },
-										]
-							}
-						/>
+						{org?.deployed ? (
+							<EnvDropdown env={env} />
+						) : (
+							<DeployToProdButton expanded={expanded} />
+						)}
+						<div className="flex flex-col px-2 gap-1">
+							<CollapsibleNavGroup
+								value="products"
+								icon={<Package size={14} />}
+								title="Plans"
+								env={env}
+								isOpen={productGroupOpen}
+								onToggle={onProductTabClick}
+								subTabs={[
+									{ title: "Plans", value: "products" },
+									{ title: "Features", value: "features" },
+									{ title: "Rewards", value: "rewards" },
+								]}
+							/>
+
+							<NavButton
+								value="customers"
+								icon={<CircleUserRound size={14} />}
+								title="Customers"
+								env={env}
+							/>
+							<NavButton
+								value="analytics"
+								icon={<ChartColumnBig size={14} />}
+								title="Analytics"
+								env={env}
+							/>
+							<CollapsibleNavGroup
+								value="dev"
+								icon={<SquareTerminal size={14} />}
+								title="Developer"
+								env={env}
+								isOpen={devGroupOpen}
+								onToggle={() => setDevGroupOpen((prev) => !prev)}
+								subTabs={
+									webhooks
+										? [
+												{ title: "API Keys", value: "api_keys" },
+												{ title: "Stripe", value: "stripe" },
+												{ title: "Webhooks", value: "webhooks" },
+											]
+										: [
+												{ title: "API Keys", value: "api_keys" },
+												{ title: "Stripe", value: "stripe" },
+											]
+								}
+							/>
+						</div>
 					</div>
-				</div>
 
-				<SidebarBottom />
+					<SidebarBottom />
+				</div>
 			</div>
 		</SidebarContext.Provider>
 	);


### PR DESCRIPTION
## Summary
Added a clickable rail on the edge of the collapsed sidebar to make it easier to expand. When the sidebar is minimized, a subtle vertical line appears that can be clicked to re-open it.

## Related Issues
Fixes https://lindie.app/share/670cc31c69f9ab7d3d1d61e0fb2cc7c3b3ada74b/ENG-711

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Changes Made
Added a clickable rail (1px line expanding to 4px on hover) on the right edge of the collapsed sidebar. The rail uses `bg-stone-200` to match the border color, positioned with `top-[18px] bottom-[18px]` to align with the main content border and avoid extending past rounded corners.

## Before
When the sidebar was collapsed, users could only expand it via the invisible toggle button at the top or the keyboard shortcut (Ctrl+B / Cmd+B).

## After
A clear visual rail provides an easy click target to expand the sidebar, with hover feedback to indicate interactivity.

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

on hover it'll show like this
<img width="356" height="287" alt="on-hover" src="https://github.com/user-attachments/assets/3bb81fdb-9ddb-40d3-b57c-b4ef27070e4c" />

view of the sidebar when collapsed
<img width="364" height="290" alt="when-collapsed" src="https://github.com/user-attachments/assets/210a5941-1c4e-4991-8b3d-378625204e9e" />


