### PR TITLE
fix: attach dashboard oneoff

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleStripeCheckoutErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleStripeCheckoutErrors.ts
@@ -53,6 +53,8 @@ export const handleStripeCheckoutErrors = ({
 		autumnBillingPlan,
 	});
 
+	console.log("recurringIntervals", recurringIntervals);
+
 	// If we have more than one unique recurring interval, throw an error
 	if (recurringIntervals.size > 1) {
 		throw new RecaseError({

--- a/server/tests/integration/billing/stripe-webhooks/checkout-session-completed/setup-payment-after-trial.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/checkout-session-completed/setup-payment-after-trial.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
+import { FreeTrialDuration } from "@autumn/shared";
 import { completeSetupPaymentForm } from "@tests/utils/browserPool";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { advanceTestClock } from "@tests/utils/stripeUtils.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
-import { FreeTrialDuration } from "@autumn/shared";
 import chalk from "chalk";
 
 /**

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -6,7 +6,7 @@ import {
 	type FreeTrialDuration,
 	type PlanTiming,
 	type ProductItem,
-	ProductItemInterval,
+	type ProductItemInterval,
 	type ProductV2,
 	UsageModel,
 } from "@autumn/shared";
@@ -117,8 +117,7 @@ export function buildAttachRequestBody({
 	if (items !== null) {
 		body.items = items.map((item) => ({
 			...item,
-			interval: (item.interval ||
-				ProductItemInterval.Month) as ProductItemInterval,
+			interval: (item.interval ?? null) as ProductItemInterval | null,
 		}));
 	}
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the attach flow in the dashboard for one‑off prepaid features by sending item interval as null instead of defaulting to monthly. Mixed checkout (recurring plan + one‑off purchase) now completes and allocates prepaid balance correctly.

- **Bug Fixes**
  - Do not default ProductItem interval to Month; send null when unspecified to support one‑off items.
  - Added integration test for Stripe Checkout combining a recurring plan with a one‑off prepaid feature; verifies product activation and feature balance after trial.
  - Minor cleanup: type-only import for ProductItemInterval and a debug log of recurring intervals.

<sup>Written for commit 635845b771bc2f49ca7d0fb53446ad43a9b22a4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes handling of one-off dashboard payments in Stripe checkout by correctly preserving null intervals for one-off product items.

**Key Changes:**
- **Bug fixes**: Fixed frontend incorrectly defaulting one-off item intervals to `Month` instead of preserving `null`, which caused multi-interval validation errors
- **Improvements**: Changed `ProductItemInterval` from value import to type import in `useAttachRequestBody.ts` to avoid importing unused enum values
- **Improvements**: Added test coverage for annual plans with one-off payments
- **Improvements**: Added debug logging to help troubleshoot interval validation (should be removed before merge)
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after removing the debug console.log
- The fix correctly addresses the one-off interval handling issue and includes test coverage. Score reduced by 1 point due to debug console.log that should be removed before merging to production
- server/src/internal/billing/v2/actions/attach/errors/handleStripeCheckoutErrors.ts requires removing the debug console.log statement

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/errors/handleStripeCheckoutErrors.ts | Added debug console.log that should be removed before production |
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Fixed one-off item interval handling - changed from default to null for one-off products, and changed ProductItemInterval from value import to type import |
| server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-multi-interval.test.ts | Added test for annual plan with one-off payment, verifying Stripe checkout handles mixed intervals correctly |
| server/tests/integration/billing/stripe-webhooks/checkout-session-completed/setup-payment-after-trial.test.ts | Reordered imports to follow style guide (moved FreeTrialDuration import before local imports) |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User attaches product with one-off item] --> B{Check interval in frontend}
    B -->|Old: Default to Month| C[Error: Multiple intervals]
    B -->|New: Keep null| D[Send null interval to backend]
    D --> E{handleStripeCheckoutErrors}
    E -->|Check recurring intervals| F{Filter out one-off items}
    F -->|interval === null| G[Skip one-off]
    F -->|interval !== null| H[Count recurring intervals]
    H --> I{Multiple recurring intervals?}
    I -->|Yes| J[Throw error]
    I -->|No| K[Create Stripe checkout]
    G --> K
```
</details>


<sub>Last reviewed commit: 635845b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->