### PR TITLE
chore: ctx customerId

### DIFF
--- a/server/src/external/sentry/sentryUtils.ts
+++ b/server/src/external/sentry/sentryUtils.ts
@@ -46,7 +46,7 @@ export const getSentryTags = ({
 		env: ctx.env || "unknown",
 		auth_type: ctx.authType,
 		request_id: ctx.id || "",
-		customer_id: customerId,
+		customer_id: customerId || ctx.customerId,
 		message_id: messageId,
 		path: path,
 		method: method,

--- a/server/src/honoMiddlewares/analyticsMiddleware.ts
+++ b/server/src/honoMiddlewares/analyticsMiddleware.ts
@@ -147,6 +147,8 @@ export const analyticsMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		user_id: ctx.userId || null,
 	};
 
+	ctx.customerId = customerId;
+
 	// Update logger with enriched context
 	ctx.logger = ctx.logger.child({
 		context: {

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -39,6 +39,7 @@ export type RequestContext = {
 	skipCacheDeletion?: boolean;
 
 	// Optional (should be populated in Stripe customer?)
+	customerId?: string;
 };
 
 export type AutumnContext = RequestContext;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `customerId` field to request context for improved tracking and observability across the system.

**Improvements:**
- Added `customerId` to `RequestContext` type definition
- Populated `ctx.customerId` in analytics middleware after parsing from request body or URL
- Updated `getSentryTags` to use `ctx.customerId` as fallback when explicit `customerId` parameter not provided
- Enhanced Sentry error tracking with consistent customer identification

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are straightforward and improve observability by adding `customerId` to the request context. The implementation uses the logical OR operator to provide a fallback, maintains backward compatibility, and follows existing patterns in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoUtils/HonoEnv.ts | Added optional `customerId` field to `RequestContext` type |
| server/src/honoMiddlewares/analyticsMiddleware.ts | Populated `ctx.customerId` after extracting from request body or URL |
| server/src/external/sentry/sentryUtils.ts | Updated `getSentryTags` to fallback to `ctx.customerId` when explicit `customerId` not provided |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Request
    participant analyticsMiddleware
    participant Context
    participant errorMiddleware
    participant getSentryTags
    participant Sentry

    Request->>analyticsMiddleware: Incoming HTTP Request
    analyticsMiddleware->>analyticsMiddleware: Extract customerId from body or URL
    analyticsMiddleware->>Context: Set ctx.customerId
    analyticsMiddleware->>Context: Enrich logger with customerId
    
    alt Error occurs during request
        errorMiddleware->>getSentryTags: Get Sentry tags
        getSentryTags->>Context: Read ctx.customerId (fallback)
        getSentryTags->>errorMiddleware: Return tags with customerId
        errorMiddleware->>Sentry: captureException with customerId tag
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->