### PR TITLE
fix proration visibility

### DIFF
--- a/vite/src/views/products/plan/components/edit-plan-feature/AdvancedSettings.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/AdvancedSettings.tsx
@@ -1,5 +1,9 @@
 /** biome-ignore-all lint/a11y/noStaticElementInteractions: shush */
-import { FeatureUsageType, isFeaturePriceItem } from "@autumn/shared";
+import {
+	FeatureUsageType,
+	isFeaturePriceItem,
+	UsageModel,
+} from "@autumn/shared";
 import { AreaCheckbox } from "@/components/v2/checkboxes/AreaCheckbox";
 import {
 	SheetAccordion,
@@ -41,8 +45,11 @@ export function AdvancedSettings() {
 	const showUsageLimits = isPriced;
 	const showRollover = hasCreditSystem || usageType === FeatureUsageType.Single;
 	const showEntityFeature = hasEntityFeatureId && hasOtherContinuousFeatures;
-	// Proration shows for priced features (simplified check)
-	const showProration = isPriced;
+	// Proration shows for prepaid or continuous use features (not consumable + pay-per-use)
+	const showProration =
+		isPriced &&
+		(item.usage_model === UsageModel.Prepaid ||
+			usageType === FeatureUsageType.Continuous);
 
 	// Hide Advanced section if nothing will render inside it
 	const hasAnyContent =


### PR DESCRIPTION
- **fix safari and zen pricing agent bug**
- **rm proration config for usage-based pricing**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Advanced Settings to show proration only for priced features that are prepaid or continuous. Removed proration config for usage-based (pay-per-use) features and fixed a Safari/Zen pricing agent bug.

<sup>Written for commit aa02be5bf9945e04acc30b7cfc77e990b77e235e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Refined proration configuration visibility to only show for prepaid or continuous use features, hiding it for consumable pay-per-use features where proration doesn't apply.

**Key Changes:**
- **Bug fixes**: Fixed proration config showing inappropriately for usage-based (pay-per-use) pricing on consumable features
- **Improvements**: Added `UsageModel` import and improved conditional logic with clearer comment explaining when proration should be visible

The change correctly identifies that proration (billing adjustments for quantity changes) is only relevant for:
1. Prepaid features (where customers pay upfront)
2. Continuous use features (allocated resources like seats)

Proration does not apply to consumable pay-per-use features where customers are billed based on actual consumption at the end of the billing period.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a straightforward UI visibility fix that adds proper conditional logic to hide proration configuration when it doesn't apply. The logic is sound: proration is only relevant for prepaid or continuous-use features, not for consumable pay-per-use features. The change is minimal, well-commented, and aligns with the business logic.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/edit-plan-feature/AdvancedSettings.tsx | Added logic to conditionally show proration config based on usage model and feature type - only shows for prepaid or continuous use features |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant AdvancedSettings
    participant ProrationConfig
    participant ProductItem

    User->>AdvancedSettings: Edit plan feature
    AdvancedSettings->>ProductItem: Get item details
    ProductItem-->>AdvancedSettings: item data (usage_model, feature_id)
    
    AdvancedSettings->>AdvancedSettings: Check isPriced = isFeaturePriceItem(item)
    AdvancedSettings->>AdvancedSettings: Get usageType from feature
    
    alt isPriced is true
        alt item.usage_model === Prepaid
            AdvancedSettings->>AdvancedSettings: showProration = true
            AdvancedSettings->>ProrationConfig: Render proration config
        else usageType === Continuous
            AdvancedSettings->>AdvancedSettings: showProration = true
            AdvancedSettings->>ProrationConfig: Render proration config
        else PayPerUse + Single Use (consumable)
            AdvancedSettings->>AdvancedSettings: showProration = false
            AdvancedSettings->>User: Hide proration section
        end
    else isPriced is false
        AdvancedSettings->>AdvancedSettings: showProration = false
        AdvancedSettings->>User: Hide proration section
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->