### PR TITLE
dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ COPY apps/checkout/package.json ./apps/checkout/package.json
 COPY packages/autumn-js/package.json ./packages/autumn-js/package.json
 COPY packages/openapi/package.json ./packages/openapi/package.json
 COPY packages/sdk/package.json ./packages/sdk/package.json
+COPY apps/sdk-test/package.json ./apps/sdk-test/package.json
+COPY apps/docs/package.json ./apps/docs/package.json
 
 # Install dependencies
 RUN bun install --ignore-scripts


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Docker build by copying apps/sdk-test and apps/docs package.json files so Bun installs their dependencies. Prevents missing packages during monorepo builds.

<sup>Written for commit 3eaf46f91fbfa67e06233897f01961236178cb07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Added missing workspace package dependencies to the Docker build process. This change ensures that the `apps/sdk-test` and `apps/docs` packages have their `package.json` files copied before running `bun install`, which is required for proper dependency resolution in Bun workspaces.

**Key changes:**
- **Improvements**: Added `COPY` commands for `apps/sdk-test/package.json` and `apps/docs/package.json` to align with workspace configuration
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal and necessary - they simply add two missing workspace packages to the Dockerfile's dependency installation process. Both packages exist in the workspace configuration and have valid `package.json` files. This fix prevents potential build failures when these packages are required during Docker builds.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Added `package.json` copy commands for `apps/sdk-test` and `apps/docs` workspace packages to enable proper dependency installation |

</details>



<sub>Last reviewed commit: 3eaf46f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->