### PR TITLE
fix: 🐛 continuous usage not remaining upon cancel immediately

### DIFF
--- a/server/src/internal/billing/v2/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts
+++ b/server/src/internal/billing/v2/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts
@@ -50,6 +50,14 @@ export const computeDefaultCustomerProduct = ({
 			resetCycleAnchor: startsAt,
 			now: currentEpochMs,
 			freeTrial: null,
+
+			existingUsagesConfig: {
+				fromCustomerProduct: customerProduct,
+			},
+
+			existingRolloversConfig: {
+				fromCustomerProduct: customerProduct,
+			},
 		},
 		initOptions: {
 			isCustom: false,

--- a/server/src/internal/billing/v2/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts
+++ b/server/src/internal/billing/v2/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts
@@ -2,8 +2,7 @@ import type { FullCusProduct, FullProduct } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpdateSubscriptionBillingContext } from "@/internal/billing/v2/billingContext";
 import { computeCancelFields } from "@/internal/billing/v2/updateSubscription/compute/cancel/computeCancelFields";
-import { cusProductToExistingRollovers } from "@/internal/billing/v2/utils/handleExistingRollovers/cusProductToExistingRollovers";
-import { cusProductToExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages";
+
 import { initFullCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct";
 
 export const computeCustomPlanNewCustomerProduct = ({
@@ -29,20 +28,6 @@ export const computeCustomPlanNewCustomerProduct = ({
 		cancelAction,
 	} = updateSubscriptionContext;
 
-	const existingUsages = cusProductToExistingUsages({
-		cusProduct: customerProduct,
-		entityId: fullCustomer.entity?.id,
-	});
-
-	const existingRollovers = cusProductToExistingRollovers({
-		cusProduct: customerProduct,
-	});
-
-	ctx.logger.debug(
-		`[computeNewCustomerProduct] existing usages:`,
-		existingUsages,
-	);
-
 	const cancelFields = computeCancelFields({
 		cancelAction,
 		currentCustomerProduct,
@@ -56,8 +41,14 @@ export const computeCustomPlanNewCustomerProduct = ({
 			fullCustomer,
 			fullProduct,
 			featureQuantities,
-			existingUsages,
-			existingRollovers,
+			existingUsagesConfig: {
+				fromCustomerProduct: customerProduct,
+				carryAllConsumableFeatures: true,
+			},
+
+			existingRolloversConfig: {
+				fromCustomerProduct: customerProduct,
+			},
 			resetCycleAnchor: resetCycleAnchorMs,
 			now: currentEpochMs,
 

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/applyExisting/applyExistingStatesToCustomerProduct.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/applyExisting/applyExistingStatesToCustomerProduct.ts
@@ -1,0 +1,60 @@
+import type {
+	ExistingRollover,
+	ExistingRolloversConfig,
+	ExistingUsages,
+	ExistingUsagesConfig,
+	FullCusProduct,
+	FullCustomer,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { applyExistingRollovers } from "@/internal/billing/v2/utils/handleExistingRollovers/applyExistingRollovers";
+import { cusProductToExistingRollovers } from "@/internal/billing/v2/utils/handleExistingRollovers/cusProductToExistingRollovers";
+import { applyExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages";
+import { cusProductToExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages";
+
+export const applyExistingStatesToCustomerProduct = ({
+	ctx,
+	fullCustomer,
+	customerProduct,
+	existingUsagesConfig,
+	existingRolloversConfig,
+}: {
+	ctx: AutumnContext;
+	fullCustomer: FullCustomer;
+	customerProduct: FullCusProduct;
+	existingUsagesConfig?: ExistingUsagesConfig;
+	existingRolloversConfig?: ExistingRolloversConfig;
+}) => {
+	let existingUsages: ExistingUsages = {};
+	if (existingUsagesConfig) {
+		const { fromCustomerProduct } = existingUsagesConfig;
+
+		existingUsages = cusProductToExistingUsages({
+			cusProduct: fromCustomerProduct,
+			entityId: fullCustomer.entity?.id,
+			...existingUsagesConfig,
+		});
+	}
+
+	applyExistingUsages({
+		ctx,
+		customerProduct,
+		existingUsages,
+		entities: fullCustomer.entities,
+	});
+
+	let existingRollovers: ExistingRollover[] = [];
+
+	if (existingRolloversConfig) {
+		const { fromCustomerProduct } = existingRolloversConfig;
+
+		existingRollovers = cusProductToExistingRollovers({
+			cusProduct: fromCustomerProduct,
+		});
+	}
+
+	applyExistingRollovers({
+		customerProduct,
+		existingRollovers,
+	});
+};

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct.ts
@@ -5,9 +5,8 @@ import {
 	type InitFullCustomerProductOptions,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { applyExistingStatesToCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/applyExisting/applyExistingStatesToCustomerProduct";
 import { generateId } from "@/utils/genUtils";
-import { applyExistingRollovers } from "../handleExistingRollovers/applyExistingRollovers";
-import { applyExistingUsages } from "../handleExistingUsages/applyExistingUsages";
 import { initCustomerEntitlement } from "./initCustomerEntitlement/initCustomerEntitlement";
 import { initCustomerPrice } from "./initCustomerPrice";
 import { initCustomerProduct } from "./initCustomerProduct";
@@ -59,18 +58,15 @@ export const initFullCustomerProduct = ({
 		product: rawProduct,
 		customer_entitlements: newFullCusEnts,
 		customer_prices: newCusPrices,
+		free_trial: initContext.freeTrial ?? null,
 	};
 
-	applyExistingUsages({
+	applyExistingStatesToCustomerProduct({
 		ctx,
+		fullCustomer,
 		customerProduct: newFullCustomerProduct,
-		existingUsages: initContext.existingUsages,
-		entities: fullCustomer.entities,
-	});
-
-	applyExistingRollovers({
-		customerProduct: newFullCustomerProduct,
-		existingRollovers: initContext.existingRollovers ?? [],
+		existingUsagesConfig: initContext.existingUsagesConfig,
+		existingRolloversConfig: initContext.existingRolloversConfig,
 	});
 
 	const { valid: isPaidRecurring } = cp(newFullCustomerProduct)

--- a/server/src/internal/customers/add-product/createFullCusProduct.ts
+++ b/server/src/internal/customers/add-product/createFullCusProduct.ts
@@ -326,13 +326,14 @@ export const createFullCusProduct = async ({
 		attachParams;
 
 	// Try to get current cus product or set to null...
-	const curCusProduct = await getExistingCusProduct({
-		db,
-		cusProducts: attachParams.cusProducts,
-		product,
-		internalCustomerId: customer.internal_id,
-		internalEntityId: attachParams.internalEntityId,
-	});
+	const curCusProduct =
+		(await getExistingCusProduct({
+			db,
+			cusProducts: attachParams.cusProducts,
+			product,
+			internalCustomerId: customer.internal_id,
+			internalEntityId: attachParams.internalEntityId,
+		})) || attachParams.curCusProduct;
 
 	freeTrial = disableFreeTrial ? null : freeTrial;
 

--- a/server/src/internal/customers/cusProducts/cusProductUtils.ts
+++ b/server/src/internal/customers/cusProducts/cusProductUtils.ts
@@ -16,6 +16,7 @@ import { nullish } from "@/utils/genUtils.js";
 import type { AutumnContext } from "../../../honoUtils/HonoEnv.js";
 import { handleAddProduct } from "../attach/attachFunctions/addProductFlow/handleAddProduct.js";
 import { newCusToAttachParams } from "../attach/attachUtils/attachParams/convertToParams.js";
+import { getDefaultAttachConfig } from "../attach/attachUtils/getAttachConfig.js";
 import { initStripeCusAndProducts } from "../handlers/handleCreateCustomer.js";
 import { CusProductService, RELEVANT_STATUSES } from "./CusProductService.js";
 import { getExistingCusProducts } from "./cusProductUtils/getExistingCusProducts.js";
@@ -99,14 +100,27 @@ export const activateDefaultProduct = async ({
 		return false;
 	}
 
+	const attachParams = newCusToAttachParams({
+		ctx,
+		newCus: fullCus,
+		products: [defaultProd],
+		stripeCli,
+	});
+
+	// Pass the expiring product so allocated feature usage can be carried to the default
+	if (curCusProduct) {
+		attachParams.cusProduct = curCusProduct;
+	}
+
+	const config = {
+		...getDefaultAttachConfig(),
+		carryUsage: true,
+	};
+
 	await handleAddProduct({
 		ctx,
-		attachParams: newCusToAttachParams({
-			ctx,
-			newCus: fullCus,
-			products: [defaultProd],
-			stripeCli,
-		}),
+		attachParams,
+		config,
 	});
 
 	return true;

--- a/server/src/internal/products/productUtils.ts
+++ b/server/src/internal/products/productUtils.ts
@@ -322,6 +322,7 @@ export const attachToInsertParams = (
 		entitlements: getEntitlementsForProduct(product, attachParams.entitlements),
 		entityId: attachEntityId,
 		internalEntityId: internalEntityId,
+		curCusProduct: attachParams.cusProduct,
 	} as InsertCusProductParams;
 };
 

--- a/server/tests/attach/upgrade/upgrade8.test.ts
+++ b/server/tests/attach/upgrade/upgrade8.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "bun:test";
+import type { ApiCustomer } from "@shared/index";
+import { TestFeature } from "@tests/setup/v2Features";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem";
+
+const testCase = "upgrade8";
+/**
+ * Allocated feature usage preserved through upgrade and immediate cancel
+ */
+test.concurrent(`${chalk.yellowBright("continuous_use: usage carries through upgrade + cancel_immediately to default")}`, async () => {
+	const productsList = [
+		products.base({
+			isDefault: true,
+			items: [
+				constructFeatureItem({
+					featureId: TestFeature.Workflows,
+					includedUsage: 5,
+				}),
+			],
+		}),
+		products.pro({
+			items: [
+				constructFeatureItem({
+					featureId: TestFeature.Workflows,
+					includedUsage: 10,
+				}),
+			],
+		}),
+	];
+	const { autumnV1, autumnV2 } = await initScenario({
+		customerId: testCase,
+		setup: [
+			s.products({
+				list: productsList,
+			}),
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+				withDefault: true,
+			}),
+		],
+		actions: [],
+	});
+
+	let customer = (await autumnV2.customers.get(testCase)) as ApiCustomer;
+	let balance = customer.balances[TestFeature.Workflows] ?? {
+		current_balance: "Unknown",
+		granted_balance: "Unknown",
+	};
+	expect(balance.current_balance).toBe(5);
+	expect(balance.granted_balance).toBe(5);
+	console.log(
+		JSON.stringify(
+			`${balance.current_balance} / ${balance.granted_balance} - default`,
+			null,
+			4,
+		),
+	);
+
+	await autumnV1.track(
+		{
+			customer_id: testCase,
+			feature_id: TestFeature.Workflows,
+			value: 3,
+		},
+		{
+			skipCache: true,
+		},
+	);
+
+	customer = await autumnV2.customers.get(testCase);
+	balance = customer.balances[TestFeature.Workflows] ?? {
+		current_balance: "Unknown",
+		granted_balance: "Unknown",
+	};
+	expect(balance.current_balance).toBe(2);
+	expect(balance.granted_balance).toBe(5);
+	console.log(
+		JSON.stringify(
+			`${balance.current_balance} / ${balance.granted_balance} - tracked 3`,
+			null,
+			4,
+		),
+	);
+
+	await autumnV1.attach({
+		customer_id: testCase,
+		product_id: productsList[1].id,
+	});
+
+	customer = await autumnV2.customers.get(testCase);
+	balance = customer.balances[TestFeature.Workflows] ?? {
+		current_balance: "Unknown",
+		granted_balance: "Unknown",
+	};
+	expect(balance.current_balance).toBe(7);
+	expect(balance.granted_balance).toBe(10);
+	console.log(
+		JSON.stringify(
+			`${balance.current_balance} / ${balance.granted_balance} - attached pro upgrade`,
+			null,
+			4,
+		),
+	);
+
+	await autumnV1.cancel({
+		customer_id: testCase,
+		product_id: productsList[1].id,
+		cancel_immediately: true,
+	});
+
+	customer = await autumnV2.customers.get(testCase);
+	balance = customer.balances[TestFeature.Workflows] ?? {
+		current_balance: "Unknown",
+		granted_balance: "Unknown",
+	};
+	expect(balance.current_balance).toBe(2);
+	expect(balance.granted_balance).toBe(5);
+	console.log(
+		JSON.stringify(
+			`${balance.current_balance} / ${balance.granted_balance} - cancelled pro upgrade`,
+			null,
+			4,
+		),
+	);
+});

--- a/server/tests/attach/upgrade/upgrade9.test.ts
+++ b/server/tests/attach/upgrade/upgrade9.test.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "bun:test";
+import type { ApiCustomer } from "@shared/index";
+import { TestFeature } from "@tests/setup/v2Features";
+import { products } from "@tests/utils/fixtures/products.js";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem";
+
+const testCase = "upgrade9";
+/**
+ * Allocated feature usage preserved through upgrade and end-of-cycle cancel
+ */
+test.concurrent(`${chalk.yellowBright("continuous_use: usage carries through upgrade + cancel_end_of_cycle to default")}`, async () => {
+	const productsList = [
+		products.base({
+			isDefault: true,
+			items: [
+				constructFeatureItem({
+					featureId: TestFeature.Workflows,
+					includedUsage: 5,
+				}),
+			],
+		}),
+		products.pro({
+			items: [
+				constructFeatureItem({
+					featureId: TestFeature.Workflows,
+					includedUsage: 10,
+				}),
+			],
+		}),
+	];
+	const { autumnV1, autumnV2, testClockId, ctx } = await initScenario({
+		customerId: testCase,
+		setup: [
+			s.products({
+				list: productsList,
+			}),
+			s.customer({
+				testClock: true,
+				paymentMethod: "success",
+				withDefault: true,
+			}),
+		],
+		actions: [],
+	});
+
+	let customer = (await autumnV2.customers.get(testCase)) as ApiCustomer;
+	let balance = customer.balances[TestFeature.Workflows] ?? {
+		current_balance: "Unknown",
+		granted_balance: "Unknown",
+	};
+	console.log(
+		JSON.stringify(
+			`${balance.current_balance} / ${balance.granted_balance} - default`,
+			null,
+			4,
+		),
+	);
+	expect(balance.current_balance).toBe(5);
+	expect(balance.granted_balance).toBe(5);
+
+	await autumnV1.track(
+		{
+			customer_id: testCase,
+			feature_id: TestFeature.Workflows,
+			value: 3,
+		},
+		{
+			skipCache: true,
+		},
+	);
+
+	customer = await autumnV2.customers.get(testCase);
+	balance = customer.balances[TestFeature.Workflows] ?? {
+		current_balance: "Unknown",
+		granted_balance: "Unknown",
+	};
+	console.log(
+		JSON.stringify(
+			`${balance.current_balance} / ${balance.granted_balance} - tracked 3`,
+			null,
+			4,
+		),
+	);
+	expect(balance.current_balance).toBe(2);
+	expect(balance.granted_balance).toBe(5);
+
+	await autumnV1.attach({
+		customer_id: testCase,
+		product_id: productsList[1].id,
+	});
+
+	customer = await autumnV2.customers.get(testCase);
+	balance = customer.balances[TestFeature.Workflows] ?? {
+		current_balance: "Unknown",
+		granted_balance: "Unknown",
+	};
+	console.log(
+		JSON.stringify(
+			`${balance.current_balance} / ${balance.granted_balance} - attached pro upgrade`,
+			null,
+			4,
+		),
+	);
+	expect(balance.current_balance).toBe(7);
+	expect(balance.granted_balance).toBe(10);
+
+	await autumnV1.cancel({
+		customer_id: testCase,
+		product_id: productsList[1].id,
+	});
+
+	await advanceTestClock({
+		stripeCli: ctx.stripeCli,
+		testClockId: testClockId!,
+		numberOfDays: 35,
+		waitForSeconds: 10,
+	});
+
+	customer = await autumnV2.customers.get(testCase);
+	balance = customer.balances[TestFeature.Workflows] ?? {
+		current_balance: "Unknown",
+		granted_balance: "Unknown",
+	};
+	console.log(
+		JSON.stringify(
+			`${balance.current_balance} / ${balance.granted_balance} - cancelled pro upgrade`,
+			null,
+			4,
+		),
+	);
+	expect(balance.current_balance).toBe(2);
+	expect(balance.granted_balance).toBe(5);
+});

--- a/server/tests/unit/billing/existing-usages/cus-product-to-existing-usages/cus-product-to-existing-usages-paid-features.test.ts
+++ b/server/tests/unit/billing/existing-usages/cus-product-to-existing-usages/cus-product-to-existing-usages-paid-features.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { FeatureUsageType } from "@autumn/shared";
 import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements";
 import { customerProducts } from "@tests/utils/fixtures/db/customerProducts";
 import { prices } from "@tests/utils/fixtures/db/prices";
@@ -45,7 +46,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Usage should be 150: 100 from included + 50 from overage
 				// Formula: usage = includedUsage - balance = 100 - (-50) = 150
@@ -83,7 +87,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Usage should be 70: allowance 100 - balance 30 = 70
 				expect(existingUsages[internalFeatureId]).toBeDefined();
@@ -121,7 +128,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Usage should be 200: all from overage (0 - (-200) = 200)
 				expect(existingUsages[internalFeatureId]).toBeDefined();
@@ -158,7 +168,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Usage should be 100: exactly at the limit
 				expect(existingUsages[internalFeatureId]).toBeDefined();
@@ -183,6 +196,7 @@ describe(
 					featureName: "Users",
 					allowance: 5, // 5 included seats
 					balance: 2, // 3 seats used
+					featureConfig: { usage_type: FeatureUsageType.Continuous },
 				});
 
 				const allocatedPrice = prices.createAllocated({
@@ -220,6 +234,7 @@ describe(
 					featureName: "Users",
 					allowance: 3, // 3 included seats
 					balance: -2, // 5 seats used (2 over)
+					featureConfig: { usage_type: FeatureUsageType.Continuous },
 				});
 
 				const allocatedPrice = prices.createAllocated({
@@ -257,6 +272,7 @@ describe(
 					featureName: "Users",
 					allowance: 0, // no included seats
 					balance: -10, // 10 seats purchased/used
+					featureConfig: { usage_type: FeatureUsageType.Continuous },
 				});
 
 				const allocatedPrice = prices.createAllocated({
@@ -320,7 +336,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// For prepaid, usage = purchasedQuantity - balance
 				// purchasedQuantity from 10 billing units = 1000
@@ -362,7 +381,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				expect(existingUsages[internalFeatureId]).toBeDefined();
 			});
@@ -399,7 +421,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				expect(existingUsages[internalFeatureId]).toBeDefined();
 				// Overage should be captured
@@ -442,6 +467,7 @@ describe(
 					featureName: "Users",
 					allowance: 5,
 					balance: -2, // 7 used
+					featureConfig: { usage_type: FeatureUsageType.Continuous },
 				});
 
 				const usersPrice = prices.createAllocated({
@@ -471,7 +497,10 @@ describe(
 					],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Messages: 100 - (-20) = 120 used
 				expect(existingUsages[messagesFeatureId]).toBeDefined();
@@ -550,7 +579,10 @@ describe(
 					],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Messages: 50 - (-150) = 200 used
 				expect(existingUsages[messagesFeatureId]).toBeDefined();
@@ -601,7 +633,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Usage should be 0
 				expect(existingUsages[internalFeatureId]).toBeDefined();
@@ -638,7 +673,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Usage should be 10100: 100 - (-10000) = 10100
 				expect(existingUsages[internalFeatureId]).toBeDefined();
@@ -675,7 +713,10 @@ describe(
 					customerPrices: [customerPrice],
 				});
 
-				const existingUsages = cusProductToExistingUsages({ cusProduct });
+				const existingUsages = cusProductToExistingUsages({
+					cusProduct,
+					carryAllConsumableFeatures: true,
+				});
 
 				// Usage should be 150.5
 				expect(existingUsages[internalFeatureId]).toBeDefined();

--- a/server/tests/unit/billing/existing-usages/cus-product-to-existing-usages/cus-product-to-existing-usages.test.ts
+++ b/server/tests/unit/billing/existing-usages/cus-product-to-existing-usages/cus-product-to-existing-usages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { EntInterval } from "@autumn/shared";
+import { EntInterval, FeatureUsageType } from "@autumn/shared";
 import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements";
 import { customerProducts } from "@tests/utils/fixtures/db/customerProducts";
 import { rollovers } from "@tests/utils/fixtures/db/rollovers";
@@ -19,6 +19,7 @@ describe(chalk.yellowBright("cusProductToExistingUsages"), () => {
 				allowance: 100,
 				balance: 80,
 				interval: EntInterval.Lifetime,
+				featureConfig: { usage_type: FeatureUsageType.Continuous },
 			});
 
 			// Monthly cusEnt: allowance 50, balance 30 -> usage = 20
@@ -30,6 +31,7 @@ describe(chalk.yellowBright("cusProductToExistingUsages"), () => {
 				balance: 30,
 				interval: EntInterval.Month,
 				nextResetAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+				featureConfig: { usage_type: FeatureUsageType.Continuous },
 			});
 
 			const cusProduct = customerProducts.create({
@@ -57,6 +59,7 @@ describe(chalk.yellowBright("cusProductToExistingUsages"), () => {
 				featureName: "Feature A",
 				allowance: 100,
 				balance: 70,
+				featureConfig: { usage_type: FeatureUsageType.Continuous },
 			});
 
 			// Entity-scoped cusEnt with entities
@@ -71,6 +74,7 @@ describe(chalk.yellowBright("cusProductToExistingUsages"), () => {
 					entity1: { id: "entity1", balance: 40, adjustment: 0 },
 					entity2: { id: "entity2", balance: 25, adjustment: 0 },
 				},
+				featureConfig: { usage_type: FeatureUsageType.Continuous },
 			});
 
 			const cusProduct = customerProducts.create({
@@ -114,6 +118,7 @@ describe(chalk.yellowBright("cusProductToExistingUsages"), () => {
 				featureName: "Feature A",
 				allowance: 100,
 				balance: 80, // Current balance
+				featureConfig: { usage_type: FeatureUsageType.Continuous },
 			});
 
 			// Add rollover to the cusEnt

--- a/server/tests/utils/fixtures/products.ts
+++ b/server/tests/utils/fixtures/products.ts
@@ -134,6 +134,25 @@ const proWithTrial = ({
 	});
 
 /**
+ * Premium product - $50/month base price
+ * @param items - Product items (features)
+ * @param id - Product ID (default: "premium")
+ */
+const premium = ({
+	items,
+	id = "premium",
+}: {
+	items: ProductItem[];
+	id?: string;
+}): ProductV2 =>
+	constructProduct({
+		id,
+		items: [...items],
+		type: "premium",
+		isDefault: false,
+	});
+
+/**
  * Premium product with free trial - $50/month base price with configurable trial
  * @param items - Product items (features)
  * @param id - Product ID (default: "premium-trial")
@@ -272,6 +291,7 @@ export const products = {
 	pro,
 	proAnnual,
 	proWithTrial,
+	premium,
 	premiumWithTrial,
 	oneOff,
 	recurringAddOn,

--- a/shared/models/billingModels/initFullCustomerProductContext.ts
+++ b/shared/models/billingModels/initFullCustomerProductContext.ts
@@ -1,4 +1,3 @@
-import type { ExistingRollover } from "@models/billingModels/existingRollovers";
 import type { FreeTrial } from "@models/productModels/freeTrialModels/freeTrialModels";
 import type { ApiVersion } from "../../api/versionUtils/ApiVersion";
 import type { FullCustomer } from "../cusModels/fullCusModel";
@@ -6,9 +5,21 @@ import type {
 	CollectionMethod,
 	CusProductStatus,
 } from "../cusProductModels/cusProductEnums";
-import type { FeatureOptions } from "../cusProductModels/cusProductModels";
+import type {
+	FeatureOptions,
+	FullCusProduct,
+} from "../cusProductModels/cusProductModels";
 import type { FullProduct } from "../productModels/productModels";
-import type { ExistingUsages } from "./existingUsages";
+
+export interface ExistingUsagesConfig {
+	fromCustomerProduct: FullCusProduct;
+	carryAllConsumableFeatures?: boolean;
+	consumableFeatureIdsToCarry?: string[];
+}
+
+export interface ExistingRolloversConfig {
+	fromCustomerProduct: FullCusProduct;
+}
 
 export interface InitFullCustomerProductContext {
 	fullCustomer: FullCustomer;
@@ -17,13 +28,15 @@ export interface InitFullCustomerProductContext {
 
 	// For customer entitlements
 	resetCycleAnchor: number | "now"; // Unix timestamp of the next
-	existingUsages?: ExistingUsages;
-	existingRollovers?: ExistingRollover[];
 
 	// Others
 	freeTrial: FreeTrial | null;
 	trialEndsAt?: number;
 	now: number; // milliseconds since epoch
+
+	existingUsagesConfig?: ExistingUsagesConfig;
+
+	existingRolloversConfig?: ExistingRolloversConfig;
 }
 
 export interface InitFullCustomerProductOptions {

--- a/shared/utils/featureUtils/classifyFeature/isAllocatedFeature.ts
+++ b/shared/utils/featureUtils/classifyFeature/isAllocatedFeature.ts
@@ -1,0 +1,14 @@
+import {
+	FeatureType,
+	FeatureUsageType,
+} from "@models/featureModels/featureEnums";
+import type { Feature } from "@models/featureModels/featureModels";
+
+export const isAllocatedFeature = (feature: Feature) => {
+	if (feature.type === FeatureType.Boolean) return false;
+
+	return (
+		feature.config?.usage_type === FeatureUsageType.Continuous &&
+		feature.type !== FeatureType.CreditSystem
+	);
+};

--- a/shared/utils/featureUtils/classifyFeature/isConsumableFeature.ts
+++ b/shared/utils/featureUtils/classifyFeature/isConsumableFeature.ts
@@ -1,0 +1,14 @@
+import {
+	FeatureType,
+	FeatureUsageType,
+} from "@models/featureModels/featureEnums";
+import type { Feature } from "@models/featureModels/featureModels";
+
+export const isConsumableFeature = (feature: Feature) => {
+	if (feature.type === FeatureType.Boolean) return false;
+
+	return (
+		feature.config?.usage_type === FeatureUsageType.Single ||
+		feature.type === FeatureType.CreditSystem
+	);
+};

--- a/shared/utils/featureUtils/index.ts
+++ b/shared/utils/featureUtils/index.ts
@@ -1,5 +1,18 @@
+import { isAllocatedFeature } from "@utils/featureUtils/classifyFeature/isAllocatedFeature.js";
+import { isConsumableFeature } from "@utils/featureUtils/classifyFeature/isConsumableFeature.js";
+import { findFeatureById } from "@utils/featureUtils/findFeatureUtils.js";
+
 export * from "./apiFeatureToDbFeature.js";
 
 export * from "./convertFeatureUtils.js";
 export * from "./creditSystemUtils.js";
 export * from "./findFeatureUtils.js";
+
+export const featureUtils = {
+	isConsumable: isConsumableFeature,
+	isAllocated: isAllocatedFeature,
+
+	find: {
+		byId: findFeatureById,
+	},
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes continuous (allocated) usage resetting on upgrade cancel by carrying existing usage and rollovers into the new/default customer product. Adds tests to ensure balances persist for both cancel_immediately and end-of-cycle.

- **Bug Fixes**
  - Carry allocated feature usage and rollovers from the previous customer product when creating the replacement/default product.
  - Default product activation now sets carryUsage and passes the expiring cusProduct so usage is preserved.
  - Existing usage logic only carries allocated features by default; optional flags allow carrying consumable features.
  - New tests (upgrade8, upgrade9) verify balances survive upgrade → cancel (immediate and EOC).

- **Refactors**
  - Centralized applying existing states with applyExistingStatesToCustomerProduct; initFullCustomerProduct now takes config objects.
  - Added featureUtils.isAllocated and isConsumable for clear feature classification.
  - Introduced ExistingUsagesConfig and ExistingRolloversConfig for controlled carry-over behavior.
  - Plumbed curCusProduct through attach/create flows to support usage transfer.

<sup>Written for commit b593be728a347111c3c253731d1c849602435bd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where continuous usage (allocated features) was not being preserved when a customer cancels immediately after upgrading. The fix introduces a distinction between allocated features (continuous usage) and consumable features (single-use), ensuring that allocated feature usage is properly carried over during subscription changes.

**Key changes:**

- **Bug fixes**: Fixed continuous usage not remaining upon cancel immediately - allocated feature usage now properly carries over when downgrading to default product
- **Improvements**: Refactored existing usage/rollover handling to use configuration objects instead of direct arrays, providing better control over which features to carry over
- **Improvements**: Added new utility functions `isAllocatedFeature` and `isConsumableFeature` to classify features based on their usage type
- **Improvements**: Enhanced `cusProductToExistingUsages` to automatically distinguish between allocated (always carry) and consumable (opt-in carry) features

The changes ensure that when a customer upgrades to a pro plan, uses some of their allocated features (like workflows), and then immediately cancels back to the default plan, their usage is correctly preserved (e.g., 3 used out of 5 remains as 3 used when they go back to default, rather than resetting).
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with comprehensive test coverage and well-structured refactoring
- The changes are well-tested with two new integration tests covering both immediate cancel and end-of-cycle cancel scenarios. The refactoring introduces clear abstractions (config objects, feature classification utilities) that improve code maintainability. All existing tests have been updated appropriately to work with the new behavior. The logic correctly distinguishes between feature types and only carries over allocated features by default, which matches the intended business logic.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/featureUtils/classifyFeature/isAllocatedFeature.ts | New utility function to determine if a feature is allocated (continuous usage, non-credit-system) |
| shared/models/billingModels/initFullCustomerProductContext.ts | Refactored to use config objects instead of direct usage/rollover arrays for better flexibility |
| server/src/internal/billing/v2/utils/initFullCustomerProduct/applyExisting/applyExistingStatesToCustomerProduct.ts | New function that extracts existing usage/rollover logic from customer products and applies to new ones |
| server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts | Enhanced to distinguish between allocated and consumable features, only carrying over allocated by default |
| server/src/internal/billing/v2/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts | Updated to carry over existing usages and rollovers when canceling to default product |
| server/src/internal/customers/cusProducts/cusProductUtils.ts | Updated activateDefaultProduct to pass expiring product for usage carryover to default |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant CancelFlow as Cancel Flow
    participant ComputeDefault as computeDefaultCustomerProduct
    participant InitFull as initFullCustomerProduct
    participant ApplyExisting as applyExistingStatesToCustomerProduct
    participant CusToUsage as cusProductToExistingUsages
    participant FeatureUtils as featureUtils
    participant ApplyUsage as applyExistingUsages

    Client->>CancelFlow: cancel({ cancel_immediately: true })
    CancelFlow->>ComputeDefault: Compute default product
    
    Note over ComputeDefault: Pass existingUsagesConfig &<br/>existingRolloversConfig
    
    ComputeDefault->>InitFull: initFullCustomerProduct(context)
    
    Note over InitFull: Context includes:<br/>existingUsagesConfig.fromCustomerProduct
    
    InitFull->>ApplyExisting: applyExistingStatesToCustomerProduct()
    
    ApplyExisting->>CusToUsage: cusProductToExistingUsages(fromCustomerProduct)
    
    loop For each customer_entitlement
        CusToUsage->>FeatureUtils: isAllocated(feature)
        FeatureUtils-->>CusToUsage: true/false
        
        alt Feature is allocated (continuous usage)
            Note over CusToUsage: Always carry over usage
            CusToUsage->>CusToUsage: Calculate usage from balance
        else Feature is consumable (single-use)
            alt carryAllConsumableFeatures = true
                Note over CusToUsage: Carry over usage
            else Feature ID in consumableFeatureIdsToCarry
                Note over CusToUsage: Carry over usage
            else
                Note over CusToUsage: Skip - don't carry over
            end
        end
    end
    
    CusToUsage-->>ApplyExisting: existingUsages
    
    ApplyExisting->>ApplyUsage: applyExistingUsages(customerProduct, existingUsages)
    ApplyUsage->>ApplyUsage: Update balances on new product
    
    ApplyUsage-->>ApplyExisting: Updated product
    ApplyExisting-->>InitFull: Product with carried usage
    InitFull-->>ComputeDefault: Full customer product
    ComputeDefault-->>CancelFlow: Default product with preserved usage
    CancelFlow-->>Client: Success
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->