### PR TITLE
feat: 🎸 worlds most commited commit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "autumn",

--- a/server/src/queue/bullmq/initBullMqWorkers.ts
+++ b/server/src/queue/bullmq/initBullMqWorkers.ts
@@ -129,6 +129,7 @@ const initWorker = ({ id, db }: { id: number; db: DrizzleCli }) => {
 			}
 		},
 		{
+			// @ts-expect-error - workerRedis is a valid connection
 			connection: workerRedis,
 			concurrency: 1,
 			removeOnComplete: {


### PR DESCRIPTION
this is the best pull request body to ever be pushed to requests

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds a `@ts-expect-error` comment to suppress a TypeScript error when passing `workerRedis` to the BullMQ Worker constructor. However, based on TypeScript compilation output, this directive is unused - meaning there is no actual type error to suppress. The bun.lock file was also updated with a `configVersion` field, likely from running `bun install`.

## Key Changes

**Improvements**
- None - the `@ts-expect-error` directive is unnecessary

**Bug fixes**
- Attempts to suppress a TypeScript error, but the error does not exist

**API changes**
- None

### Confidence Score: 4/5

- Safe to merge after removing the unnecessary @ts-expect-error comment
- The PR introduces an unused @ts-expect-error directive which TypeScript flags as TS2578. While this doesn't break functionality, it adds technical debt by suppressing a non-existent error. The bun.lock change is benign. No logic changes were made.
- server/src/queue/bullmq/initBullMqWorkers.ts - remove the unused @ts-expect-error comment on line 132

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/queue/bullmq/initBullMqWorkers.ts | 3/5 | Added unused @ts-expect-error directive - TypeScript reports TS2578: Unused '@ts-expect-error' directive |
| bun.lock | 5/5 | Added configVersion field - lockfile metadata update from bun install |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant Worker as BullMQ Worker
    participant Redis as workerRedis Connection
    
    PR->>Worker: Add @ts-expect-error comment
    Note over Worker: Comment claims type error exists
    Worker->>Redis: Pass workerRedis as connection
    Note over Redis: Type is already compatible
    Redis-->>Worker: No type error (TS2578: Unused directive)
    Note over PR: Comment should be removed
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/queue/bullmq/initBullMqWorkers.ts | 3/5 | Added unused @ts-expect-error directive - TypeScript reports TS2578: Unused '@ts-expect-error' directive |
| bun.lock | 5/5 | Added configVersion field - lockfile metadata update from bun install |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant Worker as BullMQ Worker
    participant Redis as workerRedis Connection
    
    PR->>Worker: Add @ts-expect-error comment
    Note over Worker: Comment claims type error exists
    Worker->>Redis: Pass workerRedis as connection
    Note over Redis: Type is already compatible
    Redis-->>Worker: No type error (TS2578: Unused directive)
    Note over PR: Comment should be removed
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->