### PR TITLE
chore: add immediate cancel when already scheduled for cancellation

### DIFF
--- a/vite/src/components/forms/uncancel-subscription/components/UncancelFooter.tsx
+++ b/vite/src/components/forms/uncancel-subscription/components/UncancelFooter.tsx
@@ -1,14 +1,19 @@
-import { motion } from "motion/react";
-import { useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { useUpdateSubscriptionFormContext } from "@/components/forms/update-subscription-v2";
 import { Button } from "@/components/v2/buttons/Button";
 import { SheetFooter } from "@/components/v2/sheets/SharedSheetComponents";
 
 const FOOTER_DELAY_MS = 350;
 
+function FooterButton({ children }: { children: ReactNode }) {
+	return <div className="animate-in fade-in duration-200">{children}</div>;
+}
+
 export function UncancelFooter() {
-	const { isPending, previewQuery, handleConfirm } =
+	const { isPending, previewQuery, handleConfirm, form, formValues } =
 		useUpdateSubscriptionFormContext();
+
+	const isCancelMode = formValues.cancelAction === "cancel_immediately";
 
 	const isLoading = previewQuery.isLoading;
 	const hasError = !!previewQuery.error;
@@ -24,15 +29,57 @@ export function UncancelFooter() {
 		setShowFooter(false);
 	}, [isReady]);
 
+	const handleCancelImmediatelyClick = () => {
+		form.setFieldValue("cancelAction", "cancel_immediately");
+		form.setFieldValue("billingBehavior", "prorate_immediately");
+	};
+
+	const handleGoBack = () => {
+		form.setFieldValue("cancelAction", "uncancel");
+	};
+
 	if (!showFooter) return null;
 
+	if (isCancelMode) {
+		return (
+			<SheetFooter className="grid-cols-2">
+				<FooterButton>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={handleGoBack}
+						disabled={isPending}
+					>
+						Go Back
+					</Button>
+				</FooterButton>
+				<FooterButton>
+					<Button
+						variant="destructive"
+						className="w-full"
+						onClick={handleConfirm}
+						isLoading={isPending}
+					>
+						Confirm Cancellation
+					</Button>
+				</FooterButton>
+			</SheetFooter>
+		);
+	}
+
 	return (
-		<SheetFooter className="grid-cols-1">
-			<motion.div
-				initial={{ opacity: 0 }}
-				animate={{ opacity: 1 }}
-				transition={{ duration: 0.2 }}
-			>
+		<SheetFooter className="grid-cols-2">
+			<FooterButton>
+				<Button
+					variant="destructive"
+					className="w-full"
+					onClick={handleCancelImmediatelyClick}
+					disabled={isPending}
+				>
+					Cancel Immediately
+				</Button>
+			</FooterButton>
+			<FooterButton>
 				<Button
 					variant="primary"
 					className="w-full"
@@ -41,7 +88,7 @@ export function UncancelFooter() {
 				>
 					Uncancel Subscription
 				</Button>
-			</motion.div>
+			</FooterButton>
 		</SheetFooter>
 	);
 }

--- a/vite/src/components/forms/update-subscription/use-update-subscription-preview.ts
+++ b/vite/src/components/forms/update-subscription/use-update-subscription-preview.ts
@@ -63,15 +63,21 @@ export function useUpdateSubscriptionPreview({
 	);
 
 	const [debouncedQueryKey, setDebouncedQueryKey] = useState(queryKeyDeps);
+	const [isDebouncing, setIsDebouncing] = useState(false);
 
 	useEffect(() => {
+		if (queryKeyDeps === debouncedQueryKey) {
+			setIsDebouncing(false);
+			return;
+		}
+
+		setIsDebouncing(true);
 		const timer = setTimeout(() => {
 			setDebouncedQueryKey(queryKeyDeps);
+			setIsDebouncing(false);
 		}, 300);
 		return () => clearTimeout(timer);
-	}, [queryKeyDeps]);
-
-	const isDebouncing = queryKeyDeps !== debouncedQueryKey;
+	}, [queryKeyDeps, debouncedQueryKey]);
 
 	const query = useQuery({
 		queryKey: ["update-subscription-preview", debouncedQueryKey],

--- a/vite/src/components/v2/InfoRow.tsx
+++ b/vite/src/components/v2/InfoRow.tsx
@@ -13,9 +13,9 @@ export function InfoRow({ icon, label, value, className, mono }: InfoRowProps) {
 		typeof value !== "string" && typeof value !== "number" && value !== null;
 
 	return (
-		<div className="flex items-center gap-2">
-			{icon && <div className="text-t4/60">{icon}</div>}
-			<div className="flex min-w-0 items-center">
+		<div className="flex items-center gap-2 min-w-0 overflow-hidden">
+			{icon && <div className="text-t4/60 shrink-0">{icon}</div>}
+			<div className="flex min-w-0 items-center overflow-hidden">
 				<div className="text-t3 text-sm font-medium w-20 whitespace-nowrap">
 					{label}
 				</div>

--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -10,6 +10,7 @@ import {
 import {
 	ArrowSquareOutIcon,
 	CalendarBlankIcon,
+	CreditCardIcon,
 	CubeIcon,
 	GitBranchIcon,
 	HashIcon,
@@ -23,6 +24,7 @@ import { format } from "date-fns";
 import { useEffect } from "react";
 import { useNavigate } from "react-router";
 import { Button } from "@/components/v2/buttons/Button";
+import { MiniCopyButton } from "@/components/v2/buttons/CopyButton";
 import { IconButton } from "@/components/v2/buttons/IconButton";
 import { InfoRow } from "@/components/v2/InfoRow";
 import { SheetHeader, SheetSection } from "@/components/v2/sheets/InlineSheet";
@@ -211,8 +213,8 @@ export function SubscriptionDetailSheet() {
 				)}
 				{/* Product Information */}
 				<SheetSection withSeparator={true}>
-					<div className="flex gap-2 justify-between">
-						<div className="space-y-3">
+					<div className="flex gap-2 justify-between overflow-hidden">
+						<div className="space-y-3 min-w-0 overflow-hidden">
 							<InfoRow
 								icon={<CubeIcon size={16} weight="duotone" />}
 								label="Plan"
@@ -235,6 +237,32 @@ export function SubscriptionDetailSheet() {
 									label="Quantity"
 									value={cusProduct.quantity.toString()}
 								/>
+							)}
+							{cusProduct.subscription_ids?.length > 0 && (
+								<div className="flex items-center gap-2 min-w-0 overflow-hidden">
+									<div className="text-t4/60 shrink-0">
+										<CreditCardIcon size={16} />
+									</div>
+									<div className="flex min-w-0 items-center overflow-hidden">
+										<div className="text-t3 text-sm font-medium w-20 shrink-0 whitespace-nowrap">
+											Sub ID
+										</div>
+										<div className="min-w-0 overflow-hidden">
+											<MiniCopyButton
+												text={cusProduct.subscription_ids[0]}
+												innerClassName="text-sm text-t1 font-mono truncate"
+											/>
+										</div>
+									</div>
+									<IconButton
+										variant="secondary"
+										onClick={handleViewStripe}
+										icon={<ArrowSquareOutIcon size={16} weight="duotone" />}
+										className="shrink-0"
+									>
+										View Stripe
+									</IconButton>
+								</div>
 							)}
 						</div>
 					</div>
@@ -259,64 +287,53 @@ export function SubscriptionDetailSheet() {
 				)}
 				{/* Status & Dates */}
 				<SheetSection>
-					<div className="flex gap-2 justify-between">
-						<div className="space-y-3">
+					<div className="space-y-3">
+						<InfoRow
+							icon={<HeartbeatIcon size={16} weight="duotone" />}
+							label="Status"
+							value={
+								<CustomerProductsStatus
+									status={cusProduct.status}
+									canceled={cusProduct.canceled}
+									canceled_at={cusProduct.canceled_at ?? undefined}
+									trialing={
+										isCustomerProductTrialing(cusProduct, {
+											nowMs: Date.now(),
+										}) || false
+									}
+									trial_ends_at={cusProduct.trial_ends_at ?? undefined}
+								/>
+							}
+						/>
+
+						<InfoRow
+							icon={<CalendarBlankIcon size={16} weight="duotone" />}
+							label="Started"
+							value={formatDate(cusProduct.starts_at)}
+						/>
+
+						{cusProduct.trial_ends_at && (
 							<InfoRow
-								icon={<HeartbeatIcon size={16} weight="duotone" />}
-								label="Status"
-								value={
-									<CustomerProductsStatus
-										status={cusProduct.status}
-										canceled={cusProduct.canceled}
-										canceled_at={cusProduct.canceled_at ?? undefined}
-										trialing={
-											isCustomerProductTrialing(cusProduct, {
-												nowMs: Date.now(),
-											}) || false
-										}
-										trial_ends_at={cusProduct.trial_ends_at ?? undefined}
-									/>
-								}
+								icon={<TimerIcon size={16} weight="duotone" />}
+								label="Trial Ends"
+								value={formatDate(cusProduct.trial_ends_at)}
 							/>
+						)}
 
+						{cusProduct.canceled_at && (
 							<InfoRow
-								icon={<CalendarBlankIcon size={16} weight="duotone" />}
-								label="Started"
-								value={formatDate(cusProduct.starts_at)}
+								icon={<XCircle size={16} weight="duotone" />}
+								label="Canceled"
+								value={formatDate(cusProduct.canceled_at)}
 							/>
+						)}
 
-							{cusProduct.trial_ends_at && (
-								<InfoRow
-									icon={<TimerIcon size={16} weight="duotone" />}
-									label="Trial Ends"
-									value={formatDate(cusProduct.trial_ends_at)}
-								/>
-							)}
-
-							{cusProduct.canceled_at && (
-								<InfoRow
-									icon={<XCircle size={16} weight="duotone" />}
-									label="Canceled"
-									value={formatDate(cusProduct.canceled_at)}
-								/>
-							)}
-
-							{cusProduct.ended_at && (
-								<InfoRow
-									icon={<XCircle size={16} weight="duotone" />}
-									label="Ended"
-									value={formatDate(cusProduct.ended_at)}
-								/>
-							)}
-						</div>
-						{cusProduct.subscription_ids?.length > 0 && (
-							<IconButton
-								variant="secondary"
-								onClick={handleViewStripe}
-								icon={<ArrowSquareOutIcon size={16} weight="duotone" />}
-							>
-								View Stripe
-							</IconButton>
+						{cusProduct.ended_at && (
+							<InfoRow
+								icon={<XCircle size={16} weight="duotone" />}
+								label="Ended"
+								value={formatDate(cusProduct.ended_at)}
+							/>
 						)}
 					</div>
 				</SheetSection>
@@ -338,7 +355,7 @@ export function SubscriptionDetailSheet() {
 								setSheet({ type: "subscription-uncancel", itemId })
 							}
 						>
-							Uncancel Subscription
+							Manage Cancellation
 						</Button>
 					) : (
 						<Button

--- a/vite/src/views/customers2/components/sheets/SubscriptionUncancelSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionUncancelSheet.tsx
@@ -1,5 +1,7 @@
 import type { FullCusProduct, ProductV2 } from "@autumn/shared";
 import { useMemo } from "react";
+import { BillingBehaviorSection } from "@/components/forms/cancel-subscription/components/BillingBehaviorSection";
+import { CancelPreviewSection } from "@/components/forms/cancel-subscription/components/CancelPreviewSection";
 import { UncancelFooter } from "@/components/forms/uncancel-subscription/components/UncancelFooter";
 import { UncancelPreviewSection } from "@/components/forms/uncancel-subscription/components/UncancelPreviewSection";
 import {
@@ -19,15 +21,21 @@ import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
 
 function SheetContent() {
-	const { formContext } = useUpdateSubscriptionFormContext();
+	const { formContext, formValues } = useUpdateSubscriptionFormContext();
 	const { customerProduct } = formContext;
+
+	const isCancelMode = formValues.cancelAction === "cancel_immediately";
 
 	return (
 		<LayoutGroup>
 			<div className="flex flex-col h-full overflow-y-auto">
 				<SheetHeader
-					title="Uncancel Subscription"
-					description={`Resume ${customerProduct.product.name} for this customer`}
+					title={isCancelMode ? "Cancel Subscription" : "Uncancel Subscription"}
+					description={
+						isCancelMode
+							? `Cancel ${customerProduct.product.name} immediately`
+							: `Resume ${customerProduct.product.name} for this customer`
+					}
 					breadcrumbs={[
 						{
 							name: customerProduct.product.name,
@@ -37,15 +45,18 @@ function SheetContent() {
 					itemId={customerProduct.id}
 				/>
 
-				<div className="px-4 pt-4">
-					<InfoBox variant="warning" classNames={{ infoBox: "w-full" }}>
-						This subscription is scheduled to cancel on{" "}
-						{formatUnixToDateTime(customerProduct.canceled_at).date}.
-						Uncancelling will resume normal billing.
-					</InfoBox>
-				</div>
+				{!isCancelMode && (
+					<div className="px-4 pt-4">
+						<InfoBox variant="warning" classNames={{ infoBox: "w-full" }}>
+							This subscription is scheduled to cancel on{" "}
+							{formatUnixToDateTime(customerProduct.canceled_at).date}.
+							Uncancelling will resume normal billing.
+						</InfoBox>
+					</div>
+				)}
 
-				<UncancelPreviewSection />
+				<BillingBehaviorSection />
+				{isCancelMode ? <CancelPreviewSection /> : <UncancelPreviewSection />}
 				<UncancelFooter />
 			</div>
 		</LayoutGroup>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds “Cancel Immediately” to the Uncancel flow so users can either uncancel or cancel now from the same sheet, with billing behavior and preview. Also polishes subscription details and improves preview debouncing.

- **New Features**
  - Add Cancel Immediately option in the Uncancel sheet with Go Back/Confirm flow.
  - Show billing behavior controls and the correct preview for cancel vs. uncancel.
  - Change button on Subscription Detail to “Manage Cancellation.”
  - Display Sub ID with copy and “View Stripe” in Product Information.

- **Refactors**
  - Improve debounced preview hook to track isDebouncing and fix effect deps.
  - Replace motion animation with a simpler fade-in for footer buttons.
  - Tweak InfoRow and sheet layouts to prevent overflow and improve truncation.

<sup>Written for commit 90891a72eceec292fabab85f5973faa32ffb8882. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the ability to immediately cancel a subscription that is already scheduled for cancellation, directly from the "Manage Cancellation" flow.

## Key Changes

**Improvements:**
- Users can now cancel immediately from the uncancel sheet by clicking "Cancel Immediately", which toggles the form into cancel mode with billing behavior options
- Added Stripe subscription ID display with copy button in subscription detail sheet for easier navigation
- Improved overflow handling in `InfoRow` component to prevent text truncation issues

**Bug fixes:**
- Fixed debouncing state management in subscription preview hook by explicitly tracking `isDebouncing` state with proper useEffect dependencies

The implementation reuses existing cancellation components (`BillingBehaviorSection`, `CancelPreviewSection`) and provides a smooth UX with proper state management. The footer adapts based on `cancelAction` form value, showing either uncancel controls or cancellation confirmation controls.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are well-structured UI improvements and bug fixes. The code reuses existing components appropriately, follows the codebase patterns (v2 components, proper form state management), and the debouncing fix is a clear improvement. No security issues, no breaking changes, and the logic is sound.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/uncancel-subscription/components/UncancelFooter.tsx | Replaced motion animation with simpler CSS animation, added two-mode footer (uncancel vs cancel immediately) with proper state management |
| vite/src/components/forms/update-subscription/use-update-subscription-preview.ts | Fixed debouncing state management by tracking isDebouncing explicitly with useEffect dependencies |
| vite/src/views/customers2/components/sheets/SubscriptionUncancelSheet.tsx | Added cancel immediately mode toggle with BillingBehaviorSection, conditionally renders CancelPreviewSection or UncancelPreviewSection |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant DetailSheet as SubscriptionDetailSheet
    participant UncancelSheet as SubscriptionUncancelSheet
    participant Footer as UncancelFooter
    participant BillingSection as BillingBehaviorSection
    participant Preview as CancelPreviewSection
    participant API as Backend API

    User->>DetailSheet: Click "Manage Cancellation"
    DetailSheet->>UncancelSheet: Open sheet (type: subscription-uncancel)
    UncancelSheet->>UncancelSheet: Initialize form with cancelAction: "uncancel"
    UncancelSheet->>Footer: Render footer
    Footer->>Footer: Check isCancelMode (false initially)
    Footer->>User: Show "Cancel Immediately" + "Uncancel Subscription" buttons
    
    User->>Footer: Click "Cancel Immediately"
    Footer->>Footer: handleCancelImmediatelyClick()
    Footer->>Footer: Set cancelAction: "cancel_immediately"
    Footer->>Footer: Set billingBehavior: "prorate_immediately"
    
    Footer->>UncancelSheet: Form state updated (isCancelMode: true)
    UncancelSheet->>UncancelSheet: Header changes to "Cancel Subscription"
    UncancelSheet->>BillingSection: Render billing behavior options
    BillingSection->>User: Show "Prorate immediately" / "Next cycle only" options
    UncancelSheet->>Preview: Render CancelPreviewSection (not UncancelPreviewSection)
    Preview->>API: POST /v1/subscriptions/preview_update
    API-->>Preview: Return cancellation preview with line items
    Preview->>User: Display pricing preview
    
    Footer->>Footer: Check isCancelMode (true now)
    Footer->>User: Show "Go Back" + "Confirm Cancellation" buttons
    
    User->>Footer: Click "Confirm Cancellation"
    Footer->>API: POST /v1/subscriptions/update (with cancel_immediately)
    API-->>Footer: Success
    Footer->>DetailSheet: Close sheet and refresh
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->