### PR TITLE
Charlie/eng 952 update subscription frontend

### DIFF
--- a/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx
@@ -8,22 +8,18 @@ import {
 	UsageModel,
 } from "@autumn/shared";
 import { PencilSimpleIcon } from "@phosphor-icons/react";
-import { LayoutGroup, motion, type Transition } from "motion/react";
+import { LayoutGroup, motion } from "motion/react";
 import { useMemo } from "react";
 import { Button } from "@/components/v2/buttons/Button";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { useOrg } from "@/hooks/common/useOrg";
+import { LAYOUT_TRANSITION } from "../constants/animationConstants";
 import { useUpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 import { PriceDisplay } from "./PriceDisplay";
 import { SectionTitle } from "./SectionTitle";
 import { SubscriptionItemRow } from "./SubscriptionItemRow";
 import { TrialEditorRow } from "./TrialEditorRow";
 import { VersionChangeRow } from "./VersionChangeRow";
-
-const LAYOUT_TRANSITION: Transition = {
-	duration: 0.35,
-	ease: [0.32, 0.72, 0, 1],
-};
 
 export function EditPlanSection() {
 	const {

--- a/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
@@ -9,6 +9,7 @@ import {
 	CheckIcon,
 	PencilSimpleIcon,
 } from "@phosphor-icons/react";
+import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 import { IconButton } from "@/components/v2/buttons/IconButton";
 import {
@@ -21,6 +22,7 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { cn } from "@/lib/utils";
 import { PlanFeatureIcon } from "@/views/products/plan/components/plan-card/PlanFeatureIcon";
 import { CustomDotIcon } from "@/views/products/plan/components/plan-card/PlanFeatureRow";
+import { FAST_TRANSITION } from "../constants/animationConstants";
 import type { UseUpdateSubscriptionForm } from "../hooks/useUpdateSubscriptionForm";
 import { getEditIcon } from "../utils/getEditIcon";
 import { getItemRingClass } from "../utils/ringClassUtils";
@@ -243,42 +245,64 @@ export function SubscriptionItemRow({
 					(showPrepaidOutside || hasEditableEdit) &&
 					form &&
 					featureId && (
-						<div className="flex items-center h-10 px-3 rounded-xl input-base w-fit shrink-0 gap-2">
-							{isEditingQuantity ? (
-								<>
-									<form.AppField name={`prepaidOptions.${featureId}`}>
-										{(field) => (
-											<field.QuantityField label="" min={0} hideFieldInfo />
-										)}
-									</form.AppField>
-									<IconButton
-										icon={<CheckIcon size={14} />}
-										variant="skeleton"
-										size="sm"
-										className="text-green-600 dark:text-green-500 hover:text-green-700! dark:hover:text-green-400! hover:bg-black/5 dark:hover:bg-white/10"
-										onClick={() => setIsEditingQuantity(false)}
-									/>
-								</>
-							) : (
-								<>
-									<span className="text-sm tabular-nums text-t3">
-										x{prepaidQuantity ?? 0}
-									</span>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<IconButton
-												icon={<PencilSimpleIcon size={14} />}
-												variant="skeleton"
-												size="sm"
-												className="text-t4 hover:text-t2 hover:bg-muted"
-												onClick={() => setIsEditingQuantity(true)}
-											/>
-										</TooltipTrigger>
-										<TooltipContent>Update prepaid quantity</TooltipContent>
-									</Tooltip>
-								</>
-							)}
-						</div>
+						<motion.div
+							layout
+							transition={FAST_TRANSITION}
+							className="flex items-center h-10 px-3 rounded-xl input-base w-fit shrink-0 gap-2 overflow-hidden"
+						>
+							<AnimatePresence mode="popLayout" initial={false}>
+								{isEditingQuantity ? (
+									<motion.div
+										key="edit"
+										layout
+										initial={{ opacity: 0, x: 10 }}
+										animate={{ opacity: 1, x: 0 }}
+										exit={{ opacity: 0, x: -10 }}
+										transition={FAST_TRANSITION}
+										className="flex items-center gap-2"
+									>
+										<form.AppField name={`prepaidOptions.${featureId}`}>
+											{(field) => (
+												<field.QuantityField label="" min={0} hideFieldInfo />
+											)}
+										</form.AppField>
+										<IconButton
+											icon={<CheckIcon size={14} />}
+											variant="skeleton"
+											size="sm"
+											className="text-green-600 dark:text-green-500 hover:text-green-700! dark:hover:text-green-400! hover:bg-black/5 dark:hover:bg-white/10"
+											onClick={() => setIsEditingQuantity(false)}
+										/>
+									</motion.div>
+								) : (
+									<motion.div
+										key="display"
+										layout
+										initial={{ opacity: 0, x: -10 }}
+										animate={{ opacity: 1, x: 0 }}
+										exit={{ opacity: 0, x: 10 }}
+										transition={FAST_TRANSITION}
+										className="flex items-center gap-2"
+									>
+										<span className="text-sm tabular-nums text-t3">
+											x{prepaidQuantity ?? 0}
+										</span>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<IconButton
+													icon={<PencilSimpleIcon size={14} />}
+													variant="skeleton"
+													size="sm"
+													className="text-t4 hover:text-t2 hover:bg-muted"
+													onClick={() => setIsEditingQuantity(true)}
+												/>
+											</TooltipTrigger>
+											<TooltipContent>Update prepaid quantity</TooltipContent>
+										</Tooltip>
+									</motion.div>
+								)}
+							</AnimatePresence>
+						</motion.div>
 					)}
 			</div>
 

--- a/vite/src/components/forms/update-subscription-v2/components/TrialEditorRow.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/TrialEditorRow.tsx
@@ -2,10 +2,12 @@ import { type FreeTrialDuration, getTrialLengthInDays } from "@autumn/shared";
 import {
 	ArrowCounterClockwiseIcon,
 	CalendarBlankIcon,
+	CheckIcon,
 	PencilSimpleIcon,
 	TrashIcon,
 } from "@phosphor-icons/react";
 import { useStore } from "@tanstack/react-form";
+import { AnimatePresence, motion } from "motion/react";
 import { useRef, useState } from "react";
 import { IconButton } from "@/components/v2/buttons/IconButton";
 import {
@@ -14,6 +16,7 @@ import {
 	TooltipTrigger,
 } from "@/components/v2/tooltips/Tooltip";
 import { cn } from "@/lib/utils";
+import { FAST_TRANSITION } from "../constants/animationConstants";
 import {
 	formatTrialDuration,
 	TRIAL_DURATION_OPTIONS,
@@ -139,11 +142,10 @@ export function TrialEditorRow({
 		);
 	}
 
-	if (
-		!isEditing &&
-		!isAddingNewTrial &&
-		(hasTrialValue || isCurrentlyTrialing)
-	) {
+	const showDisplayMode =
+		!isEditing && !isAddingNewTrial && (hasTrialValue || isCurrentlyTrialing);
+
+	if (showDisplayMode) {
 		return (
 			<div className="flex items-center gap-2">
 				<div
@@ -176,18 +178,34 @@ export function TrialEditorRow({
 						</span>
 					) : null}
 				</div>
-				<div className="flex items-center h-10 px-3 rounded-xl input-base gap-2">
-					<IconButton
-						icon={<PencilSimpleIcon size={14} />}
-						variant="skeleton"
-						size="sm"
-						className="text-t4 hover:text-t2 hover:bg-muted"
-						onClick={() => {
-							setIsEditing(true);
-							setIsAddingNewTrial(false);
-						}}
-					/>
-				</div>
+				<motion.div
+					layout
+					transition={FAST_TRANSITION}
+					className="flex items-center h-10 px-3 rounded-xl input-base gap-2 overflow-hidden"
+				>
+					<AnimatePresence mode="popLayout" initial={false}>
+						<motion.div
+							key="display"
+							layout
+							initial={{ opacity: 0, x: -10 }}
+							animate={{ opacity: 1, x: 0 }}
+							exit={{ opacity: 0, x: 10 }}
+							transition={FAST_TRANSITION}
+							className="flex items-center gap-2"
+						>
+							<IconButton
+								icon={<PencilSimpleIcon size={14} />}
+								variant="skeleton"
+								size="sm"
+								className="text-t4 hover:text-t2 hover:bg-muted"
+								onClick={() => {
+									setIsEditing(true);
+									setIsAddingNewTrial(false);
+								}}
+							/>
+						</motion.div>
+					</AnimatePresence>
+				</motion.div>
 			</div>
 		);
 	}
@@ -230,43 +248,73 @@ export function TrialEditorRow({
 					<span className="text-sm text-t2">Free Trial</span>
 				</div>
 			</div>
-			<div className="flex items-center h-10 px-3 rounded-xl input-base gap-2">
-				<form.AppField name="trialLength">
-					{(field) => (
-						<field.NumberField
-							label=""
-							placeholder="7"
-							min={1}
-							className="w-16"
-							inputClassName="placeholder:opacity-50"
-							hideFieldInfo
+			<motion.div
+				layout
+				transition={FAST_TRANSITION}
+				className="flex items-center h-10 px-3 rounded-xl input-base gap-2 overflow-hidden"
+			>
+				<AnimatePresence mode="popLayout" initial={false}>
+					<motion.div
+						key="edit"
+						layout
+						initial={{ opacity: 0, x: 10 }}
+						animate={{ opacity: 1, x: 0 }}
+						exit={{ opacity: 0, x: -10 }}
+						transition={FAST_TRANSITION}
+						className="flex items-center gap-2"
+					>
+						<form.AppField name="trialLength">
+							{(field) => (
+								<field.NumberField
+									label=""
+									placeholder="7"
+									min={1}
+									className="w-16"
+									inputClassName="placeholder:opacity-50"
+									hideFieldInfo
+								/>
+							)}
+						</form.AppField>
+						<form.AppField name="trialDuration">
+							{(field) => (
+								<field.SelectField
+									placeholder="7"
+									label=""
+									options={
+										TRIAL_DURATION_OPTIONS as unknown as {
+											label: string;
+											value: FreeTrialDuration;
+										}[]
+									}
+									className="w-24"
+									hideFieldInfo
+								/>
+							)}
+						</form.AppField>
+						<IconButton
+							icon={<CheckIcon size={14} />}
+							variant="skeleton"
+							size="sm"
+							className="text-green-600 dark:text-green-500 hover:text-green-700! dark:hover:text-green-400! hover:bg-black/5 dark:hover:bg-white/10"
+							onClick={() => {
+								if (hasTrialValue) {
+									setIsEditing(false);
+									setIsAddingNewTrial(false);
+								} else {
+									handleClearTrial();
+								}
+							}}
 						/>
-					)}
-				</form.AppField>
-				<form.AppField name="trialDuration">
-					{(field) => (
-						<field.SelectField
-							placeholder="7"
-							label=""
-							options={
-								TRIAL_DURATION_OPTIONS as unknown as {
-									label: string;
-									value: FreeTrialDuration;
-								}[]
-							}
-							className="w-24"
-							hideFieldInfo
+						<IconButton
+							icon={<TrashIcon size={14} />}
+							variant="skeleton"
+							size="sm"
+							className="text-t4 hover:text-red-400!"
+							onClick={handleClearTrial}
 						/>
-					)}
-				</form.AppField>
-				<IconButton
-					icon={<TrashIcon size={14} />}
-					variant="skeleton"
-					size="sm"
-					className="text-t4 hover:text-red-400"
-					onClick={handleClearTrial}
-				/>
-			</div>
+					</motion.div>
+				</AnimatePresence>
+			</motion.div>
 		</div>
 	);
 }

--- a/vite/src/components/forms/update-subscription-v2/constants/animationConstants.ts
+++ b/vite/src/components/forms/update-subscription-v2/constants/animationConstants.ts
@@ -1,0 +1,16 @@
+import type { Transition } from "motion/react";
+
+export const FAST_TRANSITION: Transition = {
+	duration: 0.1,
+	ease: [0.32, 0.72, 0, 1],
+};
+
+export const TRANSITION: Transition = {
+	duration: 0.2,
+	ease: [0.32, 0.72, 0, 1],
+};
+
+export const LAYOUT_TRANSITION: Transition = {
+	duration: 0.35,
+	ease: [0.32, 0.72, 0, 1],
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds smooth layout and edit animations to the Update Subscription v2 form to reduce UI jank and make plan and trial edits feel responsive. Supports ENG-952 by improving the subscription editing UX.

- **New Features**
  - Added motion-based layout animations (LayoutGroup + motion) for items, deleted items, version change, and trial rows.
  - Used AnimatePresence for prepaid quantity and trial editor edit/display toggles.
  - Introduced shared animation constants (FAST_TRANSITION, TRANSITION, LAYOUT_TRANSITION).

- **Refactors**
  - Replaced CSS grid height hacks with motion layout transitions.
  - Wrapped “Edit Plan Items” button in motion for consistent layout shifts.
  - Fixed check icon hover color and tightened classes.
  - No API or behavior changes.

<sup>Written for commit 6a3da85e1fe33b2290e95a49120f341f764282ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR enhances the subscription update form with smooth animations and improved UX interactions.

**Key Changes:**

- **Improvements**: Created centralized animation constants file (`animationConstants.ts`) with three reusable transition configs (FAST_TRANSITION, TRANSITION, LAYOUT_TRANSITION) using a consistent cubic-bezier easing curve [0.32, 0.72, 0, 1]

- **Improvements**: Added `LayoutGroup` wrapper in `EditPlanSection.tsx` to enable coordinated layout animations when subscription items are added, removed, or reordered, with all items wrapped in `motion.div` components

- **Improvements**: Implemented `AnimatePresence` transitions in `SubscriptionItemRow.tsx` for prepaid quantity editing with smooth enter/exit animations (x: ±10px) that provide visual feedback during state changes

- **Improvements**: Enhanced `TrialEditorRow.tsx` with `AnimatePresence` for edit/display mode transitions, added a check icon button for confirming trial edits, and improved edit mode ring styling

- **Bug fixes**: Fixed button placement in `EditPlanSection.tsx` by moving "Edit Plan Items" button inside the conditional render block to prevent duplicate buttons when no items exist


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues
- The changes are well-structured UI improvements focused on animations. The code follows best practices by centralizing animation constants, using proper Framer Motion patterns (LayoutGroup, AnimatePresence), and maintaining consistent timing/easing values. The bug fix properly resolves duplicate button rendering. No logic errors, security concerns, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/update-subscription-v2/constants/animationConstants.ts | Created new file with reusable animation transition constants |
| vite/src/components/forms/update-subscription-v2/components/EditPlanSection.tsx | Added motion layout animations to subscription items and improved button placement |
| vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx | Added smooth AnimatePresence transitions for prepaid quantity editing |
| vite/src/components/forms/update-subscription-v2/components/TrialEditorRow.tsx | Enhanced trial editor with AnimatePresence transitions and added check button |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant EditPlanSection
    participant SubscriptionItemRow
    participant TrialEditorRow
    participant MotionFramer as Framer Motion

    User->>EditPlanSection: View subscription items
    EditPlanSection->>MotionFramer: Wrap items in LayoutGroup
    
    alt Edit prepaid quantity
        User->>SubscriptionItemRow: Click edit icon
        SubscriptionItemRow->>MotionFramer: Trigger AnimatePresence (edit mode)
        MotionFramer->>SubscriptionItemRow: Animate transition (x: -10→0)
        User->>SubscriptionItemRow: Update quantity
        User->>SubscriptionItemRow: Click check icon
        SubscriptionItemRow->>MotionFramer: Trigger AnimatePresence (display mode)
        MotionFramer->>SubscriptionItemRow: Animate transition (x: 10→0)
    end
    
    alt Edit trial
        User->>TrialEditorRow: Click edit icon
        TrialEditorRow->>MotionFramer: Trigger AnimatePresence (edit mode)
        MotionFramer->>TrialEditorRow: Animate transition (x: 10→0)
        User->>TrialEditorRow: Modify trial settings
        User->>TrialEditorRow: Click check/trash icon
        TrialEditorRow->>MotionFramer: Trigger AnimatePresence (display mode)
        MotionFramer->>TrialEditorRow: Animate transition (x: -10→0)
    end
    
    alt Add/remove items
        User->>EditPlanSection: Modify subscription items
        EditPlanSection->>MotionFramer: Trigger layout animations
        MotionFramer->>EditPlanSection: Animate item reordering (LAYOUT_TRANSITION)
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->