### PR TITLE
chore: fix product cache invalidation

### DIFF
--- a/server/src/internal/misc/pricingAgent/handlers/handleSyncPreviewPricing.ts
+++ b/server/src/internal/misc/pricingAgent/handlers/handleSyncPreviewPricing.ts
@@ -15,6 +15,7 @@ import { createFeature } from "@/internal/features/featureActions/createFeature.
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { createProduct } from "@/internal/products/handlers/productActions/createProduct.js";
 import { ProductService } from "@/internal/products/ProductService.js";
+import { invalidateProductsCache } from "@/internal/products/productCacheUtils.js";
 import { buildPreviewOrgSlug } from "./handleSetupPreviewOrg.js";
 
 const SyncPreviewPricingSchema = z.object({
@@ -155,6 +156,11 @@ export const handleSyncPreviewPricing = createRoute({
 				}),
 			),
 		);
+
+		await invalidateProductsCache({
+			orgId: previewOrg.id,
+			env: AppEnv.Sandbox,
+		});
 
 		ctx.logger.debug(
 			`[Preview Sync] Summary: ${body.features.length} features, ${body.products.length} products`,

--- a/server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts
+++ b/server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts
@@ -164,6 +164,8 @@ export const handleUpdatePlan = createRoute({
 				return c.json(newProduct);
 			}
 
+			// Product details (name, group, etc.) may have changed via handleUpdateProductDetails
+			await invalidateProductsCache({ orgId: org.id, env });
 			return c.json(fullProduct);
 		}
 

--- a/server/src/internal/products/handlers/productActions/updateProduct.ts
+++ b/server/src/internal/products/handlers/productActions/updateProduct.ts
@@ -1,4 +1,5 @@
 import {
+	type AppEnv,
 	type FreeTrial,
 	mapToProductV2,
 	notNullish,
@@ -20,6 +21,7 @@ import {
 } from "../../free-trials/freeTrialUtils.js";
 import { ProductService } from "../../ProductService.js";
 import { handleNewProductItems } from "../../product-items/productItemUtils/handleNewProductItems.js";
+import { invalidateProductsCache } from "../../productCacheUtils.js";
 import { getProductResponse } from "../../productUtils/productResponseUtils/getProductResponse.js";
 import { initProductInStripe } from "../../productUtils.js";
 import { handleUpdateProductDetails } from "../handleUpdateProduct/updateProductDetails.js";
@@ -139,9 +141,12 @@ export const updateProduct = async ({
 				env,
 			});
 
+			await invalidateProductsCache({ orgId: org.id, env: env as AppEnv });
 			return newProduct;
 		}
 
+		// Product details (name, group, etc.) may have changed via handleUpdateProductDetails
+		await invalidateProductsCache({ orgId: org.id, env: env as AppEnv });
 		return fullProduct;
 	}
 
@@ -215,6 +220,8 @@ export const updateProduct = async ({
 		product: newFullProduct,
 		features,
 	});
+
+	await invalidateProductsCache({ orgId: org.id, env: env as AppEnv });
 
 	return productResponse;
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes products cache invalidation so product changes show up immediately. Uses deterministic keys and deletes them across all Redis regions.

- **Bug Fixes**
  - Switched from SCAN to targeted DEL using deterministic keys with Redis hash tags {orgId}; covers archived variants (undefined/false/true).
  - Invalidates in all regions via regional Redis clients.
  - Triggers invalidation after updateProduct, handleUpdatePlan, and preview pricing sync.

<sup>Written for commit 44ebe351ffabe6b1b5364e341e449aa05bc0d664. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes product cache invalidation to work correctly in a multi-region Redis Cluster deployment.

**Key Changes:**

**[Bug fixes]** Fixed cache invalidation to delete from all configured regions instead of only the local region, preventing stale cache issues in multi-region deployments

**[Improvements]** Replaced SCAN-based wildcard pattern matching with deterministic key deletion using predefined `ARCHIVED_VARIANTS`, eliminating race conditions and improving performance in Redis Cluster

**[Improvements]** Added Redis hash tags `{orgId}` to cache keys to ensure all keys for the same organization hash to the same Redis Cluster slot, enabling efficient multi-key DEL operations

**[Bug fixes]** Added missing cache invalidation calls in `updateProduct.ts`, `handleUpdatePlan.ts`, and `handleSyncPreviewPricing.ts` to ensure cache consistency after product modifications

The previous implementation used `redis.scan()` with pattern matching, which has several issues: it only targeted the local region's Redis instance, cannot work reliably in Redis Cluster environments (SCAN doesn't support cross-slot operations), and could miss keys if new cache entries were created during the scan. The new approach builds all possible cache keys deterministically based on the known query parameter variants (undefined, false, true for the `archived` param) and deletes them atomically across all regions.
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor consideration for the deterministic key approach
- The implementation correctly addresses multi-region cache invalidation and adds necessary invalidation calls throughout the codebase. The deterministic key deletion approach is more robust than SCAN-based deletion. However, the approach assumes all possible cache key variants are known at invalidation time, which could become a maintenance burden if new query parameters are added to the product list endpoint in the future
- Pay close attention to `productCacheUtils.ts` - verify the `ARCHIVED_VARIANTS` array includes all possible cached query parameter combinations

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/productCacheUtils.ts | Replaced SCAN-based cache invalidation with deterministic key deletion across multi-region Redis clusters, adding hash tags for Redis Cluster compatibility |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Product Update API
    participant PCache as productCacheUtils
    participant Redis_West as Redis us-west-2
    participant Redis_East as Redis us-east-2

    Client->>API: Update Product/Plan
    API->>API: Process product update
    API->>API: Update database
    API->>PCache: invalidateProductsCache({orgId, env})
    
    Note over PCache: Build deterministic keys:<br/>- products_full:{orgId}:env:default<br/>- products_full:{orgId}:env:hash(archived=false)<br/>- products_full:{orgId}:env:hash(archived=true)
    
    par Delete from all regions
        PCache->>Redis_West: DEL (3 keys)
        Redis_West-->>PCache: deleted count
    and
        PCache->>Redis_East: DEL (3 keys)
        Redis_East-->>PCache: deleted count
    end
    
    PCache-->>API: Cache invalidated
    API-->>Client: Product updated
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->