### PR TITLE
fix: zero denom issue fix

### DIFF
--- a/server/tests/unit/billing/invoicing/proration/apply-proration.test.ts
+++ b/server/tests/unit/billing/invoicing/proration/apply-proration.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { applyProration } from "@autumn/shared";
+
+const ONE_DAY = 86_400_000;
+const THIRTY_DAYS = 30 * ONE_DAY;
+
+describe("applyProration", () => {
+	describe("normal proration", () => {
+		test("returns full amount when now equals period start", () => {
+			const result = applyProration({
+				now: 1000,
+				billingPeriod: { start: 1000, end: 1000 + THIRTY_DAYS },
+				amount: 3000,
+			});
+			expect(result).toBe(3000);
+		});
+
+		test("returns zero when now equals period end", () => {
+			const result = applyProration({
+				now: 1000 + THIRTY_DAYS,
+				billingPeriod: { start: 1000, end: 1000 + THIRTY_DAYS },
+				amount: 3000,
+			});
+			expect(result).toBe(0);
+		});
+
+		test("returns half when now is at midpoint", () => {
+			const start = 1000;
+			const end = start + THIRTY_DAYS;
+			const mid = start + THIRTY_DAYS / 2;
+
+			const result = applyProration({
+				now: mid,
+				billingPeriod: { start, end },
+				amount: 3000,
+			});
+			expect(result).toBe(1500);
+		});
+	});
+
+	describe("zero-length billing period", () => {
+		test("returns 0 when start equals end (not NaN)", () => {
+			const result = applyProration({
+				now: 1000,
+				billingPeriod: { start: 1000, end: 1000 },
+				amount: 3000,
+			});
+			expect(result).toBe(0);
+			expect(Number.isNaN(result)).toBe(false);
+		});
+
+		test("returns 0 when start equals end with zero amount", () => {
+			const result = applyProration({
+				now: 1000,
+				billingPeriod: { start: 1000, end: 1000 },
+				amount: 0,
+			});
+			expect(result).toBe(0);
+			expect(Number.isNaN(result)).toBe(false);
+		});
+
+		test("returns 0 when start equals end and now differs", () => {
+			const result = applyProration({
+				now: 5000,
+				billingPeriod: { start: 1000, end: 1000 },
+				amount: 3000,
+			});
+			expect(result).toBe(0);
+			expect(Number.isNaN(result)).toBe(false);
+		});
+	});
+});

--- a/shared/utils/billingUtils/invoicingUtils/prorationUtils/applyProration.ts
+++ b/shared/utils/billingUtils/invoicingUtils/prorationUtils/applyProration.ts
@@ -14,6 +14,8 @@ export const applyProration = ({
 
 	const denom = new Decimal(end).minus(start);
 
+	if (denom.isZero()) return 0;
+
 	const num = new Decimal(end).minus(now);
 
 	return num.div(denom).mul(amount).toNumber();


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Handled zero-length billing periods in applyProration to avoid divide-by-zero and NaN results. Returns 0 when period start equals end to keep invoices stable.

- **Bug Fixes**
  - Added denom.isZero() guard in applyProration to return 0.
  - Added unit tests for normal proration and zero-length periods; verifies results are not NaN.

<sup>Written for commit 306812c306005ea23738ffd586baefd063c9b642. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixed division by zero bug in `applyProration` that would return `NaN` when billing period start equals end. The fix adds an early return of 0 when the denominator is zero, which is the correct proration amount for a zero-length period.

**Key Changes:**
- **Bug fixes**: Added guard clause `if (denom.isZero()) return 0;` in `applyProration.ts:17` to prevent division by zero
- **Improvements**: Added comprehensive test suite with 6 test cases covering normal proration scenarios and zero-length billing period edge cases
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, well-tested guard clause that prevents a critical division by zero bug. The change is minimal (2 lines), has comprehensive test coverage including edge cases, and the logic is mathematically correct (zero-length period should have zero proration)
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/billingUtils/invoicingUtils/prorationUtils/applyProration.ts | Added zero denominator guard to prevent NaN when start equals end |
| server/tests/unit/billing/invoicing/proration/apply-proration.test.ts | New comprehensive test suite covering normal proration and zero-length billing period edge cases |

</details>



<sub>Last reviewed commit: 306812c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->