### PR TITLE
fix: migration update sub

### DIFF
--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -1,5 +1,5 @@
 import {
-	type AttachBranch,
+	AttachBranch,
 	type AttachConfig,
 	type AttachReplaceable,
 	ProrationBehavior,
@@ -93,9 +93,14 @@ export const updateStripeSub2 = async ({
 
 		// cancel_at_period_end: false,
 		// TODO: will error if sub managed by a schedule
-		cancel_at_period_end: isStripeSubscriptionCanceled({ sub: curSub })
-			? false
-			: undefined,
+		cancel_at_period_end:
+			isStripeSubscriptionCanceled({ sub: curSub }) &&
+			!(
+				branch === AttachBranch.SameCustomEnts ||
+				branch === AttachBranch.NewVersion
+			)
+				? false
+				: undefined,
 	});
 
 	let latestInvoice = updatedSub.latest_invoice as Stripe.Invoice | null;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed subscription migration logic to prevent automatically uncanceling subscriptions during version updates and custom entitlement changes.

**Key Changes**
- **Bug fixes**: Modified `cancel_at_period_end` logic in `updateStripeSub2` to exclude `SameCustomEnts` and `NewVersion` branches from automatic uncancellation
- **Bug fixes**: Changed `AttachBranch` import from type-only to runtime value to support conditional logic

The change ensures that when customers migrate between product versions (`NewVersion`) or update custom entitlements (`SameCustomEnts`), their subscription cancellation status is preserved. Previously, the migration process would always uncancel subscriptions, which was unintended behavior.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a focused bug fix with clear intent. The logic correctly preserves subscription cancellation status during migrations by adding explicit branch checks. The import change from `type AttachBranch` to `AttachBranch` is necessary for runtime comparison. No side effects or edge cases identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts | Added conditional logic to prevent uncanceling subscriptions during `SameCustomEnts` and `NewVersion` migrations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant updateStripeSub2
    participant Stripe API
    participant isStripeSubscriptionCanceled

    Client->>updateStripeSub2: Call with branch (SameCustomEnts/NewVersion)
    updateStripeSub2->>isStripeSubscriptionCanceled: Check if subscription is canceled
    isStripeSubscriptionCanceled-->>updateStripeSub2: Returns cancellation status
    
    alt Subscription is canceled AND branch is NOT SameCustomEnts/NewVersion
        updateStripeSub2->>Stripe API: Update sub with cancel_at_period_end: false
        Note over updateStripeSub2,Stripe API: Uncancel the subscription
    else Subscription is canceled AND branch IS SameCustomEnts/NewVersion
        updateStripeSub2->>Stripe API: Update sub with cancel_at_period_end: undefined
        Note over updateStripeSub2,Stripe API: Preserve cancellation status (migration)
    else Subscription is not canceled
        updateStripeSub2->>Stripe API: Update sub with cancel_at_period_end: undefined
        Note over updateStripeSub2,Stripe API: No change to cancellation status
    end
    
    Stripe API-->>updateStripeSub2: Return updated subscription
    updateStripeSub2-->>Client: Return result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->