### PR TITLE
fix: added sqs client restart

### DIFF
--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -1,334 +1,261 @@
 await import("../sentry.js");
 
+import { ms } from "@autumn/shared";
 import {
 	DeleteMessageBatchCommand,
 	DeleteMessageCommand,
 	type Message,
 	ReceiveMessageCommand,
+	type SQSClient,
 } from "@aws-sdk/client-sqs";
 import * as Sentry from "@sentry/bun";
-import type { Logger } from "pino";
 import { type DrizzleCli, initDrizzle } from "@/db/initDrizzle.js";
 import { logger } from "@/external/logtail/logtailUtils.js";
-import { runActionHandlerTask } from "@/internal/analytics/runActionHandlerTask.js";
-import { runInsertEventBatch } from "@/internal/balances/events/runInsertEventBatch.js";
-import { syncItemV3 } from "@/internal/balances/utils/sync/syncItemV3.js";
-import { grantCheckoutReward } from "@/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.js";
-import { sendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.js";
 import { verifyCacheConsistency } from "@/internal/billing/v2/workflows/verifyCacheConsistency/verifyCacheConsistency.js";
-import { runClearCreditSystemCacheTask } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
-import { generateFeatureDisplay } from "@/internal/features/workflows/generateFeatureDisplay.js";
-import { runMigrationTask } from "@/internal/migrations/runMigrationTask.js";
-import { runRewardMigrationTask } from "@/internal/migrations/runRewardMigrationTask.js";
-import { detectBaseVariant } from "@/internal/products/productUtils/detectProductVariant.js";
-import { runTriggerCheckoutReward } from "@/internal/rewards/triggerCheckoutReward.js";
 import { generateId } from "@/utils/genUtils.js";
-import { addWorkflowToLogs } from "@/utils/logging/addContextToLogs.js";
 import { hatchet } from "../external/hatchet/initHatchet.js";
-import { setSentryTags } from "../external/sentry/sentryUtils.js";
-import { createWorkerContext } from "./createWorkerContext.js";
-import { QUEUE_URL, sqs } from "./initSqs.js";
+import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
+import { processMessage, type SqsJob } from "./processMessage.js";
 
-const actionHandlers = [
-	JobName.HandleProductsUpdated,
-	JobName.HandleCustomerCreated,
-];
-
-interface SqsJob {
-	name: string;
-	data: any;
-}
-
-/**
- * Process a single SQS message
- */
-const processMessage = async ({
-	message,
-	db,
-}: {
-	message: Message;
-	db: DrizzleCli;
-}) => {
-	if (!message.Body) {
-		console.warn("Received message without body");
-		return;
-	}
-
-	const job: SqsJob = JSON.parse(message.Body);
-
-	const workerLogger = addWorkflowToLogs({
-		logger: logger,
-		workflowContext: {
-			id: message.MessageId ?? generateId("job"),
-			name: job.name,
-			payload: job.data,
-		},
-	});
-
-	workerLogger.info(`Processing message: ${job.name}`);
-
-	try {
-		if (job.name === JobName.DetectBaseVariant) {
-			await detectBaseVariant({
-				db,
-				curProduct: job.data.curProduct,
-				logger: workerLogger as Logger,
-			});
-			return;
-		}
-
-		if (job.name === JobName.ClearCreditSystemCustomerCache) {
-			await runClearCreditSystemCacheTask({
-				db,
-				payload: job.data,
-				logger: workerLogger,
-			});
-			return;
-		}
-
-		// Jobs below need worker context
-		const ctx = await createWorkerContext({
-			db,
-			payload: job.data,
-			logger: workerLogger,
-		});
-
-		if (ctx) {
-			setSentryTags({
-				ctx,
-				messageId: message.MessageId,
-			});
-		}
-
-		if (job.name === JobName.Migration) {
-			if (!ctx) {
-				workerLogger.error("No context found for migration job");
-				return;
-			}
-			await runMigrationTask({ ctx, payload: job.data });
-			return;
-		}
-
-		if (job.name === JobName.GenerateFeatureDisplay) {
-			if (!ctx) {
-				workerLogger.error("No context found for generate feature display job");
-				return;
-			}
-			await generateFeatureDisplay({
-				ctx,
-				payload: job.data,
-			});
-			return;
-		}
-
-		if (job.name === JobName.SendProductsUpdated) {
-			if (!ctx) {
-				workerLogger.error("No context found for send products updated job");
-				return;
-			}
-			await sendProductsUpdated({
-				ctx,
-				payload: job.data,
-			});
-			return;
-		}
-
-		if (actionHandlers.includes(job.name as JobName)) {
-			// Note: action handlers need BullMQ queue for nested jobs
-			// This will need to be refactored when migrating action handlers to SQS
-			await runActionHandlerTask({
-				ctx,
-				jobName: job.name as JobName,
-				payload: job.data,
-			});
-			return;
-		}
-
-		if (job.name === JobName.RewardMigration) {
-			await runRewardMigrationTask({
-				db,
-				payload: job.data,
-				logger: workerLogger,
-			});
-			return;
-		}
-
-		if (job.name === JobName.SyncBalanceBatchV3) {
-			if (!ctx) {
-				workerLogger.error("No context found for sync balance batch v3 job");
-				return;
-			}
-
-			await syncItemV3({
-				ctx,
-				payload: job.data,
-			});
-			return;
-		}
-
-		if (job.name === JobName.InsertEventBatch) {
-			await runInsertEventBatch({
-				db,
-				payload: job.data,
-				logger: workerLogger as Logger,
-			});
-			return;
-		}
-
-		if (job.name === JobName.TriggerCheckoutReward) {
-			if (!ctx) {
-				workerLogger.error("No context found for trigger checkout reward job");
-				return;
-			}
-			await runTriggerCheckoutReward({
-				ctx,
-				payload: job.data,
-			});
-		}
-
-		if (job.name === JobName.GrantCheckoutReward) {
-			if (!ctx) {
-				workerLogger.error("No context found for grant checkout reward job");
-				return;
-			}
-			await grantCheckoutReward({
-				ctx,
-				payload: job.data,
-			});
-		}
-	} catch (error) {
-		Sentry.captureException(error);
-		if (error instanceof Error) {
-			workerLogger.error(`Failed to process SQS job: ${job.name}`, {
-				jobName: job.name,
-				error: {
-					message: error.message,
-					stack: error.stack,
-				},
-			});
-		}
-	}
-};
-
+// ============ State ============
 let isRunning = true;
-const isFifoQueue = QUEUE_URL.endsWith(".fifo");
 let abortController: AbortController;
+const isFifoQueue = QUEUE_URL.endsWith(".fifo");
 
-// Tracking for periodic stats
+// Stats tracking
 let messagesProcessed = 0;
 let lastStatsTime = Date.now();
 
-/**
- * Single SQS polling loop - runs continuously until shutdown
- */
+// Stale connection detection
+let consecutiveEmptyPolls = 0;
+let lastHeartbeatTime = Date.now();
+const EMPTY_POLL_THRESHOLD = 15; // ~5 min of empty polls (15 * 20s wait)
+const HEARTBEAT_INTERVAL_MS = ms.minutes(5);
+
+// Zero-message alert tracking
+let consecutiveZeroMessageIntervals = 0;
+const ZERO_MESSAGE_ALERT_THRESHOLD = 15; // ~15 min of 0 messages
+
+// ============ Helper Functions ============
+
+const logPrefix = () => `[SQS Worker ${process.pid}]`;
+
+const alertZeroMessages = () => {
+	const minutes = consecutiveZeroMessageIntervals;
+	logger.warn(`${logPrefix()} No messages processed for ${minutes} minutes`, {
+		type: "worker",
+		queueUrl: QUEUE_URL,
+		consecutiveIntervals: minutes,
+	});
+	Sentry.captureMessage(
+		`SQS Worker ${process.pid}: No messages processed for ${minutes} minutes`,
+		"warning",
+	);
+};
+
+const logStatsAndCheckZeroMessages = () => {
+	const elapsedSeconds = ((Date.now() - lastStatsTime) / 1000).toFixed(0);
+	console.log(
+		`${logPrefix()} Processed ${messagesProcessed} messages in ${elapsedSeconds}s`,
+	);
+
+	if (messagesProcessed === 0) {
+		consecutiveZeroMessageIntervals++;
+		if (consecutiveZeroMessageIntervals >= ZERO_MESSAGE_ALERT_THRESHOLD) {
+			alertZeroMessages();
+			consecutiveZeroMessageIntervals = 0;
+		}
+	} else {
+		consecutiveZeroMessageIntervals = 0;
+	}
+
+	messagesProcessed = 0;
+	lastStatsTime = Date.now();
+};
+
+const createReceiveCommand = () =>
+	new ReceiveMessageCommand({
+		QueueUrl: QUEUE_URL,
+		MaxNumberOfMessages: 10,
+		WaitTimeSeconds: 20,
+		VisibilityTimeout: 30,
+		...(isFifoQueue && { ReceiveRequestAttemptId: generateId("receive") }),
+	});
+
+const deleteMigrationJobImmediately = async ({
+	sqs,
+	message,
+	job,
+}: {
+	sqs: SQSClient;
+	message: Message;
+	job: SqsJob;
+}) => {
+	logger.info(
+		`Returning success immediately for migration job ${job.data.migrationJobId}`,
+	);
+	await sqs.send(
+		new DeleteMessageCommand({
+			QueueUrl: QUEUE_URL,
+			ReceiptHandle: message.ReceiptHandle,
+		}),
+	);
+};
+
+const handleSingleMessage = async ({
+	sqs,
+	message,
+	db,
+}: {
+	sqs: SQSClient;
+	message: Message;
+	db: DrizzleCli;
+}): Promise<{ id: string; receiptHandle: string } | null> => {
+	if (!isRunning || !message.Body) return null;
+
+	const job: SqsJob = JSON.parse(message.Body);
+
+	// Migration jobs: delete IMMEDIATELY before processing (long-running, avoid timeout redelivery)
+	if (job.name === JobName.Migration) {
+		await deleteMigrationJobImmediately({ sqs, message, job });
+	}
+
+	await processMessage({ message, db });
+	messagesProcessed++;
+
+	// Return delete info (skip migration jobs - already deleted)
+	if (message.ReceiptHandle && job.name !== JobName.Migration) {
+		return { id: message.MessageId!, receiptHandle: message.ReceiptHandle };
+	}
+	return null;
+};
+
+const batchDeleteMessages = async ({
+	sqs,
+	toDelete,
+}: {
+	sqs: SQSClient;
+	toDelete: { Id: string; ReceiptHandle: string }[];
+}) => {
+	if (toDelete.length === 0) return;
+
+	try {
+		await sqs.send(
+			new DeleteMessageBatchCommand({ QueueUrl: QUEUE_URL, Entries: toDelete }),
+		);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		console.error(`${logPrefix()} Batch delete failed: ${message}`);
+	}
+};
+
+const handleEmptyPoll = (): SQSClient | null => {
+	consecutiveEmptyPolls++;
+
+	// Periodic heartbeat
+	const now = Date.now();
+	if (now - lastHeartbeatTime > HEARTBEAT_INTERVAL_MS) {
+		console.log(
+			`${logPrefix()} Heartbeat - polling active, ${consecutiveEmptyPolls} consecutive empty polls`,
+		);
+		lastHeartbeatTime = now;
+	}
+
+	// Recreate client if too many empty polls
+	if (consecutiveEmptyPolls >= EMPTY_POLL_THRESHOLD) {
+		console.warn(
+			`${logPrefix()} ${consecutiveEmptyPolls} consecutive empty polls - recreating SQS client`,
+		);
+		consecutiveEmptyPolls = 0;
+		abortController = new AbortController();
+		return recreateSqsClient();
+	}
+
+	return null;
+};
+
+const handlePollingError = async (
+	error: unknown,
+): Promise<SQSClient | null> => {
+	const err = error as { name?: string; message?: string };
+
+	if (err.name === "AbortError" || err.name === "RequestAbortedError") {
+		console.log(`${logPrefix()} Polling aborted (shutdown)`);
+		return null;
+	}
+
+	if (!isRunning) return null;
+
+	console.error(`${logPrefix()} Polling error: ${err.message}`);
+
+	// Recreate client on repeated errors
+	consecutiveEmptyPolls++;
+	if (consecutiveEmptyPolls >= EMPTY_POLL_THRESHOLD) {
+		console.warn(`${logPrefix()} Repeated errors - recreating SQS client`);
+		consecutiveEmptyPolls = 0;
+		abortController = new AbortController();
+		await new Promise((resolve) => setTimeout(resolve, 5000));
+		return recreateSqsClient();
+	}
+
+	await new Promise((resolve) => setTimeout(resolve, 5000));
+	return null;
+};
+
+// ============ Main Polling Loop ============
+
 const startPollingLoop = async ({ db }: { db: DrizzleCli }) => {
-	console.log(`[SQS Worker ${process.pid}] Started polling ${QUEUE_URL}`);
+	console.log(`${logPrefix()} Started polling ${QUEUE_URL}`);
 	abortController = new AbortController();
 
-	// Log stats every 60 seconds
-	const statsInterval = setInterval(() => {
-		const elapsed = ((Date.now() - lastStatsTime) / 1000).toFixed(0);
-		console.log(
-			`[SQS Worker ${process.pid}] Processed ${messagesProcessed} messages in ${elapsed}s`,
-		);
-		messagesProcessed = 0;
-		lastStatsTime = Date.now();
-	}, 60000);
+	const statsInterval = setInterval(logStatsAndCheckZeroMessages, 60000);
+
+	let sqs = getSqsClient();
 
 	while (isRunning) {
 		try {
-			const command = new ReceiveMessageCommand({
-				QueueUrl: QUEUE_URL,
-				MaxNumberOfMessages: 10,
-				WaitTimeSeconds: 20,
-				VisibilityTimeout: 30,
-				...(isFifoQueue && {
-					ReceiveRequestAttemptId: generateId("receive"),
-				}),
-			});
-
-			const response = await sqs.send(command, {
+			const response = await sqs.send(createReceiveCommand(), {
 				abortSignal: abortController.signal,
 			});
 
-			if (response.Messages && response.Messages.length > 0) {
-				// Track messages to batch delete (excludes migration jobs which are deleted immediately)
-				const toDelete: { Id: string; ReceiptHandle: string }[] = [];
+			const messages = response.Messages ?? [];
 
-				await Promise.allSettled(
-					response.Messages.map(async (message) => {
-						if (!isRunning || !message.Body) return;
+			if (messages.length > 0) {
+				consecutiveEmptyPolls = 0;
 
-						const job: SqsJob = JSON.parse(message.Body);
-
-						// Migration jobs: delete IMMEDIATELY before processing (long-running, avoid timeout redelivery)
-						if (job.name === JobName.Migration) {
-							logger.info(
-								`Returning success immediately for migration job ${job.data.migrationJobId}`,
-							);
-							await sqs.send(
-								new DeleteMessageCommand({
-									QueueUrl: QUEUE_URL,
-									ReceiptHandle: message.ReceiptHandle,
-								}),
-							);
-						}
-
-						try {
-							await processMessage({ message, db });
-							messagesProcessed++;
-						} catch (error) {
-							if (error instanceof Error) {
-								logger.error(
-									`Failed to process message ${message.MessageId}: ${error.message}`,
-								);
-							}
-						}
-
-						// Queue for batch delete (skip migration jobs - already deleted)
-						if (message.ReceiptHandle && job.name !== JobName.Migration) {
-							toDelete.push({
-								Id: message.MessageId!,
-								ReceiptHandle: message.ReceiptHandle,
-							});
-						}
-					}),
+				const results = await Promise.allSettled(
+					messages.map((message) => handleSingleMessage({ sqs, message, db })),
 				);
 
-				// Batch delete all non-migration messages
-				if (toDelete.length > 0) {
-					try {
-						await sqs.send(
-							new DeleteMessageBatchCommand({
-								QueueUrl: QUEUE_URL,
-								Entries: toDelete,
-							}),
-						);
-					} catch (deleteError: any) {
-						console.error(
-							`[SQS Worker ${process.pid}] Batch delete failed: ${deleteError.message}`,
-						);
-					}
-				}
-			}
-		} catch (error: any) {
-			if (error.name === "AbortError" || error.name === "RequestAbortedError") {
-				console.log(`[SQS Worker ${process.pid}] Polling aborted (shutdown)`);
-				break;
-			}
+				const toDelete = results
+					.filter(
+						(
+							r,
+						): r is PromiseFulfilledResult<{
+							id: string;
+							receiptHandle: string;
+						}> => r.status === "fulfilled" && r.value !== null,
+					)
+					.map((r) => ({
+						Id: r.value.id,
+						ReceiptHandle: r.value.receiptHandle,
+					}));
 
-			if (isRunning) {
-				console.error(
-					`[SQS Worker ${process.pid}] Polling error: ${error.message}`,
-				);
-				await new Promise((resolve) => setTimeout(resolve, 5000));
+				await batchDeleteMessages({ sqs, toDelete });
+			} else {
+				const newClient = handleEmptyPoll();
+				if (newClient) sqs = newClient;
 			}
+		} catch (error) {
+			const newClient = await handlePollingError(error);
+			if (newClient) sqs = newClient;
+			else if ((error as { name?: string }).name === "AbortError") break;
 		}
 	}
 
 	clearInterval(statsInterval);
-	console.log(`[SQS Worker ${process.pid}] Stopped`);
+	console.log(`${logPrefix()} Stopped`);
 };
 
 /**

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -1,0 +1,199 @@
+import type { Message } from "@aws-sdk/client-sqs";
+import * as Sentry from "@sentry/bun";
+import type { Logger } from "pino";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { runActionHandlerTask } from "@/internal/analytics/runActionHandlerTask.js";
+import { runInsertEventBatch } from "@/internal/balances/events/runInsertEventBatch.js";
+import { syncItemV3 } from "@/internal/balances/utils/sync/syncItemV3.js";
+import { grantCheckoutReward } from "@/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.js";
+import { sendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.js";
+import { runClearCreditSystemCacheTask } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
+import { generateFeatureDisplay } from "@/internal/features/workflows/generateFeatureDisplay.js";
+import { runMigrationTask } from "@/internal/migrations/runMigrationTask.js";
+import { runRewardMigrationTask } from "@/internal/migrations/runRewardMigrationTask.js";
+import { detectBaseVariant } from "@/internal/products/productUtils/detectProductVariant.js";
+import { runTriggerCheckoutReward } from "@/internal/rewards/triggerCheckoutReward.js";
+import { generateId } from "@/utils/genUtils.js";
+import { addWorkflowToLogs } from "@/utils/logging/addContextToLogs.js";
+import { setSentryTags } from "../external/sentry/sentryUtils.js";
+import { createWorkerContext } from "./createWorkerContext.js";
+import { JobName } from "./JobName.js";
+
+const actionHandlers = [
+	JobName.HandleProductsUpdated,
+	JobName.HandleCustomerCreated,
+];
+
+export interface SqsJob {
+	name: string;
+	data: any;
+}
+
+export const processMessage = async ({
+	message,
+	db,
+}: {
+	message: Message;
+	db: DrizzleCli;
+}) => {
+	if (!message.Body) {
+		console.warn("Received message without body");
+		return;
+	}
+
+	const job: SqsJob = JSON.parse(message.Body);
+
+	const workerLogger = addWorkflowToLogs({
+		logger: logger,
+		workflowContext: {
+			id: message.MessageId ?? generateId("job"),
+			name: job.name,
+			payload: job.data,
+		},
+	});
+
+	workerLogger.info(`Processing message: ${job.name}`);
+
+	try {
+		if (job.name === JobName.DetectBaseVariant) {
+			await detectBaseVariant({
+				db,
+				curProduct: job.data.curProduct,
+				logger: workerLogger as Logger,
+			});
+			return;
+		}
+
+		if (job.name === JobName.ClearCreditSystemCustomerCache) {
+			await runClearCreditSystemCacheTask({
+				db,
+				payload: job.data,
+				logger: workerLogger,
+			});
+			return;
+		}
+
+		// Jobs below need worker context
+		const ctx = await createWorkerContext({
+			db,
+			payload: job.data,
+			logger: workerLogger,
+		});
+
+		if (ctx) {
+			setSentryTags({
+				ctx,
+				messageId: message.MessageId,
+			});
+		}
+
+		if (job.name === JobName.Migration) {
+			if (!ctx) {
+				workerLogger.error("No context found for migration job");
+				return;
+			}
+			await runMigrationTask({ ctx, payload: job.data });
+			return;
+		}
+
+		if (job.name === JobName.GenerateFeatureDisplay) {
+			if (!ctx) {
+				workerLogger.error("No context found for generate feature display job");
+				return;
+			}
+			await generateFeatureDisplay({
+				ctx,
+				payload: job.data,
+			});
+			return;
+		}
+
+		if (job.name === JobName.SendProductsUpdated) {
+			if (!ctx) {
+				workerLogger.error("No context found for send products updated job");
+				return;
+			}
+			await sendProductsUpdated({
+				ctx,
+				payload: job.data,
+			});
+			return;
+		}
+
+		if (actionHandlers.includes(job.name as JobName)) {
+			// Note: action handlers need BullMQ queue for nested jobs
+			// This will need to be refactored when migrating action handlers to SQS
+			await runActionHandlerTask({
+				ctx,
+				jobName: job.name as JobName,
+				payload: job.data,
+			});
+			return;
+		}
+
+		if (job.name === JobName.RewardMigration) {
+			await runRewardMigrationTask({
+				db,
+				payload: job.data,
+				logger: workerLogger,
+			});
+			return;
+		}
+
+		if (job.name === JobName.SyncBalanceBatchV3) {
+			if (!ctx) {
+				workerLogger.error("No context found for sync balance batch v3 job");
+				return;
+			}
+
+			await syncItemV3({
+				ctx,
+				payload: job.data,
+			});
+			return;
+		}
+
+		if (job.name === JobName.InsertEventBatch) {
+			await runInsertEventBatch({
+				db,
+				payload: job.data,
+				logger: workerLogger as Logger,
+			});
+			return;
+		}
+
+		if (job.name === JobName.TriggerCheckoutReward) {
+			if (!ctx) {
+				workerLogger.error("No context found for trigger checkout reward job");
+				return;
+			}
+			await runTriggerCheckoutReward({
+				ctx,
+				payload: job.data,
+			});
+		}
+
+		if (job.name === JobName.GrantCheckoutReward) {
+			if (!ctx) {
+				workerLogger.error("No context found for grant checkout reward job");
+				return;
+			}
+			await grantCheckoutReward({
+				ctx,
+				payload: job.data,
+			});
+		}
+	} catch (error) {
+		Sentry.captureException(error);
+		if (error instanceof Error) {
+			workerLogger.error(`Failed to process SQS job: ${job.name}`, {
+				jobName: job.name,
+				error: {
+					message: error.message,
+					stack: error.stack,
+				},
+			});
+		}
+	}
+};

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -14,19 +14,32 @@ test.concurrent(`${chalk.yellowBright("attach: pro plan with failed payment meth
 		items: [messagesItem],
 	});
 
+	const premium = products.premium({
+		id: "premium",
+		items: [messagesItem],
+	});
+
 	const { autumnV1 } = await initScenario({
 		customerId: "test-failed-pm",
 		setup: [
-			s.customer({ paymentMethod: "fail" }), // Failed payment method
-			s.products({ list: [pro] }),
+			s.customer({ paymentMethod: "success" }), // Failed payment method
+			s.products({ list: [pro, premium] }),
 		],
 		actions: [],
 	});
 
+	const customerId = "test-failed-pm";
 	const result = await autumnV1.attach({
-		customer_id: "test-failed-pm",
+		customer_id: customerId,
 		product_id: pro.id,
 	});
+	const res = await autumnV1.attach({
+		customer_id: customerId,
+		product_id: premium.id,
+		finalize_invoice: true,
+		invoice: true,
+		enable_product_immediately: false,
+	});
 
-	console.log("Attach response:", JSON.stringify(result, null, 2));
+	console.log("res", res);
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-recreate the SQS client when polling stalls to recover from stale connections and keep workers processing. Also adds simple health signals and refactors the worker for clearer message handling.

- **Bug Fixes**
  - Recreate the SQS client after 15 consecutive empty polls (~5 min) or repeated polling errors.
  - Abort stuck requests during restart using AbortController.
  - Heartbeat logs and warnings when no messages are processed for ~15 minutes.

- **Refactors**
  - Extracted message handling into processMessage.ts; immediate delete for migration jobs, batch delete for others.
  - Centralized SQS client management with getSqsClient and recreateSqsClient.
  - Minor worker cleanups: FIFO ReceiveRequestAttemptId, compact stats logging.

<sup>Written for commit b9b9af14f6f6b061c9e1a52a162b411edae94b2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Implements automatic SQS client recreation to recover from stale connections when polling stalls, addressing worker freeze issues in production.

**Bug fixes**
- Auto-recreates SQS client after 15 consecutive empty polls (~5 min) or repeated errors to recover from stale connections
- Adds heartbeat logging every 5 minutes and alerts when no messages processed for 15 minutes
- Migration jobs now deleted immediately before processing to avoid timeout redelivery

**Refactors**
- Extracted message processing into `processMessage.ts` for better separation of concerns
- Centralized SQS client management with `getSqsClient()` and `recreateSqsClient()` functions
- Added FIFO queue support with `ReceiveRequestAttemptId`
- Improved stats logging to be more compact

**Issues Found**
- `sqs` export in `initSqs.ts` holds stale reference - won't update after client recreation
- Abort controllers not properly cancelled before creating new ones
</details>


<h3>Confidence Score: 3/5</h3>

- Safe to merge with fixes for abort controller and stale sqs export
- Core restart logic is sound but has critical bugs: stale `sqs` export reference won't refresh after client recreation, and abort controllers aren't properly cancelled before replacement, which could leave orphaned requests
- Pay close attention to `server/src/queue/initSqs.ts` (stale export reference) and `server/src/queue/initWorkers.ts` (abort controller handling)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/queue/initSqs.ts | Added SQS client management with `recreateSqsClient()` and `getSqsClient()` functions to enable connection refresh; configuration extraction is clean |
| server/src/queue/initWorkers.ts | Refactored worker with stale connection detection (15 empty polls), heartbeat logging, zero-message alerting, and client restart logic; improved structure and error handling |
| server/tests/_temp/temp.test.ts | Temporary test file with uncommitted debug changes; includes test description mismatch and unclear purpose |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start Worker] --> B[Initialize SQS Client]
    B --> C[Poll SQS Queue]
    C --> D{Messages Received?}
    D -->|Yes| E[Reset Empty Poll Counter]
    E --> F[Process Messages in Parallel]
    F --> G[Batch Delete Successfully Processed]
    G --> C
    D -->|No| H[Increment Empty Poll Counter]
    H --> I{Counter >= 15?}
    I -->|No| J{Heartbeat Interval?}
    J -->|Yes| K[Log Heartbeat]
    J -->|No| C
    K --> C
    I -->|Yes| L[Abort Old Requests]
    L --> M[Destroy Old SQS Client]
    M --> N[Create New SQS Client]
    N --> O[Reset Counter]
    O --> C
    C --> P{Polling Error?}
    P -->|Yes| Q[Increment Error Counter]
    Q --> R{Repeated Errors?}
    R -->|Yes| S[Wait 5s & Recreate Client]
    S --> N
    R -->|No| T[Wait 5s & Retry]
    T --> C
    P -->|No| C
    F --> U{Migration Job?}
    U -->|Yes| V[Delete Immediately]
    V --> W[Process Job]
    U -->|No| X[Process Job]
    X --> Y[Queue for Batch Delete]
```
</details>


<sub>Last reviewed commit: b9b9af1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->