### PR TITLE
main

### DIFF
--- a/.github/workflows/vite-build.yml
+++ b/.github/workflows/vite-build.yml
@@ -1,11 +1,6 @@
 name: Vite Build Check
 
 on:
-  push:
-    branches:
-      - main
-      - staging
-      - dev
   pull_request:
 
 jobs:

--- a/shared/utils/productV2Utils/compareProductUtils/generateTrialChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateTrialChanges.ts
@@ -27,11 +27,13 @@ export function generateTrialChanges({
 	removeTrial,
 	trialLength,
 	trialDuration,
+	trialEnabled = true,
 }: {
 	customerProduct: FullCusProduct;
 	removeTrial: boolean;
 	trialLength: number | null;
 	trialDuration: FreeTrialDuration;
+	trialEnabled?: boolean;
 }): ItemEdit[] {
 	const isCurrentlyTrialing = isCustomerProductTrialing(customerProduct);
 	const remainingDays = getRemainingTrialDays({
@@ -50,6 +52,11 @@ export function generateTrialChanges({
 			newValue: null,
 			isUpgrade: false,
 		});
+		return changes;
+	}
+
+	// If trial is not enabled (collapsed), don't generate changes for new trials
+	if (!trialEnabled && !isCurrentlyTrialing) {
 		return changes;
 	}
 

--- a/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
@@ -82,19 +82,30 @@ export function EditPlanSection() {
 				},
 			});
 
-		const oldIntervalText = originalInterval
-			? formatInterval({
-					interval: originalInterval,
-					intervalCount: originalIntervalCount,
-				})
-			: null;
+		const getIntervalText = (
+			interval: typeof originalInterval,
+			intervalCount: number,
+			hasPriceItem: boolean,
+		) => {
+			if (interval) {
+				return formatInterval({ interval, intervalCount });
+			}
+			// Only show "one-time" if there's a price item with no interval
+			// Otherwise it's variable/usage-based
+			return hasPriceItem ? "one-time" : null;
+		};
 
-		const newIntervalText = currentInterval
-			? formatInterval({
-					interval: currentInterval,
-					intervalCount: currentIntervalCount,
-				})
-			: (oldIntervalText ?? "per month");
+		const oldIntervalText = getIntervalText(
+			originalInterval,
+			originalIntervalCount,
+			!!originalPriceItem,
+		);
+
+		const newIntervalText = getIntervalText(
+			currentInterval,
+			currentIntervalCount,
+			!!currentPriceItem,
+		);
 
 		return {
 			oldPrice: formatPrice(originalPrice),
@@ -144,7 +155,7 @@ export function EditPlanSection() {
 							<PriceDisplay product={product} currency={currency} />
 						)}
 					</div>
