### PR TITLE
fix: cancel

### DIFF
--- a/server/src/internal/customers/cancel/handleCancelV2.ts
+++ b/server/src/internal/customers/cancel/handleCancelV2.ts
@@ -1,0 +1,85 @@
+import type { UpdateSubscriptionV0Params } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler";
+import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan";
+import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
+import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
+import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
+import { computeUpdateSubscriptionPlan } from "@/internal/billing/v2/updateSubscription/compute/computeUpdateSubscriptionPlan";
+import { handleUpdateSubscriptionErrors } from "@/internal/billing/v2/updateSubscription/errors/handleUpdateSubscriptionErrors";
+import { logUpdateSubscriptionContext } from "@/internal/billing/v2/updateSubscription/logs/logUpdateSubscriptionContext";
+import { logUpdateSubscriptionPlan } from "@/internal/billing/v2/updateSubscription/logs/logUpdateSubscriptionPlan";
+import { setupUpdateSubscriptionBillingContext } from "@/internal/billing/v2/updateSubscription/setup/setupUpdateSubscriptionBillingContext";
+
+export const handleCancelV2 = createRoute({
+	// body: CancelBodySchema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, org, env } = ctx;
+		const {
+			customer_id,
+			product_id,
+			entity_id,
+			cancel_immediately = false,
+			prorate: bodyProrate = true,
+			customer_product_id,
+		} = await c.req.json();
+
+		const updateSubscriptionBody: UpdateSubscriptionV0Params = {
+			customer_id,
+			product_id,
+			entity_id,
+			cancel_action: cancel_immediately
+				? "cancel_immediately"
+				: "cancel_end_of_cycle",
+			billing_behavior: bodyProrate ? "prorate_immediately" : "next_cycle_only",
+		};
+
+		ctx.logger.info(
+			`=============== RUNNING CANCEL FOR ${customer_id} ===============`,
+		);
+
+		const billingContext = await setupUpdateSubscriptionBillingContext({
+			ctx,
+			params: updateSubscriptionBody,
+		});
+		logUpdateSubscriptionContext({ ctx, billingContext });
+
+		const autumnBillingPlan = await computeUpdateSubscriptionPlan({
+			ctx,
+			billingContext,
+			params: updateSubscriptionBody,
+		});
+		logUpdateSubscriptionPlan({ ctx, plan: autumnBillingPlan, billingContext });
+
+		await handleUpdateSubscriptionErrors({
+			ctx,
+			billingContext,
+			autumnBillingPlan,
+			params: updateSubscriptionBody,
+		});
+
+		const stripeBillingPlan = await evaluateStripeBillingPlan({
+			ctx,
+			billingContext,
+			autumnBillingPlan,
+		});
+		logStripeBillingPlan({ ctx, stripeBillingPlan, billingContext });
+
+		const billingResult = await executeBillingPlan({
+			ctx,
+			billingContext,
+			billingPlan: {
+				autumn: autumnBillingPlan,
+				stripe: stripeBillingPlan,
+			},
+		});
+
+		logStripeBillingResult({ ctx, result: billingResult.stripe });
+
+		return c.json({
+			success: true,
+			customer_id: customer_id,
+			product_id: product_id,
+		});
+	},
+});

