### PR TITLE
fix: 🐛 a bug with irrational billing units from included usage

### DIFF
--- a/server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts
+++ b/server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts
@@ -1,8 +1,10 @@
 import {
+	ErrCode,
 	type FullProduct,
 	type Price,
 	priceToEnt,
 	priceUtils,
+	RecaseError,
 	type UsagePriceConfig,
 } from "@autumn/shared";
 import { PriceService } from "@server/internal/products/prices/PriceService";
@@ -47,6 +49,14 @@ export const createStripePrepaidPriceV2 = async ({
 		});
 
 		return;
+	}
+
+	if (entitlement.allowance % (price.config.billing_units ?? 1) !== 0) {
+		throw new RecaseError({
+			code: ErrCode.InvalidRequest,
+			message:
+				"If you have a plan feature with both an included usage and a price, the included usage must be an amount that is divisible by the billing units.",
+		});
 	}
 
 	const stripeCreatePriceParams = priceUtils.convert.toStripeCreatePriceParams({


### PR DESCRIPTION
updated error message to be cleaner

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a validation in createStripePrepaidPriceV2 to ensure included usage is divisible by billing_units. If not, we throw RecaseError with ErrCode.InvalidRequest and a clear message, preventing prepaid prices with irrational billing units.

<sup>Written for commit 399911c3a8aa77617901cc15b833bd79ad9ff0c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Added validation to prevent creating Stripe prepaid prices when the entitlement's included usage is not divisible by billing units.

**Bug fixes**
- Prevents irrational billing unit configurations by validating that `entitlement.allowance % price.config.billing_units === 0` before creating Stripe prices
- Throws a clear `RecaseError` with message explaining the divisibility requirement when validation fails
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds a simple but important validation check to prevent invalid Stripe price configurations. The logic is straightforward (modulo check), uses proper error handling with RecaseError, and prevents a specific edge case bug. No existing functionality is altered, only a new guardrail is added.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts | Added validation to ensure included usage is divisible by billing units before creating Stripe prepaid prices |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->