### PR TITLE
feat(api-keys): improve dark mode ui and backend

### DIFF
--- a/server/src/internal/dev/api-keys/apiKeyUtils.ts
+++ b/server/src/internal/dev/api-keys/apiKeyUtils.ts
@@ -5,6 +5,7 @@ import { queryWithCache } from "@/utils/cacheUtils/queryWithCache.js";
 import { generateId } from "@/utils/genUtils.js";
 import { ApiKeyService } from "../ApiKeyService.js";
 import { buildSecretKeyCacheKey } from "./cacheApiKeyUtils.js";
+import { z } from "zod";
 
 function generateApiKey(length = 32, prefix = "") {
 	try {
@@ -111,3 +112,7 @@ export const verifyKey = async ({
 // 		env,
 // 	});
 // }
+
+export const createApiKeyCreateSchema = z.object({
+	name: z.string().min(1),
+});

--- a/server/src/internal/dev/devRouter.ts
+++ b/server/src/internal/dev/devRouter.ts
@@ -18,7 +18,7 @@ import { OrgService } from "../orgs/OrgService.js";
 import { clearOrgCache } from "../orgs/orgUtils/clearOrgCache.js";
 import { isStripeConnected } from "../orgs/orgUtils.js";
 import { ApiKeyService } from "./ApiKeyService.js";
-import { createKey } from "./api-keys/apiKeyUtils.js";
+import { createApiKeyCreateSchema, createKey } from "./api-keys/apiKeyUtils.js";
 
 export const devRouter: Router = Router();
 
@@ -55,6 +55,12 @@ devRouter.post("/api_key", withOrgAuth, async (req: any, res) =>
 		handler: async (req: any, res: any) => {
 			const { db, env, orgId } = req;
 			const { name } = req.body;
+
+			const result = createApiKeyCreateSchema.safeParse(req.body);
+			if (!result.success) {
+				res.status(400).json({ error: result.error.message });
+				return;
+			}
 
 			// 1. Create API key
 			let prefix = "am_sk_test";

--- a/vite/src/components/general/SmallSpinner.tsx
+++ b/vite/src/components/general/SmallSpinner.tsx
@@ -1,11 +1,11 @@
 import { LucideLoaderCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
 
-function SmallSpinner({ size = 18 }: { size?: number }) {
+function SmallSpinner({ size = 18, className }: { size?: number; className?: string }) {
 	return (
 		<LucideLoaderCircle
-			className="animate-spin text-t3"
+			className={cn("animate-spin text-white", className)}
 			size={size}
-			color="#9D9D9D"
 		/>
 	);
 }

--- a/vite/src/views/developer/api-keys/components/APIKeyTableColumns.tsx
+++ b/vite/src/views/developer/api-keys/components/APIKeyTableColumns.tsx
@@ -1,5 +1,7 @@
 import type { ApiKey } from "@autumn/shared";
 import type { ColumnDef, Row } from "@tanstack/react-table";
+import { CalendarIcon } from "lucide-react";
+import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
 import { APIKeyToolbar } from "./APIKeyToolbar";
 
 export const createAPIKeyTableColumns = (): ColumnDef<ApiKey, unknown>[] => [
@@ -24,6 +26,24 @@ export const createAPIKeyTableColumns = (): ColumnDef<ApiKey, unknown>[] => [
 					) : (
 						<span className="px-1 text-t3">—</span>
 					)}
+				</div>
+			);
+		},
+	},
+	{
+		header: () => (
+			<div className="flex items-center gap-1.5">
+				<CalendarIcon size={14} className="text-t4" />
+				<span>Created</span>
+			</div>
+		),
+		accessorKey: "created_at",
+		size: 120,
+		cell: ({ row }: { row: Row<ApiKey> }) => {
+			const { date, time } = formatUnixToDateTime(row.original.created_at);
+			return (
+				<div className="text-xs text-t3 pr-4 w-full">
+					{date} <span className="truncate">{time}</span>
 				</div>
 			);
 		},

--- a/vite/src/views/developer/api-keys/components/DeleteApiKeyDialog.tsx
+++ b/vite/src/views/developer/api-keys/components/DeleteApiKeyDialog.tsx
@@ -61,7 +61,7 @@ export const DeleteApiKeyDialog = ({
 					<DialogTitle>Delete API Key</DialogTitle>
 					<DialogDescription>
 						To confirm the deletion of this API key, type{" "}
-						<span className="font-bold">{apiKey.name}</span> below
+						<span className="font-bold">"{apiKey.name}"</span> below
 					</DialogDescription>
 				</DialogHeader>
 				<Input

--- a/vite/src/views/products/hooks/useProductTable.ts
+++ b/vite/src/views/products/hooks/useProductTable.ts
@@ -2,6 +2,7 @@ import {
 	type ColumnDef,
 	getCoreRowModel,
 	getFilteredRowModel,
+	getSortedRowModel,
 	type TableOptions,
 	useReactTable,
 } from "@tanstack/react-table";
@@ -19,13 +20,14 @@ export function useProductTable<TData>({
 	columns: ColumnDef<TData, unknown>[];
 	options?: Partial<TableOptions<TData>>;
 }) {
-	const enableSorting = false;
+	const enableSorting = options.enableSorting ?? false;
 
 	return useReactTable({
 		data,
 		columns,
 		getCoreRowModel: getCoreRowModel(),
 		getFilteredRowModel: getFilteredRowModel(),
+		...(enableSorting && { getSortedRowModel: getSortedRowModel() }),
 		enableSorting,
 		...options,
 	});


### PR DESCRIPTION
## Summary
Improves the ui on dark mode by making the api key adapt. Also enforces an api key to have a name when being created to make sure ui doesnt break furthe down the line e.g. currently you are prompted to type "" to delete a key without name. Also added a column in the table to show when the key was created. Apart from these visual changes it also makes sure components can easier be reused!

## Related Issues
None

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<img width="1000" height="178" alt="image" src="https://github.com/user-attachments/assets/33a55a81-07a7-4bf7-aca3-d9daa8450ef6" />

<img width="546" height="202" alt="image" src="https://github.com/user-attachments/assets/a063ec4d-72b1-4c45-9384-434b0a54275e" />
