### PR TITLE
chore: pin hono version

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -86,7 +86,7 @@
 		"express": "^4.21.1",
 		"express-rate-limit": "^7.5.1",
 		"fetch-retry": "^6.0.0",
-		"hono": "^4.9.9",
+		"hono": "4.9.9",
 		"hono-rate-limiter": "^0.4.2",
 		"http-status-codes": "^2.3.0",
 		"ink": "^6.3.1",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Pinned `hono` dependency from `^4.9.9` to exact version `4.9.9` in `server/package.json`. This removes the caret (`^`) prefix, preventing the package manager from automatically installing newer minor or patch versions.

- Changed version specifier from allowing compatible updates (4.9.x, 4.10.x, etc.) to requiring exact version 4.9.9
- Ensures consistent, predictable behavior across all environments and installations
- Prevents potential breaking changes from automatic updates

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- Simple, low-risk dependency version change that only makes the build more deterministic. Pinning an exact version reduces uncertainty and prevents unintended updates
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/package.json | Pinned `hono` from `^4.9.9` to exact version `4.9.9` to prevent automatic minor/patch updates |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PM as Package Manager (Bun)
    participant NPM as NPM Registry
    participant App as Application

    Note over Dev,App: Before Change: hono: ^4.9.9
    Dev->>PM: bun install
    PM->>NPM: Request hono ^4.9.9
    Note over NPM: Resolves to latest 4.x.x<br/>(e.g., 4.10.0, 4.11.0)
    NPM->>PM: Returns latest compatible version
    PM->>App: Installs potentially newer version

    Note over Dev,App: After Change: hono: 4.9.9
    Dev->>PM: bun install
    PM->>NPM: Request hono 4.9.9 (exact)
    Note over NPM: Resolves to exact 4.9.9
    NPM->>PM: Returns exact version 4.9.9
    PM->>App: Installs exact version 4.9.9
    Note over App: Consistent, predictable behavior
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->