### PR TITLE
fix: legacy entity attach

### DIFF
--- a/server/src/external/stripe/priceToStripeItem/consumablePriceToStripeItem.ts
+++ b/server/src/external/stripe/priceToStripeItem/consumablePriceToStripeItem.ts
@@ -25,7 +25,7 @@ export const consumablePriceToStripeItem = ({
 	}
 
 	const config = price.config;
-	const priceId = config.stripe_price_id;
+	const priceId = config.stripe_price_id ?? config.stripe_empty_price_id;
 
 	const newUsageMethod =
 		withEntity || apiVersion === ApiVersion.V1_Beta || fromVercel;
@@ -38,6 +38,8 @@ export const consumablePriceToStripeItem = ({
 	}
 
 	if (!priceId) {
+		// Create custom price...?
+
 		throw new InternalError({
 			message: `[consumablePriceToStripeItem] config.stripe_price_id is empty for autumn price: ${price.id}`,
 		});

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -1,9 +1,9 @@
-import type {
-	AttachBillingContext,
-	AttachParamsV0,
-	BillingContextOverride,
-	BillingPlan,
-	BillingResult,
+import {
+	type AttachBillingContext,
+	type AttachParamsV0,
+	type BillingContextOverride,
+	type BillingPlan,
+	type BillingResult,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeAttachPlan } from "@/internal/billing/v2/actions/attach/compute/computeAttachPlan";


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix legacy entity attach by falling back to stripe_empty_price_id when stripe_price_id is missing for consumable prices. This restores Stripe item creation for legacy plans and prevents attach errors.

- **Bug Fixes**
  - Use stripe_empty_price_id as fallback in consumablePriceToStripeItem.
  - Standardize TypeScript type imports in attach action.

<sup>Written for commit 3f67ba85ad9e1ebf058d439ded24812d421a3de2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Fixed legacy entity attach errors by adding a fallback mechanism for Stripe price ID resolution in consumable prices.

**Bug Fixes**
- Falls back to `stripe_empty_price_id` when `stripe_price_id` is missing for consumable prices, restoring Stripe item creation for legacy plans
- Standardized TypeScript import syntax in attach action to align with codebase conventions
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk, addressing a specific legacy plan compatibility issue
- The fix is straightforward and well-targeted: adding a fallback for missing `stripe_price_id` to `stripe_empty_price_id`. The logic is sound and aligns with how `stripe_empty_price_id` is used elsewhere in the codebase. The only minor issue is an incomplete TODO comment that should be removed. The import style change is purely stylistic and matches codebase conventions.
- No files require special attention beyond removing the TODO comment in `consumablePriceToStripeItem.ts`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/priceToStripeItem/consumablePriceToStripeItem.ts | Added fallback to `stripe_empty_price_id` when `stripe_price_id` is missing, fixing legacy entity attach errors. Contains a TODO comment that should be removed. |
| server/src/internal/billing/v2/actions/attach/attach.ts | Standardized TypeScript import style by converting from `type` import to inline `type` keywords, aligning with codebase conventions. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->