### PR TITLE
fix: dashboard checkout success url

### DIFF
--- a/vite/src/components/forms/attach-product/use-attach-body-builder.ts
+++ b/vite/src/components/forms/attach-product/use-attach-body-builder.ts
@@ -1,4 +1,4 @@
-import { type ProductV2, UsageModel } from "@autumn/shared";
+import { AppEnv, type ProductV2, UsageModel } from "@autumn/shared";
 import Decimal from "decimal.js";
 import { useMemo } from "react";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
@@ -93,7 +93,10 @@ export function useAttachBodyBuilder(params: AttachBodyBuilderParams = {}) {
 				version,
 				useInvoice: mergedParams.useInvoice,
 				enableProductImmediately: mergedParams.enableProductImmediately,
-				successUrl: `${import.meta.env.VITE_FRONTEND_URL}${redirectUrl}`,
+				successUrl:
+					env === AppEnv.Sandbox
+						? `${import.meta.env.VITE_FRONTEND_URL}${redirectUrl}`
+						: undefined,
 			});
 		},
 		[products, hasChanges, storeProduct, storeEntityId, params],


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes the checkout session success URL behavior in the dashboard. When attaching a product via the dashboard, the `successUrl` is now only set for Sandbox environments, allowing Production environments to use the organization's configured default success URL from `org.stripe_config.success_url` instead of the dashboard URL.

**Key changes:**
- Imported `AppEnv` enum to check current environment
- Added conditional logic: `successUrl` is only set when `env === AppEnv.Sandbox`
- Production environment (`AppEnv.Live`) now passes `undefined`, which causes the server to fall back to the org's configured success URL

**Impact:**
- Sandbox: Checkout redirects back to dashboard after payment (existing behavior preserved)
- Production: Checkout redirects to the organization's configured success URL (fixes the issue mentioned in PR title)

<h3>Confidence Score: 3/5</h3>


- This PR is mostly safe but has a React dependency issue that could cause stale closures
- The logic correctly implements environment-based success URL handling, but the `useMemo` hook is missing `env` in its dependency array, which could lead to stale values when switching between environments. The fix is straightforward and the change is otherwise sound.
- Pay attention to `vite/src/components/forms/attach-product/use-attach-body-builder.ts` - add `env` to the dependency array on line 102

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-product/use-attach-body-builder.ts | Modified `successUrl` to be conditionally set based on environment (only for Sandbox), but `env` is missing from useMemo dependency array |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dashboard
    participant Hook as useAttachBodyBuilder
    participant Utils as getAttachBody
    participant API as Attach API
    participant Server as handleCreateCheckout
    participant Stripe

    Dashboard->>Hook: Attach product request
    Hook->>Hook: Check env (Sandbox/Live)
    
    alt env === Sandbox
        Hook->>Utils: Build attach body with successUrl
        Note over Hook,Utils: successUrl = VITE_FRONTEND_URL + redirectUrl
    else env === Live (Production)
        Hook->>Utils: Build attach body without successUrl
        Note over Hook,Utils: successUrl = undefined
    end
    
    Utils->>API: Send attach body
    API->>Server: Create checkout session
    
    alt successUrl provided
        Server->>Stripe: Create session with custom successUrl
    else successUrl undefined
        Server->>Server: Use org.stripe_config.success_url
        Server->>Stripe: Create session with org default URL
    end
    
    Stripe-->>Server: Checkout session created
    Server-->>API: Return checkout URL
    API-->>Dashboard: Display checkout
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->