### PR TITLE
chore: x code samples utility

### DIFF
--- a/shared/api/_openapi/prevVersions/openapi1.2/balancesOpenApi1.2.0.ts
+++ b/shared/api/_openapi/prevVersions/openapi1.2/balancesOpenApi1.2.0.ts
@@ -1,26 +1,41 @@
 import { SuccessResponseSchema } from "../../../common/commonResponses.js";
 import { CreateBalanceParamsSchema } from "../../../models.js";
+import { xCodeSamplesLegacy } from "../../../utils/xCodeSamplesLegacy.js";
 
 export const balancesOpenApi = {
-    "/balances/create": {
-        post: {
-            summary: "Create Balance",
-            description:
-                "Create a new balance for a specific feature for a customer.",
-            tags: ["balances"],
-            requestBody: {
-                content: {
-                    "application/json": { schema: CreateBalanceParamsSchema },
-                },
-            },
-            responses: {
-                "200": {
-                    description: "Balance created successfully",
-                    content: {
-                        "application/json": { schema: SuccessResponseSchema },
-                    },
-                },
-            },
-        },
-    },
+	"/balances/create": {
+		post: {
+			summary: "Create Balance",
+			description:
+				"Create a new balance for a specific feature for a customer.",
+			tags: ["balances"],
+			requestBody: {
+				content: {
+					"application/json": {
+						schema: CreateBalanceParamsSchema,
+					},
+				},
+			},
+			responses: {
+				"200": {
+					description: "Balance created successfully",
+					content: {
+						"application/json": { schema: SuccessResponseSchema },
+					},
+				},
+			},
+
+			"x-codeSamples": xCodeSamplesLegacy({
+				methodPath: "balances.create",
+				example: {
+					customer_id: "cus_123",
+					feature_id: "api_tokens",
+					granted_balance: 100,
+					reset: {
+						interval: "month",
+					},
+				},
+			}),
+		},
+	},
 };

--- a/shared/api/_openapi/prevVersions/openapi1.2/openapi1.2.0.ts
+++ b/shared/api/_openapi/prevVersions/openapi1.2/openapi1.2.0.ts
@@ -5,7 +5,10 @@ import { createDocument } from "zod-openapi";
 import { CustomerDataSchema } from "../../../common/customerData.js";
 import { EntityDataSchema } from "../../../common/entityData.js";
 import { ApiCusProductV3Schema } from "../../../customers/cusPlans/previousVersions/apiCusProductV3.js";
-import { ApiCusFeatureV3Schema, ApiProductItemSchema } from "../../../models.js";
+import {
+	ApiCusFeatureV3Schema,
+	ApiProductItemSchema,
+} from "../../../models.js";
 import { balancesOpenApi } from "./balancesOpenApi1.2.0.js";
 import { coreOpenApi } from "./coreOpenApi.js";
 import { ApiCustomerWithMeta, customersOpenApi } from "./customersOpenApi.js";
@@ -13,6 +16,7 @@ import { ApiEntityWithMeta, entitiesOpenApi } from "./entitiesOpenApi.js";
 import { eventsOpenApi } from "./eventsOpenApi.js";
 import { ApiFeatureWithMeta, featuresOpenApi } from "./featuresOpenApi.js";
 import { ApiProductWithMeta, productsOpenApi } from "./productsOpenApi.js";
+import { referralsOpenApi } from "./referralsOpenApi.js";
 
 // Register schema with .meta() for OpenAPI spec generation
 
