### PR TITLE
fix: delete cache logs

### DIFF
--- a/server/src/external/redis/initRedis.ts
+++ b/server/src/external/redis/initRedis.ts
@@ -123,9 +123,8 @@ const configureRedisInstance = (redisInstance: Redis): Redis => {
 		lua: BATCH_DELETE_FULL_CUSTOMER_CACHE_SCRIPT,
 	});
 
-	// biome-ignore lint/correctness/noUnusedFunctionParameters: Might uncomment this back in in the future
 	redisInstance.on("error", (error) => {
-		// logger.error(`redis (cache) error: ${error.message}`);
+		console.error(`[Redis] Connection error:`, error.message);
 	});
 
 	return redisInstance;

--- a/server/src/internal/customers/cusUtils/apiCusCacheUtils/batchDeleteCachedCustomers.ts
+++ b/server/src/internal/customers/cusUtils/apiCusCacheUtils/batchDeleteCachedCustomers.ts
@@ -50,10 +50,7 @@ export const batchDeleteCachedCustomers = async ({
 	const regions = getConfiguredRegions();
 
 	try {
-		await batchDeleteCachedFullCustomers({
-			customers,
-			source: `batchDeleteCachedCustomers, deleting ${customers.length} customers`,
-		});
+		await batchDeleteCachedFullCustomers({ customers });
 		// Delete from all regions in parallel
 		const regionPromises = regions.map(async (region) => {
 			const regionalRedis = getRegionalRedis(region);

--- a/server/src/internal/customers/cusUtils/apiCusCacheUtils/deleteCachedApiCustomer.ts
+++ b/server/src/internal/customers/cusUtils/apiCusCacheUtils/deleteCachedApiCustomer.ts
@@ -38,11 +38,7 @@ export const deleteCachedApiCustomer = async ({
 	const regions = getConfiguredRegions();
 
 	try {
-		await deleteCachedFullCustomer({
-			ctx,
-			customerId,
-			source,
-		});
+		await deleteCachedFullCustomer({ ctx, customerId, source });
 		// Delete from all regions in parallel to avoid race conditions
 		const deletePromises = regions.map(async (region) => {
 			const regionalRedis = getRegionalRedis(region);

--- a/server/src/internal/customers/cusUtils/cusUtils.ts
+++ b/server/src/internal/customers/cusUtils/cusUtils.ts
@@ -63,7 +63,7 @@ export const updateCustomerDetails = async ({
 		});
 		customer = { ...customer, ...updates };
 
-		// In updateCustomerDetails, after updating DB:
+		// Invalidate cache after DB update
 		await deleteCachedFullCustomer({
 			customerId: idOrInternalId,
 			ctx,

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.ts
@@ -5,7 +5,6 @@ import {
 import {
 	getConfiguredRegions,
 	getRegionalRedis,
-	redis,
 } from "@/external/redis/initRedis.js";
 import {
 	buildFullCustomerCacheGuardKey,
@@ -22,34 +21,19 @@ type CustomerToDelete = {
 
 /**
  * Batch delete multiple FullCustomer caches across ALL regions.
- * Groups by orgId to ensure all keys in each batch are on the same Redis Cluster node.
- * Sets guard keys to prevent stale writes from in-flight requests.
- * This ensures cache consistency and prevents race conditions where
- * a stale cache in another region could be read after deletion.
  */
 export const batchDeleteCachedFullCustomers = async ({
 	customers,
-	source,
 	logger,
 }: {
 	customers: CustomerToDelete[];
-	source?: string;
 	logger?: Logger;
 }): Promise<number> => {
 	const log = logger || loggerInstance;
 
-	if (redis.status !== "ready") {
-		log.warn(
-			`[batchDeleteCachedFullCustomers] Redis not ready, skipping deletion for ${customers.length} customers`,
-		);
-		return 0;
-	}
+	if (customers.length === 0) return 0;
 
-	if (customers.length === 0) {
-		return 0;
-	}
-
-	// Group customers by orgId to ensure all keys hash to the same Redis Cluster slot
+	// Group customers by orgId for Redis Cluster slot consistency
 	const customersByOrg = new Map<string, CustomerToDelete[]>();
 	for (const customer of customers) {
 		const existing = customersByOrg.get(customer.orgId) || [];
@@ -58,103 +42,58 @@ export const batchDeleteCachedFullCustomers = async ({
 	}
 
 	const regions = getConfiguredRegions();
+	const guardTimestamp = Date.now().toString();
 
-	try {
-		const guardTimestamp = Date.now().toString();
-
-		// Build customers data once (shared across all regions)
-		const customersDataByOrg = new Map<string, object[]>();
-		for (const [orgId, orgCustomers] of customersByOrg) {
-			const customersData = orgCustomers.map(({ env, customerId }) => ({
-				testGuardKey: buildTestFullCustomerCacheGuardKey({
-					orgId,
-					env,
-					customerId,
-				}),
-				guardKey: buildFullCustomerCacheGuardKey({ orgId, env, customerId }),
-				cacheKey: buildFullCustomerCacheKey({ orgId, env, customerId }),
-			}));
-			customersDataByOrg.set(orgId, customersData);
-		}
-
-		// Delete from all regions in parallel
-		const regionPromises = regions.map(async (region) => {
-			const regionalRedis = getRegionalRedis(region);
-
-			if (regionalRedis.status !== "ready") {
-				log.warn(
-					`[batchDeleteCachedFullCustomers] Redis not ready for region ${region}, skipping`,
-				);
-				return { region, deleted: 0, skipped: 0, notReady: true };
-			}
-
-			// Use pipeline to batch all org deletions into one network round trip
-			const pipeline = regionalRedis.pipeline();
-
-			for (const customersData of customersDataByOrg.values()) {
-				pipeline.batchDeleteFullCustomerCache(
-					guardTimestamp,
-					FULL_CUSTOMER_CACHE_GUARD_TTL_SECONDS.toString(),
-					JSON.stringify(customersData),
-				);
-			}
-
-			const results = await pipeline.exec();
-
-			// Sum up results from all orgs for this region
-			let regionDeleted = 0;
-			let regionSkipped = 0;
-
-			if (results) {
-				for (const [error, resultJson] of results) {
-					if (error) {
-						log.error(
-							`[batchDeleteCachedFullCustomers] Pipeline error for region ${region}: ${error}`,
-						);
-						throw error;
-					}
-					const result = JSON.parse(resultJson as string) as {
-						deleted: number;
-						skipped: number;
-					};
-					regionDeleted += result.deleted;
-					regionSkipped += result.skipped;
-				}
-			}
-
-			return {
-				region,
-				deleted: regionDeleted,
-				skipped: regionSkipped,
-				notReady: false,
-			};
-		});
-
-		const regionResults = await Promise.all(regionPromises);
-
-		// Sum up results from all regions
-		const totalDeleted = regionResults.reduce((sum, r) => sum + r.deleted, 0);
-		const totalSkipped = regionResults.reduce((sum, r) => sum + r.skipped, 0);
-		const regionsSummary = regionResults
-			.map(
-				(r) =>
-					`${r.region}: ${r.notReady ? "not_ready" : `del=${r.deleted},skip=${r.skipped}`}`,
-			)
-			.join(", ");
-
-		if (totalSkipped > 0) {
-			log.info(
-				`[batchDeleteCachedFullCustomers] Skipped ${totalSkipped} customers (test guard), deleted ${totalDeleted}, source: ${source}, regions: ${regionsSummary}`,
-			);
-		} else {
-			log.info(
-				`[batchDeleteCachedFullCustomers] Deleted ${totalDeleted} keys for ${customers.length} customers across ${customersByOrg.size} orgs, source: ${source}, regions: ${regionsSummary}`,
-			);
-		}
-
-		return totalDeleted;
-	} catch (error) {
-		log.error(`[batchDeleteCachedFullCustomers] Error: ${error}`);
-		throw error;
+	// Build customers data once (shared across all regions)
+	const customersDataByOrg = new Map<string, object[]>();
+	for (const [orgId, orgCustomers] of customersByOrg) {
+		const customersData = orgCustomers.map(({ env, customerId }) => ({
+			testGuardKey: buildTestFullCustomerCacheGuardKey({
+				orgId,
+				env,
+				customerId,
+			}),
+			guardKey: buildFullCustomerCacheGuardKey({ orgId, env, customerId }),
+			cacheKey: buildFullCustomerCacheKey({ orgId, env, customerId }),
+		}));
+		customersDataByOrg.set(orgId, customersData);
 	}
+
+	// Delete from all regions in parallel
+	const regionPromises = regions.map(async (region) => {
+		const regionalRedis = getRegionalRedis(region);
+
+		if (regionalRedis.status !== "ready") {
+			log.warn(`[batchDeleteCachedFullCustomers] ${region}: not_ready`);
+			return 0;
+		}
+
+		const pipeline = regionalRedis.pipeline();
+		for (const customersData of customersDataByOrg.values()) {
+			pipeline.batchDeleteFullCustomerCache(
+				guardTimestamp,
+				FULL_CUSTOMER_CACHE_GUARD_TTL_SECONDS.toString(),
+				JSON.stringify(customersData),
+			);
+		}
+
+		const results = await pipeline.exec();
+		let deleted = 0;
+
+		if (results) {
+			for (const [error, resultJson] of results) {
+				if (error) throw error;
+				const result = JSON.parse(resultJson as string) as { deleted: number };
+				deleted += result.deleted;
+			}
+		}
+
+		log.info(
+			`[batchDeleteCachedFullCustomers] ${region}: deleted ${deleted} keys, customers (${customers.length}), orgs (${customersByOrg.size})`,
+		);
+		return deleted;
+	});
+
+	const regionDeleted = await Promise.all(regionPromises);
+	return regionDeleted.reduce((sum, d) => sum + d, 0);
 };

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts
@@ -13,9 +13,6 @@ import { buildTestFullCustomerCacheGuardKey } from "./testFullCustomerCacheGuard
 
 /**
  * Delete FullCustomer from Redis cache across ALL regions.
- * Sets a guard key to prevent stale writes from in-flight requests.
- * This ensures cache consistency and prevents race conditions where
- * a stale cache in another region could be read after deletion.
  */
 export const deleteCachedFullCustomer = async ({
 	customerId,
@@ -28,14 +25,7 @@ export const deleteCachedFullCustomer = async ({
 }): Promise<void> => {
 	const { org, env, logger } = ctx;
 
-	if (redis.status !== "ready") {
-		logger.warn(
-			`[deleteCachedFullCustomer] Redis not ready, skipping deletion for ${customerId}`,
-		);
-		return;
-	}
-
-	if (!customerId) return;
+	if (redis.status !== "ready" || !customerId) return;
 
 	const testGuardKey = buildTestFullCustomerCacheGuardKey({
 		orgId: org.id,
@@ -54,23 +44,16 @@ export const deleteCachedFullCustomer = async ({
 	});
 
 	const regions = getConfiguredRegions();
+	const guardTimestamp = Date.now().toString();
 
-	try {
-		const guardTimestamp = Date.now().toString();
-
-		// Delete from all regions in parallel to avoid race conditions
-		const deletePromises = regions.map(async (region) => {
+	// Delete from all regions in parallel
+	const deletePromises = regions.map(async (region) => {
+		try {
 			const regionalRedis = getRegionalRedis(region);
 
-			// Check if this regional instance is ready
 			if (regionalRedis.status !== "ready") {
-				logger.warn(
-					`[deleteCachedFullCustomer] Redis not ready for region ${region}, skipping`,
-					{
-						data: { status: regionalRedis.status, customerId, region },
-					},
-				);
-				return { region, result: "SKIPPED_NOT_READY" as const };
+				logger.warn(`[deleteCachedFullCustomer] ${region}: not_ready`);
+				return;
 			}
 
 			const result = await regionalRedis.deleteFullCustomerCache(
@@ -81,32 +64,15 @@ export const deleteCachedFullCustomer = async ({
 				FULL_CUSTOMER_CACHE_GUARD_TTL_SECONDS.toString(),
 			);
 
-			return { region, result };
-		});
-
-		const results = await Promise.all(deletePromises);
-
-		const deletedCount = results.filter((r) => r.result === "DELETED").length;
-		const skippedCount = results.filter((r) => r.result === "SKIPPED").length;
-		const regionsSummary = results
-			.map((r) => `${r.region}: ${r.result}`)
-			.join(", ");
-
-		if (skippedCount > 0) {
 			logger.info(
-				`[deleteCachedFullCustomer] Test guard exists, skipped ${skippedCount} regions for ${customerId}`,
+				`[deleteCachedFullCustomer] ${region}: ${result}, customer: ${customerId}, source: ${source}`,
 			);
-		} else if (deletedCount > 0) {
-			logger.info(
-				`[deleteCachedFullCustomer] Deleted cache for ${customerId}, source: ${source}, regions: ${regionsSummary}`,
-			);
-		} else {
-			logger.debug(
-				`[deleteCachedFullCustomer] Cache key didn't exist for ${customerId}, source: ${source}`,
+		} catch (error) {
+			logger.error(
+				`[deleteCachedFullCustomer] ${region}: error, customer: ${customerId}, source: ${source}, error: ${error}`,
 			);
 		}
-	} catch (error) {
-		logger.error(`[deleteCachedFullCustomer] Error: ${error}`);
-		throw error;
-	}
+	});
+
+	await Promise.all(deletePromises);
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified and clarified Redis cache deletion logs across regions. Reduced noisy summaries, added concise per‑region messages, and made deletion paths more resilient.

- **Refactors**
  - Log per-region results for full-customer deletes; removed aggregate “skipped”/summary logs.
  - Removed source parameter from batchDeleteCachedFullCustomers and its caller.
  - Catch and log region errors without failing the whole delete; return total deleted count.
  - Shortened not-ready handling with early returns; keep parallel execution.
  - Switched Redis connection errors to console.error with a clear prefix.
  - Minor comment cleanup: “Invalidate cache after DB update.”

<sup>Written for commit 50eadabf28087823fa2274ea43c88434074bd9ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR refactors Redis cache deletion logging to improve clarity and resilience. The changes simplify logging by providing per-region messages instead of aggregate summaries, remove the `source` parameter from `batchDeleteCachedFullCustomers`, and improve error handling in `deleteCachedFullCustomer` by catching per-region errors.

## Key Changes

- **Bug fixes**: `deleteCachedFullCustomer` now catches and logs region-specific errors without failing the entire operation, making cache deletion more resilient to regional failures.

- **Improvements**: Logging has been simplified to show concise per-region results instead of noisy aggregate summaries. The `source` parameter has been removed from `batchDeleteCachedFullCustomers` to reduce verbosity.

- **Improvements**: Redis connection errors now use `console.error` with a clear `[Redis] Connection error:` prefix for better visibility.

The changes improve observability while making the cache deletion logic more fault-tolerant. However, there is a critical bug in `batchDeleteCachedFullCustomers` where pipeline errors will still cause the entire operation to fail across all regions.

### Confidence Score: 1/5

- Critical bug in error handling will cause regional failures to break entire deletion operation
- The PR introduces a critical bug in batchDeleteCachedFullCustomers where pipeline errors throw and break Promise.all, preventing other regions from completing deletion. This directly contradicts the PR's goal of making deletions more resilient. The fix in deleteCachedFullCustomer shows the correct pattern (per-region try-catch), but it wasn't applied to batchDeleteCachedFullCustomers.
- server/src/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.ts requires immediate attention for error handling

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/external/redis/initRedis.ts | 5/5 | Enabled Redis connection error logging with console.error |
| server/src/internal/customers/cusUtils/apiCusCacheUtils/batchDeleteCachedCustomers.ts | 5/5 | Removed source parameter from batchDeleteCachedFullCustomers call |
| server/src/internal/customers/cusUtils/apiCusCacheUtils/deleteCachedApiCustomer.ts | 5/5 | Removed unnecessary line breaks in deleteCachedFullCustomer call |
| server/src/internal/customers/cusUtils/cusUtils.ts | 5/5 | Updated comment to be more concise |
| server/src/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.ts | 1/5 | Refactored logging and removed source param; critical error handling bug where pipeline errors break all regions |
| server/src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.ts | 5/5 | Improved error handling with per-region try-catch blocks and simplified logging |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant batchDeleteCachedCustomers
    participant batchDeleteCachedFullCustomers
    participant Redis_USEast2
    participant Redis_USWest2
    
    Caller->>batchDeleteCachedCustomers: delete customers
    batchDeleteCachedCustomers->>batchDeleteCachedFullCustomers: delete full customer caches
    
    par Delete across regions
        batchDeleteCachedFullCustomers->>Redis_USEast2: pipeline.batchDeleteFullCustomerCache()
        batchDeleteCachedFullCustomers->>Redis_USWest2: pipeline.batchDeleteFullCustomerCache()
        Redis_USEast2-->>batchDeleteCachedFullCustomers: {deleted, skipped}
        Note over batchDeleteCachedFullCustomers,Redis_USEast2: ⚠️ Error here breaks all regions
        Redis_USWest2-->>batchDeleteCachedFullCustomers: {deleted, skipped}
    end
    
    batchDeleteCachedFullCustomers-->>batchDeleteCachedCustomers: total deleted count
    
    par Delete API customer cache
        batchDeleteCachedCustomers->>Redis_USEast2: pipeline.batchDeleteCustomers()
        batchDeleteCachedCustomers->>Redis_USWest2: pipeline.batchDeleteCustomers()
        Redis_USEast2-->>batchDeleteCachedCustomers: deleted count
        Redis_USWest2-->>batchDeleteCachedCustomers: deleted count
    end
    
    batchDeleteCachedCustomers-->>Caller: total deleted count
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->