### PR TITLE
dev

### DIFF
--- a/packages/autumn-js/tsconfig.json
+++ b/packages/autumn-js/tsconfig.json
@@ -16,8 +16,8 @@
 		"skipLibCheck": true,
 
 		"paths": {
-			"@useautumn/sdk": ["../sdk/dist/esm/index.d.ts"],
-			"@useautumn/sdk/*": ["../sdk/dist/esm/*"],
+			"@useautumn/sdk": ["../sdk/src/index.ts"],
+			"@useautumn/sdk/*": ["../sdk/src/*"],
 			"@utils/*": ["./src/utils/*"]
 		}
 	},


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated autumn-js tsconfig to point @useautumn/sdk path aliases to the SDK source files instead of the built ESM output. This improves local development by resolving types from source and avoids stale definitions.

<sup>Written for commit ae5f894e2adc1b28926a493261ace4f6cf0ec466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updated TypeScript path mappings in `autumn-js` package to resolve `@useautumn/sdk` imports from source files instead of built artifacts. This aligns the tsconfig.json with the existing tsup.config.ts configuration (line 10), ensuring consistent module resolution across development and build processes.

**Key Changes:**
- **Improvements**: TypeScript now resolves `@useautumn/sdk` imports from `../sdk/src/` (source) instead of `../sdk/dist/esm/` (built artifacts), providing better IDE support and faster type checking during development
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple configuration update that aligns TypeScript's path mapping with the existing bundler configuration. It only affects development-time type checking and doesn't change runtime behavior. The SDK source files exist at the specified location, and tsup.config.ts already uses the same path resolution.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/autumn-js/tsconfig.json | Changed TypeScript path mappings for `@useautumn/sdk` to point to source files (`../sdk/src/`) instead of built artifacts (`../sdk/dist/esm/`), aligning with tsup.config.ts bundler configuration |

</details>



<sub>Last reviewed commit: ae5f894</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->