### PR TITLE
fix: one off action required

### DIFF
--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlow.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlow.ts
@@ -4,6 +4,7 @@ import {
 	AttachFunctionResponseSchema,
 	AttachScenario,
 	CusProductStatus,
+	cusProductToPrices,
 	cusProductToProduct,
 	ProrationBehavior,
 	SuccessCode,
@@ -21,7 +22,10 @@ import {
 	attachToInvoiceResponse,
 	insertInvoiceFromAttach,
 } from "@/internal/invoices/invoiceUtils.js";
-import { attachToInsertParams } from "@/internal/products/productUtils.js";
+import {
+	attachToInsertParams,
+	isOneOff,
+} from "@/internal/products/productUtils.js";
 import type { AutumnContext } from "../../../../../honoUtils/HonoEnv.js";
 import {
 	attachParamsToCurCusProduct,
@@ -179,7 +183,10 @@ export const handleUpgradeFlow = async ({
 		latestInvoice = res.latestInvoice || undefined;
 	}
 
-	if (curCusProduct) {
+	if (
+		curCusProduct &&
+		!isOneOff(cusProductToPrices({ cusProduct: curCusProduct }))
+	) {
 		logger.info(`UPGRADE FLOW: expiring previous cus product`);
 		await CusProductService.update({
 			db,

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -7,6 +7,8 @@ import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
 import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
 import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+import { attachAuthenticatePaymentMethod } from "../../src/external/stripe/stripeCusUtils";
+import { CusService } from "../../src/internal/customers/CusService";
 import { initCustomerV3 } from "../../src/utils/scriptUtils/testUtils/initCustomerV3";
 
 const pro = constructProduct({
@@ -18,20 +20,19 @@ const pro = constructProduct({
 		}),
 	],
 });
-
-const premium = constructProduct({
-	type: "premium",
+const oneOffCredits = constructProduct({
+	type: "one_off",
 	items: [
 		constructFeatureItem({
-			featureId: TestFeature.Messages,
-			includedUsage: 300,
+			featureId: TestFeature.Credits,
+			includedUsage: 100,
 		}),
 	],
 });
 
-const testCase = "attach-misc3";
+const testCase = "temp";
 
-describe(`${chalk.yellowBright("attach-misc3: cache invalidation guard test")}`, () => {
+describe(`${chalk.yellowBright("temp: one off credits test")}`, () => {
 	const customerId = testCase;
 	const autumnV1: AutumnInt = new AutumnInt({ version: ApiVersion.V1_2 });
 
@@ -45,10 +46,27 @@ describe(`${chalk.yellowBright("attach-misc3: cache invalidation guard test")}`,
 
 		await initProductsV0({
 			ctx,
-			products: [pro, premium],
+			products: [pro, oneOffCredits],
 			prefix: testCase,
 		});
 	});
 
-	it("should block cache writes when guard is active", async () => {});
+	it("should attach one off credits product", async () => {
+		await autumnV1.attach({
+			customer_id: customerId,
+			product_id: oneOffCredits.id,
+		});
+
+		const customer = await CusService.get({
+			db: ctx.db,
+			idOrInternalId: customerId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+
+		await attachAuthenticatePaymentMethod({
+			ctx,
+			customerId,
+		});
+	});
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixed an issue where one-off products were incorrectly expired during the upgrade flow. Previously, when a customer upgraded or modified their subscription, the system would expire the previous customer product regardless of type. This caused problems with one-off products (like credits or one-time purchases) which shouldn't be expired when subscription changes occur.

**Key changes:**
- Added conditional check in `handleUpgradeFlow.ts:186-189` to skip expiring customer products if they are one-off type
- Imported `isOneOff` and `cusProductToPrices` utilities to determine product type
- One-off products now remain active when customers upgrade their subscriptions, allowing the invoice action required flow to work correctly
- Added test case to verify one-off product attachment with payment authentication

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is a targeted, logical improvement that adds a necessary conditional check. The change correctly prevents one-off products from being expired during subscription upgrades, which aligns with the expected behavior since one-off products are independent of recurring subscriptions. The logic is sound and uses existing utility functions appropriately.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlow.ts | Added check to prevent expiring one-off products during upgrade flow, fixing invoice action required flow for one-off products |
| server/tests/_temp/temp.test.ts | Test file for verifying one-off product attachment and payment authentication flow |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant handleUpgradeFlow
    participant CusProductService
    participant isOneOff
    participant StripeAPI

    Client->>handleUpgradeFlow: Upgrade product request
    handleUpgradeFlow->>handleUpgradeFlow: Get current customer product (curCusProduct)
    
    alt curCusProduct exists
        handleUpgradeFlow->>isOneOff: Check if cusProduct is one-off
        isOneOff-->>handleUpgradeFlow: Return true/false
        
        alt NOT one-off product
            handleUpgradeFlow->>CusProductService: Update curCusProduct status to Expired
            CusProductService->>StripeAPI: Update subscription
            handleUpgradeFlow->>handleUpgradeFlow: Trigger webhook for expired product
        else one-off product
            Note over handleUpgradeFlow: Skip expiring product (NEW LOGIC)
            Note over handleUpgradeFlow: One-off products shouldn't be expired<br/>as they don't interfere with subscriptions
        end
    end
    
    handleUpgradeFlow->>handleUpgradeFlow: Create new customer product
    handleUpgradeFlow-->>Client: Return success response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->