### PR TITLE
ayush

### DIFF
--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -1,46 +1,49 @@
-import type { ProductV2 } from "@autumn/shared";
-import { Archive, ArchiveRestore, Copy, Delete, Pen } from "lucide-react";
+import { AppEnv, type ProductV2 } from "@autumn/shared";
+import {
+	ArchiveIcon,
+	ArrowCounterClockwiseIcon,
+	CopyIcon,
+	TrashIcon,
+} from "@phosphor-icons/react";
 import { useState } from "react";
 import { ToolbarButton } from "@/components/general/table-components/ToolbarButton";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+} from "@/components/v2/dropdowns/DropdownMenu";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { DeletePlanDialog } from "@/views/products/plan/components/DeletePlanDialog";
 import { CopyProductDialog } from "../CopyProductDialog";
-import { UpdateProductDialog } from "../UpdateProductDialog";
 
 export const ProductListRowToolbar = ({ product }: { product: ProductV2 }) => {
 	const [dropdownOpen, setDropdownOpen] = useState(false);
-	const [updateOpen, setUpdateOpen] = useState(false);
 	const [copyOpen, setCopyOpen] = useState(false);
+	const [copyToEnv, setCopyToEnv] = useState<AppEnv>(AppEnv.Sandbox);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 	const { counts } = useProductsQuery();
 
 	const productCounts = counts[product.id];
 	const allCount = productCounts?.all || 0;
 	let deleteText = allCount > 0 ? "Archive" : "Delete";
-	let DeleteIcon = allCount > 0 ? Archive : Delete;
+	let DeleteIcon = allCount > 0 ? ArchiveIcon : TrashIcon;
 
 	if (product.archived) {
 		deleteText = "Unarchive";
-		DeleteIcon = ArchiveRestore;
+		DeleteIcon = ArrowCounterClockwiseIcon;
 	}
 
 	return (
 		<>
-			<UpdateProductDialog
-				open={updateOpen}
-				setOpen={setUpdateOpen}
-				selectedProduct={product}
-			/>
 			<CopyProductDialog
 				open={copyOpen}
 				setOpen={setCopyOpen}
 				product={product}
+				targetEnv={copyToEnv}
 			/>
 			<DeletePlanDialog
 				propProduct={product}
@@ -53,37 +56,41 @@ export const ProductListRowToolbar = ({ product }: { product: ProductV2 }) => {
 				<DropdownMenuTrigger asChild>
 					<ToolbarButton />
 				</DropdownMenuTrigger>
-				<DropdownMenuContent className="text-t2" align="end">
+				<DropdownMenuContent align="end">
+					<DropdownMenuSub>
+						<DropdownMenuSubTrigger className="flex gap-2">
+							<CopyIcon />
+							Copy to
+						</DropdownMenuSubTrigger>
+						<DropdownMenuSubContent>
+							<DropdownMenuItem
+								className="flex gap-2"
+								onClick={(e) => {
+									e.stopPropagation();
+									e.preventDefault();
+									setDropdownOpen(false);
+									setCopyToEnv(AppEnv.Sandbox);
+									setCopyOpen(true);
+								}}
+							>
+								Sandbox
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="flex gap-2"
+								onClick={(e) => {
+									e.stopPropagation();
+									e.preventDefault();
+									setDropdownOpen(false);
+									setCopyToEnv(AppEnv.Live);
+									setCopyOpen(true);
+								}}
+							>
+								Production
+							</DropdownMenuItem>
+						</DropdownMenuSubContent>
+					</DropdownMenuSub>
 					<DropdownMenuItem
-						className="flex items-center text-xs"
-						onClick={(e) => {
-							e.stopPropagation();
-							e.preventDefault();
-							setDropdownOpen(false);
-							setCopyOpen(true);
-						}}
-					>
-						<div className="flex items-center justify-between w-full gap-2">
-							Copy
-							<Copy size={12} className="text-t3" />
-						</div>
-					</DropdownMenuItem>
-					<DropdownMenuItem
-						className="flex items-center text-xs"
-						onClick={(e) => {
-							e.stopPropagation();
-							e.preventDefault();
-							setDropdownOpen(false);
-							setUpdateOpen(true);
-						}}
-					>
-						<div className="flex items-center justify-between w-full gap-2">
-							Edit
-							<Pen size={12} className="text-t3" />
-						</div>
-					</DropdownMenuItem>
-					<DropdownMenuItem
-						className="flex items-center text-xs"
+						className="flex gap-2"
 						onClick={(e) => {
 							e.stopPropagation();
 							e.preventDefault();
@@ -91,10 +98,8 @@ export const ProductListRowToolbar = ({ product }: { product: ProductV2 }) => {
 							setDeleteOpen(true);
 						}}
 					>
-						<div className="flex items-center justify-between w-full gap-2">
-							{deleteText}
-							<DeleteIcon size={12} className="text-t3" />
-						</div>
+						<DeleteIcon />
+						{deleteText}
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR enhances the product copy workflow by streamlining environment selection and updating UI components. The changes enable a more direct copy-to-environment flow from the product list toolbar.

## Key Changes
- Enhanced `CopyProductDialog` to accept optional `targetEnv` prop that pre-selects the destination environment
- When `targetEnv` is provided, the environment selector is hidden for a streamlined experience
- Updated `ProductListRowToolbar` to replace single "Copy" button with "Copy to" submenu offering direct Sandbox/Production options
- Removed "Edit" functionality from `ProductListRowToolbar` (still available in other toolbars like `ProductRowToolbar`)
- Migrated from Lucide icons to Phosphor icons and from deprecated `@/components/ui/` to v2 components (`@/components/v2/`)
- Updated dialog title and button text to reflect the selected environment when using `targetEnv`
- Navigation only occurs when copying to the same environment (prevents navigation when copying cross-environment)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-implemented UI improvements with proper prop handling, conditional rendering, and backwards compatibility. The dialog maintains all existing functionality while adding optional enhancement. The component migration follows established patterns in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/products/components/CopyProductDialog.tsx | Added optional `targetEnv` prop to pre-select environment and conditionally hide environment selector for streamlined copy workflow |
| vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx | Removed Edit option, converted Copy to submenu with direct environment selection (Sandbox/Production), and updated to v2 components and Phosphor icons |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ProductListRowToolbar
    participant CopyProductDialog
    participant ProductService
    participant Backend

    User->>ProductListRowToolbar: Click toolbar button
    ProductListRowToolbar->>ProductListRowToolbar: Open dropdown menu
    User->>ProductListRowToolbar: Click "Copy to" → Select "Sandbox" or "Production"
    ProductListRowToolbar->>ProductListRowToolbar: Set copyToEnv state
    ProductListRowToolbar->>CopyProductDialog: Open dialog with targetEnv prop
    CopyProductDialog->>CopyProductDialog: Use effectiveEnv (targetEnv ?? toEnv)
    CopyProductDialog->>CopyProductDialog: Hide environment selector
    CopyProductDialog->>CopyProductDialog: Update dialog title to "Copy to [Sandbox|Production]"
    User->>CopyProductDialog: Enter name and ID
    User->>CopyProductDialog: Click "Copy to [Sandbox|Production]"
    CopyProductDialog->>CopyProductDialog: Validate (check if env + id already exists)
    CopyProductDialog->>ProductService: copyProduct(id, {id, name, env: effectiveEnv})
    ProductService->>Backend: POST /products/{id}/copy
    Backend-->>ProductService: Success
    ProductService-->>CopyProductDialog: Product copied
    CopyProductDialog->>CopyProductDialog: Show success toast
    alt onSuccess callback provided
        CopyProductDialog->>ProductListRowToolbar: Call onSuccess(copiedProduct)
    else env === effectiveEnv (same environment)
        CopyProductDialog->>CopyProductDialog: Navigate to /products/{newId}
    else different environment
        CopyProductDialog->>CopyProductDialog: Don't navigate
    end
    CopyProductDialog->>ProductListRowToolbar: Close dialog
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->