### PR TITLE
fix: warmup init

### DIFF
--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -1,7 +1,7 @@
 import { initInfisical } from "./external/infisical/initInfisical.js";
-import { warmupRegionalRedis } from "./external/redis/initRedis.js";
 
 await initInfisical();
+const { warmupRegionalRedis } = await import("./external/redis/initRedis.js");
 await warmupRegionalRedis();
 
 await import("./cron/cronInit.js");


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix startup order so Redis warmup runs only after Infisical is initialized. Switched the top‑level import to a dynamic import to ensure secrets are loaded before warming up Redis.

<sup>Written for commit 118b88bce4fe5a9c1262fe7429b4b3732137434a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a critical startup order bug in the cron service where Redis initialization attempted to access environment variables before Infisical loaded the secrets.

## Key Changes

**Bug fixes:**
- Converted the `warmupRegionalRedis` import from a static top-level import to a dynamic import that executes after `initInfisical()` completes
- This ensures `CACHE_URL` and other Redis-related environment variables are available when `initRedis.ts` validates their presence

## Analysis

**Root Cause:**
The previous implementation imported `initRedis.ts` at the top of the file, causing its module-level code to execute immediately—including the validation check for `CACHE_URL` at line 22. If this environment variable was only available through Infisical secrets (not in `.env`), the service would crash before secrets could be loaded.

**The Fix:**
By using a dynamic import (`await import("./external/redis/initRedis.js")`), the module loads only after `initInfisical()` completes and populates `process.env` with secrets. This ensures all required environment variables are available when Redis initialization validates them.

**Pattern Consistency:**
This change aligns with the established pattern used in other entry points:
- `index.ts`: Calls `initInfisical()` then dynamically imports `init.js`
- `workers.ts`: Calls `initInfisical()` then dynamically imports worker modules
- `cron.ts` (now): Calls `initInfisical()` then dynamically imports Redis and cron modules

The implementation is correct, minimal, and follows best practices for managing initialization order in Node.js applications with external secret management.

### Confidence Score: 5/5

- This PR is safe to merge with no risk
- The change is a focused, well-understood fix for a specific startup order issue. It follows established patterns from other entry points (index.ts, workers.ts), maintains proper error handling, and has no side effects on other parts of the codebase. The implementation correctly solves the problem of ensuring Infisical secrets are loaded before Redis initialization validates environment variables.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/cron.ts | 5/5 | Changed warmupRegionalRedis import from static to dynamic to ensure Infisical secrets load first. Implementation is correct and follows established patterns. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as cron.ts
    participant Infisical as initInfisical()
    participant Env as process.env
    participant Redis as initRedis.ts
    participant Warmup as warmupRegionalRedis()
    participant CronInit as cronInit.ts

    Note over Cron: Startup sequence
    Cron->>Infisical: await initInfisical()
    Infisical->>Env: Load secrets (including CACHE_URL)
    Infisical-->>Cron: Secrets loaded
    
    Note over Cron: Dynamic import (after secrets loaded)
    Cron->>Redis: await import("./external/redis/initRedis.js")
    Note over Redis: Module loads, validates CACHE_URL exists
    Redis->>Env: Check process.env.CACHE_URL
    Env-->>Redis: CACHE_URL available
    Redis->>Redis: Create primary Redis connection
    Redis-->>Cron: Export { warmupRegionalRedis }
    
    Cron->>Warmup: await warmupRegionalRedis()
    Warmup->>Warmup: Pre-warm regional Redis connections
    Warmup-->>Cron: Warmup complete
    
    Cron->>CronInit: await import("./cron/cronInit.js")
    CronInit->>CronInit: Start cron jobs
    Note over Cron,CronInit: Cron service fully initialized
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->