### PR TITLE
ayush

### DIFF
--- a/vite/src/views/onboarding4/OnboardingGuide.tsx
+++ b/vite/src/views/onboarding4/OnboardingGuide.tsx
@@ -12,7 +12,7 @@ import {
 import { X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type { ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CopyButton } from "@/components/v2/buttons/CopyButton";
 import { IconButton } from "@/components/v2/buttons/IconButton";
@@ -217,15 +217,6 @@ export function OnboardingGuide() {
 	const { steps, currentStep, isLoading, isDismissed, dismiss } =
 		useOnboardingProgress();
 	const [activeStep, setActiveStep] = useState<string | null>(null);
-	const prevCurrentStepRef = useRef<OnboardingStepId | null>(null);
-
-	// Sync activeStep with currentStep when it changes (initial load or progress made)
-	useEffect(() => {
-		if (currentStep !== prevCurrentStepRef.current) {
-			setActiveStep(currentStep);
-			prevCurrentStepRef.current = currentStep;
-		}
-	}, [currentStep]);
 
 	// Don't render cards until activeStep is synced
 	const resolvedActiveStep = activeStep ?? currentStep;
@@ -257,7 +248,7 @@ export function OnboardingGuide() {
 					{[4, 1, 1, 1].map((flex, i) => (
 						<Skeleton
 							key={i}
-							className={cn("rounded-lg h-30 bg-card/50", `flex-${flex}`)}
+							className={cn("rounded-lg h-30 bg-card/70", `flex-${flex}`)}
 						/>
 					))}
 				</div>


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

**Improvements**: Removes `useEffect` synchronization logic and unused imports (`useEffect`, `useRef`) from the onboarding guide component. Updates skeleton loading state opacity from `bg-card/50` to `bg-card/70` for slightly more prominent loading indicators.

**Bug fixes**: This PR inadvertently introduces a bug rather than fixing one - the removed synchronization logic was necessary for auto-advancing the active step when users complete onboarding tasks.

### Confidence Score: 1/5

- High risk - introduces a logic bug that breaks core onboarding auto-advancement functionality
- The removal of the `useEffect` hook that synchronized `activeStep` with `currentStep` breaks the expected behavior where the onboarding guide automatically advances to the next incomplete step when users complete a task. After this change, if a user manually clicks on a step card and then completes that step, the UI will remain stuck on the completed step instead of advancing to the next one. This affects the core user experience of the onboarding flow.
- `vite/src/views/onboarding4/OnboardingGuide.tsx` requires immediate attention - the removed synchronization logic must be restored

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| vite/src/views/onboarding4/OnboardingGuide.tsx | 1/5 | Removes synchronization between activeStep and currentStep; breaks auto-advancement when steps complete |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Component
    participant Hook as useOnboardingProgress
    
    User->>Component: Loads page
    Component->>Hook: Get currentStep
    Hook-->>Component: Returns "plans"
    Note over Component: activeStep = null, shows "plans"
    
    User->>Component: Clicks "customer" card
    Component->>Component: setActiveStep("customer")
    Note over Component: Now shows "customer" card
    
    User->>Hook: Completes customer step
    Hook->>Component: currentStep changes to "payments"
    Note over Component: BUG: activeStep still "customer"<br/>Should show "payments" but shows "customer"
```