### PR TITLE
fix: 🐛 build errors

### DIFF
--- a/server/src/internal/analytics/actions/eventActions.ts
+++ b/server/src/internal/analytics/actions/eventActions.ts
@@ -1,4 +1,4 @@
-import { aggregate } from "./eventValidationUtils.js";
+import { aggregate } from "./aggregate";
 import { getCountAndSum } from "./getCountAndSum.js";
 import { getEventById } from "./getEventById.js";
 import { getTopEventNames } from "./getTopEventNames.js";

--- a/shared/api/_openapi/prevVersions/openapi1.2/balancesOpenApi1.2.0.ts
+++ b/shared/api/_openapi/prevVersions/openapi1.2/balancesOpenApi1.2.0.ts
@@ -1,8 +1,9 @@
+import type { ZodOpenApiPathsObject } from "zod-openapi";
 import { SuccessResponseSchema } from "../../../common/commonResponses.js";
 import { CreateBalanceParamsSchema } from "../../../models.js";
 import { xCodeSamplesLegacy } from "../../../utils/xCodeSamplesLegacy.js";
 
-export const balancesOpenApi = {
+export const balancesOpenApi: ZodOpenApiPathsObject = {
 	"/balances/create": {
 		post: {
 			summary: "Create Balance",

--- a/shared/api/balances/track/trackLegacyData.ts
+++ b/shared/api/balances/track/trackLegacyData.ts
@@ -4,4 +4,4 @@ export const TrackLegacyDataSchema = z.object({
 	feature_id: z.string(),
 });
 
-type TrackLegacyData = z.infer<typeof TrackLegacyDataSchema>;
+export type TrackLegacyData = z.infer<typeof TrackLegacyDataSchema>;

--- a/shared/models/billingModels/cusProductActions.ts
+++ b/shared/models/billingModels/cusProductActions.ts
@@ -20,14 +20,15 @@ export interface CusProductActions {
 	newProductActions: NewProductAction[];
 }
 
-export const CusProductActionsSchema = z.object({
+export const CusProductActionsSchema: z.ZodObject = z.object({
 	ongoingCusProductAction: OngoingCusProductActionSchema,
 	scheduledCusProductAction: ScheduledCusProductActionSchema,
 	newProductActions: z.array(NewProductActionSchema),
 });
 
-export const EnrichedCusProductActionsSchema = CusProductActionsSchema.extend({
-	ongoingCusProductAction: OngoingCusProductActionSchema,
-	scheduledCusProductAction: ScheduledCusProductActionSchema,
-	newProductActions: z.array(EnrichedNewProductActionSchema),
-});
+export const EnrichedCusProductActionsSchema: z.ZodObject =
+	CusProductActionsSchema.extend({
+		ongoingCusProductAction: OngoingCusProductActionSchema,
+		scheduledCusProductAction: ScheduledCusProductActionSchema,
+		newProductActions: z.array(EnrichedNewProductActionSchema),
+	});

--- a/shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts
+++ b/shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts
@@ -1,8 +1,9 @@
 import type { AppEnv } from "@models/genModels/genEnums";
 import { organizations } from "@models/orgModels/orgTable.js";
+import type { Table } from "drizzle-orm";
 import { foreignKey, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 
-export const revenuecatMappings = pgTable(
+export const revenuecatMappings: Table = pgTable(
 	"revenuecat_mappings",
 	{
 		org_id: text("org_id").notNull(),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes TypeScript build errors by correcting a bad import and adding explicit types across analytics and shared models. Unblocks the analytics v2 setup build.

- **Bug Fixes**
  - Fixed wrong import in eventActions (use "./aggregate").
  - Typed balancesOpenApi as ZodOpenApiPathsObject.
  - Exported TrackLegacyData type for external use.
  - Added explicit z.ZodObject types for CusProductActions schemas.
  - Annotated revenuecatMappings as drizzle Table and imported its type.

<sup>Written for commit 58ef81c5e07367f721c6fb48e0df8d427546b600. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses TypeScript build errors by adding type annotations and fixing import paths.

**Key Changes:**

- **Bug fixes**: Fixed incorrect import path in `eventActions.ts` from `eventValidationUtils.js` to `aggregate`
- **Bug fixes**: Added missing type export for `TrackLegacyData` in `trackLegacyData.ts`
- **Improvements**: Added type annotations to `balancesOpenApi`, `CusProductActionsSchema`, `EnrichedCusProductActionsSchema`, and `revenuecatMappings`

**Issues Found:**

The PR introduces incomplete type annotations that may cause type errors:
- `shared/models/billingModels/cusProductActions.ts` uses wrong zod import style (default import instead of named import per CLAUDE.md)
- `z.ZodObject` type annotations lack required generic parameters in `cusProductActions.ts`
- `Table` type annotation lacks required generic parameter in `revenuecatMappingsTable.ts`

These incomplete generics may not provide the intended type safety and could cause compilation errors depending on TypeScript's strictness settings.
</details>


<h3>Confidence Score: 3/5</h3>

- This PR has TypeScript syntax issues that need to be resolved before merging
- While the import path fix is correct, the PR introduces incomplete type annotations (`z.ZodObject` and `Table` without generics) and violates the codebase style guide (wrong zod import). These syntax issues could cause build failures.
- `shared/models/billingModels/cusProductActions.ts` and `shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts` need corrections for incomplete type annotations

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/eventActions.ts | Fixed import path from `eventValidationUtils.js` to `aggregate` without file extension |
| shared/api/_openapi/prevVersions/openapi1.2/balancesOpenApi1.2.0.ts | Added type annotation `ZodOpenApiPathsObject` to `balancesOpenApi` export |
| shared/api/balances/track/trackLegacyData.ts | Exported `TrackLegacyData` type that was previously defined but not exported |
| shared/models/billingModels/cusProductActions.ts | Added incomplete `z.ZodObject` type annotations (missing generic parameters) and uses wrong zod import style |
| shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts | Added incomplete `Table` type annotation (missing generic parameters) to `revenuecatMappings` |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Build as Build Process
    participant TS as TypeScript Compiler
    participant EventActions as eventActions.ts
    participant Aggregate as aggregate.ts
    participant Schemas as Zod Schemas
    participant Drizzle as Drizzle ORM
    
    Note over Build,Drizzle: Build Errors Detected
    
    Build->>TS: Compile TypeScript
    TS->>EventActions: Check imports
    EventActions-->>TS: ❌ Invalid import path
    Note over EventActions: Import from wrong file<br/>(eventValidationUtils.js vs aggregate)
    
    TS->>Schemas: Check type definitions
    Schemas-->>TS: ❌ Missing type annotations
    Note over Schemas: balancesOpenApi, TrackLegacyData<br/>not properly typed
    
    TS->>Drizzle: Check table definitions
    Drizzle-->>TS: ❌ Missing type annotations
    Note over Drizzle: revenuecatMappings missing<br/>Table type
    
    Note over Build,Drizzle: Fixes Applied
    
    EventActions->>EventActions: Fix import path to ./aggregate
    Schemas->>Schemas: Add ZodOpenApiPathsObject type
    Schemas->>Schemas: Export TrackLegacyData type
    Schemas->>Schemas: Add z.ZodObject annotations
    Drizzle->>Drizzle: Add Table type annotation
    
    Build->>TS: Recompile
    TS-->>Build: ✅ Build successful
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))

<!-- /greptile_comment -->