-					<div className="space-y-2 mb-4">
+					<div className="space-y-2">
 						{product?.items?.map((item: ProductItem, index: number) => {
 							if (!item.feature_id) return null;
 
@@ -203,11 +214,8 @@ export function EditPlanSection() {
 						<div
 							className={cn(
 								"grid transition-[grid-template-rows] duration-200 ease-out",
-								trialState.isTrialExpanded ||
-									trialState.removeTrial ||
-									trialState.isCurrentlyTrialing ||
-									trialState.hasTrialValue
-									? "grid-rows-[1fr]"
+								trialState.isTrialExpanded || trialState.removeTrial
+									? "grid-rows-[1fr] mb-2"
 									: "grid-rows-[0fr]",
 							)}
 						>

--- a/vite/src/components/forms/update-subscription-v2/components/SectionTitle.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SectionTitle.tsx
@@ -45,7 +45,7 @@ export function SectionTitle({
 
 	const showTrialToggle = !trialState.isCurrentlyTrialing;
 	const trialIsActive =
-		(trialState.isCurrentlyTrialing || trialState.hasTrialValue) &&
+		(trialState.isCurrentlyTrialing || trialState.isTrialExpanded) &&
 		!trialState.removeTrial;
 
 	return (

--- a/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
@@ -255,7 +255,7 @@ export function SubscriptionItemRow({
 										icon={<CheckIcon size={14} />}
 										variant="skeleton"
 										size="sm"
-										className="text-t4 hover:text-t2 hover:bg-muted"
+										className="text-green-600 dark:text-green-500 hover:text-green-700 dark:hover:text-green-400 hover:bg-black/5 dark:hover:bg-white/10"
 										onClick={() => setIsEditingQuantity(false)}
 									/>
 								</>

--- a/vite/src/components/forms/update-subscription-v2/components/TrialEditorRow.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/TrialEditorRow.tsx
@@ -156,9 +156,7 @@ export function TrialEditorRow({
 						<CalendarBlankIcon
 							size={14}
 							weight="fill"
-							className={cn(
-								isTrialModified ? "text-amber-400" : "text-blue-400",
-							)}
+							className="text-blue-400"
 						/>
 						<span className="text-sm text-t2">Free Trial</span>
 					</div>
@@ -195,20 +193,21 @@ export function TrialEditorRow({
 	}
 
 	const handleClearTrial = () => {
-		if (!hasTrialValue && !isCurrentlyTrialing) {
-			onCollapse();
-			setIsEditing(false);
-			setIsAddingNewTrial(true);
-			return;
-		}
+		// Just collapse - preserve the value so it can be restored
+		onCollapse();
+		setIsEditing(false);
+		setIsAddingNewTrial(true);
 
-		form.setFieldValue("trialLength", null);
+		// Only mark for removal if they're currently trialing (ending an active trial)
 		if (isCurrentlyTrialing) {
 			onEndTrial();
 		}
-		setIsEditing(false);
-		setIsAddingNewTrial(true);
 	};
+
+	const isNewTrial = !isCurrentlyTrialing;
+	const editModeRingClass = isNewTrial
+		? "ring-1 ring-inset ring-green-500/50"
+		: "ring-1 ring-inset ring-amber-500/50";
 
 	return (
 		<div
@@ -219,14 +218,14 @@ export function TrialEditorRow({
 			<div
 				className={cn(
 					"flex items-center flex-1 h-10 px-3 rounded-xl input-base",
-					"ring-1 ring-inset ring-amber-500/50",
+					editModeRingClass,
 				)}
 			>
 				<div className="flex items-center gap-2">
 					<CalendarBlankIcon
 						size={14}
 						weight="fill"
-						className="text-amber-400"
+						className="text-blue-400"
 					/>
 					<span className="text-sm text-t2">Free Trial</span>
 				</div>
@@ -239,6 +238,7 @@ export function TrialEditorRow({
 							placeholder="7"
 							min={1}
 							className="w-16"
+							inputClassName="placeholder:opacity-50"
 							hideFieldInfo
 						/>
 					)}

--- a/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
+++ b/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
@@ -172,6 +172,7 @@ export function UpdateSubscriptionFormProvider({
 			removeTrial: formValues.removeTrial,
 			trialLength: formValues.trialLength,
 			trialDuration: formValues.trialDuration,
+			trialEnabled: formValues.trialEnabled,
 		});
 		const freeTrialValue =
 			freeTrial === null ? undefined : (freeTrial ?? base.free_trial);
@@ -187,6 +188,7 @@ export function UpdateSubscriptionFormProvider({
 		formValues.removeTrial,
 		formValues.trialLength,
 		formValues.trialDuration,
+		formValues.trialEnabled,
 	]);
 
 	const hasBillingChanges = useHasBillingChanges({
@@ -202,6 +204,7 @@ export function UpdateSubscriptionFormProvider({
 		removeTrial: formValues.removeTrial,
 		trialLength: formValues.trialLength,
 		trialDuration: formValues.trialDuration,
+		trialEnabled: formValues.trialEnabled,
 	});
 
 	const previewQuery = useUpdateSubscriptionPreview({

--- a/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
@@ -34,6 +34,7 @@ export function useHasSubscriptionChanges({
 			removeTrial: formValues.removeTrial,
 			trialLength: formValues.trialLength,
 			trialDuration: formValues.trialDuration,
+			trialEnabled: formValues.trialEnabled,
 		});
 
 		if (trialChanges.length > 0) return true;
@@ -74,6 +75,7 @@ export function useHasSubscriptionChanges({
 		formValues.removeTrial,
 		formValues.trialLength,
 		formValues.trialDuration,
+		formValues.trialEnabled,
 		formValues.version,
 		formValues.items,
 		formValues.prepaidOptions,

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm.ts
@@ -49,6 +49,7 @@ export function useUpdateSubscriptionForm({
 			trialLength: remainingTrialDays,
 			trialDuration: FreeTrialDuration.Day,
 			removeTrial: false,
+			trialEnabled: isTrialing,
 			version: currentVersion,
 			items: null,
 		} as UpdateSubscriptionForm,

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
@@ -25,6 +25,7 @@ export function useUpdateSubscriptionRequestBody({
 			trialLength,
 			trialDuration,
 			removeTrial,
+			trialEnabled,
 			version,
 			items,
 		} = formValues;
@@ -89,6 +90,7 @@ export function useUpdateSubscriptionRequestBody({
 			removeTrial,
 			trialLength,
 			trialDuration,
+			trialEnabled,
 		});
 		if (freeTrial !== undefined) {
 			requestBody.free_trial = freeTrial;

--- a/vite/src/components/forms/update-subscription-v2/updateSubscriptionFormSchema.ts
+++ b/vite/src/components/forms/update-subscription-v2/updateSubscriptionFormSchema.ts
@@ -7,6 +7,7 @@ export const UpdateSubscriptionFormSchema = z.object({
 	trialLength: z.number().positive().nullable(),
 	trialDuration: z.enum(FreeTrialDuration),
 	removeTrial: z.boolean(),
+	trialEnabled: z.boolean(),
 
 	version: z.number().positive(),
 

--- a/vite/src/components/forms/update-subscription-v2/utils/getFreeTrial.ts
+++ b/vite/src/components/forms/update-subscription-v2/utils/getFreeTrial.ts
@@ -7,12 +7,15 @@ export function getFreeTrial({
 	removeTrial,
 	trialLength,
 	trialDuration,
+	trialEnabled,
 }: {
 	removeTrial: boolean;
 	trialLength: number | null;
 	trialDuration: FreeTrialDuration;
+	trialEnabled: boolean;
 }): CreateFreeTrial | null | undefined {
 	if (removeTrial) return null;
+	if (!trialEnabled) return undefined;
 	if (trialLength !== null && trialLength > 0) {
 		return {
 			length: trialLength,

--- a/vite/src/components/general/form/fields/number-field.tsx
+++ b/vite/src/components/general/form/fields/number-field.tsx
@@ -10,6 +10,7 @@ export function NumberField({
 	min,
 	max,
 	className,
+	inputClassName,
 	hideFieldInfo,
 	disabled,
 }: {
@@ -18,6 +19,7 @@ export function NumberField({
 	min?: number;
 	max?: number;
 	className?: string;
+	inputClassName?: string;
 	hideFieldInfo?: boolean;
 	disabled?: boolean;
 }) {
@@ -51,7 +53,7 @@ export function NumberField({
 				placeholder={placeholder}
 				value={field.state.value ?? ""}
 				onChange={handleChange}
-				className="text-sm"
+				className={cn("text-sm", inputClassName)}
 				disabled={disabled}
 			/>
 			{!hideFieldInfo && <FieldInfo field={field} />}

--- a/vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx
+++ b/vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx
@@ -15,15 +15,16 @@ import { useHasPlanChanges, useProduct, useSheet } from "./PlanEditorContext";
 
 interface InlinePlanEditorProps {
 	product: FrontendProduct;
-	productName?: string;
 	onSave: (items: ProductItem[]) => void;
 	onCancel: () => void;
+	isOpen: boolean;
 }
 
 export function InlinePlanEditor({
 	product,
 	onSave,
 	onCancel,
+	isOpen,
 }: InlinePlanEditorProps) {
 	const mainContent = document.querySelector("[data-main-content]");
 
@@ -33,9 +34,13 @@ export function InlinePlanEditor({
 	}
 
 	return createPortal(
-		<InlineEditorProvider initialProduct={product}>
-			<InlinePlanEditorContent onSave={onSave} onCancel={onCancel} />
-		</InlineEditorProvider>,
+		<AnimatePresence>
+			{isOpen && (
+				<InlineEditorProvider initialProduct={product}>
+					<InlinePlanEditorContent onSave={onSave} onCancel={onCancel} />
+				</InlineEditorProvider>
+			)}
+		</AnimatePresence>,
 		mainContent,
 	);
 }
@@ -52,7 +57,13 @@ function InlinePlanEditorContent({
 	const hasPlanChanges = useHasPlanChanges();
 
 	return (
-		<div className="absolute inset-0 z-100 bg-background flex flex-col">
+		<motion.div
+			initial={{ opacity: 0, scale: 0.97, y: 8 }}
+			animate={{ opacity: 1, scale: 1, y: 0 }}
+			exit={{ opacity: 0, scale: 0.97, y: 8 }}
+			transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+			className="absolute inset-0 z-100 bg-background flex flex-col"
+		>
 			<div className="flex w-full h-full overflow-hidden relative flex-1">
 				<motion.div
 					className={cn(
@@ -103,6 +114,6 @@ function InlinePlanEditorContent({
 
 				<ProductSheets />
 			</div>
-		</div>
+		</motion.div>
 	);
 }

--- a/vite/src/views/customers2/components/sheets/SubscriptionUpdateSheet2.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionUpdateSheet2.tsx
@@ -75,12 +75,12 @@ function SheetContent() {
 			<UpdateSubscriptionPreviewSection />
 			<UpdateSubscriptionFooter />
 
-			{showPlanEditor && productWithFormItems && (
+			{productWithFormItems && (
 				<InlinePlanEditor
 					product={productWithFormItems}
-					productName={customerProduct.product.name}
 					onSave={handlePlanEditorSave}
 					onCancel={handlePlanEditorCancel}
+					isOpen={showPlanEditor}
 				/>
 			)}
 		</div>

--- a/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
@@ -33,7 +33,7 @@ export function SelectFeatureSheet({
 	const [searchValue, setSearchValue] = useState("");
 
 	const { features } = useFeaturesQuery();
-	const { product, setProduct } = useProduct();
+	const { product, setProduct, initialProduct } = useProduct();
 	const { setSheet } = useSheet();
 
 	useEffect(() => {
@@ -60,8 +60,14 @@ export function SelectFeatureSheet({
 		const selectedFeature = features.find((f) => f.id === featureId);
 		if (!selectedFeature) return;
 
-		// Create a new item with the selected feature
-		const newItem = getDefaultItem({ feature: selectedFeature });
+		// Check if this feature was previously configured in initialProduct
+		const previousItem = initialProduct?.items?.find(
+			(i) => i.feature_id === featureId,
+		);
+
+		// Use the previous configuration if available, otherwise create a new default item
+		const newItem =
+			previousItem ?? getDefaultItem({ feature: selectedFeature });
 
 		// Add the new item to the product
 		const newItems = [...product.items, newItem];

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -84,7 +84,7 @@ export const PlanFeatureRow = ({
 	}, [itemId, currentItemId]);
 
 	const handleRowClicked = () => {
-		if (isDisabled) return;
+		if (readOnly || isDisabled) return;
 		const currentItemId = getItemId({ item, itemIndex: index });
 
 		setItem(item);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved trial editing and plan editor UX in Update Subscription V2 to prevent accidental trial changes and clarify one-time pricing. Addresses Linear ENG-952.

- **New Features**
  - Added trialEnabled to form state to control trial editing; collapsed trials don’t generate changes.
  - Inline plan editor now animates open/close and mounts only when isOpen is true.
  - Select Feature restores a feature’s previous item config if it exists.
  - NumberField supports inputClassName for finer input styling.

- **Bug Fixes**
  - Correct interval text: show “one-time” only when a price item has no interval.
  - Trial actions respect enabled state; ending an active trial sets removeTrial and disables the editor.
  - Prevent clicks when rows are read-only; minor UI polish for buttons and spacing.
  - CI: run Vite build check only on pull requests.

<sup>Written for commit 8d75202cd9ee05ca14338120b941717f45d494d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR improves the subscription update UI by refining trial management, enhancing the inline plan editor animations, and adding feature configuration restoration. The changes focus on better state management for trial toggles and improved user experience when editing subscription plans.

**Key Changes:**

- **Improvements**: Replaced local trial expansion state with form-managed `trialEnabled` field for consistent state tracking across the subscription update form
- **Improvements**: Added AnimatePresence wrapper to `InlinePlanEditor` with smooth entry/exit animations controlled by `isOpen` prop
- **Improvements**: Feature configuration is now restored from `initialProduct` when re-adding previously configured features in the plan editor
- **Improvements**: Trial section collapse now preserves values instead of clearing them, allowing users to restore configurations
- **Improvements**: Refactored interval text generation to properly distinguish between one-time, recurring, and variable/usage-based pricing
- **Improvements**: Updated trial editor styling to visually distinguish new trials (green ring) from existing trials being modified (amber ring)
- **Bug fixes**: Fixed workflow to only run on pull requests, removing redundant push triggers
- **Bug fixes**: Added `readOnly` check in `PlanFeatureRow` to prevent interactions in read-only mode


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-structured refactorings that improve state management and user experience. All modifications follow consistent patterns, properly thread the new `trialEnabled` parameter through all necessary functions, and include appropriate UI improvements. The code follows the repository's style guidelines and maintains backward compatibility.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/productV2Utils/compareProductUtils/generateTrialChanges.ts | Added `trialEnabled` parameter to prevent generating trial changes when trial section is collapsed |
| vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx | Refactored interval text generation logic to handle one-time vs variable pricing, adjusted trial expansion logic, removed unnecessary spacing |
| vite/src/components/forms/update-subscription-v2/hooks/useTrialState.ts | Replaced local `isTrialExpanded` state with form-managed `trialEnabled` field for better state management |
| vite/src/components/v2/inline-custom-plan-editor/InlinePlanEditor.tsx | Added `isOpen` prop and AnimatePresence wrapper with animation transitions, removed unused `productName` prop |
| vite/src/views/products/plan/components/SelectFeatureSheet.tsx | Added logic to restore previous feature configuration from `initialProduct` when re-adding features |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SubscriptionUpdateSheet
    participant UpdateSubscriptionForm
    participant TrialState
    participant InlinePlanEditor
    participant SelectFeatureSheet
    
    User->>SubscriptionUpdateSheet: Open subscription update
    SubscriptionUpdateSheet->>UpdateSubscriptionForm: Initialize form with trialEnabled
    UpdateSubscriptionForm->>TrialState: Set trialEnabled based on current trial status
    
    User->>TrialState: Toggle trial section
    TrialState->>UpdateSubscriptionForm: Update trialEnabled field
    UpdateSubscriptionForm->>UpdateSubscriptionForm: Generate trial changes (with trialEnabled check)
    
    User->>SubscriptionUpdateSheet: Click "Edit Plan Items"
    SubscriptionUpdateSheet->>InlinePlanEditor: Show editor with isOpen=true
    InlinePlanEditor->>InlinePlanEditor: Animate in with AnimatePresence
    
    User->>InlinePlanEditor: Click "Select Feature"
    InlinePlanEditor->>SelectFeatureSheet: Open feature selection
    User->>SelectFeatureSheet: Select feature
    SelectFeatureSheet->>SelectFeatureSheet: Check initialProduct for previous config
    SelectFeatureSheet->>InlinePlanEditor: Add feature (with restored config if available)
    
    User->>InlinePlanEditor: Save changes
    InlinePlanEditor->>UpdateSubscriptionForm: Update form items
    UpdateSubscriptionForm->>UpdateSubscriptionForm: Calculate subscription changes
    
    User->>SubscriptionUpdateSheet: Submit update
    SubscriptionUpdateSheet->>UpdateSubscriptionForm: Generate request body (with trialEnabled)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->