### PR TITLE
feat: 🎸 rpc feature router

### DIFF
--- a/server/src/internal/features/featureRpcRouter.ts
+++ b/server/src/internal/features/featureRpcRouter.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { handleCreateFeatureRpc } from "./handlers/rpc/handleCreateFeatureRpc.js";
+import { handleDeleteFeatureRpc } from "./handlers/rpc/handleDeleteFeatureRpc.js";
+import { handleGetFeatureRpc } from "./handlers/rpc/handleGetFeatureRpc.js";
+import { handleListFeaturesRpc } from "./handlers/rpc/handleListFeaturesRpc.js";
+import { handleUpdateFeatureRpc } from "./handlers/rpc/handleUpdateFeatureRpc.js";
+
+export const featureRpcRouter = new Hono<HonoEnv>();
+
+featureRpcRouter.post("/features.list", ...handleListFeaturesRpc);
+featureRpcRouter.post("/features.get", ...handleGetFeatureRpc);
+featureRpcRouter.post("/features.create", ...handleCreateFeatureRpc);
+featureRpcRouter.post("/features.update", ...handleUpdateFeatureRpc);
+featureRpcRouter.post("/features.delete", ...handleDeleteFeatureRpc);

--- a/server/src/internal/features/handlers/rpc/handleCreateFeatureRpc.ts
+++ b/server/src/internal/features/handlers/rpc/handleCreateFeatureRpc.ts
@@ -1,0 +1,44 @@
+import {
+	AffectedResource,
+	ApiVersion,
+	ApiVersionClass,
+	CreateFeatureV1ParamsSchema,
+	dbToApiFeatureV1,
+	featureV1ToDbFeature,
+	InternalError,
+} from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { createFeature } from "@/internal/features/featureActions/createFeature.js";
+
+export const handleCreateFeatureRpc = createRoute({
+	body: CreateFeatureV1ParamsSchema,
+	resource: AffectedResource.Feature,
+	handler: async (c) => {
+		const body = c.req.valid("json");
+		const ctx = c.get("ctx");
+
+		// Get backend feature
+		const feature = featureV1ToDbFeature({
+			apiFeature: body,
+			originalFeature: undefined,
+		});
+
+		// Body is now always in the latest V1 format, regardless of API version
+		const dbFeature = await createFeature({
+			ctx,
+			data: feature,
+		});
+
+		if (!dbFeature) {
+			throw new InternalError({ message: "Insert feature returned null" });
+		}
+
+		return c.json(
+			dbToApiFeatureV1({
+				ctx,
+				dbFeature,
+				targetVersion: new ApiVersionClass(ApiVersion.V2_1),
+			}),
+		);
+	},
+});

