### PR TITLE
fix: add on carry usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"db:pull": "bun scripts/db/pull.ts",
 		"db:push": " bun -F @autumn/shared db:push",
 		"db:generate": "bun -F @autumn/shared db:generate",
-		"db:migrate": " bun -F @autumn/shared db:migrate"
+		"db:migrate": " bun -F @autumn/shared db:migrate",
+		"kill-ports": "lsof -ti:8080 -ti:3000 | xargs kill -9"
 	},
 	"dependencies": {
 		"@wooorm/starry-night": "^3.8.0",

--- a/server/src/internal/customers/add-product/createFullCusProduct.ts
+++ b/server/src/internal/customers/add-product/createFullCusProduct.ts
@@ -263,6 +263,8 @@ export const getExistingCusProduct = async ({
 		internalEntityId,
 	});
 
+	if (product.is_add_on) return undefined;
+
 	return curMainProduct;
 };
 
@@ -323,7 +325,6 @@ export const createFullCusProduct = async ({
 		product,
 		internalCustomerId: customer.internal_id,
 		internalEntityId: attachParams.internalEntityId,
-		// processorType,
 	});
 
 	freeTrial = disableFreeTrial ? null : freeTrial;

--- a/server/src/internal/customers/attach/attachUtils/convertAttachParams.ts
+++ b/server/src/internal/customers/attach/attachUtils/convertAttachParams.ts
@@ -121,8 +121,10 @@ export const getCustomerSub = async ({
 
 	cusProducts.sort((a, b) => {
 		if (targetSubId) {
-			if (a.subscription_ids && a.subscription_ids.includes(targetSubId)) return -1;
-			if (b.subscription_ids && b.subscription_ids.includes(targetSubId)) return 1;
+			if (a.subscription_ids && a.subscription_ids.includes(targetSubId))
+				return -1;
+			if (b.subscription_ids && b.subscription_ids.includes(targetSubId))
+				return 1;
 		}
 		// 1. Check same group
 		const aGroupMatches = a.product.group === targetGroup;

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -1,11 +1,20 @@
 import { beforeAll, describe, it } from "bun:test";
 import { ApiVersion } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectProductAttached } from "@tests/utils/expectUtils/expectProductAttached";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import chalk from "chalk";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
-import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
-import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { AutumnCliV2 } from "@/external/autumn/autumnCliV2";
+import { timeout } from "@/utils/genUtils";
+import {
+	constructFeatureItem,
+	constructPrepaidItem,
+} from "@/utils/scriptUtils/constructItem.js";
+import {
+	constructProduct,
+	constructRawProduct,
+} from "@/utils/scriptUtils/createTestProducts.js";
 import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
 import { attachAuthenticatePaymentMethod } from "../../src/external/stripe/stripeCusUtils";
 import { CusService } from "../../src/internal/customers/CusService";
@@ -15,17 +24,21 @@ const pro = constructProduct({
 	type: "pro",
 	items: [
 		constructFeatureItem({
-			featureId: TestFeature.Messages,
-			includedUsage: 100,
+			featureId: TestFeature.Users,
+			includedUsage: 1,
 		}),
 	],
 });
-const oneOffCredits = constructProduct({
-	type: "one_off",
+
+export const addOn = constructRawProduct({
+	id: "addOn",
+	isAddOn: true,
 	items: [
-		constructFeatureItem({
-			featureId: TestFeature.Credits,
-			includedUsage: 100,
+		constructPrepaidItem({
+			featureId: TestFeature.Users,
+			includedUsage: 0,
+			billingUnits: 1,
+			price: 10,
 		}),
 	],
 });
@@ -46,27 +59,35 @@ describe(`${chalk.yellowBright("temp: one off credits test")}`, () => {
 
 		await initProductsV0({
 			ctx,
-			products: [pro, oneOffCredits],
+			products: [pro, addOn],
 			prefix: testCase,
 		});
-	});
 
-	it("should attach one off credits product", async () => {
 		await autumnV1.attach({
 			customer_id: customerId,
-			product_id: oneOffCredits.id,
+			product_id: pro.id,
 		});
 
-		const customer = await CusService.get({
-			db: ctx.db,
-			idOrInternalId: customerId,
-			orgId: ctx.org.id,
-			env: ctx.env,
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Users,
+			value: 1,
 		});
 
-		await attachAuthenticatePaymentMethod({
-			ctx,
-			customerId,
+		await timeout(4000);
+
+		await autumnV1.attach({
+			customer_id: customerId,
+			product_id: addOn.id,
+			options: [
+				{
+					feature_id: TestFeature.Users,
+					quantity: 3,
+				},
+			],
 		});
+
+		const customer = await autumnV1.customers.get(customerId);
+		console.log("Customer:", customer);
 	});
 });

--- a/server/tests/utils/stripeUtils/completeInvoiceCheckout.ts
+++ b/server/tests/utils/stripeUtils/completeInvoiceCheckout.ts
@@ -139,7 +139,7 @@ export const completeInvoiceCheckout = async ({
 			);
 			if (postalInput) {
 				await postalInput.click();
-				await postalInput.type("SW59SX");
+				await postalInput.type("94107");
 			}
 		} catch (error) {
 			console.log("Could not find postal code input:", error);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a bug where usage from main products was incorrectly being carried over to add-ons when they were attached to customers.

**Key Changes:**
- Added early return in `getExistingCusProduct()` to prevent returning main product when attaching add-ons
- Removed commented-out code in `createFullCusProduct()`
- Added `kill-ports` script for developer convenience
- Formatting improvements in `convertAttachParams.ts`

**How It Works:**
When an add-on is attached, `getExistingCusProduct()` now returns `undefined` instead of the current main product. This prevents the system from carrying over usage from the main product to the add-on, which was unintended behavior. Add-ons should start fresh without inheriting usage from other products in the same group.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk
- The fix is targeted and addresses a specific bug in add-on attachment logic. The change is straightforward - preventing usage carry-over for add-ons by returning undefined early. However, confidence is 4/5 rather than 5/5 because the test file appears to be incomplete (ends abruptly without assertions) and there's no comprehensive test coverage shown for edge cases.
- Pay attention to `server/tests/_temp/temp.test.ts` - the test appears incomplete and should be finalized or removed before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| package.json | Added `kill-ports` script for port management convenience |
| server/src/internal/customers/add-product/createFullCusProduct.ts | Prevents carrying usage from main products when attaching add-ons, removes commented code |
| server/src/internal/customers/attach/attachUtils/convertAttachParams.ts | Formatting change only - split long conditional statements across multiple lines |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant AttachAPI
    participant GetAttachConfig
    participant CreateFullCusProduct
    participant GetExistingCusProduct
    participant GetExistingCusProducts
    
    Client->>AttachAPI: Attach add-on product
    AttachAPI->>GetAttachConfig: Determine attach configuration
    GetAttachConfig->>GetAttachConfig: Check if branch === AddOn
    GetAttachConfig-->>AttachAPI: config.carryUsage = false (for AddOn)
    
    AttachAPI->>CreateFullCusProduct: Create customer product
    CreateFullCusProduct->>GetExistingCusProduct: Get existing customer product
    
    GetExistingCusProduct->>GetExistingCusProducts: Find current main product
    GetExistingCusProducts-->>GetExistingCusProduct: Return curMainProduct
    
    Note over GetExistingCusProduct: NEW: Check if product.is_add_on
    GetExistingCusProduct->>GetExistingCusProduct: if (product.is_add_on) return undefined
    GetExistingCusProduct-->>CreateFullCusProduct: Return undefined (not curMainProduct)
    
    Note over CreateFullCusProduct: curCusProduct = undefined prevents<br/>carrying usage from main product
    CreateFullCusProduct->>CreateFullCusProduct: Create add-on without carried usage
    CreateFullCusProduct-->>AttachAPI: New customer product created
    AttachAPI-->>Client: Add-on attached successfully
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->