### PR TITLE
fix: 🐛 a bug where the breakdown doesn't show the expires_at

### DIFF
--- a/shared/api/customers/cusFeatures/changes/V1.2_CusFeatureChange.ts
+++ b/shared/api/customers/cusFeatures/changes/V1.2_CusFeatureChange.ts
@@ -160,7 +160,18 @@ const toV3BalanceParams = ({
 		? new Decimal(input.max_purchase).add(includedUsage).toNumber()
 		: undefined;
 
-	return { includedUsage, balance, usage, overageAllowed, usageLimit };
+	// 6. Expires at
+	const expiresAt =
+		"expires_at" in input ? (input as ApiBalanceBreakdown).expires_at : null;
+
+	return {
+		includedUsage,
+		balance,
+		usage,
+		overageAllowed,
+		usageLimit,
+		expiresAt,
+	};
 };
 
 export function transformBalanceToCusFeatureV3({
@@ -202,14 +213,20 @@ export function transformBalanceToCusFeatureV3({
 					unlimited: isUnlimited,
 				});
 
-			const { includedUsage, balance, usage, overageAllowed, usageLimit } =
-				toV3BalanceParams({
-					input: breakdown,
-					feature,
-					unlimited: isUnlimited,
-					legacyData,
-					isBreakdown: true,
-				});
+			const {
+				includedUsage,
+				balance,
+				usage,
+				overageAllowed,
+				usageLimit,
+				expiresAt,
+			} = toV3BalanceParams({
+				input: breakdown,
+				feature,
+				unlimited: isUnlimited,
+				legacyData,
+				isBreakdown: true,
+			});
 
 			return {
 				interval: interval === "multiple" || !interval ? null : interval,
@@ -222,6 +239,7 @@ export function transformBalanceToCusFeatureV3({
 				next_reset_at: next_reset_at,
 				usage_limit: usageLimit,
 				overage_allowed: overageAllowed,
+				expires_at: expiresAt,
 			} satisfies ApiCusFeatureV3Breakdown;
 		});
 	}

--- a/shared/api/customers/cusFeatures/previousVersions/apiCusFeatureV3.ts
+++ b/shared/api/customers/cusFeatures/previousVersions/apiCusFeatureV3.ts
@@ -17,6 +17,8 @@ const breakdownDescriptions = {
 		"The maximum usage allowed for this feature. null if unlimited or no limit is set",
 	overage_allowed:
 		"Whether the customer can continue using the feature beyond the usage limit. If false, access is blocked when limit is reached",
+	expires_at:
+		"Unix timestamp (in milliseconds) when the balance will expire. Only present for loose entitlements",
 };
 
 const coreFeatureDescriptions = {
@@ -74,7 +76,9 @@ export const ApiCusFeatureV3BreakdownSchema = z.object({
 	usage_limit: z.number().nullish().meta({
 		description: breakdownDescriptions.usage_limit,
 	}),
-
+	expires_at: z.number().nullish().meta({
+		description: breakdownDescriptions.expires_at,
+	}),
 	overage_allowed: z.boolean().nullish().meta({
 		description: breakdownDescriptions.overage_allowed,
 	}),

--- a/vite/src/utils/formatUtils/formatDateUtils.ts
+++ b/vite/src/utils/formatUtils/formatDateUtils.ts
@@ -25,10 +25,13 @@ export const formatUnixToDate = (
 
 export const formatUnixToDateTime = (
 	unix: number | null | undefined,
-	options?: { ampm?: boolean; case?: TimeCase },
+	options?: { ampm?: boolean; case?: TimeCase; withYear?: boolean },
 ) => {
 	if (!unix) return { date: "", time: "" };
-	const date = format(new Date(unix), "d MMM");
+	const date = format(
+		new Date(unix),
+		options?.withYear ? "d MMM yyyy" : "d MMM",
+	);
 
 	const pattern = options?.ampm ? "HH:mm a" : "HH:mm";
 	let time = format(new Date(unix), pattern);

--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -22,6 +22,7 @@ import { SheetHeader, SheetSection } from "@/components/v2/sheets/InlineSheet";
 import { useCustomerBalanceSheetStore } from "@/hooks/stores/useCustomerBalanceSheetStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
 import { getBackendErr, notNullish } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
@@ -279,6 +280,17 @@ export function BalanceEditSheet() {
 										Unlimited
 									</span>
 								}
+							/>
+						)}
+
+						{selectedCusEnt.expires_at && (
+							<InfoRow
+								label="Expires At"
+								value={`${
+									formatUnixToDateTime(selectedCusEnt.expires_at, {
+										withYear: true,
+									}).date
+								}, ${formatUnixToDateTime(selectedCusEnt.expires_at).time}`}
 							/>
 						)}
 					</div>

--- a/vite/src/views/customers2/components/sheets/BalanceSelectionSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceSelectionSheet.tsx
@@ -153,8 +153,22 @@ export function BalanceSelectionSheet() {
 										)}
 										<InfoRow
 											label="Created"
-											value={`${formatUnixToDateTime(cusEnt.created_at).date}, ${formatUnixToDateTime(cusEnt.created_at).time}`}
+											value={`${
+												formatUnixToDateTime(cusEnt.created_at, {
+													withYear: true,
+												}).date
+											}, ${formatUnixToDateTime(cusEnt.created_at).time}`}
 										/>
+										{cusEnt.expires_at && (
+											<InfoRow
+												label="Expires At"
+												value={`${
+													formatUnixToDateTime(cusEnt.expires_at, {
+														withYear: true,
+													}).date
+												}, ${formatUnixToDateTime(cusEnt.expires_at).time}`}
+											/>
+										)}
 									</div>
 
 									<div className="bg-muted px-1 py-0.5 rounded-md text-t1 w-fit flex items-center gap-1">


### PR DESCRIPTION
update v1.2 breakdown to show expires_at; update frontend to show expiry in selection and edit sheet; update frontend to show year aswell 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing expires_at in the V1.2 balance breakdown and surfaces it in the UI. Exposes expires_at in the V3 breakdown API and shows expiry (with year) in selection and edit sheets.

- **Bug Fixes**
  - Backend: include expires_at in toV3BalanceParams and ApiCusFeatureV3Breakdown; update schema with field and description.
  - Frontend: show “Expires At” in BalanceSelectionSheet and BalanceEditSheet when present; “Created” now includes the year via a withYear option in formatUnixToDateTime.

<sup>Written for commit df8953248e02b26a2546bffb7e3c98c864a77f01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed a bug where the `expires_at` field for loose customer entitlements was not being displayed in the balance breakdown UI or exposed through the V1.2 API transformation layer. The fix ensures that expiration timestamps are now properly propagated from the backend to the frontend and displayed to users.

**Key Changes:**

**Bug fixes:**
- Added `expires_at` field extraction in V1.2 API transformation for balance breakdowns
- Added `expires_at` field to `ApiCusFeatureV3Breakdown` schema with descriptive documentation
- Display expiration date/time in Balance Selection Sheet when present
- Display expiration date/time in Balance Edit Sheet when present

**Improvements:**
- Enhanced date formatting utility to support optional year display via `withYear` option
- Updated "Created" date displays to include year for better temporal context
- Consistent date formatting across balance sheets with year included
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- The changes are straightforward and focused: adding a missing field to the API response and displaying it in the UI. The implementation correctly extracts `expires_at` from breakdown data, adds it to the schema with proper typing, and conditionally displays it in the UI only when present. The date formatting changes are backward-compatible with the optional `withYear` parameter.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/customers/cusFeatures/changes/V1.2_CusFeatureChange.ts | Added `expires_at` extraction and propagation from breakdowns to V3 schema |
| shared/api/customers/cusFeatures/previousVersions/apiCusFeatureV3.ts | Added `expires_at` field to breakdown schema with appropriate description |
| vite/src/utils/formatUtils/formatDateUtils.ts | Added `withYear` option to include year in date formatting |
| vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx | Added conditional display of expires_at timestamp with year in balance edit sheet |
| vite/src/views/customers2/components/sheets/BalanceSelectionSheet.tsx | Added expires_at display with year to created_at display, also updated to include year |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API as Backend API
    participant Transform as V1.2 Transform
    participant Schema as ApiCusFeatureV3
    participant Frontend as React Components
    participant Utils as Date Format Utils
    participant User as User Interface

    Note over API,Schema: Backend Changes
    API->>Transform: ApiBalanceBreakdown with expires_at
    Transform->>Transform: Extract expires_at from breakdown
    Transform->>Schema: Add expires_at to breakdown schema
    Schema-->>API: V3 breakdown with expires_at field

    Note over Frontend,User: Frontend Changes
    Frontend->>Utils: Request date format with withYear option
    Utils-->>Frontend: Return formatted date with year
    Frontend->>Frontend: Check if cusEnt.expires_at exists
    alt expires_at exists
        Frontend->>Utils: Format expires_at timestamp
        Utils-->>Frontend: Return date and time
        Frontend->>User: Display "Expires At" row with date/time
    end
    Frontend->>User: Display balance information with expiry
```
</details>


<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->