### PR TITLE
fix: update one off trial

### DIFF
--- a/server/src/internal/billing/v2/billingContext.ts
+++ b/server/src/internal/billing/v2/billingContext.ts
@@ -22,6 +22,7 @@ export interface TrialContext {
 	freeTrial?: FreeTrial | null;
 	trialEndsAt: number | null;
 	customFreeTrial?: FreeTrial;
+	appliesToBilling: boolean;
 }
 
 export interface BillingContext {

--- a/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
@@ -1,4 +1,4 @@
-import type { FullCusProduct, FullCustomer } from "@autumn/shared";
+import { type FullCusProduct, type FullCustomer } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { fetchStripeCustomerForBilling } from "./fetchStripeCustomerForBilling";
 import { fetchStripeSubscriptionForBilling } from "./fetchStripeSubscriptionForBilling";

--- a/server/src/internal/billing/v2/setup/setupTrialContext.ts
+++ b/server/src/internal/billing/v2/setup/setupTrialContext.ts
@@ -28,6 +28,7 @@ export const setupTrialContext = ({
 	fullProduct: FullProduct;
 }): TrialContext | undefined => {
 	const freeTrialParams = params.free_trial;
+	const newProductIsPaidRecurring = isProductPaidAndRecurring(fullProduct);
 
 	// Case 1: If free trial is null (removing free trial)
 	if (freeTrialParams === null) {
@@ -37,7 +38,11 @@ export const setupTrialContext = ({
 			isStripeSubscriptionTrialing(stripeSubscription) ||
 			isCustomerProductTrialing(customerProduct, { nowMs: currentEpochMs })
 		) {
-			return { freeTrial: null, trialEndsAt: null };
+			return {
+				freeTrial: null,
+				trialEndsAt: null,
+				appliesToBilling: newProductIsPaidRecurring,
+			};
 		} else {
 			return undefined;
 		}
@@ -61,6 +66,7 @@ export const setupTrialContext = ({
 			freeTrial: dbFreeTrial,
 			trialEndsAt,
 			customFreeTrial: dbFreeTrial,
+			appliesToBilling: newProductIsPaidRecurring,
 		};
 	}
 
@@ -77,6 +83,7 @@ export const setupTrialContext = ({
 			return {
 				freeTrial: null,
 				trialEndsAt: trialEndsAt,
+				appliesToBilling: newProductIsPaidRecurring,
 			};
 		} else {
 			return undefined;
@@ -88,6 +95,7 @@ export const setupTrialContext = ({
 		return {
 			freeTrial: customerProduct.free_trial, // can be undefined...
 			trialEndsAt: customerProduct.trial_ends_at ?? null,
+			appliesToBilling: false,
 		};
 	}
 

--- a/server/src/internal/billing/v2/updateSubscription/errors/handleOneOffErrors.ts
+++ b/server/src/internal/billing/v2/updateSubscription/errors/handleOneOffErrors.ts
@@ -5,6 +5,7 @@ import {
 	isOneOffPrice,
 	productsAreSame,
 	RecaseError,
+	type UpdateSubscriptionV0Params,
 } from "@autumn/shared";
 import { cusProductToPrices } from "@shared/utils/cusProductUtils/convertCusProduct";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -16,15 +17,26 @@ export const handleOneOffErrors = ({
 	ctx,
 	billingContext,
 	autumnBillingPlan,
+	params,
 }: {
 	ctx: AutumnContext;
 	billingContext: UpdateSubscriptionBillingContext;
 	autumnBillingPlan: AutumnBillingPlan;
+	params: UpdateSubscriptionV0Params;
 }) => {
 	const { customerProduct } = billingContext;
 
 	// Only apply these checks to one-off products
 	if (!isCustomerProductOneOff(customerProduct)) return;
+
+	// 1. Check that free trial param isn't passed in
+	const { free_trial } = params;
+
+	if (free_trial) {
+		throw new RecaseError({
+			message: "Cannot set / remove a free trial on one off plans.",
+		});
+	}
 
 	const newCustomerProduct = autumnBillingPlan.insertCustomerProducts?.[0];
 	if (!newCustomerProduct) return;

--- a/server/src/internal/billing/v2/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -50,7 +50,7 @@ export const handleUpdateSubscriptionErrors = async ({
 	handleCustomPlanErrors({ ctx, billingContext, autumnBillingPlan, params });
 
 	// 5. One-off errors
-	handleOneOffErrors({ ctx, billingContext, autumnBillingPlan });
+	handleOneOffErrors({ ctx, billingContext, autumnBillingPlan, params });
 
 	// 6. Trial removal with one-off items
 	checkTrialRemovalWithOneOffItems({ billingContext, autumnBillingPlan });

--- a/server/src/internal/billing/v2/updateSubscription/handlePreviewUpdateSubscription.ts
+++ b/server/src/internal/billing/v2/updateSubscription/handlePreviewUpdateSubscription.ts
@@ -1,6 +1,7 @@
 import { UpdateSubscriptionV0ParamsSchema } from "@autumn/shared";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
+import { handleUpdateSubscriptionErrors } from "@/internal/billing/v2/updateSubscription/errors/handleUpdateSubscriptionErrors";
 import { billingPlanToPreviewResponse } from "@/internal/billing/v2/utils/billingPlanToPreviewResponse";
 import { createRoute } from "../../../../honoMiddlewares/routeHandler";
 import { computeUpdateSubscriptionPlan } from "./compute/computeUpdateSubscriptionPlan";
@@ -37,6 +38,13 @@ export const handlePreviewUpdateSubscription = createRoute({
 			ctx,
 			plan: autumnBillingPlan,
 			billingContext: updateSubscriptionBillingContext,
+		});
+
+		await handleUpdateSubscriptionErrors({
+			ctx,
+			billingContext: updateSubscriptionBillingContext,
+			autumnBillingPlan,
+			params: body,
 		});
 
 		const stripeBillingPlan = await evaluateStripeBillingPlan({

--- a/vite/src/App.tsx
+++ b/vite/src/App.tsx
@@ -21,7 +21,6 @@ import CustomerPlanEditor from "./views/customers2/customer-plan/CustomerPlanEdi
 import { DefaultView } from "./views/DefaultView";
 import DevScreen from "./views/developer/DevView";
 import { CloseScreen } from "./views/general/CloseScreen";
-import OnboardingView3 from "./views/onboarding3/OnboardingView3";
 import QuickstartView from "./views/onboarding4/QuickstartView";
 import ProductsView from "./views/products/ProductsView";
 import PlanEditorView from "./views/products/plan/PlanEditorView";
@@ -61,7 +60,6 @@ export default function App() {
 
 				{/* Onboarding routes without sidebar */}
 				<Route element={<OnboardingLayout />}>
-					<Route path="/sandbox/onboarding" element={<OnboardingView3 />} />
 					<Route path="/sandbox/quickstart" element={<QuickstartView />} />
 				</Route>
 

--- a/vite/src/views/onboarding3/hooks/actions/useSharedActions.tsx
+++ b/vite/src/views/onboarding3/hooks/actions/useSharedActions.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 import { useProductStore } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useEnv } from "@/utils/envUtils";
+import { navigateTo } from "@/utils/genUtils";
 import { OnboardingStep } from "../../utils/onboardingUtils";
 import { useOnboarding3QueryState } from "../useOnboarding3QueryState";
 
@@ -101,7 +102,6 @@ export const useSharedActions = ({
 				setSheet({ type: "edit-plan" });
 			} catch (error) {
 				console.error("Failed to load new plan:", error);
-				const { navigateTo } = await import("@/utils/genUtils");
 				navigateTo(`/products/${newProduct.id}`, navigate, env);
 			}
 		},


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes trial handling for one-off and free products in merged subscriptions. Trials now only affect billing for paid recurring plans, and adding/removing trials on one-off items is blocked with clear errors (also surfaced in preview).

- **Bug Fixes**
  - Add appliesToBilling to TrialContext; only set/unset Stripe trial_end when the target product is paid and recurring.
  - Reject free_trial params for one-off plans with a clear error.
  - Run update-subscription validations during preview to fail early.
  - Expand tests for one-off trial errors and multi-entity free→paid with trial.
  - Minor cleanup: type-only import fix, remove old onboarding route, and replace dynamic navigateTo import.

<sup>Written for commit d493ccd196b2d120ac193c33af17c1f6f6ee1bda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


- Fixes critical trial handling bug where trials were incorrectly applied to one-off and free products in merged subscriptions
- Introduces `appliesToBilling` field to `TrialContext` to only affect Stripe billing for paid recurring plans
- Adds validation to block free trial parameters on one-off products with clear error messages and early preview validation


</details>
<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/billingContext.ts | Added `appliesToBilling` boolean field to TrialContext interface to control when trials should affect billing |
| server/src/internal/billing/v2/updateSubscription/errors/handleOneOffErrors.ts | Added validation to reject free_trial parameters for one-off plans with clear error messages |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts | Modified to conditionally set Stripe trial_end only when appliesToBilling is true, preventing inappropriate billing changes |

<h3>Confidence score: 4/5</h3>


- This PR addresses a significant billing bug that could cause incorrect charges or subscription states for customers
- Score reduced due to potential undefined behavior in Stripe subscription logic when appliesToBilling isfalse (variables remain undefined)  
- Pay close attention to `buildStripeSubscriptionUpdateAction.ts` for proper handling of undefined trial variables in conditional logic

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant API as Update Subscription API
    participant Context as setupUpdateSubscriptionBillingContext
    participant TrialSetup as setupTrialContext
    participant Compute as computeUpdateSubscriptionPlan
    participant Errors as handleUpdateSubscriptionErrors
    participant OneOffErrors as handleOneOffErrors
    participant Stripe as evaluateStripeBillingPlan
    participant Execute as executeBillingPlan

    User->>API: "POST /subscriptions/update"
    API->>Context: "setupUpdateSubscriptionBillingContext(params)"
    Context->>Context: "fetchStripeCustomerForBilling()"
    Context->>Context: "fetchStripeSubscriptionForBilling()"
    Context->>TrialSetup: "setupTrialContext(params, fullProduct)"
    TrialSetup->>TrialSetup: "Check if product is paid & recurring"
    TrialSetup->>TrialSetup: "Set appliesToBilling = isProductPaidAndRecurring"
    TrialSetup-->>Context: "Return TrialContext with appliesToBilling"
    Context-->>API: "Return UpdateSubscriptionBillingContext"
    
    API->>Compute: "computeUpdateSubscriptionPlan(billingContext, params)"
    Compute-->>API: "Return AutumnBillingPlan"
    
    API->>Errors: "handleUpdateSubscriptionErrors(billingContext, plan, params)"
    Errors->>OneOffErrors: "handleOneOffErrors(params)"
    OneOffErrors->>OneOffErrors: "Check if free_trial param on one-off product"
    OneOffErrors->>OneOffErrors: "Throw error if trial on one-off"
    OneOffErrors-->>Errors: "Validation complete"
    Errors-->>API: "Validation passed"
    
    API->>Stripe: "evaluateStripeBillingPlan(billingContext, plan)"
    Stripe->>Stripe: "buildStripeSubscriptionUpdateAction()"
    Stripe->>Stripe: "Check trialContext.appliesToBilling"
    Stripe->>Stripe: "Only set/unset trial_end if appliesToBilling = true"
    Stripe-->>API: "Return StripeBillingPlan"
    
    API->>Execute: "executeBillingPlan(billingContext, billingPlan)"
    Execute-->>API: "Return BillingResult"
    
    API-->>User: "Return subscription update response"
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))

<!-- /greptile_comment -->