### PR TITLE
feat: add group filter to product and plan listing endpoints

### DIFF
--- a/server/src/internal/products/ProductService.ts
+++ b/server/src/internal/products/ProductService.ts
@@ -217,6 +217,7 @@ export class ProductService {
 		version,
 		excludeEnts = false,
 		archived,
+		group,
 	}: {
 		db: DrizzleCli;
 		orgId: string;
@@ -226,6 +227,7 @@ export class ProductService {
 		version?: number;
 		excludeEnts?: boolean;
 		archived?: boolean;
+		group?: string;
 	}): Promise<FullProduct[]> {
 		// Use caching for simple queries (no inIds, returnAll, version, or excludeEnts)
 		const canCache = !inIds && !returnAll && !version && !excludeEnts;
@@ -235,10 +237,11 @@ export class ProductService {
 				key: buildProductsCacheKey({
 					orgId,
 					env,
-					queryParams: { archived },
+					queryParams: { archived, group },
 				}),
 				ttl: PRODUCTS_CACHE_TTL,
-				fn: () => ProductService._listFullQuery({ db, orgId, env, archived }),
+				fn: () =>
+					ProductService._listFullQuery({ db, orgId, env, archived, group }),
 			});
 		}
 
@@ -251,6 +254,7 @@ export class ProductService {
 			version,
 			excludeEnts,
 			archived,
+			group,
 		});
 	}
 
@@ -263,6 +267,7 @@ export class ProductService {
 		version,
 		excludeEnts = false,
 		archived,
+		group,
 	}: {
 		db: DrizzleCli;
 		orgId: string;
@@ -272,6 +277,7 @@ export class ProductService {
 		version?: number;
 		excludeEnts?: boolean;
 		archived?: boolean;
+		group?: string;
 	}): Promise<FullProduct[]> {
 		// Optimization: Use a subquery to only fetch the latest version of each product
 		const latestVersionsSubquery =
@@ -301,6 +307,7 @@ export class ProductService {
 				eq(products.env, env),
 				inIds ? inArray(products.id, inIds) : undefined,
 				version ? eq(products.version, version) : undefined,
+				group ? eq(products.group, group) : undefined,
 				latestVersionsSubquery
 					? exists(
 							db

--- a/server/src/internal/products/handlers/handleListPlans.ts
+++ b/server/src/internal/products/handlers/handleListPlans.ts
@@ -16,7 +16,8 @@ export const handleListPlans = createRoute({
 		const { org, features, env, db } = ctx;
 		const query = c.req.valid("query");
 
-		const { customer_id, entity_id, include_archived, v1_schema } = query;
+		const { customer_id, group, entity_id, include_archived, v1_schema } =
+			query;
 
 		const startedAt = Date.now();
 
@@ -26,6 +27,7 @@ export const handleListPlans = createRoute({
 				orgId: org.id,
 				env,
 				archived: include_archived ? undefined : false,
+				group,
 			}),
 			customer_id
 				? CusService.getFull({

--- a/server/src/internal/products/internalHandlers/handleGetProducts.ts
+++ b/server/src/internal/products/internalHandlers/handleGetProducts.ts
@@ -13,7 +13,14 @@ export const handleGetProducts = createRoute({
 	handler: async (c) => {
 		const { db, org, env, features } = c.get("ctx");
 
-		const products = await ProductService.listFull({ db, orgId: org.id, env });
+		const group = c.req.query("group");
+
+		const products = await ProductService.listFull({
+			db,
+			orgId: org.id,
+			env,
+			group,
+		});
 
 		const groupToDefaults = getGroupToDefaults({ defaultProds: products });
 

--- a/shared/api/products/crud/listPlanParams.ts
+++ b/shared/api/products/crud/listPlanParams.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 
 export const ListPlansQuerySchema = z.object({
 	customer_id: z.string().optional(),
+	group: z.string().optional(),
 	entity_id: z.string().optional().meta({
 		internal: true,
 	}),


### PR DESCRIPTION
## Summary
Add group filter to product and plan listing endpoints — Both the public GET /plans and internal GET /products endpoints now accept an optional group query parameter, which filters products by their group field.

PR in SDK: https://github.com/useautumn/typescript/pull/71

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Added optional `group` query parameter to product and plan listing endpoints, enabling filtering of products by their group field.

**API changes**
- Public `GET /plans` endpoint now accepts optional `group` query parameter
- Internal `GET /products/products` endpoint now accepts optional `group` query parameter

**Improvements**
- Cache key generation updated to include `group` parameter in hash for cache differentiation
- Database query filtering properly implements group-based filtering using Drizzle ORM

**Bug fixes**
- Cache invalidation logic needs updating - currently doesn't clear group-filtered cache entries when products are modified (see inline comment)
</details>


<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge with moderate risk due to cache invalidation issue
- The implementation correctly adds group filtering to the database queries and cache key generation. However, the cache invalidation mechanism in `productCacheUtils.ts` only handles `archived` parameter variants and doesn't account for group-filtered cache entries. This means when products are modified, stale cached data may persist for queries with specific group filters. The core functionality works correctly, but the caching issue could lead to data inconsistency until cache TTL expires (1 day).
- Pay close attention to `server/src/internal/products/ProductService.ts` - the cache invalidation logic needs to be updated to handle group-filtered cache entries

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/products/crud/listPlanParams.ts | Added optional `group` query parameter to ListPlansQuerySchema for filtering plans by group |
| server/src/internal/products/handlers/handleListPlans.ts | Extracted `group` from query parameters and passed it to ProductService.listFull for filtering |
| server/src/internal/products/internalHandlers/handleGetProducts.ts | Added `group` query parameter extraction and passed it to ProductService.listFull for internal products endpoint |
| server/src/internal/products/ProductService.ts | Added `group` parameter to listFull and _listFullQuery methods with database filtering and cache key integration, but cache invalidation doesn't account for group-filtered cache entries |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant handleListPlans
    participant ProductService
    participant Cache
    participant Database

    Client->>handleListPlans: GET /plans?group=premium
    handleListPlans->>ProductService: listFull({orgId, env, group: "premium"})
    
    ProductService->>ProductService: Check if canCache
    
    alt Can use cache
        ProductService->>Cache: buildProductsCacheKey({orgId, env, queryParams: {group}})
        Cache-->>ProductService: Cache key with group hash
        ProductService->>Cache: queryWithCache(key, fn)
        
        alt Cache hit
            Cache-->>ProductService: Cached products
        else Cache miss
            ProductService->>Database: _listFullQuery with group filter
            Database-->>ProductService: Filtered products
            ProductService->>Cache: Store with group-specific key
        end
    else Cannot use cache
        ProductService->>Database: _listFullQuery directly
        Database-->>ProductService: Filtered products
    end
    
    ProductService-->>handleListPlans: Products filtered by group
    handleListPlans-->>Client: JSON response with filtered plans
```
</details>


<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->