### PR TITLE
chore: clean up cache logic

### DIFF
--- a/server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts
+++ b/server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts
@@ -117,12 +117,6 @@ export const handleUpdatePlan = createRoute({
 			curProduct: fullProduct,
 		});
 
-		validateDefaultFlag({
-			ctx,
-			body: v1_2Body,
-			curProduct: fullProduct,
-		});
-
 		await handleUpdateProductDetails({
 			db,
 			curProduct: fullProduct,

--- a/server/src/internal/products/internalHandlers/handleGetProducts.ts
+++ b/server/src/internal/products/internalHandlers/handleGetProducts.ts
@@ -1,13 +1,7 @@
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { ProductService } from "@/internal/products/ProductService";
 import { getGroupToDefaults } from "@/internal/products/productUtils";
-import { sortFullProducts } from "@/internal/products/productUtils/sortProductUtils";
 import { mapToProductV2 } from "@/internal/products/productV2Utils";
-import { queryWithCache } from "@/utils/cacheUtils/queryWithCache";
-import {
-	buildProductsCacheKey,
-	PRODUCTS_CACHE_TTL,
-} from "../productCacheUtils";
 
 /**
  * GET /products/products
@@ -19,23 +13,9 @@ export const handleGetProducts = createRoute({
 	handler: async (c) => {
 		const { db, org, env, features } = c.get("ctx");
 
-		const products = await queryWithCache({
-			key: buildProductsCacheKey({ orgId: org.id, env, queryParams: {} }),
-			ttl: PRODUCTS_CACHE_TTL,
-			fn: async () => {
-				const prods = await ProductService.listFull({
-					db,
-					orgId: org.id,
-					env: env,
-				});
-				sortFullProducts({ products: prods });
-				return prods;
-			},
-		});
+		const products = await ProductService.listFull({ db, orgId: org.id, env });
 
-		const groupToDefaults = getGroupToDefaults({
-			defaultProds: products,
-		});
+		const groupToDefaults = getGroupToDefaults({ defaultProds: products });
 
 		return c.json({
 			products: products.map((p) =>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralizes product caching in ProductService.listFull and removes ad‑hoc caching from handlers. Caching now only applies to simple, safe queries and results are consistently sorted in the service.

- **Refactors**
  - Added conditional caching to ProductService.listFull using queryWithCache and buildProductsCacheKey; only for queries without ids, returnAll, version, or excludeEnts.
  - Introduced _listFullQuery and moved sorting (sortFullProducts) into the service for consistent ordering.
  - Simplified handleListPlans and handleGetProducts to call ProductService.listFull directly; removed local cache logic and redundant sorting.
  - Downgraded plan list timing log to debug.
  - Removed unused includeAll param and a validateDefaultFlag call in plan update handler.

<sup>Written for commit 626dd63fc0a00d256241c7dd576e62f2e15e6d03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes product caching logic by moving cache management from multiple API handlers into the `ProductService.listFull` method. The refactoring eliminates code duplication and ensures consistent caching behavior across all product list operations.

**Key changes:**

**Improvements**
- Centralized caching logic in `ProductService.listFull` with conditional caching based on query complexity
- Moved `sortFullProducts` call into `ProductService._listFullQuery` for consistent sorting
- Removed duplicate cache handling code from `handleListPlans` and `handleGetProducts` handlers
- Extracted database query logic to private `_listFullQuery` method for better separation of concerns

**Bug fixes**
- Removed duplicate `validateDefaultFlag` call in `handleUpdatePlan` (one awaited, one not awaited)
- Changed log level from `info` to `debug` in `handleListPlans` for query timing

**API changes**
- Removed unused `includeAll` parameter from `ProductService.listFull`

The refactoring maintains the same caching behavior (1-day TTL) while reducing code duplication across handlers. Cache is only applied to simple queries without `inIds`, `returnAll`, `version`, or `excludeEnts` parameters.
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it's a well-structured refactoring that centralizes caching logic
- Score reflects good refactoring practices (DRY principle, separation of concerns) and removal of a duplicate function call bug. The only concern is the duplicate validateDefaultFlag call removal needs verification that the remaining awaited call is sufficient
- Pay close attention to `handleUpdatePlan.ts` to verify the validateDefaultFlag removal was correct

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/ProductService.ts | refactored caching logic into listFull method, extracted query logic to private _listFullQuery, removed includeAll parameter |
| server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts | removed duplicate validateDefaultFlag call that was appearing twice in the handler |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Handler as API Handler
    participant PS as ProductService
    participant Cache as queryWithCache
    participant DB as Database
    participant Sort as sortFullProducts

    Note over Handler,Sort: BEFORE (Manual Cache)
    Handler->>Cache: queryWithCache(key, fn, ttl)
    Cache->>DB: ProductService.listFull(...)
    DB-->>Cache: products[]
    Cache->>Sort: sortFullProducts(products)
    Sort-->>Cache: sorted products
    Cache-->>Handler: cached/sorted products

    Note over Handler,Sort: AFTER (Centralized Cache)
    Handler->>PS: ProductService.listFull(...)
    PS->>PS: Check canCache conditions
    alt canCache = true
        PS->>Cache: queryWithCache(key, fn, ttl)
        Cache->>PS: _listFullQuery(...)
        PS->>DB: execute query
        DB-->>PS: products[]
        PS->>Sort: sortFullProducts(products)
        Sort-->>PS: sorted products
        PS-->>Cache: return products
        Cache-->>PS: cached products
    else canCache = false
        PS->>PS: _listFullQuery(...)
        PS->>DB: execute query
        DB-->>PS: products[]
        PS->>Sort: sortFullProducts(products)
        Sort-->>PS: sorted products
    end
    PS-->>Handler: products[]
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->