### PR TITLE
fix: double default

### DIFF
--- a/scripts/db/replicate.ts
+++ b/scripts/db/replicate.ts
@@ -185,7 +185,7 @@ async function replicateDatabase({
 		// Step 1: Dump the source database
 		console.log("📦 Dumping source database...");
 		await execWithOutput(
-			`pg_dump "${cleanedFromUrl}" --no-owner --no-privileges -f "${tempFile}" 2>&1`,
+			`pg_dump "${cleanedFromUrl}" --no-owner --no-privileges --exclude-schema='ddb$*' -f "${tempFile}" 2>&1`,
 		);
 		console.log("✅ Source database dumped successfully");
 

--- a/scripts/testGroups/stripe-webhooks.sh
+++ b/scripts/testGroups/stripe-webhooks.sh
@@ -4,7 +4,7 @@
 source "$(dirname "$0")/config.sh"
 
 BUN_PARALLEL_V2 \
-  'stripe-webhooks/invoice-created' \
   'stripe-webhooks/subscription-deleted'\
+  'stripe-webhooks/invoice-created' \
   'stripe-webhooks/subscription-updated' \
   --max=3

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
 		"parallel-tests:verbose": "ENV_FILE=.env infisical run --env=dev -- bun tests/testRunner/runParallelGroups.ts --verbose",
 		"parallel-tests:debug": "ENV_FILE=.env infisical run --env=dev -- bun tests/testRunner/runParallelGroups.ts --debug",
 		"clear-master": "ENV_FILE=.env infisical run --env=dev -- bun tests/clearMasterOrg.ts",
+		"cm": "ENV_FILE=.env infisical run --env=dev -- bun tests/clearMaster.ts",
 		"ts": "bunx tsgo --build --noEmit",
 		"test:integration": "ENV_FILE=.env infisical run --env=dev -- bun test --timeout 0 --preload ./tests/setup-integration-tests.ts"
 	},

--- a/server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts
+++ b/server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts
@@ -31,7 +31,10 @@ export const expireCustomerProductAndActivateDefault = async ({
 	ctx: AutumnContext;
 	customerProduct: FullCusProduct;
 	fullCustomer: FullCustomer;
-}): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
+}): Promise<{
+	updates: Partial<InsertCustomerProduct>;
+	activatedDefault?: boolean;
+}> => {
 	const { db, org, env, logger } = ctx;
 
 	// 1. Expire the product
@@ -83,12 +86,13 @@ export const expireCustomerProductAndActivateDefault = async ({
 		internalEntityId: customerProduct.internal_entity_id ?? undefined,
 	});
 
+	let activatedDefault = false;
 	if (!hasActiveInGroup) {
 		logger.info(
 			`No active product in group "${customerProduct.product.group}", activating default`,
 		);
 
-		await activateDefaultProduct({
+		activatedDefault = await activateDefaultProduct({
 			ctx,
 			productGroup: customerProduct.product.group,
 			fullCus: fullCustomer,
@@ -96,5 +100,5 @@ export const expireCustomerProductAndActivateDefault = async ({
 		});
 	}
 
-	return { updates };
+	return { updates, activatedDefault };
 };

--- a/server/tests/utils/stripeUtils/completeInvoiceCheckout.ts
+++ b/server/tests/utils/stripeUtils/completeInvoiceCheckout.ts
@@ -141,7 +141,7 @@ export const completeInvoiceCheckout = async ({
 			);
 			if (postalInput) {
 				await postalInput.click();
-				await postalInput.type("SW59SX");
+				await postalInput.type("94107");
 			}
 		} catch (error) {
 			console.log("Could not find postal code input:", error);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate activation of the default product after a Stripe subscription is deleted. Ensures only one fallback is activated and scheduled items are handled correctly.

- **Bug Fixes**
  - expireAndActivateDefault now returns activatedDefault; the subscription-deleted handler skips activating a scheduled free product when the default was already activated.
  - Simplified scheduled handling: activate free scheduled only if no default was activated; delete any non-free scheduled.

- **Refactors**
  - DB replicate excludes ddb$* schemas; test group order runs subscription-deleted before invoice-created; added cm script to clear master.
  - Stripe checkout test uses ZIP 94107 for better reliability.

<sup>Written for commit ab8356ba0bc5b18d98ccd477b37412487db69eba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where two default products could be activated simultaneously when a Stripe subscription is deleted.

**Key changes:**

- **Bug fixes**: Fixed double default product activation by tracking whether `expireAndActivateDefault` already activated a default product, and skipping scheduled free product activation when a default was already activated
- **Improvements**: Added `activatedDefault` return value to `expireAndActivateDefault` function to communicate state back to caller
- **Improvements**: Added `--exclude-schema='ddb$*'` flag to pg_dump to skip DynamoDB schemas during database replication
- **Improvements**: Reordered test execution to run subscription-deleted tests before invoice-created tests
- **Improvements**: Added `cm` script alias for faster test data cleanup
- **Improvements**: Updated test postal code from UK to US format

The core fix addresses the scenario where:
1. A paid subscription is deleted
2. `expireAndActivateDefault` activates the default free product (e.g., "Free Plan")
3. A scheduled free product also exists in the same group
4. Previously, the scheduled free product would also activate, resulting in two active products
5. Now, the code checks `activatedDefault` flag and skips activating the scheduled product if default was already activated
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a clear bug with a logical solution, the changes are focused and well-structured, and all modifications are either bug fixes or developer experience improvements
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionDeleted/tasks/expireAndActivateCustomerProducts.ts | Fixed double default bug by checking activatedDefault flag before activating scheduled free products |
| server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts | Added activatedDefault return value to track whether default product was activated |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant WebhookHandler
    participant expireAndActivate
    participant activateDefault
    participant DB

    Stripe->>WebhookHandler: subscription.deleted event
    WebhookHandler->>expireAndActivate: expireAndActivateCustomerProducts()
    
    loop For each customer product on subscription
        expireAndActivate->>activateDefault: expireAndActivateDefault()
        activateDefault->>DB: Expire customer product
        activateDefault->>activateDefault: Check if active product in group
        
        alt No active product in group
            activateDefault->>DB: Activate default product
            activateDefault-->>expireAndActivate: {updates, activatedDefault: true}
        else Active product exists
            activateDefault-->>expireAndActivate: {updates, activatedDefault: false}
        end
        
        expireAndActivate->>expireAndActivate: Find scheduled product in group
        
        alt Scheduled product exists
            alt Is free AND !activatedDefault
                expireAndActivate->>DB: Activate scheduled free product
            else Is paid OR activatedDefault
                expireAndActivate->>DB: Delete scheduled product
            end
        end
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->