### PR TITLE
fix: Migrate GET /:product_id/has_customers route to Hono

### DIFF
--- a/server/src/internal/products/productRouter.ts
+++ b/server/src/internal/products/productRouter.ts
@@ -9,11 +9,10 @@ import { handleGetPlan } from "./handlers/handleGetPlan.js";
 import { handleGetPlanDeleteInfo } from "./handlers/handleGetPlanDeleteInfo.js";
 import { handleListPlans } from "./handlers/handleListPlans.js";
 import { handleMigrateProductV2 } from "./handlers/handleMigrateProductV2.js";
-import { handlePlanHasCustomers } from "./handlers/handlePlanHasCustomers.js";
+
 import { handleUpdatePlan } from "./handlers/handleUpdateProduct/handleUpdatePlan.js";
 
 export const expressProductRouter = express.Router();
-expressProductRouter.get("/:product_id/has_customers", handlePlanHasCustomers);
 
 export const honoProductBetaRouter = new Hono<HonoEnv>();
 honoProductBetaRouter.get("", ...handleListPlans);
@@ -37,6 +36,7 @@ honoProductRouter.delete("/:product_id", ...handleDeleteProductHono);
 honoProductRouter.post("/:product_id/copy", ...handleCopyProductV2);
 
 // Info before deleting plan
+honoProductRouter.get("/:product_id/has_customers", ...handlePlanHasCustomersV2);
 honoProductRouter.post(
 	"/:product_id/has_customers",
 	...handlePlanHasCustomersV2,


### PR DESCRIPTION
## Summary
- Migrates the final Express route `GET /:product_id/has_customers` to Hono
- Uses existing `handlePlanHasCustomersV2` handler
- Removes unused `handlePlanHasCustomers` import

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated GET /:product_id/has_customers from Express to Hono and routed it through handlePlanHasCustomersV2. Removed the old Express route and unused handler import so GET now matches the existing POST behavior.

<sup>Written for commit 34b3ef4106c3b536ea3920e670da809ec59dd1b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Completed migration of the final Express route to Hono by moving the GET `/:product_id/has_customers` endpoint from Express to the Hono router.

**Key Changes:**
- **Bug fixes**: Removed the Express-based `/:product_id/has_customers` route and associated imports
- **API changes**: Added GET `/:product_id/has_customers` route to Hono router using `handlePlanHasCustomersV2` handler
- **Improvements**: Cleaned up unused `handlePlanHasCustomers` import, completing the Express-to-Hono migration

The migration maintains functional parity with the previous Express implementation. Both the old Express handler and the new Hono handler read a request body and perform the same logic: fetching the product, querying customer products, comparing product versions, and returning versioning information. A POST route for this same endpoint already exists (lines 40-42), so the GET route appears to maintain backward compatibility.
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it's a straightforward framework migration with minimal logic changes
- Score reflects that this is a simple migration from Express to Hono with identical handler logic. The changes are minimal (removed Express route, added Hono route, cleaned up imports) and maintain backward compatibility. One minor concern is the non-standard use of GET with a request body, but this was present in the original Express implementation and a POST route exists as an alternative.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/productRouter.ts | Migrated final Express route to Hono by adding GET `/:product_id/has_customers` route using `handlePlanHasCustomersV2` handler and removing unused Express router and handler import |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant HonoRouter as Hono Product Router
    participant Handler as handlePlanHasCustomersV2
    participant ProductService
    participant CusProductService
    participant Database

    Client->>HonoRouter: GET /products/:product_id/has_customers
    HonoRouter->>Handler: Route request
    Handler->>Handler: Extract product_id from params
    Handler->>Handler: Get context (db, features, org, env)
    Handler->>Handler: Parse JSON body (ProductV2)
    Handler->>ProductService: getFull(product_id, orgId, env)
    ProductService->>Database: Query product by ID/internal_id
    Database-->>ProductService: Return product
    ProductService-->>Handler: Return full product
    alt Product not found
        Handler-->>Client: Throw ProductNotFoundError
    end
    Handler->>CusProductService: getByInternalProductId(internal_id)
    CusProductService->>Database: Query customer products
    Database-->>CusProductService: Return customer products
    CusProductService-->>Handler: Return cusProductsCurVersion[]
    Handler->>Handler: Compare products using productsAreSame()
    Handler->>Handler: Calculate productSame (itemsSame && freeTrialsSame)
    Handler->>Handler: Determine will_version based on productSame and customers
    Handler-->>Client: Return {current_version, will_version, archived}
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->