### PR TITLE
fix: invoice created to db

### DIFF
--- a/server/src/external/stripe/invoices/operations/getStripeInvoice.ts
+++ b/server/src/external/stripe/invoices/operations/getStripeInvoice.ts
@@ -21,6 +21,15 @@ type InvoiceExpandMap = {
 	"discounts.source.coupon": {
 		discounts: (Stripe.Discount & { source: { coupon: Stripe.Coupon } })[];
 	};
+	total_discount_amounts: {
+		total_discount_amounts: Stripe.Invoice.TotalDiscountAmount[];
+	};
+	"total_discount_amounts.discount": {
+		total_discount_amounts: (Omit<
+			Stripe.Invoice.TotalDiscountAmount,
+			"discount"
+		> & { discount: Stripe.Discount })[];
+	};
 };
 
 type InvoiceExpandKey = keyof InvoiceExpandMap;

--- a/server/src/external/stripe/stripeInvoiceUtils.ts
+++ b/server/src/external/stripe/stripeInvoiceUtils.ts
@@ -147,6 +147,13 @@ export const updateInvoiceIfExists = async ({
 			updates: {
 				status: invoice.status as InvoiceStatus,
 				hosted_invoice_url: invoice.hosted_invoice_url,
+				total: stripeToAtmnAmount({
+					amount: invoice.total,
+					currency: invoice.currency,
+				}),
+				discounts: getInvoiceDiscounts({
+					expandedInvoice: invoice,
+				}),
 			},
 		});
 

