### PR TITLE
fix: ui balance bug

### DIFF
--- a/shared/utils/cusProductUtils/convertCusProduct.ts
+++ b/shared/utils/cusProductUtils/convertCusProduct.ts
@@ -55,11 +55,20 @@ export const cusProductsToCusPrices = ({
 export const cusProductsToCusEnts = ({
 	cusProducts,
 	featureIds,
+	inStatuses,
 }: {
 	cusProducts: FullCusProduct[];
 	featureIds?: string[];
+	inStatuses?: CusProductStatus[];
 }) => {
 	let cusEnts: FullCusEntWithFullCusProduct[] = [];
+
+	cusProducts = cusProducts.filter((cusProduct) => {
+		if (inStatuses) {
+			return inStatuses.includes(cusProduct.status);
+		}
+		return true;
+	});
 
 	for (const cusProduct of cusProducts) {
 		cusEnts.push(

--- a/vite/src/views/customers2/hooks/useFeatureUsageBalance.ts
+++ b/vite/src/views/customers2/hooks/useFeatureUsageBalance.ts
@@ -1,4 +1,5 @@
 import {
+	ACTIVE_STATUSES,
 	cusEntsToAllowance,
 	cusEntsToBalance,
 	cusEntsToGrantedBalance,
@@ -36,6 +37,7 @@ export function useFeatureUsageBalance({
 	const cusEnts = cusProductsToCusEnts({
 		cusProducts,
 		featureIds: [featureId],
+		inStatuses: ACTIVE_STATUSES,
 	});
 
 	//without manual update adjustment, no rollovers


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 35cda21bc4a62631b0426a20442b75e618ab78b6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix feature usage balances to exclude expired customer products, so the UI shows accurate current balances.

- **Bug Fixes**
  - Added inStatuses filter to cusProductsToCusEnts and used ACTIVE_STATUSES to include only active products.
  - Updated useFeatureUsageBalance to pass ACTIVE_STATUSES, preventing expired products from inflating balances.

<sup>Written for commit 35cda21bc4a62631b0426a20442b75e618ab78b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR successfully addresses the UI balance bug by filtering out expired customer products from feature usage balance calculations. The implementation adds status filtering capability to the `cusProductsToCusEnts` utility function and applies `ACTIVE_STATUSES` filter in the `useFeatureUsageBalance` hook.

## Key Changes
- **Bug fixes**: Added `inStatuses` parameter to `cusProductsToCusEnts` function, enabling filtering of customer products by status
- **Bug fixes**: Updated `useFeatureUsageBalance` to pass `ACTIVE_STATUSES` (Active, PastDue), preventing expired products from inflating displayed balances in the UI

## Implementation Details
The changes follow existing patterns in the codebase - `cusProductsToCusPrices` already implemented the same `inStatuses` filtering pattern, so this brings consistency across utility functions.

The filtering approach uses `.filter()` before the main loop (lines 66-71), which differs slightly from the `continue` approach used in `cusProductsToCusPrices` but is functionally equivalent and arguably cleaner.

## Considerations
One area to verify: `ACTIVE_STATUSES` includes only `Active` and `PastDue` statuses, which excludes not just `Expired` products but also `Trialing` and `Scheduled` products. This may be intentional, but worth confirming that trial users shouldn't see their balances in the UI.

The change affects 3 call sites:
1. ✅ `useFeatureUsageBalance` (this PR) - now filters for active statuses
2. ✅ `checkForMisingBalance` - doesn't pass inStatuses, so includes all statuses except those already filtered (line 37 filters out Scheduled)
3. ✅ Other backend usages appropriately filter as needed

### Confidence Score: 4/5

- This PR is generally safe to merge with low risk, addressing the core issue of excluding expired products from UI balance calculations
- The implementation is clean, follows existing patterns in the codebase, and successfully filters out expired products. Score of 4 rather than 5 because there's a question about whether Trialing status products should be included in balance calculations - this needs product/business logic confirmation to ensure the behavior aligns with user expectations for trial users
- Pay attention to vite/src/views/customers2/hooks/useFeatureUsageBalance.ts to verify that excluding Trialing products from balance calculations is the intended behavior

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| shared/utils/cusProductUtils/convertCusProduct.ts | 4/5 | Added inStatuses parameter to cusProductsToCusEnts for filtering customer products by status, consistent with existing cusProductsToCusPrices function |
| vite/src/views/customers2/hooks/useFeatureUsageBalance.ts | 3/5 | Added ACTIVE_STATUSES filter to exclude expired products from balance calculations, but also excludes Trialing products which may need review |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as UI Component
    participant Hook as useFeatureUsageBalance
    participant Convert as cusProductsToCusEnts
    participant Filter as Status Filter
    participant Calc as Balance Calculators

    UI->>Hook: Call with cusProducts, featureId
    Hook->>Convert: cusProductsToCusEnts(cusProducts, featureIds, ACTIVE_STATUSES)
    Convert->>Filter: Filter cusProducts by inStatuses
    Filter->>Filter: Check if status in [Active, PastDue]
    Filter-->>Convert: Filtered cusProducts
    Convert->>Convert: Map to cusEnts with customer_product
    Convert->>Convert: Filter by featureIds
    Convert->>Convert: Sort cusEnts for deduction
    Convert-->>Hook: Filtered cusEnts
    Hook->>Calc: cusEntsToAllowance(cusEnts)
    Calc-->>Hook: initialAllowance
    Hook->>Calc: cusEntsToGrantedBalance(cusEnts)
    Calc-->>Hook: allowance
    Hook->>Calc: cusEntsToPrepaidQuantity(cusEnts)
    Calc-->>Hook: prepaidAllowance
    Hook->>Calc: cusEntsToBalance(cusEnts)
    Calc-->>Hook: balance
    Hook-->>UI: Return balance metrics
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->