### PR TITLE
chore: fix product cache invalidation again

### DIFF
--- a/server/src/honoMiddlewares/refreshProductsCacheMiddleware.ts
+++ b/server/src/honoMiddlewares/refreshProductsCacheMiddleware.ts
@@ -1,0 +1,54 @@
+import type { Context, Next } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { invalidateProductsCache } from "@/internal/products/productCacheUtils.js";
+import { matchRoute } from "./middlewareUtils.js";
+
+/**
+ * Route patterns that trigger products cache invalidation.
+ * These are the simple CRUD routes - complex cases (copy across envs, conditional invalidation)
+ * are handled explicitly in their respective handlers.
+ */
+const productRoutes = [
+	{ method: "POST", url: "/products" },
+	{ method: "POST", url: "/products/:product_id" },
+	{ method: "PATCH", url: "/products/:product_id" },
+	{ method: "DELETE", url: "/products/:product_id" },
+];
+
+/**
+ * Hono middleware that clears products cache after successful responses
+ * for specific routes. Only handles simple cases where orgId/env come from ctx.
+ *
+ * Edge cases handled explicitly in handlers:
+ * - handleCopyProductV2: invalidates source + target envs
+ * - handleCopyEnvironment: invalidates live env specifically
+ * - handleSyncPreviewPricing: different org context (preview org)
+ * - handlePushOrganisationConfiguration: conditional (only if products created)
+ * - handleNukeOrganisationConfiguration: internal route
+ */
+export const refreshProductsCacheMiddleware = async (
+	c: Context<HonoEnv>,
+	next: Next,
+) => {
+	await next();
+
+	if (c.res.status < 200 || c.res.status >= 300) return;
+
+	const ctx = c.get("ctx");
+
+	if (ctx.testOptions?.skipCacheDeletion) return;
+
+	const pathname = new URL(c.req.url).pathname.replace("/v1", "");
+	const method = c.req.method;
+
+	const match = productRoutes.find((pattern) =>
+		matchRoute({ url: pathname, method, pattern }),
+	);
+
+	if (!match) return;
+
+	await invalidateProductsCache({
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+};

--- a/server/src/internal/products/handlers/handleCreatePlan.ts
+++ b/server/src/internal/products/handlers/handleCreatePlan.ts
@@ -25,7 +25,6 @@ import {
 } from "../free-trials/freeTrialUtils.js";
 import { ProductService } from "../ProductService.js";
 import { handleNewProductItems } from "../product-items/productItemUtils/handleNewProductItems.js";
-import { invalidateProductsCache } from "../productCacheUtils.js";
 import { getPlanResponse } from "../productUtils/productResponseUtils/getPlanResponse.js";
 import { constructProduct, initProductInStripe } from "../productUtils.js";
 import { validateDefaultFlag } from "./productActions/validateDefaultFlag.js";
@@ -169,8 +168,6 @@ export const handleCreatePlan = createRoute({
 				env,
 			},
 		});
-
-		await invalidateProductsCache({ orgId: org.id, env });
 
 		return c.json(versionedResponse);
 	},

--- a/server/src/internal/products/handlers/handleDeleteProduct.ts
+++ b/server/src/internal/products/handlers/handleDeleteProduct.ts
@@ -7,7 +7,6 @@ import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { CusProdReadService } from "@/internal/customers/cusProducts/CusProdReadService.js";
 import { ProductService } from "@/internal/products/ProductService.js";
-import { invalidateProductsCache } from "../productCacheUtils.js";
 
 const DeleteProductParamsSchema = z.object({
 	product_id: z.string(),
@@ -75,8 +74,6 @@ export const handleDeleteProduct = createRoute({
 				env,
 			});
 		}
-
-		await invalidateProductsCache({ orgId: org.id, env });
 
 		return c.json({ success: true });
 	},

--- a/server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts
+++ b/server/src/internal/products/handlers/handleUpdateProduct/handleUpdatePlan.ts
@@ -30,7 +30,6 @@ import {
 } from "../../free-trials/freeTrialUtils.js";
 import { ProductService } from "../../ProductService.js";
 import { handleNewProductItems } from "../../product-items/productItemUtils/handleNewProductItems.js";
