### PR TITLE
fix: update plan invoice

### DIFF
--- a/server/src/internal/analytics/AnalyticsService.ts
+++ b/server/src/internal/analytics/AnalyticsService.ts
@@ -1,10 +1,11 @@
 /** biome-ignore-all lint/complexity/noStaticOnlyClass: wrap it up buddy */
 
-import { ErrCode, type FullCustomer } from "@autumn/shared";
+/** biome-ignore-all lint/complexity/noStaticOnlyClass: wrap it up buddy */
+
+import { ErrCode, type FullCustomer, RecaseError } from "@autumn/shared";
 import type { ClickHouseClient } from "@clickhouse/client";
 import { Decimal } from "decimal.js";
 import { StatusCodes } from "http-status-codes";
-import RecaseError from "@/utils/errorUtils.js";
 import type { ExtendedRequest } from "@/utils/models/Request.js";
 import {
 	generateEventCountExpressions,

--- a/server/src/internal/analytics/internalAnalyticsRouter.ts
+++ b/server/src/internal/analytics/internalAnalyticsRouter.ts
@@ -22,6 +22,7 @@ analyticsRouter.get("/event_names", async (req: any, res: any) =>
 		res,
 		action: "query event names",
 		handler: async () => {
+			AnalyticsService.handleEarlyExit();
 			const { org, env, features } = req;
 
 			const result = await queryWithCache({
@@ -35,12 +36,6 @@ analyticsRouter.get("/event_names", async (req: any, res: any) =>
 					return res?.eventNames;
 				},
 			});
-
-			// const topEventNamesRes = await AnalyticsService.getTopEventNames({
-			//   req,
-			// });
-
-			// let result = topEventNamesRes?.eventNames;
 
 			const featureIds: string[] = [];
 			const eventNames: string[] = [];
@@ -114,6 +109,7 @@ analyticsRouter.post("/events", async (req: any, res: any) =>
 		res,
 		action: "query events by customer id",
 		handler: async () => {
+			AnalyticsService.handleEarlyExit();
 			const { db, org, env, features } = req;
 			let { interval, event_names, customer_id } = req.body;
 
@@ -192,6 +188,7 @@ analyticsRouter.post("/raw", async (req: any, res: any) =>
 		res,
 		action: "query raw events by customer id",
 		handler: async () => {
+			AnalyticsService.handleEarlyExit();
 			const { db, org, env } = req;
 			const { interval, customer_id } = req.body;
 

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -12,7 +12,6 @@ import {
 	constructProduct,
 	constructRawProduct,
 } from "@/utils/scriptUtils/createTestProducts.js";
-import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
 import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
 import { CusService } from "../../src/internal/customers/CusService";
 
@@ -27,6 +26,18 @@ const paidAddOn = constructRawProduct({
 	],
 });
 
+const free = constructProduct({
+	type: "free",
+	isDefault: false,
+	isAddOn: true,
+	items: [
+		constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		}),
+	],
+});
+
 const pro = constructProduct({
 	type: "pro",
 
@@ -35,12 +46,12 @@ const pro = constructProduct({
 			featureId: TestFeature.Messages,
 			includedUsage: 100,
 		}),
-		constructFeatureItem({
-			featureId: TestFeature.Workflows,
-			includedUsage: 10,
-		}),
+		// constructFeatureItem({
+		// 	featureId: TestFeature.Workflows,
+		// 	includedUsage: 10,
+		// }),
 	],
-	trial: true,
+	// trial: true,
 });
 const premium = constructProduct({
 	type: "premium",
@@ -69,47 +80,22 @@ describe(`${chalk.yellowBright("temp: temporary script for testing")}`, () => {
 			env: ctx.env,
 		});
 
-		const result = await initCustomerV3({
-			ctx,
-			customerId,
-			withTestClock: true,
-			attachPm: "success",
-		});
+		// const result = await initCustomerV3({
+		// 	ctx,
+		// 	customerId,
+		// 	withTestClock: true,
+		// 	attachPm: "success",
+		// });
 
 		await initProductsV0({
 			ctx,
-			products: [pro, premium],
+			products: [free],
 			prefix: testCase,
-		});
-
-		// const entities = [
-		// 	{
-		// 		id: "1",
-		// 		name: "Entity 1",
-		// 		feature_id: TestFeature.Users,
-		// 	},
-		// 	{
-		// 		id: "2",
-		// 		name: "Entity 2",
-		// 		feature_id: TestFeature.Users,
-		// 	},
-		// ];
-
-		// await autumnV1.entities.create(customerId, entities);
-		const res = await autumnV1.attach({
-			customer_id: customerId,
-			product_id: pro.id,
-			// entity_id: entities[0].id,
 		});
 
 		// await autumnV1.attach({
 		// 	customer_id: customerId,
-		// 	product_id: pro.id,
-		// 	entity_id: entities[1].id,
+		// 	product_id: free.id,
 		// });
-
-		console.log(res);
-
-		// await autumnV1.attach({ customer_id: customerId, product_id: premium.id });
 	});
 });

--- a/vite/src/components/forms/attach-product/attach-product-actions.tsx
+++ b/vite/src/components/forms/attach-product/attach-product-actions.tsx
@@ -83,6 +83,13 @@ export function AttachProductActions({
 			return;
 		}
 
+		console.log("[attach product actions] handleAttach", {
+			useInvoice,
+			enableProductImmediately,
+		});
+
+		console.log("Calling attachMutation");
+
 		try {
 			//does the attach
 			const result = await attachMutation.mutateAsync({

--- a/vite/src/components/forms/attach-product/update-product-actions.tsx
+++ b/vite/src/components/forms/attach-product/update-product-actions.tsx
@@ -64,7 +64,9 @@ export function UpdateProductActions({
 		useInvoice: boolean;
 		enableProductImmediately?: boolean;
 	}) => {
-		if (previewData?.url) {
+		// Only redirect to checkout URL for the "Checkout" button flow (useInvoice: false)
+		// When useInvoice is true, we always call the attach mutation to generate an invoice
+		if (previewData?.url && !useInvoice) {
 			window.open(previewData.url, "_blank");
 			return;
 		}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enforces a ClickHouse-disabled early-exit across analytics endpoints and updates the plan update flow to redirect only for checkout while always generating an invoice for invoice actions, with minor test tweaks and debug logs.
> 
> - **Backend/Analytics**:
>   - Add `handleEarlyExit` usage in `internalAnalyticsRouter` (`/event_names`, `/events`, `/raw`) to error when ClickHouse is unavailable via `RecaseError` from `@autumn/shared`.
>   - Switch `RecaseError` import in `AnalyticsService` to `@autumn/shared`.
> - **Frontend**:
>   - Update `update-product-actions.tsx` to redirect to checkout only when `useInvoice` is false; when invoicing, always call `attachMutation` to generate an invoice and open the Stripe invoice link.
>   - Add debug logs in `attach-product-actions.tsx` before calling the attach mutation.
> - **Tests**:
>   - Simplify temp test to initialize only the `free` product and comment out other setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8858cdee65ddaf776cb5371ff29684d9bc648dbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->