### PR TITLE
fix: cleanup otel tracing

### DIFF
--- a/server/src/honoMiddlewares/analyticsMiddleware.ts
+++ b/server/src/honoMiddlewares/analyticsMiddleware.ts
@@ -93,16 +93,17 @@ const logResponse = async ({
 			extras: ctx.extraLogs,
 		});
 
-		// Try to extract response body if it's JSON
+		// Only clone and log response body for /v1 API routes (saves memory on webhooks, health checks, etc.)
 		let responseBody: Record<string, unknown> | null = null;
-		const contentType = c.res.headers.get("content-type");
-		if (contentType?.includes("application/json")) {
-			try {
-				// Clone response to read body without consuming it
-				const clonedResponse = c.res.clone();
-				responseBody = await clonedResponse.json();
-			} catch (_error) {
-				// Response might not be JSON or already consumed
+		if (c.req.path.includes("/v1")) {
+			const contentType = c.res.headers.get("content-type");
+			if (contentType?.includes("application/json")) {
+				try {
+					const clonedResponse = c.res.clone();
+					responseBody = await clonedResponse.json();
+				} catch (_error) {
+					// Response might not be JSON or already consumed
+				}
 			}
 		}
 

--- a/server/src/honoMiddlewares/traceMiddleware.ts
+++ b/server/src/honoMiddlewares/traceMiddleware.ts
@@ -1,45 +1,30 @@
 import { context, trace } from "@opentelemetry/api";
 import type { Context, Next } from "hono";
-import { logger } from "@/external/logtail/logtailUtils.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 
-const tracer = trace.getTracer("express");
+const tracer = trace.getTracer("hono");
 
 /**
- * Tracing middleware for OpenTelemetry spans
- * Handles request tracing and span management
+ * Lightweight tracing middleware for OpenTelemetry spans.
+ * Creates one span per request (removed redundant "response_closed" span).
  */
 export const traceMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 	const ctx = c.get("ctx");
 
-	// Create span for tracing
-	const spanName = `${c.req.method} ${c.req.url} - ${ctx.id}`;
-	const span = tracer.startSpan(spanName);
+	const span = tracer.startSpan(`${c.req.method} ${c.req.path}`);
 	span.setAttributes({
 		req_id: ctx.id,
 		method: c.req.method,
-		url: c.req.url,
+		path: c.req.path,
 	});
 
-	// Run the request within the span's context
-	await context.with(trace.setSpan(context.active(), span), async () => {
-		await next();
-
-		// End span after response
-		try {
-			span.setAttributes({
-				"http.response.status_code": c.res.status,
-				"http.response.duration": Date.now() - ctx.timestamp!,
-			});
-			span.end();
-
-			const closeSpan = tracer.startSpan("response_closed");
-			closeSpan.setAttributes({
-				req_id: ctx.id,
-			});
-			closeSpan.end();
-		} catch (error) {
-			logger.error("Error ending span", { error });
-		}
-	});
+	try {
+		await context.with(trace.setSpan(context.active(), span), next);
+	} finally {
+		span.setAttributes({
+			"http.status_code": c.res.status,
+			"http.duration_ms": Date.now() - ctx.timestamp!,
+		});
+		span.end();
+	}
 };

--- a/server/src/internal/api/apiRouter.ts
+++ b/server/src/internal/api/apiRouter.ts
@@ -4,8 +4,6 @@ import { apiAuthMiddleware } from "@/middleware/apiAuthMiddleware.js";
 import { expressApiVersionMiddleware } from "@/middleware/expressApiVersionMiddleware.js";
 import { pricingMiddleware } from "@/middleware/pricingMiddleware.js";
 import { refreshCacheMiddleware } from "@/middleware/refreshCacheMiddleware.js";
-import { expressCusRouter } from "../customers/cusRouter.js";
-import { expressProductRouter } from "../products/productRouter.js";
 
 const apiRouter: Router = Router();
 
@@ -14,9 +12,5 @@ apiRouter.use(pricingMiddleware);
 apiRouter.use(analyticsMiddleware);
 apiRouter.use(expressApiVersionMiddleware as any);
 apiRouter.use(refreshCacheMiddleware);
-
-// Analytics
-apiRouter.use("/products", expressProductRouter);
-apiRouter.use("/customers", expressCusRouter);
 
 export { apiRouter };

--- a/server/src/internal/customers/cusRouter.ts
+++ b/server/src/internal/customers/cusRouter.ts
@@ -1,4 +1,3 @@
-import express from "express";
 import { Hono } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { handleAddCouponToCusV2 } from "./handlers/handleAddCouponToCusV2.js";
@@ -13,9 +12,6 @@ import { handlePostCustomer } from "./handlers/handlePostCustomerV2.js";
 import { handleTransferProductV2 } from "./handlers/handleTransferProductV2.js";
 import { handleUpdateBalancesV2 } from "./handlers/handleUpdateBalancesV2.js";
 import { handleUpdateCustomerV2 } from "./handlers/handleUpdateCustomerV2.js";
-
-export const expressCusRouter = express.Router();
-// expressCusRouter.get("/:customer_id/billing_portal", handleGetBillingPortal);
 
 export const cusRouter = new Hono<HonoEnv>();
 

--- a/server/src/internal/products/productRouter.ts
+++ b/server/src/internal/products/productRouter.ts
@@ -1,4 +1,3 @@
-import express from "express";
 import { Hono } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { handlePlanHasCustomersV2 } from "@/internal/products/handlers/handlePlanHasCustomersV2.js";
@@ -11,8 +10,6 @@ import { handleListPlans } from "./handlers/handleListPlans.js";
 import { handleMigrateProductV2 } from "./handlers/handleMigrateProductV2.js";
 
 import { handleUpdatePlan } from "./handlers/handleUpdateProduct/handleUpdatePlan.js";
-
-export const expressProductRouter = express.Router();
 
 export const honoProductBetaRouter = new Hono<HonoEnv>();
 honoProductBetaRouter.get("", ...handleListPlans);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up OpenTelemetry tracing to reduce memory usage and standardize on Hono-based spans. Removed redundant Express tracing and limited response body logging to /v1 JSON to save memory.

- **Refactors**
  - Use Hono tracer with one span per request; set path, http.status_code, and http.duration_ms; removed redundant response_closed span.
  - Switched to minimal OTEL SDK: disabled auto-instrumentations and tightened BatchSpanProcessor limits.
  - Removed Express-based tracing and request logging from init; rely on Hono routing.
  - Only clone/log response bodies for /v1 JSON responses.
  - Removed unused Express routers for customers/products.

- **Migration**
  - Local dev CORS: dynamic localhost port whitelisting was removed. Set CLIENT_URL or update CORS config if you use non-default local ports.

<sup>Written for commit c5b7e1f32e5bf6d813f8e552a2b11b5733e293dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR optimizes OpenTelemetry tracing to reduce memory footprint across the server application. The changes focus on eliminating unnecessary overhead from both auto-instrumentation and redundant manual spans.

**Key Changes:**

- **Improvements**: Disabled OpenTelemetry auto-instrumentations in `instrumentation.ts`, drastically reducing memory and CPU overhead by only tracing manually created spans
- **Improvements**: Configured aggressive `BatchSpanProcessor` limits (`maxQueueSize: 512`, `maxExportBatchSize: 128`) to drop spans early and reduce memory buildup
- **Improvements**: Optimized response body cloning in `analyticsMiddleware.ts` to only run for `/v1` API routes, saving memory on webhooks and health checks
- **Bug fixes**: Simplified `traceMiddleware.ts` by removing redundant "response_closed" span that provided no additional value
- **Improvements**: Updated span naming from full URL to just path (`c.req.path` instead of `c.req.url`) for cleaner traces
- **Improvements**: Added try-finally block to `traceMiddleware.ts` ensuring spans are always properly closed even if errors occur
- **Improvements**: Removed obsolete Express tracing and logging middleware from `init.ts` (now fully migrated to Hono)
- **Improvements**: Cleaned up unused Express router exports (`expressCusRouter`, `expressProductRouter`) from router files
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- All changes are performance optimizations and cleanup with no functional regressions. The tracing logic has been simplified without losing critical observability, memory optimizations are well-documented and reasonable, and dead code removal is properly scoped to already-migrated routes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/analyticsMiddleware.ts | Added conditional response body cloning only for `/v1` routes to reduce memory usage on webhooks and health checks |
| server/src/honoMiddlewares/traceMiddleware.ts | Simplified tracing by removing redundant `response_closed` span, improved span naming, and added try-finally for proper cleanup |
| server/src/instrumentation.ts | Disabled auto-instrumentations and configured aggressive BatchSpanProcessor limits to reduce memory footprint |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Hono as Hono App
    participant Base as baseMiddleware
    participant Trace as traceMiddleware
    participant Analytics as analyticsMiddleware
    participant Handler as Route Handler
    participant Axiom as Axiom (OTLP)

    Client->>Hono: HTTP Request
    Hono->>Base: Setup ctx (db, logger, etc.)
    Base-->>Hono: ctx initialized
    
    Hono->>Trace: Create OpenTelemetry span
    Note over Trace: Start span: "GET /v1/customers"<br/>Set attributes: req_id, method, path
    
    Trace->>Analytics: Log request start
    Note over Analytics: Extract customer_id<br/>Enrich logger context
    
    Analytics->>Handler: Process request
    Handler-->>Analytics: Response ready
    
    Analytics-->>Trace: After next()
    Note over Analytics: Clone & log response body<br/>(only for /v1 routes)
    
    Trace-->>Hono: Finally block
    Note over Trace: Set status_code & duration_ms<br/>End span (removed redundant "response_closed" span)
    
    Trace->>Axiom: Export span via BatchSpanProcessor
    Note over Axiom: Batched export with<br/>maxQueueSize: 512<br/>maxExportBatchSize: 128
    
    Hono-->>Client: HTTP Response
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->