### PR TITLE
fix: sub cache multi region

### DIFF
--- a/server/src/external/redis/initRedis.ts
+++ b/server/src/external/redis/initRedis.ts
@@ -355,4 +355,7 @@ declare module "ioredis" {
 	}
 }
 
+/** Get the primary Redis instance (us-west-2) to avoid replication lag issues */
+export const getPrimaryRedis = () => getRegionalRedis(REGION_US_WEST_2);
+
 export { redis };

--- a/server/src/external/stripe/subscriptions/utils/lockStripeSubscriptionUtils.ts
+++ b/server/src/external/stripe/subscriptions/utils/lockStripeSubscriptionUtils.ts
@@ -1,4 +1,4 @@
-import { redis } from "@/external/redis/initRedis";
+import { getPrimaryRedis } from "@/external/redis/initRedis";
 import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils";
 
 export const setStripeSubscriptionLock = async ({
@@ -8,14 +8,17 @@ export const setStripeSubscriptionLock = async ({
 	stripeSubscriptionId: string;
 	lockedAtMs: number;
 }) => {
-	await tryRedisWrite(async () => {
-		await redis.set(
-			`sub:${stripeSubscriptionId}`,
-			JSON.stringify({ lockedAtMs }),
-			"EX",
-			process.env.NODE_ENV === "production" ? 60 : 3,
-		);
-	});
+	const primaryRedis = getPrimaryRedis();
+	await tryRedisWrite(
+		async () =>
+			primaryRedis.set(
+				`sub:${stripeSubscriptionId}`,
+				JSON.stringify({ lockedAtMs }),
+				"EX",
+				process.env.NODE_ENV === "production" ? 60 : 3,
+			),
+		primaryRedis,
+	);
 };
 
 export type StripeSubscriptionLock = {
@@ -27,9 +30,10 @@ export const getStripeSubscriptionLock = async ({
 }: {
 	stripeSubscriptionId: string;
 }): Promise<StripeSubscriptionLock | null> => {
-	return await tryRedisRead(async () => {
-		const value = await redis.get(`sub:${stripeSubscriptionId}`);
+	const primaryRedis = getPrimaryRedis();
+	return tryRedisRead(async () => {
+		const value = await primaryRedis.get(`sub:${stripeSubscriptionId}`);
 		if (!value) return null;
 		return JSON.parse(value) as StripeSubscriptionLock;
-	});
+	}, primaryRedis);
 };

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -17,6 +17,7 @@ import express from "express";
 import { addRequestToLogs } from "@/utils/logging/addContextToLogs.js";
 import { client, db } from "./db/initDrizzle.js";
 import { ClickHouseManager } from "./external/clickhouse/ClickHouseManager.js";
+import { warmupRegionalRedis } from "./external/redis/initRedis.js";
 import { logger } from "./external/logtail/logtailUtils.js";
 import { redirectToHono } from "./initHono.js";
 import { apiRouter } from "./internal/api/apiRouter.js";
@@ -118,7 +119,7 @@ const init = async () => {
 	app.all("/api/auth/*", toNodeHandler(auth));
 
 	// Initialize managers in parallel for faster startup
-	await Promise.all([ClickHouseManager.getInstance()]);
+	await Promise.all([ClickHouseManager.getInstance(), warmupRegionalRedis()]);
 
 	app.use(async (req: any, res: any, next: any) => {
 		// Add Render region identifier headers for load balancer verification


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes subscription lock caching to always use the primary Redis (us-west-2), preventing replication lag across regions and stabilizing attach/cancel flows.

- **Bug Fixes**
  - Read/write subscription locks via the primary Redis to avoid race conditions from cross-region lag.
  - tryRedisRead/tryRedisWrite now accept a Redis instance and check readiness on that instance.
  - Warm up regional Redis connections on startup to reduce cold-start latency.

- **Refactors**
  - Added getPrimaryRedis and warmupRegionalRedis helpers.
  - Updated temp test to cover attach pro annual and immediate cancel scenario.

<sup>Written for commit dd2a65fb09efd8b08fb5b22ad995be91b11feb82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes subscription cache race conditions in multi-region deployments by ensuring all subscription lock operations use the primary Redis instance (us-west-2) instead of regional instances.

**Key Changes:**

- **Bug fixes**: Fixed race conditions in subscription locking caused by Redis replication lag between us-east-2 and us-west-2 regions
- **Improvements**: Added `warmupRegionalRedis()` to pre-establish cross-region connections at startup for better performance
- **API changes**: Extended `tryRedisRead` and `tryRedisWrite` utility functions to accept optional Redis instance parameter

The changes correctly address the replication lag issue by routing all subscription lock reads/writes to the primary region, preventing scenarios where a lock written in one region might not be immediately visible in another region.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-targeted and solve a specific race condition issue. The implementation is backward-compatible (optional parameters with sensible defaults), properly handles the primary Redis instance retrieval, and includes startup warmup for better reliability.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/redis/initRedis.ts | Added `getPrimaryRedis()` helper to explicitly use us-west-2 Redis for avoiding replication lag |
| server/src/utils/cacheUtils/cacheUtils.ts | Added optional `redisInstance` parameter to `tryRedisRead` and `tryRedisWrite` for multi-region support |
| server/src/external/stripe/subscriptions/utils/lockStripeSubscriptionUtils.ts | Updated to use `getPrimaryRedis()` for subscription locking to prevent race conditions from replication lag |
| server/src/init.ts | Added `warmupRegionalRedis()` to startup initialization to pre-warm cross-region connections |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API as API Handler (Any Region)
    participant Lock as lockStripeSubscriptionUtils
    participant Primary as Primary Redis (us-west-2)
    participant Local as Local Redis (us-east-2)
    
    Note over API,Primary: Subscription Update Flow
    
    API->>Lock: setStripeSubscriptionLock(subId, timestamp)
    Lock->>Lock: getPrimaryRedis()
    Lock->>Primary: SET sub:{id} (with TTL)
    Note right of Primary: Writes always go to primary<br/>to avoid replication lag
    Primary-->>Lock: OK
    Lock-->>API: Lock acquired
    
    Note over API,Primary: Check Lock from Different Region
    
    API->>Lock: getStripeSubscriptionLock(subId)
    Lock->>Lock: getPrimaryRedis()
    Lock->>Primary: GET sub:{id}
    Note right of Primary: Reads from primary ensure<br/>latest lock state
    Primary-->>Lock: {lockedAtMs: timestamp}
    Lock-->>API: Lock data or null
    
    Note over API,Local: Why Primary Redis?
    Note right of Local: Replication lag between regions<br/>could cause race conditions<br/>if writes/reads used local region
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->