### PR TITLE
fix: seperated product keys for cancelled products

### DIFF
--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCusProduct/getApiCusProducts.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCusProduct/getApiCusProducts.ts
@@ -17,7 +17,8 @@ const mergeCusProductResponses = ({
 		const status = ACTIVE_STATUSES.includes(product.status as CusProductStatus)
 			? "active"
 			: product.status;
-		return `${product.id}:${status}`;
+		const cancellationStatus = product.canceled_at ? "cancelled" : "active";
+		return `${product.id}:${status}:${cancellationStatus}`;
 	};
 
 	const record: Record<string, any> = {};


### PR DESCRIPTION
## Summary
Adding product keys to seperate out cancelled products. This is useful for simple add-ons where a single add-on could be cancelled, while other add-ons of the same type are active. This way we know which ones are active and which ones are cancelled. 

## Related Issues
NA

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
