### PR TITLE
fix: return active scenario for owned free products

### DIFF
--- a/server/src/internal/products/productUtils/productResponseUtils/getAttachScenario.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getAttachScenario.ts
@@ -74,6 +74,12 @@ export const getAttachScenario = ({
 		isFreeProduct(curFullProduct.prices) &&
 		isFreeProduct(fullProduct.prices)
 	) {
+		if (curSameProduct) {
+			if (isCustomerProductCanceling(curSameProduct)) {
+				return AttachScenario.Renew;
+			}
+			return AttachScenario.Active;
+		}
 		return AttachScenario.New;
 	}
 


### PR DESCRIPTION
When a customer owns a free product and another free product exists in the same group, getAttachScenario incorrectly returns 'new' instead of 'active'. This happens because curMainProduct matches by group (not exact ID), so it may pick a different product. The fix checks curSameProduct (exact ID match) before returning 'new' in the free-to-free block.

## Summary
- **Bug:** Free products owned by a customer show `scenario: 'new'` instead of `scenario: 'active'` in `GET /products_beta`, causing the pricing table to miss the "Current Plan" badge
- **Root cause:** In `getAttachScenario.ts`, the free-to-free check at lines 73-78 always returns `AttachScenario.New` without checking if the customer actually owns that specific product via `curSameProduct`
- **Fix:** Check `curSameProduct` (exact product ID match) before returning `New` in the free-to-free block, consistent with the existing pattern used for paid products


## Related Issues


## Type of Change
- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
The fix adds 6 lines to `server/src/internal/products/productUtils/productResponseUtils/getAttachScenario.ts`. It reuses the existing `curSameProduct` variable (already destructured but unused in this code path) and the existing `isCustomerProductCanceling` helper to handle the canceling edge case consistently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes attach scenario for free products so owned free plans return "active" (or "renew" if canceling) instead of "new". This ensures GET /products_beta marks the current free plan correctly and the pricing table shows the "Current Plan" badge.

- **Bug Fixes**
  - In free-to-free logic, check curSameProduct (exact ID) before defaulting to "new".
  - Return "active" when the customer owns the exact product; return "renew" if it’s canceling.
  - Change limited to getAttachScenario.ts (+6 lines).

<sup>Written for commit 9acd89468b6f485d91e01ff5957ab265868e902b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a bug where `GET /products_beta` returned `scenario: 'new'` instead of `scenario: 'active'` for free products the customer already owns. This caused the pricing table to miss the "Current Plan" badge.

- **Bug Fixes**
  - In the free-to-free code path of `getAttachScenario`, added a check for `curSameProduct` (exact product ID match) before defaulting to `AttachScenario.New`. When a customer owns the exact free product, it now correctly returns `Active` or `Renew` (if canceling).
  - The root cause was that `curMainProduct` matches by group (not exact ID), so when multiple free products exist in the same group, it could pick a different product — causing the exact-ID check at line 61 to miss and the free-to-free block to unconditionally return `New`.
  - The fix is consistent with the existing pattern used for paid add-ons (lines 42-51) and reuses the already-destructured `curSameProduct` variable.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix that follows existing patterns.
- The change adds 6 lines to a single file, reusing an already-destructured variable and an already-imported helper. The new logic mirrors the exact pattern used for paid add-ons earlier in the same function (lines 42-51). The fix addresses a clear bug where group-level matching caused incorrect scenario classification for owned free products.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/productUtils/productResponseUtils/getAttachScenario.ts | Adds `curSameProduct` check in the free-to-free block to return Active/Renew when the customer owns the exact free product, instead of unconditionally returning New. Clean, minimal fix consistent with existing patterns. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getAttachScenario] --> B{fullCus exists?}
    B -- No --> C[Return New]
    B -- Yes --> D[getExistingCusProducts]
    D --> E{isOneOff?}
    E -- Yes --> C
    E -- No --> F{is paid add-on?}
    F -- Yes --> G{curSameProduct exists?}
    G -- Yes --> H{canceling?}
    H -- Yes --> I[Return Renew]
    H -- No --> J[Return Active]
    G -- No --> K[Return New]
    F -- No --> L{is add-on?}
    L -- Yes --> K
    L -- No --> M{curMainProduct exists?}
    M -- No --> K
    M -- Yes --> N{curMainProduct.id == fullProduct.id?}
    N -- Yes --> O{canceling?}
    O -- Yes --> I
    O -- No --> J
    N -- No --> P{scheduled product?}
    P -- Yes --> Q[Return Scheduled]
    P -- No --> R{both free?}
    R -- Yes --> S{curSameProduct exists?}
    S -- Yes --> T{canceling?}
    T -- Yes --> I
    T -- No --> J
    S -- No --> K
    R -- No --> U{isUpgrade?}
    U -- Yes --> V[Return Upgrade]
    U -- No --> W{cur is paid, target is free?}
    W -- Yes --> X[Return Cancel]
    W -- No --> Y[Return Downgrade]

    style S fill:#90EE90,stroke:#006400,color:#000
    style T fill:#90EE90,stroke:#006400,color:#000
```
</details>


<sub>Last reviewed commit: 9acd894</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->