### PR TITLE
chore: fix table column selection bug

### DIFF
--- a/vite/src/components/general/table/table-body.tsx
+++ b/vite/src/components/general/table/table-body.tsx
@@ -19,6 +19,12 @@ export function TableBody() {
 	} = useTableContext();
 	const rows = table.getRowModel().rows;
 
+	// Compute visible column key on every render - table reference is stable so useMemo won't work
+	const visibleColumnKey = table
+		.getVisibleLeafColumns()
+		.map((col) => col.id)
+		.join(",");
+
 	if (!rows.length) {
 		return (
 			<TableEmptyState
@@ -52,6 +58,7 @@ export function TableBody() {
 							enableSelection={enableSelection}
 							flexibleTableColumns={flexibleTableColumns}
 							rowHref={rowHref}
+							visibleColumnKey={visibleColumnKey}
 						/>
 					</TableRow>
 				);

--- a/vite/src/components/general/table/table-row-cells.tsx
+++ b/vite/src/components/general/table/table-row-cells.tsx
@@ -16,6 +16,7 @@ interface TableRowCellsProps<T> {
 	enableSelection?: boolean;
 	flexibleTableColumns?: boolean;
 	rowHref?: string;
+	visibleColumnKey?: string;
 }
 
 function TableRowCellsInner<T>({
@@ -86,7 +87,7 @@ export const TableRowCells = memo(
 	(prevProps, nextProps) => {
 		// Only re-render if essential data changed
 		// Check row.original identity to handle data changes with keepPreviousData
-		// Check visible cells length to catch column additions/removals
+		// Check visibleColumnKey to handle column visibility changes (not just length)
 		return (
 			prevProps.row.id === nextProps.row.id &&
 			prevProps.row.original === nextProps.row.original &&
@@ -94,8 +95,7 @@ export const TableRowCells = memo(
 			prevProps.rowHref === nextProps.rowHref &&
 			prevProps.enableSelection === nextProps.enableSelection &&
 			prevProps.flexibleTableColumns === nextProps.flexibleTableColumns &&
-			prevProps.row.getVisibleCells().length ===
-				nextProps.row.getVisibleCells().length
+			prevProps.visibleColumnKey === nextProps.visibleColumnKey
 		);
 	},
 ) as typeof TableRowCellsInner;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a bug where toggling column visibility didn’t update row cells. Rows now re-render correctly in both virtualized and standard tables when columns are shown/hidden.

- **Bug Fixes**
  - Generate a visibleColumnKey by joining visible leaf column IDs each render.
  - Pass visibleColumnKey to VirtualRow and TableRowCells and use it in memo comparisons (instead of visible cell count).
  - Prevents stale cells when columns are toggled, including in virtualized lists.

<sup>Written for commit c41511fa367347fca33a1d83c94ef468a21f598f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed a bug where toggling column visibility didn't update row cells. The previous implementation compared `getVisibleCells().length` in memo comparisons, which failed when columns were swapped (hiding one, showing another) because the count remained the same.

**Bug fixes**
- Generated `visibleColumnKey` by joining visible leaf column IDs on every render
- Passed `visibleColumnKey` to `VirtualRow` and `TableRowCells` components
- Updated memo comparisons to use `visibleColumnKey` instead of visible cell count
- Prevents stale cells when columns are toggled, including in virtualized tables
</details>


<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-designed fix for a specific memoization bug
- The fix correctly addresses the root cause by tracking column identity rather than count, implementation is clean and consistent across both virtualized and standard tables, and the approach follows React best practices for memoization
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/general/table/table-body-virtualized.tsx | Generates `visibleColumnKey` from visible column IDs and passes it to `VirtualRow` for accurate memoization when columns are toggled |
| vite/src/components/general/table/table-body.tsx | Generates `visibleColumnKey` from visible column IDs and passes it to `TableRowCells` for accurate re-rendering on column toggle |
| vite/src/components/general/table/table-row-cells.tsx | Receives `visibleColumnKey` prop and uses it in memo comparison instead of visible cell count to detect column visibility changes |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ColumnToggle
    participant TableBody
    participant VirtualRow
    participant TableRowCells
    
    User->>ColumnToggle: Toggle column visibility
    ColumnToggle->>TableBody: Update table state
    
    Note over TableBody: Before fix: memo compares<br/>visible cell count only<br/>(same count = no re-render)
    
    Note over TableBody: After fix: generates<br/>visibleColumnKey from<br/>column IDs
    
    TableBody->>TableBody: Generate visibleColumnKey<br/>from getVisibleLeafColumns()
    TableBody->>VirtualRow: Pass visibleColumnKey
    VirtualRow->>VirtualRow: Memo compares<br/>visibleColumnKey
    
    alt visibleColumnKey changed
        VirtualRow->>TableRowCells: Re-render with new key
        TableRowCells->>TableRowCells: Memo compares<br/>visibleColumnKey
        TableRowCells->>User: Render updated cells
    else visibleColumnKey unchanged
        VirtualRow->>User: Skip re-render
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->