### PR TITLE
chore add posthog session

### DIFF
--- a/server/src/internal/pricingAgent/pricingAgentRouter.ts
+++ b/server/src/internal/pricingAgent/pricingAgentRouter.ts
@@ -304,7 +304,8 @@ This creates: $Y/month base price that includes 1 unit, then $Y per additional u
 export const pricingAgentRouter = new Hono<HonoEnv>();
 
 pricingAgentRouter.post("/chat", async (c) => {
-	const { messages }: { messages: UIMessage[] } = await c.req.json();
+	const { messages, sessionId }: { messages: UIMessage[]; sessionId?: string } =
+		await c.req.json();
 	const ctx = c.var.ctx;
 
 	if (!process.env.ANTHROPIC_API_KEY) {
@@ -327,6 +328,7 @@ pricingAgentRouter.post("/chat", async (c) => {
 		? withTracing(baseModel, posthog, {
 				posthogDistinctId: distinctId,
 				posthogProperties: {
+					...(sessionId && { $ai_session_id: sessionId }),
 					org_id: ctx.org?.id,
 					org_slug: ctx.org?.slug,
 					feature: "pricing_agent",

--- a/vite/src/views/onboarding4/AIChatView.tsx
+++ b/vite/src/views/onboarding4/AIChatView.tsx
@@ -5,7 +5,7 @@ import {
 } from "ai";
 import { ImageIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import {
 	Conversation,
 	ConversationContent,
@@ -108,6 +108,10 @@ export function AIChatView({ onBack }: AIChatViewProps) {
 	const previewSetupRef = useRef<Promise<PreviewOrg | null> | null>(null);
 	const axiosInstance = useAxiosInstance();
 
+	// Session ID for PostHog AI tracing - groups all messages in a conversation
+	const reactId = useId();
+	const chatSessionIdRef = useRef(`pricing-chat-${reactId}-${Date.now()}`);
+
 	/** Setup the preview org (called once, memoized) */
 	const setupPreviewOrg = useCallback(async (): Promise<PreviewOrg | null> => {
 		// If already setting up, return the existing promise
@@ -201,6 +205,9 @@ export function AIChatView({ onBack }: AIChatViewProps) {
 			credentials: "include",
 			headers: {
 				"x-client-type": "dashboard",
+			},
+			body: {
+				sessionId: chatSessionIdRef.current,
 			},
 		}),
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PostHog session tracking to the pricing-agent chat to group all messages in a conversation under one session. Improves tracing and analysis of the onboarding chat.

- New Features
  - Client: AIChatView creates a per-conversation sessionId and sends it with /chat requests.
  - Server: /chat accepts sessionId and sets $ai_session_id in PostHog tracing.

<sup>Written for commit e6e794d2298b7e6ddd6a258e577de9e1bbaac6e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added PostHog AI session tracking to the pricing agent chat feature to group related messages and AI interactions for better analytics visibility.

## Key Changes

**Improvements:**
- Generated unique session ID on the frontend using React's `useId()` combined with timestamp to ensure uniqueness across component instances
- Integrated session ID with PostHog's AI tracing via the `$ai_session_id` property for grouping conversation messages
- Session ID persists across all messages within a single chat session via ref, enabling proper conversation tracking

The implementation enables PostHog to correlate all AI model calls and user messages within a conversation, providing better insights into user interactions with the pricing agent during onboarding.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and non-breaking. The session ID implementation uses standard React patterns (`useId()` + ref) and integrates cleanly with PostHog's AI tracing API. The optional `sessionId` parameter maintains backward compatibility. No logical errors, security issues, or edge cases detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/pricingAgent/pricingAgentRouter.ts | Added `sessionId` parameter to chat endpoint and integrated it with PostHog AI tracing for session grouping |
| vite/src/views/onboarding4/AIChatView.tsx | Generated unique session ID using `useId()` and timestamp, sent with each chat request for PostHog tracking |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AIChatView
    participant PricingAgentRouter
    participant PostHog
    participant AnthropicAI

    User->>AIChatView: Mounts component
    AIChatView->>AIChatView: Generate sessionId (useId + timestamp)
    
    User->>AIChatView: Sends chat message
    AIChatView->>PricingAgentRouter: POST /pricing-agent/chat<br/>{messages, sessionId}
    
    PricingAgentRouter->>PricingAgentRouter: Extract sessionId from request
    PricingAgentRouter->>PostHog: Configure withTracing<br/>{$ai_session_id: sessionId}
    PostHog->>AnthropicAI: Wrap model with tracing
    
    PricingAgentRouter->>AnthropicAI: streamText with traced model
    AnthropicAI-->>PricingAgentRouter: Stream response
    PostHog->>PostHog: Log AI interactions with session ID
    PricingAgentRouter-->>AIChatView: Return streamed response
    AIChatView-->>User: Display chat response
    
    Note over AIChatView,PostHog: Session ID persists across all messages<br/>in the same component instance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->