### PR TITLE
fix: 3ds invoices one off

### DIFF
--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -7,12 +7,13 @@ import {
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import { sanitizeSubItems } from "@/external/stripe/stripeSubUtils/getStripeSubItems.js";
-import { createProrationInvoice } from "@/external/stripe/stripeSubUtils/updateStripeSub/createProrationInvoice.js";
+
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
 import { freeTrialToStripeTimestamp } from "@/internal/products/free-trials/freeTrialUtils.js";
 import { SubService } from "@/internal/subscriptions/SubService.js";
 import { nullish } from "@/utils/genUtils.js";
 import type { ItemSet } from "@/utils/models/ItemSet.js";
+import { createProrationInvoice } from "../../../../../external/stripe/stripeSubUtils/updateStripeSub/createProrationinvoice.js";
 import { subIsCanceled } from "../../../../../external/stripe/stripeSubUtils.js";
 import type { AutumnContext } from "../../../../../honoUtils/HonoEnv.js";
 import { attachParamsToCurCusProduct } from "../../attachUtils/convertAttachParams.js";


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes the import path for `createProrationInvoice` in the subscription update flow and removes obsolete `checkout_url` handling from the frontend attach product flow.

**Changes:**
- Fixed import path in `updateStripeSub2.ts` to use correct filename case (`createProrationinvoice.ts`)
- Removed `checkout_url` conditional logic from frontend - now only handles invoice URLs directly
- Removed keyboard shortcut "b" from customer portal button

**Context:**
The PR title mentions "3ds invoices one off" - the changes align with simplifying the invoice action required (IAR) flow for 3D Secure payments. The backend already returns `hosted_invoice_url` when payment action is required, so the frontend `checkout_url` handling was redundant.

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor import path inconsistency to address
- The changes are straightforward - fixing an import path and removing unused code. However, the import uses a relative path instead of the path alias, which is inconsistent with the codebase pattern.
- server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts should use path alias `@/` instead of relative path

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts | Import path changed from alias to relative path and fixed filename casing to match actual file (`createProrationinvoice.ts`) |
| vite/src/components/forms/attach-product/attach-product-actions.tsx | Removed `checkout_url` handling logic, now only handles invoice links |
| vite/src/components/forms/attach-product/use-attach-product-mutation.ts | Removed `checkout_url` success handling and simplified flow to always show success toast |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Frontend Client
    participant Server as Attach API
    participant Stripe as Stripe API
    participant DB as Database

    Client->>Server: POST /attach (product, payment method)
    Server->>Server: updateStripeSub2()
    Server->>Stripe: subscriptions.update()
    Stripe-->>Server: updated subscription
    Server->>DB: SubService.updateFromStripe()
    
    alt Proration = Immediately
        Server->>Server: createProrationInvoice()
        Server->>Stripe: invoiceItems.list() (pending)
        Stripe-->>Server: invoice items
        Server->>Stripe: invoices.create()
        Stripe-->>Server: draft invoice
        Server->>Stripe: invoices.finalizeInvoice()
        Stripe-->>Server: finalized invoice
        
        alt Invoice requires action (3DS)
            Server->>Stripe: payForInvoice()
            Stripe-->>Server: payment incomplete
            Server->>Stripe: undoSubUpdate()
            Server->>DB: attachParamsToMetadata()
            Server->>Stripe: invoices.update() (add metadata)
            Server-->>Client: {invoice, url: hosted_invoice_url}
            Client->>Client: window.open(invoice URL)
        else Invoice paid
            Server-->>Client: {invoice}
            Client->>Client: window.open(invoice URL)
        end
    else Proration = None
        Server-->>Client: {updatedSub}
        Client->>Client: toast.success()
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->