### PR TITLE
charlie/eng 902 filtering in list customer endpoint

### DIFF
--- a/shared/api/_openapi2.0_/customersOpenApi.ts
+++ b/shared/api/_openapi2.0_/customersOpenApi.ts
@@ -55,11 +55,7 @@ export const customersOpenApi = {
 					description: "200 OK",
 					content: {
 						"application/json": {
-							schema: createPagePaginatedResponseSchema(
-								BaseApiCustomerSchema,
-							).meta({
-								id: "CustomerListResponse",
-							}),
+							schema: createPagePaginatedResponseSchema(BaseApiCustomerSchema),
 						},
 					},
 				},

--- a/shared/api/_openapi2.0_/openapi2.0.ts
+++ b/shared/api/_openapi2.0_/openapi2.0.ts
@@ -3,7 +3,11 @@ import { ApiPlanFeatureWithMeta } from "@api/products/planFeature/apiPlanFeature
 import yaml from "yaml";
 import { createDocument } from "zod-openapi";
 import { CustomerDataSchema } from "../common/customerData.js";
-import { ApiCustomerSchema, EntityDataSchema } from "../models.js";
+import {
+	ApiCustomerSchema,
+	BaseApiCustomerSchema,
+	EntityDataSchema,
+} from "../models.js";
 import { balancesOpenApi } from "./balancesOpenApi.js";
 import { coreOps } from "./coreOpenApi.js";
 import { customersOpenApi } from "./customersOpenApi.js";
@@ -39,6 +43,7 @@ const openapi2_0 = createDocument(
 				Plan: ApiPlanWithMeta,
 				PlanFeature: ApiPlanFeatureWithMeta,
 				Customer: ApiCustomerSchema,
+				BaseCustomer: BaseApiCustomerSchema,
 				Entity: ApiEntityWithMeta,
 			},
 			securitySchemes: {

--- a/shared/api/common/customerData.ts
+++ b/shared/api/common/customerData.ts
@@ -25,8 +25,7 @@ export const CustomerDataSchema = z
 	})
 	.meta({
 		id: "CustomerData",
-		description:
-			"Unique identifier (eg, serial number) to detect duplicate customers and prevent free trial abuse",
+		description: "Customer details to set when creating a customer",
 	});
 
 export type CustomerData = z.infer<typeof CustomerDataSchema>;

--- a/shared/api/common/pagePaginationSchemas.ts
+++ b/shared/api/common/pagePaginationSchemas.ts
@@ -32,7 +32,9 @@ export const createPagePaginatedResponseSchema = <T extends z.ZodType>(
 	itemSchema: T,
 ) =>
 	z.object({
-		list: z.array(itemSchema).describe("Array of items for current page"),
+		list: z.array(itemSchema).meta({
+			description: "Array of items for current page",
+		}),
 		has_more: z
 			.boolean()
 			.describe("Whether more results exist after this page"),

--- a/shared/api/customers/apiCustomer.ts
+++ b/shared/api/customers/apiCustomer.ts
@@ -20,7 +20,9 @@ export const ApiCusExpandSchema = z.object({
 
 export const BaseApiCustomerSchema = z
 	.object({
-		autumn_id: z.string().optional(),
+		autumn_id: z.string().optional().meta({
+			internal: true,
+		}),
 		id: z.string().nullable(),
 		name: z.string().nullable(),
 		email: z.string().nullable(),


### PR DESCRIPTION
- **added footer to edit plan bar**
- **rm console log**
- **cleanups to editor**
- **clean up plan row toolbar and copy plan options**
- **fix: carrying usge from main -> add on disabled**
- **removed auto-changing numbers on balance update**
- **add_to_balance in backend and sheet**
- **styling changes**
- **fix: calculating current balance**
- **fix: one off action required**
- **fix: add auto trial badge**
- **fix: 🐛 revcat statuses not erroring**
- **fix: 🐛 fixed caase where default stripe product can kill flows**
- **fix: 🐛 bugs**
- **changed balance to always return a breakdown item**
- **updated breakdown handling to be based on customer_entitlement_id**
- **created new sync item function and moved update balance to cache**
- **wip**
- **wip**
- **finalized tests for new update balance**
- **fix: duplicate features in plan editor on closing sheet**
- **wip**
- **fix: create stripe customer if not exists, only happens if stripe get error code is resource_missing**
- **feat: add product_id filtering to list customers endpoint**
- **feat: adding product status, version & search filtering**
- **fix: 🐛 revcat dupes**
- **chore: adding integration tests for list customers endpoint**
- **chore: add list customers updated openapi schema**
- **chore: fix stainless schema**
- **feat: add new customers/list POST endpoint**
- **chore: minor cleanup**
- **wip**
- **added rate limit to attach endpoint**
- **chore: updated vite config**
- **dynamic import initHatchet**
- **added customer_id to stripe webhook for logging, standardised stripe webhook pattern**
- **updated openapi for api customer**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refines the OpenAPI schema generation for customer endpoints, specifically improving the documentation for the list customers endpoint.

**Key Changes:**

- **API changes**: Registered `BaseApiCustomerSchema` as a reusable component in OpenAPI spec, ensuring the `/customers/list` endpoint documentation accurately reflects that it returns base customer data without expanded fields
- **Improvements**: Marked `autumn_id` field as internal to hide it from public API documentation
- **Improvements**: Standardized metadata handling by converting `.describe()` to `.meta()` for the paginated response `list` field
- **Improvements**: Updated `CustomerData` schema description to be more accurate and concise

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- All changes are limited to OpenAPI schema documentation and metadata configuration with no runtime logic changes. The modifications improve API documentation accuracy by properly separating base and expanded customer schemas, marking internal fields appropriately, and standardizing metadata handling patterns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/_openapi2.0_/customersOpenApi.ts | Removed redundant `.meta()` call on response schema, using `BaseApiCustomerSchema` for list endpoint |
| shared/api/_openapi2.0_/openapi2.0.ts | Added `BaseApiCustomerSchema` to components schemas for OpenAPI documentation |
| shared/api/customers/apiCustomer.ts | Marked `autumn_id` as internal in `BaseApiCustomerSchema` to hide from public API docs |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant OpenAPISpec
    participant ZodSchema

    Note over Client,ZodSchema: List Customers Endpoint Flow

    Client->>API: POST /customers/list
    API->>ZodSchema: Validate with ListCustomersV2ParamsSchema
    ZodSchema-->>API: Validated params
    API->>API: Query customers from DB
    API->>ZodSchema: Format response with BaseApiCustomerSchema
    Note over API,ZodSchema: Uses createPagePaginatedResponseSchema(BaseApiCustomerSchema)
    ZodSchema-->>API: Validated response
    API-->>Client: Return paginated customer list
    
    Note over OpenAPISpec: OpenAPI Documentation
    OpenAPISpec->>ZodSchema: Register BaseCustomer schema
    Note over OpenAPISpec: BaseCustomer excludes expand fields<br/>(invoices, entities, trials_used, etc.)
    OpenAPISpec->>ZodSchema: Mark autumn_id as internal
    Note over OpenAPISpec: Internal fields hidden from public docs
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->