-import { invalidateProductsCache } from "../../productCacheUtils.js";
 import { getPlanResponse } from "../../productUtils/productResponseUtils/getPlanResponse.js";
 import { initProductInStripe } from "../../productUtils.js";
 import { handleVersionProductV2 } from "../handleVersionProduct.js";
@@ -159,13 +158,10 @@ export const handleUpdatePlan = createRoute({
 					env,
 				});
 
-				await invalidateProductsCache({ orgId: org.id, env });
-
 				return c.json(newProduct);
 			}
 
 			// Product details (name, group, etc.) may have changed via handleUpdateProductDetails
-			await invalidateProductsCache({ orgId: org.id, env });
 			return c.json(fullProduct);
 		}
 
@@ -249,8 +245,6 @@ export const handleUpdatePlan = createRoute({
 			},
 			ctx,
 		});
-
-		await invalidateProductsCache({ orgId: org.id, env });
 
 		return c.json(versionedResponse);
 	},

--- a/server/src/internal/products/handlers/productActions/updateProduct.ts
+++ b/server/src/internal/products/handlers/productActions/updateProduct.ts
@@ -1,5 +1,4 @@
 import {
-	type AppEnv,
 	type FreeTrial,
 	mapToProductV2,
 	notNullish,
@@ -21,7 +20,6 @@ import {
 } from "../../free-trials/freeTrialUtils.js";
 import { ProductService } from "../../ProductService.js";
 import { handleNewProductItems } from "../../product-items/productItemUtils/handleNewProductItems.js";
-import { invalidateProductsCache } from "../../productCacheUtils.js";
 import { getProductResponse } from "../../productUtils/productResponseUtils/getProductResponse.js";
 import { initProductInStripe } from "../../productUtils.js";
 import { handleUpdateProductDetails } from "../handleUpdateProduct/updateProductDetails.js";
@@ -141,12 +139,9 @@ export const updateProduct = async ({
 				env,
 			});
 
-			await invalidateProductsCache({ orgId: org.id, env: env as AppEnv });
 			return newProduct;
 		}
 
-		// Product details (name, group, etc.) may have changed via handleUpdateProductDetails
-		await invalidateProductsCache({ orgId: org.id, env: env as AppEnv });
 		return fullProduct;
 	}
 
@@ -220,8 +215,6 @@ export const updateProduct = async ({
 		product: newFullProduct,
 		features,
 	});
-
-	await invalidateProductsCache({ orgId: org.id, env: env as AppEnv });
 
 	return productResponse;
 };

