### PR TITLE
fix: show entity id for entity-level loose entitlements in Balance List

### DIFF
--- a/vite/src/views/customers2/components/sheets/BalanceSelectionSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceSelectionSheet.tsx
@@ -74,11 +74,19 @@ export function BalanceSelectionSheet() {
 								entityId,
 							}).balance;
 
-							const entity = customer?.entities?.find(
-								(e: Entity) =>
+							// For loose entitlements (no customer_product), check cusEnt.internal_entity_id
+							// For product entitlements, check cusProduct.internal_entity_id/entity_id
+							const entity = customer?.entities?.find((e: Entity) => {
+								// Check for entity-level loose entitlement
+								if (cusEnt.internal_entity_id) {
+									return e.internal_id === cusEnt.internal_entity_id;
+								}
+								// Check for entity-level product entitlement
+								return (
 									e.internal_id === cusProduct?.internal_entity_id ||
-									e.id === cusProduct?.entity_id,
-							);
+									e.id === cusProduct?.entity_id
+								);
+							});
 
 							const entitlement = cusEnt.entitlement;
 							const isConsumable =


### PR DESCRIPTION
## Summary
- Fixed entity lookup in BalanceSelectionSheet to correctly display entity info for entity-level loose entitlements
- Previously, the entity lookup only checked `cusProduct.internal_entity_id` which is null for loose entitlements
- Now it first checks `cusEnt.internal_entity_id` for loose entitlements before falling back to product-level entity lookup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Balance List to show the correct entity for entity-scoped loose entitlements. We now read the entitlement’s internal_entity_id and fall back to product-level when missing.

- **Bug Fixes**
  - BalanceSelectionSheet: entity lookup prioritizes cusEnt.internal_entity_id for loose entitlements to avoid null entity display.

- **Refactors**
  - Split Stripe customer helpers into create/get/get-or-create operations and updated call sites.
  - Added atomic Redis Lua script to set FullCustomer cache with stale-write guard.
  - Introduced create-customer-with-defaults action and queued customer.products.updated webhooks during billing execution.

<sup>Written for commit d108ee8cb6f589e9cc34979ae888acd2d918147d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

