### PR TITLE
fix: 🐛 entity scoped customer balance on frontend, email bug

### DIFF
--- a/server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts
+++ b/server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts
@@ -36,9 +36,9 @@ export const prepareNewBalanceForInsertion = async ({
 
 	const entity = fullCustomer.entity;
 
-	if (entity) {
-		newEntitlement.entity_feature_id = entity.feature_id;
-	}
+	// NOTE: We do NOT set entity_feature_id here. That field means "per-entity balances"
+	// (e.g., 10 messages per seat). For entity-scoped loose balances, we only set
+	// internal_entity_id on the cusEnt to scope the balance to a specific entity.
 
 	const newEntitlementWithFeature = enrichEntitlementWithFeature({
 		entitlement: newEntitlement,

--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -4,7 +4,6 @@ import { Mail } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
-import { z } from "zod";
 import { CustomToaster } from "@/components/general/CustomToaster";
 import { IconButton } from "@/components/v2/buttons/IconButton";
 import { Input } from "@/components/v2/inputs/Input";
@@ -13,7 +12,7 @@ import { authClient, signIn } from "@/lib/auth-client";
 import { getBackendErr } from "@/utils/genUtils";
 import { OTPSignIn } from "./components/OTPSignIn";
 
-export const emailSchema = z.email();
+export const emailRegex = /^[^@]+@[^@]+\.[^@]+$/;
 
 export const SignIn = () => {
 	const [email, setEmail] = useState("");
@@ -39,7 +38,7 @@ export const SignIn = () => {
 
 	const handleEmailSignIn = async (e: React.FormEvent) => {
 		e.preventDefault();
-		if (!email || !emailSchema.safeParse(email).success) {
+		if (!email || !emailRegex.test(email)) {
 			toast.error("Please enter a valid email address.");
 			return;
 		}

--- a/vite/src/views/auth/components/PasswordSignIn.tsx
+++ b/vite/src/views/auth/components/PasswordSignIn.tsx
@@ -5,7 +5,7 @@ import { CustomToaster } from "@/components/general/CustomToaster";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { authClient, useSession } from "@/lib/auth-client";
-import { emailSchema } from "../SignIn";
+import { emailRegex } from "../SignIn";
 
 export const PasswordSignIn = () => {
 	const [email, setEmail] = useState("");
@@ -25,7 +25,7 @@ export const PasswordSignIn = () => {
 
 	const handleEmailSignIn = async (e: React.FormEvent) => {
 		e.preventDefault();
-		if (!email || !emailSchema.safeParse(email).success) {
+		if (!email || !emailRegex.test(email)) {
 			toast.error("Please enter a valid email address.");
 			return;
 		}
@@ -67,48 +67,46 @@ export const PasswordSignIn = () => {
 					</h1>
 				</div>
 
-				<>
-					<div className="space-y-6">
-						<div className="space-y-2">
-							<Input
-								type="email"
-								placeholder="Email"
-								value={email}
-								onChange={(e) => setEmail(e.target.value)}
-								required
-								className="text-base"
-								autoComplete="email"
-							/>
-							<Input
-								type="password"
-								placeholder="Password"
-								value={password}
-								onChange={(e) => setPassword(e.target.value)}
-								required
-								className="text-base"
-								autoComplete="email"
-							/>
-						</div>
-
-						{/* Sign In Button */}
-						<Button
-							type="submit"
-							variant="auth"
-							isLoading={loading}
-							onClick={handleEmailSignIn}
-							className={height}
-						>
-							Sign in
-						</Button>
+				<div className="space-y-6">
+					<div className="space-y-2">
+						<Input
+							type="email"
+							placeholder="Email"
+							value={email}
+							onChange={(e) => setEmail(e.target.value)}
+							required
+							className="text-base"
+							autoComplete="email"
+						/>
+						<Input
+							type="password"
+							placeholder="Password"
+							value={password}
+							onChange={(e) => setPassword(e.target.value)}
+							required
+							className="text-base"
+							autoComplete="email"
+						/>
 					</div>
 
-					{/* Footer */}
-					{/* <div className="text-center space-y-2">
+					{/* Sign In Button */}
+					<Button
+						type="submit"
+						variant="auth"
+						isLoading={loading}
+						onClick={handleEmailSignIn}
+						className={height}
+					>
+						Sign in
+					</Button>
+				</div>
+
+				{/* Footer */}
+				{/* <div className="text-center space-y-2">
               <Link to="/sign-up" className="hover:underline text-t3 text-sm">
                 Create an account here
               </Link>
             </div> */}
-				</>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes entity-scoped balances so loose entitlements are correctly scoped and displayed per entity. Also fixes email sign-in validation to prevent errors with valid addresses.

- **Bug Fixes**
  - Backend: Stop setting entity_feature_id for loose balances; use internal_entity_id only to scope balances to an entity.
  - Customers UI: When an entity is selected, show only that entity’s loose entitlements; at the customer level, show all. Selected entity is memoized for correct filtering.
  - Auth: Replace zod email validation with a simple regex in SignIn and PasswordSignIn to avoid sign-in failures with valid emails; minor UI cleanup.

<sup>Written for commit b43f520efe84b58d8b9a42973a1752f0a9c12d9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


fixed entity-scoped customer balance visibility and email validation

**Key Changes:**

**Bug fixes**
- Fixed entity-scoped loose entitlements filtering in `CustomerFeatureUsageTable` - at customer level shows all loose entitlements (including entity-scoped ones), at entity level shows only that specific entity's loose entitlements
- Removed incorrect `entity_feature_id` assignment in `prepareNewBalanceForInsertion` - this field is for per-entity balances (e.g., 10 messages per seat), not entity-scoped loose balances which use `internal_entity_id` instead
- Replaced Zod email validation with simpler regex pattern in auth components

**Improvements**
- Added explanatory comment in `prepareNewBalanceForInsertion.ts` clarifying the distinction between `entity_feature_id` (per-entity balances) and `internal_entity_id` (entity-scoped balances)
- Removed unnecessary empty fragment wrapper in `PasswordSignIn.tsx`
- Removed unused Zod import from `SignIn.tsx`


</details>
<h3>Confidence Score: 4/5</h3>


- safe to merge after fixing email regex validation issue
- the entity-scoped balance fixes are correct and well-documented, but the email regex accepts invalid emails with spaces and consecutive dots which should be fixed before merging
- vite/src/views/auth/SignIn.tsx requires fix for email validation regex

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts | removed incorrect entity_feature_id assignment for entity-scoped loose balances, clarified with comment |
| vite/src/views/auth/SignIn.tsx | replaced zod email validation with simpler regex pattern, removed unused zod import |
| vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx | fixed entity-scoped loose entitlements filtering to show only relevant entitlements at entity level while keeping all at customer level |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SignIn
    participant Backend
    participant DB
    participant CustomerFeatureUsageTable
    
    Note over SignIn: Email Validation Fix
    User->>SignIn: Enter email
    SignIn->>SignIn: Validate with emailRegex
    alt Valid email
        SignIn->>Backend: Send OTP request
        Backend-->>SignIn: Success
    else Invalid email
        SignIn-->>User: Show error toast
    end
    
    Note over CustomerFeatureUsageTable: Entity-Scoped Balance Fix
    User->>CustomerFeatureUsageTable: View customer balances
    CustomerFeatureUsageTable->>CustomerFeatureUsageTable: Filter by selectedEntity
    alt No entity selected (customer level)
        CustomerFeatureUsageTable->>CustomerFeatureUsageTable: Show ALL loose entitlements
    else Entity selected
        CustomerFeatureUsageTable->>CustomerFeatureUsageTable: Filter loose entitlements by entity
    end
    CustomerFeatureUsageTable-->>User: Display filtered balances
    
    Note over Backend,DB: Balance Creation Fix
    Backend->>Backend: prepareNewBalanceForInsertion()
    Backend->>Backend: Skip entity_feature_id assignment
    Backend->>Backend: Set internal_entity_id if entity provided
    Backend->>DB: Insert customer_entitlement
    DB-->>Backend: Success
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->