### PR TITLE
fix: attach cache race condition

### DIFF
--- a/server/src/_luaScripts/cacheConfig.ts
+++ b/server/src/_luaScripts/cacheConfig.ts
@@ -15,7 +15,14 @@ import { ApiVersion } from "@autumn/shared";
 export const CACHE_CUSTOMER_VERSION = ApiVersion.V1_2;
 
 /**
- * Cache time-to-live in seconds (7 days)
+ * Cache time-to-live in seconds (3 days)
  * All customer and entity caches will expire after this duration
  */
-export const CACHE_TTL_SECONDS = 3 * 24 * 60 * 60; // 7 days = 604800 seconds
+export const CACHE_TTL_SECONDS = 3 * 24 * 60 * 60; // 3 days
+
+/**
+ * Cache guard TTL in milliseconds
+ * When cache is deleted, a guard key is set to prevent stale writes
+ * Any cache writes within this window will be blocked
+ */
+export const CACHE_GUARD_TTL_MS = 500;

--- a/server/src/_luaScripts/entityLuaScripts/setEntity.lua
+++ b/server/src/_luaScripts/entityLuaScripts/setEntity.lua
@@ -15,6 +15,12 @@ local entityId = ARGV[5]
 -- Build versioned cache key using shared utility
 local cacheKey = buildEntityCacheKey(orgId, env, customerId, entityId)
 
+-- Check if cache guard is active (prevents stale writes after deletion)
+local guardKey = buildCacheGuardKey(orgId, env, customerId)
+if redis.call("EXISTS", guardKey) == 1 then
+    return "GUARD_ACTIVE"
+end
+
 -- Check if complete cache already exists
 if checkCacheExists(cacheKey) then
     return "CACHE_EXISTS"

