### PR TITLE
ui tweaks

### DIFF
--- a/vite/src/views/onboarding4/OnboardingGuide.tsx
+++ b/vite/src/views/onboarding4/OnboardingGuide.tsx
@@ -119,7 +119,9 @@ function StepCard({
 			transition={STEP_CARD_ANIMATION}
 			className={cn(
 				"relative rounded-xl bg-muted dark:bg-card border cursor-pointer h-21 overflow-hidden",
-				isActive ? "cursor-default" : "hover:border-primary/20",
+				isActive
+					? "cursor-default min-w-[515px]"
+					: "hover:border-primary/20 min-w-[120px]",
 				isComplete && !isActive && "opacity-50",
 			)}
 			onClick={onClick}
@@ -157,7 +159,7 @@ function StepCard({
 						initial={{ opacity: 0 }}
 						animate={{ opacity: 1, transition: { duration: 0.5 } }}
 						exit={{ opacity: 0, transition: { duration: 0.1 } }}
-						className="absolute top-0 left-0 bottom-0 w-[515px] px-4 flex gap-6"
+						className="absolute top-0 left-0 bottom-0 w-[515px] px-4 flex gap-6 shrink-0!"
 					>
 						<div className="flex flex-col justify-center">
 							<h3 className="font-medium text-sm text-foreground mb-1">
@@ -271,16 +273,16 @@ export function OnboardingGuide() {
 
 	if (isLoading) {
 		return (
-			<div className="relative overflow-hidden border-dashed border-b pb-4">
+			<div className="relative overflow-hidden border-dashed border-b pb-4 mb-2">
 				{/* Header skeleton */}
-				<div className="mb-3 pr-8">
+				<div className="pr-8 mb-2.75">
 					<div className="flex items-center gap-2">
 						<Skeleton className="h-3.5 w-36" />
 						<Skeleton className="h-4 w-16 rounded-md" />
 					</div>
 				</div>
 				{/* Steps skeleton - 4 cards */}
-				<div className="flex gap-3 items-start min-w-[700px]">
+				<div className="flex gap-3 items-start w-[700px] shrink-0">
 					{["flex-[4]", "flex-1", "flex-1", "flex-1"].map((flexClass, i) => (
 						<Skeleton key={i} className={cn("rounded-xl h-21", flexClass)} />
 					))}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the feature picker to show “Already in plan” and tightened onboarding card sizing to prevent layout shifts. This helps avoid duplicate feature adds and keeps the onboarding UI stable.

- **New Features**
  - Show “Already in plan” in the feature selector, including metered features inside credit systems.

- **Bug Fixes**
  - Onboarding Guide: added min-widths and non-shrinking elements to prevent card collapse during load.
  - Tweaked loading skeleton spacing and widths for more consistent layout.

<sup>Written for commit 9b4c13f9941da7ac6cdc462c38447de82f84d992. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

[Improvements] Tweaks onboarding step card sizing/min-width behavior and adjusts the loading skeleton spacing to reduce layout shift.

[Improvements] Enhances the plan feature picker dropdown to show an "Already in plan" badge by computing feature IDs already present in the plan, including underlying metered features referenced by credit-system schemas.
</details>


<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge after fixing a small Tailwind class typo that currently prevents the intended non-shrinking layout.
- Changes are limited to UI tweaks in two React components. One invalid utility class (`shrink-0!`) will be ignored, so the expanded onboarding step layout may still shrink; otherwise the logic for computing existing feature IDs is straightforward and side-effect free.
- vite/src/views/onboarding4/OnboardingGuide.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/onboarding4/OnboardingGuide.tsx | UI sizing tweaks for onboarding step cards and skeleton; includes a Tailwind class typo (`shrink-0!`) that will be ignored. |
| vite/src/views/products/plan/components/SelectFeatureSheet.tsx | Adds an "Already in plan" badge by computing existing feature IDs (including credit-system underlying metered features) and adjusts dropdown item layout; no functional issues found in diff. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant S as SelectFeatureSheet
  participant F as useFeaturesQuery
  participant P as PlanEditorContext
  participant Sh as useSheet

  U->>S: "Open sheet"
  S->>S: "After 350ms open dropdown"
  S->>F: "Read features"
  S->>P: "Read product + initialProduct"
  S->>S: "Compute featuresInPlan"

  U->>S: "Select feature"
  S->>P: "setProduct(add item)"
  S->>Sh: "setSheet(edit-feature)"

  U->>S: "Close dropdown"
  S->>S: "Reset search"
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->