### PR TITLE
fix: create customer body expand

### DIFF
--- a/server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomer.ts
+++ b/server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomer.ts
@@ -1,6 +1,7 @@
 import {
 	AffectedResource,
 	ApiVersion,
+	addToExpand,
 	backwardsChangeActive,
 	CreateCustomerParamsV0Schema,
 	CreateCustomerQuerySchema,
@@ -21,7 +22,7 @@ export const handlePostCustomer = createRoute({
 	body: CreateCustomerParamsV0Schema,
 
 	handler: async (c) => {
-		const ctx = c.get("ctx");
+		let ctx = c.get("ctx");
 
 		const { expand = [], with_autumn_id } = c.req.valid("query");
 		const createCusParams = c.req.valid("json");
@@ -34,6 +35,18 @@ export const handlePostCustomer = createRoute({
 			})
 		) {
 			expand.push(CustomerExpand.Invoices);
+		}
+
+		// SECOND SIDE EFFECT
+		if (ctx.apiVersion.lte(ApiVersion.V1_2)) {
+			ctx = addToExpand({
+				ctx,
+				add: [
+					CustomerExpand.SubscriptionsPlan,
+					CustomerExpand.PurchasesPlan,
+					CustomerExpand.BalancesFeature,
+				],
+			});
 		}
 
 		const start = Date.now();

--- a/server/tests/integration/crud/customers/get-customer.test.ts
+++ b/server/tests/integration/crud/customers/get-customer.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(`${chalk.yellowBright("get-customer: expand empty array returns items")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+
+	const customerId = "get-customer-expand-empty";
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const customer = await autumnV1.customers.create({
+		id: customerId,
+		expand: [],
+	});
+
+	expect(customer.products).toBeDefined();
+	expect(customer.products.length).toBeGreaterThan(0);
+	expect(customer.products[0].items).toBeDefined();
+	expect(customer.products[0].items!.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix customer creation so expand: [] still returns products with items for older API versions. Adds default expands for plans and balances to keep responses backward-compatible.

- **Bug Fixes**
  - For ApiVersion <= v1.2, automatically add SubscriptionsPlan, PurchasesPlan, and BalancesFeature to expand via addToExpand.
  - Allow ctx to be updated so expand settings can be merged correctly.
  - Added an integration test to ensure expand: [] returns products with items.

<sup>Written for commit 660fb4288a0be5ac805633f38faf52ec358424ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixed backwards compatibility issue where the create customer endpoint wasn't expanding nested plan and feature data for V1.2 and earlier API versions when the `expand` parameter was empty or not provided.

**Key Changes:**
- **Bug fixes**: Fixed create customer endpoint to properly expand `subscriptions.plan`, `purchases.plan`, and `balances.feature` for V1.2 API clients when expand array is empty, maintaining backwards compatibility
- **Bug fixes**: Changed `ctx` from `const` to `let` to allow reassignment when adding expand fields
- **Improvements**: Added `addToExpand` utility import to cleanly extend the context's expand array for older API versions
- **Improvements**: Added integration test to verify that V1 API clients receive product items even when expand is an empty array
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a backwards compatibility regression by ensuring V1.2 API clients receive expanded nested data. The implementation uses the existing `addToExpand` utility properly, includes a comprehensive integration test, and follows the established pattern of API versioning side effects in this handler. No edge cases or security concerns identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomer.ts | Added backwards compatibility for V1.2 API by expanding subscriptions.plan, purchases.plan, and balances.feature when expand array is empty |
| server/tests/integration/crud/customers/get-customer.test.ts | Added integration test to verify that creating a customer with empty expand array returns product items for V1 API |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /customers request] --> B{Check API Version}
    B -->|V1.2 or earlier| C[Add expand fields to ctx]
    C --> D[ctx.expand += SubscriptionsPlan]
    C --> E[ctx.expand += PurchasesPlan]
    C --> F[ctx.expand += BalancesFeature]
    B -->|V2.0+| G[Use provided expand]
    D --> H[getOrCreateCachedFullCustomer]
    E --> H
    F --> H
    G --> H
    H --> I[getApiCustomer]
    I --> J{Check ctx.expand}
    J -->|Has SubscriptionsPlan| K[Expand plan in subscriptions]
    J -->|Has PurchasesPlan| L[Expand plan in purchases]
    J -->|Has BalancesFeature| M[Expand feature in balances]
    K --> N[Return ApiCustomer with nested data]
    L --> N
    M --> N
```
</details>


<sub>Last reviewed commit: 660fb42</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->