### PR TITLE
fix: next reset at null

### DIFF
--- a/server/src/internal/balances/track/trackUtils/runDeductionTx.ts
+++ b/server/src/internal/balances/track/trackUtils/runDeductionTx.ts
@@ -6,7 +6,6 @@ import type {
 import {
 	CusProductStatus,
 	cusEntToCusPrice,
-	cusEntToPrepaidQuantity,
 	cusProductsToCusEnts,
 	FeatureUsageType,
 	type FullCustomer,
@@ -14,7 +13,6 @@ import {
 	getRelevantFeatures,
 	getStartingBalance,
 	InternalError,
-	isPrepaidCusEnt,
 	notNullish,
 	nullish,
 	orgToInStatuses,
@@ -22,7 +20,6 @@ import {
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
 import { sql } from "drizzle-orm";
-import { getResetBalancesUpdate } from "@/internal/customers/cusProducts/cusEnts/groupByUtils.js";
 import { getEntOptions } from "@/internal/products/prices/priceUtils.js";
 import type { AutumnContext } from "../../../../honoUtils/HonoEnv.js";
 import { EventService } from "../../../api/events/EventService.js";
@@ -144,6 +141,7 @@ export const deductFromCusEnts = async ({
 				ce.entitlement.feature.config?.usage_type ===
 					FeatureUsageType.Continuous && nullish(cusPrice);
 
+			// NOTE: WE USE STARTING BALANCE BECAUSE ADJUSTMENT IS ADDED IN performDeduction.sql function
 			const resetBalance = getStartingBalance({
 				entitlement: ce.entitlement,
 				options:

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -31,13 +31,16 @@ const pro = constructProduct({
 	type: "pro",
 
 	items: [
-		constructPrepaidItem({
+		constructFeatureItem({
 			featureId: TestFeature.Messages,
 			includedUsage: 100,
-			price: 10,
-			billingUnits: 100,
+		}),
+		constructFeatureItem({
+			featureId: TestFeature.Workflows,
+			includedUsage: 10,
 		}),
 	],
+	trial: true,
 });
 const premium = constructProduct({
 	type: "premium",
@@ -70,7 +73,7 @@ describe(`${chalk.yellowBright("temp: temporary script for testing")}`, () => {
 			ctx,
 			customerId,
 			withTestClock: true,
-			// attachPm: "success",
+			attachPm: "success",
 		});
 
 		await initProductsV0({
@@ -79,11 +82,31 @@ describe(`${chalk.yellowBright("temp: temporary script for testing")}`, () => {
 			prefix: testCase,
 		});
 
+		// const entities = [
+		// 	{
+		// 		id: "1",
+		// 		name: "Entity 1",
+		// 		feature_id: TestFeature.Users,
+		// 	},
+		// 	{
+		// 		id: "2",
+		// 		name: "Entity 2",
+		// 		feature_id: TestFeature.Users,
+		// 	},
+		// ];
+
+		// await autumnV1.entities.create(customerId, entities);
 		const res = await autumnV1.attach({
 			customer_id: customerId,
 			product_id: pro.id,
-			options: [{ feature_id: TestFeature.Messages, quantity: 0 }],
+			// entity_id: entities[0].id,
 		});
+
+		// await autumnV1.attach({
+		// 	customer_id: customerId,
+		// 	product_id: pro.id,
+		// 	entity_id: entities[1].id,
+		// });
 
 		console.log(res);
 

--- a/server/tests/balances/update/balances-update3.test.ts
+++ b/server/tests/balances/update/balances-update3.test.ts
@@ -1,280 +1,72 @@
-// import { beforeAll, describe, expect, test } from "bun:test";
-// import { type ApiCustomer, ApiVersion, type LimitedItem } from "@autumn/shared";
-// import { TestFeature } from "@tests/setup/v2Features.js";
-// import ctx from "@tests/utils/testInitUtils/createTestContext.js";
-// import chalk from "chalk";
-// import { AutumnInt } from "@/external/autumn/autumnCli.js";
-// import { CusService } from "@/internal/customers/CusService.js";
-// import { constructArrearItem } from "@/utils/scriptUtils/constructItem.js";
-// import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
-// import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
-// import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
-// import { timeout } from "../../utils/genUtils.js";
+import { beforeAll, describe, test } from "bun:test";
+import { ApiVersion, type LimitedItem } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+import { timeout } from "../../utils/genUtils";
 
-// const usersFeature = constructArrearItem({
-// 	featureId: TestFeature.Users,
-// 	price: 10,
-// 	billingUnits: 1,
-// 	includedUsage: 0,
-// }) as LimitedItem;
+const workflows = constructFeatureItem({
+	featureId: TestFeature.Workflows,
+	includedUsage: 5,
+}) as LimitedItem;
 
-// const freeProd = constructProduct({
-// 	type: "free",
-// 	id: "pay-per-use-users-balance-update3",
-// 	isDefault: false,
-// 	items: [usersFeature],
-// });
+const freeProd = constructProduct({
+	type: "free",
+	isDefault: false,
+	items: [workflows],
+});
 
-// const testCase = "balances-update3";
+const testCase = "balances-update3";
 
-// describe(`${chalk.yellowBright("balances-update3: Balance decoupling tests")}`, () => {
-// 	const customerId = testCase;
-// 	const autumnV2: AutumnInt = new AutumnInt({ version: ApiVersion.V2_0 });
+describe(`${chalk.yellowBright("balances-update3: testing update balance to increase granted balance and track negative")}`, () => {
+	const customerId = testCase;
+	const autumnV2: AutumnInt = new AutumnInt({ version: ApiVersion.V2_0 });
 
-// 	const getRawCusEnt = async () => {
-// 		const fullCus = await CusService.getFull({
-// 			db: ctx.db,
-// 			idOrInternalId: customerId,
-// 			orgId: ctx.org.id,
-// 			env: ctx.env,
-// 		});
+	beforeAll(async () => {
+		await initCustomerV3({
+			ctx,
+			customerId,
+			withTestClock: false,
+		});
 
-// 		return fullCus.customer_products
-// 			.flatMap((cp) => cp.customer_entitlements)
-// 			.find(
-// 				(ce) =>
-// 					ce.internal_feature_id ===
-// 					ctx.features.find((f) => f.id === TestFeature.Users)?.internal_id,
-// 			);
-// 	};
+		await initProductsV0({
+			ctx,
+			products: [freeProd],
+			prefix: testCase,
+		});
 
-// 	const logState = async (label: string) => {
-// 		const cusEnt = await getRawCusEnt();
-// 		const customer = (await autumnV2.customers.get(
-// 			customerId,
-// 		)) as unknown as ApiCustomer;
-// 		const balance = customer.balances[TestFeature.Users];
+		await autumnV2.attach({
+			customer_id: customerId,
+			product_id: freeProd.id,
+		});
+	});
 
-// 		console.log(`\n=== ${label} ===`);
-// 		console.log("DB:", {
-// 			bal: cusEnt?.balance,
-// 			add_bal: cusEnt?.additional_balance,
-// 			add_grant: cusEnt?.adjustment,
-// 		});
-// 		console.log("API:", {
-// 			granted: balance.granted_balance,
-// 			purchased: balance.purchased_balance,
-// 			current: balance.current_balance,
-// 			usage: balance.usage,
-// 		});
-// 	};
+	test("should update balance and have correct v2 api balance for one off interval", async () => {
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Workflows,
+			current_balance: 10,
+		});
 
-// 	beforeAll(async () => {
-// 		await initCustomerV3({
-// 			ctx,
-// 			customerId,
-// 			withTestClock: false,
-// 			attachPm: "success",
-// 		});
+		await autumnV2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Workflows,
+			value: 5,
+		});
 
-// 		await initProductsV0({
-// 			ctx,
-// 			products: [freeProd],
-// 			prefix: testCase,
-// 		});
+		await timeout(2000);
 
-// 		await autumnV2.attach({
-// 			customer_id: customerId,
-// 			product_id: freeProd.id,
-// 		});
+		await autumnV2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Workflows,
+			value: -5,
+		});
 
-// 		await timeout(1000);
-
-// 		await logState("INITIAL STATE");
-// 	});
-
-// 	test("CASE A: balances.update ADD balance", async () => {
-// 		// Setup: balance=0, add_bal=0, add_grant=0
-// 		// Update to 10: diff=+10
-// 		// Expected: balance=0, add_bal=10, add_grant=10
-
-// 		await autumnV2.balances.update({
-// 			customer_id: customerId,
-// 			feature_id: TestFeature.Users,
-// 			current_balance: 10,
-// 		});
-
-// 		await timeout(2000);
-
-// 		await logState("After CASE A");
-
-// 		const cusEnt = await getRawCusEnt();
-// 		expect(cusEnt?.balance).toBe(0); // Unchanged
-// 		expect(cusEnt?.additional_balance).toBe(10); // Added
-// 		expect(cusEnt?.adjustment).toBe(10); // Added
-
-// 		const customer = await autumnV2.customers.get<ApiCustomer>(customerId);
-// 		const balance = customer.balances[TestFeature.Users];
-// 		// current = 0 + 0 + 10 = 10
-// 		expect(balance.current_balance).toBe(10);
-// 		expect(balance.granted_balance).toBe(10);
-// 	});
-
-// 	test("CASE B: balances.update REMOVE with sufficient additional_balance", async () => {
-// 		// Setup: balance=0, add_bal=10, add_grant=10, current=10
-// 		// Update to 5: diff=-5
-// 		// Deduct 5 from add_bal → add_bal=5, balance=0
-// 		// Expected: balance=0, add_bal=5, add_grant=5
-
-// 		await autumnV2.balances.update({
-// 			customer_id: customerId,
-// 			feature_id: TestFeature.Users,
-// 			current_balance: 5,
-// 		});
-
-// 		await timeout(2000);
-
-// 		await logState("After CASE B");
-
-// 		const cusEnt = await getRawCusEnt();
-// 		expect(cusEnt?.balance).toBe(0); // Unchanged (all came from add_bal)
-// 		expect(cusEnt?.additional_balance).toBe(5); // 10 - 5
-// 		expect(cusEnt?.adjustment).toBe(5); // 10 - 5
-
-// 		const customer = await autumnV2.customers.get<ApiCustomer>(customerId);
-// 		const balance = customer.balances[TestFeature.Users];
-
-// 		expect(balance.current_balance).toBe(5);
-// 	});
-
-// 	test("CASE C: balances.update REMOVE with insufficient additional_balance", async () => {
-// 		// Setup: balance=0, add_bal=5, add_grant=5, current=5
-// 		// Update to 0: diff=-5
-// 		// Deduct 5 from add_bal → add_bal=0, remaining=0, balance=0
-// 		// Expected: balance=0, add_bal=0, add_grant=0
-
-// 		await autumnV2.balances.update({
-// 			customer_id: customerId,
-// 			feature_id: TestFeature.Users,
-// 			current_balance: 0,
-// 		});
-
-// 		await timeout(2000);
-
-// 		await logState("After CASE C");
-
-// 		const cusEnt = await getRawCusEnt();
-// 		expect(cusEnt?.balance).toBe(0);
-// 		expect(cusEnt?.additional_balance).toBe(0); // Floored
-// 		expect(cusEnt?.adjustment).toBe(0); // 5 - 5
-
-// 		const customer = await autumnV2.customers.get<ApiCustomer>(customerId);
-// 		const balance = customer.balances[TestFeature.Users];
-// 		expect(balance.current_balance).toBe(0);
-// 	});
-
-// 	test("Track +5 then update REMOVE to trigger main balance deduction", async () => {
-// 		// Track +5 to create main balance
-// 		await autumnV2.track({
-// 			customer_id: customerId,
-// 			feature_id: TestFeature.Users,
-// 			value: 5,
-// 		});
-
-// 		await timeout(2000);
-
-// 		let cusEnt = await getRawCusEnt();
-// 		expect(cusEnt?.balance).toBe(-5); // Overage
-
-// 		// Now update to add balance
-// 		await autumnV2.balances.update({
-// 			customer_id: customerId,
-// 			feature_id: TestFeature.Users,
-// 			current_balance: 10,
-// 		});
-
-// 		await timeout(2000);
-
-// 		await logState("After track +5 then update to 10");
-
-// 		cusEnt = await getRawCusEnt();
-// 		// computed_current = Math.max(0, -5) + 0 = 0
-// 		// diff = 10 - 0 = +10
-// 		// add_bal = 0 + 10 = 10, add_grant = 0 + 10 = 10, balance = -5
-// 		expect(cusEnt?.balance).toBe(-5); // Unchanged
-// 		expect(cusEnt?.additional_balance).toBe(10);
-// 		expect(cusEnt?.adjustment).toBe(10);
-
-// 		// Now remove: update to 3
-// 		// current = Math.max(0, -5) + 10 = 10
-// 		// diff = 3 - 10 = -7
-// 		// Deduct 7: 7 from add_bal → add_bal=3, balance=-5
-// 		await autumnV2.balances.update({
-// 			customer_id: customerId,
-// 			feature_id: TestFeature.Users,
-// 			current_balance: 3,
-// 		});
-
-// 		await timeout(2000);
-
-// 		await logState("After update to 3");
-
-// 		cusEnt = await getRawCusEnt();
-// 		expect(cusEnt?.balance).toBe(-5); // Unchanged
-// 		expect(cusEnt?.additional_balance).toBe(3); // 10 - 7
-// 		expect(cusEnt?.adjustment).toBe(3); // 10 - 7
-// 	});
-
-// 	test("CASE D: balances.update from negative to positive preserves paid credits", async () => {
-// 		// Setup: balance=-5, add_bal=3, add_grant=3
-// 		// Update to 0:
-// 		// current = Math.max(0,-5) + 3 = 3
-// 		// diff = 0 - 3 = -3
-// 		// Deduct 3 from add_bal → add_bal=0, balance=-5
-// 		// Result: current = Math.max(0,-5) + 0 = 0 ✅
-
-// 		await autumnV2.balances.update({
-// 			customer_id: customerId,
-// 			feature_id: TestFeature.Users,
-// 			current_balance: 0,
-// 		});
-
-// 		await timeout(2000);
-
-// 		await logState("After CASE D");
-
-// 		const cusEnt = await getRawCusEnt();
-// 		expect(cusEnt?.balance).toBe(-5); // Unchanged (still in debt)
-// 		expect(cusEnt?.additional_balance).toBe(0); // 3 - 3
-// 		expect(cusEnt?.adjustment).toBe(0); // 3 - 3
-// 	});
-
-// 	test("CASE E: Track negative to fully return debt", async () => {
-// 		// Setup: balance=-5, add_bal=0, add_grant=0 (from CASE D)
-// 		// Track -5: adds 5 to main balance
-// 		// Expected: balance=0, add_bal=0, add_grant=0
-
-// 		await autumnV2.track({
-// 			customer_id: customerId,
-// 			feature_id: TestFeature.Users,
-// 			value: -5,
-// 		});
-
-// 		await timeout(2000);
-
-// 		await logState("After CASE E");
-
-// 		const cusEnt = await getRawCusEnt();
-// 		expect(cusEnt?.balance).toBe(0); // -5 + 5 = 0
-// 		expect(cusEnt?.additional_balance).toBe(0); // Unchanged
-// 		expect(cusEnt?.adjustment).toBe(0); // Unchanged
-
-// 		const customer = await autumnV2.customers.get<ApiCustomer>(customerId);
-// 		const balance = customer.balances[TestFeature.Users];
-
-// 		expect(balance.current_balance).toBe(0);
-// 		expect(balance.purchased_balance).toBe(0);
-// 		expect(balance.granted_balance).toBe(0);
-// 		expect(balance.usage).toBe(0);
-// 	});
-// });
+		await timeout(2000);
+	});
+});

--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -132,7 +132,7 @@ export function BalanceEditSheet() {
 				granted_balance: grantedBalanceChanged ? grantedBalanceInt : undefined,
 				customer_entitlement_id: cusEnt.id,
 				entity_id: entityId ?? undefined,
-				next_reset_at: updateFields.next_reset_at,
+				next_reset_at: updateFields.next_reset_at ?? undefined,
 			});
 			toast.success("Balance updated successfully");
 			await refetch();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents sending null next_reset_at from the balance editor, caps deduction max_balance using starting balance, and adds/updates tests for balances.update and tracking flows.
> 
> - **Backend (balances)**:
>   - Cap deduction `max_balance` using `getStartingBalance` during `deduct_from_cus_ents` (cleanup unused imports).
> - **Frontend (BalanceEditSheet)**:
>   - Send `next_reset_at` only when defined (use `undefined` instead of `null`).
> - **Tests**:
>   - Add `balances-update3` test covering `balances.update` then track positive/negative flows for `Workflows`.
>   - Update temp test setup: use `constructFeatureItem`, add `Workflows`, enable trial, and attach payment method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cf0314c39848a7411754bff4032735611c9217f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->