### PR TITLE
chore add posthog session

### DIFF
--- a/server/src/internal/pricingAgent/pricingAgentRouter.ts
+++ b/server/src/internal/pricingAgent/pricingAgentRouter.ts
@@ -329,6 +329,7 @@ pricingAgentRouter.post("/chat", async (c) => {
 				posthogDistinctId: distinctId,
 				posthogProperties: {
 					...(sessionId && { $ai_session_id: sessionId }),
+					...(ctx.user?.email && { $set: { email: ctx.user.email } }),
 					org_id: ctx.org?.id,
 					org_slug: ctx.org?.slug,
 					feature: "pricing_agent",


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add user email to PostHog properties for pricing agent chat requests. We now send $set: { email } to update the user profile, improving identification alongside the existing $ai_session_id.

<sup>Written for commit cc14fa1a5a8bdf52057cfa915bf852263d81427b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Enhanced PostHog analytics tracking for the pricing agent by adding user email identification to session properties.

**Key changes:**
- **Improvements**: Added user email to PostHog session tracking using the `$set` operator, enabling better user identification and analytics correlation across pricing agent interactions


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Single line addition that enhances analytics tracking without affecting core functionality. The change uses PostHog's standard `$set` operator to associate user email with session tracking, following proper conditional spreading to handle cases where email might not be available. No logic changes, no security concerns, and purely additive for analytics purposes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/pricingAgent/pricingAgentRouter.ts | Added user email to PostHog session tracking properties using `$set` operator for better user identification in analytics |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant PricingAgentRouter
    participant Anthropic
    participant PostHog
    
    Client->>PricingAgentRouter: POST /chat (messages, sessionId)
    PricingAgentRouter->>PricingAgentRouter: Get user context (ctx.user, ctx.org)
    PricingAgentRouter->>PostHog: Initialize client (if API key present)
    PricingAgentRouter->>Anthropic: Create client with API key
    
    alt PostHog enabled
        PricingAgentRouter->>PostHog: Wrap model with withTracing()
        Note over PricingAgentRouter,PostHog: Include session properties:<br/>- $ai_session_id<br/>- $set: { email } (NEW)<br/>- org_id, org_slug<br/>- feature: pricing_agent
    end
    
    PricingAgentRouter->>Anthropic: streamText() with system prompt & tools
    Anthropic-->>PricingAgentRouter: Stream response
    
    PricingAgentRouter->>PostHog: Track AI interactions with user email
    
    PricingAgentRouter-->>Client: Return UI message stream
    
    PricingAgentRouter->>PostHog: Flush events on finish
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->