### PR TITLE
feat: analytics v2 setup

### DIFF
--- a/shared/models/eventModels/eventTypes.ts
+++ b/shared/models/eventModels/eventTypes.ts
@@ -2,6 +2,8 @@ import type { BinSizeEnum, FullCustomer, RangeEnum } from "@autumn/shared";
 
 export type ClickHouseResult<T = Record<string, string | number>> = {
 	data: T[];
+	meta: { name: string }[];
+	rows: number;
 };
 
 export interface RawEventFromClickHouse {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extended ClickHouseResult typing to include meta (column names) and rows to match ClickHouse responses for Analytics v2. This resolves type errors in event model parsing.

<sup>Written for commit a9a135b1cb8aa37b96b7bc91adbe033a429a4fd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Extended `ClickHouseResult` type definition to include `meta` and `rows` fields, aligning the type with the actual JSON response format from ClickHouse queries.

## Key Changes

**API changes**
- Added `meta: { name: string }[]` field to provide column metadata
- Added `rows: number` field to provide row count information
- These fields match the structure returned by ClickHouse JSON format responses

The changes are already being used correctly throughout the analytics codebase:
- `aggregate.ts:210,314` constructs these fields when formatting results
- `listRawEvents.ts:145-157` provides complete metadata for event listings
- `getCountAndSum.ts:135` successfully parses responses with the updated type
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Type definition change correctly aligns with actual ClickHouse response format and is already used consistently across the codebase in multiple locations
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/models/eventModels/eventTypes.ts | Extended `ClickHouseResult` type to include `meta` (column metadata) and `rows` (row count) fields to match actual ClickHouse JSON response format |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API as Analytics API
    participant Service as Analytics Service
    participant TB as Tinybird/ClickHouse
    participant Format as Result Formatter

    API->>Service: aggregate() or getCountAndSum()
    Service->>TB: Query ClickHouse
    TB-->>Service: Raw JSON Response<br/>{data, meta, rows}
    Service->>Format: formatSimpleResults() or formatGroupableResults()
    Format->>Format: Build ClickHouseResult<br/>with meta and rows fields
    Format-->>Service: ClickHouseResult<T>
    Service-->>API: Return typed result
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->