### PR TITLE
chore: table scroll fixes

### DIFF
--- a/vite/src/components/general/table/table-header.tsx
+++ b/vite/src/components/general/table/table-header.tsx
@@ -112,13 +112,12 @@ export function TableHeader({
 					)}
 					{headerGroup.headers.map((header, index, arr) => {
 						const isLast = index === arr.length - 1;
-						const headerStyle = flexibleTableColumns
-							? {
-									width: `${header.getSize()}px`,
-									maxWidth: `${header.getSize()}px`,
-									minWidth: `${header.getSize()}px`,
-								}
-							: { width: `${header.getSize()}px` };
+					const headerStyle = flexibleTableColumns
+						? {
+								width: `${header.getSize()}px`,
+								maxWidth: `${header.getSize()}px`,
+							}
+						: { width: `${header.getSize()}px` };
 						return (
 							<TableHead
 								className={cn(

--- a/vite/src/components/general/table/table-row-cells.tsx
+++ b/vite/src/components/general/table/table-row-cells.tsx
@@ -43,13 +43,12 @@ function TableRowCellsInner<T>({
 					cell.column.columnDef.cell,
 					cell.getContext(),
 				);
-				const cellStyle = flexibleTableColumns
-					? {
-							width: `${cell.column.getSize()}px`,
-							maxWidth: `${cell.column.getSize()}px`,
-							minWidth: `${cell.column.getSize()}px`,
-						}
-					: { width: `${cell.column.getSize()}px` };
+			const cellStyle = flexibleTableColumns
+				? {
+						width: `${cell.column.getSize()}px`,
+						maxWidth: `${cell.column.getSize()}px`,
+					}
+				: { width: `${cell.column.getSize()}px` };
 
 				return (
 					<TableCell

--- a/vite/src/views/customers2/components/table/customer-usage-analytics/CustomerUsageAnalyticsColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-usage-analytics/CustomerUsageAnalyticsColumns.tsx
@@ -43,7 +43,7 @@ export const CustomerUsageAnalyticsColumns: ColumnDef<Event>[] = [
 			const dateAsNumber = dateObj.getTime();
 
 			return (
-				<div className="text-tiny text-t3 font-mono min-w-fit">
+				<div className="text-tiny text-t3 font-mono truncate">
 					{format(new Date(dateAsNumber), "d MMM HH:mm:ss")}
 				</div>
 			);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix table horizontal scrolling by allowing flexible columns to shrink instead of enforcing a min width. Removed minWidth from header/cell styles and switched the Customer Usage Analytics timestamp cell to truncate, preventing overflow and jitter.

<sup>Written for commit 1735a962511fb57d88cb803844307dfd8c8f527d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed horizontal scrolling behavior in tables by removing `minWidth` constraints from column styling when `flexibleTableColumns` is enabled.

**Bug fixes**
- Removed `minWidth` property from `headerStyle` in `table-header.tsx` (vite/src/components/general/table/table-header.tsx:115-120)
- Removed `minWidth` property from `cellStyle` in `table-row-cells.tsx` (vite/src/components/general/table/table-row-cells.tsx:46-51)
- Changed timestamp column from `min-w-fit` to `truncate` class to allow proper text overflow (vite/src/views/customers2/components/table/customer-usage-analytics/CustomerUsageAnalyticsColumns.tsx:46)

The changes enable columns to shrink below their preferred width when container space is limited, allowing the browser to display horizontal scrollbars correctly. Previously, `minWidth` prevented columns from shrinking, causing layout issues.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-understood CSS adjustments that fix a specific scrolling issue without introducing new logic or dependencies
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/general/table/table-header.tsx | Removed minWidth from headerStyle to fix horizontal scroll issues in flexible table columns |
| vite/src/components/general/table/table-row-cells.tsx | Removed minWidth from cellStyle to fix horizontal scroll issues in flexible table columns |
| vite/src/views/customers2/components/table/customer-usage-analytics/CustomerUsageAnalyticsColumns.tsx | Changed min-w-fit to truncate for timestamp column to allow proper text overflow handling |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Table
    participant TableHeader
    participant TableRowCells
    participant Browser

    User->>Table: Renders table with flexibleTableColumns=true
    Table->>TableHeader: Renders header with column sizing
    
    Note over TableHeader: Previous: width, maxWidth, minWidth all set<br/>Problem: minWidth prevents shrinking
    
    TableHeader->>Browser: Applies headerStyle {width, maxWidth}
    Note over Browser: Without minWidth, columns can shrink<br/>allowing horizontal scroll
    
    Table->>TableRowCells: Renders cells with column sizing
    
    Note over TableRowCells: Previous: width, maxWidth, minWidth all set<br/>Problem: minWidth prevents shrinking
    
    TableRowCells->>Browser: Applies cellStyle {width, maxWidth}
    Note over Browser: Without minWidth, cells match headers<br/>and can shrink properly
    
    Browser->>User: Displays table with working horizontal scroll
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->