### PR TITLE
Fix: OTP input disappearing during verification

### DIFF
--- a/vite/src/views/auth/components/OTPSignIn.tsx
+++ b/vite/src/views/auth/components/OTPSignIn.tsx
@@ -102,7 +102,7 @@ export const OTPSignIn = ({
 			<p className="text-sm text-muted-foreground">
 				Check your email for the 6 digit code
 			</p>
-			<div className={cn(verifying && "shimmer")}>
+			<div className={cn(verifying && "opacity-50 pointer-events-none")}>
 				<InputOTP
 					maxLength={6}
 					value={otp}


### PR DESCRIPTION
**What changed**

Replaced the shimmer class on the OTP input with:
opacity-50 pointer-events-none

**Why**
The shimmer class makes text transparent, causing the OTP digits to disappear during verification.
The new classes keep the input visible while still showing a disabled/loading state.

**Result**
OTP stays visible during verification and the UI works as expected.