### PR TITLE
fix: redis floating point error

### DIFF
--- a/server/src/internal/balances/track/utils/handleRedisTrackError.ts
+++ b/server/src/internal/balances/track/utils/handleRedisTrackError.ts
@@ -27,6 +27,7 @@ export const handleRedisTrackError = async ({
 	body: TrackParams;
 	featureDeductions: FeatureDeduction[];
 }): Promise<TrackResponseV2> => {
+	ctx.logger.warn(`Redis track error: ${error.message}`);
 	if (!(error instanceof RedisDeductionError)) {
 		throw error;
 	}

--- a/server/src/internal/balances/utils/deduction/executeRedisDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/executeRedisDeduction.ts
@@ -122,6 +122,12 @@ export const executeRedisDeduction = async ({
 
 		const resultJson = JSON.parse(result) as LuaDeductionResult;
 
+		// if (resultJson.logs && resultJson.logs.length > 0) {
+		// 	ctx.logger.debug(
+		// 		`[executeRedisDeduction] Logs: ${resultJson.logs.join("\n")}`,
+		// 	);
+		// }
+
 		if (resultJson.error) {
 			throw new RedisDeductionError({
 				message: `Redis deduction failed: ${resultJson.error}`,
@@ -129,7 +135,7 @@ export const executeRedisDeduction = async ({
 			});
 		}
 
-		const { updates, rollover_updates, logs } = resultJson;
+		const { updates, rollover_updates } = resultJson;
 		logDeductionUpdates({
 			ctx,
 			fullCustomer,
@@ -139,10 +145,6 @@ export const executeRedisDeduction = async ({
 
 		allUpdates = { ...allUpdates, ...updates };
 		allRolloverUpdates = { ...allRolloverUpdates, ...rollover_updates };
-
-		// if (logs && logs.length > 0) {
-		// 	ctx.logger.debug(`[executeRedisDeduction] Logs: ${logs.join("\n")}`);
-		// }
 
 		// Handle paid allocated entitlements and update fullCus in memory
 		try {

--- a/server/src/queue/hatchetWorkflows/verifyCacheConsistencyWorkflow/verifyCacheConsistencyWorkflow.ts
+++ b/server/src/queue/hatchetWorkflows/verifyCacheConsistencyWorkflow/verifyCacheConsistencyWorkflow.ts
@@ -51,6 +51,7 @@ const checkSubscriptionsMatch = ({
 		const cachedSubscription = cachedCustomer.subscriptions.find(
 			(s) => s.plan_id === subscription.plan_id,
 		);
+
 		if (!cachedSubscription) {
 			return {
 				success: false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 22b8afebf0edcf3966c52ff4bcdf147c318fffe5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a floating point precision error in Redis-based balance deductions that could cause false INSUFFICIENT_BALANCE rejections.

## Key Changes

**Bug fixes:**
- Added `round_to_precision()` helper function in Lua script to round `remaining_amount` to 10 decimal places before the critical overage check
- Prevents scenarios where accumulated floating point errors (e.g., `0.0000000001` instead of `0`) incorrectly trigger insufficient balance errors in reject mode

**Improvements:**
- Added warning log in `handleRedisTrackError.ts` to track Redis deduction failures
- Cleaned up commented debug code in `executeRedisDeduction.ts` and removed unused `logs` variable
- Minor formatting improvements

## How It Works

The Lua deduction script performs multiple arithmetic operations including division (`remaining_amount -= deducted / credit_cost`) which accumulates floating point errors. Previously, when checking `if remaining_amount > 0` to determine if rejection should occur, tiny residual values like `1e-15` would incorrectly trigger INSUFFICIENT_BALANCE errors.

The fix applies rounding immediately before this critical check, ensuring that effectively-zero values are treated as exactly zero. The rounding uses 10 decimal places of precision, which is appropriate for currency and usage tracking.

## Areas for Future Enhancement

While the fix correctly addresses the rejection check, there are two comparison points that happen before rounding:
1. The loop early-exit condition (`remaining_amount == 0`) could still fail to break due to FP precision
2. The Pass 2 trigger condition (`remaining_amount ~= 0`) could unnecessarily run Pass 2

These are performance issues rather than correctness issues, as the safety checks in `calculate_change()` prevent incorrect deductions. Consider applying rounding earlier or using epsilon-based comparisons for these checks.

### Confidence Score: 4/5

- This PR is safe to merge with minor style improvements recommended
- The core fix correctly addresses a real floating point precision bug that could cause false rejections. The rounding function is mathematically sound and applied at the critical decision point. However, the score is 4 rather than 5 due to: (1) exact equality checks before rounding that could cause minor performance issues, (2) trailing whitespace, and (3) commented code that should be cleaned up. These are all style/optimization issues rather than correctness problems.
- The main Lua script (deductFromCustomerEntitlements.lua) would benefit from applying rounding earlier to improve loop efficiency, but the current implementation is functionally correct.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/_luaScriptsV2/deductFromCustomerEntitlements/deductFromCustomerEntitlements.lua | 4/5 | Added round_to_precision function to fix floating point errors before INSUFFICIENT_BALANCE check. Minor style issues: exact equality checks before rounding could cause unnecessary processing, trailing whitespace. |
| src/internal/balances/track/utils/handleRedisTrackError.ts | 5/5 | Added warning log for Redis track errors. Simple, safe logging addition with no issues. |
| src/internal/balances/utils/deduction/executeRedisDeduction.ts | 5/5 | Cleaned up commented code and removed unused 'logs' variable from destructuring. Commented debug code could be removed for maintainability. |
| src/queue/hatchetWorkflows/verifyCacheConsistencyWorkflow/verifyCacheConsistencyWorkflow.ts | 5/5 | Added blank line for formatting. No functional changes, no issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Redis
    participant Lua as deductFromCustomerEntitlements.lua
    participant TS as executeRedisDeduction.ts
    participant Error as handleRedisTrackError.ts
    
    Client->>TS: Track usage request
    TS->>Redis: Execute Lua script
    Redis->>Lua: Process deduction
    
    Note over Lua: Step 1: Initialize remaining_amount
    Note over Lua: Step 2: Deduct from rollovers
    Note over Lua: Step 3: Pass 1 - Deduct (floor at 0)
    Note over Lua: remaining_amount -= (deducted / credit_cost)
    Note over Lua: ⚠️ Floating point errors accumulate
    
    Note over Lua: Step 4: Pass 2 - Usage allowed check
    Note over Lua: Step 5: 🔧 NEW: round_to_precision(remaining_amount, 10)
    
    alt remaining_amount > 0 AND reject mode
        Lua-->>Redis: Return INSUFFICIENT_BALANCE error
        Redis-->>TS: Error result
        TS->>Error: Handle Redis error
        Error-->>Client: InsufficientBalanceError
    else Success
        Lua-->>Redis: Return updates
        Redis-->>TS: Success result
        TS-->>Client: Track response
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->