### PR TITLE
fix: redirect to sandbox

### DIFF
--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -40,20 +40,18 @@ export function MainLayout() {
 		return () => window.removeEventListener("error", handleGlobalError);
 	}, [handleApiError]);
 
-	// useEffect(() => {
-	// 	// Only redirect if org is loaded and user is not onboarded
-	// 	if (!orgLoading && org) {
-	// 		if (!org.onboarded) {
-	// 			navigate("/sandbox/onboarding");
-	// 		} else if (!org.deployed) {
-	// 			const pathname = window.location.pathname;
-	// 			if (!pathname.startsWith("/sandbox")) {
-	// 				const search = window.location.search;
-	// 				navigate(`/sandbox${pathname}${search}`);
-	// 			}
-	// 		}
-	// 	}
-	// }, [org, orgLoading, navigate]);
+	useEffect(() => {
+		// Only redirect if org is loaded and user is not onboarded
+		if (!orgLoading && org) {
+			if (!org.deployed) {
+				const pathname = window.location.pathname;
+				if (!pathname.startsWith("/sandbox")) {
+					const search = window.location.search;
+					navigate(`/sandbox${pathname}${search}`);
+				}
+			}
+		}
+	}, [org, orgLoading, navigate]);
 
 	// 1. If not loaded, show loading screen
 	if (isPending || orgLoading) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Re-enabled previously commented redirect logic that automatically sends users with non-deployed organizations to sandbox routes. Removed the onboarding redirect check (line checking `!org.onboarded`), keeping only the deployment status check that redirects users to `/sandbox` paths when `org.deployed` is false.

<h3>Confidence Score: 5/5</h3>


- Safe to merge - straightforward logic restoration with proper guard against infinite redirects
- The change cleanly re-enables redirect logic with proper safeguards (checks pathname doesn't already start with /sandbox) to prevent infinite loops, preserves query parameters, and includes dependency array for proper useEffect behavior
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/app/layout.tsx | Re-enabled redirect logic to send non-deployed orgs to sandbox routes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MainLayout
    participant useOrg
    participant useNavigate
    participant Router

    User->>MainLayout: Access app
    MainLayout->>useOrg: Request org data
    useOrg-->>MainLayout: Return org & loading state
    
    alt orgLoading is true
        MainLayout->>User: Show loading screen
    else orgLoading is false and org exists
        alt org.deployed is false
            MainLayout->>MainLayout: Check current pathname
            alt pathname does not start with /sandbox
                MainLayout->>useNavigate: navigate(`/sandbox${pathname}${search}`)
                useNavigate->>Router: Redirect to sandbox route
                Router->>User: Navigate to /sandbox path
            else pathname starts with /sandbox
                MainLayout->>User: No redirect (already in sandbox)
            end
        else org.deployed is true
            MainLayout->>User: No redirect (org deployed)
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->