### PR TITLE
fix: invoice no pm

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -181,6 +181,7 @@ export const setupAttachBillingContext = async ({
 		attachProduct,
 		stripeSubscription,
 		trialContext,
+		invoiceMode,
 	});
 
 	const transitionConfig = setupTransitionConfigs({

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachCheckoutMode.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachCheckoutMode.ts
@@ -1,4 +1,4 @@
-import type { CheckoutMode, TrialContext } from "@autumn/shared";
+import type { CheckoutMode, InvoiceMode, TrialContext } from "@autumn/shared";
 import {
 	type FullCusProduct,
 	type FullProduct,
@@ -19,6 +19,7 @@ export const setupAttachCheckoutMode = ({
 	currentCustomerProduct,
 	stripeSubscription,
 	trialContext,
+	invoiceMode,
 }: {
 	paymentMethod?: Stripe.PaymentMethod;
 	currentCustomerProduct?: FullCusProduct;
@@ -26,6 +27,7 @@ export const setupAttachCheckoutMode = ({
 	attachProduct: FullProduct;
 	stripeSubscription?: Stripe.Subscription;
 	trialContext?: TrialContext;
+	invoiceMode?: InvoiceMode;
 }): CheckoutMode => {
 	const hasPaymentMethod = !!paymentMethod;
 	const hasExistingSubscription = !!stripeSubscription;
@@ -40,8 +42,10 @@ export const setupAttachCheckoutMode = ({
 	}
 
 	const getStripeCheckoutOrDirectBilling = () => {
+		// If invoice mode
+
 		// A. if no payment method
-		if (hasPaymentMethod) return null;
+		if (hasPaymentMethod || invoiceMode) return null;
 
 		if (productIsOneOff) return "stripe_checkout";
 

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -22,24 +22,18 @@ test.concurrent(`${chalk.yellowBright("attach: pro plan with failed payment meth
 	const { autumnV1 } = await initScenario({
 		customerId: "test-failed-pm",
 		setup: [
-			s.customer({ paymentMethod: "success" }), // Failed payment method
+			s.customer({}), // Failed payment method
 			s.products({ list: [pro, premium] }),
 		],
 		actions: [],
 	});
 
-	const customerId = "test-failed-pm";
-	const result = await autumnV1.attach({
-		customer_id: customerId,
+	const result = await autumnV1.billing.attach({
+		customer_id: "test-failed-pm",
 		product_id: pro.id,
-	});
-	const res = await autumnV1.attach({
-		customer_id: customerId,
-		product_id: premium.id,
-		finalize_invoice: true,
 		invoice: true,
-		enable_product_immediately: false,
+		finalize_invoice: false,
 	});
 
-	console.log("res", res);
+	console.log("result", result);
 });

--- a/server/tests/integration/billing/attach/invoice/attach-invoice-draft-deferred.test.ts
+++ b/server/tests/integration/billing/attach/invoice/attach-invoice-draft-deferred.test.ts
@@ -254,7 +254,126 @@ test.concurrent(`${chalk.yellowBright("attach-invoice-draft-def 2: upgrade")}`, 
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// TEST 3: One-off (draft, deferred)
+// TEST 3: New plan without payment method (draft, deferred)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer has no payment method
+ * - Attach pro with invoice mode (draft, deferred)
+ *
+ * Expected Result:
+ * - Draft invoice created
+ * - payment_url is NOT defined (draft invoice)
+ * - Product NOT activated (deferred)
+ * - After finalizing and paying: product activates
+ */
+test.concurrent(`${chalk.yellowBright("attach-invoice-draft-def 3: new plan no pm")}`, async () => {
+	const customerId = "attach-inv-draft-def-new-plan-no-pm";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const priceItem = items.monthlyPrice({ price: 20 });
+	const pro = products.base({
+		id: "pro",
+		items: [messagesItem, priceItem],
+	});
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({}), // No payment method
+			s.products({ list: [pro] }),
+		],
+		actions: [],
+	});
+
+	// Preview attach
+	const preview = await autumnV1.billing.previewAttach({
+		customer_id: customerId,
+		product_id: pro.id,
+	});
+	expect(preview.total).toBe(20);
+
+	// Attach with invoice mode (draft, deferred)
+	const result = await autumnV1.billing.attach({
+		customer_id: customerId,
+		product_id: pro.id,
+		invoice: true,
+		finalize_invoice: false,
+		enable_product_immediately: false,
+		redirect_mode: "if_required",
+	});
+
+	// Verify invoice is draft
+	expect(result.invoice).toBeDefined();
+	expect(result.invoice!.status).toBe("draft");
+	expect(result.invoice!.stripe_id).toBeDefined();
+	expect(result.invoice!.total).toBe(preview.total);
+	expect(result.invoice!.hosted_invoice_url).toBeNull(); // Draft invoices don't have hosted URL
+
+	// payment_url should NOT be defined for draft invoices
+	expect(result.payment_url).toBeNull();
+
+	const stripeInvoice = await ctx.stripeCli.invoices.retrieve(
+		result.invoice!.stripe_id,
+	);
+	expect(stripeInvoice.status).toBe("draft");
+
+	const customerBefore =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	// Before payment - product should NOT be activated (deferred)
+	// Messages feature should not exist yet
+	expect(customerBefore.features?.[TestFeature.Messages]).toBeUndefined();
+
+	// Verify invoice status in customer
+	await expectCustomerInvoiceCorrect({
+		customer: customerBefore,
+		count: 1,
+		latestTotal: preview.total,
+		latestStatus: "draft",
+	});
+
+	// Finalize the invoice
+	const finalizedInvoice = await ctx.stripeCli.invoices.finalizeInvoice(
+		result.invoice!.stripe_id,
+	);
+	expect(finalizedInvoice.status).toBe("open");
+	expect(finalizedInvoice.hosted_invoice_url).toBeDefined();
+
+	// Complete payment
+	await completeInvoiceCheckout({
+		url: finalizedInvoice.hosted_invoice_url!,
+	});
+
+	const customerAfter = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	// After payment - product should be active
+	await expectProductActive({
+		customer: customerAfter,
+		productId: pro.id,
+	});
+
+	// Verify balance is correct
+	expectCustomerFeatureCorrect({
+		customer: customerAfter,
+		featureId: TestFeature.Messages,
+		includedUsage: 100,
+		balance: 100,
+		usage: 0,
+	});
+
+	// Verify invoice is now paid
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfter,
+		count: 1,
+		latestTotal: preview.total,
+		latestStatus: "paid",
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 4: One-off (draft, deferred)
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
@@ -267,7 +386,7 @@ test.concurrent(`${chalk.yellowBright("attach-invoice-draft-def 2: upgrade")}`, 
  * - Credits NOT granted until payment
  * - After payment: credits granted
  */
-test.concurrent(`${chalk.yellowBright("attach-invoice-draft-def 3: one-off")}`, async () => {
+test.concurrent(`${chalk.yellowBright("attach-invoice-draft-def 4: one-off")}`, async () => {
 	const customerId = "attach-inv-draft-def-oneoff";
 
 	const oneOffMessagesItem = items.oneOffMessages({


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes invoice-mode attach for customers without a payment method. We now create a draft invoice and skip Stripe Checkout; the product activates after payment when deferred.

- **Bug Fixes**
  - Pass invoiceMode through billing context and update checkout-mode logic to avoid Stripe Checkout when invoicing.
  - Ensure draft invoices have no payment_url and do not activate products until payment when deferred.
  - Add integration test for attaching a new plan with no PM in invoice mode (draft, deferred), including finalize-and-pay flow.

<sup>Written for commit c7f7919f1b0243483d602a04cc16741b22f810ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixed invoice-mode attach for customers without a payment method by ensuring `invoiceMode` is passed through billing context to checkout-mode logic, preventing incorrect Stripe Checkout redirects.

**Key Changes:**
- **Bug fixes**: prevented Stripe Checkout redirect when attaching products in invoice mode without payment method
- **Bug fixes**: ensured draft invoices correctly have no `payment_url` and products activate only after payment when deferred
- **Improvements**: added integration test covering attach flow for customers without payment method in invoice mode (draft, deferred)
</details>


<h3>Confidence Score: 4/5</h3>

- safe to merge with minor style improvement recommended
- the logic change correctly fixes the invoice mode flow for customers without payment methods, is well-tested with a comprehensive integration test, and only has a minor incomplete comment that should be improved for code clarity
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts | passes `invoiceMode` to `setupAttachCheckoutMode` for proper checkout flow handling |
| server/src/internal/billing/v2/actions/attach/setup/setupAttachCheckoutMode.ts | adds `invoiceMode` parameter and skips Stripe Checkout when invoicing; has incomplete comment on line 45 |
| server/tests/integration/billing/attach/invoice/attach-invoice-draft-deferred.test.ts | adds comprehensive test for attaching plan without payment method in invoice mode (draft, deferred) |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer attaches product] --> B{Has payment method?}
    B -->|Yes| C[Direct billing]
    B -->|No| D{Invoice mode enabled?}
    D -->|Yes| E[Create draft invoice]
    D -->|No| F[Redirect to Stripe Checkout]
    E --> G{Finalize invoice?}
    G -->|No| H[Invoice stays draft]
    G -->|Yes| I[Invoice finalized]
    I --> J[Customer pays invoice]
    J --> K{Enable product immediately?}
    H --> L[Manual finalize later]
    L --> J
    K -->|Yes| M[Product activated]
    K -->|No| N[Product activated after payment]
    C --> M
    F --> O[Collect payment method]
    O --> M
```
</details>


<sub>Last reviewed commit: c7f7919</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->