--- a/server/src/internal/products/productCacheUtils.ts
+++ b/server/src/internal/products/productCacheUtils.ts
@@ -8,6 +8,9 @@ import {
 
 const PRODUCTS_CACHE_PREFIX = "products_full";
 
+/** Cache version - bump when cache schema changes to auto-invalidate old entries */
+const PRODUCTS_CACHE_VERSION = "1.0.0";
+
 /** TTL for products cache: 1 day */
 export const PRODUCTS_CACHE_TTL = 60 * 60 * 24;
 
@@ -36,7 +39,7 @@ export const buildProductsCacheKeyPrefix = ({
 	orgId: string;
 	env: AppEnv;
 }) => {
-	return `${PRODUCTS_CACHE_PREFIX}:{${orgId}}:${env}`;
+	return `${PRODUCTS_CACHE_PREFIX}:{${orgId}}:${env}:${PRODUCTS_CACHE_VERSION}`;
 };
 
 /** Builds the cache key for products list with optional query params */

--- a/server/src/internal/products/productUtils/detectProductVariant.ts
+++ b/server/src/internal/products/productUtils/detectProductVariant.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { nullish } from "@/utils/genUtils.js";
 import { ProductService } from "../ProductService.js";
+import { invalidateProductsCache } from "../productCacheUtils.js";
 
 const prompt = `Detect whether a given product (called "product_to_detect") is an interval variant of a base product from the list of existing products (called "existing_products").
 
@@ -114,6 +115,11 @@ export const detectBaseVariant = async ({
 			update: {
 				base_variant_id: baseVariantId,
 			},
+		});
+
+		await invalidateProductsCache({
+			orgId: curProduct.org_id,
+			env: curProduct.env,
 		});
 	}
 

--- a/server/src/routers/apiRouter.ts
+++ b/server/src/routers/apiRouter.ts
@@ -11,6 +11,7 @@ import { orgConfigMiddleware } from "../honoMiddlewares/orgConfigMiddleware.js";
 import { queryMiddleware } from "../honoMiddlewares/queryMiddleware.js";
 import { rateLimitMiddleware } from "../honoMiddlewares/rateLimitMiddleware.js";
 import { refreshCacheMiddleware } from "../honoMiddlewares/refreshCacheMiddleware.js";
+import { refreshProductsCacheMiddleware } from "../honoMiddlewares/refreshProductsCacheMiddleware.js";
 import { secretKeyMiddleware } from "../honoMiddlewares/secretKeyMiddleware.js";
 import type { HonoEnv } from "../honoUtils/HonoEnv.js";
 import {
@@ -39,6 +40,7 @@ apiRouter.use("*", secretKeyMiddleware);
 apiRouter.use("*", orgConfigMiddleware);
 apiRouter.use("*", apiVersionMiddleware);
 apiRouter.use("*", refreshCacheMiddleware);
+apiRouter.use("*", refreshProductsCacheMiddleware);
 apiRouter.use("*", analyticsMiddleware);
 apiRouter.use("*", rateLimitMiddleware);
 apiRouter.use("*", queryMiddleware());

--- a/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListColumns.tsx
@@ -10,8 +10,10 @@ import { ProductListRowToolbar } from "./ProductListRowToolbar";
 
 export const createProductListColumns = ({
 	showGroup = false,
+	onDeleteClick,
 }: {
 	showGroup?: boolean;
+	onDeleteClick?: (product: ProductV2) => void;
 } = {}) => [
 	{
 		size: 300,
@@ -98,7 +100,10 @@ export const createProductListColumns = ({
 					className="flex justify-end w-full pr-2"
 					onClick={(e) => e.stopPropagation()}
 				>
-					<ProductListRowToolbar product={row.original} />
+					<ProductListRowToolbar
+						product={row.original}
+						onDeleteClick={onDeleteClick}
+					/>
 				</div>
 			);
 		},

--- a/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListRowToolbar.tsx
@@ -17,14 +17,18 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/v2/dropdowns/DropdownMenu";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
-import { DeletePlanDialog } from "@/views/products/plan/components/DeletePlanDialog";
 import { CopyProductDialog } from "../CopyProductDialog";
 
-export const ProductListRowToolbar = ({ product }: { product: ProductV2 }) => {
+export const ProductListRowToolbar = ({
+	product,
+	onDeleteClick,
+}: {
+	product: ProductV2;
+	onDeleteClick?: (product: ProductV2) => void;
+}) => {
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [copyOpen, setCopyOpen] = useState(false);
 	const [copyToEnv, setCopyToEnv] = useState<AppEnv>(AppEnv.Sandbox);
-	const [deleteOpen, setDeleteOpen] = useState(false);
 	const { counts } = useProductsQuery();
 
 	const productCounts = counts[product.id];
@@ -44,12 +48,6 @@ export const ProductListRowToolbar = ({ product }: { product: ProductV2 }) => {
 				setOpen={setCopyOpen}
 				product={product}
 				targetEnv={copyToEnv}
-			/>
-			<DeletePlanDialog
-				propProduct={product}
-				open={deleteOpen}
-				setOpen={setDeleteOpen}
-				dropdownOpen={dropdownOpen}
 			/>
 
 			<DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
@@ -95,7 +93,7 @@ export const ProductListRowToolbar = ({ product }: { product: ProductV2 }) => {
 							e.stopPropagation();
 							e.preventDefault();
 							setDropdownOpen(false);
-							setDeleteOpen(true);
+							onDeleteClick?.(product);
 						}}
 					>
 						<DeleteIcon />


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralized product cache invalidation with a new Hono middleware and cache key versioning to fix stale product data. Also improved the delete dialog UX by closing immediately and invalidating in the background.

- **Bug Fixes**
  - Added refreshProductsCacheMiddleware to clear products cache after successful POST/PATCH/DELETE on /products routes; registered in apiRouter.
  - Removed ad-hoc invalidateProductsCache calls from product handlers to prevent missed or duplicated invalidations.
  - Versioned cache keys (PRODUCTS_CACHE_VERSION) to auto-expire old entries after schema changes.
  - Invalidate cache when linking base/variant products in detectProductVariant.

- **Refactors**
  - Moved DeletePlanDialog to table level and opened via onDeleteClick from row toolbar; query loads only when dialog is open.
  - Close dialog and show toast immediately on delete/archive/unarchive; run products/product invalidations in the background.
  - Passed onDeleteClick through ProductListColumns and ProductListRowToolbar; removed unused dropdownOpen prop.

<sup>Written for commit 657cc92473781d1e44e103af5c13fdee47490047. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors product cache invalidation to use a centralized middleware approach, fixing inconsistencies and improving UX on the client side.

**Key Changes:**

**Bug fixes:**
- Fixed product cache invalidation by centralizing logic in `refreshProductsCacheMiddleware` instead of manual calls scattered across handlers
- Fixed client-side issue where delete dialog would unmount prematurely when row was removed from table during deletion

**Improvements:**
- Improved UX by showing dialog close and success toast immediately, then invalidating cache in background (non-blocking)
- Removed 6 explicit `invalidateProductsCache()` calls from product handlers
- Added explicit cache invalidation to `detectProductVariant` (AI-based variant detection that updates products outside normal request flow)
- Preserved explicit cache invalidation for edge cases: cross-environment copies, preview org syncing, and conditional invalidation

**Implementation Details:**

The new middleware intercepts all successful (200-299) product mutation requests matching:
- `POST /products`
- `POST /products/:product_id`
- `PATCH /products/:product_id`
- `DELETE /products/:product_id`

Edge cases documented in middleware comments continue to handle cache invalidation explicitly in their handlers, as they require special context (different org, different env, or conditional logic).
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes follow a clear architectural pattern of centralizing cache invalidation. The middleware properly checks response status codes, preserves edge case handling, and respects test options. Client-side changes improve UX without introducing new bugs.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/refreshProductsCacheMiddleware.ts | New middleware to automatically invalidate products cache after successful product mutations, centralizing cache invalidation logic |
| server/src/internal/products/productUtils/detectProductVariant.ts | Added explicit cache invalidation after AI-detected variant updates (not covered by middleware) |
| server/src/routers/apiRouter.ts | Registered new `refreshProductsCacheMiddleware` in the middleware chain |
| vite/src/views/products/plan/components/DeletePlanDialog.tsx | Improved UX by showing dialog close and toast immediately, invalidating cache in background without blocking |
| vite/src/views/products/products/components/product-list/ProductListTable.tsx | Lifted delete dialog state to table level to prevent unmounting when row is removed from list |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as API Router
    participant Middleware as refreshProductsCacheMiddleware
    participant Handler as Product Handler
    participant DB as Database
    participant Redis as Redis (Multi-region)

    Client->>API: POST/PATCH/DELETE /products/:id
    API->>Handler: Route to handler
    Handler->>DB: Mutate product data
    DB-->>Handler: Success
    Handler-->>Middleware: Response (200-299)
    
    alt Success Response
        Middleware->>Middleware: Check status code (200-299)
        Middleware->>Middleware: Match route pattern
        Middleware->>Redis: invalidateProductsCache({orgId, env})
        
        loop For each region
            Redis->>Redis: Delete cache keys (all archived variants)
        end
        
        Redis-->>Middleware: Cache invalidated
    else Non-success Response
        Middleware->>Middleware: Skip cache invalidation
    end
    
    Middleware-->>API: Continue
    API-->>Client: JSON response
    
    Note over Client,Redis: Edge cases (copy, preview) handle cache explicitly in handlers
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->