--- a/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-discounts.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-discounts.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Invoice Created Webhook Tests - Discounts
+ *
+ * Tests for verifying that discounts are correctly stored in the Autumn DB
+ * when the `invoice.created` Stripe webhook is processed.
+ *
+ * These tests verify that:
+ * 1. Subscription-level discounts are correctly persisted to the invoice.discounts field
+ * 2. Discount amounts and coupon names are correctly extracted
+ */
+
+import { expect, test } from "bun:test";
+import { InvoiceStatus } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { InvoiceService } from "@/internal/invoices/InvoiceService.js";
+
+const getStripeInfo = async ({ customerId }: { customerId: string }) => {
+	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+
+	const fullCustomer = await CusService.getFull({
+		db: ctx.db,
+		idOrInternalId: customerId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+	const stripeCustomerId =
+		fullCustomer.processor?.id || fullCustomer.processor?.processor_id;
+
+	if (!stripeCustomerId) {
+		throw new Error("Missing Stripe customer ID");
+	}
+
+	const subscriptions = await stripeCli.subscriptions.list({
+		customer: stripeCustomerId,
+		status: "all",
+	});
+
+	return {
+		stripeCli,
+		stripeCustomerId,
+		subscription: subscriptions.data[0],
+		fullCustomer,
+	};
+};
+
+// =============================================================================
+// TEST: Subscription discount persisted to Autumn invoice on invoice.created
+// =============================================================================
+
+/**
+ * Scenario:
+ * - Customer has Pro with $20/month base price
+ * - Apply a 20% discount to the subscription
+ * - Advance to next billing cycle (triggers invoice.created)
+ *
+ * Expected Result:
+ * - The Autumn invoice should have the discount in the discounts array
+ * - discount.coupon_name should match the coupon name
+ * - discount.amount_used should be ~$4 (20% of $20)
+ */
+test.concurrent(`${chalk.yellowBright("invoice.created discounts: subscription 20% discount persisted to Autumn invoice")}`, async () => {
+	const customerId = "inv-created-disc-sub-20pct";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.dashboard()],
+	});
+
+	const { autumnV1, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const { stripeCli, subscription, fullCustomer } = await getStripeInfo({
+		customerId,
+	});
+
+	// Create a 20% off coupon with a name
+	const couponName = "Test 20% Off Coupon";
+	const coupon = await stripeCli.coupons.create({
+		percent_off: 20,
+		duration: "forever",
+		name: couponName,
+	});
+
+	// Apply coupon to the subscription
+	await stripeCli.subscriptions.update(subscription.id, {
+		discounts: [{ coupon: coupon.id }],
+	});
+
+	// Advance to next billing cycle - this triggers invoice.created webhook
+	await advanceTestClock({
+		stripeCli,
+		testClockId: testClockId!,
+		numberOfMonths: 1,
+	});
+
+	// Wait for webhook processing
+	await new Promise((resolve) => setTimeout(resolve, 5000));
+
+	// Query the Autumn invoice from DB
+	const invoices = await InvoiceService.list({
+		db: ctx.db,
+		internalCustomerId: fullCustomer.internal_id,
+	});
+
+	// Should have 2 invoices: initial + renewal
+	expect(invoices.length).toBeGreaterThanOrEqual(2);
+
+	// Get the latest invoice (renewal invoice with discount)
+	const latestInvoice = invoices[0];
+
+	// Verify the discount is present
+	expect(latestInvoice.status).toBe(InvoiceStatus.Draft);
+	expect(latestInvoice.discounts).toBeDefined();
+	expect(latestInvoice.discounts.length).toBe(1);
+
+	const discount = latestInvoice.discounts[0];
+	expect(discount.coupon_name).toBe(couponName);
+	expect(discount.stripe_coupon_id).toBe(coupon.id);
+
+	// 20% of $20 = $4
+	expect(discount.amount_used).toBe(4);
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensures invoices from Stripe’s invoice.created webhook are saved with correct totals and discounts in the DB. Adds integration tests to verify totals and subscription-level discount persistence.

- **Bug Fixes**
  - Fetch expanded Stripe invoice (discount coupon and total_discount_amounts) before upsert.
  - Persist invoice total and discounts on update/create.
  - Add tests validating invoice total after webhook and a 20% subscription coupon being stored as a $4 discount with coupon name.

<sup>Written for commit bedd38aced026dfc4db1daadb0ef6ca3d208d6f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed invoice data persistence on `invoice.created` webhook by fetching expanded Stripe invoice with discount information and updating the `total` field in the Autumn database.

**Key Changes:**

- **Bug fixes**: Fetches re-expanded invoice from Stripe API to get accurate `total` and `total_discount_amounts` data during `invoice.created` webhook processing
- **Bug fixes**: Updates invoice `total` field in DB on both create and update paths to reflect final invoice amount
- **Bug fixes**: Updates invoice `discounts` field in `updateInvoiceIfExists` utility to keep discount data current
- **Improvements**: Added type-safe expansion options for `total_discount_amounts` in `getStripeInvoice` type map
- **Improvements**: Changed webhook logging from debug to info level for better visibility
- **Improvements**: Added comprehensive tests verifying invoice totals and discounts are correctly persisted to DB

**Critical Issue Found:**

The update path in `upsertAutumnInvoice.ts` (lines 84-91) updates `total`, `product_ids`, and `internal_product_ids` but is missing the `discounts` field. This creates an inconsistency where the create path includes discounts via `createInvoiceFromStripe`, but if an invoice already exists (race condition), its discounts won't be updated even though the expanded invoice data is available. This needs to be fixed to match the behavior in `updateInvoiceIfExists` in `stripeInvoiceUtils.ts`.
</details>


<h3>Confidence Score: 3/5</h3>

- This PR has a logical bug in the update path that will cause discount data to not be persisted in certain race conditions
- The PR correctly implements fetching expanded invoice data and adds comprehensive tests, but has a critical bug where the update path doesn't include the `discounts` field. While the create path works correctly, any invoice that already exists when this webhook fires won't have its discounts updated, creating data inconsistency. The fix is straightforward (add `discounts` field and import `getInvoiceDiscounts`), but this bug will cause incorrect data in production.
- `server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/upsertAutumnInvoice.ts` needs the `discounts` field added to the update path and the `getInvoiceDiscounts` import

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/invoices/operations/getStripeInvoice.ts | added `total_discount_amounts` and `total_discount_amounts.discount` type mappings for invoice expansion - type-safe change with no runtime issues |
| server/src/external/stripe/stripeInvoiceUtils.ts | updated `updateInvoiceIfExists` to sync `total` and `discounts` fields when invoice exists - ensures invoice data stays current |
| server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/upsertAutumnInvoice.ts | fetches expanded invoice with discounts and updates `total` field on invoice.created webhook, but update path missing `discounts` field while create path includes it via `createInvoiceFromStripe` |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Webhook as Stripe Webhook Handler
    participant UpsertTask as upsertAutumnInvoice
    participant StripeAPI as Stripe API
    participant InvoiceService
    participant DB as Autumn DB

    Stripe->>Webhook: invoice.created event
    Webhook->>UpsertTask: handle event
    
    alt billing_reason != "subscription_cycle"
        UpsertTask->>UpsertTask: skip (non-periodic invoice)
    else billing_reason == "subscription_cycle"
        UpsertTask->>StripeAPI: getStripeInvoice(expand: discounts, total_discount_amounts)
        StripeAPI-->>UpsertTask: updatedStripeInvoice (with expanded data)
        
        UpsertTask->>UpsertTask: calculate product IDs & entity IDs
        
        UpsertTask->>InvoiceService: updateByStripeId(total, product_ids, internal_product_ids)
        InvoiceService->>DB: check if invoice exists
        
        alt invoice exists
            DB-->>InvoiceService: found
            InvoiceService->>DB: update invoice fields
            DB-->>InvoiceService: updated
            InvoiceService-->>UpsertTask: updated=true
            UpsertTask->>UpsertTask: return (skip create)
        else invoice doesn't exist
            DB-->>InvoiceService: not found
            InvoiceService-->>UpsertTask: updated=false
            
            UpsertTask->>InvoiceService: createInvoiceFromStripe(updatedStripeInvoice)
            InvoiceService->>InvoiceService: getInvoiceDiscounts(updatedStripeInvoice)
            InvoiceService->>DB: insert invoice (with total, discounts, product_ids)
            DB-->>InvoiceService: created
            InvoiceService-->>UpsertTask: success
        end
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->