### PR TITLE
dev

### DIFF
--- a/server/src/external/stripe/webhookHandlers/legacy/handleSubUpdated/handleSchedulePhaseCompleted.ts
+++ b/server/src/external/stripe/webhookHandlers/legacy/handleSubUpdated/handleSchedulePhaseCompleted.ts
@@ -3,7 +3,7 @@ import {
 	CusProductStatus,
 	type FullCustomer,
 	formatMs,
-	isCustomerProductExpired,
+	hasCustomerProductEnded,
 } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { stripeCustomerToNowMs } from "@/external/stripe/customers/index";
@@ -66,7 +66,7 @@ export const handleSchedulePhaseCompleted = async ({
 	);
 
 	for (const cusProduct of customerProducts) {
-		const shouldExpire = isCustomerProductExpired(cusProduct, { nowMs });
+		const shouldExpire = hasCustomerProductEnded(cusProduct, { nowMs });
 
 		if (shouldExpire) {
 			logger.info(

--- a/server/src/internal/billing/v2/updateSubscription/errors/handleCurrentCustomerProductErrors.ts
+++ b/server/src/internal/billing/v2/updateSubscription/errors/handleCurrentCustomerProductErrors.ts
@@ -1,0 +1,26 @@
+import {
+	isCustomerProductExpired,
+	isCustomerProductScheduled,
+	RecaseError,
+} from "@autumn/shared";
+import type { UpdateSubscriptionBillingContext } from "@/internal/billing/v2/billingContext";
+
+export const handleCurrentCustomerProductErrors = ({
+	billingContext,
+}: {
+	billingContext: UpdateSubscriptionBillingContext;
+}) => {
+	const { customerProduct } = billingContext;
+
+	if (isCustomerProductScheduled(customerProduct)) {
+		throw new RecaseError({
+			message: `Cannot update subscription for '${customerProduct.product.name}' because it is scheduled and not yet active`,
+		});
+	}
+
+	if (isCustomerProductExpired(customerProduct)) {
+		throw new RecaseError({
+			message: `Cannot update subscription for '${customerProduct.product.name}' because it has expired`,
+		});
+	}
+};

--- a/server/src/internal/billing/v2/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -7,6 +7,7 @@ import { cusProductToProcessorType } from "@shared/utils/cusProductUtils/convert
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpdateSubscriptionBillingContext } from "@/internal/billing/v2/billingContext";
 import type { AutumnBillingPlan } from "@/internal/billing/v2/types/autumnBillingPlan";
+import { handleCurrentCustomerProductErrors } from "./handleCurrentCustomerProductErrors";
 import { handleCustomPlanErrors } from "./handleCustomPlanErrors";
 import { handleFeatureQuantityErrors } from "./handleFeatureQuantityErrors";
 import {
@@ -34,6 +35,9 @@ export const handleUpdateSubscriptionErrors = async ({
 			message: `Cannot update '${customerProduct.product.name}' because it is managed by RevenueCat.`,
 		});
 	}
+
+	// 1. Current customer product errors
+	handleCurrentCustomerProductErrors({ billingContext });
 
 	// 2. Product type transition errors
 	handleProductTypeTransitionErrors({ billingContext, autumnBillingPlan });

--- a/server/src/internal/billing/v2/updateSubscription/handlePreviewUpdateSubscription.ts
+++ b/server/src/internal/billing/v2/updateSubscription/handlePreviewUpdateSubscription.ts
@@ -67,10 +67,6 @@ export const handlePreviewUpdateSubscription = createRoute({
 			},
 		});
 
-		return c.json({
-			...previewResponse,
-			autumn: autumnBillingPlan,
-			stripe: stripeBillingPlan,
-		});
+		return c.json(previewResponse);
 	},
 });

--- a/server/src/internal/products/handlers/handleGetProductDeleteInfo.ts
+++ b/server/src/internal/products/handlers/handleGetProductDeleteInfo.ts
@@ -1,68 +1,51 @@
-import { ProductNotFoundError } from "@autumn/shared";
+import { AffectedResource, ProductNotFoundError } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { CusProdReadService } from "@/internal/customers/cusProducts/CusProdReadService.js";
-import { handleRequestError } from "@/utils/errorUtils.js";
-import type { ExtendedRequest } from "@/utils/models/Request.js";
-import { routeHandler } from "@/utils/routerUtils.js";
 import { ProductService } from "../ProductService.js";
 
