### PR TITLE
fix: checkout preview returns scenario='renew' for cancelling products

### DIFF
--- a/server/src/internal/billing/attachPreview/attachParamsToPreview.ts
+++ b/server/src/internal/billing/attachPreview/attachParamsToPreview.ts
@@ -99,6 +99,16 @@ export const attachParamsToPreview = async ({
 		});
 	}
 
+	if (func === AttachFunction.Renew) {
+		preview = await getNewProductPreview({
+			branch,
+			attachParams,
+			logger,
+			config,
+			withPrepaid,
+		});
+	}
+
 	const { curScheduledProduct } = attachParamToCusProducts({ attachParams });
 	const curCusProduct = attachParamsToCurCusProduct({ attachParams });
 


### PR DESCRIPTION
Fixes #425 

Not tested locally

  ## Problem
  `checkout()` preview returns `scenario: "new"` instead of `scenario: "renew"`
  for entity-scoped products that are active but scheduled for cancellation.

  ## Root Cause
  `attachParamsToPreview.ts` handles AddProduct, ScheduleProduct, and upgrade
  functions but has no case for `AttachFunction.Renew`. The preview variable
  stays null, causing fallback to `AttachScenario.New`.

  ## Fix
  Add handler for `AttachFunction.Renew` that calls `getNewProductPreview()`.
  The branch already contains `AttachBranch.Renew`, and `getAttachScenario.ts`
  correctly maps this to `AttachScenario.Renew`.