### PR TITLE
fix/link and table styling

### DIFF
--- a/vite/src/components/general/table/table-body.tsx
+++ b/vite/src/components/general/table/table-body.tsx
@@ -1,5 +1,5 @@
 import { flexRender } from "@tanstack/react-table";
-import { useNavigate } from "react-router";
+import { Link } from "react-router";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
 	TableBody as ShadcnTableBody,
@@ -24,7 +24,6 @@ export function TableBody() {
 		selectedItemId,
 		flexibleTableColumns,
 	} = useTableContext();
-	const navigate = useNavigate();
 	const rows = table.getRowModel().rows;
 
 	if (!rows.length) {
@@ -62,22 +61,10 @@ export function TableBody() {
 							"text-t3 transition-none h-12 py-4 relative",
 							rowClassName,
 							isSelected ? "z-100" : "hover:bg-interactive-secondary-hover",
-							(rowHref || onRowClick) && "cursor-pointer",
 						)}
 						data-state={row.getIsSelected() && "selected"}
 						key={row.id}
-						onClick={(e) => {
-							if (rowHref) {
-								// Support cmd/ctrl+click to open in new tab
-								if (e.metaKey || e.ctrlKey) {
-									window.open(rowHref, "_blank");
-								} else {
-									navigate(rowHref);
-								}
-							} else {
-								onRowClick?.(row.original);
-							}
-						}}
+						onClick={!rowHref ? () => onRowClick?.(row.original) : undefined}
 					>
 						{enableSelection && (
 							<TableCell className="w-[50px]">
@@ -88,22 +75,47 @@ export function TableBody() {
 								/>
 							</TableCell>
 						)}
-						{row.getVisibleCells().map((cell, index) => (
-							<TableCell
-								className={cn(
-									"px-2 h-4 text-t3",
-									index === 0 && "pl-4 text-t2 font-medium",
-								)}
-								key={cell.id}
-								style={
-									flexibleTableColumns
-										? undefined
-										: { width: `${cell.column.getSize()}px` }
-								}
-							>
-								{flexRender(cell.column.columnDef.cell, cell.getContext())}
-							</TableCell>
-						))}
+						{row.getVisibleCells().map((cell, index) => {
+							const cellContent = flexRender(
+								cell.column.columnDef.cell,
+								cell.getContext(),
+							);
+							const cellStyle = flexibleTableColumns
+								? {
+										width: `${cell.column.getSize()}px`,
+										maxWidth: `${cell.column.getSize()}px`,
+										minWidth: cell.column.columnDef.minSize
+											? `${cell.column.columnDef.minSize}px`
+											: undefined,
+									}
+								: { width: `${cell.column.getSize()}px` };
+
+							return (
+								<TableCell
+									className={cn(
+										"px-2 h-4 text-t3",
+										index === 0 && "pl-4 text-t2 font-medium",
+										rowHref && "p-0",
+									)}
+									key={cell.id}
+									style={cellStyle}
+								>
+									{rowHref ? (
+										<Link
+											to={rowHref}
+											className={cn(
+												"flex items-center h-full w-full px-2",
+												index === 0 && "pl-4",
+											)}
+										>
+											{cellContent}
+										</Link>
+									) : (
+										cellContent
+									)}
+								</TableCell>
+							);
+						})}
 					</TableRow>
 				);
 			})}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix table row link behavior and styling. Rows with rowHref now use react-router Link and cells have corrected padding and sizing for consistent layout and accessibility.

- **Bug Fixes**
  - Render rowHref as Link inside cells; only use onRowClick when no rowHref.
  - Add width, maxWidth, and minWidth for flexible columns to prevent overflow.
  - Adjust cell padding when linked and remove navigate usage for proper open-in-new-tab and focus behavior.

<sup>Written for commit 3daba1a19423bb5b2b9d762a0e59897145a21b6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Refactored table row navigation from imperative `useNavigate` with `onClick` handlers to declarative `Link` components. This improves accessibility and enables proper browser navigation features (middle-click, right-click menu, link preview).

**Key Changes:**
- **Bug fixes**: Replaced `navigate()` calls with `Link` components wrapped around cell content when `rowHref` is provided
- **Bug fixes**: Inverted `flexibleTableColumns` logic - now applies width constraints when true (previously applied when false)
- **Improvements**: Removed `cursor-pointer` class from rows entirely (now handled by Links)

**Issues Found:**
- Missing `cursor-pointer` class for rows with `onRowClick` but no `rowHref` - users won't see visual feedback that row is clickable
- The `flexibleTableColumns` logic inversion affects 7 tables across the codebase - needs verification that styling works correctly
</details>


<h3>Confidence Score: 3/5</h3>

- PR has a UX bug (missing cursor-pointer) and inverted logic that needs verification across 7 tables
- The PR improves navigation architecture by using Link components, but introduces a cursor styling regression for clickable rows and inverts flexibleTableColumns behavior which could affect multiple tables
- vite/src/components/general/table/table-body.tsx requires cursor-pointer fix and flexibleTableColumns verification

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/general/table/table-body.tsx | Replaced `useNavigate` with `Link` component for row navigation, inverted `flexibleTableColumns` styling logic, removed cursor-pointer class |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant TableRow
    participant LinkComponent
    participant Router
    
    alt Row has href
        User->>TableRow: "Click on cell"
        TableRow->>LinkComponent: "Event propagates to Link"
        LinkComponent->>Router: "Navigate to href"
        Router-->>User: "Page navigation"
    else Row has onRowClick only
        User->>TableRow: "Click on row"
        TableRow->>TableRow: "Call onRowClick(row.original)"
        TableRow-->>User: "Handle click action"
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->