### PR TITLE
chore: add open in stripe in reward dropdown

### DIFF
--- a/vite/src/utils/linkUtils.ts
+++ b/vite/src/utils/linkUtils.ts
@@ -100,3 +100,18 @@ export const getStripeConnectViewAsLink = ({
 	const withTest = env === AppEnv.Live ? "" : "/test";
 	return `${baseUrl}/${masterAccountId}/connect/view-as/${connectedAccountId}${withTest}/${path}`;
 };
+
+export const getStripeCouponLink = ({
+	couponId,
+	env,
+	accountId,
+}: {
+	couponId: string;
+	env: AppEnv;
+	accountId?: string;
+}) => {
+	const baseUrl = `https://dashboard.stripe.com`;
+	const accountPath = accountId ? `/${accountId}` : "";
+	const withTest = env === AppEnv.Live ? "" : "/test";
+	return `${baseUrl}${accountPath}${withTest}/coupons/${encodeURIComponent(couponId)}`;
+};

--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -13,7 +13,7 @@ import { authClient, signIn } from "@/lib/auth-client";
 import { getBackendErr } from "@/utils/genUtils";
 import { OTPSignIn } from "./components/OTPSignIn";
 
-export const emailSchema = z.email();
+export const emailSchema = z.string().email();
 
 /**
  * Check if URL has OAuth parameters (from OAuth provider redirect)

--- a/vite/src/views/products/rewards/components/RewardRowToolbar.tsx
+++ b/vite/src/views/products/rewards/components/RewardRowToolbar.tsx
@@ -1,27 +1,31 @@
-import SmallSpinner from "@/components/general/SmallSpinner";
-
-import {
-	DropdownMenu,
-	DropdownMenuTrigger,
-	DropdownMenuContent,
-	DropdownMenuItem,
-} from "@/components/ui/dropdown-menu";
+import type { Reward } from "@autumn/shared";
+import { RewardType } from "@autumn/shared";
+import { ArrowSquareOut, Trash } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
-
-import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { Reward } from "@autumn/shared";
-import { getBackendErr } from "@/utils/genUtils";
-import { RewardService } from "@/services/products/RewardService";
+import SmallSpinner from "@/components/general/SmallSpinner";
 import { ToolbarButton } from "@/components/general/table-components/ToolbarButton";
-import { Delete } from "lucide-react";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useRewardsQuery } from "@/hooks/queries/useRewardsQuery";
+import { RewardService } from "@/services/products/RewardService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useEnv } from "@/utils/envUtils";
+import { getBackendErr } from "@/utils/genUtils";
+import { getStripeCouponLink } from "@/utils/linkUtils";
 
 export const RewardRowToolbar = ({ reward }: { reward: Reward }) => {
 	const { refetch } = useRewardsQuery();
+	const { stripeAccount } = useOrgStripeQuery();
 	const axiosInstance = useAxiosInstance();
+	const env = useEnv();
 	const [deleteLoading, setDeleteLoading] = useState(false);
-	const [deleteOpen, setDeleteOpen] = useState(false);
+	const [dropdownOpen, setDropdownOpen] = useState(false);
 
 	const handleDelete = async () => {
 		setDeleteLoading(true);
@@ -37,14 +41,43 @@ export const RewardRowToolbar = ({ reward }: { reward: Reward }) => {
 		}
 
 		setDeleteLoading(false);
-		setDeleteOpen(false);
+		setDropdownOpen(false);
 	};
+
+	const handleOpenInStripe = () => {
+		if (!reward.id) return;
+		window.open(
+			getStripeCouponLink({
+				couponId: reward.id,
+				env,
+				accountId: stripeAccount?.id,
+			}),
+			"_blank",
+		);
+	};
+
+	const isDiscountReward = reward.type !== RewardType.FreeProduct;
+
 	return (
-		<DropdownMenu open={deleteOpen} onOpenChange={setDeleteOpen}>
+		<DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
 			<DropdownMenuTrigger asChild>
 				<ToolbarButton />
 			</DropdownMenuTrigger>
 			<DropdownMenuContent className="text-t2" align="end">
+				{isDiscountReward && reward.id && (
+					<DropdownMenuItem
+						className="flex items-center"
+						onClick={(e) => {
+							e.stopPropagation();
+							handleOpenInStripe();
+						}}
+					>
+						<div className="flex items-center justify-between w-full gap-2">
+							Open in Stripe
+							<ArrowSquareOut size={12} className="text-t3" />
+						</div>
+					</DropdownMenuItem>
+				)}
 				<DropdownMenuItem
 					className="flex items-center"
 					onClick={async (e) => {
@@ -58,7 +91,7 @@ export const RewardRowToolbar = ({ reward }: { reward: Reward }) => {
 						{deleteLoading ? (
 							<SmallSpinner />
 						) : (
-							<Delete size={12} className="text-t3" />
+							<Trash size={12} className="text-t3" />
 						)}
 					</div>
 				</DropdownMenuItem>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds “Open in Stripe” to the reward row dropdown to quickly view the associated Stripe coupon for discount rewards. Also fixes email validation in SignIn.

- **New Features**
  - “Open in Stripe” appears for non-FreeProduct rewards with an ID and opens the coupon in a new tab, using the org’s connected Stripe account and env (test/live).
  - Added getStripeCouponLink utility to generate the correct dashboard URL.

- **Bug Fixes**
  - Corrected email schema to z.string().email() in SignIn.

<sup>Written for commit a9770fbbf0fa26833830f66fe5949e09b71433b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the ability to open discount rewards in Stripe from the reward dropdown menu and includes a minor bug fix for email validation.

**Key Changes:**

- **Improvements**: Added `getStripeCouponLink` utility function to `linkUtils.ts` following the existing pattern for generating Stripe dashboard URLs
- **Improvements**: Added "Open in Stripe" menu item to reward dropdown for discount rewards (percentage, fixed, and invoice credits), allowing quick navigation to Stripe dashboard
- **Improvements**: Changed delete icon from lucide `Delete` to phosphor `Trash` for consistency with the new `ArrowSquareOut` icon from phosphor
- **Bug fixes**: Fixed email schema validation in `SignIn.tsx` from deprecated `z.email()` to correct `z.string().email()` syntax for zod/v4
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - the changes are straightforward and follow existing patterns.
- Score reflects clean implementation following existing codebase patterns with one minor question about FreeProduct reward handling. The new utility function mirrors existing Stripe link generators, the email fix corrects deprecated syntax, and the UI changes are minimal. No breaking changes or risky logic modifications.
- Check `RewardRowToolbar.tsx` to confirm if FreeProduct rewards should also support "Open in Stripe".

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/rewards/components/RewardRowToolbar.tsx | Added Open in Stripe functionality for discount rewards, changed Delete icon from lucide to phosphor, but has potential logic issue with InvoiceCredits reward type |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant RewardRowToolbar
    participant Browser
    participant StripeAPI
    
    User->>RewardRowToolbar: Click toolbar button
    RewardRowToolbar->>RewardRowToolbar: Check reward type
    
    alt Discount Reward (not FreeProduct) && has reward.id
        RewardRowToolbar->>User: Show "Open in Stripe" option
        User->>RewardRowToolbar: Click "Open in Stripe"
        RewardRowToolbar->>RewardRowToolbar: Call getStripeCouponLink()
        RewardRowToolbar->>Browser: window.open(stripeCouponUrl, "_blank")
        Browser->>StripeAPI: Navigate to Stripe coupon page
    end
    
    User->>RewardRowToolbar: Click "Delete"
    RewardRowToolbar->>RewardRowToolbar: handleDelete()
    RewardRowToolbar->>StripeAPI: DELETE reward
    StripeAPI-->>RewardRowToolbar: Success
    RewardRowToolbar->>RewardRowToolbar: refetch()
    RewardRowToolbar->>User: Update UI
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->