### PR TITLE
fix: stripe canceling condition

### DIFF
--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handlePaidProduct.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handlePaidProduct.ts
@@ -12,7 +12,7 @@ import { addMinutes } from "date-fns";
 import type Stripe from "stripe";
 import { getEarliestPeriodEnd } from "@/external/stripe/stripeSubUtils/convertSubUtils.js";
 import { getStripeSubItems2 } from "@/external/stripe/stripeSubUtils/getStripeSubItems.js";
-import { isStripeSubscriptionCanceled } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.js";
+import { isStripeSubscriptionCanceling } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.js";
 
 import { attachParamsToMetadata } from "@/internal/billing/attach/utils/attachParamsToMetadata.js";
 import { createFullCusProduct } from "@/internal/customers/add-product/createFullCusProduct.js";
@@ -129,7 +129,7 @@ export const handlePaidProduct = async ({
 			});
 		}
 
-		if (isStripeSubscriptionCanceled(mergeSub)) {
+		if (isStripeSubscriptionCanceling(mergeSub)) {
 			logger.info("ADD PRODUCT FLOW, CREATING NEW SCHEDULE");
 			schedule = await subToNewSchedule({
 				ctx,

--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -14,7 +14,7 @@ import { SubService } from "@/internal/subscriptions/SubService.js";
 import { nullish } from "@/utils/genUtils.js";
 import type { ItemSet } from "@/utils/models/ItemSet.js";
 import { createProrationInvoice } from "../../../../../external/stripe/stripeSubUtils/updateStripeSub/createProrationinvoice.js";
-import { isStripeSubscriptionCanceled } from "../../../../../external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.js";
+import { isStripeSubscriptionCanceling } from "../../../../../external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.js";
 
 import type { AutumnContext } from "../../../../../honoUtils/HonoEnv.js";
 import { attachParamsToCurCusProduct } from "../../attachUtils/convertAttachParams.js";
@@ -92,7 +92,7 @@ export const updateStripeSub2 = async ({
 		// cancel_at_period_end: false,
 		// TODO: will error if sub managed by a schedule
 		cancel_at_period_end:
-			isStripeSubscriptionCanceled(curSub) &&
+			isStripeSubscriptionCanceling(curSub) &&
 			!(
 				branch === AttachBranch.SameCustomEnts ||
 				branch === AttachBranch.NewVersion


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch checks to use the Stripe subscription “canceling” state in add-product and upgrade flows. This ensures we create new schedules and set cancel_at_period_end only when a cancellation is in progress, not after a subscription is fully canceled.

<sup>Written for commit 25d78f5e06230040683faf2cfd43fffc5b6799d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed incorrect subscription state checks in add-product and upgrade flows by switching from `isStripeSubscriptionCanceled` to `isStripeSubscriptionCanceling`.

**Key Changes:**
- **Bug fixes**: Corrected logic to detect subscriptions that are in the process of being canceled (have `cancel_at`, `canceled_at`, or `cancel_at_period_end` set) rather than subscriptions that are already fully canceled (status === "canceled")

**Impact:**
- `handlePaidProduct.ts:132` - When adding products to a subscription, the code now correctly creates a new schedule for subscriptions that are **canceling** (scheduled to cancel at period end) rather than waiting for them to be fully canceled. This ensures new products can be scheduled to start after the current billing period ends.
- `updateStripeSub2.ts:94-101` - When updating a subscription, the code now correctly un-cancels (sets `cancel_at_period_end: false`) subscriptions that are **in the process of being canceled** rather than attempting to un-cancel already-canceled subscriptions (which would fail).

This fix aligns with Stripe's subscription lifecycle where a "canceling" subscription is still active but scheduled to end, while a "canceled" subscription has already ended and cannot be modified in the same way.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The changes are minimal, focused, and correct the logic to match Stripe's subscription lifecycle. The fix addresses a clear bug where the code was checking for fully canceled subscriptions (status === "canceled") when it should have been checking for subscriptions in the process of being canceled (cancel_at_period_end, cancel_at, or canceled_at set). The changes are consistent across both files and align with the utility function definitions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/attach/attachFunctions/addProductFlow/handlePaidProduct.ts | Changed condition from `isStripeSubscriptionCanceled` to `isStripeSubscriptionCanceling` to correctly detect subscriptions in the process of being canceled (not already fully canceled) |
| server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts | Changed condition from `isStripeSubscriptionCanceled` to `isStripeSubscriptionCanceling` to correctly uncancel subscriptions that are in the process of being canceled |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AddProductFlow as Add Product Flow
    participant UpdateSubFlow as Update Subscription Flow
    participant StripeAPI as Stripe API
    participant SubUtils as classifyStripeSubscriptionUtils

    Note over Client,SubUtils: Add Product Flow (when merging with existing subscription)
    
    Client->>AddProductFlow: Request to add product
    AddProductFlow->>AddProductFlow: Get merge subscription
    AddProductFlow->>SubUtils: isStripeSubscriptionCanceling(mergeSub)
    SubUtils-->>AddProductFlow: Check canceled_at, cancel_at, cancel_at_period_end
    
    alt Subscription is canceling (not fully canceled)
        AddProductFlow->>AddProductFlow: Create new schedule for period end
        AddProductFlow->>StripeAPI: Create subscription schedule
        Note over AddProductFlow: New products scheduled to start<br/>after current billing period ends
    else Subscription is active
        AddProductFlow->>AddProductFlow: Handle existing schedule
        AddProductFlow->>StripeAPI: Update existing schedule if present
    end

    Note over Client,SubUtils: Update Subscription Flow (upgrade/migration)

    Client->>UpdateSubFlow: Request to update subscription
    UpdateSubFlow->>StripeAPI: Migrate to flexible billing if needed
    UpdateSubFlow->>SubUtils: isStripeSubscriptionCanceling(curSub)
    SubUtils-->>UpdateSubFlow: Check canceled_at, cancel_at, cancel_at_period_end
    
    alt Subscription is canceling AND not SameCustomEnts/NewVersion branch
        UpdateSubFlow->>StripeAPI: Update sub with cancel_at_period_end: false
        Note over UpdateSubFlow: Un-cancel the subscription<br/>as new products are being added
    else Other cases
        UpdateSubFlow->>StripeAPI: Update sub without changing cancellation
    end
    
    UpdateSubFlow-->>Client: Return updated subscription
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->