### PR TITLE
fix: init hatchet

### DIFF
--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -12,7 +12,6 @@ import "dotenv/config";
 import cluster from "node:cluster";
 
 import { initInfisical } from "./external/infisical/initInfisical.js";
-import { initHatchetWorker } from "./queue/initWorkers.js";
 
 // Number of worker processes (defaults to CPU cores)
 const NUM_PROCESSES = process.env.NODE_ENV === "development" ? 1 : 4;
@@ -23,6 +22,7 @@ let isShuttingDown = false;
 if (cluster.isPrimary) {
 	await initInfisical();
 
+	const { initHatchetWorker } = await import("./queue/initWorkers.js");
 	await initHatchetWorker();
 
 	// Check if queue is configured before starting workers


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Converted static import to dynamic import for `initHatchetWorker` to fix initialization order issue where Sentry was being initialized before Infisical loaded environment variables.

**Key Changes:**
- **Bug fixes:** Removed static import of `initHatchetWorker` from top of file
- **Bug fixes:** Added dynamic import of `initHatchetWorker` after `initInfisical()` completes

The static import was causing `server/src/queue/initWorkers.ts` to execute its top-level `await import("../sentry.js")` before Infisical could load secrets. This meant Sentry's DSN and other configuration might not be available. The dynamic import ensures proper initialization order: Infisical → Sentry → Hatchet.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is a targeted fix for an initialization order bug. Converting to dynamic import is the correct solution and doesn't introduce any runtime behavior changes beyond fixing the timing issue. The functionality remains identical.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/workers.ts | Changed static import to dynamic import for `initHatchetWorker` to ensure Infisical initializes before Sentry side effects |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as workers.ts (Primary)
    participant I as initInfisical()
    participant IW as initWorkers.ts
    participant S as sentry.ts
    participant H as initHatchetWorker()
    participant Hatchet as Hatchet SDK

    Note over W: Static imports executed
    Note over W: (dotenv, cluster, etc)
    
    W->>I: await initInfisical()
    activate I
    Note over I: Load secrets from Infisical
    I-->>W: Environment variables loaded
    deactivate I
    
    W->>IW: await import("./queue/initWorkers.js")
    activate IW
    IW->>S: await import("../sentry.js")
    activate S
    Note over S: Initialize Sentry with DSN<br/>(now available from Infisical)
    S-->>IW: Sentry initialized
    deactivate S
    Note over IW: Import dependencies & functions
    IW-->>W: { initHatchetWorker }
    deactivate IW
    
    W->>H: await initHatchetWorker()
    activate H
    Note over H: Check if Hatchet configured
    H->>Hatchet: hatchet.worker()
    Hatchet-->>H: worker instance
    H->>Hatchet: worker.start()
    Note over Hatchet: Runs indefinitely
    H-->>W: Started (non-blocking)
    deactivate H
    
    Note over W: Continue with worker forking
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->