### PR TITLE
fix: added sqs client restart

### DIFF
--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -30,12 +30,12 @@ let lastStatsTime = Date.now();
 // Stale connection detection
 let consecutiveEmptyPolls = 0;
 let lastHeartbeatTime = Date.now();
-const EMPTY_POLL_THRESHOLD = 15; // ~5 min of empty polls (15 * 20s wait)
+const EMPTY_POLL_THRESHOLD = 9; // ~3 min of empty polls (9 * 20s wait)
 const HEARTBEAT_INTERVAL_MS = ms.minutes(5);
 
 // Zero-message alert tracking
 let consecutiveZeroMessageIntervals = 0;
-const ZERO_MESSAGE_ALERT_THRESHOLD = 15; // ~15 min of 0 messages
+const ZERO_MESSAGE_ALERT_THRESHOLD = 20; // ~20 min of 0 messages
 
 // ============ Helper Functions ============
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lowered the empty poll threshold to restart the SQS client sooner and adjusted zero-message alert timing to reduce noise.

- Changed EMPTY_POLL_THRESHOLD from 15 to 9 (~3 min)
- Changed ZERO_MESSAGE_ALERT_THRESHOLD from 15 to 20 (~20 min)

<sup>Written for commit d270c66de5d59855b618d8db32f74e4b21e45dbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tunes SQS worker connection health thresholds to improve reliability. The changes make the system more proactive in detecting and recovering from stale SQS connections while reducing false-positive alerts.

**Key changes:**
- **Bug fixes**: `EMPTY_POLL_THRESHOLD` reduced from 15 to 9 polls (~5 min to ~3 min) - restarts SQS client connection sooner when no messages are received, addressing potential stale connection issues faster
- **Improvements**: `ZERO_MESSAGE_ALERT_THRESHOLD` increased from 15 to 20 minutes - reduces alert noise by waiting longer before alerting on zero message processing

Both thresholds work together: the faster restart helps recover from connection issues, while the longer alert threshold prevents false alarms during legitimate low-traffic periods.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Changes only adjust two constant values for operational tuning. The logic is sound: lowering `EMPTY_POLL_THRESHOLD` from 15 to 9 makes connection recovery more aggressive (3 min vs 5 min), while increasing `ZERO_MESSAGE_ALERT_THRESHOLD` from 15 to 20 reduces false alerts. Both changes improve system reliability without introducing new logic or behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/queue/initWorkers.ts | Tuned SQS connection thresholds to restart client faster (3 min) and reduce alert noise (20 min) |

</details>



<sub>Last reviewed commit: d270c66</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->