### PR TITLE
fix: rate limit list products

### DIFF
--- a/server/src/external/upstash/rateLimitConstants.ts
+++ b/server/src/external/upstash/rateLimitConstants.ts
@@ -1,6 +1,7 @@
 export const GENERAL_RATE_LIMIT = 1000; // per org
 export const TRACK_RATE_LIMIT = 10000; // per customer ID
 export const CHECK_RATE_LIMIT = 10000; // per customer ID
+export const LIST_PRODUCTS_RATE_LIMIT = 20; // per org
 
 // const TRACK_RATE_LIMIT = 10;
 // const CHECK_RATE_LIMIT = 10;
@@ -12,4 +13,5 @@ export enum RateLimitType {
 	Check = "check",
 	Events = "events",
 	Attach = "attach",
+	ListProducts = "list_products",
 }

--- a/server/src/external/upstash/rateLimitUtils.ts
+++ b/server/src/external/upstash/rateLimitUtils.ts
@@ -9,6 +9,7 @@ import type { HonoEnv } from "../../honoUtils/HonoEnv";
 import {
 	CHECK_RATE_LIMIT,
 	GENERAL_RATE_LIMIT,
+	LIST_PRODUCTS_RATE_LIMIT,
 	RateLimitType,
 	TRACK_RATE_LIMIT,
 } from "./rateLimitConstants";
@@ -77,6 +78,29 @@ export const getRateLimitType = (c: Context<HonoEnv>) => {
 			url: "/v1/attach",
 		},
 	];
+
+	const listProductsPatterns = [
+		{
+			method: "GET",
+			url: "/v1/products",
+		},
+		{
+			method: "GET",
+			url: "/v1/products_beta",
+		},
+		{
+			method: "GET",
+			url: "/v1/plans",
+		},
+	];
+
+	if (
+		listProductsPatterns.some((pattern) =>
+			matchRoute({ url: path, method, pattern }),
+		)
+	) {
+		return RateLimitType.ListProducts;
+	}
 
 	if (
 		attachPatterns.some((pattern) => matchRoute({ url: path, method, pattern }))
@@ -149,6 +173,9 @@ export const getRateLimitKey = async ({
 			return `attach:${orgId}:${env}:${customerId}`;
 		}
 
+		case RateLimitType.ListProducts:
+			return `list_products:${orgId}:${env}`;
+
 		case RateLimitType.General:
 			return `general:${orgId}:${env}`;
 	}
@@ -169,6 +196,11 @@ const getRateLimitConfig = ({
 			return {
 				windowMs: 1000, // 1 second window
 				limit: CHECK_RATE_LIMIT,
+			};
+		case RateLimitType.ListProducts:
+			return {
+				windowMs: 1000, // 1 second window
+				limit: LIST_PRODUCTS_RATE_LIMIT,
 			};
 		case RateLimitType.General:
 			return {

--- a/server/src/honoMiddlewares/rateLimitMiddleware.ts
+++ b/server/src/honoMiddlewares/rateLimitMiddleware.ts
@@ -4,6 +4,7 @@ import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import {
 	CHECK_RATE_LIMIT,
 	GENERAL_RATE_LIMIT,
+	LIST_PRODUCTS_RATE_LIMIT,
 	RateLimitType,
 	TRACK_RATE_LIMIT,
 } from "../external/upstash/rateLimitConstants";
@@ -63,6 +64,13 @@ const attachRateLimiter = rateLimiter({
 	keyGenerator: getRateLimitKeyFromContext,
 });
 
+const listProductsLimiter = rateLimiter({
+	windowMs: 1000,
+	limit: LIST_PRODUCTS_RATE_LIMIT,
+	standardHeaders: "draft-6",
+	keyGenerator: getRateLimitKeyFromContext,
+});
+
 const getLimiterForType = (type: RateLimitType) => {
 	switch (type) {
 		case RateLimitType.General:
@@ -75,6 +83,8 @@ const getLimiterForType = (type: RateLimitType) => {
 			return eventsLimiter;
 		case RateLimitType.Attach:
 			return attachRateLimiter;
+		case RateLimitType.ListProducts:
+			return listProductsLimiter;
 	}
 };
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a dedicated rate limit for product listing endpoints to reduce load and prevent abuse. Limits GET /v1/products, /v1/products_beta, and /v1/plans to 20 requests/sec per org.

- **Bug Fixes**
  - Added RateLimitType.ListProducts with LIST_PRODUCTS_RATE_LIMIT=20 (1s window).
  - Matched routes for products/plans and generate keys as list_products:{orgId}:{env}.
  - Integrated a new limiter in the Hono middleware with standard headers.

<sup>Written for commit 0c1969a3582431fbee7fe6111dc89e6fa49df5e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Implements stricter rate limiting for product listing endpoints (`/v1/products`, `/v1/products_beta`, `/v1/plans`) by creating a dedicated rate limit type with 20 requests per second per organization.

**Key changes:**
- **Bug fixes**: Fixed incomplete switch statement in `getRateLimitConfig` that was missing `Events` and `Attach` cases
- **Improvements**: Added new `ListProducts` rate limit type (20 req/s per org) to prevent abuse of product listing endpoints
- **Improvements**: Extended rate limit pattern matching to cover all three product-related endpoints

The implementation follows the existing rate limiting architecture consistently, with proper pattern matching, key generation (org-level), and limiter configuration.
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the incomplete switch statement in `getRateLimitConfig`
- The core implementation is solid and follows existing patterns correctly. One logical issue exists in `getRateLimitConfig` with missing switch cases, but since the function appears unused, the risk is low. The new rate limiting logic is properly integrated across all three files.
- server/src/external/upstash/rateLimitUtils.ts needs the incomplete switch statement fixed

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/upstash/rateLimitConstants.ts | Added `LIST_PRODUCTS_RATE_LIMIT` constant (20 requests/second per org) and `ListProducts` enum value for rate limiting product listing endpoints |
| server/src/external/upstash/rateLimitUtils.ts | Added `ListProducts` rate limit handling for `/v1/products`, `/v1/products_beta`, and `/v1/plans` endpoints with org-level key generation; missing Events and Attach cases in `getRateLimitConfig` |
| server/src/honoMiddlewares/rateLimitMiddleware.ts | Created `listProductsLimiter` with 20 req/s limit and added it to the limiter selection logic |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant RateLimitMiddleware
    participant RateLimitUtils
    participant ListProductsLimiter
    participant ProductsEndpoint

    Client->>RateLimitMiddleware: GET /v1/products
    RateLimitMiddleware->>RateLimitUtils: getRateLimitType(context)
    RateLimitUtils-->>RateLimitMiddleware: RateLimitType.ListProducts
    
    RateLimitMiddleware->>RateLimitUtils: getRateLimitKey(context, type)
    RateLimitUtils-->>RateLimitMiddleware: "list_products:orgId:env"
    
    RateLimitMiddleware->>RateLimitMiddleware: setRateLimitKeyInContext(key)
    RateLimitMiddleware->>RateLimitMiddleware: getLimiterForType(ListProducts)
    RateLimitMiddleware->>ListProductsLimiter: Apply rate limit (20 req/s)
    
    alt Within rate limit
        ListProductsLimiter-->>RateLimitMiddleware: Allow
        RateLimitMiddleware->>ProductsEndpoint: Process request
        ProductsEndpoint-->>Client: Return products
    else Rate limit exceeded
        ListProductsLimiter-->>RateLimitMiddleware: Block (429)
        RateLimitMiddleware-->>Client: 429 Too Many Requests
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->