### PR TITLE
Add validation for Credit System feature selection

### DIFF
--- a/vite/src/views/products/features/credit-systems/components/CreateCreditSystemSheet.tsx
+++ b/vite/src/views/products/features/credit-systems/components/CreateCreditSystemSheet.tsx
@@ -35,6 +35,7 @@ const defaultCreditSystem: CreateFeature = {
 
 export function CreateCreditSystemSheet() {
 	const { refetch } = useFeaturesQuery();
+	const { features } = useFeaturesQuery();
 	const axiosInstance = useAxiosInstance();
 
 	const [loading, setLoading] = useState(false);
@@ -79,12 +80,25 @@ export function CreateCreditSystemSheet() {
 	const handleCancel = () => {
 		setOpen(false);
 	};
+	
+const OpenCreditModal = () => {
+	try{
+       if (!features || features.length === 0) {
+		toast.error("Add at least one feature to continue with credit allocation.");
+		return;
+	}
 
+	setOpen(true);
+	}catch(error){
+		console.error("Error opening credit system modal:", error);
+		toast.error("An unexpected error occurred while opening the credit system modal.");
+	}
+	};
 	return (
 		<Sheet open={open} onOpenChange={setOpen}>
-			<SheetTrigger asChild>
-				<Button variant="add">Credit System</Button>
-			</SheetTrigger>
+				
+				<Button variant="add" onClick={OpenCreditModal}>Credit System</Button>
+
 			<SheetContent className="flex flex-col overflow-hidden">
 				<SheetHeader
 					title="Create Credit System"


### PR DESCRIPTION
Before:
If there were zero features, the credit system could still be added, and clicking on it caused incorrect behavior (the modal would not open properly).

Now:
If there are zero features, an toast message is shown when clicking 'Credit System': 'Add at least one feature to continue with credit allocation.'


https://github.com/user-attachments/assets/d44be8dc-e071-4a36-8056-27b47263c165


## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ .] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ .] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ .] My code follows the code style of this project
- [. ] I have added tests where applicable
- [. ] I have tested my changes locally
- [ .] I have linked relevant issues
- [. ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Include before and after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 