### PR TITLE
fix: update subscription billing version

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -137,8 +137,6 @@ export const setupUpdateSubscriptionBillingContext = async ({
 
 		billingVersion: contextOverride.billingVersion
 			? contextOverride.billingVersion
-			: contextOverride.inheritBillingVersion
-				? customerProduct.billing_version
-				: BillingVersion.V2,
+			: (customerProduct.billing_version ?? BillingVersion.V2),
 	};
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the v2 `updateSubscription` billing context to explicitly set the subscription billing version.

**Key changes**
- (Bug fixes) Set/override `billingVersion` to `"v2"` when building the update-subscription billing context.
</details>


<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge if the intent is to force v2 routing, but it risks misrouting updates if billing version selection is supposed to come from upstream context.
- Only one small change, but it affects control flow/routing: hardcoding `billingVersion: "v2"` can override request/tenant-selected versioning if that exists elsewhere in the stack.
- server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts | Updates subscription billing context to set `billingVersion: "v2"`; this may override an upstream/request-selected billing version and route updates through the wrong billing path. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Setup as setupUpdateSubscriptionBillingContext
    participant Update as updateSubscription (v2)

    Caller->>Setup: build context (request, subscription)
    Setup-->>Caller: BillingContext{ billingVersion: "v2", ... }
    Caller->>Update: updateSubscription(context)
    Update-->>Caller: result
```
</details>


<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context from `dashboard` - server/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=e38717a3-e8ad-4054-9219-102b893d3b3c))
</details>


<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix billing version selection in the updateSubscription context to respect the customer's product version and only fall back to v2 when missing. This prevents forced v2 routing and aligns updates with the correct billing path.

- **Bug Fixes**
  - Default to customerProduct.billing_version; fallback to BillingVersion.V2.
  - Keep honoring contextOverride.billingVersion when provided.
  - Remove inheritBillingVersion branching from selection.

<sup>Written for commit ae3441070b07b5f7f67497d8083c867fba929cd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