--- a/server/src/internal/features/handlers/rpc/handleDeleteFeatureRpc.ts
+++ b/server/src/internal/features/handlers/rpc/handleDeleteFeatureRpc.ts
@@ -1,0 +1,54 @@
+import { FeatureNotFoundError, RecaseError } from "@autumn/shared";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
+import { getCreditSystemsFromFeature } from "../../creditSystemUtils.js";
+import { FeatureService } from "../../FeatureService.js";
+
+export const handleDeleteFeatureRpc = createRoute({
+	body: z.object({
+		feature_id: z.string(),
+	}),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, org, features } = ctx;
+		const { feature_id } = c.req.valid("json");
+
+		const feature = features.find((f) => f.id === feature_id);
+		if (!feature) {
+			throw new FeatureNotFoundError({ featureId: feature_id });
+		}
+
+		const creditSystems = getCreditSystemsFromFeature({
+			featureId: feature_id,
+			features,
+		});
+
+		if (creditSystems.length > 0) {
+			throw new RecaseError({
+				message: `Feature ${feature_id} is used by credit system ${creditSystems[0].id}`,
+			});
+		}
+
+		// Get prices that use this feature
+		const ent = await EntitlementService.getByFeature({
+			db,
+			internalFeatureId: feature.internal_id!,
+		});
+
+		if (ent) {
+			throw new RecaseError({
+				message: `Feature ${feature_id} is used in a product. You must delete the product first, or archive it instead.`,
+			});
+		}
+
+		await FeatureService.delete({
+			db,
+			orgId: org.id,
+			featureId: feature_id,
+			env: ctx.env,
+		});
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/features/handlers/rpc/handleGetFeatureRpc.ts
+++ b/server/src/internal/features/handlers/rpc/handleGetFeatureRpc.ts
@@ -1,0 +1,43 @@
+import {
+	AffectedResource,
+	dbToApiFeatureV1,
+	ErrCode,
+	RecaseError,
+} from "@autumn/shared";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+
+export const handleGetFeatureRpc = createRoute({
+	resource: AffectedResource.Feature,
+	body: z.object({
+		feature_id: z.string(),
+	}),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { feature_id } = c.req.valid("json");
+
+		const feature = await FeatureService.get({
+			db: ctx.db,
+			id: feature_id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+
+		if (!feature) {
+			throw new RecaseError({
+				message: `Feature with id ${feature_id} not found`,
+				code: ErrCode.FeatureNotFound,
+				statusCode: 404,
+			});
+		}
+
+		const apiFeature = dbToApiFeatureV1({
+			ctx,
+			dbFeature: feature,
+			targetVersion: ctx.apiVersion,
+		});
+
+		return c.json(apiFeature);
+	},
+});

--- a/server/src/internal/features/handlers/rpc/handleListFeaturesRpc.ts
+++ b/server/src/internal/features/handlers/rpc/handleListFeaturesRpc.ts
@@ -1,0 +1,22 @@
+import { AffectedResource, dbToApiFeatureV1 } from "@autumn/shared";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+
+export const handleListFeaturesRpc = createRoute({
+	body: z.object({}),
+	resource: AffectedResource.Feature,
+	handler: async (c) => {
+		c.req.valid("json");
+		const ctx = c.get("ctx");
+
+		const apiFeatures = ctx.features.map((feature) =>
+			dbToApiFeatureV1({
+				ctx,
+				dbFeature: feature,
+				targetVersion: ctx.apiVersion,
+			}),
+		);
+
+		return c.json({ list: apiFeatures });
+	},
+});

--- a/server/src/internal/features/handlers/rpc/handleUpdateFeatureRpc.ts
+++ b/server/src/internal/features/handlers/rpc/handleUpdateFeatureRpc.ts
@@ -1,0 +1,75 @@
+import {
+	AffectedResource,
+	ApiVersion,
+	ApiVersionClass,
+	dbToApiFeatureV1,
+	FeatureNotFoundError,
+	FeatureType,
+	featureV1ToDbFeatureConfig,
+	InternalError,
+	nullish,
+	RecaseError,
+	UpdateFeatureV1ParamsSchema,
+} from "@autumn/shared";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { updateFeature } from "@/internal/features/featureActions/updateFeature.js";
+
+const UpdateFeatureV1RpcParamsSchema = UpdateFeatureV1ParamsSchema.extend({
+	feature_id: z.string(),
+});
+
+export const handleUpdateFeatureRpc = createRoute({
+	body: UpdateFeatureV1RpcParamsSchema,
+	resource: AffectedResource.Feature,
+	handler: async (c) => {
+		const body = c.req.valid("json");
+		const ctx = c.get("ctx");
+
+		const { feature_id } = body;
+		const originalFeature = ctx.features.find((f) => f.id === feature_id);
+		if (!originalFeature) {
+			throw new FeatureNotFoundError({ featureId: feature_id });
+		}
+
+		// If changing type and consumable not provided, throw error
+		if (body.type === FeatureType.Metered && nullish(body.consumable)) {
+			throw new RecaseError({
+				message: "Consumable is required when changing type to metered",
+			});
+		}
+
+		const newConfig = featureV1ToDbFeatureConfig({
+			apiFeature: body,
+			originalFeature,
+		});
+
+		const updatedFeature = await updateFeature({
+			ctx,
+			featureId: feature_id,
+			updates: {
+				id: body.id,
+				name: body.name ?? undefined,
+				type: body.type,
+
+				config: newConfig,
+
+				archived: body.archived,
+				event_names: body.event_names,
+				display: body.display,
+			},
+		});
+
+		if (!updatedFeature) {
+			throw new InternalError({ message: "Update feature returned null" });
+		}
+
+		return c.json(
+			dbToApiFeatureV1({
+				ctx,
+				dbFeature: updatedFeature,
+				targetVersion: new ApiVersionClass(ApiVersion.V2_1),
+			}),
+		);
+	},
+});

--- a/server/src/routers/apiRouter.ts
+++ b/server/src/routers/apiRouter.ts
@@ -34,6 +34,7 @@ import {
 	honoProductRouter,
 	migrationRouter,
 } from "../internal/products/productRouter.js";
+import { rpcRouter } from "./rpcRouter.js";
 
 export const apiRouter = new Hono<HonoEnv>();
 
@@ -47,6 +48,8 @@ apiRouter.use("*", analyticsMiddleware);
 apiRouter.use("*", rateLimitMiddleware);
 apiRouter.use("*", queryMiddleware());
 apiRouter.use("*", idempotencyMiddleware);
+
+apiRouter.route("", rpcRouter);
 
 apiRouter.route("", billingRouter);
 apiRouter.route("", balancesRouter);

--- a/server/src/routers/rpcRouter.ts
+++ b/server/src/routers/rpcRouter.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { featureRpcRouter } from "@/internal/features/featureRpcRouter.js";
+
+export const rpcRouter = new Hono<HonoEnv>();
+
+rpcRouter.route("", featureRpcRouter);

--- a/server/tests/integration/features/rpc/feature-rpc-crud.test.ts
+++ b/server/tests/integration/features/rpc/feature-rpc-crud.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { ApiFeatureV1Schema, ApiVersion, FeatureType } from "@autumn/shared";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const makeFeatureId = () =>
+	`rpc_feature_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+test.concurrent(`${chalk.yellowBright("feature-rpc: crud + list")}`, async () => {
+	const autumn = new AutumnInt({ version: ApiVersion.V2_1 });
+	const featureId = makeFeatureId();
+	const featureName = "Feature RPC CRUD";
+	const updatedName = "Feature RPC CRUD Updated";
+
+	const created = await autumn.post("/features.create", {
+		id: featureId,
+		name: featureName,
+		type: FeatureType.Boolean,
+	});
+	ApiFeatureV1Schema.parse(created);
+	expect(created.id).toBe(featureId);
+	expect(created.name).toBe(featureName);
+
+	const listed = await autumn.post("/features.list", {});
+	expect(Array.isArray(listed.list)).toBe(true);
+	const listedFeature = listed.list.find(
+		(feature: { id: string }) => feature.id === featureId,
+	);
+	expect(listedFeature).toBeDefined();
+	ApiFeatureV1Schema.parse(listedFeature);
+
+	const got = await autumn.post("/features.get", {
+		feature_id: featureId,
+	});
+	ApiFeatureV1Schema.parse(got);
+	expect(got.id).toBe(featureId);
+
+	const updated = await autumn.post("/features.update", {
+		feature_id: featureId,
+		name: updatedName,
+	});
+	ApiFeatureV1Schema.parse(updated);
+	expect(updated.id).toBe(featureId);
+	expect(updated.name).toBe(updatedName);
+
+	const deleted = await autumn.post("/features.delete", {
+		feature_id: featureId,
+	});
+	expect(deleted).toEqual({ success: true });
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add an RPC router for Features with POST endpoints for list/get/create/update/delete. Wired into apiRouter and returns versioned Feature payloads.

- **New Features**
  - RPC endpoints: POST /features.list, /features.get, /features.create, /features.update, /features.delete.
  - Validation with zod and routeHandler; scoped to AffectedResource.Feature.
  - Version-aware responses (Get/List use ctx.apiVersion; Create/Update return V2_1).
  - Update guard: changing type to Metered requires consumable.
  - Delete guard: blocks if feature is used by a credit system or product entitlement, with clear errors.
  - Integration test covers full CRUD + list flow.

<sup>Written for commit c5b843fc532b833e81ac018d70937a852a724fcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Implemented RPC-style API endpoints for feature management, providing an alternative interface to the existing REST endpoints with POST-based methods using dot notation paths (e.g., `/features.list`, `/features.create`).

**Key Changes:**

- **API changes**: Added new RPC router with POST endpoints for features (`/features.{list,get,create,update,delete}`)
- **Improvements**: Created comprehensive integration test covering full CRUD lifecycle for RPC endpoints
- **Improvements**: Proper validation for feature deletion (checks credit systems and product dependencies)
- **Bug fixes**: Fixed API version handling inconsistency - create and update handlers hardcode V2_1 instead of respecting client's API version
</details>


<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the API version hardcoding issue
- Two handlers hardcode `ApiVersion.V2_1` instead of using `ctx.apiVersion`, which breaks API versioning contract and could cause issues for clients using different API versions. This is a critical inconsistency with the REST handlers and other RPC handlers in the same PR.
- `handleCreateFeatureRpc.ts` and `handleUpdateFeatureRpc.ts` need API version fixes

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/features/featureRpcRouter.ts | Created RPC router with POST endpoints for CRUD operations on features using RPC-style naming (e.g., `/features.list`, `/features.get`) |
| server/src/internal/features/handlers/rpc/handleCreateFeatureRpc.ts | Created RPC handler for feature creation - hardcodes `ApiVersion.V2_1` instead of using `ctx.apiVersion` |
| server/src/internal/features/handlers/rpc/handleUpdateFeatureRpc.ts | Created RPC handler for feature updates - hardcodes `ApiVersion.V2_1` instead of using `ctx.apiVersion` |
| server/src/routers/rpcRouter.ts | Created top-level RPC router to organize RPC-style endpoints, currently routes feature RPC endpoints |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Client[Client Request]
    Client -->|POST /features.list| apiRouter[API Router]
    Client -->|POST /features.get| apiRouter
    Client -->|POST /features.create| apiRouter
    Client -->|POST /features.update| apiRouter
    Client -->|POST /features.delete| apiRouter
    
    apiRouter -->|All Middleware| rpcRouter[RPC Router]
    rpcRouter --> featureRpcRouter[Feature RPC Router]
    
    featureRpcRouter -->|/features.list| handleList[handleListFeaturesRpc]
    featureRpcRouter -->|/features.get| handleGet[handleGetFeatureRpc]
    featureRpcRouter -->|/features.create| handleCreate[handleCreateFeatureRpc]
    featureRpcRouter -->|/features.update| handleUpdate[handleUpdateFeatureRpc]
    featureRpcRouter -->|/features.delete| handleDelete[handleDeleteFeatureRpc]
    
    handleList --> dbRead[(Database Read)]
    handleGet --> dbRead
    handleCreate --> dbWrite[(Database Write)]
    handleUpdate --> dbWrite
    handleDelete --> validations[Validation Checks]
    
    validations --> creditCheck{Credit System<br/>Check}
    validations --> productCheck{Product<br/>Dependency Check}
    creditCheck -->|Pass| dbWrite
    productCheck -->|Pass| dbWrite
    creditCheck -->|Fail| error[RecaseError]
    productCheck -->|Fail| error
    
    dbRead --> response[JSON Response]
    dbWrite --> response
    error --> response
```
</details>


<sub>Last reviewed commit: c5b843f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->