### PR TITLE
test: 💍 for free trials to have correct next_reset_at

### DIFF
--- a/server/src/utils/scriptUtils/constructItem.ts
+++ b/server/src/utils/scriptUtils/constructItem.ts
@@ -23,6 +23,7 @@ export const constructFeatureItem = ({
 	unlimited = false,
 	rolloverConfig,
 	featureType,
+	resetUsageWhenEnabled = false,
 }: {
 	featureId: string;
 	includedUsage?: number;
@@ -33,6 +34,7 @@ export const constructFeatureItem = ({
 	rolloverConfig?: RolloverConfig;
 	featureType?: ProductItemFeatureType;
 	unlimited?: boolean;
+	resetUsageWhenEnabled?: boolean;
 }) => {
 	if (isBoolean) {
 		return {
@@ -54,6 +56,7 @@ export const constructFeatureItem = ({
 		feature_type: featureType,
 		interval: interval,
 		interval_count: intervalCount,
+		reset_usage_when_enabled: resetUsageWhenEnabled,
 	};
 
 	if (rolloverConfig) {

--- a/server/tests/merged/trial/freeTrialResetUsage.test.ts
+++ b/server/tests/merged/trial/freeTrialResetUsage.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+import { FreeTrialDuration } from "@shared/index";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { ProductStatus } from "autumn-js";
+import chalk from "chalk";
+
+const testCase = "free-trial-reset-usage";
+test.concurrent(`${chalk.yellowBright(`${testCase}: ensure free trial resets usage on correct date`)}`, async () => {
+	const customerId = testCase;
+	const { autumnV1, autumnV2 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({
+				list: [
+					products.pro({
+						id: "pro",
+						items: [
+							items.monthlyMessages({
+								includedUsage: 100,
+								resetUsageWhenEnabled: true,
+							}),
+						],
+						freeTrial: {
+							length: 7,
+							duration: FreeTrialDuration.Day,
+							cardRequired: true,
+							uniqueFingerprint: false,
+						},
+					}),
+				],
+			}),
+		],
+		actions: [
+			s.attach({ productId: "pro" }),
+			s.assert(
+				"user is on pro, and is trialing with correct balance and next reset at",
+				async (ctx) => {
+					const customer = await ctx.autumnV1.customers.get(customerId);
+					const product = customer.products.find(
+						(p) => p.id === `pro_${testCase}`,
+					);
+					expect(
+						product?.status,
+						`Product status is not trialing, current status: ${product?.status}, expected status: ${ProductStatus.Trialing}`,
+					).toBe(ProductStatus.Trialing);
+
+					const messages = customer.features[TestFeature.Messages];
+					const now = Date.now();
+					const resetAt = new Date(messages.next_reset_at!).getTime();
+					const balance = messages.balance;
+					const gapDays = Math.round((resetAt - now) / (1000 * 60 * 60 * 24));
+
+					expect(
+						gapDays,
+						`Days until next reset is not correct, current gap: ${gapDays}, expected gap: between 35 and 37`,
+					).toBeGreaterThanOrEqual(35);
+
+					expect(
+						gapDays,
+						`Days until next reset is not correct, current gap: ${gapDays}, expected gap: between 35 and 37`,
+					).toBeLessThanOrEqual(37);
+
+					expect(
+						balance,
+						`Balance is not correct, current balance: ${balance}, expected balance: 100`,
+					).toBe(100);
+				},
+			),
+		],
+	});
+});

--- a/server/tests/utils/fixtures/items.ts
+++ b/server/tests/utils/fixtures/items.ts
@@ -49,14 +49,17 @@ const adminRights = () =>
 const monthlyMessages = ({
 	includedUsage = 100,
 	entityFeatureId,
+	resetUsageWhenEnabled = false,
 }: {
 	includedUsage?: number;
 	entityFeatureId?: string;
+	resetUsageWhenEnabled?: boolean;
 } = {}): LimitedItem =>
 	constructFeatureItem({
 		featureId: TestFeature.Messages,
 		includedUsage,
 		entityFeatureId,
+		resetUsageWhenEnabled,
 	}) as LimitedItem;
 
 /**

--- a/server/tests/utils/fixtures/products.ts
+++ b/server/tests/utils/fixtures/products.ts
@@ -71,15 +71,30 @@ const base = ({
 const pro = ({
 	items,
 	id = "pro",
+	freeTrial,
 }: {
 	items: ProductItem[];
 	id?: string;
+	freeTrial?: {
+		length: number;
+		duration: FreeTrialDuration;
+		cardRequired?: boolean;
+		uniqueFingerprint?: boolean;
+	};
 }): ProductV2 =>
 	constructProduct({
 		id,
 		items: [...items],
 		type: "pro",
 		isDefault: false,
+		freeTrial: freeTrial
+			? ({
+					length: freeTrial.length,
+					duration: freeTrial.duration,
+					unique_fingerprint: freeTrial.uniqueFingerprint ?? false,
+					card_required: freeTrial.cardRequired ?? true,
+				} as unknown as FreeTrial)
+			: undefined,
 	});
 
 /**


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a test to ensure free-trial subscriptions set next_reset_at correctly when usage resets on enable. Also updated test utilities and fixtures to model free trials and propagate reset_usage_when_enabled.

- **New Features**
  - Added s.assert to run inline assertions in scenario tests.
  - Updated fixtures: pro() accepts freeTrial config; monthlyMessages() supports resetUsageWhenEnabled.
  - constructFeatureItem now accepts resetUsageWhenEnabled and maps it to reset_usage_when_enabled.

<sup>Written for commit 5f59482bffb1013593a75209a81179d3cfa4d3f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

## What changed
- [Improvements] Added `resetUsageWhenEnabled` support to `constructFeatureItem` so tests can set `reset_usage_when_enabled` on limited feature items.
- [Improvements] Extended test fixtures (`items.monthlyMessages`, `products.pro`) to accept `resetUsageWhenEnabled` and configurable free-trial settings.
- [Improvements] Added `s.assert()` to `initScenario` to run inline assertions with access to the full scenario context.
- [Bug fixes] Added an integration test covering free-trial behavior: product is `Trialing`, initial feature balance is correct, and `next_reset_at` aligns with the intended reset schedule.

## Fit with the codebase
These changes expand the existing server test harness/fixtures so scenarios can express free-trial + reset semantics without bespoke per-test wiring. The new merged test validates the API surface via `initScenario` and `autumnV1.customers.get`, using the same fixture builders and scenario actions used by other integration tests.
</details>


<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, with a couple of test-harness sharp edges that could cause confusion or flaky tests.
- Core changes are test/fixture oriented and the `reset_usage_when_enabled` plumbing is straightforward, but `s.assert()` currently ignores its description parameter and the new test relies on wall-clock `Date.now()` with rounded day windows, which can lead to non-deterministic failures depending on timing and date parsing behavior.
- server/tests/merged/trial/freeTrialResetUsage.test.ts, server/tests/utils/testInitUtils/initScenario.ts, server/tests/utils/fixtures/products.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/utils/scriptUtils/constructItem.ts | Adds `resetUsageWhenEnabled` param to `constructFeatureItem` and maps it to `reset_usage_when_enabled` on limited items. |
| server/tests/merged/trial/freeTrialResetUsage.test.ts | Adds a new concurrent test asserting free-trial reset date and initial balance; uses `Date.now()`/rounded day math which may be flaky. |
| server/tests/utils/fixtures/items.ts | Extends `items.monthlyMessages` fixture to accept `resetUsageWhenEnabled` and forward it to `constructFeatureItem`. |
| server/tests/utils/fixtures/products.ts | Extends `products.pro` fixture to accept free-trial config; uses `as unknown as FreeTrial` casts which can hide schema mismatches (also in base). |
| server/tests/utils/testInitUtils/initScenario.ts | Adds `s.assert()` action to run inline assertions with scenario context; description parameter is accepted but ignored. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant T as freeTrialResetUsage.test.ts
  participant S as initScenario
  participant P as initProductsV0
  participant C as initCustomerV3
  participant A as AutumnInt (V1)

  T->>S: initScenario({setup, actions})
  S->>P: create products (with free_trial + item reset_usage_when_enabled)
  S->>C: create customer (optional test clock)
  S->>A: attach({product_id})
  S->>A: customers.get(customerId)
  Note over T,A: Test asserts product Trialing
  Note over T,A: Test asserts feature balance + next_reset_at gap

```
</details>


<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context from `dashboard` - server/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
</details>


<!-- /greptile_comment -->