### PR TITLE
feat: 🎸 entity id in legacy balance update set feature

### DIFF
--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -434,6 +434,22 @@ export class AutumnInt {
 			});
 			return data;
 		},
+
+		setBalance: async ({
+			customerId,
+			balances,
+			entityId,
+		}: {
+			customerId: string;
+			balances: Array<{ feature_id: string; balance: number }>;
+			entityId?: string;
+		}) => {
+			const data = await this.post(`/customers/${customerId}/balances`, {
+				balances,
+				entity_id: entityId,
+			});
+			return data;
+		},
 	};
 
 	entities = {

--- a/server/src/internal/customers/handlers/handleUpdateBalancesV2.ts
+++ b/server/src/internal/customers/handlers/handleUpdateBalancesV2.ts
@@ -14,13 +14,14 @@ export const handleUpdateBalancesV2 = createRoute({
 
 		const { org, env, db, features } = ctx;
 		const { customer_id } = c.req.param();
-		const { balances } = c.req.valid("json");
+		const { balances, entity_id } = c.req.valid("json");
 
 		const fullCus = await CusService.getFull({
 			db,
 			idOrInternalId: customer_id,
 			orgId: org.id,
 			env,
+			entityId: entity_id,
 		});
 
 		for (const balance of balances) {

--- a/server/tests/balances/update/legacy-balance-update1.test.ts
+++ b/server/tests/balances/update/legacy-balance-update1.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { ApiVersion } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+
+const pro = constructProduct({
+    type: "pro",
+    items: [
+        constructFeatureItem({
+            featureId: TestFeature.Credits,
+            includedUsage: 500,
+        }),
+    ],
+});
+
+const testCase = "legacy-balance-update1";
+
+describe(`${chalk.yellowBright("legacy-balance-update1: allow updating balances for an entity")}`, () => {
+    const customerId = testCase;
+    const entityId = `${testCase}-user-1`;
+    const autumnV1: AutumnInt = new AutumnInt({ version: ApiVersion.V1_2 });
+
+    beforeAll(async () => {
+        await initCustomerV3({
+            ctx,
+            customerId,
+            withTestClock: true,
+            attachPm: "success",
+        });
+
+        await autumnV1.entities.create(customerId, [
+            {
+                id: entityId,
+                name: "User 1",
+                feature_id: TestFeature.Credits,
+            },
+        ]);
+
+        await initProductsV0({
+            ctx,
+            products: [pro],
+            prefix: testCase,
+        });
+
+        await autumnV1.attach({
+            customer_id: customerId,
+            entity_id: entityId,
+            product_id: pro.id,
+        });
+    });
+
+    test("should allow updating balances for an entity", async () => {
+        await autumnV1.customers.setBalance({
+            customerId: customerId,
+            entityId: entityId,
+            balances: [
+                {
+                    feature_id: TestFeature.Credits,
+                    balance: 100,
+                },
+            ],
+        });
+
+        const entity = await autumnV1.entities.get(customerId, entityId);
+
+        expect(entity.features.credits.balance).toBe(100);
+    });
+});

--- a/shared/api/balances/prevVersions/legacyUpdateBalanceModels.ts
+++ b/shared/api/balances/prevVersions/legacyUpdateBalanceModels.ts
@@ -11,4 +11,7 @@ export const UpdateBalancesParamsSchema = z.object({
 			}),
 		}),
 	),
+	entity_id: z.string().optional().meta({
+		description: "The ID of the entity to update balance for.",
+	}),
 });


### PR DESCRIPTION
habosh babosh skadoosh

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

Adds `entity_id` parameter support to legacy balance update endpoint, allowing entity-specific balance updates via the v1.2 API.

**Key Changes:**
- **API changes**: Added optional `entity_id` field to `UpdateBalancesParamsSchema` in legacy models
- **Improvements**: Enhanced `handleUpdateBalancesV2` to pass `entity_id` through `CusService.getFull()` and `runDeductionTx()`
- **API changes**: New `setBalance` method in `AutumnInt` client for easier entity balance updates
- **Improvements**: Test coverage for entity-specific balance updates

