### PR TITLE
fix: migration while downgrading

### DIFF
--- a/scripts/testGroups/g5.sh
+++ b/scripts/testGroups/g5.sh
@@ -7,12 +7,12 @@ BUN_PARALLEL_COMPACT \
   'server/tests/merged/downgrade' \
   'server/tests/merged/separate' \
   'server/tests/merged/add' \
-  # 'server/tests/merged/group' \
-  # 'server/tests/merged/prepaid' \
-  # 'server/tests/merged/upgrade' \
-  # 'server/tests/merged/addOn' \
-  # 'server/tests/merged/trial' \
-  # 'server/tests/core/cancel' \
+  'server/tests/merged/group' \
+  'server/tests/merged/prepaid' \
+  'server/tests/merged/upgrade' \
+  'server/tests/merged/addOn' \
+  'server/tests/merged/trial' \
+  'server/tests/core/cancel' \
   --max=6 \
   
   

--- a/server/src/external/stripe/stripeSubUtils/stripeSubItemUtils.ts
+++ b/server/src/external/stripe/stripeSubUtils/stripeSubItemUtils.ts
@@ -132,7 +132,8 @@ export const findPriceInStripeItems = ({
 		if (subItem) {
 			itemMatch =
 				config.stripe_price_id === subItem.price?.id ||
-				config.stripe_product_id === subItem.price?.product;
+				config.stripe_product_id === subItem.price?.product ||
+				config.stripe_empty_price_id === subItem.price?.id;
 		}
 
 		if (lineItem) {

--- a/server/src/internal/balances/utils/sync/SyncBatchingManager.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManager.ts
@@ -159,6 +159,7 @@ export class SyncBatchingManager {
 					payload: {
 						orgId: item.orgId,
 						env: item.env,
+						customerId: item.customerId,
 						item, // Single item
 					},
 					messageGroupId: customerId, // FIFO ordering per customer

--- a/server/src/internal/balances/utils/sync/runSyncBalanceBatch.ts
+++ b/server/src/internal/balances/utils/sync/runSyncBalanceBatch.ts
@@ -14,18 +14,9 @@ export const runSyncBalanceBatch = async ({
 	payload,
 }: {
 	ctx?: AutumnContext;
-	payload: SyncBatchPayload | any; // Allow any for backwards compatibility
+	payload: SyncBatchPayload;
 }) => {
-	// Backwards compatibility: handle both old (items array) and new (item object) formats
-	let item = payload.item;
-
-	// Old format: { items: [...] }
-	if (!item && payload.items && Array.isArray(payload.items)) {
-		item = payload.items[0];
-		console.warn(
-			"⚠️  Received old format sync message with items array, using first item",
-		);
-	}
+	const item = payload.item;
 
 	if (!item || !ctx) {
 		console.warn("⚠️  No sync item provided");

--- a/server/src/internal/customers/add-product/createFullCusProduct.ts
+++ b/server/src/internal/customers/add-product/createFullCusProduct.ts
@@ -72,6 +72,7 @@ export const initCusProduct = ({
 	trialEndsAt,
 	subscriptionStatus,
 	canceledAt,
+	endedAt,
 	createdAt,
 	collectionMethod,
 	subscriptionIds,
@@ -95,6 +96,7 @@ export const initCusProduct = ({
 	trialEndsAt?: number | null;
 	subscriptionStatus?: CusProductStatus;
 	canceledAt?: number | null;
+	endedAt?: number | null;
 	createdAt?: number | null;
 	collectionMethod?: CollectionMethod;
 	subscriptionIds?: string[];
@@ -121,7 +123,7 @@ export const initCusProduct = ({
 		product_id: product.id,
 		created_at: createdAt || Date.now(),
 		canceled: notNullish(canceledAt),
-
+		ended_at: endedAt,
 		status: subscriptionStatus
 			? subscriptionStatus
 			: isFuture
@@ -280,6 +282,7 @@ export const createFullCusProduct = async ({
 	trialEndsAt,
 	subscriptionStatus,
 	canceledAt = null,
+	endedAt,
 	createdAt = null,
 	subscriptionIds = [],
 	subscriptionScheduleIds = [],
@@ -302,6 +305,7 @@ export const createFullCusProduct = async ({
 	trialEndsAt?: number;
 	subscriptionStatus?: CusProductStatus;
 	canceledAt?: number | null;
+	endedAt?: number | null;
 	createdAt?: number | null;
 	subscriptionIds?: string[];
 	subscriptionScheduleIds?: string[];
@@ -464,6 +468,7 @@ export const createFullCusProduct = async ({
 		entityId: attachParams.entityId,
 		apiVersion: attachParams.apiVersion,
 		quantity: productOptions?.quantity ?? undefined,
+		endedAt,
 	});
 
 	if (!isOneOff(prices) && !product.is_add_on) {

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handlePaidProduct.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handlePaidProduct.ts
@@ -109,7 +109,6 @@ export const handlePaidProduct = async ({
 			itemSet: newItemSet,
 			config,
 			branch,
-			fromCreate: true,
 		});
 
 		sub = updatedSub;

--- a/server/src/internal/customers/attach/attachFunctions/multiAttach/handleMultiAttachFlow.ts
+++ b/server/src/internal/customers/attach/attachFunctions/multiAttach/handleMultiAttachFlow.ts
@@ -107,8 +107,6 @@ export const handleMultiAttachFlow = async ({
 			curSub: curSub!,
 			itemSet,
 			branch,
-			// fromCreate: attachParams.products.length === 0, // just for now, if no products, it comes from cancel product...
-			fromCreate: true, // just for now, if no products, it comes from cancel product...
 		});
 
 		// TODO: Add these missing functions or remove if not needed

--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlow.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlow.ts
@@ -42,11 +42,13 @@ export const handleUpgradeFlow = async ({
 	attachParams,
 	config,
 	branch,
+	fromMigration = false,
 }: {
 	ctx: AutumnContext;
 	attachParams: AttachParams;
 	config: AttachConfig;
 	branch: AttachBranch;
+	fromMigration?: boolean;
 }) => {
 	const curCusProduct = attachParamsToCurCusProduct({ attachParams });
 
@@ -84,7 +86,8 @@ export const handleUpgradeFlow = async ({
 		if (
 			product.is_add_on ||
 			branch === AttachBranch.NewVersion ||
-			branch === AttachBranch.SameCustomEnts
+			branch === AttachBranch.SameCustomEnts ||
+			fromMigration
 		)
 			continue;
 
@@ -136,17 +139,7 @@ export const handleUpgradeFlow = async ({
 			curSub: curSub,
 			itemSet,
 			branch,
-			fromCreate: attachParams.products.length === 0, // just for now, if no products, it comes from cancel product...
 		});
-
-		// // Renew sub
-		// console.log("Sub is canceled!", isStripeSubscriptionCanceled({ sub: res.updatedSub }));
-		// if (isStripeSubscriptionCanceled({ sub: res.updatedSub })) {
-		// 	await attachParams.stripeCli.subscriptions.update(res.updatedSub.id, {
-		// 		cancel_at_period_end: false,
-		// 		cancel_at: null,
-		// 	});
-		// }
 
 		if (res?.latestInvoice) {
 			logger.info(`UPGRADE FLOW: inserting invoice ${res.latestInvoice.id}`);
@@ -175,6 +168,9 @@ export const handleUpgradeFlow = async ({
 				config,
 				schedule,
 				curSub,
+				removeCusProducts:
+					fromMigration && curCusProduct ? [curCusProduct!] : undefined,
+				addNewProducts: !(fromMigration && curCusProduct?.canceled_at),
 			});
 		}
 
@@ -219,10 +215,16 @@ export const handleUpgradeFlow = async ({
 		const anchorToUnix = sub ? getEarliestPeriodEnd({ sub }) * 1000 : undefined;
 
 		let canceledAt: number | undefined;
+		let endedAt: number | undefined;
 		if (sub && isStripeSubscriptionCanceled({ sub })) {
 			canceledAt = sub.canceled_at
 				? sub.canceled_at * 1000
 				: curCusProduct?.canceled_at || undefined;
+		}
+
+		if (fromMigration && curCusProduct?.canceled_at) {
+			canceledAt = curCusProduct.canceled_at;
+			endedAt = curCusProduct.ended_at ?? undefined;
 		}
 
 		await createFullCusProduct({
@@ -238,6 +240,7 @@ export const handleUpgradeFlow = async ({
 			anchorToUnix: anchorToUnix,
 			scenario: AttachScenario.Upgrade,
 			canceledAt: canceledAt,
+			endedAt: endedAt,
 			subscriptionStatus:
 				sub?.status === "past_due" ? CusProductStatus.PastDue : undefined,
 			logger,
@@ -251,25 +254,4 @@ export const handleUpgradeFlow = async ({
 			? attachToInvoiceResponse({ invoice: latestInvoice || undefined })
 			: undefined,
 	});
-
-	// if (res) {
-	// 	if (req.apiVersion.gte(ApiVersion.V1_1)) {
-	// 		res.status(200).json(
-	// 			AttachResultSchema.parse({
-	// 				customer_id: attachParams.customer.id,
-	// 				product_ids: attachParams.products.map((p) => p.id),
-	// 				invoice: attachParams.invoiceOnly
-	// 					? attachToInvoiceResponse({ invoice: latestInvoice || undefined })
-	// 					: undefined,
-	// 				code: "updated_product_successfully",
-	// 				message: `Successfully updated product`,
-	// 			}),
-	// 		);
-	// 	} else {
-	// 		res.status(200).json({
-	// 			success: true,
-	// 			message: `Successfully updated product`,
-	// 		});
-	// 	}
-	// }
 };

--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlowSchedule.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlowSchedule.ts
@@ -20,6 +20,7 @@ export const handleUpgradeFlowSchedule = async ({
 	curSub,
 	removeCusProducts,
 	fromAddProduct = false,
+	addNewProducts = true,
 }: {
 	ctx: AutumnContext;
 	attachParams: AttachParams;
@@ -28,6 +29,7 @@ export const handleUpgradeFlowSchedule = async ({
 	curSub: Stripe.Subscription;
 	removeCusProducts?: FullCusProduct[];
 	fromAddProduct?: boolean;
+	addNewProducts?: boolean;
 }) => {
 	const { logger } = ctx;
 
@@ -57,7 +59,10 @@ export const handleUpgradeFlowSchedule = async ({
 		config,
 		billingPeriodEnd: schedule?.phases?.[nextPhaseIndex]?.start_date,
 		removeCusProducts,
+		addNewProducts,
 	});
+
+	// await logPhases({ phases: newItems.phases, db: ctx.db });
 
 	// Should release schedule...
 	const newCurPhaseIndex = getCurrentPhaseIndex({

--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -31,7 +31,6 @@ export const updateStripeSub2 = async ({
 	curSub,
 	itemSet,
 	branch,
-	fromCreate = false,
 }: {
 	ctx: AutumnContext;
 	attachParams: AttachParams;
@@ -39,7 +38,6 @@ export const updateStripeSub2 = async ({
 	curSub: Stripe.Subscription;
 	itemSet: ItemSet;
 	branch: AttachBranch;
-	fromCreate?: boolean;
 }) => {
 	const { db, logger } = ctx;
 
@@ -113,13 +111,6 @@ export const updateStripeSub2 = async ({
 			latestInvoice: null,
 		};
 	}
-
-	// if (fromCreate) {
-	// 	return {
-	// 		updatedSub,
-	// 		latestInvoice: updatedSub.latest_invoice as Stripe.Invoice,
-	// 	};
-	// }
 
 	const curCusProduct = attachParamsToCurCusProduct({ attachParams });
 	const cusEntIds: string[] = [];

--- a/server/src/internal/customers/attach/mergeUtils/paramsToScheduleItems.ts
+++ b/server/src/internal/customers/attach/mergeUtils/paramsToScheduleItems.ts
@@ -200,15 +200,8 @@ const computeUpdatedScheduleItems = async ({
 		removeCusProducts ||
 		getCusProductsToRemove({ attachParams, includeScheduled: true });
 
-	// console.log(
-	//   "REMOVING CUS PRODUCTS:",
-	//   cusProductsToRemove?.map((cp) => `${cp.product.id} (E: ${cp.entity_id})`)
-	// );
-
 	const allCusProducts = attachParams.customer.customer_products;
 
-	// console.log("New schedule items:");
-	// logScheduleItems({ items: newScheduleItems, cusProducts: allCusProducts });
 	for (const cusProduct of cusProductsToRemove) {
 		newScheduleItems = await removeCusProductFromScheduleItems({
 			curScheduleItems: baseCurScheduleItems,
@@ -220,9 +213,6 @@ const computeUpdatedScheduleItems = async ({
 			attachParams,
 		});
 	}
-
-	// console.log("New schedule items after removing cus products:");
-	// logScheduleItems({ items: newScheduleItems, cusProducts: allCusProducts });
 
 	return newScheduleItems;
 };
@@ -236,6 +226,7 @@ export const paramsToScheduleItems = async ({
 	config,
 	removeCusProducts,
 	billingPeriodEnd,
+	addNewProducts = true,
 }: {
 	ctx: AutumnContext;
 	sub?: Stripe.Subscription;
@@ -244,11 +235,18 @@ export const paramsToScheduleItems = async ({
 	config: AttachConfig;
 	removeCusProducts?: FullCusProduct[];
 	billingPeriodEnd?: number;
+	addNewProducts?: boolean;
 }) => {
-	const itemSet = await getStripeSubItems2({
-		attachParams,
-		config,
-	});
+	const itemSet = addNewProducts
+		? await getStripeSubItems2({
+				attachParams,
+				config,
+			})
+		: {
+				subItems: [],
+				invoiceItems: [],
+				usageFeatures: [],
+			};
 
 	let phaseIndex = -1;
 

--- a/server/src/internal/customers/attach/mergeUtils/paramsToSubItems.ts
+++ b/server/src/internal/customers/attach/mergeUtils/paramsToSubItems.ts
@@ -39,6 +39,11 @@ export const getCusProductsToRemove = ({
 			? products
 			: [cusProductToProduct({ cusProduct: attachParams.cusProduct! })];
 
+	console.log(
+		"Getting customer products to remove, internal entity ID:",
+		attachParams.internalEntityId,
+	);
+
 	for (const product of prods) {
 		// Get cur main and cur same
 		const { curMainProduct, curSameProduct, curScheduledProduct } =
@@ -120,10 +125,9 @@ export const paramsToSubItems = async ({
 		? removeCusProducts!
 		: getCusProductsToRemove({ attachParams });
 
-	// console.log(
-	// 	"Cus products to remove:",
-	// 	cusProductsToRemove.map((cp) => cp.product.name),
-	// );
+	ctx.logger.info(
+		`[paramsToSubItems] Removing cus products: ${cusProductsToRemove.map((cp) => `${cp.product.id} (E: ${cp.entity_id})`).join(", ")}`,
+	);
 
 	const newSubItems = mergeNewSubItems({
 		itemSet,
@@ -185,6 +189,10 @@ export const paramsToSubItems = async ({
 					itemSet.subItems.some((si) => si.price === existingSubItem.price?.id)
 				) {
 					continue;
+				}
+
+				if (printRemoveLogs) {
+					console.log(`Deleting consumable sub item ${existingSubItem.id}`);
 				}
 
 				newSubItems.push({

--- a/server/src/internal/entities/entityUtils/apiEntityCacheUtils/getCachedApiEntity.ts
+++ b/server/src/internal/entities/entityUtils/apiEntityCacheUtils/getCachedApiEntity.ts
@@ -2,6 +2,7 @@ import {
 	type ApiEntityV1,
 	ApiEntityV1Schema,
 	type AppEnv,
+	CusExpand,
 	type EntityLegacyData,
 	EntityLegacyDataSchema,
 	EntityNotFoundError,
@@ -112,8 +113,11 @@ export const getCachedApiEntity = async ({
 				inStatuses: RELEVANT_STATUSES,
 				withEntities: true,
 				withSubs: true,
-				entityId,
+				// entityId,
+				expand: [CusExpand.Invoices],
 			});
+
+			fullCus.entity = fullCus.entities.find((e) => e.id === entityId);
 		}
 
 		const entity = fullCus.entity;

--- a/server/src/internal/migrations/MigrationService.ts
+++ b/server/src/internal/migrations/MigrationService.ts
@@ -1,19 +1,18 @@
 import {
-	AppEnv,
-	migrationErrors,
-	MigrationJob,
+	type AppEnv,
+	ErrCode,
+	type MigrationJob,
 	MigrationJobStep,
+	migrationErrors,
+	migrationJobs,
 } from "@autumn/shared";
-
-import { DrizzleCli } from "@/db/initDrizzle.js";
-import { migrationJobs } from "@autumn/shared";
-import RecaseError from "@/utils/errorUtils.js";
-import { ErrCode } from "@autumn/shared";
 import { and, eq, ne } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import RecaseError from "@/utils/errorUtils.js";
 
 export class MigrationService {
 	static async createJob({ db, data }: { db: DrizzleCli; data: MigrationJob }) {
-		let result = await db.insert(migrationJobs).values(data).returning();
+		const result = await db.insert(migrationJobs).values(data).returning();
 
 		if (result.length === 0) {
 			throw new RecaseError({
@@ -34,7 +33,7 @@ export class MigrationService {
 		migrationJobId: string;
 		updates: any;
 	}) {
-		let results = await db
+		const results = await db
 			.update(migrationJobs)
 			.set({
 				...updates,
@@ -51,7 +50,7 @@ export class MigrationService {
 	}
 
 	static async getJob({ db, id }: { db: DrizzleCli; id: string }) {
-		let job = await db.query.migrationJobs.findFirst({
+		const job = await db.query.migrationJobs.findFirst({
 			where: eq(migrationJobs.id, id),
 		});
 
@@ -74,7 +73,7 @@ export class MigrationService {
 		orgId: string;
 		env: AppEnv;
 	}) {
-		let jobs = await db.query.migrationJobs.findMany({
+		const jobs = await db.query.migrationJobs.findMany({
 			where: and(
 				eq(migrationJobs.org_id, orgId),
 				eq(migrationJobs.env, env),
@@ -87,7 +86,7 @@ export class MigrationService {
 	}
 
 	static async insertError({ db, data }: { db: DrizzleCli; data: any }) {
-		let result = await db.insert(migrationErrors).values(data).returning();
+		const result = await db.insert(migrationErrors).values(data).returning();
 
 		if (result.length === 0) {
 			throw new RecaseError({
@@ -106,7 +105,7 @@ export class MigrationService {
 		db: DrizzleCli;
 		migrationJobId: string;
 	}) {
-		let errors = await db.query.migrationErrors.findMany({
+		const errors = await db.query.migrationErrors.findMany({
 			where: eq(migrationErrors.migration_job_id, migrationJobId),
 			with: {
 				customer: true,

--- a/server/src/internal/migrations/migrationSteps/migrateRevenuecatCustomer.ts
+++ b/server/src/internal/migrations/migrationSteps/migrateRevenuecatCustomer.ts
@@ -1,5 +1,4 @@
 import {
-	type AppEnv,
 	AttachScenario,
 	CusProductStatus,
 	type FullCusProduct,
@@ -8,30 +7,27 @@ import {
 	ProcessorType,
 } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { createFullCusProduct } from "@/internal/customers/add-product/createFullCusProduct.js";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
 import { attachToInsertParams } from "@/internal/products/productUtils.js";
-import type { ExtendedRequest } from "@/utils/models/Request.js";
 import { deleteCachedApiCustomer } from "../../customers/cusUtils/apiCusCacheUtils/deleteCachedApiCustomer.js";
 
 export const migrateRevenueCatCustomer = async ({
-	req,
+	ctx,
 	fullCus,
 	cusProduct,
 	toProduct,
 	customerId,
-	orgId,
-	env,
 }: {
-	req: ExtendedRequest;
+	ctx: AutumnContext;
 	fullCus: FullCustomer;
 	cusProduct: FullCusProduct;
 	toProduct: FullProduct;
 	customerId: string;
-	orgId: string;
-	env: AppEnv;
 }) => {
-	const { logger } = req;
+	const { db, logger, org, env, features } = ctx;
+
 	fullCus.customer_products = fullCus.customer_products.filter(
 		(cp) => cp.processor?.type === ProcessorType.RevenueCat,
 	);
@@ -50,7 +46,7 @@ export const migrateRevenueCatCustomer = async ({
 	});
 
 	await CusProductService.update({
-		db: req.db,
+		db,
 		cusProductId: cusProduct.id,
 		updates: {
 			status: CusProductStatus.Expired,
@@ -59,29 +55,11 @@ export const migrateRevenueCatCustomer = async ({
 	});
 
 	const createdAtToPass = cusProduct.created_at;
-	const startsAtToPass = cusProduct.starts_at;
 	const anchorToPass = cusProduct.created_at;
 
-	// // Debug: Log what we're passing to createFullCusProduct
-	// logger.info(`[RC Migration] Passing to createFullCusProduct:`, {
-	// 	createdAt: createdAtToPass,
-	// 	createdAt_date: createdAtToPass
-	// 		? new Date(createdAtToPass).toISOString()
-	// 		: null,
-	// 	startsAt: startsAtToPass,
-	// 	startsAt_date: startsAtToPass
-	// 		? new Date(startsAtToPass).toISOString()
-	// 		: null,
-	// 	anchorToUnix: anchorToPass,
-	// 	anchorToUnix_date: anchorToPass
-	// 		? new Date(anchorToPass).toISOString()
-	// 		: null,
-	// 	createdAt_type: typeof createdAtToPass,
-	// });
-
 	await createFullCusProduct({
-		db: req.db,
-		logger: req.logger,
+		db,
+		logger,
 		scenario: AttachScenario.New,
 		processorType: ProcessorType.RevenueCat,
 		// Preserve the original created_at, starts_at, and billing cycle anchor
@@ -95,14 +73,14 @@ export const migrateRevenueCatCustomer = async ({
 				prices: toProduct.prices,
 				entitlements: toProduct.entitlements,
 				entities: fullCus.entities || [],
-				org: req.org,
-				stripeCli: createStripeCli({ org: req.org, env: req.env }),
+				org,
+				stripeCli: createStripeCli({ org, env }),
 				paymentMethod: null,
 				freeTrial: null,
 				optionsList: cusProduct.options || [],
 				cusProducts: fullCus.customer_products,
 				replaceables: [],
-				features: req.features,
+				features,
 				fromMigration: true,
 			},
 			toProduct,
@@ -111,7 +89,7 @@ export const migrateRevenueCatCustomer = async ({
 
 	await deleteCachedApiCustomer({
 		customerId,
-		orgId,
+		orgId: org.id,
 		env,
 	});
 };

--- a/server/src/internal/migrations/migrationSteps/migrateStripeCustomer.ts
+++ b/server/src/internal/migrations/migrationSteps/migrateStripeCustomer.ts
@@ -1,39 +1,31 @@
-import {
-	type AppEnv,
-	type FullCusProduct,
-	type FullCustomer,
-	type FullProduct,
-} from "@autumn/shared";
+import type { FullCusProduct, FullCustomer, FullProduct } from "@autumn/shared";
 import type { Stripe } from "stripe";
-import type { ExtendedRequest } from "@/utils/models/Request.js";
-import type { AutumnContext } from "../../../honoUtils/HonoEnv.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { deleteCachedApiCustomer } from "../../customers/cusUtils/apiCusCacheUtils/deleteCachedApiCustomer.js";
 import { migrationToAttachParams } from "../migrationUtils/migrationToAttachParams.js";
 import { runMigrationAttach } from "../migrationUtils/runMigrationAttach.js";
 
 export const migrateStripeCustomer = async ({
-	req,
+	ctx,
 	stripeCli,
 	fullCus,
 	cusProduct,
 	toProduct,
 	fromProduct,
 	customerId,
-	orgId,
-	env,
 }: {
-	req: ExtendedRequest;
+	ctx: AutumnContext;
 	stripeCli: Stripe;
 	fullCus: FullCustomer;
 	cusProduct: FullCusProduct;
 	toProduct: FullProduct;
 	fromProduct: FullProduct;
 	customerId: string;
-	orgId: string;
-	env: AppEnv;
 }) => {
+	const { org, env } = ctx;
+
 	const attachParams = await migrationToAttachParams({
-		req,
+		ctx,
 		stripeCli,
 		customer: fullCus,
 		cusProduct,
@@ -41,14 +33,14 @@ export const migrateStripeCustomer = async ({
 	});
 
 	await runMigrationAttach({
-		ctx: req as unknown as AutumnContext,
+		ctx,
 		attachParams,
 		fromProduct,
 	});
 
 	await deleteCachedApiCustomer({
 		customerId,
-		orgId,
+		orgId: org.id,
 		env,
 	});
 };

--- a/server/src/internal/migrations/migrationUtils/createMigrationCustomerLogger.ts
+++ b/server/src/internal/migrations/migrationUtils/createMigrationCustomerLogger.ts
@@ -1,0 +1,28 @@
+import { AuthType } from "@autumn/shared";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export const createMigrationCustomerLogger = ({
+	ctx,
+	customerId,
+	migrationJobId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	migrationJobId?: string;
+}): Logger => {
+	const { logger, org, env } = ctx;
+
+	return logger.child({
+		context: {
+			context: {
+				migration_job_id: migrationJobId,
+				org_id: org.id,
+				org_slug: org.slug,
+				customer_id: customerId,
+				env: env,
+				authType: AuthType.Worker,
+			},
+		},
+	});
+};

--- a/server/src/internal/migrations/migrationUtils/runMigrationAttach.ts
+++ b/server/src/internal/migrations/migrationUtils/runMigrationAttach.ts
@@ -67,7 +67,7 @@ export const runMigrationAttach = async ({
 	const customer = attachParams.customer;
 	logger.info(`--------------------------------`);
 	logger.info(
-		`Running migration for ${customer.id}, function: ${attachFunction}`,
+		`Running migration for ${customer.id} (E: ${attachParams.entityId || "N/A"}), function: ${attachFunction}`,
 	);
 
 	let sameCustomBranch: AttachBranch | undefined;
@@ -97,6 +97,7 @@ export const runMigrationAttach = async ({
 			ctx,
 			attachParams,
 			config,
+			fromMigration: true,
 			branch:
 				sameCustomBranch === AttachBranch.SameCustomEnts
 					? AttachBranch.SameCustomEnts

--- a/server/src/internal/migrations/runMigrationTask.ts
+++ b/server/src/internal/migrations/runMigrationTask.ts
@@ -1,26 +1,27 @@
-/** biome-ignore-all lint/suspicious/noExplicitAny: ok */
-import { MigrationJobStep } from "@autumn/shared";
-import type { DrizzleCli } from "@/db/initDrizzle.js";
-import { FeatureService } from "../features/FeatureService.js";
+import { type AppEnv, MigrationJobStep } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ProductService } from "../products/ProductService.js";
 import { MigrationService } from "./MigrationService.js";
 import { getMigrationCustomers } from "./migrationSteps/getMigrationCustomers.js";
 import { migrateCustomers } from "./migrationSteps/migrateCustomers.js";
 
+export interface MigrationTaskPayload {
+	migrationJobId: string;
+	orgId: string;
+	env: AppEnv;
+}
+
 export const runMigrationTask = async ({
-	db,
+	ctx,
 	payload,
-	logger,
 }: {
-	db: DrizzleCli;
-	payload: any;
-	logger: any;
+	ctx: AutumnContext;
+	payload: MigrationTaskPayload;
 }) => {
+	const { db, logger } = ctx;
 	const { migrationJobId } = payload;
 
 	try {
-		logger.info(`Running migration task, ID: ${migrationJobId}`);
-
 		const migrationJob = await MigrationService.getJob({
 			db,
 			id: migrationJobId,
@@ -66,26 +67,18 @@ export const runMigrationTask = async ({
 			fromProduct,
 		});
 
-		const features = await FeatureService.list({
-			db,
-			orgId,
-			env,
-		});
-
-		logger.info(`Job ${migrationJobId} | Found ${customers?.length} customers`);
+		logger.info(
+			`Running migration for org ${ctx.org.id}, from ${fromProduct.name} to ${toProduct.name}`,
+		);
 
 		// STEP 2: MIGRATE CUSTOMERS..
 		await migrateCustomers({
-			db,
+			ctx,
 			migrationJob,
 			fromProduct,
 			toProduct,
 			customers,
-			logger,
-			features,
 		});
-
-		// await new Promise((resolve) => setTimeout(resolve, 10000));
 	} catch (error) {
 		logger.error(`Migration failed: ${migrationJobId}`);
 		logger.error(error);

--- a/server/src/internal/products/handlers/handleMigrateProductV2.ts
+++ b/server/src/internal/products/handlers/handleMigrateProductV2.ts
@@ -147,6 +147,8 @@ export const handleMigrateProductV2 = createRoute({
 			jobName: JobName.Migration,
 			payload: {
 				migrationJobId: migrationJob.id,
+				orgId: org.id,
+				env,
 			},
 		});
 

--- a/server/src/queue/bullmq/initBullMqWorkers.ts
+++ b/server/src/queue/bullmq/initBullMqWorkers.ts
@@ -42,6 +42,7 @@ const initWorker = ({ id, db }: { id: number; db: DrizzleCli }) => {
 			const ctx = await createWorkerContext({
 				db,
 				logger: workerLogger,
+				payload: job.data,
 			});
 
 			try {
@@ -64,10 +65,13 @@ const initWorker = ({ id, db }: { id: number; db: DrizzleCli }) => {
 				}
 
 				if (job.name === JobName.Migration) {
+					if (!ctx) {
+						workerLogger.error("No context found for migration job");
+						return;
+					}
 					await runMigrationTask({
-						db,
+						ctx,
 						payload: job.data,
-						logger: workerLogger,
 					});
 					return;
 				}

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -7,24 +7,27 @@ import { generateId } from "../utils/genUtils.js";
 
 export const createWorkerContext = async ({
 	db,
-	orgId,
-	env,
+	payload,
 	logger,
 	workflowId,
 }: {
 	db: DrizzleCli;
-	orgId?: string;
-	env?: AppEnv;
+	payload: {
+		orgId?: string;
+		env?: AppEnv;
+		customerId?: string;
+	};
 	logger: Logger;
 	workflowId?: string;
 }) => {
+	const { orgId, env, customerId } = payload;
 	if (!orgId || !env) return;
 
 	// Fetch org with features once for all items
 	const orgData = await OrgService.getWithFeatures({
 		db,
 		orgId,
-		env: env as AppEnv,
+		env,
 	});
 
 	if (!orgData) {
@@ -39,6 +42,7 @@ export const createWorkerContext = async ({
 				workflow_id: workflowId,
 				org_id: org?.id,
 				org_slug: org?.slug,
+				customer_id: customerId,
 				env: env,
 				authType: AuthType.Worker,
 			},
@@ -52,12 +56,12 @@ export const createWorkerContext = async ({
 		db,
 		logger: workerLogger,
 
-		id: generateId("job"),
+		id: workflowId || generateId("job"),
 		timestamp: Date.now(),
 		isPublic: false,
 		authType: AuthType.Unknown,
 		apiVersion: createdAtToVersion({ createdAt: org.created_at! }),
-		clickhouseClient: null as any,
+		clickhouseClient: undefined,
 		expand: [],
 		skipCache: true,
 	};

--- a/server/src/queue/hatchetWorkflows/createWorkflowTask.ts
+++ b/server/src/queue/hatchetWorkflows/createWorkflowTask.ts
@@ -40,8 +40,7 @@ export const createWorkflowTask = <TInput extends BaseWorkflowInput, TOutput>({
 
 		const autumnContext = await createWorkerContext({
 			db,
-			orgId,
-			env,
+			payload: input,
 			logger,
 			workflowId: workflowMetadata.workflowId,
 		});

--- a/server/tests/attach/migrations/migration6.test.ts
+++ b/server/tests/attach/migrations/migration6.test.ts
@@ -1,0 +1,177 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import {
+	type AppEnv,
+	CusProductStatus,
+	type Organization,
+} from "@autumn/shared";
+import { defaultApiVersion } from "@tests/constants.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { attachAndExpectCorrect } from "@tests/utils/expectUtils/expectAttach.js";
+import { expectDowngradeCorrect } from "@tests/utils/expectUtils/expectScheduleUtils.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { timeout } from "@/utils/genUtils.js";
+import { constructArrearItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+import { expectSubToBeCorrect } from "../../merged/mergeUtils/expectSubCorrect.js";
+import { expectProductAttached } from "../../utils/expectUtils/expectProductAttached.js";
+
+const testCase = "migrations6";
+
+const wordsItem = constructArrearItem({
+	featureId: TestFeature.Words,
+	includedUsage: 1000,
+});
+
+const pro = constructProduct({
+	id: "pro",
+	items: [wordsItem],
+	type: "pro",
+	isDefault: false,
+});
+
+const premiumWordsItem = constructArrearItem({
+	featureId: TestFeature.Words,
+	includedUsage: 5000,
+});
+
+const premium = constructProduct({
+	id: "premium",
+	items: [premiumWordsItem],
+	type: "premium",
+	isDefault: false,
+});
+
+const updatedPremiumWordsItem = constructArrearItem({
+	featureId: TestFeature.Words,
+	includedUsage: 10000,
+});
+
+describe(`${chalk.yellowBright(`${testCase}: Testing migration for premium v1 -> premium v2 after downgrade to pro`)}`, () => {
+	const customerId = testCase;
+	const autumn: AutumnInt = new AutumnInt({ version: defaultApiVersion });
+	let db: DrizzleCli, org: Organization, env: AppEnv;
+	let stripeCli: Stripe;
+
+	beforeAll(async () => {
+		db = ctx.db;
+		org = ctx.org;
+		env = ctx.env;
+		stripeCli = ctx.stripeCli;
+
+		await initProductsV0({
+			ctx,
+			products: [pro, premium],
+			prefix: testCase,
+			customerId,
+		});
+
+		await initCustomerV3({
+			ctx,
+			customerId,
+			customerData: {},
+			attachPm: "success",
+			withTestClock: true,
+		});
+	});
+
+	test("should attach premium product", async () => {
+		await attachAndExpectCorrect({
+			autumn,
+			customerId,
+			product: premium,
+			stripeCli,
+			db,
+			org,
+			env,
+		});
+
+		const customer = await autumn.customers.get(customerId);
+		const wordsBalance = customer.features[TestFeature.Words].balance;
+		expect(wordsBalance).toBe(5000);
+	});
+
+	test("should downgrade to pro", async () => {
+		await expectDowngradeCorrect({
+			autumn,
+			customerId,
+			curProduct: premium,
+			newProduct: pro,
+			stripeCli,
+			db,
+			org,
+			env,
+		});
+
+		// Customer should still have premium active (with scheduled pro)
+		const customer = await autumn.customers.get(customerId);
+		const wordsBalance = customer.features[TestFeature.Words].balance;
+		expect(wordsBalance).toBe(5000);
+	});
+
+	test("should update premium product to new version", async () => {
+		await autumn.products.update(premium.id, {
+			items: [updatedPremiumWordsItem],
+		});
+	});
+
+	test("should migrate premium v1 to premium v2 after downgrade", async () => {
+		const wordsUsage = 2000;
+		await autumn.track({
+			customer_id: customerId,
+			value: wordsUsage,
+			feature_id: TestFeature.Words,
+		});
+
+		await timeout(4000);
+
+		// Verify usage was tracked correctly before migration
+		const customerBeforeMigration = await autumn.customers.get(customerId);
+		expect(customerBeforeMigration.features[TestFeature.Words].balance).toBe(
+			5000 - wordsUsage,
+		);
+
+		// Create updated premium with version 2
+		const premiumV2 = { ...premium, version: 2 };
+		premiumV2.items = [updatedPremiumWordsItem];
+
+		await autumn.migrate({
+			from_product_id: premium.id,
+			to_product_id: premiumV2.id,
+			from_version: premium.version,
+			to_version: premiumV2.version,
+		});
+
+		await timeout(10000);
+
+		// 1. Check that premium v2 active, pro scheduled
+		const customer = await autumn.customers.get(customerId);
+		expectProductAttached({
+			customer,
+			product: premiumV2,
+			status: CusProductStatus.Active,
+		});
+		expectProductAttached({
+			customer,
+			product: pro,
+			status: CusProductStatus.Scheduled,
+		});
+
+		await expectSubToBeCorrect({
+			db,
+			customerId,
+			org,
+			env,
+		});
+
+		// After migration, customer should have premium v2 with new included usage
+		const wordsBalance = customer.features[TestFeature.Words].balance;
+		// New included usage is 10000, minus 2000 used = 8000
+		expect(wordsBalance).toBe(10000 - wordsUsage);
+	});
+});

--- a/server/tests/attach/migrations/migration7.test.ts
+++ b/server/tests/attach/migrations/migration7.test.ts
@@ -1,0 +1,143 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import {
+	type AppEnv,
+	CusProductStatus,
+	type Organization,
+} from "@autumn/shared";
+import { defaultApiVersion } from "@tests/constants.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { attachAndExpectCorrect } from "@tests/utils/expectUtils/expectAttach.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { timeout } from "@/utils/genUtils.js";
+import { constructArrearItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+import { expectSubToBeCorrect } from "../../merged/mergeUtils/expectSubCorrect.js";
+import { expectProductAttached } from "../../utils/expectUtils/expectProductAttached.js";
+
+const testCase = "migrations7";
+
+const premiumWordsItem = constructArrearItem({
+	featureId: TestFeature.Words,
+	includedUsage: 5000,
+});
+
+const premium = constructProduct({
+	id: "premium",
+	items: [premiumWordsItem],
+	type: "premium",
+	isDefault: false,
+});
+
+const updatedPremiumWordsItem = constructArrearItem({
+	featureId: TestFeature.Words,
+	includedUsage: 10000,
+});
+
+describe(`${chalk.yellowBright(`${testCase}: Testing migration for premium v1 -> premium v2 after cancellation at cycle end`)}`, () => {
+	const customerId = testCase;
+	const autumn: AutumnInt = new AutumnInt({ version: defaultApiVersion });
+	let db: DrizzleCli, org: Organization, env: AppEnv;
+	let stripeCli: Stripe;
+
+	beforeAll(async () => {
+		db = ctx.db;
+		org = ctx.org;
+		env = ctx.env;
+		stripeCli = ctx.stripeCli;
+
+		await initProductsV0({
+			ctx,
+			products: [premium],
+			prefix: testCase,
+			customerId,
+		});
+
+		await initCustomerV3({
+			ctx,
+			customerId,
+			customerData: {},
+			attachPm: "success",
+			withTestClock: true,
+		});
+	});
+
+	test("should attach premium product", async () => {
+		await attachAndExpectCorrect({
+			autumn,
+			customerId,
+			product: premium,
+			stripeCli,
+			db,
+			org,
+			env,
+		});
+
+		const customer = await autumn.customers.get(customerId);
+		const wordsBalance = customer.features[TestFeature.Words].balance;
+		expect(wordsBalance).toBe(5000);
+	});
+
+	test("should cancel premium at cycle end", async () => {
+		await autumn.cancel({
+			customer_id: customerId,
+			product_id: premium.id,
+			cancel_immediately: false,
+		});
+
+		const customer = await autumn.customers.get(customerId);
+		expectProductAttached({
+			customer,
+			product: premium,
+			status: CusProductStatus.Active,
+			isCanceled: true,
+		});
+	});
+
+	test("should update premium product to new version", async () => {
+		await autumn.products.update(premium.id, {
+			items: [updatedPremiumWordsItem],
+		});
+	});
+
+	test("should migrate premium v1 to premium v2 and preserve cancellation", async () => {
+		const premiumV2 = { ...premium, version: 2 };
+		premiumV2.items = [updatedPremiumWordsItem];
+
+		await autumn.migrate({
+			from_product_id: premium.id,
+			to_product_id: premiumV2.id,
+			from_version: premium.version,
+			to_version: premiumV2.version,
+		});
+
+		await timeout(10000);
+
+		// Check that premium v2 is active but still cancelling
+		const customer = await autumn.customers.get(customerId);
+		expectProductAttached({
+			customer,
+			product: premiumV2,
+			status: CusProductStatus.Active,
+			isCanceled: true,
+		});
+
+		// Subscription should be cancelled at period end
+		await expectSubToBeCorrect({
+			db,
+			customerId,
+			org,
+			env,
+			shouldBeCanceled: true,
+		});
+
+		// Should have updated included usage
+		const wordsBalance = customer.features[TestFeature.Words].balance;
+		expect(wordsBalance).toBe(10000);
+	});
+});

--- a/server/tests/attach/migrations/migration8.test.ts
+++ b/server/tests/attach/migrations/migration8.test.ts
@@ -1,0 +1,199 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import {
+	type AppEnv,
+	CusProductStatus,
+	type Organization,
+} from "@autumn/shared";
+import { defaultApiVersion } from "@tests/constants.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { attachAndExpectCorrect } from "@tests/utils/expectUtils/expectAttach.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { timeout } from "@/utils/genUtils.js";
+import { constructArrearItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+import { expectSubToBeCorrect } from "../../merged/mergeUtils/expectSubCorrect.js";
+import { expectProductAttached } from "../../utils/expectUtils/expectProductAttached.js";
+
+const testCase = "migrations8";
+
+const premiumWordsItem = constructArrearItem({
+	featureId: TestFeature.Words,
+	includedUsage: 5000,
+});
+
+const premium = constructProduct({
+	id: "premium",
+	items: [premiumWordsItem],
+	type: "premium",
+	isDefault: false,
+});
+
+const updatedPremiumWordsItem = constructArrearItem({
+	featureId: TestFeature.Words,
+	includedUsage: 10000,
+});
+
+const entities = [
+	{
+		id: "1",
+		name: "Entity 1",
+		feature_id: TestFeature.Users,
+	},
+	{
+		id: "2",
+		name: "Entity 2",
+		feature_id: TestFeature.Users,
+	},
+];
+
+describe(`${chalk.yellowBright(`${testCase}: Testing migration with entities - one cancelled, one active`)}`, () => {
+	const customerId = testCase;
+	const autumn: AutumnInt = new AutumnInt({ version: defaultApiVersion });
+	let db: DrizzleCli, org: Organization, env: AppEnv;
+	let stripeCli: Stripe;
+
+	const entity1 = entities[0];
+	const entity2 = entities[1];
+
+	beforeAll(async () => {
+		db = ctx.db;
+		org = ctx.org;
+		env = ctx.env;
+		stripeCli = ctx.stripeCli;
+
+		await initProductsV0({
+			ctx,
+			products: [premium],
+			prefix: testCase,
+			customerId,
+		});
+
+		await initCustomerV3({
+			ctx,
+			customerId,
+			customerData: {},
+			attachPm: "success",
+			withTestClock: true,
+		});
+	});
+
+	test("should create entities", async () => {
+		await autumn.entities.create(customerId, entities);
+	});
+
+	test("should attach premium product to entity 1", async () => {
+		await attachAndExpectCorrect({
+			autumn,
+			customerId,
+			product: premium,
+			stripeCli,
+			db,
+			org,
+			env,
+			entityId: entity1.id,
+			numSubs: 1,
+		});
+	});
+
+	test("should attach premium product to entity 2", async () => {
+		await attachAndExpectCorrect({
+			autumn,
+			customerId,
+			product: premium,
+			stripeCli,
+			db,
+			org,
+			env,
+			entityId: entity2.id,
+			numSubs: 2,
+		});
+	});
+
+	test("should cancel premium on entity 1", async () => {
+		await autumn.cancel({
+			customer_id: customerId,
+			product_id: premium.id,
+			entity_id: entity1.id,
+			cancel_immediately: false,
+		});
+
+		await timeout(3000);
+
+		const entity = await autumn.entities.get(customerId, entity1.id);
+		expectProductAttached({
+			customer: entity,
+			product: premium,
+			status: CusProductStatus.Active,
+			isCanceled: true,
+		});
+
+		// Entity 2 should still be active and not cancelled
+		const entity2Res = await autumn.entities.get(customerId, entity2.id);
+
+		expectProductAttached({
+			customer: entity2Res,
+			product: premium,
+			status: CusProductStatus.Active,
+		});
+		expect(entity2Res.products[0].canceled_at).toBeFalsy();
+	});
+
+	test("should update premium product to new version", async () => {
+		await autumn.products.update(premium.id, {
+			items: [updatedPremiumWordsItem],
+		});
+	});
+
+	test("should migrate premium v1 to premium v2", async () => {
+		const premiumV2 = { ...premium, version: 2 };
+		premiumV2.items = [updatedPremiumWordsItem];
+
+		await autumn.migrate({
+			from_product_id: premium.id,
+			to_product_id: premiumV2.id,
+			from_version: premium.version,
+			to_version: premiumV2.version,
+		});
+
+		await timeout(10000);
+
+		// Entity 1 should have premium v2, still cancelling
+		const entity1Res = await autumn.entities.get(customerId, entity1.id);
+		expectProductAttached({
+			customer: entity1Res,
+			product: premiumV2,
+			status: CusProductStatus.Active,
+			isCanceled: true,
+		});
+
+		// Entity 1 should have updated included usage
+		const entity1Words = entity1Res.features[TestFeature.Words].balance;
+		expect(entity1Words).toBe(10000);
+
+		// Entity 2 should have premium v2, active and NOT cancelled
+		const entity2Res = await autumn.entities.get(customerId, entity2.id);
+		expectProductAttached({
+			customer: entity2Res,
+			product: premiumV2,
+			status: CusProductStatus.Active,
+		});
+		expect(entity2Res.products[0].canceled_at).toBeFalsy();
+
+		// Entity 2 should have updated included usage
+		const entity2Words = entity2Res.features[TestFeature.Words].balance;
+		expect(entity2Words).toBe(10000);
+
+		await expectSubToBeCorrect({
+			db,
+			customerId,
+			org,
+			env,
+		});
+	});
+});

--- a/server/tests/merged/add/mergedAdd1.test.ts
+++ b/server/tests/merged/add/mergedAdd1.test.ts
@@ -102,6 +102,8 @@ describe(`${chalk.yellowBright("mergedAdd1: Testing merged subs, with track")}`,
 			org,
 			env,
 		});
+
+		await timeout(3000);
 	});
 
 	test("should track usage and have correct invoice end of month", async () => {

--- a/server/tests/merged/mergeUtils/expectSubCorrect.ts
+++ b/server/tests/merged/mergeUtils/expectSubCorrect.ts
@@ -83,7 +83,11 @@ const compareActualItems = async ({
 
 		expect(actualItem).toBeDefined();
 
-		if (actualItem?.quantity !== (expectedItem as any).quantity) {
+		// Treat 0 and undefined as equivalent for quantity
+		const actualQty = actualItem?.quantity ?? 0;
+		const expectedQty = (expectedItem as any).quantity ?? 0;
+
+		if (actualQty !== expectedQty) {
 			if (phaseStartsAt) {
 				console.log(`Phase starts at: ${formatUnixToDateTime(phaseStartsAt)}`);
 			}
@@ -100,9 +104,7 @@ const compareActualItems = async ({
 				items: expectedItems,
 			});
 
-			console.log(
-				`Item quantity mismatch: ${actualItem?.quantity} !== ${expectedItem.quantity}`,
-			);
+			console.log(`Item quantity mismatch: ${actualQty} !== ${expectedQty}`);
 
 			const price = await PriceService.getByStripeId({
 				db,
@@ -118,7 +120,7 @@ const compareActualItems = async ({
 			console.log("--------------------------------");
 		}
 
-		expect(actualItem?.quantity).toBe((expectedItem as any).quantity);
+		expect(actualQty).toBe(expectedQty);
 	}
 
 	expect(actualItems.length).toBe(expectedItems.length);
@@ -299,7 +301,7 @@ export const expectSubToBeCorrect = async ({
 				org,
 				options,
 				existingUsage,
-				withEntity: !!entityId,
+				withEntity: !!cusProduct.internal_entity_id,
 				isCheckout: false,
 				apiVersion,
 				productOptions: cusProduct.quantity

--- a/server/tests/merged/separate/separate2.test.ts
+++ b/server/tests/merged/separate/separate2.test.ts
@@ -113,7 +113,7 @@ describe(`${chalk.yellowBright(`${testCase}: Testing separate subscriptions beca
 	});
 
 	const subIds: string[] = [];
-	test("should attach pro  product", async () => {
+	test("should attach pro product", async () => {
 		for (const op of ops) {
 			const res = await autumn.attach({
 				customer_id: customerId,

--- a/server/tests/merged/upgrade/mergedUpgrade1.test.ts
+++ b/server/tests/merged/upgrade/mergedUpgrade1.test.ts
@@ -17,6 +17,7 @@ import { addWeeks } from "date-fns";
 import type { Stripe } from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { timeout } from "@/utils/genUtils";
 import { constructArrearItem } from "@/utils/scriptUtils/constructItem.js";
 import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
 import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
@@ -129,6 +130,7 @@ describe(`${chalk.yellowBright("mergedUpgrade1: Testing merged subs, upgrade 1 &
 	const entity2Val = 300000;
 
 	test("should advance test clock and upgrade entity 1 to premium, and have correct invoice", async () => {
+		await timeout(3000);
 		await autumn.track({
 			customer_id: customerId,
 			feature_id: TestFeature.Words,


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Fixed migration logic to properly handle product downgrades and cancellations by preserving subscription state and timestamps during version upgrades.

## Key Changes

**Bug fixes**
- Fixed migration for products with scheduled downgrades by conditionally skipping new product addition when customer product is canceled
- Preserved `canceled_at` and `ended_at` timestamps during migration to maintain subscription cancellation state
- Fixed entity ID resolution in attach params to prevent entity context loss during migration
- Fixed customer product refresh between multiple migrations to ensure latest state is used

**Improvements**
- Refactored migration code to use `AutumnContext` instead of `ExtendedRequest` for better type safety and consistency
- Added customer-specific logger with migration context for better debugging and traceability
- Enhanced logging to include entity IDs in migration operations
- Improved test coverage with three new migration scenarios: downgrade with migration, cancellation with migration, and entity-based migrations

**API changes**
- Added `fromMigration` parameter to `handleUpgradeFlow` to enable migration-specific behavior
- Added `addNewProducts` parameter to `handleUpgradeFlowSchedule` and `paramsToScheduleItems` to control product addition during migration
- Added `endedAt` parameter to `createFullCusProduct` and `initCusProduct` to support preserving ended timestamps
- Added `removeCusProducts` parameter to upgrade flow schedule to support targeted customer product removal

### Confidence Score: 4/5

- Safe to merge with minor style improvement needed
- The PR addresses important edge cases in migration logic with comprehensive test coverage (3 new migration test scenarios). The implementation is sound with proper preservation of subscription state during downgrades. The refactoring to `AutumnContext` improves type safety. One minor style issue exists (debug console.log should be removed), but it doesn't affect functionality.
- The debug console.log in `server/src/internal/customers/attach/mergeUtils/paramsToSubItems.ts` should be removed before merge, though it's non-critical

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/internal/migrations/migrationSteps/migrateCustomer.ts | 4/5 | refactored to use `AutumnContext` instead of `ExtendedRequest`, added customer-specific logger, and implemented customer product refresh between migrations |
| server/src/internal/migrations/migrationUtils/migrationToAttachParams.ts | 5/5 | refactored to use `AutumnContext` and added `entityId` parameter to attach params |
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlow.ts | 4/5 | added `fromMigration` parameter to handle canceled product migrations, preserving `canceled_at` and `ended_at` timestamps |
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/handleUpgradeFlowSchedule.ts | 5/5 | added `addNewProducts` parameter to control whether new products are added during migration |
| server/src/internal/customers/attach/mergeUtils/paramsToSubItems.ts | 4/5 | added logging for removed customer products and debug console.log (needs removal) |
| server/src/internal/customers/attach/mergeUtils/paramsToScheduleItems.ts | 5/5 | added `addNewProducts` parameter to conditionally skip adding new products during migration |
| server/tests/attach/migrations/migration6.test.ts | 5/5 | new test for migrating premium v1 to v2 after downgrade to pro |
| server/tests/attach/migrations/migration7.test.ts | 5/5 | new test for migrating premium v1 to v2 after cancellation at cycle end |
| server/tests/attach/migrations/migration8.test.ts | 5/5 | new test for migration with entities where one is cancelled and one is active |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MC as migrateCustomer
    participant MSC as migrateStripeCustomer
    participant MTA as migrationToAttachParams
    participant RMA as runMigrationAttach
    participant HUF as handleUpgradeFlow
    participant HUFS as handleUpgradeFlowSchedule
    participant PSI as paramsToSubItems
    participant PSCI as paramsToScheduleItems
    participant CPS as CusProductService
    participant Stripe as Stripe API

    MC->>MC: Create customer logger
    MC->>MC: Get full customer with active statuses
    MC->>MC: Filter customer products by fromProduct
    
    loop For each filtered cusProduct
        MC->>MSC: migrateStripeCustomer
        MSC->>MTA: migrationToAttachParams
        MTA->>MTA: Get stripe customer data
        MTA->>MTA: Build AttachParams with entityId
        MTA-->>MSC: Return AttachParams
        
        MSC->>RMA: runMigrationAttach
        RMA->>RMA: Determine attach function
        RMA->>HUF: handleUpgradeFlow(fromMigration=true)
        
        alt Has scheduled items
            HUF->>HUFS: handleUpgradeFlowSchedule
            HUFS->>PSCI: paramsToScheduleItems(addNewProducts)
            
            alt addNewProducts=false (canceled cusProduct)
                PSCI->>PSCI: Skip adding new products
                PSCI->>PSCI: Remove old cusProduct from schedule
            else addNewProducts=true
                PSCI->>PSCI: Add new products to schedule
                PSCI->>PSCI: Remove old cusProduct from schedule
            end
            
            PSCI-->>HUFS: Return updated schedule items
            HUFS->>Stripe: Update subscription schedule
            Stripe-->>HUFS: Updated schedule
        else No scheduled items
            HUF->>PSI: paramsToSubItems(removeCusProducts)
            PSI->>PSI: Get cusProducts to remove
            PSI->>PSI: Remove sub items for old product
            PSI->>PSI: Add sub items for new product
            PSI-->>HUF: Return new sub items
            
            HUF->>Stripe: Update subscription
            Stripe-->>HUF: Updated subscription
        end
        
        alt fromMigration && canceled cusProduct
            HUF->>HUF: Preserve canceled_at and ended_at
        end
        
        HUF->>HUF: Create new cusProduct with migration data
        HUF-->>RMA: Migration complete
        RMA-->>MSC: Attach complete
        MSC-->>MC: Customer migrated
        
        alt Not last cusProduct
            MC->>CPS: Refresh customer products
            CPS-->>MC: Updated customer products
            MC->>MC: Update fullCus.customer_products
        end
    end
    
    MC-->>MC: Return migration success
```