### PR TITLE
fix: update quantity from zero

### DIFF
--- a/server/src/db/initClickHouse.ts
+++ b/server/src/db/initClickHouse.ts
@@ -1,7 +1,7 @@
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
 
 export const clickhouseClient: ClickHouseClient = createClient({
-	url: process.env.CLICKHOUSE_URL!,
+	url: process.env.CLICKHOUSE_URL || undefined,
 	username: process.env.CLICKHOUSE_USERNAME!,
 	password: process.env.CLICKHOUSE_PASSWORD!,
 	max_open_connections: 10,

--- a/server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityUpgrade.ts
+++ b/server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityUpgrade.ts
@@ -164,11 +164,27 @@ export const handleQuantityUpgrade = async ({
 		}
 	}
 
-	await stripeCli.subscriptionItems.update(subItem.id, {
-		// quantity: newOptions.quantity,
-		quantity: (subItem.quantity || 0) + subItemDifference,
-		proration_behavior: "none",
-	});
+	// 1. If no sub item, add
+	if (!subItem) {
+		if (!cusPrice.price.config.stripe_price_id) {
+			throw new Error(
+				"Trying to add new sub item for upgrade quantity flow, but no Stripe price ID found",
+			);
+		}
+
+		await stripeCli.subscriptionItems.create({
+			subscription: stripeSub.id,
+			price: cusPrice.price.config.stripe_price_id,
+			quantity: subItemDifference,
+			proration_behavior: "none",
+		});
+	} else {
+		await stripeCli.subscriptionItems.update(subItem.id, {
+			// quantity: newOptions.quantity,
+			quantity: (subItem.quantity || 0) + subItemDifference,
+			proration_behavior: "none",
+		});
+	}
 
 	// Update cus ent
 

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -4,7 +4,10 @@ import { TestFeature } from "@tests/setup/v2Features.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import chalk from "chalk";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
-import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import {
+	constructFeatureItem,
+	constructPrepaidItem,
+} from "@/utils/scriptUtils/constructItem.js";
 import {
 	constructProduct,
 	constructRawProduct,
@@ -28,13 +31,23 @@ const pro = constructProduct({
 	type: "pro",
 
 	items: [
-		constructFeatureItem({
+		constructPrepaidItem({
 			featureId: TestFeature.Messages,
-			includedUsage: 300,
+			includedUsage: 100,
+			price: 10,
+			billingUnits: 100,
 		}),
-		constructFeatureItem({
-			featureId: TestFeature.Users,
-			includedUsage: 5,
+	],
+});
+const premium = constructProduct({
+	type: "premium",
+
+	items: [
+		constructPrepaidItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+			price: 12,
+			billingUnits: 100,
 		}),
 	],
 });
@@ -43,7 +56,7 @@ const testCase = "temp";
 
 describe(`${chalk.yellowBright("temp: temporary script for testing")}`, () => {
 	const customerId = "temp";
-	const autumnV0: AutumnInt = new AutumnInt({ version: ApiVersion.V0_2 });
+
 	const autumnV1: AutumnInt = new AutumnInt({ version: ApiVersion.V1_2 });
 
 	beforeAll(async () => {
@@ -57,23 +70,23 @@ describe(`${chalk.yellowBright("temp: temporary script for testing")}`, () => {
 			ctx,
 			customerId,
 			withTestClock: true,
-			attachPm: "success",
+			// attachPm: "success",
 		});
 
 		await initProductsV0({
 			ctx,
-			products: [pro, paidAddOn],
+			products: [pro, premium],
 			prefix: testCase,
 		});
 
-		await autumnV1.attach({
+		const res = await autumnV1.attach({
 			customer_id: customerId,
 			product_id: pro.id,
+			options: [{ feature_id: TestFeature.Messages, quantity: 0 }],
 		});
 
-		await autumnV1.attach({
-			customer_id: customerId,
-			product_id: paidAddOn.id,
-		});
+		console.log(res);
+
+		// await autumnV1.attach({ customer_id: customerId, product_id: premium.id });
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Handle quantity upgrades from zero by creating a Stripe subscription item when absent, update temp prepaid test setup, and make ClickHouse URL optional.
> 
> - **Billing/Subscriptions**:
>   - In `handleQuantityUpgrade`, create a new Stripe `subscription_item` when none exists (using `stripe_price_id`) and otherwise update quantity; preserves no-proration behavior.
>   - Continues prorated invoice item creation and optional immediate billing when configured.
> - **Tests**:
>   - Update `server/tests/_temp/temp.test.ts` to use prepaid items (`constructPrepaidItem`), add a `premium` product, pass attach options with `quantity: 0`, and log attach result.
> - **Infra/DB**:
>   - In `server/src/db/initClickHouse.ts`, set `CLICKHOUSE_URL` to `undefined` when not provided instead of asserting non-null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5e625a9e48b9345743f72b2cc8f1f47df5b323a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->