### PR TITLE
fix: 🐛 consent screen overflow

### DIFF
--- a/vite/src/views/auth/Consent.tsx
+++ b/vite/src/views/auth/Consent.tsx
@@ -286,9 +286,9 @@ export const Consent = () => {
 	}
 
 	return (
-		<div className="w-screen h-screen bg-background flex items-center justify-center p-4">
+		<div className="w-screen min-h-screen bg-background flex items-center justify-center py-8 px-4">
 			<CustomToaster />
-			<div className="w-full max-w-[420px] space-y-6">
+			<div className="w-full max-w-[420px] space-y-6 max-h-full overflow-y-auto">
 				{/* Logo */}
 				<div className="flex justify-center">
 					<img src="/logo_hd.png" alt="Autumn" className="w-12 h-12" />


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed content overflow on the auth consent screen by using min-h-screen, increasing vertical padding, and enabling overflow-y-auto on the content container. The screen now stays centered and scrolls on small viewports, preventing cut-off content.

<sup>Written for commit fff78f9e283737171d3df44f5e335b2ca99cb2bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed content overflow on the OAuth consent screen by replacing `h-screen` with `min-h-screen` and adding `overflow-y-auto` to the content container.

**Bug fixes**
- Prevented content cutoff on small viewports by enabling vertical scrolling
- Increased vertical padding from `p-4` to `py-8 px-4` for better spacing
- Content now properly scrolls while maintaining centered layout
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- Simple CSS changes that fix a legitimate overflow issue without affecting functionality or introducing bugs
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/auth/Consent.tsx | Fixed overflow issue by using min-h-screen, increasing padding, and adding overflow-y-auto |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant Consent Screen
    
    User->>Browser: Access OAuth consent page
    Browser->>Consent Screen: Load with client_id & scopes
    
    alt Screen content overflows viewport
        Consent Screen->>Browser: Apply min-h-screen (instead of h-screen)
        Consent Screen->>Browser: Add overflow-y-auto to content
        Consent Screen->>Browser: Increase padding (py-8 px-4)
        Browser->>User: Display scrollable content
    end
    
    User->>Consent Screen: Scroll to view all content
    User->>Consent Screen: Click Authorize/Cancel
    Consent Screen->>Browser: Handle user action
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->