### PR TITLE
fix: invoice checkout cache

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleInvoicePaid/handleInvoiceCheckoutPaid.ts
+++ b/server/src/external/stripe/webhookHandlers/handleInvoicePaid/handleInvoiceCheckoutPaid.ts
@@ -4,6 +4,7 @@ import { createFullCusProduct } from "@/internal/customers/add-product/createFul
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
 import { attachToInsertParams } from "@/internal/products/productUtils.js";
 import type { AutumnContext } from "../../../../honoUtils/HonoEnv.js";
+import { CusService } from "../../../../internal/customers/CusService.js";
 import { deleteCachedApiCustomer } from "../../../../internal/customers/cusUtils/apiCusCacheUtils/deleteCachedApiCustomer.js";
 import { MetadataService } from "../../../../internal/metadata/MetadataService.js";
 
@@ -57,8 +58,22 @@ export const handleInvoiceCheckoutPaid = async ({
 		id: metadata.id,
 	});
 
+	// Fetch customer by internal ID
+	let customerId = attachParams.customer.id;
+
+	if (!customerId) {
+		const customer = await CusService.get({
+			db,
+			idOrInternalId: attachParams.customer.internal_id,
+			orgId: org.id,
+			env,
+		});
+
+		customerId = customer?.id;
+	}
+
 	await deleteCachedApiCustomer({
-		customerId: attachParams.customer.id || "",
+		customerId: customerId || "",
 		orgId: org.id,
 		env,
 	});


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed cache invalidation for invoice checkout when customer ID is null by fetching customer via `internal_id` as a fallback.

- Added `CusService.get()` call to resolve customer ID when `attachParams.customer.id` is null
- Prevents cache invalidation failures for customers created without explicit IDs
- Maintains graceful degradation: if customer lookup fails, cache deletion is safely skipped

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change adds defensive logic to handle edge cases without altering core behavior. The fallback mechanism is well-designed with proper null handling, and the existing guard in `deleteCachedApiCustomer` prevents errors if the lookup fails.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleInvoicePaid/handleInvoiceCheckoutPaid.ts | Added fallback logic to fetch customer ID by internal_id when customer.id is null for cache clearing |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Stripe
    participant Handler as handleInvoiceCheckoutPaid
    participant MetadataService
    participant CusService
    participant Cache as deleteCachedApiCustomer
    participant Redis

    Stripe->>Handler: invoice.paid webhook
    Handler->>Handler: Extract AttachParams from metadata
    Handler->>Handler: Create customer products (batch)
    Handler->>MetadataService: Delete metadata by ID
    
    alt customer.id exists
        Handler->>Handler: Use customer.id directly
    else customer.id is null
        Handler->>CusService: get(internal_id)
        CusService-->>Handler: Return customer with id
        Handler->>Handler: Extract customer.id
    end
    
    Handler->>Cache: deleteCachedApiCustomer(customerId)
    
    alt customerId exists
        Cache->>Redis: Delete customer cache keys
        Redis-->>Cache: Return deleted count
    else customerId is empty/null
        Cache->>Cache: Early return (skip deletion)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->