-export const handleGetProductDeleteInfo = async (req: any, res: any) =>
-	routeHandler({
-		req,
-		res,
-		action: "Get product deletion info",
-		handler: async (req: ExtendedRequest, res: any) => {
-			try {
-				// 1. Get number of versions
-				const { db } = req;
-				const productId = Array.isArray(req.params.productId)
-					? req.params.productId[0]
-					: req.params.productId;
+export const handleGetProductDeleteInfo = createRoute({
+	resource: AffectedResource.Product,
+	handler: async (c) => {
+		// 1. Get number of versions
+		const ctx = c.get("ctx");
+		const { db, org, env } = ctx;
+		const { productId } = c.req.param();
 
-				const product = await ProductService.get({
-					db,
-					id: productId,
-					orgId: req.orgId,
-					env: req.env,
-				});
+		const product = await ProductService.get({
+			db,
+			id: productId,
+			orgId: org.id,
+			env,
+		});
 
-				if (!product) {
-					throw new ProductNotFoundError({ productId });
-				}
+		if (!product) {
+			throw new ProductNotFoundError({ productId });
+		}
 
-				const [allVersions, latestVersion, deletionText] = await Promise.all([
-					CusProdReadService.existsForProduct({
-						db,
-						productId,
-					}),
-					CusProdReadService.existsForProduct({
-						db,
-						internalProductId: product.internal_id,
-					}),
-					ProductService.getDeletionText({
-						db,
-						productId,
-						orgId: req.orgId,
-						env: req.env,
-					}),
-				]);
+		const [allVersions, latestVersion, deletionText] = await Promise.all([
+			CusProdReadService.existsForProduct({
+				db,
+				productId,
+			}),
+			CusProdReadService.existsForProduct({
+				db,
+				internalProductId: product.internal_id,
+			}),
+			ProductService.getDeletionText({
+				db,
+				productId,
+				orgId: org.id,
+				env,
+			}),
+		]);
 
-				res.status(200).send({
-					numVersion: product.version,
-					hasCusProducts: allVersions,
-					hasCusProductsLatest: latestVersion,
-					customerName:
-						deletionText[0]?.name ||
-						deletionText[0]?.email ||
-						deletionText[0]?.id,
-					totalCount: deletionText[0]?.totalCount,
-				});
-			} catch (error) {
-				handleRequestError({
-					error,
-					req,
-					res,
-					action: "Get product info",
-				});
-			}
-		},
-	});
+		return c.json({
+			numVersion: product.version,
+			hasCusProducts: allVersions,
+			hasCusProductsLatest: latestVersion,
+			customerName:
+				deletionText[0]?.name || deletionText[0]?.email || deletionText[0]?.id,
+			totalCount: deletionText[0]?.totalCount,
+		});
+	},
+});

--- a/shared/utils/cusProductUtils/classifyCustomerProduct/classifyCustomerProduct.ts
+++ b/shared/utils/cusProductUtils/classifyCustomerProduct/classifyCustomerProduct.ts
@@ -75,17 +75,22 @@ export const isCustomerProductCanceling = (cp?: FullCusProduct) => {
 	return notNullish(cp.canceled_at);
 };
 
