### PR TITLE
fix: use stable empty object reference for product counts to prevent …

### DIFF
--- a/vite/src/hooks/queries/useProductsQuery.tsx
+++ b/vite/src/hooks/queries/useProductsQuery.tsx
@@ -2,6 +2,9 @@ import type { FullProduct, ProductCounts, ProductV2 } from "@autumn/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 
+// Stable empty object reference to prevent infinite re-renders
+const EMPTY_COUNTS: Record<string, ProductCounts> = {};
+
 /**
  * Fetch all products for the current org.
  */
@@ -48,7 +51,7 @@ export const useProductsQuery = () => {
 
 	return {
 		products: data?.products || [],
-		counts: countsData || {},
+		counts: countsData ?? EMPTY_COUNTS,
 		groupToDefaults: data?.groupToDefaults || {},
 		isLoading,
 		isCountsLoading,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a render loop in the product list by returning a stable empty counts object when counts are missing. This stops flicker and reduces unnecessary renders.

- **Bug Fixes**
  - Use a shared EMPTY_COUNTS constant with countsData ?? EMPTY_COUNTS to avoid creating a new {} each render.

<sup>Written for commit c8b6156313be31f7af3cc550c14db80e01fdb006. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed a render loop in `useProductsQuery` by using a stable empty object reference for product counts when data is unavailable.

**Bug fixes**
- Replaced `countsData || {}` with `countsData ?? EMPTY_COUNTS` where `EMPTY_COUNTS` is a constant defined outside the hook
- Previously, a new empty object `{}` was created on each render when `countsData` was undefined/null, causing referential inequality and triggering re-renders in components using `counts` in dependency arrays
- The stable reference prevents unnecessary re-renders and UI flicker across the 50+ components consuming this hook
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward performance fix using a well-established React pattern (stable reference for default values). The fix correctly addresses the render loop issue without changing the hook's API or behavior. All consumers use optional chaining when accessing counts, so the empty object behaves identically whether inline or constant.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/hooks/queries/useProductsQuery.tsx | Fixed render loop by using stable EMPTY_COUNTS reference instead of creating new {} each render |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Component
    participant useProductsQuery
    participant ReactQuery
    participant API

    Component->>useProductsQuery: Call hook
    useProductsQuery->>ReactQuery: Query products
    ReactQuery->>API: GET /products/products
    API-->>ReactQuery: products data
    ReactQuery-->>useProductsQuery: products data
    
    useProductsQuery->>ReactQuery: Query product_counts
    ReactQuery->>API: GET /products/product_counts
    
    alt countsData available
        API-->>ReactQuery: countsData
        ReactQuery-->>useProductsQuery: countsData
        useProductsQuery-->>Component: Return {counts: countsData}
    else countsData unavailable
        API-->>ReactQuery: undefined
        ReactQuery-->>useProductsQuery: undefined
        Note over useProductsQuery: Use EMPTY_COUNTS constant<br/>(stable reference)
        useProductsQuery-->>Component: Return {counts: EMPTY_COUNTS}
    end
    
    Note over Component: No re-render triggered<br/>by referential equality
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->