### PR TITLE
chore: add list products cache

### DIFF
--- a/server/src/internal/misc/configs/handlers/handleNukeOrganisationConfiguration.ts
+++ b/server/src/internal/misc/configs/handlers/handleNukeOrganisationConfiguration.ts
@@ -3,6 +3,7 @@ import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { CusService } from "@/internal/customers/CusService";
 import { FeatureService } from "@/internal/features/FeatureService";
 import { ProductService } from "@/internal/products/ProductService";
+import { invalidateProductsCache } from "@/internal/products/productCacheUtils";
 
 export const handleNukeOrganisationConfiguration = createRoute({
 	handler: async (c) => {
@@ -29,6 +30,8 @@ export const handleNukeOrganisationConfiguration = createRoute({
 			orgId: org.id,
 			env: AppEnv.Sandbox,
 		});
+
+		await invalidateProductsCache({ orgId: org.id, env: AppEnv.Sandbox });
 
 		return c.json({ message: "Organisation configuration cleared" });
 	},

--- a/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyEnvironment.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/handleCopyEnvironment.ts
@@ -1,6 +1,7 @@
 import { AppEnv } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
+import { invalidateProductsCache } from "../../productCacheUtils.js";
 import { handleCopyFeatures } from "./handleCopyFeatures.js";
 import { handleCopyProducts } from "./handleCopyProducts.js";
 
@@ -44,6 +45,8 @@ export const handleCopyEnvironment = createRoute({
 			fromEnv,
 			toEnv,
 		});
+
+		await invalidateProductsCache({ orgId: org.id, env: toEnv });
 
 		return c.json({
 			message: "Products copied to production",

--- a/server/src/internal/products/handlers/handleCopyProduct/handleCopyProductV2.ts
+++ b/server/src/internal/products/handlers/handleCopyProduct/handleCopyProductV2.ts
@@ -6,8 +6,8 @@ import {
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
-
 import { ProductService } from "@/internal/products/ProductService.js";
+import { invalidateProductsCache } from "@/internal/products/productCacheUtils.js";
 import { copyProduct } from "@/internal/products/productUtils.js";
 import RecaseError from "@/utils/errorUtils.js";
 import { generateId } from "../../../../utils/genUtils";
@@ -133,6 +133,12 @@ export const handleCopyProductV2 = createRoute({
 			org,
 			logger,
 		});
+
+		// Invalidate cache for target environment (and source if same org)
+		await invalidateProductsCache({ orgId: org.id, env: toEnv });
+		if (fromEnv !== toEnv) {
+			await invalidateProductsCache({ orgId: org.id, env: fromEnv });
+		}
 
 		return c.json({ message: "Product copied" });
 	},

--- a/server/src/internal/products/handlers/handleCreatePlan.ts
+++ b/server/src/internal/products/handlers/handleCreatePlan.ts
@@ -25,6 +25,7 @@ import {
 } from "../free-trials/freeTrialUtils.js";
 import { ProductService } from "../ProductService.js";
 import { handleNewProductItems } from "../product-items/productItemUtils/handleNewProductItems.js";
+import { invalidateProductsCache } from "../productCacheUtils.js";
 import { getPlanResponse } from "../productUtils/productResponseUtils/getPlanResponse.js";
 import { constructProduct, initProductInStripe } from "../productUtils.js";
 import { validateDefaultFlag } from "./productActions/validateDefaultFlag.js";
@@ -168,6 +169,8 @@ export const handleCreatePlan = createRoute({
 				env,
 			},
 		});
+
+		await invalidateProductsCache({ orgId: org.id, env });
 
 		return c.json(versionedResponse);
 	},

--- a/server/src/internal/products/handlers/handleDeleteProduct.ts
+++ b/server/src/internal/products/handlers/handleDeleteProduct.ts
@@ -7,6 +7,7 @@ import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { CusProdReadService } from "@/internal/customers/cusProducts/CusProdReadService.js";
 import { ProductService } from "@/internal/products/ProductService.js";
+import { invalidateProductsCache } from "../productCacheUtils.js";
 
 const DeleteProductParamsSchema = z.object({
 	product_id: z.string(),
@@ -74,6 +75,8 @@ export const handleDeleteProduct = createRoute({
 				env,
 			});
 		}
+
+		await invalidateProductsCache({ orgId: org.id, env });
 
 		return c.json({ success: true });
 	},

--- a/server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts
+++ b/server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts
@@ -30,6 +30,7 @@ import {
 } from "../../free-trials/freeTrialUtils.js";
 import { ProductService } from "../../ProductService.js";
 import { handleNewProductItems } from "../../product-items/productItemUtils/handleNewProductItems.js";
+import { invalidateProductsCache } from "../../productCacheUtils.js";
 import { getPlanResponse } from "../../productUtils/productResponseUtils/getPlanResponse.js";
 import { initProductInStripe } from "../../productUtils.js";
 import { handleVersionProductV2 } from "../handleVersionProduct.js";
@@ -164,6 +165,8 @@ export const handleUpdatePlan = createRoute({
 					env,
 				});
 
+				await invalidateProductsCache({ orgId: org.id, env });
+
 				return c.json(newProduct);
 			}
 
@@ -250,6 +253,9 @@ export const handleUpdatePlan = createRoute({
 			},
 			ctx,
 		});
