### PR TITLE
fix: 🐛 types

### DIFF
--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -13,7 +13,7 @@ import { freeTrialToStripeTimestamp } from "@/internal/products/free-trials/free
 import { SubService } from "@/internal/subscriptions/SubService.js";
 import { nullish } from "@/utils/genUtils.js";
 import type { ItemSet } from "@/utils/models/ItemSet.js";
-import { createProrationInvoice } from "../../../../../external/stripe/stripeSubUtils/updateStripeSub/createProrationinvoice.js";
+import { createProrationInvoice } from "../../../../../external/stripe/stripeSubUtils/updateStripeSub/createProrationInvoice.js";
 import { isStripeSubscriptionCanceled } from "../../../../../external/stripe/stripeSubUtils.js";
 
 import type { AutumnContext } from "../../../../../honoUtils/HonoEnv.js";

--- a/shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts
+++ b/shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts
@@ -2,7 +2,7 @@ import type { AppEnv } from "@models/genModels/genEnums";
 import { organizations } from "@models/orgModels/orgTable.js";
 import { foreignKey, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 
-export const revenuecatMappings: any = pgTable(
+export const revenuecatMappings = pgTable(
 	"revenuecat_mappings",
 	{
 		org_id: text("org_id").notNull(),


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

## Key Changes

**Bug fixes:**
- ❌ **Critical Issue**: Import path in `updateStripeSub2.ts` changed incorrectly
- ✅ Removed `:any` type annotation from `revenuecatMappings` table definition

## Analysis

This PR attempts to fix type issues but introduces a critical bug:

### Critical Issue: Import Path Case Mismatch
The import path for `createProrationInvoice` was changed from `createProrationinvoice.js` (lowercase 'i') to `createProrationInvoice.js` (uppercase 'I'). However, the actual filename is `createProrationinvoice.ts` with a lowercase 'i'. This mismatch will cause module resolution to fail because:

1. The TypeScript config has `"forceConsistentCasingInFileNames": true`
2. The actual file is `createProrationinvoice.ts` (lowercase 'i')
3. The new import uses `createProrationInvoice.js` (uppercase 'I')

**This change will break the build and prevent the code from running.**

### Correct Change: Removing :any
The change to `revenuecatMappingsTable.ts` is correct and beneficial:
- Removes the `:any` type annotation, which violates the codebase guideline "Do NOT use 'any' type" (from AGENTS.md)
- Aligns with patterns used throughout the codebase (other table definitions don't use `:any`)
- Allows TypeScript to properly infer the Drizzle table type
- The inferred type is fully compatible with existing usages in `RCMappingService`

## Recommendation
Revert the import path change in `updateStripeSub2.ts` while keeping the `:any` removal in `revenuecatMappingsTable.ts`.

### Confidence Score: 0/5

- This PR is NOT safe to merge - it contains a critical bug that will break the build
- Score of 0 reflects a critical module resolution error in updateStripeSub2.ts. The import path case change does not match the actual filename (createProrationinvoice.ts vs createProrationInvoice.js), which will cause the build to fail with TypeScript's forceConsistentCasingInFileNames setting. This is a blocking issue that must be fixed before merge.
- Pay immediate attention to server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts - the import path must be reverted to use lowercase 'i' in 'invoice'

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts | 0/5 | Import path case changed incorrectly - will cause module resolution failure due to filename mismatch |
| shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts | 5/5 | Correctly removes :any type annotation, aligning with codebase guidelines and patterns |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Code
    participant USub2 as updateStripeSub2.ts
    participant CPI as createProrationInvoice
    participant RCMap as revenuecatMappings Table
    participant DB as Database (Drizzle ORM)

    Note over USub2,CPI: ❌ BROKEN: Import path case mismatch
    App->>USub2: Call updateStripeSub2()
    rect rgb(255, 200, 200)
        Note over USub2,CPI: Module resolution fails here
        USub2--xCPI: import { createProrationInvoice }<br/>from "...createProrationInvoice.js"<br/>❌ File is actually "createProrationinvoice.ts"
    end

    Note over RCMap,DB: ✅ FIXED: Type inference improved
    App->>DB: Query revenuecatMappings
    rect rgb(200, 255, 200)
        Note over RCMap: Before: export const revenuecatMappings: any<br/>After: export const revenuecatMappings<br/>✅ Proper type inference enabled
        DB->>RCMap: Use properly typed table schema
        RCMap-->>DB: Return typed results
    end
    DB-->>App: Typed query results
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts | 0/5 | Import path case changed incorrectly - will cause module resolution failure due to filename mismatch |
| shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts | 5/5 | Correctly removes :any type annotation, aligning with codebase guidelines and patterns |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Code
    participant USub2 as updateStripeSub2.ts
    participant CPI as createProrationInvoice
    participant RCMap as revenuecatMappings Table
    participant DB as Database (Drizzle ORM)

    Note over USub2,CPI: ❌ BROKEN: Import path case mismatch
    App->>USub2: Call updateStripeSub2()
    rect rgb(255, 200, 200)
        Note over USub2,CPI: Module resolution fails here
        USub2--xCPI: import { createProrationInvoice }<br/>from "...createProrationInvoice.js"<br/>❌ File is actually "createProrationinvoice.ts"
    end

    Note over RCMap,DB: ✅ FIXED: Type inference improved
    App->>DB: Query revenuecatMappings
    rect rgb(200, 255, 200)
        Note over RCMap: Before: export const revenuecatMappings: any<br/>After: export const revenuecatMappings<br/>✅ Proper type inference enabled
        DB->>RCMap: Use properly typed table schema
        RCMap-->>DB: Return typed results
    end
    DB-->>App: Typed query results
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->