-export const isCustomerProductExpired = (
-	cp: FullCusProduct,
-	params: { nowMs?: number },
-) => {
-	const nowMs = params.nowMs ?? Date.now();
+export const isCustomerProductExpired = (cp?: FullCusProduct) => {
+	if (!cp) return false;
+	return cp.status === CusProductStatus.Expired;
+};
 
-	return (
+export const hasCustomerProductEnded = (
+	cp: FullCusProduct,
+	params?: { nowMs?: number },
+) => {
+	const nowMs = params?.nowMs ?? Date.now();
+
+	const hasEnded =
 		isCustomerProductCanceling(cp) &&
 		notNullish(cp.ended_at) &&
-		nowMs >= cp.ended_at
-	);
+		nowMs >= cp.ended_at;
+	return hasEnded;
 };
 
 export const isCustomerProductTrialing = (


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Strengthens subscription update validation and cleans up product routes. Blocks updates on scheduled/expired products, fixes end-state checks, and moves product endpoints to Hono.

- **Bug Fixes**
  - Block updates when the current customer product is scheduled or expired with clear errors.
  - Split end-state helpers: isCustomerProductExpired (status) vs hasCustomerProductEnded (time-based) and update Stripe webhook to use the correct check.
  - Return only the preview payload from subscriptions.previewUpdate for a consistent response.
  - Add integration test for free-to-paid to unlimited with monthly price; verifies invoices and unlimited feature state.

- **Refactors**
  - Migrate product delete info and has_entity_feature_id to Hono createRoute; use org.id/env from context and unified JSON responses.
  - Remove legacy Express handler/error utilities for these routes.

<sup>Written for commit 2542d470e695e616d7e35e958861228b8187f1ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR improves subscription update validation, refactors product expiration checks, migrates Express handlers to Hono, and fixes API response schema compliance.

## Key Changes


</details>
<h4>Bug fixes</h4>
- Removed debug fields (`autumn` and `stripe` billing plans) from preview update subscription response to match `BillingPreviewResponse` schema

<h4>Improvements</h4>
- Added validation to prevent updating scheduled or expired customer products with clear error messages via new `handleCurrentCustomerProductErrors` function
- Refactored `isCustomerProductExpired` to check status only (status-based check) and introduced `hasCustomerProductEnded` for time-based expiration checks, improving semantic clarity
- Migrated `handleGetProductDeleteInfo` and `/has_entity_feature_id` routes from Express to Hono `createRoute` pattern for consistency

<h4>API changes</h4>
- Preview update subscription endpoint now returns only the documented `BillingPreviewResponse` fields (removed undocumented debug fields)

## Tests
- Added comprehensive test case for converting free plan to paid subscription, then upgrading feature to unlimited

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- All changes are well-structured improvements: the refactoring of expiration checks separates concerns cleanly (status vs time-based), new validation prevents invalid operations on expired/scheduled products, Express-to-Hono migration follows established patterns, API response fix ensures schema compliance, and comprehensive test coverage validates the free-to-paid subscription upgrade flow
- Check `server/tests/integration/billing/update-subscription/custom-plan/update-free-to-paid.test.ts` for incomplete TODO comment at line 497

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/cusProductUtils/classifyCustomerProduct/classifyCustomerProduct.ts | Refactored `isCustomerProductExpired` to check status only and added new `hasCustomerProductEnded` function to check if product has physically ended based on time |
| server/src/internal/billing/v2/updateSubscription/errors/handleCurrentCustomerProductErrors.ts | New error handler to prevent updating scheduled or expired customer products with clear error messages |
| server/src/internal/billing/v2/updateSubscription/handlePreviewUpdateSubscription.ts | Removed debug fields (`autumn` and `stripe` billing plans) from preview response to match API schema |
| server/tests/integration/billing/update-subscription/custom-plan/update-free-to-paid.test.ts | Added test for converting free plan to paid then upgrading feature to unlimited, includes incomplete TODO comment at end |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant PreviewUpdateSub as handlePreviewUpdateSubscription
    participant UpdateSub as handleUpdateSubscription
    participant ErrorHandler as handleUpdateSubscriptionErrors
    participant CusProductErrors as handleCurrentCustomerProductErrors
    participant Utils as classifyCustomerProduct

    Note over Client,Utils: Subscription Update Flow

    Client->>PreviewUpdateSub: Preview update subscription
    PreviewUpdateSub->>ErrorHandler: Validate subscription update
    ErrorHandler->>CusProductErrors: Check current product state
    CusProductErrors->>Utils: isCustomerProductScheduled()
    Utils-->>CusProductErrors: Returns status check
    CusProductErrors->>Utils: isCustomerProductExpired()
    Note over Utils: NEW: Checks status === Expired<br/>(not time-based)
    Utils-->>CusProductErrors: Returns status check
    alt Product is scheduled or expired
        CusProductErrors-->>ErrorHandler: Throws RecaseError
        ErrorHandler-->>PreviewUpdateSub: Error propagated
        PreviewUpdateSub-->>Client: Error response
    else Product is valid
        ErrorHandler-->>PreviewUpdateSub: Validation passed
        PreviewUpdateSub-->>Client: Preview response (without debug fields)
    end

    Client->>UpdateSub: Execute update subscription
    UpdateSub->>ErrorHandler: Validate subscription update
    ErrorHandler->>CusProductErrors: Check current product state
    CusProductErrors-->>ErrorHandler: Validation passed
    UpdateSub-->>Client: Update response

    Note over Client,Utils: Webhook Flow (Schedule Phase Completed)
    
    participant Webhook as Stripe Webhook
    participant Handler as handleSchedulePhaseCompleted
    
    Webhook->>Handler: subscription.updated event
    loop For each customer product
        Handler->>Utils: hasCustomerProductEnded(product, {nowMs})
        Note over Utils: NEW: Checks canceled_at + ended_at + nowMs<br/>(time-based check)
        Utils-->>Handler: Returns if product ended
        alt Product has ended
            Handler->>Handler: Mark as Expired
        end
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->