### PR TITLE
fix: removed plan version

### DIFF
--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiSubscription/getApiSubscription.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiSubscription/getApiSubscription.ts
@@ -85,7 +85,6 @@ export const getApiSubscription = async ({
 		plan: apiPlan,
 
 		plan_id: fullProduct.id,
-		plan_version: fullProduct.version,
 		add_on: fullProduct.is_add_on,
 		default: fullProduct.is_default,
 

--- a/shared/api/customers/cusPlans/apiSubscription.ts
+++ b/shared/api/customers/cusPlans/apiSubscription.ts
@@ -4,7 +4,6 @@ import { z } from "zod/v4";
 export const ApiSubscriptionSchema = z.object({
 	plan: ApiPlanSchema.optional(),
 	plan_id: z.string(),
-	plan_version: z.number(),
 
 	default: z.boolean(),
 	add_on: z.boolean(),

--- a/shared/api/customers/cusPlans/changes/V1.2_CusPlanChange.ts
+++ b/shared/api/customers/cusPlans/changes/V1.2_CusPlanChange.ts
@@ -74,7 +74,7 @@ export function transformSubscriptionToCusProductV3({
 		group: input.plan?.group ?? null,
 		is_default: input.plan?.default ?? false,
 		is_add_on: input.add_on,
-		version: input.plan_version,
+		version: input.plan?.version ?? undefined,
 		items: items, // Map from plan to product v2 items...
 
 		status: cusPlanToCusProductV3Status(input),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


removed redundant `plan_version` field from the subscription API schema to eliminate data duplication, since version information is already available in the nested `plan` object.

**Key changes:**
- **API changes** - removed `plan_version` field from `ApiSubscriptionSchema` (V2.0+ API)
- **Bug fixes** - eliminated redundant field in `getApiSubscription.ts` that duplicated version data
- **API changes** - updated V1.2 transformation to source version from `plan?.version` instead of removed `plan_version`

**Important consideration:**
The transformation for legacy V1.2 API clients now relies on the plan object being expanded to provide version information. When plan is not expanded, V1.2 responses will have `undefined` version (previously always had a value from `plan_version`).

<h3>Confidence Score: 3/5</h3>


- safe to merge with verification needed for V1.2 API backward compatibility
- the change successfully eliminates data duplication by removing the redundant `plan_version` field. however, the V1.2 transformation logic now depends on the plan being expanded to provide version information. when plan is not expanded, V1.2 clients will receive `undefined` for version (previously always had a value). this could be a breaking change for V1.2 clients that expect version to always be present.
- pay close attention to `shared/api/customers/cusPlans/changes/V1.2_CusPlanChange.ts` - verify V1.2 backward compatibility when plan is not expanded

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusUtils/apiCusUtils/getApiSubscription/getApiSubscription.ts | removed redundant `plan_version` field from subscription response - version is available via nested plan object |
| shared/api/customers/cusPlans/apiSubscription.ts | removed `plan_version` field from schema - eliminates data duplication since version exists in nested plan |
| shared/api/customers/cusPlans/changes/V1.2_CusPlanChange.ts | updated transformation to use `plan?.version` instead of removed `plan_version` - version may be undefined when plan is not expanded |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant getApiSubscription
    participant cusProductToProduct
    participant ApiSubscriptionSchema
    participant V1.2Transform
    
    Client->>getApiSubscription: Request subscription (with expand option)
    getApiSubscription->>cusProductToProduct: Convert cusProduct to fullProduct
    cusProductToProduct-->>getApiSubscription: fullProduct (includes version from product.version)
    
    alt Plan should be expanded
        getApiSubscription->>getApiSubscription: Get plan response with version
        getApiSubscription->>ApiSubscriptionSchema: Parse with plan object
        ApiSubscriptionSchema-->>getApiSubscription: Subscription with plan.version
    else Plan not expanded
        getApiSubscription->>ApiSubscriptionSchema: Parse without plan object
        ApiSubscriptionSchema-->>getApiSubscription: Subscription without plan (no version)
    end
    
    alt V1.2 API version
        getApiSubscription->>V1.2Transform: Transform to V1.2 format
        V1.2Transform->>V1.2Transform: Use plan?.version ?? undefined
        V1.2Transform-->>Client: V1.2 response (version may be undefined)
    else V2.0+ API version
        getApiSubscription-->>Client: V2.0 response (version in plan object)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->