### PR TITLE
db timestamp error while migration fixed and dependency fixed

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "autumn",
       "dependencies": {
-        "@better-auth/core": "^1.4.12",
-        "@better-auth/oauth-provider": "^1.4.12",
+        "@better-auth/core": "1.4.12",
+        "@better-auth/oauth-provider": "1.4.12",
         "@wooorm/starry-night": "^3.8.0",
         "ag-charts-react": "^12.3.0",
         "better-auth": "1.4.12",
@@ -565,7 +565,7 @@
 
     "@better-auth/core": ["@better-auth/core@1.4.12", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.7", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-VfqZwMAEl9rnGx092BIZ2Q5z8rt7jjN2OAbvPqehufSKZGmh8JsdtZRBMl/CHQir9bwi2Ev0UF4+7TQp+DXEMg=="],
 
-    "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.4.13", "", { "dependencies": { "jose": "^6.1.0", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/core": "1.4.13", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-auth": "1.4.13", "better-call": "1.1.7" } }, "sha512-gMQYfxfe9QeCvhTE6mljEYqcxZIxxfstFsCmhKNOsbeuD95R7ePs/LwDZaxmqnjFEPyS+rkavyR1P7QSfKPstQ=="],
+    "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.4.12", "", { "dependencies": { "jose": "^6.1.0", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/core": "1.4.12", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-auth": "1.4.12", "better-call": "1.1.7" } }, "sha512-YzyXU7dWUESfui1KVs18GwkQNHfcRHj1ZkXqSLMlWfVZp3LJzLXhVdYQx5WBkj0B/UIY4aJQTX15dNxu5eaKGw=="],
 
     "@better-auth/stripe": ["@better-auth/stripe@1.4.13", "", { "dependencies": { "defu": "^6.1.4", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/core": "1.4.13", "better-auth": "1.4.13", "stripe": "^18 || ^19 || ^20" } }, "sha512-euzQtEWD9061ggcfeX4UZ5IifzVaeXcGMEtksKBhy5vFvz1rVU2FvcWELS48kb9siKZs27E13G0QfOSBrE3U/w=="],
 
@@ -4051,6 +4051,8 @@
 
     "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "@autumn/server/@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.4.13", "", { "dependencies": { "jose": "^6.1.0", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/core": "1.4.13", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-auth": "1.4.13", "better-call": "1.1.7" } }, "sha512-gMQYfxfe9QeCvhTE6mljEYqcxZIxxfstFsCmhKNOsbeuD95R7ePs/LwDZaxmqnjFEPyS+rkavyR1P7QSfKPstQ=="],
+
     "@autumn/server/@types/node": ["@types/node@25.0.8", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg=="],
 
     "@autumn/shared/@date-fns/utc": ["@date-fns/utc@2.1.0", "", {}, "sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA=="],
@@ -4996,6 +4998,8 @@
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@autumn/server/@better-auth/oauth-provider/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "@autumn/vite/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
 		"q": "lsof -ti:8080 -ti:3000 | xargs kill -9"
 	},
 	"dependencies": {
-		"@better-auth/core": "^1.4.12",
-		"@better-auth/oauth-provider": "^1.4.12",
+		"@better-auth/core": "1.4.12",
+		"@better-auth/oauth-provider": "1.4.12",
 		"@wooorm/starry-night": "^3.8.0",
 		"ag-charts-react": "^12.3.0",
 		"better-auth": "1.4.12",

--- a/shared/db/auth-schema.ts
+++ b/shared/db/auth-schema.ts
@@ -11,7 +11,6 @@ import {
 	type Organization,
 	organizations,
 } from "../models/orgModels/orgTable.js";
-import { sqlNow } from "./utils.js";
 
 export const user = pgTable(
 	"user",
@@ -132,8 +131,8 @@ export const invitation = pgTable(
 		role: text("role"),
 		status: text("status").default("pending").notNull(),
 		createdAt: timestamp("created_at", { withTimezone: true })
-			.notNull()
-			.default(sqlNow),
+			.$defaultFn(() => /* @__PURE__ */ new Date())
+			.notNull(),
 		expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
 		inviterId: text("inviter_id")
 			.notNull()


### PR DESCRIPTION
## Summary
Fix `invitation.created_at` default type mismatch (timestamp vs BIGINT) that caused migration errors, and improve local setup flow so dependencies used during `bun setup` no longer conflict.

## Related Issues
Fixes #423 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

## Additional Context
- `shared/db/auth-schema.ts`: changed `invitation.createdAt` to use `.$defaultFn(() => new Date())` instead of `sqlNow`, aligning the default with the `timestamp with time zone` column type.
- Verified that new migrations no longer generate the invalid `created_at` default expression and that DB setup/migration runs successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes migration failures by aligning invitation.created_at’s default with a timestamp type, and pins auth deps to avoid setup conflicts.

- **Bug Fixes**
  - Set invitation.createdAt default via $defaultFn(() => new Date()) to match timestamp with time zone and stop invalid default errors during migration.

- **Dependencies**
  - Pin @better-auth/core and @better-auth/oauth-provider to 1.4.12 (no caret) to prevent version drift and local setup conflicts.

<sup>Written for commit fb6ad6b94ac9bb93c3e866cdbdf5feef53bb5c6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


- Fixed critical database migration failure by correcting `invitation.created_at` default type mismatch from BIGINT to timestamp with time zone
- Resolved dependency conflicts during setup by pinning `@better-auth/core` and `@better-auth/oauth-provider` to exact version 1.4.12


</details>
<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| shared/db/auth-schema.ts | Fixed invitation.createdAt default from sqlNow to .$defaultFn(() => new Date()) to match timestamp type |
| package.json | Pinned auth dependencies to exact versions (removed caret ranges) to prevent version conflicts |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects clear bug fixes with targeted, well-understood changes to resolve specific migration and dependency issues
- No files require special attention as both changes are straightforward fixes addressing known problems

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Scripts as "Migration Scripts"
    participant DB as "Database"
    participant Schema as "Auth Schema"
    participant DrizzleKit as "Drizzle Kit"
    
    User->>Scripts: "Run bun setup or db:migrate"
    Scripts->>Schema: "Load auth-schema.ts"
    Schema->>Schema: "Define invitation table with createdAt field"
    Note over Schema: "Before: sqlNow (BIGINT conflict)<br/>After: $defaultFn(() => new Date())"
    Schema->>DrizzleKit: "Generate migration SQL"
    DrizzleKit->>DB: "Execute CREATE/ALTER table commands"
    DB-->>DrizzleKit: "Migration success"
    DrizzleKit-->>Scripts: "Migration complete"
    Scripts->>Scripts: "Run initializeDatabaseFunctions()"
    Scripts->>DB: "Load SQL function files"
    DB-->>Scripts: "Functions loaded"
    Scripts-->>User: "Setup complete"
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))

<!-- /greptile_comment -->