### PR TITLE
fix: add total_available to GET /v1/customers response

### DIFF
--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -8,14 +8,29 @@ import {
 	type CustomerLegacyData,
 	type FullCustomer,
 	type Organization,
+	customers,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { RequestContext } from "@/honoUtils/HonoEnv.js";
 import { RELEVANT_STATUSES } from "./cusProducts/CusProductService.js";
 import { getApiCustomerBase } from "./cusUtils/apiCusUtils/getApiCustomerBase.js";
 import { getPaginatedFullCusQuery } from "./getFullCusQuery.js";
+import { count, eq, and } from "drizzle-orm";
 
 export class CusBatchService {
+	static async getTotalCount({
+		ctx,
+	}: {
+		ctx: RequestContext;
+	}): Promise<number> {
+		const result = await ctx.db
+			.select({ count: count() })
+			.from(customers)
+			.where(and(eq(customers.orgId, ctx.org.id), eq(customers.env, ctx.env)));
+
+		return result[0]?.count ?? 0;
+	}
+
 	static async getByInternalIds({
 		db,
 		org,

--- a/server/src/internal/customers/handlers/handleListCustomers.ts
+++ b/server/src/internal/customers/handlers/handleListCustomers.ts
@@ -21,16 +21,20 @@ export const handleListCustomers = createRoute({
 		// Note: expand and statuses are not exposed in the query params for list endpoint
 		const statuses: any[] = [];
 
-		const customers = await CusBatchService.getPage({
-			ctx,
-			limit,
-			offset,
-			statuses,
-		});
+		const [customers, totalAvailable] = await Promise.all([
+			CusBatchService.getPage({
+				ctx,
+				limit,
+				offset,
+				statuses,
+			}),
+			CusBatchService.getTotalCount({ ctx }),
+		]);
 
 		return c.json({
 			list: customers,
 			total: customers.length,
+			total_available: totalAvailable,
 			limit,
 			offset,
 		});

--- a/shared/api/customers/customerOpModels.ts
+++ b/shared/api/customers/customerOpModels.ts
@@ -134,7 +134,10 @@ export const ListCustomersResponseSchema = z.object({
 		description: "List of customers",
 	}),
 	total: z.number().int().meta({
-		description: "Total number of customers available",
+		description: "Number of customers returned in this response",
+	}),
+	total_available: z.number().int().meta({
+		description: "Total number of customers available in the database",
 	}),
 	limit: z.number().int().meta({
 		description: "Maximum number of customers returned",


### PR DESCRIPTION
## Summary

The GET /v1/customers endpoint was returning total as the number of customers in the current page, but the schema documented it as "Total number of customers available". This PR fixes the documentation to reflect actual behavior and adds a new total_available field that returns the true total count of customers in the database, enabling proper pagination.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):
## Checklist
- [x] I have read the CONTRIBUTING.md (https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
N/A - API only change

## Additional Context
Response now looks like:
{
  list: [...],
  total: 10,            // customers returned in this page
  total_available: 250, // total customers in the database
  limit: 10,
  offset: 0
}