### PR TITLE
fix: new group by max

### DIFF
--- a/server/src/internal/events/EventsAggregationService.ts
+++ b/server/src/internal/events/EventsAggregationService.ts
@@ -305,9 +305,9 @@ export class EventsAggregationService {
 			}>;
 			const distinctCount = Number(distinctJson.data[0]?.distinct_count ?? 0);
 
-			if (distinctCount > 30) {
+			if (distinctCount > 100) {
 				throw new RecaseError({
-					message: `Too many distinct group values (${distinctCount}). Maximum allowed is 30. Please choose a property with fewer unique values.`,
+					message: `Too many distinct group values (${distinctCount}). Maximum allowed is 100. Please choose a property with fewer unique values.`,
 					code: ErrCode.InvalidInputs,
 					statusCode: StatusCodes.BAD_REQUEST,
 				});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Raised the max allowed distinct group-by values from 30 to 100 to support broader segmentations and reduce false “too many groups” errors. Updated the validation and error message to reflect the new limit.

<sup>Written for commit c163b7deebfc2f91a5dabd5f6cb96f46e998fd47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Increased the maximum allowed distinct group-by values from 30 to 100 to support broader data segmentation capabilities and reduce false "too many groups" validation errors.

**Key Changes:**
- **Bug fixes**: Raised limit from 30 to 100 distinct values for `group_by` aggregations (lines 308-310)
- **Bug fixes**: Updated error message to reflect new 100-value maximum (line 310)
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple configuration update that increases a validation threshold. Both the validation logic (line 308) and error message (line 310) are updated consistently, maintaining code correctness. No logic changes, security implications, or architectural modifications are introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/events/EventsAggregationService.ts | Increased max distinct group-by values from 30 to 100 in validation check and error message |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as handleAggregateEvents
    participant EAS as EventsAggregationService
    participant CH as ClickHouse

    Client->>API: POST /aggregate-events<br/>{group_by: "properties.country"}
    API->>EAS: getTimeseriesEvents(params)
    
    alt group_by is provided
        EAS->>EAS: Extract property path and validate
        EAS->>CH: Query distinct count for group_by field
        CH-->>EAS: Return distinct_count
        
        alt distinct_count > 100 (NEW LIMIT)
            EAS-->>API: Throw RecaseError<br/>"Too many distinct values"
            API-->>Client: 400 Bad Request
        else distinct_count <= 100
            EAS->>CH: Execute timeseries query with GROUP BY
            CH-->>EAS: Return grouped results
            EAS-->>API: Return aggregated data
            API-->>Client: 200 OK with grouped timeseries
        end
    else no group_by
        EAS->>CH: Execute timeseries query without grouping
        CH-->>EAS: Return results
        EAS-->>API: Return aggregated data
        API-->>Client: 200 OK with timeseries
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->