### PR TITLE
chore: init husky

### DIFF
--- a/.github/workflows/server-typecheck.yml
+++ b/.github/workflows/server-typecheck.yml
@@ -1,0 +1,24 @@
+name: Server Type Check
+
+on:
+  pull_request:
+
+jobs:
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run TypeScript type check
+        run: cd server && bun ts

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd server && bun ts

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@types/node": "^24.9.1",
         "concurrently": "^9.2.1",
         "dotenv": "^16.6.1",
+        "husky": "^9.1.7",
         "inquirer": "^12.10.0",
       },
     },
@@ -2459,6 +2460,8 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
 		"q": "lsof -ti:8080 -ti:3000 | xargs kill -9",
 		"knip": "knip",
 		"knip:fix": "knip --fix",
-		"knip:fix-all": "knip --fix --allow-remove-files"
+		"knip:fix-all": "knip --fix --allow-remove-files",
+		"prepare": "husky"
 	},
 	"dependencies": {
 		"@aws-sdk/client-firehose": "^3.975.0",
@@ -70,6 +71,7 @@
 		"@types/node": "^24.9.1",
 		"concurrently": "^9.2.1",
 		"dotenv": "^16.6.1",
+		"husky": "^9.1.7",
 		"inquirer": "^12.10.0"
 	}
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set up Husky pre-commit hook to run server TypeScript type checks and added a CI workflow to typecheck the server on every PR. This prevents committing or merging server type errors.

- **Migration**
  - Run bun install to initialize the Husky hook.
  - Ensure Bun is installed locally (CI uses v1.3.2).

<sup>Written for commit 7cd1d5a75d6373760acbaaebddda7368bdc5fb73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces Husky to run a server TypeScript check locally on pre-commit, and adds a GitHub Actions workflow to run the same check on pull requests.

## Key changes
- [Improvements] Add `husky` dependency and `prepare` script to initialize git hooks via package manager installs.
- [Improvements] Add `.husky/pre-commit` hook to typecheck the `server` package before allowing commits.
- [Improvements] Add `Server Type Check` GitHub Actions workflow to run server typechecking on PRs.

## Findings
- **[P0] Typecheck command likely broken (`bun ts`)**: both the CI workflow and the pre-commit hook run `cd server && bun ts`, which will fail unless the server package defines a `ts` script (Bun won’t execute arbitrary `ts` commands by default). Consider switching to `bun run <script>` (e.g. `bun run typecheck`) or `bunx tsc --noEmit`, depending on how `server` is set up.
- **[P1] Husky hook may not run without install setup**: Husky v9 requires `husky install` (or equivalent setup) and the hook file to be executable; if `prepare` doesn’t run in your install environment (e.g. CI with `--ignore-scripts`) or if install isn’t performed, `.husky/pre-commit` will be inert.

</details>


<h3>Confidence Score: 3/5</h3>

- Reasonably safe, but CI/local hooks may fail due to the invoked typecheck command and Husky setup assumptions.
- Changes are limited to workflow/hook wiring and dependency additions, but the current `bun ts` invocation is likely incorrect and would break pre-commit and the new CI job until adjusted.
- .github/workflows/server-typecheck.yml, .husky/pre-commit

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/server-typecheck.yml | Adds a new GitHub Actions workflow to run server type checks, but the command uses `bun ts` which likely fails unless a matching script exists. |
| .husky/pre-commit | Adds a Husky pre-commit hook that runs `cd server && bun ts`; likely fails unless `ts` is a script and requires Husky install/setup to actually run. |
| bun.lock | Locks Husky dependency (`husky@9.1.7`) after adding it to package.json. |
| package.json | Adds Husky dependency and a `prepare` script to enable git hook installation; no other behavior changes. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Dev as Developer
  participant Git as Git commit
  participant Husky as Husky pre-commit
  participant Server as server/ TS scripts
  participant GH as GitHub Actions

  Dev->>Git: git commit
  Git->>Husky: invoke .husky/pre-commit
  Husky->>Server: cd server && bun ts
  Server-->>Husky: typecheck result
  Husky-->>Git: allow/deny commit

  GH->>GH: pull_request event
  GH->>GH: checkout + setup bun
  GH->>Server: cd server && bun ts
  Server-->>GH: typecheck result
```
</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))

<!-- /greptile_comment -->