--- a/server/src/internal/products/ProductService.ts
+++ b/server/src/internal/products/ProductService.ts
@@ -14,7 +14,17 @@ import {
 import type { DrizzleCli } from "@server/db/initDrizzle";
 import RecaseError from "@server/utils/errorUtils";
 import { notNullish } from "@server/utils/genUtils";
-import { and, desc, eq, exists, inArray, ne, or, sql } from "drizzle-orm";
+import {
+	and,
+	desc,
+	eq,
+	exists,
+	inArray,
+	isNull,
+	ne,
+	or,
+	sql,
+} from "drizzle-orm";
 import { StatusCodes } from "http-status-codes";
 import { getLatestProducts } from "./productUtils";
 
@@ -131,7 +141,11 @@ export class ProductService {
 				eq(products.env, env),
 				eq(products.is_default, true),
 				ne(products.archived, true),
-				group ? eq(products.group, group) : undefined,
+				group === "" || group === null
+					? or(isNull(products.group), eq(products.group, ""))
+					: notNullish(group)
+						? eq(products.group, group)
+						: undefined,
 				inIds ? inArray(products.id, inIds) : undefined,
 			),
 			with: {

--- a/server/src/utils/scriptUtils/createTestProducts.ts
+++ b/server/src/utils/scriptUtils/createTestProducts.ts
@@ -175,7 +175,7 @@ export const constructProduct = ({
 		is_add_on: isAddOn,
 		is_default: (type === "free" && isDefault) || forcePaidDefault,
 		version,
-		group: group || "",
+		group: group ?? null,
 		free_trial: freeTrialConfig as FreeTrial,
 		created_at: Date.now(),
 	};

--- a/server/tests/attach/others/others1.test.ts
+++ b/server/tests/attach/others/others1.test.ts
@@ -1,5 +1,5 @@
-import { beforeAll, describe, expect, test } from "bun:test";
-import { type AppEnv, LegacyVersion, type Organization } from "@autumn/shared";
+import { beforeAll, describe, test } from "bun:test";
+import { LegacyVersion } from "@autumn/shared";
 import { attachAndExpectCorrect } from "@tests/utils/expectUtils/expectAttach.js";
 import {
 	expectDowngradeCorrect,
@@ -7,8 +7,6 @@ import {
 } from "@tests/utils/expectUtils/expectScheduleUtils.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import chalk from "chalk";
-import type Stripe from "stripe";
-import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
 import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
@@ -46,6 +44,7 @@ describe(`${chalk.yellowBright(`${testCase}: Testing trials: pro with trial -> p
 			ctx,
 			products: [free, pro, premium],
 			prefix: testCase,
+			customerId,
 		});
 
 		const { testClockId: testClockId1 } = await initCustomerV3({

--- a/server/tests/utils/testProductUtils/testProductUtils.ts
+++ b/server/tests/utils/testProductUtils/testProductUtils.ts
@@ -20,8 +20,9 @@ export const addPrefixToProducts = ({
 	for (const product of products) {
 		product.id = `${product.id}_${prefix}`;
 		product.name = `${product.name} ${prefix}`;
-		// Only set group to prefix if not already defined
-		if (!product.group) {
+		// Only set group to prefix if not explicitly defined (null/undefined)
+		// Preserve empty string "" as an explicit "no group" value
+		if (product.group === null || product.group === undefined) {
 			product.group = prefix;
 		}
 	}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes cancel-at-end-of-cycle so a free default plan is only scheduled when its group matches the canceled product. Adds a v2 cancel handler that routes cancellations through the v2 billing/update flow.

- New Features
  - Added handleCancelV2 route that maps cancel_immediately and prorate to UpdateSubscriptionV0Params and executes via billing v2 (compute/evaluate/execute + logging).

- Bug Fixes
  - Correct group handling when selecting default products: treat null and "" distinctly, and only match exact groups; supports “no group” products.
  - Test product creation now sets group to null by default; prefixing preserves an explicit empty string.
  - Added integration test for “pro with empty group” to ensure free default is not scheduled on EOC cancel when groups differ.

<sup>Written for commit 10a39d6a96e9124bf1279cba01e2469fe27045db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the handling of product groups in cancel operations, specifically addressing edge cases where products have empty string (`""`) groups versus `null` groups.

## Key Changes

### **Bug fixes**
- Fixed `ProductService.listDefault()` to properly distinguish between empty string (`""`) and `null` product groups - previously treated both as "no group" but now correctly handles `""` as an explicit value
- Updated `constructProduct()` to use `null` instead of empty string for default group value
- Fixed `addPrefixToProducts()` to preserve explicit empty string groups instead of overwriting them with prefix

### **Improvements**
- Added `handleCancelV2` using the v2 billing system architecture, delegating to the update subscription flow for better code reuse
- Enhanced test coverage with new edge case test verifying that canceling a product with empty group does not schedule default product from different group
- Removed unused imports in test file

## Technical Details

The core fix addresses a product group matching bug in the cancellation flow. When a user cancels a product, the system attempts to schedule a default product from the same group. The issue occurred when:
- Product A has `group: ""` (explicit empty string)
- Default product has `group: "some-prefix"` (from test setup)

Previously, the `listDefault()` method would treat `""` the same as no group filter, causing incorrect matches. The fix uses `or(isNull(products.group), eq(products.group, ""))` to properly match both `null` and empty string when searching for products without a group, ensuring group matching works correctly during cancellation.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive edge case coverage, fix a clear bug in group matching logic, and follow established patterns. The new handleCancelV2 handler properly delegates to existing v2 billing infrastructure. Only minor style improvement suggested (unused variables).
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cancel/handleCancelV2.ts | New cancel handler using v2 billing system, delegates to update subscription flow |
| server/src/internal/products/ProductService.ts | Fixed group filtering logic to properly handle empty string and null group values |
| server/src/utils/scriptUtils/createTestProducts.ts | Changed default group from empty string to null for consistency |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant handleCancelV2
    participant setupContext as setupUpdateSubscriptionBillingContext
    participant computePlan as computeUpdateSubscriptionPlan
    participant handleErrors as handleUpdateSubscriptionErrors
    participant evaluatePlan as evaluateStripeBillingPlan
    participant execute as executeBillingPlan
    participant ProductService as ProductService.listDefault
    participant scheduleDefault as scheduleDefaultProduct

    Client->>handleCancelV2: Cancel request (customer_id, product_id, cancel_immediately)
    handleCancelV2->>handleCancelV2: Map to UpdateSubscriptionV0Params
    Note over handleCancelV2: cancel_action: cancel_immediately or cancel_end_of_cycle<br/>billing_behavior: prorate_immediately or next_cycle_only
    
    handleCancelV2->>setupContext: Setup billing context
    setupContext-->>handleCancelV2: billingContext
    
    handleCancelV2->>computePlan: Compute cancellation plan
    computePlan->>ProductService: listDefault(group=product.group)
    Note over ProductService: Fixed: Properly matches empty string "" vs null groups<br/>Uses: or(isNull(products.group), eq(products.group, ""))
    ProductService-->>computePlan: Default products for group
    computePlan->>scheduleDefault: Schedule default if canceling EOC
    Note over scheduleDefault: Only schedules if:<br/>- group matches exactly<br/>- not already scheduled
    scheduleDefault-->>computePlan: Scheduled product or null
    computePlan-->>handleCancelV2: autumnBillingPlan
    
    handleCancelV2->>handleErrors: Validate plan
    handleErrors-->>handleCancelV2: Validation complete
    
    handleCancelV2->>evaluatePlan: Generate Stripe actions
    evaluatePlan-->>handleCancelV2: stripeBillingPlan
    
    handleCancelV2->>execute: Execute cancellation
    execute-->>handleCancelV2: billingResult
    
    handleCancelV2-->>Client: Success response
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->