### PR TITLE
fix: add to balance cache

### DIFF
--- a/server/src/internal/balances/updateBalance/runAddToBalance.ts
+++ b/server/src/internal/balances/updateBalance/runAddToBalance.ts
@@ -1,16 +1,141 @@
 import {
 	FeatureNotFoundError,
+	InternalError,
+	nullish,
 	type SortCusEntParams,
 	type UpdateBalanceParams,
 } from "@autumn/shared";
+import { currentRegion, redis } from "@/external/redis/initRedis.js";
+import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
+import { normalizeToArray } from "@/utils/cacheUtils/normalizeFromSchema.js";
 import type { AutumnContext } from "../../../honoUtils/HonoEnv.js";
+import { getOrCreateApiCustomer } from "../../customers/cusUtils/getOrCreateApiCustomer.js";
+import { executeBatchDeduction } from "../track/redisTrackUtils/executeBatchDeduction.js";
 import { runDeductionTx } from "../track/trackUtils/runDeductionTx.js";
+import { syncItemV2 } from "../utils/sync/syncItemV2.js";
+
+interface RedisAddToBalanceResult {
+	fallback: boolean;
+	code: "success" | "skip_cache" | "redis_write_failed" | "allocated_feature";
+	customerChanged?: boolean;
+	changedEntityIds?: string[];
+	modifiedBreakdownIds?: string[];
+}
+
+/**
+ * Executes add-to-balance against cached customer data in Redis
+ * Uses negative deduction with adjustGrantedBalance=true to add to granted_balance
+ */
+const runRedisAddToBalance = async ({
+	ctx,
+	customerId,
+	entityId,
+	featureId,
+	amountToAdd,
+	cusEntId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	entityId?: string;
+	featureId: string;
+	amountToAdd: number;
+	cusEntId?: string;
+}): Promise<RedisAddToBalanceResult> => {
+	const { org, env, skipCache } = ctx;
+
+	if (skipCache) {
+		return {
+			fallback: true,
+			code: "skip_cache",
+		};
+	}
+
+	// Warm cache first
+	await getOrCreateApiCustomer({
+		ctx,
+		customerId,
+		entityId,
+	});
+
+	const result = await tryRedisWrite<RedisAddToBalanceResult>(async () => {
+		// Execute batch deduction with adjustGrantedBalance=true
+		// Negative deduction = add to granted_balance
+		const deductionResult = await executeBatchDeduction({
+			redis,
+			requests: [
+				{
+					featureDeductions: [
+						{
+							featureId,
+							amount: -amountToAdd, // Negative = add to balance
+						},
+					],
+					overageBehavior: "allow", // Allow mode bypasses restrictions for adding
+					entityId,
+					filters: cusEntId ? { id: cusEntId } : undefined,
+				},
+			],
+			orgId: org.id,
+			env,
+			customerId,
+			adjustGrantedBalance: true, // This makes it modify granted_balance instead of usage
+		});
+
+		// Handle PAID_ALLOCATED error - fallback to Postgres
+		if (deductionResult.error === "PAID_ALLOCATED") {
+			ctx.logger.info(
+				`[runRedisAddToBalance] Paid allocated feature detected, falling back to Postgres`,
+			);
+			return {
+				fallback: true,
+				code: "allocated_feature",
+			};
+		}
+
+		// Handle CUSTOMER_NOT_FOUND - fallback to Postgres
+		if (deductionResult.error === "CUSTOMER_NOT_FOUND") {
+			ctx.logger.info(
+				`[runRedisAddToBalance] Customer not found in cache, falling back to Postgres`,
+			);
+			return {
+				fallback: true,
+				code: "redis_write_failed",
+			};
+		}
+
+		if (!deductionResult.success) {
+			return {
+				fallback: true,
+				code: "redis_write_failed",
+			};
+		}
+
+		return {
+			fallback: false,
+			code: "success",
+			customerChanged: deductionResult.customerChanged,
+			changedEntityIds: normalizeToArray(deductionResult.changedEntityIds),
+			modifiedBreakdownIds: normalizeToArray(
+				deductionResult.modifiedBreakdownIds,
+			),
+		};
+	});
+
+	if (result === null) {
+		return {
+			fallback: true,
+			code: "redis_write_failed",
+		};
+	}
+
+	return result;
+};
 
 /**
  * Coordinates adding to a balance in both Redis and Postgres
  *
- * Uses negative deduction to add to balance atomically.
- * Requires params.add_to_balance to be set.
+ * Uses Redis-first approach with negative deduction + adjustGrantedBalance=true
+ * to atomically add to granted_balance, then syncs to Postgres.
  */
 export const runAddToBalance = async ({
 	ctx,
@@ -19,7 +144,7 @@ export const runAddToBalance = async ({
 	ctx: AutumnContext;
 	params: UpdateBalanceParams;
 }) => {
-	const { features } = ctx;
+	const { org, env, features } = ctx;
 	const {
 		customer_id: customerId,
 		entity_id: entityId,
@@ -27,6 +152,12 @@ export const runAddToBalance = async ({
 		add_to_balance: amountToAdd,
 		customer_entitlement_id: cusEntId,
 	} = params;
+
+	if (nullish(cusEntId)) {
+		throw new InternalError({
+			message: "Balance ID param is required if add_to_balance is passed in",
+		});
+	}
 
 	// Look up feature
 	const feature = features.find((f) => f.id === featureId);
@@ -39,26 +170,86 @@ export const runAddToBalance = async ({
 		throw new Error("add_to_balance is required for runAddToBalance");
 	}
 
-	// For add_to_balance, we use Postgres-first approach since it uses
-	// negative deduction which is different from syncMode.
-	// The refreshCache: true will invalidate Redis cache after Postgres update.
-	const sortParams: SortCusEntParams | undefined = cusEntId
-		? { cusEntIds: [cusEntId] }
-		: undefined;
-
-	await runDeductionTx({
+	// 1. Try Redis first
+	const redisResult = await runRedisAddToBalance({
 		ctx,
 		customerId,
 		entityId,
-		deductions: [
-			{
-				feature,
-				deduction: -amountToAdd, // Negative deduction = add to balance
-			},
-		],
-		sortParams,
-		skipAdditionalBalance: true,
-		alterGrantedBalance: true,
-		refreshCache: true,
+		featureId,
+		amountToAdd,
+		cusEntId,
 	});
+
+	// 2. If Redis failed, fall back to Postgres-only
+	if (redisResult.fallback) {
+		ctx.logger.info(
+			`[runAddToBalance] Redis fallback (${redisResult.code}), using Postgres-only approach`,
+		);
+
+		const sortParams: SortCusEntParams | undefined = cusEntId
+			? { cusEntIds: [cusEntId] }
+			: undefined;
+
+		await runDeductionTx({
+			ctx,
+			customerId,
+			entityId,
+			deductions: [
+				{
+					feature,
+					deduction: -amountToAdd, // Negative deduction = add to balance
+				},
+			],
+			sortParams,
+			skipAdditionalBalance: true,
+			alterGrantedBalance: true,
+			refreshCache: true,
+		});
+
+		return;
+	}
+
+	// 3. Queue sync to Postgres
+	const { customerChanged, changedEntityIds, modifiedBreakdownIds } =
+		redisResult;
+
+	ctx.logger.info(
+		`[runAddToBalance] Redis updated successfully, customerChanged: ${customerChanged}, changedEntityIds: ${changedEntityIds?.join(", ") || "none"}`,
+	);
+
+	// Sync customer-level balance if changed
+	if (customerChanged) {
+		await syncItemV2({
+			item: {
+				customerId,
+				featureId: feature.id,
+				orgId: org.id,
+				env,
+				entityId: undefined, // Customer-level sync
+				region: currentRegion,
+				timestamp: Date.now(),
+				breakdownIds: modifiedBreakdownIds || [],
+			},
+			ctx,
+		});
+	}
+
+	// Sync each changed entity's balance
+	if (changedEntityIds && changedEntityIds.length > 0) {
+		for (const changedEntityId of changedEntityIds) {
+			await syncItemV2({
+				item: {
+					customerId,
+					featureId: feature.id,
+					orgId: org.id,
+					env,
+					entityId: changedEntityId,
+					region: currentRegion,
+					timestamp: Date.now(),
+					breakdownIds: modifiedBreakdownIds || [],
+				},
+				ctx,
+			});
+		}
+	}
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


**Bug fixes**: Implements Redis-first caching approach for add-to-balance operations to improve performance and consistency. Previously used Postgres-first with cache invalidation; now uses Redis for immediate consistency with Postgres fallback.

**Key changes**:
- Adds `runRedisAddToBalance` helper function that attempts Redis write with graceful fallback
- Implements cache warming via `getOrCreateApiCustomer` before Redis operations
- Adds validation requiring `customer_entitlement_id` parameter (previously optional)
- Queues asynchronous sync operations via `syncItemV2` for changed balances instead of synchronous refresh
- Maintains atomic negative deduction semantics with `adjustGrantedBalance=true` flag
- Handles Redis-specific error cases (PAID_ALLOCATED, CUSTOMER_NOT_FOUND) with appropriate fallback

The implementation properly handles failure scenarios where Redis operations fail by falling back to the Postgres-only approach, ensuring data consistency and system resilience.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk. The Redis-first approach maintains backward compatibility through fallback logic.
- Score of 4 reflects solid implementation with proper error handling and fallback mechanisms. The addition of `cusEntId` validation requirement is a good safety improvement. The code properly handles Redis failures by falling back to Postgres. Main deduction from 5 is that this changes the operational behavior from Postgres-first to Redis-first, which requires operational monitoring to ensure Redis cache stays consistent with database state, but the code itself is well-structured with appropriate error handling for all identified failure modes.
- No files require special attention. The single file changed is well-structured with clear error handling and proper separation between Redis and Postgres paths.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/updateBalance/runAddToBalance.ts | Refactored to implement Redis-first caching strategy for add-to-balance operations. Introduces `runRedisAddToBalance` helper that executes negative deductions in Redis with cache fallback to Postgres. Adds validation requiring `customer_entitlement_id` parameter and implements sync queuing via `syncItemV2` for changed balances. Core logic is sound with proper error handling and graceful Postgres fallback. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant runAddToBalance
    participant runRedisAddToBalance
    participant Redis
    participant Postgres
    participant syncItemV2

    Client->>runAddToBalance: call with params
    runAddToBalance->>runAddToBalance: validate feature & params
    runAddToBalance->>runRedisAddToBalance: try Redis first

    rect rgb(200, 220, 255)
    Note over runRedisAddToBalance,Redis: Redis Path (Happy Case)
    runRedisAddToBalance->>runRedisAddToBalance: check skipCache
    runRedisAddToBalance->>Redis: warm cache (getOrCreateApiCustomer)
    runRedisAddToBalance->>Redis: executeBatchDeduction with negative amount
    Redis-->>runRedisAddToBalance: success + changed entities
    runRedisAddToBalance-->>runAddToBalance: {fallback: false, code: success, ...}
    end

    rect rgb(255, 220, 200)
    Note over runRedisAddToBalance,Postgres: Fallback Path (Redis Failed/PAID_ALLOCATED)
    alt Redis Error or PAID_ALLOCATED
        runRedisAddToBalance-->>runAddToBalance: {fallback: true, code: ...}
        runAddToBalance->>Postgres: runDeductionTx (synchronous)
        Postgres->>Postgres: update balances + refresh cache
        Postgres-->>runAddToBalance: complete
    end
    end

    rect rgb(200, 255, 220)
    Note over runAddToBalance,syncItemV2: Sync on Redis Success
    runAddToBalance->>syncItemV2: queue sync if customerChanged
    syncItemV2-->>runAddToBalance: queued (async)
    runAddToBalance->>syncItemV2: queue sync for each changedEntity
    syncItemV2-->>runAddToBalance: queued (async)
    runAddToBalance-->>Client: complete
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->