### PR TITLE
fix: transfer cache

### DIFF
--- a/server/src/honoMiddlewares/refreshCacheMiddleware.ts
+++ b/server/src/honoMiddlewares/refreshCacheMiddleware.ts
@@ -33,7 +33,7 @@ const cusPrefixedUrls = [
 	},
 	{
 		method: "POST",
-		url: "/customers/:customer_id/transfer_product",
+		url: "/customers/:customer_id/transfer",
 	},
 ];
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed middleware cache clearing for the transfer endpoint by updating the URL pattern from `/customers/:customer_id/transfer_product` to `/customers/:customer_id/transfer`, aligning with the actual route definition in `cusRouter.ts:28`.

**Key Changes:**
- Updated cache middleware URL pattern to match the transfer route that was renamed in a previous commit (9252d3d1)
- Ensures customer cache is properly cleared after successful transfer operations

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Single-line fix that corrects a URL pattern mismatch - straightforward and necessary to ensure cache invalidation works correctly for the transfer endpoint
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/refreshCacheMiddleware.ts | Updated cache clearing URL pattern from `transfer_product` to `transfer` to match the actual route definition |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as refreshCacheMiddleware
    participant Handler as TransferHandler
    participant Cache as Customer Cache
    participant DB as Database

    Client->>Middleware: POST /customers/:customer_id/transfer
    Middleware->>Handler: Forward request
    Handler->>DB: Transfer product
    DB-->>Handler: Success (2xx)
    Handler-->>Middleware: Response
    
    Note over Middleware: Check status code (2xx)
    Note over Middleware: Match URL pattern
    
    Middleware->>Cache: deleteCachedApiCustomer(customer_id)
    Cache-->>Middleware: Cache cleared
    Middleware-->>Client: Return response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->