### PR TITLE
fix: cron warmup redis

### DIFF
--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -1,5 +1,7 @@
 import { initInfisical } from "./external/infisical/initInfisical.js";
+import { warmupRegionalRedis } from "./external/redis/initRedis.js";
 
 await initInfisical();
+await warmupRegionalRedis();
 
 await import("./cron/cronInit.js");

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.ts
@@ -64,7 +64,7 @@ export const batchDeleteCachedFullCustomers = async ({
 		const regionalRedis = getRegionalRedis(region);
 
 		if (regionalRedis.status !== "ready") {
-			log.warn(`[batchDeleteCachedFullCustomers] ${region}: not_ready`);
+			console.warn(`[batchDeleteCachedFullCustomers] ${region}: not_ready`);
 			return 0;
 		}
 
@@ -88,7 +88,7 @@ export const batchDeleteCachedFullCustomers = async ({
 			}
 		}
 
-		log.info(
+		console.info(
 			`[batchDeleteCachedFullCustomers] ${region}: deleted ${deleted} keys, customers (${customers.length}), orgs (${customersByOrg.size})`,
 		);
 		return deleted;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Warm up regional Redis connections during cron startup to ensure Redis is ready before jobs run. This reduces startup errors and noisy "not_ready" logs.

- **Bug Fixes**
  - Added warmupRegionalRedis to initialize and wait for all configured Redis regions (10s timeout) before starting cron tasks.
  - Warmup logs connection status and does not block startup if a region fails.
  - Invoked warmup in cron.ts after Infisical init.
  - Switched batchDeleteCachedFullCustomers logging to console.warn/info.

<sup>Written for commit 2be9a4d119a1eb303ce417d164d0984a04e419ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds Redis connection warmup functionality to the cron startup process to prevent "not_ready" errors when cron jobs begin executing.

## Key Changes

**Bug fixes:**
- Added `warmupRegionalRedis()` function that initializes and waits for all configured Redis regions (us-east-2, us-west-2) to be ready before starting cron tasks
- Warmup uses a 10-second timeout per region and gracefully handles failures without blocking startup
- Changed `batchDeleteCachedFullCustomers` logging from Logtail logger to console for consistency with other Redis initialization logs

## Implementation Details

The warmup flow ensures Redis connections are established before cron jobs execute:
1. `cron.ts` calls `warmupRegionalRedis()` after Infisical initialization
2. For each configured region, it calls `getRegionalRedis()` to get/create the instance
3. `waitForRedisReady()` waits up to 10 seconds for each instance to reach "ready" state
4. If any region fails to connect, it logs an error but continues (non-blocking)
5. Only after warmup completes (or times out) do cron jobs start via `cronInit.js`

This prevents the race condition where cron jobs would attempt to use Redis before connections were established, causing errors and noisy logs.

## Review Notes

The implementation is generally solid with appropriate error handling and graceful degradation. Two minor style improvements are suggested:
1. Event listener cleanup in `waitForRedisReady` to prevent potential memory leaks
2. Removing the now-unused `logger` parameter from `batchDeleteCachedFullCustomers`

The warmup approach properly addresses the stated problem without introducing breaking changes or blocking startup if Redis is unavailable.

### Confidence Score: 4/5

- This PR is safe to merge with minimal risk - it improves startup reliability without introducing breaking changes
- Score reflects that the implementation is sound with proper error handling and graceful degradation. The warmup logic correctly prevents race conditions during cron startup. Two minor style improvements were identified (event listener cleanup and unused parameter) but these don't affect functionality or safety. No logic errors or security issues were found.
- Pay attention to server/src/external/redis/initRedis.ts for the event listener cleanup suggestion, though the current implementation is functional

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/cron.ts | 5/5 | Added warmupRegionalRedis call to ensure Redis is ready before cron jobs start. Change is straightforward and correct. |
| server/src/external/redis/initRedis.ts | 3/5 | Added waitForRedisReady and warmupRegionalRedis functions. Event listener cleanup issue could cause minor memory leak. |
| server/src/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.ts | 5/5 | Changed logging from log.warn/info to console.warn/info for consistency. Logger parameter now unused but not harmful. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as cron.ts
    participant Infisical
    participant WarmupFn as warmupRegionalRedis
    participant GetRegions as getConfiguredRegions
    participant GetRedis as getRegionalRedis
    participant WaitFn as waitForRedisReady
    participant Redis as Redis Instance
    participant CronInit as cronInit.ts

    Cron->>Infisical: await initInfisical()
    Infisical-->>Cron: Initialized
    
    Cron->>WarmupFn: await warmupRegionalRedis()
    WarmupFn->>GetRegions: getConfiguredRegions()
    GetRegions-->>WarmupFn: [us-east-2, us-west-2]
    
    par For each region
        WarmupFn->>GetRedis: getRegionalRedis(region)
        GetRedis-->>WarmupFn: Redis instance
        WarmupFn->>WaitFn: waitForRedisReady(instance, region, 10000ms)
        
        alt Instance already ready
            WaitFn-->>WarmupFn: resolve immediately
        else Instance connecting
            WaitFn->>Redis: Listen for 'ready' event
            WaitFn->>Redis: Listen for 'error' event
            alt Connection succeeds
                Redis-->>WaitFn: 'ready' event
                WaitFn-->>WarmupFn: resolve
            else Connection fails or timeout
                Redis-->>WaitFn: 'error' event or timeout
                WaitFn-->>WarmupFn: reject (caught, logged)
            end
        end
    end
    
    WarmupFn-->>Cron: All warmups complete
    Cron->>CronInit: await import("./cron/cronInit.js")
    CronInit-->>Cron: Cron jobs started
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->