### PR TITLE
feat: finished new attach params

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts
@@ -34,7 +34,7 @@ export const computeAttachNewCustomerProduct = ({
 		trialContext,
 		isCustom,
 		billingVersion,
-		transitionConfigs,
+		transitionConfig,
 	} = attachBillingContext;
 
 	const currentCustomerEntitlements =
@@ -82,7 +82,7 @@ export const computeAttachNewCustomerProduct = ({
 
 			existingUsagesConfig,
 			existingRolloversConfig,
-			transitionConfigs,
+			transitionConfig,
 		},
 		initOptions: {
 			isCustom,

--- a/server/src/internal/billing/v2/actions/attach/errors/handleTransitionConfigErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleTransitionConfigErrors.ts
@@ -15,18 +15,21 @@ export const handleTransitionConfigErrors = ({
 	ctx: AutumnContext;
 	billingContext: AttachBillingContext;
 }) => {
-	const { transitionConfigs } = billingContext;
+	const { transitionConfig } = billingContext;
 
-	for (const config of transitionConfigs ?? []) {
+	const resetAfterTrialEndFeaturIds =
+		transitionConfig?.resetAfterTrialEndFeaturIds ?? [];
+
+	for (const featureId of resetAfterTrialEndFeaturIds) {
 		const feature = featureUtils.find.byId({
 			features: ctx.features,
-			featureId: config.feature_id,
+			featureId,
 			errorOnNotFound: true,
 		});
 
-		if (featureUtils.isAllocated(feature) && config.reset_after_trial_end) {
+		if (featureUtils.isAllocated(feature)) {
 			throw new RecaseError({
-				message: `reset_after_trial_end is not supported for allocated features. Feature '${config.feature_id}' is an allocated feature (continuous_use) and does not have a reset cycle.`,
+				message: `reset_after_trial_end is not supported for allocated features. Feature '${featureId}' is an allocated feature (continuous_use) and does not have a reset cycle.`,
 			});
 		}
 	}

--- a/server/src/internal/billing/v2/actions/attach/logs/logAttachContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/logs/logAttachContext.ts
@@ -18,7 +18,7 @@ export const logAttachContext = ({
 		endOfCycleMs,
 		checkoutMode,
 		featureQuantities,
-		transitionConfigs,
+		transitionConfig,
 		currentEpochMs,
 		invoiceMode,
 		stripeSubscription,
@@ -61,14 +61,10 @@ export const logAttachContext = ({
 								.join(", ")
 						: "none",
 
-				transitionConfigs: transitionConfigs
-					? transitionConfigs
-							.map(
-								(c) =>
-									`${c.feature_id}${c.reset_after_trial_end ? " (reset after trial)" : ""}`,
-							)
-							.join(", ")
-					: "none",
+				resetAfterTrialEndFeaturIds:
+					transitionConfig?.resetAfterTrialEndFeaturIds
+						? transitionConfig.resetAfterTrialEndFeaturIds.join(", ")
+						: "none",
 
 				trialContext: trialContext
 					? `trial ends at: ${formatMs(trialContext.trialEndsAt)} | free trial ID: ${trialContext.freeTrial?.id ?? "none"} | appliesToBilling: ${trialContext.appliesToBilling}`

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -12,6 +12,7 @@ import { setupFullCustomerContext } from "@/internal/billing/v2/setup/setupFullC
 import { setupInvoiceModeContext } from "@/internal/billing/v2/setup/setupInvoiceModeContext";
 import { setupResetCycleAnchor } from "@/internal/billing/v2/setup/setupResetCycleAnchor";
 import { setupTransitionConfigs } from "@/internal/billing/v2/setup/setupTransitionConfigs";
+import { setupAdjustableQuantities } from "../../../setup/setupAdjustableQuantities";
 import { setupAttachCheckoutMode } from "./setupAttachCheckoutMode";
 import { setupAttachEndOfCycleMs } from "./setupAttachEndOfCycleMs";
 import { setupAttachProductContext } from "./setupAttachProductContext";
@@ -141,7 +142,7 @@ export const setupAttachBillingContext = async ({
 		trialContext,
 	});
 
-	const transitionConfigs = setupTransitionConfigs({
+	const transitionConfig = setupTransitionConfigs({
 		params,
 		contextOverride,
 	});
@@ -151,7 +152,7 @@ export const setupAttachBillingContext = async ({
 		fullProducts: [attachProduct],
 		attachProduct,
 		featureQuantities,
-		transitionConfigs,
+		transitionConfig,
 
 		currentCustomerProduct,
 		scheduledCustomerProduct,
@@ -177,7 +178,7 @@ export const setupAttachBillingContext = async ({
 		isCustom,
 		trialContext,
 
-		checkoutQuantityAdjustable: params.adjustable_quantity,
+		adjustableFeatureQuantities: setupAdjustableQuantities({ params }),
 
 		billingVersion: contextOverride.billingVersion ?? BillingVersion.V2,
 	};

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachProductContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachProductContext.ts
@@ -23,7 +23,7 @@ export const setupAttachProductContext = async ({
 	// 1. Fetch the product being attached
 	const fullProduct = await ProductService.getFull({
 		db,
-		idOrInternalId: params.product_id,
+		idOrInternalId: params.plan_id,
 		orgId: org.id,
 		env,
 		version: params.version,

--- a/server/src/internal/billing/v2/actions/legacy/legacyAttach.ts
+++ b/server/src/internal/billing/v2/actions/legacy/legacyAttach.ts
@@ -42,7 +42,7 @@ export const legacyAttach = async ({
 
 		stripeBillingContext,
 		featureQuantities: attachParams.optionsList,
-		transitionConfigs: setupLegacyTransitionContext({ attachParams }),
+		transitionConfig: setupLegacyTransitionContext({ attachParams }),
 		billingVersion: BillingVersion.V1,
 	};
 
@@ -51,11 +51,15 @@ export const legacyAttach = async ({
 	const params: AttachParamsV1 = {
 		customer_id: fullCustomer.id || fullCustomer.internal_id,
 		entity_id: fullCustomer.entity?.id,
-		product_id: fullProduct.id,
+		plan_id: fullProduct.id,
 
-		invoice: attachParams.invoiceOnly,
-		enable_product_immediately: true,
-		finalize_invoice: attachParams.finalizeInvoice,
+		invoice_mode: attachParams.invoiceOnly
+			? {
+					enabled: attachParams.invoiceOnly,
+					enable_product_immediately: true,
+					finalize_invoice: attachParams.finalizeInvoice ?? true,
+				}
+			: undefined,
 
 		redirect_mode: "if_required",
 

--- a/server/src/internal/billing/v2/actions/legacy/renew.ts
+++ b/server/src/internal/billing/v2/actions/legacy/renew.ts
@@ -57,7 +57,7 @@ export const renew = async ({
 
 		stripeBillingContext,
 		featureQuantities: attachParams.optionsList,
-		transitionConfigs: setupLegacyTransitionContext({ attachParams }),
+		transitionConfig: setupLegacyTransitionContext({ attachParams }),
 		billingVersion: BillingVersion.V1,
 	};
 
@@ -66,13 +66,17 @@ export const renew = async ({
 	const params: UpdateSubscriptionV1Params = {
 		customer_id: fullCustomer.id || fullCustomer.internal_id,
 		entity_id: fullCustomer.entity?.id,
-		product_id: fullProduct.id,
+		plan_id: fullProduct.id,
 
-		invoice: body.invoice,
-		enable_product_immediately: body.enable_product_immediately,
-		finalize_invoice: body.finalize_invoice,
+		invoice_mode: body.invoice
+			? {
+					enabled: true,
+					enable_product_immediately: body.enable_product_immediately ?? false,
+					finalize_invoice: body.finalize_invoice ?? true,
+				}
+			: undefined,
 
-		// options: attachParams.optionsList,
+		// feature_quantities: attachParams.optionsList,
 		cancel_action: "uncancel",
 	};
 

--- a/server/src/internal/billing/v2/actions/legacy/utils/optionsListToFeatureQuantities.ts
+++ b/server/src/internal/billing/v2/actions/legacy/utils/optionsListToFeatureQuantities.ts
@@ -1,0 +1,12 @@
+import type { FeatureOptions, FeatureQuantityParamsV0 } from "@autumn/shared";
+
+export const optionsListToFeatureQuantities = ({
+	optionsList,
+}: {
+	optionsList: FeatureOptions[];
+}): FeatureQuantityParamsV0[] => {
+	return optionsList.map((option) => ({
+		feature_id: option.feature_id,
+		quantity: option.quantity,
+	}));
+};

--- a/server/src/internal/billing/v2/actions/legacy/utils/setupLegacyFeatureQuantitiesContext.ts
+++ b/server/src/internal/billing/v2/actions/legacy/utils/setupLegacyFeatureQuantitiesContext.ts
@@ -13,10 +13,9 @@ export const setupLegacyTransitionContext = ({
 		.filter((ent) => isConsumableFeature(ent.feature))
 		.map((ent) => ent.feature);
 
-	return consumableFeatures.map((f) => ({
-		feature_id: f.id,
-		reset_after_trial_end: true,
-	}));
+	return {
+		resetAfterTrialEndFeaturIds: consumableFeatures.map((f) => f.id),
+	};
 
 	// const newOptions: FeatureOptionsParamsV0[] = [];
 	// for (const feature of consumableFeatures) {

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionIntent.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionIntent.ts
@@ -21,7 +21,7 @@ export const computeUpdateSubscriptionIntent = (
 
 	// Version change = plan update (takes priority)
 	const featureQuantitiesChanges =
-		params.options?.length && params.options.length > 0;
+		params.feature_quantities?.length && params.feature_quantities.length > 0;
 
 	if (featureQuantitiesChanges) {
 		return UpdateSubscriptionIntent.UpdateQuantity;

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleFeatureQuantityErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleFeatureQuantityErrors.ts
@@ -37,7 +37,7 @@ const checkInputFeatureQuantitiesAreValid = ({
 		cusProduct: targetCustomerProduct,
 	}).filter(isPrepaidPrice);
 
-	for (const option of params.options ?? []) {
+	for (const option of params.feature_quantities ?? []) {
 		if (nullish(option.quantity)) continue;
 
 		const targetPrepaidPrice = prepaidPrices.find((p) => {

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/findTargetCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/findTargetCustomerProduct.ts
@@ -12,7 +12,7 @@ export const findTargetCustomerProduct = ({
 	fullCustomer: FullCustomer;
 }) => {
 	const cusProducts = fullCustomer.customer_products;
-	const productId = params.product_id;
+	const productId = params.plan_id;
 	const internalEntityId = fullCustomer.entity?.internal_id;
 	const cusProductId = params.customer_product_id;
 

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts
@@ -33,7 +33,7 @@ export const setupUpdateSubscriptionProductContext = async ({
 
 	if (!targetCustomerProduct) {
 		throw new RecaseError({
-			message: `Customer ${fullCustomer.id} does not have the product ${params.product_id}.`,
+			message: `Customer ${fullCustomer.id} does not have the plan ${params.plan_id}.`,
 		});
 	}
 

--- a/server/src/internal/billing/v2/compute/computeAutumnUtils/paramsToFeatureOptions.ts
+++ b/server/src/internal/billing/v2/compute/computeAutumnUtils/paramsToFeatureOptions.ts
@@ -18,7 +18,7 @@ export const paramsToFeatureOptions = ({
 }): FeatureOptions | undefined => {
 	const feature = entitlement.feature;
 
-	const options = params.options?.find(
+	const options = params.feature_quantities?.find(
 		(option) => option.feature_id === feature.id,
 	);
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/buildStripeCheckoutSessionItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/buildStripeCheckoutSessionItems.ts
@@ -54,10 +54,15 @@ export const buildStripeCheckoutSessionItems = ({
 
 		// If it's a prepaid price, allow adjustable quantity
 		if (autumnPrice && autumnEntitlement && isPrepaidPrice(autumnPrice)) {
+			const feature = autumnEntitlement.feature;
+			const isAdjustable = billingContext.adjustableFeatureQuantities?.includes(
+				feature.id,
+			);
+
 			return {
 				price: stripePriceId,
 				quantity: quantity ?? 0,
-				adjustable_quantity: billingContext.checkoutQuantityAdjustable
+				adjustable_quantity: isAdjustable
 					? {
 							enabled: true,
 							minimum: priceUtils.convert.toAllowanceInPacks({

--- a/server/src/internal/billing/v2/setup/setupAdjustableQuantities.ts
+++ b/server/src/internal/billing/v2/setup/setupAdjustableQuantities.ts
@@ -1,0 +1,13 @@
+import type { BillingParamsBaseV1 } from "@autumn/shared";
+
+export const setupAdjustableQuantities = ({
+	params,
+}: {
+	params: BillingParamsBaseV1;
+}) => {
+	return (
+		params.feature_quantities
+			?.filter((fq) => fq.adjustable)
+			.map((fq) => fq.feature_id) ?? []
+	);
+};

--- a/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
+++ b/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
@@ -8,12 +8,13 @@ export const setupInvoiceModeContext = ({
 }: {
 	params: UpdateSubscriptionV1Params | AttachParamsV1;
 }) => {
-	if (params?.invoice !== true) {
+	if (params?.invoice_mode?.enabled !== true) {
 		return undefined;
 	}
 
 	return {
-		finalizeInvoice: params.finalize_invoice === true,
-		enableProductImmediately: params.enable_product_immediately !== false,
+		finalizeInvoice: params.invoice_mode?.finalize_invoice === true,
+		enableProductImmediately:
+			params.invoice_mode?.enable_product_immediately !== false,
 	};
 };

--- a/server/src/internal/billing/v2/setup/setupTransitionConfigs.ts
+++ b/server/src/internal/billing/v2/setup/setupTransitionConfigs.ts
@@ -10,15 +10,13 @@ export const setupTransitionConfigs = ({
 }: {
 	params: BillingParamsBaseV1;
 	contextOverride?: BillingContextOverride;
-}): TransitionConfig[] => {
-	if (contextOverride.transitionConfigs) {
-		return contextOverride.transitionConfigs;
+}): TransitionConfig => {
+	if (contextOverride.transitionConfig) {
+		return contextOverride.transitionConfig;
 	}
 
-	return (
-		params.options?.map((option) => ({
-			feature_id: option.feature_id,
-			reset_after_trial_end: option.reset_after_trial_end,
-		})) ?? []
-	);
+	return {
+		resetAfterTrialEndFeaturIds:
+			params.transition_rules?.reset_after_trial_end ?? [],
+	};
 };

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementNextResetAt.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementNextResetAt.ts
@@ -7,7 +7,6 @@ import {
 	isBooleanEntitlement,
 	isLifetimeEntitlement,
 	isUnlimitedEntitlement,
-	transitionConfigsUtils,
 } from "@autumn/shared";
 
 export const initCustomerEntitlementNextResetAt = ({
@@ -26,15 +25,14 @@ export const initCustomerEntitlementNextResetAt = ({
 
 	if (isLifetime || isUnlimited || isBoolean) return null;
 
-	let { resetCycleAnchor, now, trialEndsAt, transitionConfigs } = initContext;
+	let { resetCycleAnchor, now, trialEndsAt, transitionConfig } = initContext;
+	const { resetAfterTrialEndFeaturIds } = transitionConfig ?? {};
 	const { startsAt } = initOptions ?? {};
 
-	const transitionConfig = transitionConfigsUtils.find.byFeature({
-		transitionConfigs,
-		feature: entitlement.feature,
-	});
-
-	if (transitionConfig?.reset_after_trial_end && trialEndsAt) {
+	if (
+		resetAfterTrialEndFeaturIds?.includes(entitlement.feature.id) &&
+		trialEndsAt
+	) {
 		now = trialEndsAt;
 	}
 

--- a/server/src/internal/checkouts/handlers/handlePreviewCheckout.ts
+++ b/server/src/internal/checkouts/handlers/handlePreviewCheckout.ts
@@ -49,7 +49,7 @@ export const handlePreviewCheckout = createRoute({
 		// Merge provided options with original params
 		const params: AttachParamsV1 = {
 			...originalParams,
-			options: body.options,
+			feature_quantities: body.options,
 		};
 
 		// Re-run attach in preview mode with updated options

--- a/server/src/internal/customers/cancel/handleCancelV2.ts
+++ b/server/src/internal/customers/cancel/handleCancelV2.ts
@@ -25,7 +25,7 @@ export const handleCancelV2 = createRoute({
 
 		const updateSubscriptionBody: UpdateSubscriptionV1Params = {
 			customer_id,
-			product_id,
+			plan_id: product_id,
 			entity_id,
 			cancel_action: cancel_immediately
 				? "cancel_immediately"

--- a/server/tests/integration/billing/attach/v2-params/v2-customize.test.ts
+++ b/server/tests/integration/billing/attach/v2-params/v2-customize.test.ts
@@ -33,7 +33,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize attach: both customize.price
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: base.id,
+		plan_id: base.id,
 		redirect_mode: "if_required",
 		customize: {
 			price: itemsV2.monthlyPrice({ amount: 30 }),
@@ -86,7 +86,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize attach: only customize.price
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: base.id,
+		plan_id: base.id,
 		redirect_mode: "if_required",
 		customize: {
 			price: itemsV2.monthlyPrice({ amount: 25 }),
@@ -137,7 +137,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize attach: only customize.items
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		redirect_mode: "if_required",
 		customize: {
 			// price: null,
@@ -196,7 +196,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize attach: price null makes pro
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		redirect_mode: "if_required",
 		customize: {
 			price: null,
@@ -253,9 +253,9 @@ test.concurrent(`${chalk.yellowBright("v2-customize attach: plan item v1 prepaid
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: base.id,
+		plan_id: base.id,
 		redirect_mode: "if_required",
-		options: [{ feature_id: TestFeature.Messages, quantity: 100 }],
+		feature_quantities: [{ feature_id: TestFeature.Messages, quantity: 100 }],
 		customize: {
 			price: null,
 			items: [itemsV2.prepaidMessages({ amount: 10, billingUnits: 100 })],
@@ -295,7 +295,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize attach: plan item v1 multi-f
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: base.id,
+		plan_id: base.id,
 		redirect_mode: "if_required",
 		customize: {
 			price: itemsV2.monthlyPrice({ amount: 40 }),
@@ -344,9 +344,9 @@ test.concurrent(`${chalk.yellowBright("v2-customize attach: paid feature mix (co
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: base.id,
+		plan_id: base.id,
 		redirect_mode: "if_required",
-		options: [{ feature_id: TestFeature.Words, quantity: 500 }],
+		feature_quantities: [{ feature_id: TestFeature.Words, quantity: 500 }],
 		customize: {
 			price: itemsV2.monthlyPrice({ amount: 40 }),
 			items: [

--- a/server/tests/integration/billing/attach/v2-params/v2-free-trial.test.ts
+++ b/server/tests/integration/billing/attach/v2-params/v2-free-trial.test.ts
@@ -35,7 +35,7 @@ test.concurrent(`${chalk.yellowBright("v2-free-trial attach: set trial with v1 f
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		redirect_mode: "if_required",
 		free_trial: {
 			duration_length: 7,
@@ -87,7 +87,7 @@ test.concurrent(`${chalk.yellowBright("v2-free-trial attach: remove product tria
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: proTrial.id,
+		plan_id: proTrial.id,
 		redirect_mode: "if_required",
 		free_trial: null,
 	};
@@ -133,7 +133,7 @@ test.concurrent(`${chalk.yellowBright("v2-free-trial attach: month-based v1 free
 
 	const params: AttachParamsV1Input = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		redirect_mode: "if_required",
 		free_trial: {
 			duration_length: 1,

--- a/server/tests/integration/billing/update-subscription/v2-params/v2-customize.test.ts
+++ b/server/tests/integration/billing/update-subscription/v2-params/v2-customize.test.ts
@@ -34,7 +34,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize update: both customize.price
 
 	const params: UpdateSubscriptionV1ParamsInput = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		customize: {
 			price: itemsV2.monthlyPrice({ amount: 30 }),
 			items: [itemsV2.monthlyWords({ included: 200 })],
@@ -86,7 +86,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize update: only customize.price
 
 	const params: UpdateSubscriptionV1ParamsInput = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		customize: {
 			price: itemsV2.monthlyPrice({ amount: 24 }),
 		},
@@ -137,7 +137,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize update: only customize.items
 
 	const params: UpdateSubscriptionV1ParamsInput = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		customize: {
 			price: null,
 			items: [itemsV2.monthlyMessages({ included: 180 })],
@@ -189,8 +189,8 @@ test.concurrent(`${chalk.yellowBright("v2-customize update: plan item v1 prepaid
 
 	const params: UpdateSubscriptionV1ParamsInput = {
 		customer_id: customerId,
-		product_id: pro.id,
-		options: [{ feature_id: TestFeature.Messages, quantity: 100 }],
+		plan_id: pro.id,
+		feature_quantities: [{ feature_id: TestFeature.Messages, quantity: 100 }],
 		customize: {
 			price: null,
 			items: [itemsV2.prepaidMessages({ amount: 10, billingUnits: 100 })],
@@ -235,7 +235,7 @@ test.concurrent(`${chalk.yellowBright("v2-customize update: plan item v1 multi-f
 
 	const params: UpdateSubscriptionV1ParamsInput = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		customize: {
 			price: itemsV2.monthlyPrice({ amount: 40 }),
 			items: [

--- a/server/tests/integration/billing/update-subscription/v2-params/v2-free-trial.test.ts
+++ b/server/tests/integration/billing/update-subscription/v2-params/v2-free-trial.test.ts
@@ -38,7 +38,7 @@ test.concurrent(`${chalk.yellowBright("v2-free-trial update: set trial with v1 f
 
 	const params: UpdateSubscriptionV1ParamsInput = {
 		customer_id: customerId,
-		product_id: pro.id,
+		plan_id: pro.id,
 		free_trial: {
 			duration_length: 7,
 			duration_type: FreeTrialDuration.Day,
@@ -94,7 +94,7 @@ test.concurrent(`${chalk.yellowBright("v2-free-trial update: remove trial with f
 
 	const params: UpdateSubscriptionV1ParamsInput = {
 		customer_id: customerId,
-		product_id: proTrial.id,
+		plan_id: proTrial.id,
 		free_trial: null,
 	};
 
@@ -139,7 +139,7 @@ test.concurrent(`${chalk.yellowBright("v2-free-trial update: replace active tria
 
 	const params: UpdateSubscriptionV1ParamsInput = {
 		customer_id: customerId,
-		product_id: proTrial.id,
+		plan_id: proTrial.id,
 		free_trial: {
 			duration_length: 1,
 			duration_type: FreeTrialDuration.Month,

--- a/server/tests/unit/billing/setup-feature-quantities/setup-feature-quantities-context.spec.ts
+++ b/server/tests/unit/billing/setup-feature-quantities/setup-feature-quantities-context.spec.ts
@@ -49,7 +49,7 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
+				plan_id: "prod_test",
 				// No options provided
 			};
 
@@ -94,8 +94,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [{ feature_id: "credits", quantity: 50 }],
+				plan_id: "prod_test",
+				feature_quantities: [{ feature_id: "credits", quantity: 50 }],
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -147,8 +147,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [{ feature_id: "credits", quantity: 200 }],
+				plan_id: "prod_test",
+				feature_quantities: [{ feature_id: "credits", quantity: 200 }],
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -248,8 +248,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [{ feature_id: "seats", quantity: 10 }], // Only updating seats
+				plan_id: "prod_test",
+				feature_quantities: [{ feature_id: "seats", quantity: 10 }], // Only updating seats
 			};
 
 			const ctx = contexts.create({
@@ -304,8 +304,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [{ feature_id: "credits", quantity: 150 }], // Should round up to 200
+				plan_id: "prod_test",
+				feature_quantities: [{ feature_id: "credits", quantity: 150 }], // Should round up to 200
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -351,8 +351,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [{ feature_id: "credits", quantity: 200 }], // Exact multiple
+				plan_id: "prod_test",
+				feature_quantities: [{ feature_id: "credits", quantity: 200 }], // Exact multiple
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -397,8 +397,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [{ feature_id: "credits", quantity: 1 }], // Should round to 1000
+				plan_id: "prod_test",
+				feature_quantities: [{ feature_id: "credits", quantity: 1 }], // Should round to 1000
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -465,7 +465,7 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
+				plan_id: "prod_test",
 				// No options - should inherit from current
 			};
 
@@ -534,7 +534,7 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
+				plan_id: "prod_test",
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -593,7 +593,7 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
+				plan_id: "prod_test",
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -641,8 +641,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [{ feature_id: "credits", quantity: 50 }],
+				plan_id: "prod_test",
+				feature_quantities: [{ feature_id: "credits", quantity: 50 }],
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -667,7 +667,7 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
+				plan_id: "prod_test",
 			};
 
 			const ctx = contexts.create({ features: [] });
@@ -698,7 +698,7 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
+				plan_id: "prod_test",
 			};
 
 			const ctx = contexts.create({ features: [] });
@@ -740,8 +740,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				// No options in params either
+				plan_id: "prod_test",
+				// No feature_quantities in params either
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -793,8 +793,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [], // Explicitly empty
+				plan_id: "prod_test",
+				feature_quantities: [], // Explicitly empty
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -847,8 +847,8 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
-				options: [{ feature_id: "credits", quantity: 0 }],
+				plan_id: "prod_test",
+				feature_quantities: [{ feature_id: "credits", quantity: 0 }],
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -903,7 +903,7 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
+				plan_id: "prod_test",
 			};
 
 			const ctx = contexts.create({ features: [feature] });
@@ -955,7 +955,7 @@ describe(chalk.yellowBright("setupFeatureQuantitiesContext"), () => {
 
 			const params: UpdateSubscriptionV1Params = {
 				customer_id: "cus_test",
-				product_id: "prod_test",
+				plan_id: "prod_test",
 				// No options provided - should carry over from current
 			};
 

--- a/server/tests/unit/billing/update-subscription/compute-update-subscription-intent.spec.ts
+++ b/server/tests/unit/billing/update-subscription/compute-update-subscription-intent.spec.ts
@@ -17,7 +17,7 @@ import {
 
 const baseParams: UpdateSubscriptionV1Params = {
 	customer_id: "cus_test",
-	product_id: "prod_test",
+	plan_id: "prod_test",
 };
 
 describe(chalk.yellowBright("computeUpdateSubscriptionIntent"), () => {
@@ -37,7 +37,7 @@ describe(chalk.yellowBright("computeUpdateSubscriptionIntent"), () => {
 			const params: UpdateSubscriptionV1Params = {
 				...baseParams,
 				version: 3,
-				options: [{ feature_id: "seats", quantity: 10 }],
+				feature_quantities: [{ feature_id: "seats", quantity: 10 }],
 			};
 
 			const result = computeUpdateSubscriptionIntent(params);
@@ -61,7 +61,7 @@ describe(chalk.yellowBright("computeUpdateSubscriptionIntent"), () => {
 		test("returns UpdateQuantity when options provided without customize", () => {
 			const params: UpdateSubscriptionV1Params = {
 				...baseParams,
-				options: [{ feature_id: "seats", quantity: 5 }],
+				feature_quantities: [{ feature_id: "seats", quantity: 5 }],
 			};
 
 			const result = computeUpdateSubscriptionIntent(params);
@@ -72,7 +72,7 @@ describe(chalk.yellowBright("computeUpdateSubscriptionIntent"), () => {
 		test("returns UpdateQuantity with multiple options", () => {
 			const params: UpdateSubscriptionV1Params = {
 				...baseParams,
-				options: [
+				feature_quantities: [
 					{ feature_id: "seats", quantity: 5 },
 					{ feature_id: "storage", quantity: 100 },
 				],
@@ -101,7 +101,7 @@ describe(chalk.yellowBright("computeUpdateSubscriptionIntent"), () => {
 		test("returns UpdatePlan when both options and customize provided", () => {
 			const params: UpdateSubscriptionV1Params = {
 				...baseParams,
-				options: [{ feature_id: "seats", quantity: 5 }],
+				feature_quantities: [{ feature_id: "seats", quantity: 5 }],
 				customize: {
 					items: [{ feature_id: "seats", included: 10 }],
 				},


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Finalize the new attach/update-subscription params: move to plan_id, feature_quantities, and invoice_mode, and introduce transition_rules. Adds per-feature adjustable quantities in Stripe checkout for prepaid features.

- **New Features**
  - Support adjustable quantities per feature using feature_quantities[].adjustable in checkout.
  - Transition rules: reset_after_trial_end now passed as a list and validated against allocated features; improved logs.

- **Migration**
  - product_id → plan_id across attach, update, cancel.
  - options → feature_quantities (also used to detect UpdateQuantity).
  - invoice → invoice_mode { enabled, enable_product_immediately, finalize_invoice }.
  - transition_configs → transition_rules.reset_after_trial_end; internal context renamed to transitionConfig.resetAfterTrialEndFeaturIds.
  - Tests updated to the new param names; legacy flows map to the new shapes internally.

<sup>Written for commit ed7df88c4f9752e8f20767041bad03f81763abba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors the billing v2 parameter structure to improve clarity and consistency across attach and update subscription operations.

**Key Changes:**

- **API changes**: Renamed `product_id` to `plan_id` for better semantic clarity
- **API changes**: Renamed `options` to `feature_quantities` with conversion utilities for legacy code
- **API changes**: Replaced flat `invoice`, `finalize_invoice`, `enable_product_immediately` params with nested `invoice_mode` object containing `enabled`, `finalize_invoice`, and `enable_product_immediately` fields
- **Improvements**: Replaced `adjustable_quantity` boolean with `adjustableFeatureQuantities` array extracted from `feature_quantities` items marked as adjustable
- **Improvements**: Refactored `transitionConfigs` from array of objects to single `TransitionConfig` object with `resetAfterTrialEndFeaturIds` array
- **Improvements**: Changed transition config source from per-option flags to centralized `transition_rules.reset_after_trial_end` parameter
- **Improvements**: Simplified transition config lookup by directly checking feature ID array instead of using utility functions
- **Improvements**: Added `optionsListToFeatureQuantities` utility for converting legacy `FeatureOptions` to new param format
- **Improvements**: Added `setupAdjustableQuantities` utility to extract adjustable feature IDs from params

All test files updated to reflect new parameter structure. Legacy adapters (`legacyAttach`, `renew`, `updateQuantity`, `migrate`) properly convert to new v2 param format.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-structured parameter refactoring with comprehensive test updates. All modifications follow consistent patterns, properly update legacy adapters, and maintain backward compatibility through conversion utilities. No logical errors or security issues detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/setup/setupAdjustableQuantities.ts | New utility extracts adjustable feature IDs from feature_quantities params |
| server/src/internal/billing/v2/setup/setupTransitionConfigs.ts | Refactored to return single TransitionConfig object instead of array, uses new transition_rules param structure |
| server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts | Updated to use nested invoice_mode object with enabled/finalize_invoice/enable_product_immediately fields |
| server/src/internal/billing/v2/actions/legacy/utils/optionsListToFeatureQuantities.ts | New utility converts FeatureOptions array to FeatureQuantityParamsV0 array for v2 params |
| server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts | Renamed transitionConfigs to transitionConfig, replaced adjustable_quantity param with adjustableFeatureQuantities |
| server/src/internal/billing/v2/actions/legacy/legacyAttach.ts | Migrated from product_id to plan_id, from flat invoice params to invoice_mode object |
| server/src/internal/billing/v2/actions/migrate/migrate.ts | Changed from options array to transition_rules object with reset_after_trial_end feature ID array |
| server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementNextResetAt.ts | Simplified to check resetAfterTrialEndFeaturIds array directly instead of using utils to find config |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A[V1 Attach/UpdateSubscription Params] --> B{Parameter Refactoring}
    
    B --> C[product_id renamed to plan_id]
    B --> D[options renamed to feature_quantities]
    B --> E[adjustable_quantity extracted to array]
    B --> F[Flat invoice params nested in object]
    B --> G[transitionConfigs array to single object]
    
    D --> D1[New: optionsListToFeatureQuantities utility]
    
    E --> E1[New: setupAdjustableQuantities utility]
    E1 --> E2[Filters feature_quantities by adjustable flag]
    
    F --> F1[invoice becomes invoice_mode.enabled]
    F --> F2[finalize_invoice becomes invoice_mode.finalize_invoice]
    F --> F3[enable_product_immediately becomes invoice_mode.enable_product_immediately]
    
    G --> G1[Old: Array with feature_id and reset flag]
    G --> G2[New: Object with resetAfterTrialEndFeaturIds array]
    G2 --> G3[Source: transition_rules.reset_after_trial_end]
    
    C --> H[Updated in legacy adapters]
    D --> H
    E --> H
    F --> H
    G --> H
    
    H --> I[legacyAttach.ts]
    H --> J[renew.ts]
    H --> K[updateQuantity.ts]
    H --> L[migrate.ts]
    
    style B fill:#f9f,stroke:#333,stroke-width:2px
    style G2 fill:#9f9,stroke:#333,stroke-width:2px
    style E2 fill:#9f9,stroke:#333,stroke-width:2px
```
</details>


<sub>Last reviewed commit: ed7df88</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->