### PR TITLE
fix: exclude archived features from selection dropdowns

### DIFF
--- a/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
@@ -49,9 +49,11 @@ export function SelectFeatureSheet({
 		}
 	}, [selectOpen]);
 
-	// Filter features based on search
-	const filteredFeatures = features.filter((feature: Feature) =>
-		feature.name.toLowerCase().includes(searchValue.toLowerCase()),
+	// Filter features based on search and exclude archived features
+	const filteredFeatures = features.filter(
+		(feature: Feature) =>
+			!feature.archived &&
+			feature.name.toLowerCase().includes(searchValue.toLowerCase()),
 	);
 
 	const handleFeatureSelect = (featureId: string) => {

--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/EntityFeatureConfig.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/EntityFeatureConfig.tsx
@@ -18,9 +18,10 @@ export function EntityFeatureConfig() {
 
 	if (!item) return null;
 
-	// Filter for continuous use features, excluding the current feature (can't link to itself)
+	// Filter for continuous use features, excluding the current feature (can't link to itself) and archived features
 	const continuousUseFeatures = features.filter(
 		(f) =>
+			!f.archived &&
 			f.config?.usage_type === FeatureUsageType.Continuous &&
 			f.id !== item.feature_id,
 	);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Archived features are now excluded from the Select Feature sheet and the continuous-use link dropdown. This prevents accidentally selecting or linking archived features during plan setup and advanced settings.

<sup>Written for commit f9069772694a4cb8dbfc8b8c24caf3d717b08c4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents archived features from appearing in feature selection dropdowns during plan configuration, ensuring users cannot accidentally select or link deprecated features.

**Key Changes:**

**Bug fixes**
- Excluded archived features from the Select Feature sheet dropdown by adding `!feature.archived` filter
- Excluded archived features from the continuous-use feature linking dropdown in Entity Feature Config
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and follow existing patterns in the codebase. The `!feature.archived` and `!f.archived` filter patterns are already used in 19 other files across the application, demonstrating this is a well-established pattern. The implementation is straightforward, defensive, and prevents a clear user experience issue without introducing any breaking changes or side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/SelectFeatureSheet.tsx | Added `!feature.archived` filter to exclude archived features from the dropdown |
| vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/EntityFeatureConfig.tsx | Added `!f.archived` filter to exclude archived features from continuous-use feature linking |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SelectFeatureSheet
    participant EntityFeatureConfig
    participant FeaturesQuery
    participant FeaturesList

    User->>SelectFeatureSheet: Opens feature selection dropdown
    SelectFeatureSheet->>FeaturesQuery: Request all features
    FeaturesQuery-->>SelectFeatureSheet: Return features array
    SelectFeatureSheet->>SelectFeatureSheet: Filter features (!archived && name match)
    SelectFeatureSheet->>FeaturesList: Display filtered features
    User->>SelectFeatureSheet: Selects a feature
    SelectFeatureSheet->>SelectFeatureSheet: Add feature to plan

    User->>EntityFeatureConfig: Opens continuous-use feature linking
    EntityFeatureConfig->>FeaturesQuery: Request all features
    FeaturesQuery-->>EntityFeatureConfig: Return features array
    EntityFeatureConfig->>EntityFeatureConfig: Filter features (!archived && continuous-use && not self)
    EntityFeatureConfig->>FeaturesList: Display filtered features
    User->>EntityFeatureConfig: Selects linked feature
    EntityFeatureConfig->>EntityFeatureConfig: Link feature entity
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->