### PR TITLE
fix: 🐛 wrong error code caused feature already exists

### DIFF
--- a/shared/api/errors/codes/featureErrCodes.ts
+++ b/shared/api/errors/codes/featureErrCodes.ts
@@ -1,6 +1,6 @@
 export const FeatureErrorCode = {
 	FeatureNotFound: "feature_not_found",
-	FeatureAlreadyExists: "feature_already_exists",
+	FeatureAlreadyExists: "duplicate_feature_id",
 } as const;
 
 export type FeatureErrorCode =


### PR DESCRIPTION
sillit bang and the dirt is gone