+
+		await invalidateProductsCache({ orgId: org.id, env });
+
 		return c.json(versionedResponse);
 	},
 });

--- a/server/src/internal/products/productCacheUtils.ts
+++ b/server/src/internal/products/productCacheUtils.ts
@@ -1,0 +1,81 @@
+import crypto from "node:crypto";
+import type { AppEnv } from "@autumn/shared";
+import { redis } from "@/external/redis/initRedis";
+import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils";
+
+const PRODUCTS_CACHE_PREFIX = "products_full";
+
+/** TTL for products cache: 1 day */
+export const PRODUCTS_CACHE_TTL = 60 * 60 * 24;
+
+/** Hashes query params to create a short, consistent cache key suffix */
+const hashQueryParams = (params: Record<string, unknown>): string => {
+	// Filter out undefined/null values and sort keys for consistency
+	const filtered = Object.entries(params)
+		.filter(([_, v]) => v !== undefined && v !== null)
+		.sort(([a], [b]) => a.localeCompare(b));
+
+	if (filtered.length === 0) return "default";
+
+	const str = JSON.stringify(filtered);
+	return crypto.createHash("md5").update(str).digest("hex").slice(0, 12);
+};
+
+/** Builds the base cache key prefix for products list (without query hash) */
+export const buildProductsCacheKeyPrefix = ({
+	orgId,
+	env,
+}: {
+	orgId: string;
+	env: AppEnv;
+}) => {
+	return `${PRODUCTS_CACHE_PREFIX}:${orgId}:${env}`;
+};
+
+/** Builds the cache key for products list with optional query params */
+export const buildProductsCacheKey = ({
+	orgId,
+	env,
+	queryParams,
+}: {
+	orgId: string;
+	env: AppEnv;
+	queryParams?: Record<string, unknown>;
+}) => {
+	const prefix = buildProductsCacheKeyPrefix({ orgId, env });
+	const hash = queryParams ? hashQueryParams(queryParams) : "default";
+	return `${prefix}:${hash}`;
+};
+
+/** Invalidates all products cache entries for an org/env (wildcard delete) */
+export const invalidateProductsCache = async ({
+	orgId,
+	env,
+}: {
+	orgId: string;
+	env: AppEnv;
+}) => {
+	const pattern = `${buildProductsCacheKeyPrefix({ orgId, env })}:*`;
+
+	await tryRedisWrite(async () => {
+		// Use SCAN to find all matching keys, then delete them
+		const keys: string[] = [];
+		let cursor = "0";
+
+		do {
+			const [newCursor, foundKeys] = await redis.scan(
+				cursor,
+				"MATCH",
+				pattern,
+				"COUNT",
+				100,
+			);
+			cursor = newCursor;
+			keys.push(...foundKeys);
+		} while (cursor !== "0");
+
+		if (keys.length > 0) {
+			await redis.del(...keys);
+		}
+	});
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Redis caching for product lists to speed up /products and /plans responses and reduce DB load. Cache keys include org, env (and include_archived for plans), with a 24h TTL and automatic invalidation on product/config changes.

- **New Features**
  - Cached ProductService.listFull via queryWithCache; results are sorted before storing.
  - Added productCacheUtils (buildProductsCacheKey, invalidateProductsCache) with 1-day TTL.
  - Cache invalidation on create/update plan, delete product, copy product/env, and push/nuke org configuration.

<sup>Written for commit 430912482105ef4afdab9888f8e2a6fa41c325d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Adds Redis-backed caching for “full products” reads used by `GET /products/products` and `GET /products/plans`, with cache-key helpers and a 1-day TTL, plus invalidation hooks across product/config mutations.

## Key changes
- [Improvements] Cache `ProductService.listFull` results via `queryWithCache` and stable cache keys (env/org + query hash) to reduce repeated DB work.
- [Improvements] Add `productCacheUtils` (key building + SCAN/DEL invalidation) and wire invalidation into create/update/delete/copy/push/nuke flows.
- [API changes] `handleListPlans` now logs per-request query timing at info level and sorts products within the cached function before response transformation.

## Notes
One correctness issue was found in `handleUpdatePlan` where `validateDefaultFlag` is invoked twice.
</details>


<h3>Confidence Score: 3/5</h3>

- This PR is generally safe to merge after fixing the duplicated validation call and reviewing logging volume.
- Caching changes are localized and paired with broad invalidation, but there is a concrete correctness bug in handleUpdatePlan (duplicate validateDefaultFlag invocation) and an unconditional info log on a potentially hot endpoint that could create operational noise.
- server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts; server/src/internal/products/handlers/handleListPlans.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/misc/configs/handlers/handleNukeOrganisationConfiguration.ts | Invalidates products cache after nuking sandbox org configuration. |
| server/src/internal/misc/configs/handlers/handlePushOrganisationConfiguration.ts | Tracks whether products were created during config push and invalidates products cache when needed. |
| server/src/internal/products/handlers/handleCopyEnvironment/handleCopyEnvironment.ts | Invalidates products cache after copying sandbox products to production. |
| server/src/internal/products/handlers/handleCopyProduct/handleCopyProductV2.ts | Invalidates products cache for target (and source) env after copying a product. |
| server/src/internal/products/handlers/handleCreatePlan.ts | Invalidates products cache after creating a plan/product. |
| server/src/internal/products/handlers/handleDeleteProduct.ts | Invalidates products cache after deleting a product. |
| server/src/internal/products/handlers/handleListPlans.ts | Adds caching for listing full products; introduces per-request timing log. |
| server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts | Invalidates products cache on updates/versioning; contains a duplicated validateDefaultFlag call (bug). |
| server/src/internal/products/internalHandlers/handleGetProducts.ts | Wraps ProductService.listFull in query cache with stable key and sorting inside cache function. |
| server/src/internal/products/productCacheUtils.ts | Adds cache key builders, TTL constant, and Redis SCAN-based invalidation for products list cache. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Products API
    participant Cache as Redis/Cache
    participant ProductSvc as ProductService

    Client->>API: GET /products/products OR GET /products/plans
    API->>Cache: queryWithCache(key, ttl)
    alt cache hit
        Cache-->>API: cached full products
    else cache miss
        API->>ProductSvc: listFull(orgId, env, archived?)
        ProductSvc-->>API: full products
        API->>API: sortFullProducts(products)
        API->>Cache: store result (ttl)
    end
    API-->>Client: products / plans response

    Client->>API: POST/PUT/DELETE product/plan OR copy env/product OR push/nuke config
    API->>Cache: invalidateProductsCache(orgId, env)
    Cache->>Cache: SCAN products_full:org:env:* and DEL keys
    API-->>Client: success response
```
</details>


<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context from `dashboard` - server/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
</details>


<!-- /greptile_comment -->