### PR TITLE
fix: fix balance subrow issue

### DIFF
--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -161,6 +161,12 @@ export function CustomerFeatureUsageTable() {
 		[allEnts],
 	);
 
+	// Strip CreditSystemSubRow subRows — CustomerBalanceTable uses aggregatedMap for its own sub-rows
+	const balanceEnts = useMemo(
+		() => meteredEnts.map(({ subRows, ...rest }) => rest),
+		[meteredEnts],
+	);
+
 	const booleanEnts = useMemo(
 		() =>
 			allEnts.filter(
@@ -169,7 +175,7 @@ export function CustomerFeatureUsageTable() {
 		[allEnts],
 	);
 
-	const hasMeteredBalances = meteredEnts.length > 0;
+	const hasMeteredBalances = balanceEnts.length > 0;
 	const hasBooleanBalances = booleanEnts.length > 0;
 
 	return (
@@ -203,7 +209,7 @@ export function CustomerFeatureUsageTable() {
 						<div className="flex flex-col gap-3">
 							{hasMeteredBalances && (
 								<CustomerBalanceTable
-									allEnts={meteredEnts}
+									allEnts={balanceEnts}
 									entityId={entityId ?? null}
 									aggregatedMap={aggregatedMap}
 									isLoading={isLoading}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate or incorrect balance sub-rows by passing a flat list of metered entries to CustomerBalanceTable and letting it derive sub-rows from aggregatedMap.

- **Bug Fixes**
  - Strip subRows from metered entries (balanceEnts) and use them for hasMeteredBalances and the allEnts prop, preventing duplicated sub-rows in the balances view.

<sup>Written for commit 47567a8472291b45bd30c63f67bca748ddf7b959. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Prevented duplicate balance sub-rows by stripping `subRows` from metered entries before passing to `CustomerBalanceTable`.

**Bug Fixes**
- Removed pre-existing `subRows` (from `processNonBooleanEntitlements`) before passing metered entries to `CustomerBalanceTable`, which derives its own sub-rows from `aggregatedMap`
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple, focused bug fix that correctly addresses duplicate sub-rows by using object destructuring to strip the subRows property before passing data to CustomerBalanceTable, which derives its own sub-rows from aggregatedMap
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx | Strips subRows from metered entries before passing to CustomerBalanceTable, fixing duplicate sub-row issue |

</details>



<sub>Last reviewed commit: 47567a8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->