### PR TITLE
fix: createProrationinvoice file name

### DIFF
--- a/server/src/queue/bullmq/initBullMqWorkers.ts
+++ b/server/src/queue/bullmq/initBullMqWorkers.ts
@@ -1,4 +1,4 @@
-import { type Job, Worker } from "bullmq";
+import { type ConnectionOptions, type Job, Worker } from "bullmq";
 import type { Logger } from "pino";
 import { type DrizzleCli, initDrizzle } from "@/db/initDrizzle.js";
 import { logger } from "@/external/logtail/logtailUtils.js";
@@ -129,7 +129,7 @@ const initWorker = ({ id, db }: { id: number; db: DrizzleCli }) => {
 			}
 		},
 		{
-			connection: workerRedis,
+			connection: workerRedis as ConnectionOptions,
 			concurrency: 1,
 			removeOnComplete: {
 				count: 0,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes TypeScript type compatibility by adding a type cast from `ioredis.Redis` to BullMQ's `ConnectionOptions`. The change removes the need for a `@ts-expect-error` comment that was present in the previous commit.

**Key changes:**
- **Bug fixes**: Added `ConnectionOptions` type import and explicit cast for `workerRedis` to satisfy BullMQ's Worker constructor type requirements

**Note**: The PR title mentions "createProrationinvoice file name" but that fix was actually in PR #537. This PR's actual change is fixing the Redis worker type issue.

### Confidence Score: 3/5

- This PR has a type safety improvement but contains an existing logical bug that needs fixing
- The type cast change is appropriate and improves type safety by removing a `@ts-expect-error` comment. However, review discovered a pre-existing bug where the `TriggerCheckoutReward` handler is missing a `return` statement (line 120), which affects all handlers including this file's logic
- The `TriggerCheckoutReward` handler at line 114-120 needs a `return` statement added

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/queue/bullmq/initBullMqWorkers.ts | 3/5 | Added `ConnectionOptions` type import and cast for Redis connection. Found missing `return` statement in `TriggerCheckoutReward` handler. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant Worker as BullMQ Worker
    participant Redis as Redis (ioredis)
    participant Handler as Job Handler
    
    App->>Worker: Initialize Worker with connection
    Note over Worker,Redis: ConnectionOptions type cast applied
    Worker->>Redis: Connect via workerRedis instance
    Redis-->>Worker: Connection established
    
    loop Job Processing
        Worker->>Redis: Poll for jobs
        Redis-->>Worker: Job received
        Worker->>Handler: Process job by name
        alt Job handlers with return
            Handler-->>Worker: Complete & return
        else TriggerCheckoutReward (bug)
            Handler-->>Worker: Complete (no return)
            Note over Handler,Worker: Missing return statement
        end
    end
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/queue/bullmq/initBullMqWorkers.ts | 3/5 | Added `ConnectionOptions` type import and cast for Redis connection. Found missing `return` statement in `TriggerCheckoutReward` handler. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant Worker as BullMQ Worker
    participant Redis as Redis (ioredis)
    participant Handler as Job Handler
    
    App->>Worker: Initialize Worker with connection
    Note over Worker,Redis: ConnectionOptions type cast applied
    Worker->>Redis: Connect via workerRedis instance
    Redis-->>Worker: Connection established
    
    loop Job Processing
        Worker->>Redis: Poll for jobs
        Redis-->>Worker: Job received
        Worker->>Handler: Process job by name
        alt Job handlers with return
            Handler-->>Worker: Complete & return
        else TriggerCheckoutReward (bug)
            Handler-->>Worker: Complete (no return)
            Note over Handler,Worker: Missing return statement
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->