### PR TITLE
fix: show entity id for entity-level loose entitlements in Balance Edit sheet

### DIFF
--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -2,6 +2,7 @@ import {
 	cusEntsToBalance,
 	cusEntsToGrantedBalance,
 	cusEntsToPrepaidQuantity,
+	type Entity,
 	type FullCusProduct,
 	type FullCustomerEntitlement,
 	type FullCustomerPrice,
@@ -240,12 +241,25 @@ export function BalanceEditSheet() {
 			<div className="flex-1 overflow-y-auto">
 				<SheetSection withSeparator>
 					<div className="flex flex-col gap-2 rounded-lg">
-						{cusProduct?.entity_id && (
-							<InfoRow
-								label="Entity"
-								value={cusProduct.entity_name || cusProduct.entity_id}
-							/>
-						)}
+						{(() => {
+							// For loose entitlements, check selectedCusEnt.internal_entity_id
+							// For product entitlements, check cusProduct.entity_id
+							const entity = customer?.entities?.find((e: Entity) => {
+								if (selectedCusEnt.internal_entity_id) {
+									return e.internal_id === selectedCusEnt.internal_entity_id;
+								}
+								return (
+									e.internal_id === cusProduct?.internal_entity_id ||
+									e.id === cusProduct?.entity_id
+								);
+							});
+							return entity ? (
+								<InfoRow
+									label="Entity"
+									value={entity.name || entity.id}
+								/>
+							) : null;
+						})()}
 						<div>
 							<InfoRow label="Plan" value={cusProduct?.product.name || "N/A"} />
 						</div>


### PR DESCRIPTION
## Summary
- Fixed entity lookup in BalanceEditSheet to correctly display entity info for entity-level loose entitlements
- Previously, the entity lookup only checked `cusProduct.entity_id` which is null for loose entitlements
- Now it first checks `selectedCusEnt.internal_entity_id` for loose entitlements before falling back to product-level entity lookup

Follow-up to #616

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed entity display in Balance Edit sheet for entity-level loose entitlements. The sheet now looks up the entity via selectedCusEnt.internal_entity_id, falling back to cusProduct.internal_entity_id/entity_id, so the correct entity name or ID shows.

<sup>Written for commit 88a6757cde63bcfb43f971b9cb8d5d1619956709. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Fixed entity lookup in BalanceEditSheet to correctly display entity information for entity-level loose entitlements. Previously, the lookup only checked `cusProduct.entity_id`, which is null for loose entitlements, causing entity info to not appear. The fix now prioritizes checking `selectedCusEnt.internal_entity_id` for loose entitlements before falling back to product-level entity lookup.

**Bug Fixes**
- BalanceEditSheet now correctly displays entity name/id for entity-scoped loose entitlements by checking the customer entitlement's `internal_entity_id` first


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a targeted bug fix that follows the exact same pattern previously implemented in BalanceSelectionSheet (PR #616). The logic correctly handles the entity lookup for both loose and product entitlements, properly checks for entity existence before rendering, and maintains backward compatibility with existing product entitlements.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx | Fixed entity lookup to correctly display entity info for entity-level loose entitlements by checking `selectedCusEnt.internal_entity_id` first |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant BalanceEditSheet
    participant selectedCusEnt
    participant cusProduct
    participant customer.entities

    User->>BalanceEditSheet: Open balance edit sheet
    BalanceEditSheet->>selectedCusEnt: Check internal_entity_id
    
    alt Loose entitlement (has internal_entity_id)
        BalanceEditSheet->>customer.entities: Find entity by internal_id
        customer.entities-->>BalanceEditSheet: Return matching entity
    else Product entitlement (no internal_entity_id)
        BalanceEditSheet->>cusProduct: Get internal_entity_id or entity_id
        BalanceEditSheet->>customer.entities: Find entity by internal_id or id
        customer.entities-->>BalanceEditSheet: Return matching entity
    end
    
    BalanceEditSheet->>User: Display entity name or id (if found)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->