### PR TITLE
fix: create customer

### DIFF
--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpand.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpand.ts
@@ -50,11 +50,13 @@ export const getApiCustomerExpand = async ({
 
 	const getCusTrialsUsed = () => {
 		if (expand.includes(CusExpand.TrialsUsed)) {
-			return fullCus.trials_used?.map((t) => ({
-				plan_id: t.product_id,
-				customer_id: t.customer_id,
-				fingerprint: t.fingerprint,
-			}));
+			return (
+				fullCus.trials_used?.map((t) => ({
+					plan_id: t.product_id,
+					customer_id: t.customer_id,
+					fingerprint: t.fingerprint,
+				})) ?? []
+			);
 		}
 		return undefined;
 	};

--- a/server/src/internal/customers/handlers/handlePostCustomerV2.ts
+++ b/server/src/internal/customers/handlers/handlePostCustomerV2.ts
@@ -9,6 +9,7 @@ import {
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { getApiCustomer } from "../cusUtils/apiCusUtils/getApiCustomer.js";
+import { getOrCreateCachedFullCustomer } from "../cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.js";
 import { getOrSetCachedFullCustomer } from "../cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.js";
 import { handleCreateCustomer } from "./handleCreateCustomer.js";
 
@@ -38,24 +39,19 @@ export const handlePostCustomer = createRoute({
 
 		const start = Date.now();
 
-		// Create customer if ID provided, otherwise generate new one
-		const newCustomer = await handleCreateCustomer({
+		const fullCustomer = await getOrCreateCachedFullCustomer({
 			ctx,
-			cusData: {
-				id: createCusParams.id,
-				name: createCusParams.name,
-				email: createCusParams.email,
-				fingerprint: createCusParams.fingerprint,
-				metadata: createCusParams.metadata || {},
-				stripe_id: createCusParams.stripe_id,
+			params: {
+				customer_id: createCusParams.id,
+				customer_data: {
+					name: createCusParams.name,
+					email: createCusParams.email,
+					fingerprint: createCusParams.fingerprint,
+					metadata: createCusParams.metadata || {},
+					stripe_id: createCusParams.stripe_id,
+					disable_default: createCusParams.disable_default,
+				},
 			},
-			createDefaultProducts: createCusParams.disable_default !== true,
-		});
-
-		// Get full customer from cache/DB
-		const fullCustomer = await getOrSetCachedFullCustomer({
-			ctx,
-			customerId: newCustomer.id || newCustomer.internal_id,
 			source: "handlePostCustomer",
 		});
 

--- a/server/tests/crud/customers/create-customer2.test.ts
+++ b/server/tests/crud/customers/create-customer2.test.ts
@@ -1,0 +1,76 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { ApiVersion, CusExpand } from "@autumn/shared";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const testCase = "create-customer2";
+const customerId = testCase;
+
+describe(`${chalk.yellowBright("create-customer2: Testing create customer concurrently (should have no race conditions)")}`, () => {
+	const autumnV1 = new AutumnInt({
+		secretKey: ctx.orgSecretKey,
+		version: ApiVersion.V1_2,
+	});
+
+	beforeAll(async () => {
+		try {
+			await autumnV1.customers.delete(customerId);
+		} catch {}
+	});
+
+	test("should create customer with expand params", async () => {
+		const [data1, data2] = await Promise.all([
+			autumnV1.customers.create({
+				id: customerId,
+				name: customerId,
+				email: `${customerId}@example.com`,
+				withAutumnId: false,
+			}),
+			autumnV1.customers.create({
+				id: customerId,
+				name: customerId,
+				email: `${customerId}@example.com`,
+				withAutumnId: false,
+			}),
+		]);
+
+		expect(data1.id).toBe(customerId);
+		expect(data1.name).toBe(customerId);
+		expect(data1.email).toBe(`${customerId}@example.com`);
+		expect(data1.autumn_id).toBeUndefined();
+
+		expect(data2.id).toBe(customerId);
+		expect(data2.name).toBe(customerId);
+		expect(data2.email).toBe(`${customerId}@example.com`);
+		expect(data2.autumn_id).toBeUndefined();
+	});
+
+	test("should return customer when call again", async () => {
+		const data = await autumnV1.customers.create({
+			id: customerId,
+			name: customerId,
+			email: `${customerId}@example.com`,
+			withAutumnId: false,
+		});
+
+		expect(data.id).toBe(customerId);
+		expect(data.name).toBe(customerId);
+		expect(data.email).toBe(`${customerId}@example.com`);
+		expect(data.autumn_id).toBeUndefined();
+	});
+
+	test("should return expanded params if provided", async () => {
+		const data = await autumnV1.customers.create({
+			id: customerId,
+			name: customerId,
+			email: `${customerId}@example.com`,
+			withAutumnId: false,
+			expand: [CusExpand.Invoices, CusExpand.TrialsUsed, CusExpand.Entities],
+		});
+
+		expect(data.invoices).toEqual([]);
+		expect(data.trials_used).toEqual([]);
+		expect(data.entities).toEqual([]);
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes race conditions in customer creation by making the create path idempotent and handling duplicate inserts. Expanded fields now consistently return empty arrays when no data is present.

- **Bug Fixes**
  - Switched handlePostCustomer to use getOrCreateCachedFullCustomer; on duplicate key (23505), fetches existing customer instead of failing.
  - Updated cache util to accept nullable customer_id in params for the new create flow.
  - TrialsUsed expand returns [] when absent for consistent API responses.
  - Added create-customer2 test to validate concurrent create behavior and expanded fields.

<sup>Written for commit f9a3f7b38d7ad78362be35b8e1945d6ceaa70234. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes race conditions in concurrent customer creation by making the customer creation path idempotent. When multiple requests attempt to create the same customer simultaneously, the duplicate key error (PostgreSQL error code 23505) is now caught and the existing customer is fetched instead of failing.

**Key Changes:**
- **Bug fixes**: Made customer creation idempotent by catching duplicate key errors and fetching existing customer on conflict
- **Bug fixes**: Fixed `trials_used` expand field to return empty array `[]` instead of `undefined` when no data present
- **Improvements**: Simplified `handlePostCustomer` by consolidating create and cache operations into single `getOrCreateCachedFullCustomer` call
- **Improvements**: Updated type signature to accept nullable `customer_id` parameter, enabling use in create flow

The test validates that concurrent creation requests return consistent results and that expanded fields properly return empty arrays.

<h3>Confidence Score: 4/5</h3>


- Safe to merge with one error handling inconsistency to verify
- The race condition fix is well-implemented and tested. However, there's an inconsistency in error code access pattern (`error?.code` vs `error?.data?.code`) between this file and similar code in `getOrCreateCustomer.ts` that should be verified before merging
- Verify error structure in `server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.ts:102` - ensure the duplicate key error check uses the correct path

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/handlers/handlePostCustomerV2.ts | Simplified customer creation by replacing separate create and cache-fetch calls with single `getOrCreateCachedFullCustomer` call |
| server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.ts | Made idempotent by catching duplicate key errors (23505) and fetching existing customer; accepts nullable `customer_id` for create flow |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as handlePostCustomer
    participant Cache as getOrCreateCachedFullCustomer
    participant DB as Database
    participant Redis as Redis Cache

    Client->>Handler: POST /customers (with ID)
    Handler->>Cache: getOrCreateCachedFullCustomer(params)
    
    alt Cache Hit
        Cache->>Redis: getCachedFullCustomer
        Redis-->>Cache: Return cached customer
        Cache-->>Handler: Return FullCustomer
    else Cache Miss - Customer Exists
        Cache->>Redis: getCachedFullCustomer
        Redis-->>Cache: null
        Cache->>DB: CusService.getFull(customerId)
        DB-->>Cache: Return customer
        Cache->>Redis: setCachedFullCustomer
        Cache-->>Handler: Return FullCustomer
    else Cache Miss - Create New (Race Condition)
        Cache->>Redis: getCachedFullCustomer
        Redis-->>Cache: null
        Cache->>DB: CusService.getFull(customerId)
        DB-->>Cache: null
        Cache->>DB: handleCreateCustomer(customerId)
        
        alt Insert Success
            DB-->>Cache: Customer created
            Cache->>DB: CusService.getFull (fetch full)
            DB-->>Cache: Return FullCustomer
            Cache->>Redis: setCachedFullCustomer
            Cache-->>Handler: Return FullCustomer
        else Duplicate Key (23505)
            DB-->>Cache: Error 23505
            Note over Cache: Another request created<br/>customer concurrently
            Cache->>DB: CusService.getFull(customerId)
            DB-->>Cache: Return existing customer
            Cache->>Redis: setCachedFullCustomer
            Cache-->>Handler: Return FullCustomer
        end
    end
    
    Handler->>Handler: getApiCustomer(fullCustomer)
    Handler-->>Client: Return API Customer
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->