--- a/server/src/_luaScripts/luaScripts.ts
+++ b/server/src/_luaScripts/luaScripts.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { CACHE_CUSTOMER_VERSION, CACHE_TTL_SECONDS } from "./cacheConfig.js";
+import {
+	CACHE_CUSTOMER_VERSION,
+	CACHE_GUARD_TTL_MS,
+	CACHE_TTL_SECONDS,
+} from "./cacheConfig.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -20,7 +24,9 @@ const CACHE_KEY_UTILS_RAW = readFileSync(
 const CACHE_KEY_UTILS = CACHE_KEY_UTILS_RAW.replace(
 	/{CUSTOMER_VERSION}/g,
 	CACHE_CUSTOMER_VERSION,
-).replace("{TTL_SECONDS}", CACHE_TTL_SECONDS.toString());
+)
+	.replace("{TTL_SECONDS}", CACHE_TTL_SECONDS.toString())
+	.replace("{GUARD_TTL_MS}", CACHE_GUARD_TTL_MS.toString());
 
 // Load balance storage utilities
 const CACHE_BALANCE_UTILS = readFileSync(

--- a/server/src/_luaScripts/luaUtils/cacheKeyUtils.lua
+++ b/server/src/_luaScripts/luaUtils/cacheKeyUtils.lua
@@ -5,10 +5,20 @@
 -- Cache TTL constant (replaced at load time)
 local CACHE_TTL_SECONDS = {TTL_SECONDS}
 
+-- Cache guard TTL constant in milliseconds (replaced at load time)
+-- Used to prevent stale writes after cache deletion
+local CACHE_GUARD_TTL_MS = {GUARD_TTL_MS}
+
 -- Build customer cache key with version
 -- Returns: {orgId}:env:customer:{version}:customerId
 local function buildCustomerCacheKey(orgId, env, customerId)
     return "{" .. orgId .. "}:" .. env .. ":customer:{CUSTOMER_VERSION}:" .. customerId
+end
+
+-- Build cache guard key (used to prevent stale writes after deletion)
+-- Returns: {orgId}:env:customer_guard:customerId
+local function buildCacheGuardKey(orgId, env, customerId)
+    return "{" .. orgId .. "}:" .. env .. ":customer_guard:" .. customerId
 end
 
 -- Build entity cache key with version

--- a/server/src/external/redis/initRedis.ts
+++ b/server/src/external/redis/initRedis.ts
@@ -170,6 +170,7 @@ declare module "ioredis" {
 			orgId: string,
 			env: string,
 			customerId: string,
+			fetchTimeMs: string, // Timestamp when data was fetched from Postgres (for stale write prevention)
 		): Promise<string>;
 		setEntitiesBatch(
 			entityBatch: string,

--- a/server/src/honoMiddlewares/refreshCacheMiddleware.ts
+++ b/server/src/honoMiddlewares/refreshCacheMiddleware.ts
@@ -106,7 +106,9 @@ export const refreshCacheMiddleware = async (
 		// For core URLs, check body for customer_id
 		const body = await c.req.json().catch(() => null);
 		if (body?.customer_id) {
-			logger.info(`Clearing cache for core url ${pathname}`);
+			logger.info(
+				`Clearing cache for core url ${pathname}, customerId: ${body.customer_id}`,
+			);
 			await deleteCachedApiCustomer({
 				customerId: body.customer_id,
 				orgId: org.id,

--- a/server/src/internal/balances/track/redisTrackUtils/runRedisDeduction.ts
+++ b/server/src/internal/balances/track/redisTrackUtils/runRedisDeduction.ts
@@ -203,6 +203,15 @@ export const runRedisDeduction = async ({
 			};
 		}
 
+		// Handle CUSTOMER_NOT_FOUND - fallback to Postgres (cache may be blocked by guard)
+		if (result.error === "CUSTOMER_NOT_FOUND") {
+			ctx.logger.info(`Customer not found in cache, falling back to Postgres`);
+			return {
+				fallback: true,
+				code: "redis_write_failed",
+			};
+		}
+
 		return {
 			fallback: false,
 			code:

--- a/server/src/internal/balances/track/trackUtils/runDeductionTx.ts
+++ b/server/src/internal/balances/track/trackUtils/runDeductionTx.ts
@@ -121,10 +121,22 @@ export const deductFromCusEnts = async ({
 			sortParams,
 		});
 
-		const { unlimited } = getUnlimitedAndUsageAllowed({
-			cusEnts,
-			internalFeatureId: feature.internal_id!,
-		});
+		// Check if ANY relevant feature (primary or credit system) is unlimited
+		// Add unlimited features to actualDeductions with value 0 (like Lua's changedCustomerFeatureIds)
+		let unlimited = false;
+		for (const rf of relevantFeatures) {
+			const { unlimited: featureUnlimited } = getUnlimitedAndUsageAllowed({
+				cusEnts,
+				internalFeatureId: rf.internal_id!,
+			});
+			if (featureUnlimited) {
+				unlimited = true;
+				// Add to actualDeductions with 0 so balance gets returned
+				if (actualDeductions[rf.id] === undefined) {
+					actualDeductions[rf.id] = 0;
+				}
+			}
+		}
 
 		if (cusEnts.length === 0 || unlimited) continue;
 

--- a/server/src/internal/customers/cusUtils/apiCusCacheUtils/deleteCachedApiCustomer.ts
+++ b/server/src/internal/customers/cusUtils/apiCusCacheUtils/deleteCachedApiCustomer.ts
@@ -18,9 +18,11 @@ export const deleteCachedApiCustomer = async ({
 	source?: string;
 }): Promise<void> => {
 	if (redis.status !== "ready") {
-		console.warn("❗️ Redis not ready, skipping cache deletion", {
-			status: redis.status,
-			customerId,
+		logger.warn("❗️ Redis not ready, skipping cache deletion", {
+			data: {
+				status: redis.status,
+				customerId,
+			},
 		});
 		return;
 	}
@@ -34,7 +36,7 @@ export const deleteCachedApiCustomer = async ({
 			`Deleted ${deletedCount} cache keys for customer ${customerId}, source: ${source}`,
 		);
 	} catch (error) {
-		console.error("Error deleting customer with entities:", error);
+		logger.error(`Error deleting customer with entities: ${error}`);
 		throw error;
 	}
 };

--- a/server/src/internal/customers/cusUtils/apiCusCacheUtils/getCachedApiCustomer.ts
+++ b/server/src/internal/customers/cusUtils/apiCusCacheUtils/getCachedApiCustomer.ts
@@ -96,6 +96,9 @@ export const getCachedApiCustomer = async ({
 		}
 
 		// Cache miss or skipCache - fetch from DB
+		// Record timestamp before Postgres fetch for stale write prevention
+		const fetchTimeMs = Date.now();
+
 		// Include invoices:
 		const fullCus = await CusService.getFull({
 			db,
@@ -146,6 +149,7 @@ export const getCachedApiCustomer = async ({
 				fullCus,
 				customerId,
 				source,
+				fetchTimeMs,
 			});
 		}
 

--- a/server/src/internal/entities/entityUtils/apiEntityCacheUtils/getCachedApiEntity.ts
+++ b/server/src/internal/entities/entityUtils/apiEntityCacheUtils/getCachedApiEntity.ts
@@ -97,6 +97,8 @@ export const getCachedApiEntity = async ({
 			}
 		}
 
+		// Record timestamp before Postgres fetch for stale write prevention
+		const fetchTimeMs = Date.now();
 		// Cache miss or skipCache - fetch from DB
 		if (!fullCus) {
 			fullCus = await CusService.getFull({
@@ -124,6 +126,7 @@ export const getCachedApiEntity = async ({
 				ctx,
 				fullCus,
 				customerId,
+				fetchTimeMs,
 			});
 		}
 

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe } from "bun:test";
+import { beforeAll, describe, it } from "bun:test";
 import { ApiVersion } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
@@ -9,21 +9,8 @@ import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
 import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
 import { initCustomerV3 } from "../../src/utils/scriptUtils/testUtils/initCustomerV3";
 
-const free = constructProduct({
-	type: "free",
-	isDefault: false,
-	// isAddOn: true,
-	items: [
-		constructFeatureItem({
-			featureId: TestFeature.Messages,
-			includedUsage: 100,
-		}),
-	],
-});
-
 const pro = constructProduct({
 	type: "pro",
-
 	items: [
 		constructFeatureItem({
 			featureId: TestFeature.Messages,
@@ -32,44 +19,23 @@ const pro = constructProduct({
 	],
 });
 
-const oneOff = constructProduct({
-	type: "one_off",
+const premium = constructProduct({
+	type: "premium",
 	items: [
 		constructFeatureItem({
 			featureId: TestFeature.Messages,
-			includedUsage: 100,
+			includedUsage: 300,
 		}),
 	],
 });
 
-// const oneOffCredits = constructRawProduct({
-// 	id: "one_off_credits",
-// 	items: [
-// 		constructPrepaidItem({
-// 			featureId: TestFeature.Credits,
-// 			billingUnits: 100,
-// 			price: 10,
-// 			isOneOff: true,
-// 			resetUsageWhenEnabled: false,
-// 		}),
-// 	],
-// 	isAddOn: true,
-// });
+const testCase = "attach-misc3";
 
-const testCase = "temp";
-
-describe(`${chalk.yellowBright("temp: temporary script for testing")}`, () => {
-	const customerId = "temp";
-
+describe(`${chalk.yellowBright("attach-misc3: cache invalidation guard test")}`, () => {
+	const customerId = testCase;
 	const autumnV1: AutumnInt = new AutumnInt({ version: ApiVersion.V1_2 });
 
 	beforeAll(async () => {
-		// await CusService.deleteByOrgId({
-		// 	db: ctx.db,
-		// 	orgId: ctx.org.id,
-		// 	env: ctx.env,
-		// });
-
 		await initCustomerV3({
 			ctx,
 			customerId,
@@ -79,23 +45,10 @@ describe(`${chalk.yellowBright("temp: temporary script for testing")}`, () => {
 
 		await initProductsV0({
 			ctx,
-			products: [free, pro, oneOff],
+			products: [pro, premium],
 			prefix: testCase,
 		});
-
-		const res = await autumnV1.attach({
-			customer_id: customerId,
-			product_id: oneOff.id,
-		});
-
-		console.log(res);
-		// await autumnV1.attach({
-		// 	customer_id: customerId,
-		// 	product_id: free.id,
-		// });
-		// await autumnV1.attach({
-		// 	customer_id: customerId,
-		// 	product_id: pro.id,
-		// });
 	});
+
+	it("should block cache writes when guard is active", async () => {});
 });

--- a/server/tests/attach/misc/attach-misc3.test.ts
+++ b/server/tests/attach/misc/attach-misc3.test.ts
@@ -1,0 +1,151 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { ApiVersion } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { redis } from "@/external/redis/initRedis.js";
+import { timeout } from "@/utils/genUtils.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+
+const pro = constructProduct({
+	type: "pro",
+	items: [
+		constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		}),
+	],
+});
+
+const premium = constructProduct({
+	type: "premium",
+	items: [
+		constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 300,
+		}),
+	],
+});
+
+const testCase = "attach-misc3";
+
+describe(`${chalk.yellowBright("attach-misc3: timestamp-based stale write prevention test")}`, () => {
+	const customerId = testCase;
+	const autumnV1: AutumnInt = new AutumnInt({ version: ApiVersion.V1_2 });
+
+	beforeAll(async () => {
+		await initCustomerV3({
+			ctx,
+			customerId,
+			withTestClock: true,
+			attachPm: "success",
+		});
+
+		await initProductsV0({
+			ctx,
+			products: [pro, premium],
+			prefix: testCase,
+		});
+	});
+
+	it("should block stale writes (fetchTimeMs < deletionTime) and allow fresh writes", async () => {
+		// Step 1: Attach pro product (this will cache the customer)
+		console.log("\n--- Step 1: Attach pro product ---");
+		await autumnV1.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+
+		// Verify pro is attached
+		const beforeCustomer = await autumnV1.customers.get(customerId);
+		expect(beforeCustomer.products?.[0]?.id).toBe(pro.id);
+		console.log("Pro product attached");
+
+		// Step 2: Record a "stale" fetch time (before deletion)
+		const staleFetchTimeMs = Date.now();
+		console.log(
+			`\n--- Step 2: Recorded stale fetch time: ${staleFetchTimeMs} ---`,
+		);
+
+		// Small delay to ensure deletion timestamp is definitely after fetch time
+		await timeout(50);
+
+		// Step 3: Delete cache (this sets the guard with current timestamp)
+		console.log("\n--- Step 3: Delete cache (sets guard with timestamp) ---");
+		const deletedCount = await redis.deleteCustomer(
+			ctx.org.id,
+			ctx.env,
+			customerId,
+		);
+		console.log(`Deleted ${deletedCount} cache keys`);
+
+		// Step 4: Try to write with STALE fetch time (before deletion)
+		console.log("\n--- Step 4: Try to write cache with stale fetchTimeMs ---");
+		const fakeOldCustomerData = {
+			id: customerId,
+			name: "Test Customer",
+			email: null,
+			created_at: Date.now(),
+			fingerprint: null,
+			stripe_id: null,
+			env: ctx.env,
+			metadata: {},
+			subscriptions: [{ plan_id: pro.id, status: "active" }], // OLD product!
+			scheduled_subscriptions: [],
+			invoices: [],
+			balances: {},
+			entities: [],
+		};
+
+		const writeResult = await redis.setCustomer(
+			JSON.stringify(fakeOldCustomerData),
+			ctx.org.id,
+			ctx.env,
+			customerId,
+			staleFetchTimeMs.toString(), // Stale timestamp - BEFORE deletion
+		);
+
+		console.log(`Write result with stale timestamp: ${writeResult}`);
+
+		// Verify write was blocked because fetchTimeMs < deletionTime
+		expect(writeResult).toBe("STALE_WRITE");
+		console.log("✅ Stale cache write was blocked!");
+
+		// Step 5: Try to write with FRESH fetch time (after deletion)
+		console.log("\n--- Step 5: Try to write cache with fresh fetchTimeMs ---");
+		const freshFetchTimeMs = Date.now(); // This is AFTER the deletion
+
+		const writeResult2 = await redis.setCustomer(
+			JSON.stringify(fakeOldCustomerData),
+			ctx.org.id,
+			ctx.env,
+			customerId,
+			freshFetchTimeMs.toString(), // Fresh timestamp - AFTER deletion
+		);
+
+		console.log(`Write result with fresh timestamp: ${writeResult2}`);
+		expect(writeResult2).toBe("OK");
+		console.log("✅ Fresh cache write succeeded!");
+
+		// Step 6: Verify CACHE_EXISTS for subsequent writes
+		console.log("\n--- Step 6: Verify CACHE_EXISTS for duplicate writes ---");
+		const writeResult3 = await redis.setCustomer(
+			JSON.stringify(fakeOldCustomerData),
+			ctx.org.id,
+			ctx.env,
+			customerId,
+			Date.now().toString(),
+		);
+
+		console.log(`Write result for duplicate: ${writeResult3}`);
+		expect(writeResult3).toBe("CACHE_EXISTS");
+		console.log("✅ Duplicate write correctly returned CACHE_EXISTS!");
+
+		// Cleanup: Delete the cache we wrote
+		await redis.deleteCustomer(ctx.org.id, ctx.env, customerId);
+	});
+});

--- a/server/tests/balances/check/credit-systems/credit-systems3.test.ts
+++ b/server/tests/balances/check/credit-systems/credit-systems3.test.ts
@@ -5,9 +5,9 @@ import {
 	type LimitedItem,
 	SuccessCode,
 } from "@autumn/shared";
-import chalk from "chalk";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { featureToCreditSystem } from "@/internal/features/creditSystemUtils.js";
 import { timeout } from "@/utils/genUtils.js";


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Implemented timestamp-based stale write prevention for Redis cache to fix race condition where `getCachedApiCustomer()` could write stale data after cache was cleared by `attach()`.

**Key changes:**
- Records `fetchTimeMs` timestamp before Postgres queries in `getCachedApiCustomer()` and `getCachedApiEntity()`
- `deleteCustomer.lua` sets a deletion marker with Redis TIME timestamp when clearing cache
- `setCustomer.lua` compares `fetchTimeMs` with deletion marker - blocks writes if `deletionTime > fetchTimeMs` (returns `STALE_WRITE`)
- `setEntity.lua` checks for active guard key and returns `GUARD_ACTIVE` if found
- Guard key expires after 500ms (`CACHE_GUARD_TTL_MS`), allowing fresh writes to proceed

**Race condition scenario fixed:**
1. Thread A: `getCachedApiCustomer()` starts → records `fetchTimeMs` → queries Postgres (slow)
2. Thread B: `attach()` runs → deletes cache → sets guard with current timestamp
3. Thread A: Completes Postgres query → attempts cache write → **blocked** because `fetchTimeMs < deletionTime`

**Additional improvements:**
- Fixed unlimited feature detection to check all relevant features (primary + credit systems)
- Improved balance response logic in `executePostgresTracking()` to match Lua behavior
- Added `CUSTOMER_NOT_FOUND` fallback handling when cache is blocked by guard
- Type safety improvements (`error: unknown`, explicit types)
- Added comprehensive test in `attach-misc3.test.ts`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk - the timestamp-based approach elegantly solves the race condition without breaking existing functionality
- The implementation is well-designed with atomic Lua operations, proper timestamp comparison using Redis TIME, comprehensive test coverage, and safe fallback handling. The 500ms guard window is appropriate, and the changes are backward-compatible.
- No files require special attention - all changes are well-implemented and follow consistent patterns

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/_luaScripts/cusLuaScripts/setCustomer.lua | Added `fetchTimeMs` parameter and timestamp-based stale write detection - blocks cache writes if `deletionTime > fetchTimeMs` |
| server/src/_luaScripts/cusLuaScripts/deleteCustomer.lua | Added deletion marker with Redis TIME-based timestamp when deleting cache, preventing stale writes within guard window |
| server/src/_luaScripts/entityLuaScripts/setEntity.lua | Added guard key check during entity cache writes - returns `GUARD_ACTIVE` if guard exists, preventing entity writes during deletion window |
| server/src/internal/customers/cusUtils/apiCusCacheUtils/setCachedApiCustomer.ts | Added `fetchTimeMs` parameter, records timestamp before Postgres fetch, passes to Lua for stale write detection, handles `STALE_WRITE` return |
| server/src/internal/customers/cusUtils/apiCusCacheUtils/getCachedApiCustomer.ts | Records `fetchTimeMs` before Postgres query and passes it to `setCachedApiCustomer()` for race condition prevention |
| server/src/internal/entities/entityUtils/apiEntityCacheUtils/getCachedApiEntity.ts | Records `fetchTimeMs` before Postgres query and passes it to `setCachedApiCustomer()` for consistent timestamp-based protection |
| server/tests/attach/misc/attach-misc3.test.ts | New test verifying timestamp-based stale write prevention: blocks writes with `fetchTimeMs < deletionTime`, allows fresh writes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ThreadA as Thread A (getCachedApiCustomer)
    participant Redis as Redis Cache
    participant Postgres as PostgreSQL
    participant ThreadB as Thread B (attach/delete)
    participant Lua as Lua Scripts

    Note over ThreadA,ThreadB: Race Condition Scenario

    ThreadA->>ThreadA: Record fetchTimeMs = Date.now()
    ThreadA->>Redis: Check cache (miss)
    ThreadA->>Postgres: Query customer data (SLOW)
    
    Note over ThreadB: Meanwhile...
    ThreadB->>Lua: deleteCustomer()
    Lua->>Redis: UNLINK cache keys
    Lua->>Redis: GET Redis TIME (seconds, microseconds)
    Lua->>Lua: Calculate deletionTime (ms)
    Lua->>Redis: SET guard key with deletionTime (PX 500ms)
    Lua-->>ThreadB: Cache cleared
    
    Note over ThreadA: Query completes
    ThreadA->>ThreadA: Build API customer data
    ThreadA->>Lua: setCustomer(data, fetchTimeMs)
    
    Lua->>Redis: GET guard key
    Lua->>Lua: Compare: deletionTime > fetchTimeMs?
    
    alt Stale Write (fetchTimeMs < deletionTime)
        Lua-->>ThreadA: Return "STALE_WRITE"
        Note over ThreadA: Write blocked ✓
    else Fresh Write (fetchTimeMs > deletionTime)
        Lua->>Redis: SET customer data
        Lua->>Redis: EXPIRE keys (3 days)
        Lua-->>ThreadA: Return "OK"
        Note over ThreadA: Write allowed ✓
    end

    Note over Redis: Guard expires after 500ms
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->