### PR TITLE
chore: enable editing customer id

### DIFF
--- a/vite/src/views/customers/customer/components/CustomerConfig.tsx
+++ b/vite/src/views/customers/customer/components/CustomerConfig.tsx
@@ -1,19 +1,15 @@
 import type { CreateCustomer } from "@autumn/shared";
-import { useRef } from "react";
 import { FormLabel as FieldLabel } from "@/components/v2/form/FormLabel";
 import { Input } from "@/components/v2/inputs/Input";
 
 export const CustomerConfig = ({
 	customer,
 	setCustomer,
-	isUpdate = false,
 }: {
 	customer: CreateCustomer;
 	setCustomer: (customer: CreateCustomer) => void;
 	isUpdate?: boolean;
 }) => {
-	// Keep original ref of customer id
-	const originalId = useRef(customer.id);
 	return (
 		<div className="flex flex-col gap-4 w-full">
 			<div className="flex gap-2 w-full">
@@ -29,7 +25,6 @@ export const CustomerConfig = ({
 					<Input
 						value={customer.id || ""}
 						onChange={(e) => setCustomer({ ...customer, id: e.target.value })}
-						disabled={originalId.current !== null && isUpdate}
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow editing the customer ID in CustomerConfig by removing the logic that disabled the field during updates. The ID input is now always editable (removed originalId ref and isUpdate-based disable).

<sup>Written for commit a9a5cb3808e4ac30b7830c4160e1b052d58b04e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Enables editing of a customer's ID within the customer configuration UI.

## Key changes
- [Improvements] Update `CustomerConfig` view to allow editing the customer identifier (previously read-only).

Fits into the codebase by expanding the existing customer settings/configuration page in the Vite frontend; the change is localized to the customer config component and should rely on the existing customer update flow/API integration already used for other editable customer fields.
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk once the small prop type inconsistency is addressed.
- The only definite issue identified is a stale `isUpdate` prop type that no longer matches the component’s actual API. The functional change (allow editing ID) is localized and straightforward, but editing identifiers may have broader product implications outside this diff.
- vite/src/views/customers/customer/components/CustomerConfig.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/components/CustomerConfig.tsx | Makes the customer ID editable in the config UI; needs verification that the update path actually persists the new ID and that any dependent routing/state uses the updated identifier consistently. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  autonumber
  participant U as User
  participant UI as CustomerConfig (UI)
  participant API as Backend API

  U->>UI: Edit Customer ID
  UI->>UI: Validate input
  UI->>API: PATCH/PUT customer {id: newCustomerId}
  API-->>UI: 200 OK / 4xx error
  UI-->>U: Show success or error state
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->