### PR TITLE
fix: hash idempotency key

### DIFF
--- a/server/src/honoMiddlewares/idempotencyMiddleware.ts
+++ b/server/src/honoMiddlewares/idempotencyMiddleware.ts
@@ -19,6 +19,7 @@ export const idempotencyMiddleware = async (
 			orgId: ctx.org.id,
 			env: ctx.env,
 			idempotencyKey,
+			logger: ctx.logger,
 		});
 	}
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hash idempotency keys before writing to Redis to avoid storing raw values and enforce a stable key length. Adds logger support for better visibility while keeping the 24h TTL.

- **Bug Fixes**
  - Hashes incoming key with SHA-256 (base64url) and uses the hash in the Redis key.
  - Passes logger from middleware and logs idempotency set attempts.
  - Uses ms.hours(24) for the TTL constant.

<sup>Written for commit b12d0a6c7e0d06a6dee11e186da9fe07936c7045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Idempotency handling now hashes the incoming `Idempotency-Key` before building the Redis key, reducing key length and avoiding storing raw client-provided values in Redis. The middleware is updated to pass a request-scoped logger into the idempotency checker.

### Key changes
- **[Bug fixes]** Hash `idempotencyKey` (sha256, base64url) before using it as part of the Redis key.
- **[Improvements]** Use `ms.hours(24)` for the idempotency TTL constant.
- **[Improvements]** Thread `ctx.logger` through `idempotencyMiddleware` into `checkIdempotencyKey` for observability.
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing a small logging/privacy concern.
- Core behavior (Redis SET NX with TTL) is preserved while improving key handling by hashing; the main concern is the newly added info-level log line that includes the raw idempotency key, which can leak client-supplied identifiers/tokens into logs.
- server/src/internal/misc/idempotency/checkIdempotencyKey.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/idempotencyMiddleware.ts | Passes request logger into idempotency key checker so downstream can emit logs. |
| server/src/internal/misc/idempotency/checkIdempotencyKey.ts | Hashes idempotency keys before storing in Redis and switches TTL to ms.hours(24); adds info-level log that currently includes the raw key. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A
  participant B
  participant C
  participant D

  A->>B: request
  B->>C: check
  C->>D: set-if-absent
  D-->>C: ok|exists
  C-->>B: allow|reject
  B-->>A: response
```
</details>


<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context from `dashboard` - server/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
</details>


<!-- /greptile_comment -->