### PR TITLE
fix: add discounts to upgrades in legacy attach

### DIFF
--- a/server/src/internal/billing/v2/actions/legacy/legacyAttach.ts
+++ b/server/src/internal/billing/v2/actions/legacy/legacyAttach.ts
@@ -8,6 +8,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { billingActions } from "@/internal/billing/v2/actions";
 import { attachParamsToInvoiceModeParams } from "@/internal/billing/v2/actions/legacy/utils/attachParamsToInvoiceModeParams";
 import { attachParamsToStripeBillingContext } from "@/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext";
+import { legacyRewardToAttachDiscounts } from "@/internal/billing/v2/actions/legacy/utils/legacyRewardToAttachDiscounts";
 import { setupLegacyTransitionContext } from "@/internal/billing/v2/actions/legacy/utils/setupLegacyFeatureQuantitiesContext";
 import { billingResultToResponse } from "@/internal/billing/v2/utils/billingResult/billingResultToResponse";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams";
@@ -28,6 +29,8 @@ export const legacyAttach = async ({
 		prices: attachParams.prices,
 		entitlements: attachParams.entitlements,
 	};
+
+	const paramDiscounts = legacyRewardToAttachDiscounts({ attachParams });
 
 	const stripeBillingContext = await attachParamsToStripeBillingContext({
 		ctx,
@@ -59,6 +62,7 @@ export const legacyAttach = async ({
 		redirect_mode: "if_required",
 
 		plan_schedule: planTiming,
+		discounts: paramDiscounts,
 	};
 
 	const res = await billingActions.attach({

--- a/server/src/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext.ts
@@ -1,18 +1,15 @@
 import type { StripeBillingContextOverride } from "@autumn/shared";
 import type { FullProduct } from "@shared/index";
-import { createStripeCli } from "@/external/connect/createStripeCli";
 import {
 	type StripeCustomerWithDiscount,
 	stripeSubscriptionToScheduleId,
 } from "@/external/stripe/subscriptions";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import {
-	extractStripeDiscounts,
-	filterDeletedCouponDiscounts,
-} from "@/internal/billing/v2/providers/stripe/setup/fetchStripeDiscountsForBilling";
+import { fetchStripeDiscountsForBilling } from "@/internal/billing/v2/providers/stripe/setup/fetchStripeDiscountsForBilling";
 import { fetchStripeSubscriptionForBilling } from "@/internal/billing/v2/providers/stripe/setup/fetchStripeSubscriptionForBilling";
 import { fetchStripeSubscriptionScheduleForBilling } from "@/internal/billing/v2/providers/stripe/setup/fetchStripeSubscriptionScheduleForBilling";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams";
+import { legacyRewardToAttachDiscounts } from "./legacyRewardToAttachDiscounts";
 
 export const attachParamsToStripeBillingContext = async ({
 	ctx,
@@ -40,14 +37,13 @@ export const attachParamsToStripeBillingContext = async ({
 		});
 
 	const stripeCustomer = attachParams.stripeCus as StripeCustomerWithDiscount;
+	const paramDiscounts = legacyRewardToAttachDiscounts({ attachParams });
 
-	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
-	const stripeDiscounts = await filterDeletedCouponDiscounts({
-		stripeCli,
-		discounts: extractStripeDiscounts({
-			stripeSubscription,
-			stripeCustomer,
-		}),
+	const stripeDiscounts = await fetchStripeDiscountsForBilling({
+		ctx,
+		stripeSubscription,
+		stripeCustomer,
+		paramDiscounts,
 	});
 
 	const { paymentMethod, now } = attachParams;

--- a/server/src/internal/billing/v2/actions/legacy/utils/legacyRewardToAttachDiscounts.ts
+++ b/server/src/internal/billing/v2/actions/legacy/utils/legacyRewardToAttachDiscounts.ts
@@ -1,0 +1,11 @@
+import type { AttachDiscount } from "@autumn/shared";
+import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams";
+
+export const legacyRewardToAttachDiscounts = ({
+	attachParams,
+}: {
+	attachParams: AttachParams;
+}): AttachDiscount[] | undefined =>
+	attachParams.rewards?.map((reward) => ({
+		reward_id: reward.id,
+	}));

--- a/server/tests/integration/billing/legacy/attach/upgrade/legacy-upgrade-discount.test.ts
+++ b/server/tests/integration/billing/legacy/attach/upgrade/legacy-upgrade-discount.test.ts
@@ -1,0 +1,72 @@
+import { test } from "bun:test";
+import { type ApiCustomerV3, RewardType } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { createReward } from "@tests/utils/productUtils";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli";
+import { constructCoupon } from "@/utils/scriptUtils/createTestProducts";
+
+test.concurrent(`${chalk.yellowBright("legacy-upgrade-discount 1: reward applies on upgrade")}`, async () => {
+	const customerId = "legacy-upgrade-discount-1";
+	const rewardId = `${customerId}-20-off`;
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+
+	const premium = products.premium({
+		id: "premium",
+		items: [items.monthlyMessages({ includedUsage: 1000 })],
+	});
+
+	const reward = constructCoupon({
+		id: rewardId,
+		promoCode: `UPGRADE`,
+		discountType: RewardType.PercentageDiscount,
+		discountValue: 20,
+	});
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, premium] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await createReward({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		autumn: new AutumnInt(),
+		reward,
+		productId: premium.id,
+	});
+
+	await autumnV1.attach({
+		customer_id: customerId,
+		product_id: premium.id,
+		reward: reward.id,
+	});
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	await expectCustomerProducts({
+		customer,
+		active: [premium.id],
+		notPresent: [pro.id],
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer,
+		count: 2,
+		latestTotal: 20,
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes legacy upgrade flow so reward-based discounts are applied during attach. Discounts are passed into the Stripe billing context and reflected in the customer’s invoice.

- **Bug Fixes**
  - Map attachParams.rewards to AttachDiscounts and include them in the attach call.
  - Use fetchStripeDiscountsForBilling to combine subscription/customer discounts with param discounts.
  - Add integration test verifying a 20% upgrade coupon applies on upgrade and updates the invoice total.

<sup>Written for commit f4258a563c706bc95e7c352ebab29ea87573da24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixed a bug where discounts (rewards) were not being applied during legacy product upgrades. The PR ensures that when customers upgrade products using the legacy attach flow, any specified rewards are properly converted to the attach discount format and passed through the billing pipeline.

**Key Changes:**
- **Bug fixes**: Added missing discount support to legacy upgrade flow by converting rewards to `AttachDiscount` format and passing to billing actions
- **Improvements**: Refactored `attachParamsToStripeBillingContext` to use the unified `fetchStripeDiscountsForBilling` helper, which handles discount resolution, deduplication, and filtering of deleted coupons
- **Bug fixes**: Added integration test to verify discounts are correctly applied during legacy upgrades

**Notes:**
- Check that the test's expected invoice total of $20 is correct - premium product is $50/month with 20% discount which should equal $40 (unless proration or other factors apply)
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor verification needed on test expectations
- The implementation is clean and follows existing patterns correctly. The new utility function properly converts rewards to the AttachDiscount format, and the refactoring improves code reuse. However, the test's expected invoice total appears potentially incorrect (expects $20 but premium with 20% discount should be $40), which needs verification before merge.
- server/tests/integration/billing/legacy/attach/upgrade/legacy-upgrade-discount.test.ts - verify expected invoice total calculation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/legacy/utils/legacyRewardToAttachDiscounts.ts | New utility to convert legacy rewards to attach discounts format |
| server/src/internal/billing/v2/actions/legacy/legacyAttach.ts | Added discount conversion and passed discounts to attach params |
| server/src/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext.ts | Refactored to use fetchStripeDiscountsForBilling with param discounts |
| server/tests/integration/billing/legacy/attach/upgrade/legacy-upgrade-discount.test.ts | Test expects $20 total but premium is $50 with 20% discount = $40, possible test error |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[legacyAttach called] --> B[Convert rewards to AttachDiscount format]
    B --> C[legacyRewardToAttachDiscounts]
    C --> D[Map rewards to reward_id objects]
    D --> E[attachParamsToStripeBillingContext]
    E --> F[Pass paramDiscounts to fetchStripeDiscountsForBilling]
    F --> G[resolveParamDiscounts via Stripe API]
    G --> H[Merge with existing discounts]
    H --> I[Deduplicate by coupon ID]
    I --> J[Filter deleted coupons]
    J --> K[Return validated discounts]
    K --> L[billingActions.attach with discounts param]
```
</details>


<sub>Last reviewed commit: f4258a5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->