### PR TITLE
fix: removed redis warmup

### DIFF
--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -1,7 +1,5 @@
 import { initInfisical } from "./external/infisical/initInfisical.js";
 
 await initInfisical();
-const { warmupRegionalRedis } = await import("./external/redis/initRedis.js");
-await warmupRegionalRedis();
 
 await import("./cron/cronInit.js");


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed Redis warmup from the cron startup to avoid unnecessary initialization and reduce startup failures when regional Redis isn’t available. The cron service now initializes Infisical and loads scheduled jobs without pre-warming Redis.

<sup>Written for commit f0cb4c08aee57b34abc4b6536ae4ad44a5297340. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR removes the Redis warmup step from the cron service initialization. Previously, the cron service pre-warmed all regional Redis connections on startup to ensure they were ready before processing began.

**Key Changes:**
- **Bug fixes**: Removed `warmupRegionalRedis()` call from `cron.ts` startup sequence
- **Improvements**: Simplified cron initialization by removing unnecessary warmup step

**Impact:**
The cron service now relies on lazy-loaded Redis connections via `getRegionalRedis()`, which creates connections on-demand when first accessed. The cron jobs (`cronTask`, `runProductCron`, `runInvoiceCron`) use Redis through `batchDeleteCachedCustomers`, which already has graceful degradation built in - it checks `redis.status !== "ready"` and logs a warning if Redis is unavailable rather than failing.

**Rationale:**
According to the PR description, this change avoids unnecessary initialization and reduces startup failures when regional Redis isn't available. The lazy-loading approach means Redis connections are only established when actually needed, and the existing error handling ensures the cron jobs can continue even if Redis is temporarily unavailable.

### Confidence Score: 5/5

- Safe to merge - existing fallback logic handles Redis unavailability gracefully
- The change removes a pre-warming step but the codebase already has proper lazy-loading and error handling. The batchDeleteCachedCustomers function checks redis.status and logs warnings instead of throwing errors when Redis isn't ready. The lazy-loading pattern in getRegionalRedis() means connections are still established when needed.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| server/src/cron.ts | 5/5 | Removed Redis warmup call from cron startup. The cron service will now rely on lazy-loaded Redis connections when needed, with graceful degradation if Redis is unavailable. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as cron.ts
    participant Infisical as initInfisical
    participant CronInit as cronInit.js
    participant CronJobs as Cron Jobs
    participant Redis as Redis (lazy)
    
    Note over Cron: OLD: With warmup
    Cron->>Infisical: initInfisical()
    Cron->>Redis: warmupRegionalRedis()
    Note over Redis: Pre-establish all<br/>regional connections
    Redis-->>Cron: Connections ready
    Cron->>CronInit: import cronInit.js
    CronInit->>CronJobs: Start cron tasks
    CronJobs->>Redis: Use Redis (already warmed)
    
    Note over Cron: NEW: Without warmup
    Cron->>Infisical: initInfisical()
    Cron->>CronInit: import cronInit.js
    CronInit->>CronJobs: Start cron tasks
    CronJobs->>Redis: batchDeleteCachedCustomers()
    Note over Redis: First call triggers<br/>lazy connection
    Redis-->>CronJobs: Connection established<br/>or graceful fallback
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->