### PR TITLE
fix: frontend full cus ent types

### DIFF
--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -1,5 +1,5 @@
 import type {
-	FullCusEntWithOptionalProduct,
+	FullCusEntWithFullCusProduct,
 	FullCusProduct,
 } from "@autumn/shared";
 import { Table } from "@/components/general/table";
@@ -16,10 +16,10 @@ export function CustomerBalanceTable({
 	aggregatedMap,
 	isLoading,
 }: {
-	allEnts: FullCusEntWithOptionalProduct[];
+	allEnts: FullCusEntWithFullCusProduct[];
 	filteredCustomerProducts: FullCusProduct[];
 	entityId: string | null;
-	aggregatedMap: Map<string, FullCusEntWithOptionalProduct[]>;
+	aggregatedMap: Map<string, FullCusEntWithFullCusProduct[]>;
 	isLoading: boolean;
 }) {
 	const { customer } = useCusQuery();
@@ -41,13 +41,13 @@ export function CustomerBalanceTable({
 	});
 
 	const enableSorting = false;
-	const table = useCustomerTable<FullCusEntWithOptionalProduct>({
+	const table = useCustomerTable<FullCusEntWithFullCusProduct>({
 		data: allEnts,
 		columns,
 		options: {},
 	});
 
-	const handleRowClick = (ent: FullCusEntWithOptionalProduct) => {
+	const handleRowClick = (ent: FullCusEntWithFullCusProduct) => {
 		const featureId = ent.entitlement.feature.id;
 		const ents = aggregatedMap.get(featureId) || [ent];
 		const hasMultipleBalances = ents.length > 1;

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -1,6 +1,6 @@
 import type {
 	Entity,
-	FullCusEntWithOptionalProduct,
+	FullCusEntWithFullCusProduct,
 	FullCusProduct,
 } from "@autumn/shared";
 import type { Row } from "@tanstack/react-table";
@@ -17,7 +17,7 @@ function UsageCell({
 	filteredCustomerProducts,
 	entityId,
 }: {
-	ent: FullCusEntWithOptionalProduct;
+	ent: FullCusEntWithFullCusProduct;
 	filteredCustomerProducts: FullCusProduct[];
 	entityId: string | null;
 }) {
@@ -67,7 +67,7 @@ function BarCell({
 	filteredCustomerProducts,
 	entityId,
 }: {
-	ent: FullCusEntWithOptionalProduct;
+	ent: FullCusEntWithFullCusProduct;
 	filteredCustomerProducts: FullCusProduct[];
 	entityId: string | null;
 }) {
@@ -92,9 +92,7 @@ function BarCell({
 	return (
 		<div className="flex gap-3 items-center">
 			{hasExpiry ? (
-				<span
-					className="text-t3 text-tiny flex justify-center !px-1 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-md min-w-30"
-				>
+				<span className="text-t3 text-tiny flex justify-center !px-1 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-md min-w-30">
 					Expires {formatUnixToDateTimeString(ent.expires_at)}
 				</span>
 			) : (
@@ -132,7 +130,7 @@ export const CustomerBalanceTableColumns = ({
 }: {
 	filteredCustomerProducts: FullCusProduct[];
 	entityId: string | null;
-	aggregatedMap: Map<string, FullCusEntWithOptionalProduct[]>;
+	aggregatedMap: Map<string, FullCusEntWithFullCusProduct[]>;
 	entities?: unknown[];
 }) => [
 	{
@@ -140,7 +138,7 @@ export const CustomerBalanceTableColumns = ({
 		accessorKey: "feature",
 		enableResizing: true,
 		minSize: 100,
-		cell: ({ row }: { row: Row<FullCusEntWithOptionalProduct> }) => {
+		cell: ({ row }: { row: Row<FullCusEntWithFullCusProduct> }) => {
 			const ent = row.original;
 			const featureId = ent.entitlement.feature.id;
 			const originalEnts = aggregatedMap.get(featureId);
@@ -171,7 +169,7 @@ export const CustomerBalanceTableColumns = ({
 	{
 		header: "Usage",
 		accessorKey: "usage",
-		cell: ({ row }: { row: Row<FullCusEntWithOptionalProduct> }) => (
+		cell: ({ row }: { row: Row<FullCusEntWithFullCusProduct> }) => (
 			<UsageCell
 				ent={row.original}
 				filteredCustomerProducts={filteredCustomerProducts}
@@ -183,7 +181,7 @@ export const CustomerBalanceTableColumns = ({
 		header: "Bar",
 		size: 220,
 		accessorKey: "bar",
-		cell: ({ row }: { row: Row<FullCusEntWithOptionalProduct> }) => (
+		cell: ({ row }: { row: Row<FullCusEntWithFullCusProduct> }) => (
 			<BarCell
 				ent={row.original}
 				filteredCustomerProducts={filteredCustomerProducts}

--- a/vite/src/views/customers2/components/table/customer-boolean-balance/CustomerBooleanBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-boolean-balance/CustomerBooleanBalanceTable.tsx
@@ -1,4 +1,4 @@
-import type { FullCusEntWithOptionalProduct } from "@autumn/shared";
+import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
 import { useMemo } from "react";
 import { Table } from "@/components/general/table";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
@@ -9,8 +9,8 @@ export function CustomerBooleanBalanceTable({
 	aggregatedMap,
 	isLoading,
 }: {
-	allEnts: FullCusEntWithOptionalProduct[];
-	aggregatedMap: Map<string, FullCusEntWithOptionalProduct[]>;
+	allEnts: FullCusEntWithFullCusProduct[];
+	aggregatedMap: Map<string, FullCusEntWithFullCusProduct[]>;
 	isLoading: boolean;
 }) {
 	const columns = useMemo(
@@ -22,7 +22,7 @@ export function CustomerBooleanBalanceTable({
 	);
 
 	const enableSorting = false;
-	const table = useCustomerTable<FullCusEntWithOptionalProduct>({
+	const table = useCustomerTable<FullCusEntWithFullCusProduct>({
 		data: allEnts,
 		columns,
 		options: {},

--- a/vite/src/views/customers2/components/table/customer-boolean-balance/CustomerBooleanBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-boolean-balance/CustomerBooleanBalanceTableColumns.tsx
@@ -1,17 +1,17 @@
-import type { FullCusEntWithOptionalProduct } from "@autumn/shared";
+import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
 import type { Row } from "@tanstack/react-table";
 import { CustomerFeatureConfiguration } from "../customer-feature-usage/CustomerFeatureConfiguration";
 
 export const CustomerBooleanBalanceTableColumns = ({
 	aggregatedMap,
 }: {
-	aggregatedMap: Map<string, FullCusEntWithOptionalProduct[]>;
+	aggregatedMap: Map<string, FullCusEntWithFullCusProduct[]>;
 }) => [
 	{
 		header: "Feature",
 		size: 200,
 		accessorKey: "feature",
-		cell: ({ row }: { row: Row<FullCusEntWithOptionalProduct> }) => {
+		cell: ({ row }: { row: Row<FullCusEntWithFullCusProduct> }) => {
 			const ent = row.original;
 			const featureId = ent.entitlement.feature.id;
 			const originalEnts = aggregatedMap.get(featureId);
@@ -36,7 +36,7 @@ export const CustomerBooleanBalanceTableColumns = ({
 		header: "Type",
 		size: 200,
 		accessorKey: "type",
-		cell: ({ row }: { row: Row<FullCusEntWithOptionalProduct> }) => {
+		cell: ({ row }: { row: Row<FullCusEntWithFullCusProduct> }) => {
 			const ent = row.original;
 
 			return (

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -1,6 +1,6 @@
 import type {
 	Entity,
-	FullCusEntWithOptionalProduct,
+	FullCusEntWithFullCusProduct,
 	FullCustomerEntitlement,
 } from "@autumn/shared";
 import { FeatureType, type FullCusProduct } from "@autumn/shared";
@@ -52,13 +52,13 @@ export function CustomerFeatureUsageTable() {
 		);
 	}, [customer?.customer_products, customer?.entities, entityId]);
 
-	const cusEnts = useMemo((): FullCusEntWithOptionalProduct[] => {
+	const cusEnts = useMemo((): FullCusEntWithFullCusProduct[] => {
 		const productEnts = flattenCustomerEntitlements({
 			customerProducts: filteredCustomerProducts,
 		});
 
 		// Add extra entitlements (loose entitlements not tied to a product)
-		const extraEnts: FullCusEntWithOptionalProduct[] = (
+		const extraEnts: FullCusEntWithFullCusProduct[] = (
 			customer?.extra_customer_entitlements || []
 		).map((ent: FullCustomerEntitlement) => ({
 			...ent,

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts
@@ -1,17 +1,17 @@
 import {
 	CusProductStatus,
-	type FullCusEntWithOptionalProduct,
+	type FullCusEntWithFullCusProduct,
 } from "@autumn/shared";
 
 export function filterCustomerFeatureUsage({
 	entitlements,
 	showExpired,
 }: {
-	entitlements: FullCusEntWithOptionalProduct[];
+	entitlements: FullCusEntWithFullCusProduct[];
 	showExpired: boolean;
-}): FullCusEntWithOptionalProduct[] {
+}): FullCusEntWithFullCusProduct[] {
 	return entitlements
-		.filter((ent: FullCusEntWithOptionalProduct) => {
+		.filter((ent: FullCusEntWithFullCusProduct) => {
 			if (showExpired) {
 				return true;
 			}
@@ -26,7 +26,7 @@ export function filterCustomerFeatureUsage({
 			);
 		})
 		.sort(
-			(a: FullCusEntWithOptionalProduct, b: FullCusEntWithOptionalProduct) => {
+			(a: FullCusEntWithFullCusProduct, b: FullCusEntWithFullCusProduct) => {
 				const aStatus = a.customer_product?.status;
 				const bStatus = b.customer_product?.status;
 

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTypes.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTypes.ts
@@ -1,7 +1,7 @@
 import type {
 	EntitlementWithFeature,
 	Feature,
-	FullCusEntWithOptionalProduct,
+	FullCusEntWithFullCusProduct,
 	FullCusProduct,
 } from "@autumn/shared";
 
@@ -19,7 +19,7 @@ export interface CreditSystemSubRow {
 	/** The metered feature details (looked up from features map) */
 	feature?: Feature;
 	/** The customer entitlement for this metered feature with usage data */
-	meteredCusEnt?: FullCusEntWithOptionalProduct;
+	meteredCusEnt?: FullCusEntWithFullCusProduct;
 	/** Flag to identify this as a subrow */
 	isSubRow: true;
 	/** Parent entitlement (inherited for table context) */
@@ -39,9 +39,9 @@ export type CustomerFeatureUsageRowData =
 	| FullCusEntWithSubRows;
 
 /**
- * Extended version of FullCusEntWithOptionalProduct that includes optional subrows
+ * Extended version of FullCusEntWithFullCusProduct that includes optional subrows
  * for credit system features.
  */
-export type FullCusEntWithSubRows = FullCusEntWithOptionalProduct & {
+export type FullCusEntWithSubRows = FullCusEntWithFullCusProduct & {
 	subRows?: CustomerFeatureUsageRowData[];
 };

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
@@ -1,7 +1,7 @@
 import type {
 	CreditSchemaItem,
 	Feature,
-	FullCusEntWithOptionalProduct,
+	FullCusEntWithFullCusProduct,
 	FullCusProduct,
 	FullCustomerEntitlement,
 } from "@autumn/shared";
@@ -15,7 +15,7 @@ export function flattenCustomerEntitlements({
 	customerProducts,
 }: {
 	customerProducts: FullCusProduct[];
-}): FullCusEntWithOptionalProduct[] {
+}): FullCusEntWithFullCusProduct[] {
 	return customerProducts.flatMap((cp: FullCusProduct) =>
 		cp.customer_entitlements.map((e: FullCustomerEntitlement) => ({
 			...e,
@@ -40,9 +40,9 @@ export function createFeaturesMap({
  */
 export interface DeduplicatedEntitlementsResult {
 	/** Combined entitlements (one per feature) */
-	entitlements: FullCusEntWithOptionalProduct[];
+	entitlements: FullCusEntWithFullCusProduct[];
 	/** Mapping of featureId -> array of original entitlements that were aggregated */
-	aggregatedMap: Map<string, FullCusEntWithOptionalProduct[]>;
+	aggregatedMap: Map<string, FullCusEntWithFullCusProduct[]>;
 }
 
 /**
@@ -52,10 +52,10 @@ export function deduplicateEntitlements({
 	entitlements,
 	entityId,
 }: {
-	entitlements: FullCusEntWithOptionalProduct[];
+	entitlements: FullCusEntWithFullCusProduct[];
 	entityId?: string | null;
 }): DeduplicatedEntitlementsResult {
-	const featureMap = new Map<string, FullCusEntWithOptionalProduct[]>();
+	const featureMap = new Map<string, FullCusEntWithFullCusProduct[]>();
 
 	for (const ent of entitlements) {
 		const featureId = ent.entitlement.feature.id;
@@ -65,8 +65,8 @@ export function deduplicateEntitlements({
 		featureMap.get(featureId)?.push(ent);
 	}
 
-	const combined: FullCusEntWithOptionalProduct[] = [];
-	const aggregatedMap = new Map<string, FullCusEntWithOptionalProduct[]>();
+	const combined: FullCusEntWithFullCusProduct[] = [];
+	const aggregatedMap = new Map<string, FullCusEntWithFullCusProduct[]>();
 
 	for (const [featureId, ents] of featureMap.entries()) {
 		if (ents.length === 1) {
@@ -147,13 +147,13 @@ export function processNonBooleanEntitlements({
 	cusEnts,
 	featuresMap,
 }: {
-	entitlements: FullCusEntWithOptionalProduct[];
-	cusEnts: FullCusEntWithOptionalProduct[];
+	entitlements: FullCusEntWithFullCusProduct[];
+	cusEnts: FullCusEntWithFullCusProduct[];
 	featuresMap: Map<string, Feature>;
 }): FullCusEntWithSubRows[] {
 	// Create a map of feature id to customer entitlements for quick lookup
 	const featureIdToCusEnt = new Map(
-		cusEnts.map((ent: FullCusEntWithOptionalProduct) => [
+		cusEnts.map((ent: FullCusEntWithFullCusProduct) => [
 			ent.entitlement.feature.id,
 			ent,
 		]),
@@ -161,10 +161,10 @@ export function processNonBooleanEntitlements({
 
 	return entitlements
 		.filter(
-			(ent: FullCusEntWithOptionalProduct) =>
+			(ent: FullCusEntWithFullCusProduct) =>
 				ent.entitlement.feature.type !== FeatureType.Boolean,
 		)
-		.map((ent: FullCusEntWithOptionalProduct): FullCusEntWithSubRows => {
+		.map((ent: FullCusEntWithFullCusProduct): FullCusEntWithSubRows => {
 			if (ent.entitlement.feature.type === FeatureType.CreditSystem) {
 				const creditSchema = ent.entitlement.feature.config?.schema || [];
 				const subRows = creditSchema.map((schemaItem: CreditSchemaItem) => {
@@ -197,10 +197,10 @@ export function processNonBooleanEntitlements({
 export function filterBooleanEntitlements({
 	entitlements,
 }: {
-	entitlements: FullCusEntWithOptionalProduct[];
-}): FullCusEntWithOptionalProduct[] {
+	entitlements: FullCusEntWithFullCusProduct[];
+}): FullCusEntWithFullCusProduct[] {
 	return entitlements.filter(
-		(ent: FullCusEntWithOptionalProduct) =>
+		(ent: FullCusEntWithFullCusProduct) =>
 			ent.entitlement.feature.type === FeatureType.Boolean,
 	);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit afa4e694a017203ad33299b558a8a0ce83a56695. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

## Key Changes

**Bug fixes**
- Fixes type inconsistency by replacing all usages of the redundant `FullCusEntWithOptionalProduct` type with the canonical `FullCusEntWithFullCusProduct` type across 8 frontend files

## What Changed

This PR performs a straightforward type rename to eliminate a duplicate type definition. The `FullCusEntWithOptionalProduct` type was semantically identical to `FullCusEntWithFullCusProduct` (both had `customer_product: FullCusProductSchema.nullable()`), but the former was a redundant alias that was already removed from the shared package in PR #556.

### Files Updated

All changes are purely type-related with no logic modifications:

1. **Customer Balance Tables** - Updated type imports and usage in `CustomerBalanceTable.tsx` and `CustomerBalanceTableColumns.tsx`
2. **Boolean Balance Tables** - Updated type imports in `CustomerBooleanBalanceTable.tsx` and `CustomerBooleanBalanceTableColumns.tsx`
3. **Feature Usage Components** - Updated types in `CustomerFeatureUsageTable.tsx`, filters, types definitions, and utility functions

### Type Safety Verification

The code correctly handles the nullable `customer_product` field throughout:
- Uses optional chaining (`customer_product?.status`, `customer_product?.quantity`) 
- Explicitly checks for null (`!ent.customer_product`) to identify loose entitlements
- Preserves null values in aggregation logic (`customer_product: first.customer_product ? {...} : null`)

This ensures "loose entitlements" (extra customer entitlements not tied to a product) continue to work correctly with `customer_product: null`.

## Impact Assessment

**Low Risk** - This is a purely cosmetic type rename with zero behavioral changes:
- No runtime logic modified
- Type definitions are semantically identical
- All nullable customer_product usages properly handled
- No breaking changes to any APIs or interfaces

### Confidence Score: 5/5

- This PR is completely safe to merge with zero risk of introducing bugs or breaking changes
- Maximum confidence score is justified because: (1) This is a pure type rename with no logic changes whatsoever, (2) The old and new types are semantically identical - both define customer_product as nullable FullCusProduct, (3) All 8 files are updated consistently with no remaining references to the old type name, (4) The code properly handles nullable customer_product throughout using optional chaining and null checks, (5) No behavioral changes to loose entitlements or any other feature, (6) Type safety is maintained and the change aligns with the shared package which already removed the duplicate type
- No files require special attention - all changes are straightforward type renames

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx | 5/5 | Type import and usage changed from FullCusEntWithOptionalProduct to FullCusEntWithFullCusProduct - no logic changes |
| vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx | 5/5 | Type usage updated throughout columns definition, properly handles nullable customer_product |
| vite/src/views/customers2/components/table/customer-boolean-balance/CustomerBooleanBalanceTable.tsx | 5/5 | Type import and generic parameter updated - no logic changes |
| vite/src/views/customers2/components/table/customer-boolean-balance/CustomerBooleanBalanceTableColumns.tsx | 5/5 | Type usage updated in columns definition - simple rename only |
| vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx | 5/5 | Type import and usage updated, correctly creates loose entitlements with customer_product: null |
| vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTableFilters.ts | 5/5 | Type updated in filter function, properly handles nullable customer_product with optional chaining |
| vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageTypes.ts | 5/5 | Type updated in interface definitions and comments - documentation accurately reflects the change |
| vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts | 5/5 | Type updated throughout utility functions, deduplication logic correctly preserves nullable customer_product |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PR as PR #557
    participant Shared as @autumn/shared
    participant Frontend as Frontend Components
    
    Note over Dev,Frontend: Type Cleanup & Standardization
    
    Dev->>PR: Identifies redundant type FullCusEntWithOptionalProduct
    Note over PR: Both types had identical definitions:<br/>customer_product: FullCusProductSchema.nullable()
    
    PR->>Shared: No changes to shared types<br/>(FullCusEntWithOptionalProduct already removed)
    
    PR->>Frontend: Update CustomerBalanceTable.tsx
    Note over Frontend: Import & usage: FullCusEntWithOptionalProduct<br/>→ FullCusEntWithFullCusProduct
    
    PR->>Frontend: Update CustomerBalanceTableColumns.tsx
    Note over Frontend: Type parameters & function signatures updated
    
    PR->>Frontend: Update CustomerBooleanBalanceTable.tsx
    Note over Frontend: Generic types updated
    
    PR->>Frontend: Update CustomerBooleanBalanceTableColumns.tsx
    Note over Frontend: Row types updated
    
    PR->>Frontend: Update CustomerFeatureUsageTable.tsx
    Note over Frontend: cusEnts array type & extraEnts mapping updated
    
    PR->>Frontend: Update customerFeatureUsageTableFilters.ts
    Note over Frontend: Filter function signatures updated
    
    PR->>Frontend: Update customerFeatureUsageTypes.ts
    Note over Frontend: Interface & comment documentation updated
    
    PR->>Frontend: Update customerFeatureUsageUtils.ts
    Note over Frontend: Utility function types & return types updated
    
    Frontend-->>Dev: All 8 files consistently use FullCusEntWithFullCusProduct
    Note over Dev,Frontend: ✅ Type safety maintained<br/>✅ Nullable customer_product properly handled<br/>✅ Loose entitlements work correctly
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->