### PR TITLE
chore: fix context menu on customers table right click

### DIFF
--- a/vite/src/components/general/table/table-body-virtualized.tsx
+++ b/vite/src/components/general/table/table-body-virtualized.tsx
@@ -36,16 +36,6 @@ const VirtualRowInner = <T,>({
 		if (!rowHref) onRowClick?.(row.original);
 	}, [rowHref, onRowClick, row.original]);
 
-	const handleContextMenu = useCallback(
-		(e: React.MouseEvent) => {
-			if (rowHref) {
-				e.preventDefault();
-				window.open(rowHref, "_blank", "noopener,noreferrer");
-			}
-		},
-		[rowHref],
-	);
-
 	return (
 		<TableRow
 			data-state={row.getIsSelected() && "selected"}
@@ -56,7 +46,6 @@ const VirtualRowInner = <T,>({
 				isSelected ? "z-100" : "hover:bg-interactive-secondary-hover",
 			)}
 			onClick={handleClick}
-			onContextMenu={handleContextMenu}
 		>
 			<TableRowCells
 				row={row}
@@ -81,7 +70,8 @@ const VirtualRow = memo(VirtualRowInner, (prevProps, nextProps) => {
 		prevProps.rowHref === nextProps.rowHref &&
 		prevProps.virtualRow.index === nextProps.virtualRow.index &&
 		prevProps.rowClassName === nextProps.rowClassName &&
-		prevProps.row.getVisibleCells().length === nextProps.row.getVisibleCells().length
+		prevProps.row.getVisibleCells().length ===
+			nextProps.row.getVisibleCells().length
 	);
 }) as typeof VirtualRowInner;
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restored native right-click behavior on customers table rows by removing the custom onContextMenu handler, so the browser context menu shows instead of forcing a new tab.

<sup>Written for commit 592f2ede64456a05f786281cf7a921591da7abe4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Removed the custom `onContextMenu` handler from virtualized table rows that was intercepting right-clicks and forcing new tab opens via `window.open()`. This restores native browser context menu behavior, allowing users to access standard options like "Open in new tab", "Copy link", etc.

The change brings the virtualized table body (`table-body-virtualized.tsx`) in line with the non-virtualized implementation (`table-body.tsx`), which never had this custom handler. Row links continue to work correctly through React Router's `Link` component, which natively supports all standard browser interactions including right-click.

## Key Changes
- **Bug fixes**: Restored native browser right-click context menu on table rows with links
- **Improvements**: Aligned virtualized and non-virtualized table behavior, improved user experience by allowing standard browser navigation options
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- The change removes non-standard behavior that was preventing native browser functionality. The implementation is consistent with the non-virtualized table and properly delegates link handling to React Router's Link component, which supports all standard navigation patterns
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/general/table/table-body-virtualized.tsx | Removed custom context menu handler to restore native browser right-click behavior |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant TableRow
    participant ReactRouterLink as React Router Link
    participant Browser

    Note over User,Browser: Before this PR (custom onContextMenu)
    User->>TableRow: Right-click on row
    TableRow->>Browser: e.preventDefault()
    TableRow->>Browser: window.open(rowHref, "_blank")
    Browser->>Browser: Opens new tab

    Note over User,Browser: After this PR (native behavior)
    User->>TableRow: Right-click on row
    TableRow->>ReactRouterLink: Event bubbles to Link
    ReactRouterLink->>Browser: Show native context menu
    Browser->>User: Display context menu options
    User->>Browser: Select "Open in new tab"
    Browser->>Browser: Opens new tab with rowHref
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->