### PR TITLE
fix/inline plan editor

### DIFF
--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -57,7 +57,7 @@ export const useSheetStore = create<SheetState>((set) => ({
 	...initialState,
 
 	// Set the sheet type and optional itemId
-	setSheet: ({ type, itemId = null, data = null }) => {
+	setSheet: ({ type, itemId = null, data = null }) =>
 		set((state) => ({
 			previousType: state.type,
 			type,
@@ -65,22 +65,20 @@ export const useSheetStore = create<SheetState>((set) => ({
 			data,
 			// Clear initialItem when sheet changes
 			initialItem: null,
-		}));
-	},
+		})),
 
 	// Set the initial item state for change detection
 	setInitialItem: (item) => set({ initialItem: item }),
 
 	// Close the sheet
-	closeSheet: () => {
+	closeSheet: () =>
 		set((state) => ({
 			previousType: state.type,
 			type: null,
 			itemId: null,
 			data: null,
 			initialItem: null,
-		}));
-	},
+		})),
 
 	// Reset to initial state
 	reset: () => set(initialState),

--- a/vite/src/views/products/plan/components/PlanEditor.tsx
+++ b/vite/src/views/products/plan/components/PlanEditor.tsx
@@ -1,7 +1,7 @@
 import { motion } from "motion/react";
+import { useSheet } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetOverlay } from "@/components/v2/sheet-overlay/SheetOverlay";
 import { useIsCusPlanEditor } from "@/hooks/stores/useProductStore";
-import { useIsSheetOpen } from "@/hooks/stores/useSheetStore";
 import { CustomerPlanEditorBar } from "@/views/customers2/customer-plan/CustomerPlanEditorBar";
 import { CustomerPlanInfoBox } from "@/views/customers2/customer-plan/CustomerPlanInfoBox";
 import { OnboardingGuide } from "@/views/onboarding4/OnboardingGuide";
