### PR TITLE
chore: bypass webhook creation

### DIFF
--- a/server/src/internal/orgs/handlers/stripeHandlers/handleConnectStripe.ts
+++ b/server/src/internal/orgs/handlers/stripeHandlers/handleConnectStripe.ts
@@ -45,10 +45,12 @@ export const handleConnectStripe = createRoute({
 
 			if (env === AppEnv.Sandbox) {
 				configUpdates.test_api_key = result.test_api_key;
-				configUpdates.test_webhook_secret = result.test_webhook_secret;
+				configUpdates.test_webhook_secret =
+					result.test_webhook_secret ?? undefined;
 			} else {
 				configUpdates.live_api_key = result.live_api_key;
-				configUpdates.live_webhook_secret = result.live_webhook_secret;
+				configUpdates.live_webhook_secret =
+					result.live_webhook_secret ?? undefined;
 			}
 		}
 

--- a/server/src/internal/platform/platformBeta/handlers/handleLegacyPlatformExchange.ts
+++ b/server/src/internal/platform/platformBeta/handlers/handleLegacyPlatformExchange.ts
@@ -155,7 +155,7 @@ export const handleLegacyPlatformExchange = createRoute({
 				finalStripeConfig = {
 					...finalStripeConfig,
 					test_api_key,
-					test_webhook_secret,
+					test_webhook_secret: test_webhook_secret ?? undefined,
 				};
 
 				if (!defaultCurrency) {
@@ -196,7 +196,7 @@ export const handleLegacyPlatformExchange = createRoute({
 				finalStripeConfig = {
 					...finalStripeConfig,
 					live_api_key,
-					live_webhook_secret,
+					live_webhook_secret: live_webhook_secret ?? undefined,
 				};
 
 				if (!defaultCurrency) {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow Stripe connection to succeed even if webhook endpoint creation fails. Errors are logged and we proceed without a webhook secret.

- **Bug Fixes**
  - Wrap webhook creation in try/catch and log errors; treat missing webhook as null.
  - Return null for webhook_secret when absent and coerce to undefined in config updates (connect and legacy exchange flows).
  - Prevents onboarding from failing in environments where Stripe webhooks can’t be created.

<sup>Written for commit 99dde7e8f969b4dbe5ff1c6cfcd62682c7ad44b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes Stripe onboarding flows to tolerate failures when creating Stripe webhook endpoints by allowing webhook secrets to be absent and normalizing persisted config values.

## Key changes
- **[Bug fixes]** Normalize `test_webhook_secret`/`live_webhook_secret` updates to avoid persisting `null` by converting nullish values to `undefined` during org updates.
- **[Improvements]** Wrap webhook endpoint creation in `handleStripeSecretKey` with try/catch and return `null` webhook secret when webhook creation fails.
- **[API changes]** Legacy platform exchange now may persist webhook secret fields as unset when onboarding doesn’t return a webhook secret.

## Fit with codebase
These changes affect internal Stripe connection/onboarding utilities (`handleStripeSecretKey`) and the two primary entrypoints that persist Stripe configuration (`handleConnectStripe` and `handleLegacyPlatformExchange`). The new behavior makes webhook creation non-fatal, which in turn changes the meaning/validity of the stored Stripe connection state and configuration fields downstream.
</details>


<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge until Stripe connected-state semantics are corrected for webhook creation failures.
- Core onboarding now suppresses webhook creation errors and can store a connected configuration without a webhook secret; this will break Stripe event verification/handling for affected orgs while appearing successfully connected.
- server/src/internal/orgs/orgUtils/handleStripeSecretKey.ts; server/src/internal/platform/platformBeta/handlers/handleLegacyPlatformExchange.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/orgs/handlers/stripeHandlers/handleConnectStripe.ts | Normalizes webhook secret updates by converting nullish secrets to `undefined` when updating org stripe_config. |
| server/src/internal/orgs/orgUtils/handleStripeSecretKey.ts | Wraps webhook creation in try/catch and returns null webhook secrets on failure; this can leave orgs configured without webhook secrets while continuing onboarding. |
| server/src/internal/platform/platformBeta/handlers/handleLegacyPlatformExchange.ts | Propagates possible null webhook secrets into StripeConfig while still setting `stripe_connected: true`, risking a connected state without webhook verification. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Connect as handleConnectStripe
  participant Legacy as handleLegacyPlatformExchange
  participant Onboard as handleStripeSecretKey
  participant Stripe as API
  participant OrgSvc as OrgService/DB

  Client->>Connect: request (optional credentials)
  Connect->>Onboard: onboard using provided credentials
  Onboard->>Stripe: validate + retrieve account
  Onboard->>Stripe: manage webhook endpoints
  alt webhook endpoint created
    Onboard-->>Connect: onboarding result (includes webhook secret)
  else webhook creation failed
    Onboard-->>Connect: onboarding result (webhook secret missing)
  end
  Connect->>OrgSvc: persist stripe_config

  Client->>Legacy: request (legacy exchange)
  Legacy->>Onboard: onboard using provided credentials
  Onboard-->>Legacy: onboarding result
  Legacy->>OrgSvc: persist stripe_config + stripe_connected
```
</details>


<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context from `dashboard` - server/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
</details>


<!-- /greptile_comment -->