**Critical Issue:**
The handler lacks validation when `entity_id` is provided. If an invalid entity ID is supplied, `fullCus.entity` will be null, causing `fullCus.entity?.id` to be undefined. This silently updates the customer-level balance instead of returning an error, which violates the principle of failing fast on invalid input. Other handlers like `handleTransferProductV2` properly validate entity existence.

### Confidence Score: 3/5

- This PR has a critical validation bug that should be fixed before merging
- Score reflects missing error handling for invalid entity_id - silent failures could cause confusion and data integrity issues. The feature implementation is otherwise sound with proper schema changes, API client updates, and test coverage. The bug is straightforward to fix with entity existence validation.
- Pay close attention to `server/src/internal/customers/handlers/handleUpdateBalancesV2.ts` - needs entity validation before calling runDeductionTx

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| shared/api/balances/prevVersions/legacyUpdateBalanceModels.ts | 5/5 | Added optional `entity_id` field to schema for entity-specific balance updates |
| server/src/external/autumn/autumnCli.ts | 5/5 | Added `setBalance` method to customers API supporting optional `entityId` parameter |
| server/tests/balances/update/legacy-balance-update1.test.ts | 4/5 | New test verifying entity-specific balance updates, includes missing `chalk` import that may cause test execution issues |
| server/src/internal/customers/handlers/handleUpdateBalancesV2.ts | 3/5 | Added entity support to balance updates, but missing validation for non-existent entity_id which could silently fail |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant AutumnCli
    participant API as POST /customers/:id/balances
    participant Handler as handleUpdateBalancesV2
    participant CusService
    participant DB as Database
    participant DeductionTx as runDeductionTx

    Client->>AutumnCli: setBalance({customerId, entityId, balances})
    AutumnCli->>API: POST with entity_id in body
    API->>Handler: Route to handler
    Handler->>Handler: Extract entity_id from request
    Handler->>CusService: getFull({entityId: entity_id})
    CusService->>DB: Query customer + entity
    DB-->>CusService: Return FullCustomer
    CusService-->>Handler: Return fullCus (with entity if exists)
    Handler->>Handler: Validate features exist
    Handler->>DeductionTx: runDeductionTx({entityId: fullCus.entity?.id})
    Note over DeductionTx: If entity_id invalid, fullCus.entity is null<br/>so entityId becomes undefined
    DeductionTx->>DB: Update balances (customer or entity level)
    DB-->>DeductionTx: Success
    DeductionTx-->>Handler: Return result
    Handler-->>API: Return {success: true}
    API-->>Client: Response
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| shared/api/balances/prevVersions/legacyUpdateBalanceModels.ts | 5/5 | Added optional `entity_id` field to schema for entity-specific balance updates |
| server/src/external/autumn/autumnCli.ts | 5/5 | Added `setBalance` method to customers API supporting optional `entityId` parameter |
| server/tests/balances/update/legacy-balance-update1.test.ts | 4/5 | New test verifying entity-specific balance updates, includes missing `chalk` import that may cause test execution issues |
| server/src/internal/customers/handlers/handleUpdateBalancesV2.ts | 3/5 | Added entity support to balance updates, but missing validation for non-existent entity_id which could silently fail |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant AutumnCli
    participant API as POST /customers/:id/balances
    participant Handler as handleUpdateBalancesV2
    participant CusService
    participant DB as Database
    participant DeductionTx as runDeductionTx

    Client->>AutumnCli: setBalance({customerId, entityId, balances})
    AutumnCli->>API: POST with entity_id in body
    API->>Handler: Route to handler
    Handler->>Handler: Extract entity_id from request
    Handler->>CusService: getFull({entityId: entity_id})
    CusService->>DB: Query customer + entity
    DB-->>CusService: Return FullCustomer
    CusService-->>Handler: Return fullCus (with entity if exists)
    Handler->>Handler: Validate features exist
    Handler->>DeductionTx: runDeductionTx({entityId: fullCus.entity?.id})
    Note over DeductionTx: If entity_id invalid, fullCus.entity is null<br/>so entityId becomes undefined
    DeductionTx->>DB: Update balances (customer or entity level)
    DB-->>DeductionTx: Success
    DeductionTx-->>Handler: Return result
    Handler-->>API: Return {success: true}
    API-->>Client: Response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->