### PR TITLE
fix: 🐛 remove generic type

### DIFF
--- a/shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts
+++ b/shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts
@@ -1,9 +1,8 @@
 import type { AppEnv } from "@models/genModels/genEnums";
 import { organizations } from "@models/orgModels/orgTable.js";
-import type { Table } from "drizzle-orm";
 import { foreignKey, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 
-export const revenuecatMappings: Table = pgTable(
+export const revenuecatMappings = pgTable(
 	"revenuecat_mappings",
 	{
 		org_id: text("org_id").notNull(),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the explicit Table type from revenuecatMappings and let pgTable infer the type. This resolves a Drizzle typing error in the RevenueCat mappings model.

<sup>Written for commit 56734a34d9d7b43f737afe51f76093262f26f13d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a type annotation issue in the RevenueCat mappings table definition by removing the incorrect generic `Table` type annotation and allowing TypeScript to properly infer the specific table type from the `pgTable` function call.

**Key Changes:**
- **Bug fixes**: Removed `Table` type import and annotation from `revenuecatMappings` table definition in `shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts:5-6`

The change aligns the code with the standard pattern used throughout the codebase where all other table definitions rely on type inference rather than explicit `Table` annotation. This ensures proper type safety and schema information is preserved for the table.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change removes an incorrect type annotation that was causing build errors and aligns with the established pattern used in all other table definitions across the codebase. The fix is minimal, focused, and improves type safety by allowing proper type inference.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/models/processorModels/revenuecatModels/revenuecatMappingsTable.ts | Removed incorrect generic `Table` type annotation to allow proper type inference from `pgTable` return value |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant TS as TypeScript Compiler
    participant Drizzle as Drizzle ORM
    
    Note over Dev,Drizzle: Before Fix (Type Error)
    Dev->>TS: Define revenuecatMappings: Table = pgTable(...)
    TS->>Drizzle: Request pgTable() return type
    Drizzle-->>TS: Return specific PgTable with schema info
    TS->>TS: Check assignment to generic Table type
    TS-->>Dev: ❌ Type error: Loses specific schema information
    
    Note over Dev,Drizzle: After Fix (Correct)
    Dev->>TS: Define revenuecatMappings = pgTable(...)
    TS->>Drizzle: Infer pgTable() return type
    Drizzle-->>TS: Return specific PgTable with schema info
    TS->>TS: Infer complete table structure
    TS-->>Dev: ✅ Full type safety with schema inference
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->