### PR TITLE
fix: add simple email validation before sending sign-in OTP

### DIFF
--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils";
 import { getBackendErr } from "@/utils/genUtils";
 import { OTPSignIn } from "./components/OTPSignIn";
 
-const emailSchema = z.email();
+export const emailSchema = z.email();
 
 export const SignIn = () => {
 	const [email, setEmail] = useState("");

--- a/vite/src/views/auth/components/PasswordSignIn.tsx
+++ b/vite/src/views/auth/components/PasswordSignIn.tsx
@@ -1,14 +1,11 @@
-import { Mail } from "lucide-react";
-import { toast } from "sonner";
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
+import { toast } from "sonner";
+import { CustomToaster } from "@/components/general/CustomToaster";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { useSearchParams } from "react-router";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGoogle } from "@fortawesome/free-brands-svg-icons";
-import { authClient, signIn, useSession } from "@/lib/auth-client";
-import { CustomToaster } from "@/components/general/CustomToaster";
-import { getBackendErr } from "@/utils/genUtils";
+import { authClient, useSession } from "@/lib/auth-client";
+import { emailSchema } from "../SignIn";
 
 export const PasswordSignIn = () => {
 	const [email, setEmail] = useState("");
@@ -28,7 +25,7 @@ export const PasswordSignIn = () => {
 
 	const handleEmailSignIn = async (e: React.FormEvent) => {
 		e.preventDefault();
-		if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+		if (!email || !emailSchema.safeParse(email).success) {
 			toast.error("Please enter a valid email address.");
 			return;
 		}


### PR DESCRIPTION
**fix: add email validation before sending sign-in OTP**

**Description**

Added a simple regex-based validation to check if the email is valid before calling authClient.emailOtp.sendVerificationOtp.
Improves UX by giving instant feedback and avoids unnecessary API calls.