### PR TITLE
fix: usage table balances

### DIFF
--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -1,7 +1,4 @@
-import type {
-	FullCusEntWithFullCusProduct,
-	FullCusProduct,
-} from "@autumn/shared";
+import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
 import { Table } from "@/components/general/table";
 import { useCustomerBalanceSheetStore } from "@/hooks/stores/useCustomerBalanceSheetStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
@@ -11,13 +8,11 @@ import { CustomerBalanceTableColumns } from "./CustomerBalanceTableColumns";
 
 export function CustomerBalanceTable({
 	allEnts,
-	filteredCustomerProducts,
 	entityId,
 	aggregatedMap,
 	isLoading,
 }: {
 	allEnts: FullCusEntWithFullCusProduct[];
-	filteredCustomerProducts: FullCusProduct[];
 	entityId: string | null;
 	aggregatedMap: Map<string, FullCusEntWithFullCusProduct[]>;
 	isLoading: boolean;
@@ -34,7 +29,7 @@ export function CustomerBalanceTable({
 	const selectedFeatureId = useCustomerBalanceSheetStore((s) => s.featureId);
 
 	const columns = CustomerBalanceTableColumns({
-		filteredCustomerProducts,
+		fullCustomer: customer,
 		entityId,
 		aggregatedMap,
 		entities: customer?.entities || [],

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -204,7 +204,6 @@ export function CustomerFeatureUsageTable() {
 							{hasMeteredBalances && (
 								<CustomerBalanceTable
 									allEnts={meteredEnts}
-									filteredCustomerProducts={filteredCustomerProducts}
 									entityId={entityId ?? null}
 									aggregatedMap={aggregatedMap}
 									isLoading={isLoading}

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
@@ -2,6 +2,7 @@ import {
 	CusProductStatus,
 	type CustomerSchema,
 	type FullCusProduct,
+	type FullCustomer,
 	isCustomerProductTrialing,
 } from "@autumn/shared";
 import type { ColumnDef, Row } from "@tanstack/react-table";
@@ -26,8 +27,8 @@ type CustomerWithProducts = z.infer<typeof CustomerSchema> & {
 		trial_ends_at?: number | null;
 		[key: string]: unknown;
 	}>;
-	/** Full customer products with entitlements - merged from full_customers query */
-	fullCustomerProducts?: FullCusProduct[];
+	/** Full customer data with entitlements - merged from full_customers query */
+	fullCustomer?: FullCustomer;
 	/** Whether the full customer data is still loading */
 	isFullDataLoading?: boolean;
 };
@@ -237,7 +238,7 @@ export const createUsageColumn = ({
 		const customer = row.original;
 		return (
 			<FeatureUsageCell
-				customerProducts={customer.fullCustomerProducts}
+				fullCustomer={customer.fullCustomer}
 				featureId={featureId}
 				isLoading={customer.isFullDataLoading}
 			/>

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -84,7 +84,7 @@ export function CustomerListTable({
 
 			return {
 				...customer,
-				fullCustomerProducts: fullCustomer?.customer_products,
+				fullCustomer,
 				isFullDataLoading: !fullCustomer && isFullDataLoading,
 			} as CustomerWithProducts;
 		});

--- a/vite/src/views/customers2/components/table/customer-list/FeatureUsageCell.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/FeatureUsageCell.tsx
@@ -1,10 +1,10 @@
-import type { FullCusProduct } from "@autumn/shared";
+import type { FullCustomer } from "@autumn/shared";
 import { useFeatureUsageBalance } from "@/views/customers2/hooks/useFeatureUsageBalance";
 import { CustomerFeatureUsageBar } from "../customer-feature-usage/CustomerFeatureUsageBar";
 import { FeatureBalanceDisplay } from "../customer-feature-usage/FeatureBalanceDisplay";
 
 interface FeatureUsageCellProps {
-	customerProducts: FullCusProduct[] | undefined;
+	fullCustomer: FullCustomer | undefined;
 	featureId: string;
 	isLoading?: boolean;
 }
@@ -13,7 +13,7 @@ interface FeatureUsageCellProps {
  * Displays feature usage balance and bar stacked vertically for use in the customer list table
  */
 export function FeatureUsageCell({
-	customerProducts,
+	fullCustomer,
 	featureId,
 	isLoading = false,
 }: FeatureUsageCellProps) {
@@ -28,7 +28,7 @@ export function FeatureUsageCell({
 		cusEntsCount,
 		initialAllowance,
 	} = useFeatureUsageBalance({
-		cusProducts: customerProducts ?? [],
+		fullCustomer,
 		featureId,
 	});
 
@@ -41,11 +41,7 @@ export function FeatureUsageCell({
 		);
 	}
 
-	if (
-		!customerProducts ||
-		customerProducts.length === 0 ||
-		cusEntsCount === 0
-	) {
+	if (!fullCustomer || cusEntsCount === 0) {
 		return <span className="px-1"></span>;
 	}
 

--- a/vite/src/views/customers2/hooks/useFeatureUsageBalance.ts
+++ b/vite/src/views/customers2/hooks/useFeatureUsageBalance.ts
@@ -4,13 +4,13 @@ import {
 	cusEntsToBalance,
 	cusEntsToGrantedBalance,
 	cusEntsToPrepaidQuantity,
-	cusProductsToCusEnts,
-	type FullCusProduct,
+	type FullCustomer,
+	fullCustomerToCustomerEntitlements,
 	nullish,
 } from "@autumn/shared";
 
 export interface FeatureUsageBalanceParams {
-	cusProducts: FullCusProduct[];
+	fullCustomer: FullCustomer | null | undefined;
 	featureId: string;
 	entityId?: string | null;
 }
@@ -28,18 +28,20 @@ export interface FeatureUsageBalanceResult {
 }
 
 /**
- * Calculates feature usage balance metrics from customer products
+ * Calculates feature usage balance metrics from full customer (includes extra entitlements)
  */
 export function useFeatureUsageBalance({
-	cusProducts,
+	fullCustomer,
 	featureId,
 	entityId,
 }: FeatureUsageBalanceParams): FeatureUsageBalanceResult {
-	const cusEnts = cusProductsToCusEnts({
-		cusProducts,
-		featureIds: [featureId],
-		inStatuses: ACTIVE_STATUSES,
-	});
+	const cusEnts = fullCustomer
+		? fullCustomerToCustomerEntitlements({
+				fullCustomer,
+				featureId,
+				inStatuses: ACTIVE_STATUSES,
+			})
+		: [];
 
 	//without manual update adjustment, no rollovers
 	const initialAllowance = cusEntsToAllowance({


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect usage balances by calculating from full customer entitlements instead of product-only data. Balances and usage bars now reflect loose entitlements and are consistent across the customer balance and customer list tables.

- Bug Fixes
  - Switched useFeatureUsageBalance to accept fullCustomer and use fullCustomerToCustomerEntitlements.
  - Removed ad-hoc “loose entitlement” fallbacks in table cells; values come from the hook.
  - Updated CustomerBalanceTable, CustomerList, and FeatureUsageCell to pass fullCustomer (replacing filteredCustomerProducts).
  - Corrected allowance, used, and out-of-balance logic; “Unlimited” still displays properly and empty states are handled correctly.

<sup>Written for commit c303f77f1e7330db64c744b46d9418d584979de1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Refactored the usage balance calculation system to pass `FullCustomer` objects instead of `FullCusProduct[]` arrays throughout the customer table components.

**Key Changes - Bug fixes:**
- Fixed bug where `extra_customer_entitlements` (loose entitlements without associated customer_products) were not being included in balance calculations
- The old implementation using `cusProductsToCusEnts` only extracted customer_entitlements from customer_products, missing standalone extra entitlements
- New implementation uses `fullCustomerToCustomerEntitlements` which correctly includes both customer_product entitlements and extra_customer_entitlements

**Key Changes - Improvements:**
- Simplified `CustomerBalanceTableColumns.tsx` by removing special-case handling for loose entitlements - the hook now handles all entitlement types uniformly
- Updated `useFeatureUsageBalance` hook to accept `fullCustomer` parameter instead of `cusProducts` array
- Updated all consuming components (`CustomerBalanceTable`, `FeatureUsageCell`, `CustomerListTable`, `CustomerListColumns`) to pass the full customer object
- Improved type safety by using consistent data structures across the component tree
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a well-structured refactoring that fixes a bug with loose entitlements
- The refactoring is clean and consistent across all affected files, fixes a legitimate bug where extra_customer_entitlements were being excluded, and the new approach using fullCustomerToCustomerEntitlements is more robust and correctly handles all entitlement types
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/hooks/useFeatureUsageBalance.ts | Refactored to accept `fullCustomer` instead of `cusProducts` array, now correctly includes extra customer_entitlements (loose entitlements) |
| vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx | Simplified by removing loose entitlement special-case handling, now handled uniformly through `useFeatureUsageBalance` |
| vite/src/views/customers2/components/table/customer-list/FeatureUsageCell.tsx | Updated to accept `fullCustomer` instead of `customerProducts` array, simplified null checks |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Table as CustomerBalanceTable/FeatureUsageCell
    participant Hook as useFeatureUsageBalance
    participant Converter as fullCustomerToCustomerEntitlements
    participant Utils as cusEnts* Utils

    Note over Table: Before: Passed FullCusProduct[]<br/>After: Passes FullCustomer
    
    Table->>Hook: Call with fullCustomer, featureId, entityId
    
    alt fullCustomer exists
        Hook->>Converter: fullCustomerToCustomerEntitlements({fullCustomer, featureId, inStatuses})
        Note over Converter: Extracts customer_entitlements from customer_products
        Converter->>Converter: Include extra_customer_entitlements (loose entitlements)
        Converter->>Converter: Filter by featureId and inStatuses
        Converter->>Converter: Filter expired entitlements
        Converter-->>Hook: Returns FullCusEntWithFullCusProduct[]
    else fullCustomer is null/undefined
        Hook->>Hook: Set cusEnts = []
    end
    
    Hook->>Utils: cusEntsToAllowance(cusEnts, entityId)
    Utils-->>Hook: initialAllowance
    
    Hook->>Utils: cusEntsToGrantedBalance(cusEnts, entityId)
    Utils-->>Hook: allowance
    
    Hook->>Utils: cusEntsToPrepaidQuantity(cusEnts)
    Utils-->>Hook: prepaidAllowance
    
    Hook->>Utils: cusEntsToBalance(cusEnts, entityId)
    Utils-->>Hook: balance
    
    Hook->>Hook: Calculate derived values<br/>(shouldShowOutOfBalance, shouldShowUsed, etc.)
    
    Hook-->>Table: Return FeatureUsageBalanceResult
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->