### PR TITLE
fix: one time race condition

### DIFF
--- a/server/src/internal/customers/add-product/createOneTimeCusProduct.ts
+++ b/server/src/internal/customers/add-product/createOneTimeCusProduct.ts
@@ -96,6 +96,9 @@ const updateOneOffExistingEntitlement = async ({
 				deductions: featureDeductions,
 				deductionOptions: {
 					overageBehaviour: "allow",
+					customerEntitlementFilters: {
+						cusEntIds: [cusEnt.id],
+					},
 				},
 			});
 		} catch (error) {

--- a/server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityDowngrade.ts
+++ b/server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityDowngrade.ts
@@ -207,6 +207,9 @@ export const handleQuantityDowngrade = async ({
 				],
 				deductionOptions: {
 					overageBehaviour: "allow",
+					customerEntitlementFilters: {
+						cusEntIds: [cusEnt.id],
+					},
 				},
 			});
 		} catch (error) {

--- a/server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityUpgrade.ts
+++ b/server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityUpgrade.ts
@@ -215,6 +215,9 @@ export const handleQuantityUpgrade = async ({
 				],
 				deductionOptions: {
 					overageBehaviour: "allow",
+					customerEntitlementFilters: {
+						cusEntIds: [cusEnt.id],
+					},
 				},
 			});
 		} catch (error) {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scoped feature deductions to the active customer entitlement to prevent a rare race condition during one-off entitlements and quantity changes.

- **Bug Fixes**
  - Added customerEntitlementFilters.cusEntIds: [cusEnt.id] to deductionOptions in createOneTimeCusProduct, handleQuantityUpgrade, and handleQuantityDowngrade to ensure deductions target the correct entitlement under concurrent updates.

<sup>Written for commit 59998fcd4f1dbc34a770cef98de8fe6a9b9fafcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `customerEntitlementFilters` with specific `cusEntIds` to Redis cache deduction calls in three locations. This prevents a race condition where multiple customer entitlements for the same feature could exist, and the deduction might target the wrong entitlement.

**Key Changes:**

- **Bug fixes**: Added `customerEntitlementFilters: { cusEntIds: [cusEnt.id] }` to `executeRedisDeduction` calls in `createOneTimeCusProduct.ts`, `handleQuantityDowngrade.ts`, and `handleQuantityUpgrade.ts` to ensure Redis cache deductions target the exact customer entitlement being modified

**How it works:**

The fix ensures that when updating balances in Redis cache after database updates, the deduction logic only considers the specific customer entitlement (`cusEnt.id`) being modified. The `sortCusEntsForDeduction` function prioritizes entitlements matching the filter (lines 21-32 in `sortCusEntsForDeduction.ts`), and `fullCustomerToCustomerEntitlements` then filters to only those IDs (lines 86-92). This prevents scenarios where a customer has multiple one-time products or quantity-based entitlements for the same feature, and the Redis deduction could incorrectly target a different entitlement than the one being updated in the database.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a focused bug fix that addresses a specific race condition. The changes are identical across three files, adding a single filtering parameter to ensure Redis cache deductions target the correct customer entitlement. The fix is well-understood, follows existing patterns in the codebase, and aligns with the previous commit (cc1c527e) that introduced the Redis deduction calls. No breaking changes, no new dependencies, and the change is defensive in nature.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/add-product/createOneTimeCusProduct.ts | Added `customerEntitlementFilters` to Redis deduction to target specific entitlement, preventing race condition |
| server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityDowngrade.ts | Added `customerEntitlementFilters` to Redis deduction to target specific entitlement during quantity downgrade |
| server/src/internal/customers/attach/attachFunctions/updateQuantityFlow/handleQuantityUpgrade.ts | Added `customerEntitlementFilters` to Redis deduction to target specific entitlement during quantity upgrade |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as API Handler
    participant Service as Product Service
    participant DB as Database
    participant Redis as Redis Cache
    participant Sort as sortCusEntsForDeduction

    Note over Client,Sort: Scenario: One-time product or quantity update

    Client->>API: Attach/Update Product
    API->>Service: createOneTimeCusProduct / handleQuantityUpgrade / handleQuantityDowngrade
    Service->>DB: Update customer_entitlement balance
    Service->>DB: Fetch updated cusEnt
    
    Note over Service,Redis: Redis Deduction (to sync cache)
    Service->>Redis: executeRedisDeduction()
    Redis->>Redis: prepareFeatureDeduction()
    Redis->>Sort: fullCustomerToCustomerEntitlements(customerEntitlementFilters)
    
    alt Without customerEntitlementFilters (Previous)
        Sort-->>Redis: Returns ALL matching cusEnts (sorted)
        Note over Redis: RACE CONDITION: May deduct from wrong cusEnt!
    else With customerEntitlementFilters (This PR)
        Sort->>Sort: Filter by cusEntIds FIRST (priority in sort)
        Sort->>Sort: Then filter to ONLY cusEntIds
        Sort-->>Redis: Returns ONLY specified cusEnt
        Note over Redis: SAFE: Deducts from correct cusEnt
    end
    
    Redis->>Redis: Apply deduction to customer cache
    Redis-->>Service: Deduction complete
    Service-->>API: Success
    API-->>Client: Updated product/entitlement
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->