### PR TITLE
fix: createProrationinvoice file name

### DIFF
--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -13,7 +13,7 @@ import { freeTrialToStripeTimestamp } from "@/internal/products/free-trials/free
 import { SubService } from "@/internal/subscriptions/SubService.js";
 import { nullish } from "@/utils/genUtils.js";
 import type { ItemSet } from "@/utils/models/ItemSet.js";
-import { createProrationInvoice } from "../../../../../external/stripe/stripeSubUtils/updateStripeSub/createProrationInvoice.js";
+import { createProrationInvoice } from "../../../../../external/stripe/stripeSubUtils/updateStripeSub/createProrationinvoice.js";
 import { isStripeSubscriptionCanceled } from "../../../../../external/stripe/stripeSubUtils.js";
 
 import type { AutumnContext } from "../../../../../honoUtils/HonoEnv.js";

--- a/server/src/queue/bullmq/initBullMqWorkers.ts
+++ b/server/src/queue/bullmq/initBullMqWorkers.ts
@@ -129,7 +129,6 @@ const initWorker = ({ id, db }: { id: number; db: DrizzleCli }) => {
 			}
 		},
 		{
-			// @ts-expect-error - workerRedis is a valid connection
 			connection: workerRedis,
 			concurrency: 1,
 			removeOnComplete: {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a file import path casing issue and removes an unnecessary TypeScript error suppression comment.

## Key Changes

**Bug fixes:**
- Fixed import path in `updateStripeSub2.ts` from `createProrationInvoice.js` to `createProrationinvoice.js` to match the actual file name with lowercase 'i'
- Removed unnecessary `@ts-expect-error` comment in `initBullMqWorkers.ts` as the `workerRedis` connection is properly typed and compatible with BullMQ's Worker constructor

## Context

The file `createProrationinvoice.ts` has always been named with a lowercase 'i' (as confirmed by git history). The incorrect import path with uppercase 'I' was causing module resolution issues. The `@ts-expect-error` comment was added in the previous commit (e1e93864) but is no longer needed as TypeScript compilation succeeds without it, indicating the types are now properly aligned.

### Confidence Score: 5/5

- This PR is safe to merge with no risk - it only fixes an import path casing and removes an unnecessary comment
- Both changes are trivial fixes with no functional impact. The import path correction ensures proper module resolution, and the removal of @ts-expect-error is justified as the code compiles without errors. No logic changes, no new functionality, and no breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts | 5/5 | Fixed import path casing from 'createProrationInvoice.js' to 'createProrationinvoice.js' to match actual file name |
| server/src/queue/bullmq/initBullMqWorkers.ts | 5/5 | Removed unnecessary @ts-expect-error comment as workerRedis is properly typed for BullMQ Worker connection |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant USU as updateStripeSub2.ts
    participant CPI as createProrationinvoice.ts
    participant BW as initBullMqWorkers.ts
    participant WR as workerRedis
    
    Note over USU,CPI: Import Path Fix
    USU->>CPI: import { createProrationInvoice }
    Note right of USU: Path corrected from<br/>createProrationInvoice.js<br/>to createProrationinvoice.js
    
    Note over BW,WR: Type Error Suppression Removed
    BW->>WR: connection: workerRedis
    Note right of BW: @ts-expect-error removed<br/>Types are now compatible
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts | 5/5 | Fixed import path casing from 'createProrationInvoice.js' to 'createProrationinvoice.js' to match actual file name |
| server/src/queue/bullmq/initBullMqWorkers.ts | 5/5 | Removed unnecessary @ts-expect-error comment as workerRedis is properly typed for BullMQ Worker connection |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant USU as updateStripeSub2.ts
    participant CPI as createProrationinvoice.ts
    participant BW as initBullMqWorkers.ts
    participant WR as workerRedis
    
    Note over USU,CPI: Import Path Fix
    USU->>CPI: import { createProrationInvoice }
    Note right of USU: Path corrected from<br/>createProrationInvoice.js<br/>to createProrationinvoice.js
    
    Note over BW,WR: Type Error Suppression Removed
    BW->>WR: connection: workerRedis
    Note right of BW: @ts-expect-error removed<br/>Types are now compatible
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->