### PR TITLE
fix: prevent past_due status cascading to newly paid subscriptions

### DIFF
--- a/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
+++ b/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
@@ -56,6 +56,27 @@ export const isStripeSubscriptionCanceled = (
 	return stripeSubscription.status === "canceled";
 };
 
+const UNHEALTHY_STATUSES: Stripe.Subscription.Status[] = [
+	"past_due",
+	"incomplete",
+	"incomplete_expired",
+	"unpaid",
+	"paused",
+];
+
+/**
+ * Checks if a Stripe subscription has a payment-problematic status.
+ * These statuses all map to CusProductStatus.PastDue and indicate the subscription
+ * should not be used as a merge target for new products.
+ */
+export const isStripeSubscriptionUnhealthy = (
+	stripeSubscription?: Stripe.Subscription,
+): boolean => {
+	if (!stripeSubscription) return false;
+
+	return UNHEALTHY_STATUSES.includes(stripeSubscription.status);
+};
+
 /**
  * Checks if a Stripe subscription has any metered price items.
  */

--- a/server/src/internal/billing/v2/providers/stripe/execute/cleanupOldSubscriptionItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/cleanupOldSubscriptionItems.ts
@@ -1,0 +1,88 @@
+import type { BillingPlan } from "@autumn/shared";
+import { CusProductStatus } from "@autumn/shared";
+import { createStripeCli } from "@/external/connect/createStripeCli";
+import { isStripeSubscriptionCanceled } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { customerProductToStripeItemSpecs } from "@/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerProductToStripeItemSpecs";
+import type Stripe from "stripe";
+
+/**
+ * Removes expired product items from an old subscription when transitioning to a new subscription.
+ *
+ * When a product transitions away from an unhealthy (past_due) subscription to a new one,
+ * the old product's items remain on the old subscription. This function cleans them up
+ * to prevent future charges for the expired product.
+ *
+ * If removing the items leaves the old subscription with no items, the subscription is canceled.
+ */
+export const cleanupOldSubscriptionItems = async ({
+	ctx,
+	billingPlan,
+	newStripeSubscription,
+}: {
+	ctx: AutumnContext;
+	billingPlan: BillingPlan;
+	newStripeSubscription?: Stripe.Subscription;
+}) => {
+	const { updateCustomerProduct } = billingPlan.autumn;
+	if (!updateCustomerProduct) return;
+
+	// Only clean up when the old product is being expired (immediate transition)
+	if (updateCustomerProduct.updates.status !== CusProductStatus.Expired) return;
+
+	// Cleanup only applies when transitioning to a new subscription
+	if (!newStripeSubscription) return;
+
+	const oldCustomerProduct = updateCustomerProduct.customerProduct;
+	const oldSubscriptionId = oldCustomerProduct.subscription_ids?.[0];
+
+	if (!oldSubscriptionId) return;
+
+	// Same subscription -- items already handled by buildStripeSubscriptionItemsUpdate diff
+	if (oldSubscriptionId === newStripeSubscription.id) return;
+
+	const { logger } = ctx;
+	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+
+	const oldSubscription =
+		await stripeCli.subscriptions.retrieve(oldSubscriptionId);
+
+	if (isStripeSubscriptionCanceled(oldSubscription)) return;
+
+	// Get the old product's Stripe price IDs
+	const { recurringItems } = customerProductToStripeItemSpecs({
+		ctx,
+		customerProduct: oldCustomerProduct,
+	});
+
+	const oldPriceIds = new Set(
+		recurringItems.map((item) => item.stripePriceId),
+	);
+
+	// Find subscription items belonging to the expired product
+	const itemsToRemove = oldSubscription.items.data.filter((item) =>
+		oldPriceIds.has(item.price.id),
+	);
+
+	if (itemsToRemove.length === 0) return;
+
+	// If ALL items would be removed, cancel the entire subscription
+	if (itemsToRemove.length === oldSubscription.items.data.length) {
+		logger.debug(
+			`[cleanupOldSubscriptionItems] Canceling old subscription ${oldSubscriptionId} (no items remaining)`,
+		);
+		await stripeCli.subscriptions.cancel(oldSubscriptionId);
+		return;
+	}
+
+	// Otherwise, remove only the expired product's items
+	logger.debug(
+		`[cleanupOldSubscriptionItems] Removing ${itemsToRemove.length} items from old subscription ${oldSubscriptionId}`,
+	);
+	// No proration -- the product is expired and the subscription is already past_due,
+	// so we don't want to generate prorated credits for items that weren't being paid for
+	await stripeCli.subscriptions.update(oldSubscriptionId, {
+		items: itemsToRemove.map((item) => ({ id: item.id, deleted: true })),
+		proration_behavior: "none",
+	});
+};

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
@@ -10,6 +10,7 @@ import { executeStripeCheckoutSessionAction } from "@/internal/billing/v2/provid
 import { executeStripeInvoiceAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeInvoiceAction";
 import { executeStripeSubscriptionAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction";
 import { executeStripeSubscriptionScheduleAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction";
+import { cleanupOldSubscriptionItems } from "@/internal/billing/v2/providers/stripe/execute/cleanupOldSubscriptionItems";
 import { createStripeInvoiceItems } from "@/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps";
 
 export const executeStripeBillingPlan = async ({
@@ -94,6 +95,13 @@ export const executeStripeBillingPlan = async ({
 		if (subscriptionResult?.deferred) return subscriptionResult;
 		stripeSubscription =
 			subscriptionResult.stripeSubscription ?? stripeSubscription;
+
+		// Clean up expired product items from old subscription when transitioning across subscriptions
+		await cleanupOldSubscriptionItems({
+			ctx,
+			billingPlan,
+			newStripeSubscription: subscriptionResult.stripeSubscription,
+		});
 	}
 
 	if (stripeSubscriptionScheduleAction && !isReleaseAction) {


### PR DESCRIPTION
## Summary
When a customer has an unpaid invoice, all products on the same Stripe subscription were marked as past_due — including newly purchased products with fully paid invoices. This blocked users from accessing the app even with a valid, paid subscription.

Root cause: new products were merged onto unhealthy (past_due) Stripe subscriptions via getTargetSubscriptionCusProduct, then syncCustomerProductStatus applied the subscription-level past_due status to all products uniformly.

Fix:
- Reject unhealthy subscriptions (past_due, incomplete, unpaid, paused) as merge targets in fetchStripeSubscriptionForBilling, forcing creation of a new Stripe subscription for the new product
- Clean up expired product items from the old subscription after transitioning to prevent future charges for the expired product

## Related Issues
None identified yet — this was reported by a user

## Type of Change
- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
### Changed files
- **`classifyStripeSubscriptionUtils.ts`** — Added `isStripeSubscriptionUnhealthy()` helper that detects payment-problematic statuses (`past_due`, `incomplete`, `incomplete_expired`, `unpaid`, `paused`)
- **`fetchStripeSubscriptionForBilling.ts`** — Returns `undefined` when the target subscription is unhealthy, forcing the billing system to create a new Stripe subscription instead of merging onto the problematic one. Includes an `info`-level log for production traceability.
- **`cleanupOldSubscriptionItems.ts`** (new) — After transitioning to a new subscription, removes the expired product's items from the old subscription. Cancels the old subscription entirely if no items remain. Uses `proration_behavior: "none"` to avoid generating credits for already-unpaid items.
- **`executeStripeBillingPlan.ts`** — Calls `cleanupOldSubscriptionItems()` after the subscription action completes.

### Edge cases handled
- **Downgrades (end_of_cycle)**: Old product is marked as canceling (not Expired), so cleanup is skipped — items stay on the old subscription until end of cycle.
- **Same-subscription transitions**: Guard clause skips cleanup when old and new subscription IDs match — the existing item diff handles it.
- **Cancel actions**: Early `if (!newStripeSubscription) return` exit prevents cleanup from running when no new subscription was created.
- **Already-canceled old subscriptions**: `isStripeSubscriptionCanceled` guard prevents redundant Stripe API calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented past_due status from cascading to newly paid products by avoiding merges onto unhealthy Stripe subscriptions and cleaning up old subscription items after moving. Users with a new paid product are no longer blocked by an unpaid invoice on another product.

- **Bug Fixes**
  - Skip unhealthy Stripe subscriptions (past_due, incomplete, incomplete_expired, unpaid, paused) as merge targets in fetchStripeSubscriptionForBilling; create a new subscription instead.
  - After transitioning, remove the expired product’s items from the old subscription or cancel it if empty, with no proration.

<sup>Written for commit ab8d8ae096d2f670756e18cd951191a49717c2c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Prevents newly purchased products from being blocked when customers have unpaid invoices on existing subscriptions. Previously, new products merged onto unhealthy (`past_due`) Stripe subscriptions inherited the payment-problematic status, blocking legitimate access.

**Key Changes:**

**Bug fixes**
- Reject unhealthy subscriptions (`past_due`, `incomplete`, `incomplete_expired`, `unpaid`, `paused`) as merge targets in `fetchStripeSubscriptionForBilling`, forcing creation of new Stripe subscriptions for new products
- Clean up expired product items from old subscriptions after transitioning to prevent future charges for already-expired products

**Improvements**
- Added `isStripeSubscriptionUnhealthy()` utility to centralize detection of payment-problematic subscription statuses
- Comprehensive edge case handling: skips cleanup for downgrades (end-of-cycle), same-subscription transitions, cancel actions, and already-canceled subscriptions
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with thorough testing of the cleanup flow
- The fix correctly addresses the root cause by preventing unhealthy subscription merges. The cleanup logic has comprehensive guard clauses for edge cases. However, the cleanup functionality introduces new Stripe API calls and subscription modifications that should be tested with real payment scenarios, particularly around the proration_behavior and item removal logic
- Pay close attention to `cleanupOldSubscriptionItems.ts` - ensure the item removal logic handles all edge cases correctly in production

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts | Added `isStripeSubscriptionUnhealthy()` helper to detect payment-problematic subscription statuses |
| server/src/internal/billing/v2/providers/stripe/setup/fetchStripeSubscriptionForBilling.ts | Rejects unhealthy subscriptions as merge targets, forcing creation of new subscriptions for new products |
| server/src/internal/billing/v2/providers/stripe/execute/cleanupOldSubscriptionItems.ts | New cleanup function to remove expired product items from old subscriptions; edge case handling looks solid with one potential issue |
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts | Integrates cleanup call after subscription action completes |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer purchases new product] --> B{Existing subscription?}
    B -->|No| C[Create new subscription]
    B -->|Yes| D{Check subscription health}
    D -->|Healthy: active/trialing| E[Merge onto existing subscription]
    D -->|Unhealthy: past_due/incomplete/unpaid/paused| F[Force new subscription creation]
    F --> G[Execute billing plan on new subscription]
    G --> H{Old product status?}
    H -->|Expired| I[cleanupOldSubscriptionItems]
    H -->|Canceling| J[Skip cleanup - handled at period end]
    I --> K{Remove items from old subscription}
    K --> L{Any items remaining?}
    L -->|No| M[Cancel old subscription entirely]
    L -->|Yes| N[Remove only expired product items]
    E --> O[Update existing subscription]
    C --> P[Product active on new subscription]
    M --> P
    N --> P
    O --> P
```
</details>


<sub>Last reviewed commit: ab8d8ae</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->