### PR TITLE
refactor: remove paid limitation on trials

### DIFF
--- a/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
@@ -40,9 +40,6 @@ export function EditPlanSection() {
 	const { org } = useOrg();
 	const currency = org?.default_currency ?? "USD";
 
-	const priceItem = product?.items?.find((i) => isPriceItem(i));
-	const isPaidProduct = priceItem?.price && priceItem.price > 0;
-
 	const originalItemsMap = new Map(
 		originalItems?.filter((i) => i.feature_id).map((i) => [i.feature_id, i]) ??
 			[],
@@ -123,7 +120,6 @@ export function EditPlanSection() {
 					numVersions={numVersions}
 					currentVersion={currentVersion}
 					trialState={trialState}
-					isPaidProduct={!!isPaidProduct}
 				/>
 			}
 			withSeparator
@@ -204,32 +200,30 @@ export function EditPlanSection() {
 								selectedVersion={selectedVersion}
 							/>
 						)}
-						{isPaidProduct && (
-							<div
-								className={cn(
-									"grid transition-[grid-template-rows] duration-200 ease-out",
-									trialState.isTrialExpanded ||
-										trialState.removeTrial ||
-										trialState.isCurrentlyTrialing ||
-										trialState.hasTrialValue
-										? "grid-rows-[1fr]"
-										: "grid-rows-[0fr]",
-								)}
-							>
-								<div className="overflow-hidden">
-									<TrialEditorRow
-										form={form}
-										isCurrentlyTrialing={trialState.isCurrentlyTrialing}
-										initialTrialLength={trialState.remainingTrialDays}
-										initialTrialFormatted={trialState.remainingTrialFormatted}
-										removeTrial={trialState.removeTrial}
-										onEndTrial={trialState.handleEndTrial}
-										onCollapse={() => trialState.setIsTrialExpanded(false)}
-										onRevert={trialState.handleRevertTrial}
-									/>
-								</div>
+						<div
+							className={cn(
+								"grid transition-[grid-template-rows] duration-200 ease-out",
+								trialState.isTrialExpanded ||
+									trialState.removeTrial ||
+									trialState.isCurrentlyTrialing ||
+									trialState.hasTrialValue
+									? "grid-rows-[1fr]"
+									: "grid-rows-[0fr]",
+							)}
+						>
+							<div className="overflow-hidden">
+								<TrialEditorRow
+									form={form}
+									isCurrentlyTrialing={trialState.isCurrentlyTrialing}
+									initialTrialLength={trialState.remainingTrialDays}
+									initialTrialFormatted={trialState.remainingTrialFormatted}
+									removeTrial={trialState.removeTrial}
+									onEndTrial={trialState.handleEndTrial}
+									onCollapse={() => trialState.setIsTrialExpanded(false)}
+									onRevert={trialState.handleRevertTrial}
+								/>
 							</div>
-						)}
+						</div>
 					</div>
 				</>
 			) : null}

--- a/vite/src/components/forms/update-subscription-v2/components/SectionTitle.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SectionTitle.tsx
@@ -22,7 +22,6 @@ interface SectionTitleProps {
 	numVersions?: number;
 	currentVersion?: number;
 	trialState: UseTrialStateReturn;
-	isPaidProduct: boolean;
 }
 
 export function SectionTitle({
@@ -31,7 +30,6 @@ export function SectionTitle({
 	numVersions,
 	currentVersion,
 	trialState,
-	isPaidProduct,
 }: SectionTitleProps) {
 	const showVersionSelector = numVersions !== undefined && numVersions > 1;
 
@@ -45,7 +43,7 @@ export function SectionTitle({
 			}))
 		: [];
 
-	const showTrialToggle = isPaidProduct && !trialState.isCurrentlyTrialing;
+	const showTrialToggle = !trialState.isCurrentlyTrialing;
 	const trialIsActive =
 		(trialState.isCurrentlyTrialing || trialState.hasTrialValue) &&
 		!trialState.removeTrial;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the paid-only restriction on trials so users can toggle and edit trials on any plan in Update Subscription v2. Supports ENG-952 by showing the trial UI whenever a user isn’t currently trialing.

- **Refactors**
  - Dropped isPaidProduct checks in EditPlanSection; TrialEditorRow is always rendered (still collapses based on trial state).
  - Removed isPaidProduct prop and related logic from SectionTitle; showTrialToggle now depends only on trialState.
  - Cleaned up unused priceItem lookup.

<sup>Written for commit bc81428ce503d879a3b5fdaa8875b4bc539668c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Removed paid-only restriction on trials, allowing trial UI to be displayed for all plans in Update Subscription v2.

- **Refactors**
  - Removed `isPaidProduct` computation and `priceItem` lookup from `EditPlanSection.tsx` (lines 43-44)
  - Removed conditional rendering wrapper around `TrialEditorRow` - component now always renders with collapse handled internally via CSS grid transitions
  - Removed `isPaidProduct` prop from `SectionTitle` interface and simplified trial toggle visibility logic to only check `!trialState.isCurrentlyTrialing`
  - Trial functionality remains properly gated by existing trial state management (`isTrialExpanded`, `removeTrial`, `isCurrentlyTrialing`, `hasTrialValue`)


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Clean refactor that removes unnecessary paid-product checks while preserving all trial state logic. The trial UI visibility is still properly controlled by existing state management hooks. Changes are well-scoped to two files with straightforward logic removal.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx | Removed `isPaidProduct` check and unused `priceItem` lookup; `TrialEditorRow` now always renders (still collapses based on trial state) |
| vite/src/components/forms/update-subscription-v2/components/SectionTitle.tsx | Removed `isPaidProduct` prop; trial toggle now shows whenever user isn't currently trialing |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SectionTitle
    participant TrialState
    participant EditPlanSection
    participant TrialEditorRow

    User->>SectionTitle: Click trial toggle button
    SectionTitle->>TrialState: Check isCurrentlyTrialing
    alt Not currently trialing
        SectionTitle->>SectionTitle: Show trial toggle (removed isPaidProduct check)
        User->>SectionTitle: Click toggle
        SectionTitle->>TrialState: handleToggleTrial()
        TrialState->>TrialState: setIsTrialExpanded(true)
    end
    
    TrialState->>EditPlanSection: Update trial state
    EditPlanSection->>EditPlanSection: Check trial conditions (removed isPaidProduct guard)
    alt Trial expanded OR removeTrial OR isCurrentlyTrialing OR hasTrialValue
        EditPlanSection->>TrialEditorRow: Render (grid-rows-[1fr])
        TrialEditorRow->>User: Show trial editor
    else
        EditPlanSection->>TrialEditorRow: Collapse (grid-rows-[0fr])
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->