### PR TITLE
fix: cancel billing version

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -135,6 +135,10 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		trialContext,
 		isCustom,
 
-		billingVersion: contextOverride.billingVersion ?? BillingVersion.V2,
+		billingVersion: contextOverride.billingVersion
+			? contextOverride.billingVersion
+			: contextOverride.inheritBillingVersion
+				? customerProduct.billing_version
+				: BillingVersion.V2,
 	};
 };

--- a/server/src/internal/customers/cancel/handleCancelV2.ts
+++ b/server/src/internal/customers/cancel/handleCancelV2.ts
@@ -1,13 +1,13 @@
-import type { UpdateSubscriptionV0Params } from "@autumn/shared";
+import { type UpdateSubscriptionV0Params } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
-import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan";
-import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
-import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
-import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
 import { computeUpdateSubscriptionPlan } from "@/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan";
 import { handleUpdateSubscriptionErrors } from "@/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors";
 import { logUpdateSubscriptionContext } from "@/internal/billing/v2/actions/updateSubscription/logs/logUpdateSubscriptionContext";
 import { setupUpdateSubscriptionBillingContext } from "@/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext";
+import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan";
+import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
+import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
+import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan";
 
 export const handleCancelV2 = createRoute({
@@ -40,6 +40,9 @@ export const handleCancelV2 = createRoute({
 		const billingContext = await setupUpdateSubscriptionBillingContext({
 			ctx,
 			params: updateSubscriptionBody,
+			contextOverride: {
+				inheritBillingVersion: true,
+			},
 		});
 		logUpdateSubscriptionContext({ ctx, billingContext });
 

--- a/shared/models/billingModels/context/billingContextOverride.ts
+++ b/shared/models/billingModels/context/billingContextOverride.ts
@@ -45,4 +45,6 @@ export interface UpdateSubscriptionBillingContextOverride
 		customPrices?: Price[];
 		customEnts?: Entitlement[];
 	};
+
+	inheritBillingVersion?: boolean;
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix cancel subscription to inherit the customer’s billing version instead of defaulting to V2, preventing version mismatches during cancellation. Adds an inheritBillingVersion override and uses it in the cancel flow.

- **Bug Fixes**
  - setupUpdateSubscriptionBillingContext: billingVersion now resolves as explicit override > inherited from customerProduct.billing_version (when enabled) > V2 fallback.
  - handleCancelV2: passes contextOverride { inheritBillingVersion: true } so cancellations use the customer’s billing version.
  - billingContextOverride: added inheritBillingVersion?: boolean.

<sup>Written for commit 139ab47f7f62237a2fcedf8fd7be12f86a8271e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR ensures the cancel (v2) flow uses the existing customer product’s `billing_version` when constructing the update-subscription billing context, instead of defaulting to `BillingVersion.V2`.

## Key changes
- [Bug fixes] Add `inheritBillingVersion?: boolean` to `UpdateSubscriptionBillingContextOverride` so callers can request inheriting billing version from the current `customerProduct`.
- [Bug fixes] Update `setupUpdateSubscriptionBillingContext` to compute `billingVersion` in priority order: explicit override → inherited from `customerProduct.billing_version` when requested → default `BillingVersion.V2`.
- [Bug fixes] Update `handleCancelV2` to pass `contextOverride: { inheritBillingVersion: true }`, making cancel honor the customer product’s billing version.

These changes fit into the billing v2 update-subscription pipeline by affecting only how `billingContext.billingVersion` is derived; the rest of plan computation, Stripe plan evaluation, and plan execution remain unchanged.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized to billing context setup and cancel route, and correctly prioritize explicit billingVersion overrides while allowing an opt-in inheritance path; no behavioral changes outside billingVersion selection were introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts | Changes billingVersion derivation to optionally inherit from customerProduct when contextOverride.inheritBillingVersion is set. |
| server/src/internal/customers/cancel/handleCancelV2.ts | For cancel flow, passes contextOverride.inheritBillingVersion=true into setupUpdateSubscriptionBillingContext; import order adjusted. |
| shared/models/billingModels/context/billingContextOverride.ts | Adds inheritBillingVersion?: boolean to UpdateSubscriptionBillingContextOverride to support inheriting billing version from existing customer product. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as handleCancelV2
  participant Setup as setupUpdateSubscriptionBillingContext
  participant Prod as setupUpdateSubscriptionProductContext
  participant Plan as computeUpdateSubscriptionPlan
  participant StripeEval as evaluateStripeBillingPlan
  participant Exec as executeBillingPlan

  API->>Setup: setupUpdateSubscriptionBillingContext(params, {inheritBillingVersion:true})
  Setup->>Prod: setupUpdateSubscriptionProductContext(...)
  Prod-->>Setup: customerProduct (includes billing_version)
  Setup-->>API: billingContext (billingVersion derived)
  API->>Plan: computeUpdateSubscriptionPlan(billingContext)
  Plan-->>API: autumnBillingPlan
  API->>StripeEval: evaluateStripeBillingPlan(billingContext, autumnBillingPlan)
  StripeEval-->>API: stripeBillingPlan
  API->>Exec: executeBillingPlan({autumnBillingPlan,stripeBillingPlan})
  Exec-->>API: billingResult
```
</details>


<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context from `dashboard` - server/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
</details>


<!-- /greptile_comment -->