### PR TITLE
fix: default trial cancelation

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionCreateAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionCreateAction.ts
@@ -20,7 +20,7 @@ export const buildStripeSubscriptionCreateAction = ({
 
 	const trialEndsAt = trialContext?.trialEndsAt;
 
-	const isFreeTrialWithCardRequired = trialContext?.cardRequired;
+	const freeTrialNoCardRequired = trialContext?.cardRequired === false;
 	const isCustomPaymentMethod = paymentMethod?.type === "custom";
 
 	const stripeSubscriptionCreateParams: Stripe.SubscriptionCreateParams = {
@@ -44,7 +44,7 @@ export const buildStripeSubscriptionCreateAction = ({
 
 		cancel_at: subscriptionCancelAt,
 
-		...(isFreeTrialWithCardRequired && {
+		...(freeTrialNoCardRequired && {
 			trial_settings: {
 				end_behavior: {
 					missing_payment_method: "cancel",


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes default trial behavior so subscriptions with no card required automatically cancel at trial end. Adds an integration test with Stripe test clock to verify product removal and a $0 final invoice.

- **Bug Fixes**
  - Set trial_settings.end_behavior.missing_payment_method = "cancel" only when trialContext.cardRequired === false.
  - Updated paid-defaults trial test to use a test clock, advance past trial, confirm product removal, and assert a single $0 invoice.

<sup>Written for commit da05fabfaa92334b362d34f03963d4d4333a363a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed critical logic bug in trial subscription handling where Stripe's `trial_settings.end_behavior.missing_payment_method` was being set incorrectly. Previously applied to trials with card required (inverted), now correctly applies only to trials with no card required.

## Key Changes

**Bug fixes:**
- Corrected inverted logic in `buildStripeSubscriptionCreateAction.ts:23` - renamed `isFreeTrialWithCardRequired` to `freeTrialNoCardRequired` and changed condition from `trialContext?.cardRequired` to `trialContext?.cardRequired === false`
- This ensures Stripe auto-cancels subscriptions at trial end when no payment method is present (intended behavior for `cardRequired=false` trials)

**Improvements:**
- Enhanced integration test with Stripe test clock to verify trial cancellation behavior
- Test now advances 18 days past 14-day trial to confirm product removal and $0 final invoice
- Added verification helpers: `expectProductNotPresent`, `expectCustomerInvoiceCorrect`
</details>


<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes critical bug in trial handling with proper test coverage
- Bug fix is straightforward with clear intent, properly tested with integration test using Stripe test clock to verify the cancellation behavior
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionCreateAction.ts | Fixed inverted logic for trial cancellation - now correctly cancels subscriptions when cardRequired=false |
| server/tests/integration/crud/customers/create-customer-paid-defaults.test.ts | Enhanced trial test with Stripe test clock to verify automatic cancellation after trial period ends |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Autumn
    participant BillingContext
    participant buildStripeSubscriptionCreateAction
    participant Stripe

    Client->>Autumn: Create customer with default trial product
    Autumn->>BillingContext: Setup trial context
    Note over BillingContext: trialContext.cardRequired = false<br/>(from defaultTrial product config)
    
    Autumn->>buildStripeSubscriptionCreateAction: Build subscription
    buildStripeSubscriptionCreateAction->>buildStripeSubscriptionCreateAction: Check freeTrialNoCardRequired
    Note over buildStripeSubscriptionCreateAction: OLD: isFreeTrialWithCardRequired = cardRequired<br/>NEW: freeTrialNoCardRequired = cardRequired === false
    
    alt cardRequired === false (no card required)
        buildStripeSubscriptionCreateAction->>buildStripeSubscriptionCreateAction: Set trial_settings.end_behavior.missing_payment_method = "cancel"
        Note over buildStripeSubscriptionCreateAction: Stripe will auto-cancel if no<br/>payment method at trial end
    else cardRequired === true
        buildStripeSubscriptionCreateAction->>buildStripeSubscriptionCreateAction: Do not set trial_settings
        Note over buildStripeSubscriptionCreateAction: Stripe will attempt to charge<br/>at trial end
    end
    
    buildStripeSubscriptionCreateAction->>Stripe: Create subscription with trial_settings
    Stripe-->>Autumn: Subscription created
    
    Note over Stripe: Trial period ends...
    
    alt No payment method present
        Stripe->>Stripe: Cancel subscription (due to trial_settings)
        Stripe->>Autumn: Webhook: subscription.deleted
        Autumn->>Autumn: Remove product from customer
        Autumn->>Stripe: Create $0 final invoice
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->