@@ -71,6 +75,7 @@ const OPENAPI_1_2_0 = createDocument(
 			...entitiesOpenApi,
 			...eventsOpenApi,
 			...balancesOpenApi,
+			...referralsOpenApi,
 		},
 	},
 	{

--- a/shared/api/_openapi/prevVersions/openapi1.2/referralsOpenApi.ts
+++ b/shared/api/_openapi/prevVersions/openapi1.2/referralsOpenApi.ts
@@ -1,0 +1,65 @@
+import type { ZodOpenApiPathsObject } from "zod-openapi";
+import {
+	CreateReferralCodeResponseSchema,
+	RedeemReferralCodeResponseSchema,
+} from "../../../referrals/apiReferralCode.js";
+import {
+	CreateReferralCodeParamsSchema,
+	RedeemReferralCodeParamsSchema,
+} from "../../../referrals/referralOpModels.js";
+
+const ReferralCodeSchema = CreateReferralCodeResponseSchema.meta({
+	id: "ReferralCode",
+	description: "Referral code object returned by the API",
+});
+
+const RedeemReferralCodeResponseSchemaWithMeta =
+	RedeemReferralCodeResponseSchema.meta({
+		id: "RedeemReferralCodeResponse",
+		description: "Redemption response object returned by the API",
+	});
+
+export const referralsOpenApi: ZodOpenApiPathsObject = {
+	"/referrals/code": {
+		post: {
+			summary: "Create a referral code",
+			tags: ["referrals"],
+			requestBody: {
+				content: {
+					"application/json": { schema: CreateReferralCodeParamsSchema },
+				},
+			},
+			responses: {
+				"200": {
+					description: "Referral code generated successfully",
+					content: {
+						"application/json": {
+							schema: ReferralCodeSchema,
+						},
+					},
+				},
+			},
+		},
+	},
+	"/referrals/redeem": {
+		post: {
+			summary: "Redeem a referral code",
+			tags: ["referrals"],
+			requestBody: {
+				content: {
+					"application/json": { schema: RedeemReferralCodeParamsSchema },
+				},
+			},
+			responses: {
+				"200": {
+					description: "Referral code redeemed successfully",
+					content: {
+						"application/json": {
+							schema: RedeemReferralCodeResponseSchemaWithMeta,
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/shared/api/customers/apiCustomer.ts
+++ b/shared/api/customers/apiCustomer.ts
@@ -41,9 +41,7 @@ export const BaseApiCustomerSchema = z
 
 export const ApiCustomerSchema = BaseApiCustomerSchema.extend(
 	ApiCusExpandSchema.shape,
-).meta({
-	id: "Customer",
-});
+);
 
 export type ApiCustomer = z.infer<typeof ApiCustomerSchema>;
 export type ApiCusExpand = z.infer<typeof ApiCusExpandSchema>;

--- a/shared/api/utils/xCodeSamplesLegacy.ts
+++ b/shared/api/utils/xCodeSamplesLegacy.ts
@@ -1,0 +1,26 @@
+/**
+ * Generates x-codeSamples for OpenAPI specs (legacy format).
+ * @param methodPath - The SDK method path (e.g., "balances.create")
+ * @param example - The example params object
+ */
+export const xCodeSamplesLegacy = ({
+	methodPath,
+	example,
+}: {
+	methodPath: string;
+	example: Record<string, unknown>;
+}) => {
+	const exampleStr = JSON.stringify(example, null, 2);
+
+	return [
+		{
+			lang: "JavaScript",
+			source: `import { Autumn } from 'autumn-js';
+					
+const autumn = new Autumn();
+
+const { data, error } = await autumn.${methodPath}(${exampleStr});
+`,
+		},
+	];
+};


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

Added a utility function to generate code samples for OpenAPI specifications and integrated referrals endpoints into OpenAPI 1.2.0.

**Key changes:**

- **Improvements**: Created `xCodeSamplesLegacy` utility to generate JavaScript SDK code samples for OpenAPI specs, improving documentation
- **API changes**: Added OpenAPI definitions for referrals endpoints (`/referrals/code` and `/referrals/redeem`) to version 1.2.0
- **Improvements**: Applied code samples to `/balances/create` endpoint as an example usage of the new utility
- **Improvements**: Refactored `ApiCustomerSchema` to remove version-specific `.meta()` registration, keeping it version-agnostic

### Confidence Score: 5/5

- This PR is safe to merge with minimal risk
- All changes are well-structured improvements to OpenAPI documentation tooling. The new utility follows proper TypeScript patterns, the referrals endpoints are cleanly integrated, and the schema refactoring maintains consistency with the versioning architecture.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| shared/api/utils/xCodeSamplesLegacy.ts | 5/5 | Added new utility function to generate `x-codeSamples` for OpenAPI specs with JavaScript SDK examples |
| shared/api/_openapi/prevVersions/openapi1.2/balancesOpenApi1.2.0.ts | 5/5 | Applied `xCodeSamplesLegacy` utility to `/balances/create` endpoint with example, reformatted with tabs |
| shared/api/_openapi/prevVersions/openapi1.2/referralsOpenApi.ts | 5/5 | Added new OpenAPI definitions for referrals endpoints (`/referrals/code` and `/referrals/redeem`) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant OpenAPI as OpenAPI Spec Generator
    participant Utility as xCodeSamplesLegacy
    participant Docs as Generated Documentation

    Dev->>OpenAPI: Define endpoint (e.g., balancesOpenApi)
    OpenAPI->>Utility: Call xCodeSamplesLegacy({methodPath, example})
    Utility->>Utility: Format example as JSON string
    Utility->>OpenAPI: Return x-codeSamples array with JS SDK code
    OpenAPI->>OpenAPI: Integrate referralsOpenApi into paths
    OpenAPI->>Docs: Generate OpenAPI 1.2.0 spec with code samples
    Docs-->>Dev: Documentation includes SDK usage examples
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->