### PR TITLE
fix: 🐛 block vercel transfer requests

### DIFF
--- a/server/src/external/vercel/handlers/transfers/handleResourceTransfers.ts
+++ b/server/src/external/vercel/handlers/transfers/handleResourceTransfers.ts
@@ -1,0 +1,30 @@
+import { ErrCode } from "@shared/enums/ErrCode.js";
+import { RecaseError } from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+
+const createUnsupportedTransferError = () =>
+	new RecaseError({
+		message:
+			"Resource transfers are disabled for this integration. Contact support if this is needed.",
+		code: ErrCode.InvalidRequest,
+		statusCode: StatusCodes.FORBIDDEN,
+	});
+
+export const handleCreateResourceTransfer = createRoute({
+	handler: async () => {
+		throw createUnsupportedTransferError();
+	},
+});
+
+export const handleVerifyResourceTransfer = createRoute({
+	handler: async () => {
+		throw createUnsupportedTransferError();
+	},
+});
+
+export const handleAcceptResourceTransfer = createRoute({
+	handler: async () => {
+		throw createUnsupportedTransferError();
+	},
+});

--- a/server/src/external/vercel/vercelWebhookRouter.ts
+++ b/server/src/external/vercel/vercelWebhookRouter.ts
@@ -14,6 +14,11 @@ import { handleCreateResource } from "./handlers/resources/handleCreateResource.
 import { handleDeleteResource } from "./handlers/resources/handleDeleteResource.js";
 import { handleGetResource } from "./handlers/resources/handleGetResource.js";
 import { handleUpdateResource } from "./handlers/resources/handleUpdateResource.js";
+import {
+	handleAcceptResourceTransfer,
+	handleCreateResourceTransfer,
+	handleVerifyResourceTransfer,
+} from "./handlers/transfers/handleResourceTransfers.js";
 import { captureRawBody } from "./misc/rawBodyMiddleware.js";
 import { vercelOidcAuthMiddleware } from "./misc/vercelAuth.js";
 import {
@@ -88,6 +93,27 @@ vercelWebhookRouter.patch(
 	vercelSeederMiddleware,
 	vercelOidcAuthMiddleware,
 	...handleUpdateResource,
+);
+
+vercelWebhookRouter.post(
+	"/:orgId/:env/v1/installations/:integrationConfigurationId/resource-transfer-requests",
+	vercelSeederMiddleware,
+	vercelOidcAuthMiddleware,
+	...handleCreateResourceTransfer,
+);
+
+vercelWebhookRouter.get(
+	"/:orgId/:env/v1/installations/:integrationConfigurationId/resource-transfer-requests/:providerClaimId/verify",
+	vercelSeederMiddleware,
+	vercelOidcAuthMiddleware,
+	...handleVerifyResourceTransfer,
+);
+
+vercelWebhookRouter.post(
+	"/:orgId/:env/v1/installations/:integrationConfigurationId/resource-transfer-requests/:providerClaimId/accept",
+	vercelSeederMiddleware,
+	vercelOidcAuthMiddleware,
+	...handleAcceptResourceTransfer,
 );
 
 vercelWebhookRouter.delete(


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Block Vercel resource transfer requests by explicitly rejecting create, verify, and accept calls with a 403. This prevents any unintended transfers until we support them.

- **Bug Fixes**
  - Added webhook routes for create, verify, and accept transfer requests that always throw a 403 Forbidden (ErrCode.InvalidRequest).
  - Uses vercelSeederMiddleware and vercelOidcAuthMiddleware for consistent auth and setup.
  - Returns a clear error message instructing users to contact support if needed.

<sup>Written for commit ecd796ee57691c6dff234217d780a3a1a5f5fec0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds endpoints to explicitly block Vercel resource transfer operations by returning 403 Forbidden errors.

**Key Changes:**

- **Bug fixes**: Blocked resource transfer requests for Vercel integration to prevent unsupported operations
- **API changes**: Added three new endpoints (`POST /resource-transfer-requests`, `GET /resource-transfer-requests/:providerClaimId/verify`, `POST /resource-transfer-requests/:providerClaimId/accept`) that return 403 Forbidden with a clear error message directing users to contact support

The implementation creates a new handler file with three functions that immediately throw `RecaseError` with a helpful message explaining that resource transfers are disabled. These handlers are properly registered in the webhook router with the same middleware pattern (OIDC auth) as other resource endpoints.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and defensive - they add explicit blocking behavior for unsupported resource transfer operations. The implementation follows existing codebase patterns (uses RecaseError, follows the createRoute pattern, applies proper middleware), and the error handling is clear and user-friendly. No existing functionality is modified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/vercel/handlers/transfers/handleResourceTransfers.ts | Added three handler functions that block all resource transfer operations by throwing FORBIDDEN errors |
| server/src/external/vercel/vercelWebhookRouter.ts | Registered three new routes for resource transfer endpoints, all using OIDC auth middleware |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Vercel
    participant Router as vercelWebhookRouter
    participant Middleware as vercelOidcAuthMiddleware
    participant Handler as handleResourceTransfers

    Note over Vercel,Handler: POST /resource-transfer-requests
    Vercel->>Router: POST /resource-transfer-requests
    Router->>Middleware: Authenticate request
    Middleware->>Handler: handleCreateResourceTransfer
    Handler-->>Vercel: 403 Forbidden (transfers disabled)

    Note over Vercel,Handler: GET /verify endpoint
    Vercel->>Router: GET /resource-transfer-requests/:id/verify
    Router->>Middleware: Authenticate request
    Middleware->>Handler: handleVerifyResourceTransfer
    Handler-->>Vercel: 403 Forbidden (transfers disabled)

    Note over Vercel,Handler: POST /accept endpoint
    Vercel->>Router: POST /resource-transfer-requests/:id/accept
    Router->>Middleware: Authenticate request
    Middleware->>Handler: handleAcceptResourceTransfer
    Handler-->>Vercel: 403 Forbidden (transfers disabled)
```
</details>


<sub>Last reviewed commit: ecd796e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->