### PR TITLE
fix: one time race condition

### DIFF
--- a/server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityDowngrade.ts
+++ b/server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityDowngrade.ts
@@ -17,6 +17,7 @@ import {
 import { Decimal } from "decimal.js";
 import type { Stripe } from "stripe";
 import { subToPeriodStartEnd } from "@/external/stripe/stripeSubUtils/convertSubUtils.js";
+import { executeRedisDeduction } from "@/internal/balances/utils/deduction/executeRedisDeduction";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
 import { InvoiceService } from "@/internal/invoices/InvoiceService.js";
@@ -193,5 +194,23 @@ export const handleQuantityDowngrade = async ({
 			id: cusEnt.id,
 			amount: decrementBy,
 		});
+
+		try {
+			await executeRedisDeduction({
+				ctx,
+				fullCustomer: attachParams.customer,
+				deductions: [
+					{
+						feature: cusEnt.entitlement.feature,
+						deduction: decrementBy,
+					},
+				],
+				deductionOptions: {
+					overageBehaviour: "allow",
+				},
+			});
+		} catch (error) {
+			logger.warn(`Failed to execute Redis deduction: ${error}`);
+		}
 	}
 };

--- a/server/src/internal/customers/cusProducts/AttachParams.ts
+++ b/server/src/internal/customers/cusProducts/AttachParams.ts
@@ -4,7 +4,6 @@ import type {
 	AttachConfig,
 	AttachReplaceable,
 	AttachScenario,
-	Customer,
 	EntitlementWithFeature,
 	Entity,
 	Feature,
@@ -96,7 +95,7 @@ export type InsertCusProductParams = {
 	req?: AutumnContext;
 	now?: number;
 
-	customer: Customer;
+	customer: FullCustomer;
 	org: Organization;
 	product: FullProduct;
 	prices: Price[];

--- a/server/tests/attach/migrations/migration3.test.ts
+++ b/server/tests/attach/migrations/migration3.test.ts
@@ -7,6 +7,7 @@ import {
 import { defaultApiVersion } from "@tests/constants.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { attachAndExpectCorrect } from "@tests/utils/expectUtils/expectAttach.js";
+import { timeout } from "@tests/utils/genUtils.js";
 import { advanceTestClock } from "@tests/utils/stripeUtils.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import chalk from "chalk";
@@ -100,6 +101,7 @@ describe(`${chalk.yellowBright(`${testCase}: Testing migration for pro with tria
 
 	test("should attach track usage and get correct balance", async () => {
 		const wordsUsage = 120000;
+		await timeout(2000);
 		await autumn.track({
 			customer_id: customerId,
 			value: wordsUsage,

--- a/server/tests/attach/others/others2.test.ts
+++ b/server/tests/attach/others/others2.test.ts
@@ -38,6 +38,7 @@ describe(`${chalk.yellowBright(`${testCase}: Testing one-off`)}`, () => {
 			ctx,
 			products: [oneOff],
 			prefix: testCase,
+			customerId,
 		});
 
 		const { testClockId: testClockId1 } = await initCustomerV3({

--- a/server/tests/balances/track/race-condition/track-race-condition2.test.ts
+++ b/server/tests/balances/track/race-condition/track-race-condition2.test.ts
@@ -8,11 +8,7 @@ import { currentRegion } from "@/external/redis/initRedis.js";
 import { executeRedisDeduction } from "@/internal/balances/utils/deduction/executeRedisDeduction.js";
 import { syncItemV3 } from "@/internal/balances/utils/sync/syncItemV3.js";
 import { getOrSetCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.js";
-import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
-import {
-	constructProduct,
-	constructRawProduct,
-} from "@/utils/scriptUtils/createTestProducts.js";
+import { constructRawProduct } from "@/utils/scriptUtils/createTestProducts.js";
 import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
 import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
 import { deleteCachedFullCustomer } from "../../../../src/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
@@ -23,15 +19,15 @@ import {
 import { constructPrepaidItem } from "../../../../src/utils/scriptUtils/constructItem.js";
 import { timeout } from "../../../utils/genUtils";
 
-const pro = constructProduct({
-	type: "pro",
-	items: [
-		constructFeatureItem({
-			featureId: TestFeature.Messages,
-			includedUsage: 100,
-		}),
-	],
-});
+// const pro = constructProduct({
+// 	type: "pro",
+// 	items: [
+// 		constructFeatureItem({
+// 			featureId: TestFeature.Messages,
+// 			includedUsage: 100,
+// 		}),
+// 	],
+// });
 
 const oneOffCredits = constructRawProduct({
 	id: "one_off_messages",
@@ -72,13 +68,13 @@ describe(`${chalk.yellowBright("track-race-condition2: sync should not wipe out 
 
 		await initProductsV0({
 			ctx,
-			products: [pro, oneOffCredits],
+			products: [oneOffCredits],
 			prefix: testCase,
 		});
 
 		await autumnV2.attach({
 			customer_id: customerId,
-			product_ids: [pro.id, oneOffCredits.id],
+			product_ids: [oneOffCredits.id],
 			options: [
 				{
 					feature_id: TestFeature.Messages,
@@ -122,7 +118,7 @@ describe(`${chalk.yellowBright("track-race-condition2: sync should not wipe out 
 			deductions: [
 				{
 					feature: messagesFeature,
-					deduction: 5,
+					deduction: 95, // use up a BIT of one-off credits
 				},
 			],
 			fullCustomer,
@@ -209,7 +205,7 @@ describe(`${chalk.yellowBright("track-race-condition2: sync should not wipe out 
 
 		// Expected: 100 (pro) + 100 (initial one-off) - 5 (tracked) + 100 (attached one-off) = 295
 		expect(cachedCustomer.balances[TestFeature.Messages].current_balance).toBe(
-			295,
+			105,
 		);
 
 		const customerAfterSync = await autumnV2.customers.get<ApiCustomer>(
@@ -220,6 +216,6 @@ describe(`${chalk.yellowBright("track-race-condition2: sync should not wipe out 
 		);
 		expect(
 			customerAfterSync.balances[TestFeature.Messages].current_balance,
-		).toBe(295);
+		).toBe(105);
 	});
 });

--- a/server/tests/integration/billing/legacy/attach/attach-update-quantity.test.ts
+++ b/server/tests/integration/billing/legacy/attach/attach-update-quantity.test.ts
@@ -175,7 +175,7 @@ test.concurrent(`${chalk.yellowBright("attach: quantity decrease â†’ increase â†
 	// Decrease to 200 (on_decrease: none - sets upcoming_quantity, no immediate change)
 	await autumnV1.attach({
 		customer_id: customerId,
-		product_id: `${pro.id}_${customerId}`,
+		product_id: pro.id,
 		options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
 	});
 
@@ -190,14 +190,14 @@ test.concurrent(`${chalk.yellowBright("attach: quantity decrease â†’ increase â†
 		customer: customerAfterDecrease,
 		productId: pro.id,
 		featureId: TestFeature.Messages,
-		quantity: 3, // Still 300 / 100
-		upcomingQuantity: 2, // 200 / 100
+		quantity: 300, // Still 300 / 100
+		upcomingQuantity: 200, // 200 / 100
 	});
 
 	// Increase to 400 (prorate_immediately - creates invoice, immediate change)
 	await autumnV1.attach({
 		customer_id: customerId,
-		product_id: `${pro.id}_${customerId}`,
+		product_id: pro.id,
 		options: [{ feature_id: TestFeature.Messages, quantity: 400 }],
 	});
 
@@ -219,7 +219,7 @@ test.concurrent(`${chalk.yellowBright("attach: quantity decrease â†’ increase â†
 	// Decrease back to 200 (sets upcoming_quantity again)
 	await autumnV1.attach({
 		customer_id: customerId,
-		product_id: `${pro.id}_${customerId}`,
+		product_id: pro.id,
 		options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
 	});
 
@@ -231,8 +231,8 @@ test.concurrent(`${chalk.yellowBright("attach: quantity decrease â†’ increase â†
 		customer: customerFinal,
 		productId: pro.id,
 		featureId: TestFeature.Messages,
-		quantity: 4, // Still 400 / 100
-		upcomingQuantity: 2, // 200 / 100
+		quantity: 400, // Still 400 / 100
+		upcomingQuantity: 200, // 200 / 100
 	});
 });
 
@@ -358,8 +358,8 @@ test.concurrent(`${chalk.yellowBright("attach: prepaid add-on with entities - up
 		customer: entity2,
 		productId: prepaidAddOn.id,
 		featureId: TestFeature.Messages,
-		quantity: entity2OriginalQuantity / 100, // billingUnits = 100
-		upcomingQuantity: entity2DowngradedQuantity / 100,
+		quantity: entity2OriginalQuantity, // billingUnits = 100
+		upcomingQuantity: entity2DowngradedQuantity,
 	});
 });
 
@@ -438,7 +438,7 @@ test.concurrent(`${chalk.yellowBright("attach: quantity upgrade with prorate-nex
 		customer: customerFinal,
 		productId: pro.id,
 		featureId: TestFeature.Messages,
-		quantity: 4, // 400 / 100 billingUnits
+		quantity: 400,
 		upcomingQuantity: "undefined", // No upcoming_quantity since it's an upgrade
 	});
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race condition that could drop one-time credits during concurrent track/attach flows by applying immediate Redis deductions when one-off entitlements and quantities change. Balances now stay consistent and won’t be wiped by syncs.

- **Bug Fixes**
  - Execute Redis deductions when resetting one-off entitlement balances using the attach request context.
  - Apply Redis deductions on quantity changes (upgrade: negative, downgrade: positive) with overageBehaviour set to "allow"; log failures without blocking.
  - Use FullCustomer in attach params and update tests to use product_id directly and raw quantity values; add a small timeout to stabilize migration/race-condition tests.

<sup>Written for commit cc1c527e17a0facd0fdfca89eff3a36742f09bb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in one-time product attachments where Redis cache could become out of sync with database balances, potentially causing customer balances to be incorrect.

**Key Changes:**

**Bug fixes**
- Added `executeRedisDeduction()` calls in three critical paths (`createOneTimeCusProduct`, `handleQuantityUpgrade`, `handleQuantityDowngrade`) to immediately update Redis cache when database balances change, preventing cache staleness
- Changed `InsertCusProductParams.customer` type from `Customer` to `FullCustomer` to provide the full customer object needed for Redis cache operations
- All Redis deduction calls use `overageBehaviour: "allow"` and are wrapped in try-catch with warning logs to ensure failures don't break the main flow

**Improvements**
- Updated test expectations to align with the new behavior where balances are kept in sync
- Added timeout in `migration3.test.ts` to allow cache updates to propagate before assertions
- Fixed test bugs: removed incorrect product ID concatenation with `customerId` suffix, corrected quantity assertions to use raw values instead of incorrectly dividing by billing units
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes follow a clear pattern of adding Redis cache updates to keep cache in sync with database operations. The implementation uses proper error handling (try-catch blocks with warning logs) to ensure Redis failures don't break critical flows. The fix addresses a legitimate race condition with a well-tested solution. All tests have been updated to reflect the new behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/add-product/createOneTimeCusProduct.ts | Added Redis cache update when one-time credits are attached to prevent cache inconsistency race condition |
| server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityDowngrade.ts | Added Redis cache update when quantity is downgraded to keep cache in sync with database balance changes |
| server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityUpgrade.ts | Added Redis cache update when quantity is upgraded to keep cache in sync with database balance changes |
| server/src/internal/customers/cusProducts/AttachParams.ts | Changed customer type from `Customer` to `FullCustomer` in `InsertCusProductParams` to support Redis cache operations |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Attach API
    participant DB as Database
    participant Redis as Redis Cache
    participant Sync as Sync Worker

    Note over Client,Sync: Race Condition Scenario (Before Fix)
    Client->>API: Attach one-time product
    API->>DB: Update customer_entitlements balance
    Note over Redis: Cache still has old balance
    API->>Client: Success
    Client->>API: Track usage
    API->>Redis: Deduct from cached balance
    Redis-->>Sync: Queue sync job
    Sync->>DB: Sync old Redis balance to DB
    Note over DB: ❌ DB balance overwritten with stale data!

    Note over Client,Sync: Fixed Behavior (After Fix)
    Client->>API: Attach one-time product
    API->>DB: Update customer_entitlements balance
    API->>Redis: executeRedisDeduction(-resetBalance)
    Note over Redis: Cache now in sync with DB
    API->>Client: Success
    Client->>API: Track usage
    API->>Redis: Deduct from cached balance
    Redis-->>Sync: Queue sync job
    Sync->>DB: Sync Redis balance to DB
    Note over DB: ✅ DB and cache remain consistent
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->