### PR TITLE
fix: invoice cron race

### DIFF
--- a/server/src/cron/invoiceCron/runInvoiceCron.ts
+++ b/server/src/cron/invoiceCron/runInvoiceCron.ts
@@ -86,11 +86,7 @@ export const handleVoidInvoiceCron = async ({
 		} catch (error) {
 			logger.error(`Error voiding invoice: ${error}`);
 		}
-	} else if (
-		invoice.status === "void" ||
-		invoice.status === "paid" ||
-		invoice.status === "uncollectible"
-	) {
+	} else if (invoice.status === "void" || invoice.status === "uncollectible") {
 		await MetadataService.delete({
 			db,
 			id: metadata.id,

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -7,32 +7,26 @@ import chalk from "chalk";
 /**
  * Test: Attach free default product, then attach pro with invoice mode
  */
-test.concurrent(`${chalk.yellowBright("invoice-mode: free default then pro with invoice checkout")}`, async () => {
-	const users = items.monthlyUsers({ includedUsage: 1 });
-	const free = products.base({
-		id: "free",
-		items: [items.monthlyMessages({ includedUsage: 100 }), users],
-	});
+test.concurrent(`${chalk.yellowBright("attach: pro plan with failed payment method")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
 	const pro = products.pro({
 		id: "pro",
-		items: [items.monthlyMessages({ includedUsage: 100 }), users],
-	});
-	const premium = products.premium({
-		id: "premium",
-		items: [items.monthlyMessages({ includedUsage: 100 }), users],
+		items: [messagesItem],
 	});
 
 	const { autumnV1 } = await initScenario({
-		customerId: "test",
+		customerId: "test-failed-pm",
 		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [free, pro, premium] }),
+			s.customer({ paymentMethod: "fail" }), // Failed payment method
+			s.products({ list: [pro] }),
 		],
 		actions: [],
 	});
 
-	await autumnV1.attach({
-		customer_id: "test",
+	const result = await autumnV1.attach({
+		customer_id: "test-failed-pm",
 		product_id: pro.id,
 	});
+
+	console.log("Attach response:", JSON.stringify(result, null, 2));
 });

--- a/server/tests/integration/billing/autumn-webhooks/update-subscription-webhooks.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/update-subscription-webhooks.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration tests for customer.products.updated webhook via UPDATE SUBSCRIPTION endpoint.
+ * Uses autumnV1.subscriptions.update() which calls handleUpdateSubscription.
+ *
+ * Verifies that webhooks are sent correctly for:
+ * - Update with price change: scenario "upgrade" (new customer product created)
+ * - Update with feature change only: scenario "upgrade"
+ * - Trial removal: scenario "upgrade" (trial ends, new billing cycle starts)
+ *
+ * Uses Svix Play (https://www.svix.com/play/) to receive and verify webhooks.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import type { ApiCustomerV3, ApiProduct } from "@autumn/shared";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { expectProductActive } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	generatePlayToken,
+	getPlayWebhookUrl,
+	waitForWebhook,
+} from "./utils/svixPlayClient.js";
+import {
+	createTestEndpoint,
+	deleteTestEndpoint,
+} from "./utils/svixTestEndpoint.js";
+
+type CustomerProductsUpdatedPayload = {
+	type: string;
+	data: {
+		scenario: string;
+		customer: ApiCustomerV3;
+		updated_product: ApiProduct;
+	};
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SVIX PLAY SETUP (shared across all tests)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+let playToken: string;
+let endpointId: string;
+
+beforeAll(async () => {
+	// 1. Generate Svix Play token
+	playToken = await generatePlayToken();
+	console.log(`Generated Svix Play token: ${playToken}`);
+
+	// 2. Get org's Svix app ID
+	const svixAppId = ctx.org.svix_config?.sandbox_app_id;
+	if (!svixAppId) {
+		throw new Error(
+			"Test org does not have svix_config.sandbox_app_id configured. " +
+				"Cannot run webhook integration tests without Svix app.",
+		);
+	}
+
+	// 3. Create Svix endpoint pointing to Svix Play
+	const playUrl = getPlayWebhookUrl(playToken);
+	console.log(`Creating Svix endpoint: ${playUrl}`);
+	endpointId = await createTestEndpoint({ appId: svixAppId, playUrl });
+	console.log(`Created Svix endpoint: ${endpointId}`);
+});
+
+afterAll(async () => {
+	// Cleanup: delete Svix endpoint
+	const svixAppId = ctx.org.svix_config?.sandbox_app_id;
+	if (svixAppId && endpointId) {
+		await deleteTestEndpoint({ appId: svixAppId, endpointId });
+		console.log(`Deleted Svix endpoint: ${endpointId}`);
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// UPDATE SUBSCRIPTION TESTS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("webhook update-sub: increase included usage - scenario: upgrade")}`, async () => {
+	const customerId = "webhook-update-usage";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const priceItem = items.monthlyPrice({ price: 20 });
+	const pro = products.base({
+		id: "pro",
+		items: [messagesItem, priceItem],
+	});
+
+	// Setup: customer with Pro ($20/month, 100 messages) attached
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", skipWebhooks: true }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	// Action: update subscription to increase included usage from 100 to 200 (same price)
+	const newMessagesItem = items.monthlyMessages({ includedUsage: 200 });
+
+	await autumnV1.subscriptions.update({
+		customer_id: customerId,
+		product_id: pro.id,
+		items: [newMessagesItem, priceItem],
+	});
+
+	// Assert: webhook received with scenario "upgrade"
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "upgrade" &&
+			payload.data?.updated_product?.id === pro.id,
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result?.payload.type).toBe("customer.products.updated");
+
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("upgrade");
+	expect(data.updated_product.id).toBe(pro.id);
+	expect(data.customer.id).toBe(customerId);
+
+	// Verify customer state: Pro is active with new features
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({ customer, productId: pro.id });
+	expectCustomerFeatureCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		balance: 200,
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race in the invoice voiding cron that could delete metadata for paid invoices. Adds an integration test to verify “customer.products.updated” webhooks on subscription updates.

- **Bug Fixes**
  - In handleVoidInvoiceCron, stop deleting metadata for invoices with status “paid”; only delete for “void” or “uncollectible”. This prevents cleanup when payment succeeds while the cron runs.

- **Tests**
  - Added integration test for autumnV1.subscriptions.update using Svix Play to verify “customer.products.updated” with scenario “upgrade” (increased included usage, same price), and product state.
  - Updated temp test to attach Pro with a failed payment method and log the response.

<sup>Written for commit 01e512219c5cead9697b50b97beaa12a658b6474. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a race condition in the invoice cron job where metadata for paid invoices could be deleted before the `invoice.paid` Stripe webhook handler had a chance to process them. The cron's `handleVoidInvoiceCron` no longer cleans up metadata for "paid" invoices — that responsibility is now exclusively handled by the webhook handlers (`handleInvoiceCheckoutPaid`, `handleInvoiceActionRequiredCompleted`, `executeDeferredBillingPlan`), which already call `MetadataService.delete()` after processing.

- **Bug fixes**: Removed `invoice.status === "paid"` from the cron's metadata cleanup condition, eliminating a race between the cron and the `invoice.paid` webhook handler that could result in billing operations failing silently
- **Improvements**: Added new integration test for `customer.products.updated` webhook via the subscription update endpoint, verifying the "upgrade" scenario
- **Improvements**: Updated temp test to exercise attaching a pro plan with a failed payment method
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the core fix is a small, well-motivated removal that eliminates a race condition, and the webhook handlers already cover metadata cleanup for paid invoices.
- The production code change is a 4-line deletion that removes redundant cleanup logic from the cron. All three metadata types (InvoiceActionRequired, InvoiceCheckout, DeferredInvoice) already have their metadata cleaned up in the corresponding webhook handlers when an invoice is paid. The new test file follows established patterns from existing webhook tests. No new risks introduced.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/cron/invoiceCron/runInvoiceCron.ts | Removes `invoice.status === "paid"` from the else-if cleanup condition in `handleVoidInvoiceCron`. This fixes a race condition where the cron could delete metadata for paid invoices before the `invoice.paid` webhook handler had a chance to process them. Paid invoice metadata cleanup is already handled by webhook handlers. |
| server/tests/_temp/temp.test.ts | Temporary test file updated to test attaching a pro plan with a failed payment method. Test has no assertions (only a `console.log`), consistent with its role as a scratch/exploration test. |
| server/tests/integration/billing/autumn-webhooks/update-subscription-webhooks.test.ts | New integration test for `customer.products.updated` webhook via the subscription update endpoint. Tests that updating included usage triggers an "upgrade" scenario webhook. Follows the same Svix Play pattern used by existing webhook tests. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Webhook as invoice.paid Webhook Handler
    participant Cron as Invoice Cron Job
    participant DB as MetadataService

    Note over Stripe,DB: BEFORE FIX (race condition)
    Stripe->>Webhook: invoice.paid event
    Cron->>Stripe: Retrieve invoice (status: paid)
    Cron->>DB: Delete metadata ❌ (races with webhook)
    Webhook->>DB: Delete metadata ❌ (already deleted or fails)
    Note over Webhook: Billing operation may fail silently

    Note over Stripe,DB: AFTER FIX (clean separation)
    Stripe->>Webhook: invoice.paid event
    Webhook->>DB: Process payment + Delete metadata ✅
    Cron->>Stripe: Retrieve invoice (status: paid)
    Note over Cron: Skips paid invoices — no action
    Cron->>Stripe: Retrieve invoice (status: void/uncollectible)
    Cron->>DB: Delete metadata ✅ (cleanup only)
```
</details>


<sub>Last reviewed commit: 01e5122</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->