### PR TITLE
fix: 🐛 vercel bug status not ready

### DIFF
--- a/server/src/external/vercel/handlers/resources/handleCreateResource.ts
+++ b/server/src/external/vercel/handlers/resources/handleCreateResource.ts
@@ -148,7 +148,7 @@ export const handleCreateResource = createRoute({
 				productId,
 				name,
 				metadata,
-				status: "pending", // Will become "ready" after marketplace.invoice.paid confirms payment
+				status: "ready", // Will become "ready" after marketplace.invoice.paid confirms payment
 				billingPlan: {
 					...productToBillingPlan({
 						product,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set new Vercel resources to "ready" instead of "pending" in both the database and API response. Fixes the stuck state and makes resources available immediately.

<sup>Written for commit ffbd6d1b5bc5c0c58c1fb42fd81a0cb96fb4c891. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Changed Vercel resource creation to set `status: "ready"` immediately in the database instead of `"pending"`, addressing an issue where Vercel expects resources to be ready without waiting for payment confirmation.

**Bug fixes**
- Fixed Vercel resource status initialization from `pending` to `ready` in database

**Key finding:**
- The API response on line 151 still returns `status: "pending"` to the client, creating a mismatch with the database state. This should be updated to return `"ready"` to match the database.
</details>


<h3>Confidence Score: 3/5</h3>

- This PR partially fixes a Vercel integration bug but introduces a state inconsistency that should be addressed
- The change correctly updates the database status to `ready` to fix a Vercel bug, but creates a logical inconsistency where the database has `status: "ready"` while the API response returns `status: "pending"`. The comment on line 151 about payment confirmation is now misleading since the resource is immediately ready. Additionally, the webhook handler that updates status to `ready` becomes a no-op.
- The API response status on line 151 should be updated to match the database status

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/vercel/handlers/resources/handleCreateResource.ts | Changed resource creation status from `pending` to `ready` in database, but API response still returns `pending` creating a state mismatch |

</details>



<sub>Last reviewed commit: a161d10</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->