### PR TITLE
fix: autumn provider backend url

### DIFF
--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -92,8 +92,8 @@ export function MainLayout() {
 
 	return (
 		<AutumnProvider
-			// backendUrl={import.meta.env.VITE_BACKEND_URL}
-			backendUrl="http://localhost:8080"
+			backendUrl={import.meta.env.VITE_BACKEND_URL}
+			// backendUrl="http://localhost:8080"
 			includeCredentials={true}
 		>
 			<NuqsAdapter>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched AutumnProvider to use the VITE_BACKEND_URL env variable instead of a hard-coded localhost URL. This ensures correct API routing across environments and prevents production from pointing to a local backend.

<sup>Written for commit 4ec3b70776ebae04830127a781d0d390268c6e28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR fixes the AutumnProvider configuration in the main layout to use the environment variable `VITE_BACKEND_URL` instead of a hardcoded localhost URL. This change ensures consistent environment-based configuration across the application.

## Key Changes

- **Bug fixes**: Removed hardcoded backend URL (`http://localhost:8080`) and switched to using the `VITE_BACKEND_URL` environment variable, aligning with the loading state implementation and other components in the codebase


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with zero risk - it corrects a configuration bug by using environment variables instead of hardcoded values.
- This is a straightforward, low-risk bug fix. The change removes hardcoded localhost URL and switches to the proper environment variable configuration. The change is consistent with: (1) the loading state implementation on line 63 which already uses the same environment variable, (2) other components like OnboardingLayout.tsx that follow the same pattern, and (3) the standard configuration in .env.example. There are no side effects, no new logic, and no breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/app/layout.tsx | Fixed AutumnProvider to use environment variable `VITE_BACKEND_URL` instead of hardcoded localhost URL. Change aligns with loading state behavior and other components in the codebase. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant Layout as MainLayout Component
    participant Env as Environment
    participant AutumnProvider
    participant Backend

    Browser->>Layout: Load application
    Layout->>Env: Read VITE_BACKEND_URL
    Env-->>Layout: Return backend URL from config
    Layout->>AutumnProvider: Initialize with env-based URL
    AutumnProvider->>Backend: Connect using configured URL
    Backend-->>AutumnProvider: Connection established
    AutumnProvider-->>Layout: Ready for use
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->