### PR TITLE
dev

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -1,10 +1,8 @@
-import type {
-	AttachBillingContext,
-	AttachParamsV1,
-	BillingContextOverride,
-} from "@autumn/shared";
 import {
 	ACTIVE_STATUSES,
+	type AttachBillingContext,
+	type AttachParamsV1,
+	type BillingContextOverride,
 	BillingVersion,
 	CusProductStatus,
 	cusProductToPrices,
@@ -12,6 +10,7 @@ import {
 	isFreeProduct,
 	isOneOffProduct,
 	notNullish,
+	orgToReturnUrl,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupStripeBillingContext } from "@/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext";
@@ -224,5 +223,7 @@ export const setupAttachBillingContext = async ({
 		adjustableFeatureQuantities: setupAdjustableQuantities({ params }),
 
 		billingVersion: contextOverride.billingVersion ?? BillingVersion.V2,
+		successUrl:
+			params.success_url ?? orgToReturnUrl({ org: ctx.org, env: ctx.env }),
 	};
 };

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
@@ -73,7 +73,7 @@ export const buildStripeCheckoutSessionAction = ({
 		mode,
 		line_items: lineItems,
 		subscription_data: subscriptionData,
-		success_url: orgToReturnUrl({ org, env }),
+		success_url: billingContext.successUrl ?? orgToReturnUrl({ org, env }),
 		discounts,
 	};
 

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -67,6 +67,5 @@ export interface BillingContext {
 	cancelAction?: CancelAction;
 
 	billingVersion: BillingVersion;
-
-	// checkoutQuantityAdjustable?: boolean;
+	successUrl?: string;
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes success URL handling for the v2 attach checkout so users land on the right page after payment. Adds a successUrl override that flows from attach params into Stripe.

- **Bug Fixes**
  - Added successUrl to BillingContext and set it in setupAttachBillingContext from params.success_url, falling back to orgToReturnUrl.
  - Stripe checkout now uses billingContext.successUrl for success_url, with orgToReturnUrl as fallback.

<sup>Written for commit 33e47f105c7474ab87556f56b9b2c94752334ae3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixed `success_url` handling in v2 attach checkout flow by properly propagating the custom success URL through the billing context to Stripe checkout sessions.

**Key changes:**
- **Bug fixes**: Fixed issue where `params.success_url` from attach API was ignored, causing all checkout sessions to use the default org return URL
- **API changes**: Added `successUrl` field to `BillingContext` interface to store and propagate custom success URLs
- **Improvements**: Removed commented-out code (`checkoutQuantityAdjustable`) in billing context interface

The fix ensures that when users provide a custom `success_url` in the attach v2 API call, it flows through `setupAttachBillingContext` into the billing context, and then gets properly used when building Stripe checkout session parameters. The implementation includes proper fallbacks at both levels (context setup and checkout session building) to ensure a valid URL is always provided.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-structured, and implement proper fallback handling. The fix addresses a clear bug where custom success URLs were being ignored. The implementation follows existing patterns (nullish coalescing with fallbacks), maintains backwards compatibility through optional fields, and has no breaking changes. Code quality is good with proper type safety and clean integration.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts | Added `successUrl` field to billing context, respecting `params.success_url` with fallback to `orgToReturnUrl` |
| server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts | Updated to use `billingContext.successUrl` with fallback to `orgToReturnUrl`, ensuring custom success URL is propagated |
| shared/models/billingModels/context/billingContext.ts | Added optional `successUrl` field to `BillingContext` interface, removed commented-out code |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[setupAttachBillingContext] --> B{params.success_url provided?}
    B -->|Yes| C[Use params.success_url]
    B -->|No| D[Call orgToReturnUrl with org & env]
    C --> E[Store in billingContext.successUrl]
    D --> E
    E --> F[buildStripeCheckoutSessionAction]
    F --> G{billingContext.successUrl exists?}
    G -->|Yes| H[Use billingContext.successUrl]
    G -->|No| I[Fallback to orgToReturnUrl]
    H --> J[Set success_url in Stripe checkout params]
    I --> J
    J --> K[executeStripeCheckoutSessionAction]
    K --> L[Create Stripe checkout session with success_url]
```
</details>


<sub>Last reviewed commit: 33e47f1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->