### PR TITLE
fix: 🐛 impersonation search while impersonating

### DIFF
--- a/server/src/honoMiddlewares/adminAuthMiddleware.ts
+++ b/server/src/honoMiddlewares/adminAuthMiddleware.ts
@@ -13,7 +13,8 @@ export const adminAuthMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 	});
 
 	// Check if user has admin role
-	const isAdmin = data?.user?.role === "admin";
+	const isAdmin =
+		data?.user?.role === "admin" || !!data?.session?.impersonatedBy;
 
 	if (!isAdmin) {
 		throw new RecaseError({


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix admin auth during impersonation so search endpoints remain accessible when an admin impersonates a user. Sessions with impersonatedBy are treated as admin in the middleware.

- **Bug Fixes**
  - Prevent 403s on search while impersonating.

<sup>Written for commit afb0aae8a0a31528c933b1185f3ca80d788f011e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed admin authentication during impersonation by adding a check for `session.impersonatedBy`, allowing admins to access admin-only endpoints while impersonating users.

## Key Changes

**Bug Fixes**
- Prevented 403 errors on admin endpoints (like search) when an admin impersonates a user by treating sessions with `impersonatedBy` as admin sessions

The change integrates with the better-auth admin plugin's impersonation feature, which is already configured with a 24-hour session duration. The `impersonatedBy` field is populated by better-auth when an admin starts an impersonation session, making this a safe way to preserve admin privileges during impersonation.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The change is a minimal, focused fix that correctly leverages the better-auth admin plugin's built-in impersonation feature. The logic is sound and consistent with existing patterns in the codebase
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/adminAuthMiddleware.ts | Added `impersonatedBy` check to allow admins to access admin endpoints while impersonating users |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant M as AdminAuthMiddleware
    participant A as BetterAuth
    participant E as AdminEndpoint

    C->>M: HTTP Request
    M->>A: getSession(headers)
    A-->>M: session data
    
    alt has admin role
        M->>E: allow request
        E-->>C: response
    else has impersonatedBy
        M->>E: allow request
        E-->>C: response
    else unauthorized
        M-->>C: 403 error
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->