### PR TITLE
dev

### DIFF
--- a/server/src/internal/billing/v2/handlers/handlePreviewAttach.ts
+++ b/server/src/internal/billing/v2/handlers/handlePreviewAttach.ts
@@ -16,19 +16,19 @@ export const handlePreviewAttach = createRoute({
 		[ApiVersion.V1_Beta]: AttachParamsV0Schema,
 	},
 	resource: AffectedResource.Attach,
-	lock:
-		process.env.NODE_ENV !== "development"
-			? {
-					ttlMs: 120000,
-					errorMessage:
-						"Attach already in progress for this customer, try again in a few seconds",
-					getKey: (c) => {
-						const ctx = c.get("ctx");
-						const body = c.req.valid("json");
-						return `lock:attach:${ctx.org.id}:${ctx.env}:${body.customer_id}`;
-					},
-				}
-			: undefined,
+	// lock:
+	// 	process.env.NODE_ENV !== "development"
+	// 		? {
+	// 				ttlMs: 120000,
+	// 				errorMessage:
+	// 					"Attach already in progress for this customer, try again in a few seconds",
+	// 				getKey: (c) => {
+	// 					const ctx = c.get("ctx");
+	// 					const body = c.req.valid("json");
+	// 					return `lock:attach:${ctx.org.id}:${ctx.env}:${body.customer_id}`;
+	// 				},
+	// 			}
+	// 		: undefined,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const body = c.req.valid("json");


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the concurrency lock from the preview attach endpoint so requests no longer get blocked by "Attach already in progress" errors. This allows immediate retries and parallel attach attempts.

<sup>Written for commit d4755dc6fc7b923ac9a29426302e0a5ffb9487fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the distributed lock from the `handlePreviewAttach` endpoint. Since this is a preview (read-only) endpoint that calls `billingActions.attach` with `preview: true`, the lock was unnecessary — preview operations don't mutate state and don't need concurrency protection. This aligns with `handlePreviewUpdateSubscription`, which also has no lock.

- **Bug fixes**: Removes unnecessary distributed lock from the preview attach endpoint, which could have caused false "attach already in progress" errors on concurrent preview requests for the same customer
- **Improvements**: Lock code is commented out instead of deleted — should be fully removed to keep the codebase clean
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it removes an unnecessary lock from a read-only preview endpoint
- The change is small and well-understood: removing a distributed lock from a read-only preview endpoint. The actual mutation endpoint (handleAttachV2) retains its lock. The only concern is the commented-out code that should be deleted rather than left in place.
- No files require special attention — the change is straightforward

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/handlers/handlePreviewAttach.ts | Removes distributed lock from preview attach endpoint by commenting it out. The lock was unnecessary since preview is a read-only operation. The commented-out code should be deleted entirely. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant PreviewAttach as /billing/preview_attach
    participant BillingActions as billingActions.attach
    participant Response

    Note over PreviewAttach: Lock removed (was unnecessary)
    Client->>PreviewAttach: POST preview_attach
    PreviewAttach->>BillingActions: attach({ preview: true })
    BillingActions-->>PreviewAttach: { billingContext, billingPlan }
    PreviewAttach->>Response: billingPlanToPreviewResponse()
    Response-->>Client: 200 { preview data }
```
</details>


<sub>Last reviewed commit: d4755dc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->