### PR TITLE
Entity feature config logic

### DIFF
--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/EntityFeatureConfig.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/EntityFeatureConfig.tsx
@@ -9,7 +9,6 @@ import {
 	SelectValue,
 } from "@/components/v2/selects/Select";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
-import { getFeature } from "@/utils/product/entitlementUtils";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
 
 export function EntityFeatureConfig() {
@@ -17,14 +16,6 @@ export function EntityFeatureConfig() {
 	const { item, setItem } = useProductItemContext();
 
 	if (!item) return null;
-
-	// Get the current item's feature
-	const currentFeature = getFeature(item.feature_id ?? "", features);
-
-	// Don't show if the current item itself is a continuous use feature
-	if (currentFeature?.config?.usage_type === FeatureUsageType.Continuous) {
-		return null;
-	}
 
 	// Filter for continuous use features
 	const continuousUseFeatures = features.filter(


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR fixes a logic issue that was incorrectly hiding the entity feature configuration for continuous use features. Previously, the component would return null if the current item itself was a continuous use feature, which prevented users from linking continuous use features to entity features.

**Key changes:**
- **Bug fixes**: Removed the guard clause that checked if the current item is a continuous use feature and prevented rendering
- **Bug fixes**: Removed the unused `getFeature` import from `@/utils/product/entitlementUtils`

The component now correctly shows the entity feature configuration for all feature types, as long as there are continuous use features available to link to. This aligns with the intended behavior where any feature type should be able to be linked to an entity feature.


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple bug fix that removes an incorrect guard clause. The logic is straightforward - it removes a check that was preventing continuous use features from showing the entity feature configuration. The component still maintains other guard clauses (null item check and empty continuous features check) and the remaining logic is unchanged.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/EntityFeatureConfig.tsx | Removed guard clause preventing entity feature config for continuous use features, allowing all feature types to configure entity features |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant EntityFeatureConfig
    participant useFeaturesQuery
    participant useProductItemContext
    
    User->>EntityFeatureConfig: Render component
    EntityFeatureConfig->>useFeaturesQuery: Get features
    useFeaturesQuery-->>EntityFeatureConfig: Return features array
    EntityFeatureConfig->>useProductItemContext: Get item and setItem
    useProductItemContext-->>EntityFeatureConfig: Return item context
    
    alt item is null
        EntityFeatureConfig-->>User: Return null
    end
    
    EntityFeatureConfig->>EntityFeatureConfig: Filter features for Continuous usage type
    
    alt No continuous use features
        EntityFeatureConfig-->>User: Return null
    end
    
    EntityFeatureConfig-->>User: Render AreaCheckbox with Select
    
    User->>EntityFeatureConfig: Toggle checkbox
    EntityFeatureConfig->>useProductItemContext: setItem with entity_feature_id
    useProductItemContext-->>EntityFeatureConfig: Update item
    
    User->>EntityFeatureConfig: Select feature from dropdown
    EntityFeatureConfig->>useProductItemContext: setItem with selected value
    useProductItemContext-->>EntityFeatureConfig: Update item
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->