@@ -12,7 +12,8 @@ import PlanCard from "./plan-card/PlanCard";
 import { SaveChangesBar } from "./SaveChangesBar";
 
 export const PlanEditor = () => {
-	const isSheetOpen = useIsSheetOpen();
+	const { sheetType } = useSheet();
+	const isSheetOpen = sheetType !== null;
 
 	return (
 		<div className="flex w-full h-full overflow-hidden relative">

--- a/vite/src/views/products/plan/hooks/useFeatureNavigation.ts
+++ b/vite/src/views/products/plan/hooks/useFeatureNavigation.ts
@@ -1,14 +1,15 @@
 import { type ProductItem, productV2ToFeatureItems } from "@autumn/shared";
 import { useCallback, useEffect, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { useProductStore } from "@/hooks/stores/useProductStore";
-import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import {
+	useProduct,
+	useSheet,
+} from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { getItemId } from "@/utils/product/productItemUtils";
 
 export const useFeatureNavigation = () => {
-	const product = useProductStore((s) => s.product);
-	const itemId = useSheetStore((s) => s.itemId);
-	const setSheet = useSheetStore((s) => s.setSheet);
+	const { product } = useProduct();
+	const { itemId, setSheet } = useSheet();
 	const [selectedIndex, setSelectedIndex] = useState<number>(0);
 
 	// Get filtered items (non-price items)

--- a/vite/src/views/products/plan/hooks/useOpenAddFeatureSheet.ts
+++ b/vite/src/views/products/plan/hooks/useOpenAddFeatureSheet.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
+import { useSheet } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
-import { useSheetStore } from "@/hooks/stores/useSheetStore";
 
 /**
  * Hook to open the appropriate "add feature" sheet.
@@ -8,7 +8,7 @@ import { useSheetStore } from "@/hooks/stores/useSheetStore";
  */
 export const useOpenAddFeatureSheet = () => {
 	const { features } = useFeaturesQuery();
-	const setSheet = useSheetStore((s) => s.setSheet);
+	const { setSheet } = useSheet();
 
 	return useCallback(() => {
 		if (features.length === 0) {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the inline plan editor so “Add Feature” opens the right sheet and state is scoped to the editor. Moves feature and sheet handling to PlanEditorContext to prevent conflicts with global stores.

- **Bug Fixes**
  - PlanEditor reads sheetType from PlanEditorContext to detect open sheets.
  - useOpenAddFeatureSheet uses context setSheet to open “new-feature” or “select-feature” correctly.
  - useFeatureNavigation pulls product, itemId, and setSheet from context for accurate selection; minor store cleanup for setSheet/closeSheet.

<sup>Written for commit b6ef75882ee1ec893ef65f2d877d44a478c47501. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors the inline plan editor to use a context-based abstraction layer (`PlanEditorContext`) instead of accessing Zustand stores directly.

**Key Changes:**

- **Improvements**: Migrated `PlanEditor.tsx`, `useFeatureNavigation.ts`, and `useOpenAddFeatureSheet.ts` to use `useProduct()` and `useSheet()` context hooks instead of directly accessing `useProductStore` and `useSheetStore`

- **Improvements**: The new context layer provides flexibility to override state sources while maintaining backward compatibility - when no context is provided, hooks automatically fall back to Zustand stores

- **Improvements**: Simplified arrow function syntax in `useSheetStore.ts` by removing unnecessary braces from `setSheet` and `closeSheet` methods

The refactoring maintains full backward compatibility and follows the established pattern in `PlanEditorContext.tsx`, which implements a provider that can wrap components to supply custom product and sheet state, while gracefully falling back to global Zustand stores when the provider is not present.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a clean refactoring that introduces a context abstraction layer over existing Zustand stores. The changes maintain backward compatibility by falling back to Zustand when context is unavailable, include no breaking changes, follow established patterns in PlanEditorContext.tsx, and involve only straightforward import and hook usage updates.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/hooks/stores/useSheetStore.ts | Refactored arrow function syntax for `setSheet` and `closeSheet` methods, removing unnecessary braces |
| vite/src/views/products/plan/components/PlanEditor.tsx | Migrated from `useIsSheetOpen` hook to `useSheet` context hook, computing `isSheetOpen` locally from `sheetType` |
| vite/src/views/products/plan/hooks/useFeatureNavigation.ts | Refactored to use `useProduct` and `useSheet` context hooks instead of direct Zustand store access |
| vite/src/views/products/plan/hooks/useOpenAddFeatureSheet.ts | Migrated from `useSheetStore` Zustand hook to `useSheet` context hook for accessing `setSheet` |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PlanEditor
    participant useFeatureNavigation
    participant useOpenAddFeatureSheet
    participant PlanEditorContext
    participant useSheetStore
    
    Note over PlanEditor,useSheetStore: Before: Direct Zustand Access
    PlanEditor->>useSheetStore: useIsSheetOpen()
    useFeatureNavigation->>useSheetStore: useProductStore(), useSheetStore()
    useOpenAddFeatureSheet->>useSheetStore: useSheetStore()
    
    Note over PlanEditor,useSheetStore: After: Context-based Access
    PlanEditor->>PlanEditorContext: useSheet()
    PlanEditorContext-->>PlanEditor: { sheetType }
    PlanEditor->>PlanEditor: compute isSheetOpen from sheetType
    
    useFeatureNavigation->>PlanEditorContext: useProduct(), useSheet()
    PlanEditorContext-->>useFeatureNavigation: { product, itemId, setSheet }
    
    useOpenAddFeatureSheet->>PlanEditorContext: useSheet()
    PlanEditorContext-->>useOpenAddFeatureSheet: { setSheet }
    
    Note over PlanEditorContext,useSheetStore: Context Layer
    PlanEditorContext->>PlanEditorContext: Check if context exists
    alt Context available
        PlanEditorContext-->>PlanEditor: Return context values
    else No context
        PlanEditorContext->>useSheetStore: Fallback to Zustand
        useSheetStore-->>PlanEditorContext: Return store values
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->