### PR TITLE
fix: get billing portal

### DIFF
--- a/server/src/internal/customers/cusRouter.ts
+++ b/server/src/internal/customers/cusRouter.ts
@@ -15,7 +15,7 @@ import { handleUpdateBalancesV2 } from "./handlers/handleUpdateBalancesV2.js";
 import { handleUpdateCustomerV2 } from "./handlers/handleUpdateCustomerV2.js";
 
 export const expressCusRouter = express.Router();
-expressCusRouter.get("/:customer_id/billing_portal", handleGetBillingPortal);
+// expressCusRouter.get("/:customer_id/billing_portal", handleGetBillingPortal);
 
 export const cusRouter = new Hono<HonoEnv>();
 
@@ -35,6 +35,7 @@ cusRouter.post("/:customer_id/transfer", ...handleTransferProductV2);
 
 // Billing portal
 cusRouter.post("/:customer_id/billing_portal", ...handleCreateBillingPortal);
+cusRouter.get("/:customer_id/billing_portal", ...handleGetBillingPortal);
 
 // Legacy...
 cusRouter.post("/:customer_id/balances", ...handleUpdateBalancesV2);

--- a/server/src/internal/customers/handlers/handleBillingPortal/handleGetBillingPortal.ts
+++ b/server/src/internal/customers/handlers/handleBillingPortal/handleGetBillingPortal.ts
@@ -1,67 +1,63 @@
-import { ErrCode, RecaseError } from "@autumn/shared";
+import {
+	ErrCode,
+	GetBillingPortalQuerySchema,
+	RecaseError,
+} from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
+import z from "zod/v4";
+import { createStripeCusIfNotExists } from "@/external/stripe/stripeCusUtils";
+import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { createStripeCli } from "../../../../external/connect/createStripeCli";
-import { createStripeCusIfNotExists } from "../../../../external/stripe/stripeCusUtils";
-import { routeHandler } from "../../../../utils/routerUtils";
-import { OrgService } from "../../../orgs/OrgService";
 import { toSuccessUrl } from "../../../orgs/orgUtils/convertOrgUtils";
 import { CusService } from "../../CusService";
 
-export const handleGetBillingPortal = (req: any, res: any) =>
-	routeHandler({
-		req,
-		res,
-		action: "get billing portal",
-		handler: async (req, res) => {
-			const returnUrl = req.query.return_url;
-			const customerId = req.params.customer_id;
-			const [org, customer] = await Promise.all([
-				OrgService.getFromReq(req),
-				CusService.get({
-					db: req.db,
-					idOrInternalId: customerId,
-					orgId: req.orgId,
-					env: req.env,
-				}),
-			]);
+export const handleGetBillingPortal = createRoute({
+	query: GetBillingPortalQuerySchema,
+	params: z.object({
+		customer_id: z.string(),
+	}),
+	// body: GetBillingPortalBodySchema,
+	handler: async (c) => {
+		const returnUrl = c.req.valid("query").return_url;
+		const customerId = c.req.param().customer_id;
+		const ctx = c.get("ctx");
+		const [customer] = await Promise.all([
+			CusService.get({
+				db: ctx.db,
+				idOrInternalId: customerId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			}),
+		]);
 
-			if (!customer) {
-				throw new RecaseError({
-					message: `Customer ${customerId} not found`,
-					code: ErrCode.CustomerNotFound,
-					statusCode: StatusCodes.NOT_FOUND,
-				});
-			}
-
-			const stripeCli = createStripeCli({ org, env: req.env });
-
-			let stripeCusId: string = customer.processor?.id;
-			if (!customer.processor?.id) {
-				const newCus = await createStripeCusIfNotExists({
-					db: req.db,
-					org,
-					env: req.env,
-					customer,
-					logger: req.logger,
-				});
-
-				if (!newCus) {
-					throw new RecaseError({
-						message: `Failed to create Stripe customer`,
-					});
-				}
-
-				stripeCusId = newCus.id;
-			}
-
-			const portal = await stripeCli.billingPortal.sessions.create({
-				customer: stripeCusId,
-				return_url: returnUrl || toSuccessUrl({ org, env: req.env }),
+		if (!customer) {
+			throw new RecaseError({
+				message: `Customer ${customerId} not found`,
+				code: ErrCode.CustomerNotFound,
+				statusCode: StatusCodes.NOT_FOUND,
 			});
+		}
 
-			res.status(200).json({
-				customer_id: customer.id || null,
-				url: portal.url,
-			});
-		},
-	});
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+
+		const stripeCustomer = await createStripeCusIfNotExists({
+			db: ctx.db,
+			org: ctx.org,
+			env: ctx.env,
+			customer,
+			logger: ctx.logger,
+		});
+
+		const stripeCusId = stripeCustomer.id;
+
+		const portal = await stripeCli.billingPortal.sessions.create({
+			customer: stripeCusId,
+			return_url: returnUrl || toSuccessUrl({ org: ctx.org, env: ctx.env }),
+		});
+
+		return c.json({
+			customer_id: customer.id || null,
+			url: portal.url,
+		});
+	},
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the GET /:customer_id/billing_portal endpoint by moving it to the Hono router, adding request validation, and reliably creating the Stripe customer before starting a portal session.

- **Bug Fixes**
  - Added GET route to the Hono router; removed the Express route.
  - Rewrote handler with createRoute and zod schema validation for query and params.
  - Always ensures a Stripe customer exists via createStripeCusIfNotExists.
  - Uses org/env from context and returns customer_id and portal URL.

<sup>Written for commit 673971a63b2b929f30397849f820591f7d366312. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Migrated the GET billing portal endpoint from Express to Hono framework with proper schema validation.

**Bug fixes**
- Restored GET endpoint functionality for retrieving billing portal sessions (was commented out in Express router)
- Migrated to Hono framework with proper request validation using `GetBillingPortalQuerySchema`

**API changes**
- GET `/:customer_id/billing_portal` now uses Hono router instead of Express
- Request handling now uses `createRoute` with typed params and query validation
</details>


<h3>Confidence Score: 3/5</h3>

- Safe to merge with one critical issue that needs fixing
- The migration is mostly correct, but the GET endpoint lacks error handling for missing default billing portal configurations that the POST endpoint handles properly. This could cause runtime errors in production.
- `server/src/internal/customers/handlers/handleBillingPortal/handleGetBillingPortal.ts` - missing error handling for default portal configuration

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/handlers/handleBillingPortal/handleGetBillingPortal.ts | Refactored from Express to Hono with proper validation, but missing error handling for missing default portal configuration |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant HonoRouter as Hono Router
    participant Handler as handleGetBillingPortal
    participant CusService
    participant StripeAPI as Stripe API
    participant StripeCusUtils as createStripeCusIfNotExists

    Client->>HonoRouter: GET /:customer_id/billing_portal?return_url=...
    HonoRouter->>Handler: Route to handler with validated query & params
    Handler->>CusService: CusService.get(customerId, orgId, env)
    CusService-->>Handler: Return customer or null
    
    alt customer not found
        Handler-->>Client: 404 CustomerNotFoundError
    end
    
    Handler->>StripeCusUtils: createStripeCusIfNotExists(customer)
    StripeCusUtils-->>Handler: Return Stripe customer
    Handler->>StripeAPI: billingPortal.sessions.create(stripeCustomerId, return_url)
    
    alt default config missing (not handled)
        StripeAPI-->>Handler: Error: default configuration not created
        Handler-->>Client: 500 Error (unhandled)
    end
    
    StripeAPI-->>Handler: Return portal session
    Handler-->>Client: 200 { customer_id, url }
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->