### PR TITLE
chore: updated conductor setup

### DIFF
--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -118,13 +118,13 @@ else
     echo "⚠️  Warning: $ROOT_PATH/server/shell directory not found"
 fi
 
-# # Copy drizzle migration files
-# if [ -d "$ROOT_PATH/shared/drizzle" ]; then
-#     echo "📋 Copying database migration files..."
-#     mkdir -p shared/drizzle
-#     cp -r "$ROOT_PATH/shared/drizzle/"* shared/drizzle/
-#     echo "✅ Copied migration files"
-# fi
+# Copy drizzle migration files
+if [ -d "$ROOT_PATH/shared/drizzle" ]; then
+    echo "📋 Copying database migration files..."
+    mkdir -p shared/drizzle
+    cp -r "$ROOT_PATH/shared/drizzle/"* shared/drizzle/
+    echo "✅ Copied migration files"
+fi
 
 # Shared workspace is now used directly from source (no build needed)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Setup script update**
> 
> - Activates copying of `shared/drizzle` migration files into `shared/drizzle/` during `conductor-setup.sh` execution to include database migrations in the workspace setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 710bfc44aa4f6b47059c6caaac54b0ca1e72373a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Re-enabled copying of Drizzle migration files in conductor-setup.sh so migrations are included during setup. Ensures local and CI environments have the latest schema changes by copying from source shared/drizzle to the workspace.

<sup>Written for commit 710bfc44aa4f6b47059c6caaac54b0ca1e72373a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

## Key Changes

**Bug fixes**
- Re-enabled copying of database migration files from `shared/drizzle/` to workspace during Conductor setup (lines 121-127)

## Context

This PR uncomments a previously disabled section that copies Drizzle ORM migration files into the Conductor workspace. The migration files are generated by `drizzle-kit generate` and contain SQL schema definitions needed to set up the database.

The code was originally commented out in commit `0b23d8bc` (Oct 11, 2025), and this PR re-enables it to ensure database migrations are available in both local and CI environments during workspace setup.

## Issue Found

The implementation has a **critical logic error** that will cause the setup script to fail in common scenarios:

The `cp` command on line 125 uses a glob pattern (`"$ROOT_PATH/shared/drizzle/"*`) which will fail if the directory exists but is empty. Since:
1. The script has `set -e` enabled (exits on any error)
2. The `shared/drizzle` directory is gitignored (not tracked in version control)
3. Migration files are generated dynamically by running `bun db:generate`

The script will fail with "No such file or directory" if migrations haven't been generated yet, even though the directory check on line 122 passes. This breaks the setup process for fresh clones or when migrations haven't been pre-generated.

### Confidence Score: 2/5

- This PR has a critical bug that will cause setup failures in production scenarios
- The change re-enables a necessary feature (copying migration files), but the implementation has a logic error that will cause the script to fail when the drizzle directory exists but is empty. Given that this directory is gitignored and migrations are generated dynamically, this is a likely scenario that will break the setup process for fresh clones or new developers. The script uses 'set -e' which means any error causes immediate exit, making this a blocking issue.
- conductor-setup.sh requires immediate attention - the cp command on line 125 needs proper error handling to prevent script failures

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| conductor-setup.sh | 3/5 | Re-enabled copying of drizzle migration files from source to workspace. Critical issue: cp command will fail if shared/drizzle directory is empty or doesn't exist, causing script to exit due to 'set -e' |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ConductorSetup as conductor-setup.sh
    participant RootRepo as Root Repository
    participant Workspace as Conductor Workspace
    participant DrizzleKit as drizzle-kit

    User->>ConductorSetup: Run setup script
    ConductorSetup->>ConductorSetup: Check Bun installation
    ConductorSetup->>ConductorSetup: Determine ROOT_PATH
    ConductorSetup->>Workspace: bun install (dependencies)
    
    ConductorSetup->>RootRepo: Copy .env files
    RootRepo-->>Workspace: server/.env*, vite/.env*, shared/.env*
    
    ConductorSetup->>RootRepo: Copy shell scripts
    RootRepo-->>Workspace: *.sh files
    
    Note over ConductorSetup,RootRepo: NEW: Migration files copy (re-enabled in this PR)
    ConductorSetup->>RootRepo: Check shared/drizzle exists
    alt Directory exists but empty
        ConductorSetup->>RootRepo: cp -r shared/drizzle/*
        RootRepo-->>ConductorSetup: ERROR: No such file or directory
        ConductorSetup->>User: ❌ Script exits (set -e)
    else Directory has files
        RootRepo-->>Workspace: Copy migration files
        ConductorSetup->>User: ✅ Setup complete
    end
    
    Note over User,DrizzleKit: Migrations are generated separately by:<br/>bun db:generate (runs drizzle-kit generate)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->