### PR TITLE
fix safari and zen pricing agent bug

### DIFF
--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -110,6 +110,7 @@ const init = async () => {
 				"If-None-Match",
 				"If-Modified-Since",
 				"If-Unmodified-Since",
+				"User-Agent", // Required for better-auth v1.4.0+ compatibility with Safari/Zen browser
 			],
 		}),
 	);

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -46,6 +46,7 @@ const ALLOWED_HEADERS = [
 	"If-Unmodified-Since",
 	"idempotency-key",
 	"Idempotency-Key",
+	"User-Agent", // Required for better-auth v1.4.0+ compatibility with Safari/Zen browser
 ];
 
 export const createHonoApp = () => {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes pricing agent auth failures on Safari and Zen by allowing the User-Agent header in CORS. Restores compatibility with better-auth v1.4.0+.

- **Bug Fixes**
  - Added "User-Agent" to allowed CORS headers in server/src/init.ts and server/src/initHono.ts.

<sup>Written for commit 20a4829f48ae91857d4a76fad44cd7ad5c5a0a1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Added `User-Agent` to the CORS allowed headers in both Express and Hono server configurations to fix authentication issues with Safari and Zen browsers when using better-auth v1.4.0+.

**Key changes:**
- **Bug fixes**: Added `User-Agent` header to Express CORS configuration in `server/src/init.ts:113`
- **Bug fixes**: Added `User-Agent` header to Hono CORS configuration in `server/src/initHono.ts:49`

The change ensures that the `User-Agent` header is properly forwarded to better-auth, which requires it for compatibility with Safari and Zen browsers starting from version 1.4.0. Both server entry points (Express and Hono) now consistently allow this header through CORS middleware.


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is minimal and surgical - it only adds a single standard HTTP header to CORS allow lists in two locations. The `User-Agent` header is a standard, well-understood HTTP header that poses no security risks. The change fixes a documented compatibility issue with better-auth v1.4.0+ and Safari/Zen browsers. Both changes are identical and consistent across the Express and Hono configurations.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/init.ts | Added `User-Agent` to allowed CORS headers for better-auth v1.4.0+ Safari/Zen browser compatibility |
| server/src/initHono.ts | Added `User-Agent` to ALLOWED_HEADERS constant for better-auth v1.4.0+ Safari/Zen browser compatibility |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser as Safari Browser
    participant Server as Express CORS
    participant Hono as Hono CORS
    participant Auth as Authentication

    Browser->>Server: Auth request + User-Agent
    Server->>Server: Check allowedHeaders
    Server->>Auth: Forward request
    Auth-->>Browser: Response

    Browser->>Hono: API request + User-Agent
    Hono->>Hono: Check ALLOWED_HEADERS
    Hono-->>Browser: Response
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->