### PR TITLE
feat: list events raw

### DIFF
--- a/server/src/utils/logging/initLogger.ts
+++ b/server/src/utils/logging/initLogger.ts
@@ -134,11 +134,7 @@ export const initLogger = () => {
 			stream: pino.transport({
 				target: "@axiomhq/pino",
 				options: {
-					dataset:
-						process.env.NODE_ENV === "test" ||
-						process.env.NODE_ENV === "development"
-							? "server-dev"
-							: "express",
+					dataset: "express",
 					token: process.env.AXIOM_TOKEN,
 				},
 			}),

--- a/shared/api/events/list/eventsListParams.ts
+++ b/shared/api/events/list/eventsListParams.ts
@@ -4,11 +4,12 @@ import { createPaginationParamsSchema } from "../../common/pagePaginationSchemas
 export const ApiEventsListParamsSchema = createPaginationParamsSchema({
 	defaultLimit: 100,
 }).extend({
-	customer_id: z.string().describe("Filter events by customer ID"),
+	customer_id: z.string().optional().describe("Filter events by customer ID"),
 	feature_id: z
 		.string()
 		.min(1)
 		.or(z.array(z.string().min(1)))
+		.optional()
 		.describe("Filter by specific feature ID(s)"),
 
 	custom_range: z


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allows listing events without customer_id or feature_id filters, enabling raw event retrieval. Also standardizes Axiom logging to use the "express" dataset in all environments.

- **New Features**
  - customer_id and feature_id are now optional in ApiEventsListParamsSchema for raw event listing.

- **Refactors**
  - Axiom pino transport uses the "express" dataset for all NODE_ENV values.

<sup>Written for commit 16b083ff393899f8ed90599b98b2e70bc150d4bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR enables listing all events without requiring customer or feature filters, and consolidates logging to a single Axiom dataset.

**Key Changes:**
- **API changes**: Made `customer_id` and `feature_id` parameters optional in the events list endpoint, allowing retrieval of all organization events without filtering by customer or feature
- **Improvements**: Simplified Axiom logging configuration by removing environment-based dataset branching - all environments now consistently log to the "express" dataset

The service layer (`EventListService`) already handles optional parameters correctly with conditional query building, so no backend logic changes were needed.


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are simple, well-scoped, and the backend service already handles optional parameters correctly. Making `customer_id` and `feature_id` optional enables legitimate use cases (listing all org events) without introducing bugs. The logging simplification is also safe as it just consolidates dataset configuration.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/events/list/eventsListParams.ts | Made `customer_id` and `feature_id` optional to allow listing all events without filters |
| server/src/utils/logging/initLogger.ts | Simplified Axiom dataset configuration to always use "express" regardless of environment |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as /events/list
    participant Handler as handleListEvents
    participant Service as EventListService
    participant ClickHouse

    Client->>API: POST /events/list
    Note over Client,API: customer_id: optional<br/>feature_id: optional
    API->>Handler: Validate params with ApiEventsListParamsSchema
    Handler->>Service: getEvents(ctx, params)
    Service->>Service: buildWhereConditions()
    Note over Service: Conditionally adds filters<br/>if customer_id or feature_id provided
    Service->>Service: buildQueryParams()
    Service->>ClickHouse: SELECT events WHERE org_id AND env<br/>[AND customer_id] [AND event_name]
    ClickHouse-->>Service: Raw events
    Service->>Service: transformRawEvents()
    Service-->>Handler: { list, has_more, total, offset, limit }
    Handler-->>Client: ApiEventsListResponse
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->