### PR TITLE
chore(client): remove console logs from production build

### DIFF
--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -7,6 +7,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vite.dev/config/
 export default defineConfig({
+  esbuild: {
+    pure: ['console.log']
+  },
 	plugins: [
 		react(),
 		tailwindcss(), // Automatically reads paths from tsconfig.json


### PR DESCRIPTION
## Summary

Remove `console.log` statements from the production build to reduce noise without changing runtime behavior. 

### Decision

1. The codebase is large so it’s hard to guarantee that console.log arguments have no side effects e.g `console.log('error count', initializeError())`. 
2. Using `drop: ['console']` is risky if argument evaluation exists as it would remove both the call and argument evaluation potentially changing runtime behavior. 
3. We use `pure` instead to safely remove the logs while preserving argument evaluation if any exist. If it’s later confirmed that no side-effecting arguments exist, `drop` could be used instead.

## Related Issues

Fixes #294 - Client only

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (please describe): Remove console logs from production build

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [x] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Configured ESBuild to remove `console.log` statements from production builds by marking them as pure functions, preserving argument evaluation to avoid runtime behavior changes.

- Added `esbuild.pure: ['console.log']` configuration to `vite.config.ts`
- Conservative approach ensures side effects in console arguments are preserved
- Addresses issue #294 by reducing log noise in production without altering runtime behavior

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a minimal, well-documented build configuration that uses the safe `pure` annotation approach instead of the riskier `drop` approach, preserving potential argument side effects while removing console logs from production
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/vite.config.ts | Added `esbuild.pure: ['console.log']` to safely remove console logs from production build while preserving argument evaluation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Vite as Vite Build
    participant ESBuild as ESBuild
    participant Code as Source Code
    participant Bundle as Production Bundle

    Dev->>Vite: Trigger production build
    Vite->>ESBuild: Configure with pure: ['console.log']
    ESBuild->>Code: Parse source files
    Code-->>ESBuild: Return AST with console.log calls
    ESBuild->>ESBuild: Mark console.log as pure function
    ESBuild->>ESBuild: Evaluate console.log arguments
    ESBuild->>ESBuild: Remove console.log calls (preserve side effects)
    ESBuild->>Bundle: Generate optimized bundle
    Bundle-->>Vite: Return production bundle
    Vite-->>Dev: Build complete (no console.logs)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->