### PR TITLE
feat: 🎸 sandbox docker container

### DIFF
--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -1,0 +1,116 @@
+# =============================================================================
+# Autumn Sandbox — fully self-contained throwaway stack for AI agents
+# No Stripe, no Svix, no external services required.
+#
+# Usage:
+#   docker compose -f docker-compose.sandbox.yml up --build
+# =============================================================================
+
+services:
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: autumn
+      POSTGRES_PASSWORD: autumn
+      POSTGRES_DB: autumn
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U autumn"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  valkey:
+    image: docker.io/valkey/valkey:8.0
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "-h", "localhost", "-p", "6379", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  sandbox:
+    build:
+      dockerfile: docker/sandbox.dockerfile
+      context: .
+    develop:
+      watch:
+        # Server source — sync into container, bun dev hot-reloads automatically
+        - path: server/src
+          target: /app/server/src
+          action: sync
+        # Shared source — sync, then restart so the server picks up changes
+        - path: shared/src
+          target: /app/shared/src
+          action: sync+restart
+        # Vite source — sync into container, vite dev hot-reloads automatically
+        - path: vite/src
+          target: /app/vite/src
+          action: sync
+        # Dependency changes require a full rebuild
+        - path: package.json
+          action: rebuild
+        - path: server/package.json
+          action: rebuild
+        - path: vite/package.json
+          action: rebuild
+        - path: shared/package.json
+          action: rebuild
+        - path: bun.lock
+          action: rebuild
+    ports:
+      - "${SERVER_PORT:-8080}:8080"
+      - "${VITE_PORT:-3000}:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+    environment:
+      - NODE_ENV=development
+      - MOCK_MODE=true
+      - REDIS_URL=redis://valkey:6379
+      - CACHE_URL=redis://valkey:6379
+      - QUEUE_URL=redis://valkey:6379
+      - DATABASE_URL=postgres://autumn:autumn@postgres:5432/autumn
+      # Force SQS off so workers use BullMQ/Redis instead
+      - SQS_QUEUE_URL=
+
+      # Auth
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-sandbox-secret-change-me}
+      - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:8080}
+
+      # Encryption (used for publishable key generation)
+      - ENCRYPTION_PASSWORD=${ENCRYPTION_PASSWORD:-sandbox-encryption-password-32c}
+      - ENCRYPTION_IV=${ENCRYPTION_IV:-sandbox-iv-16c!!!}
+
+      # Vite
+      - VITE_BACKEND_URL=${VITE_BACKEND_URL:-http://localhost:8080}
+      - VITE_MOCK_MODE=true
+      - VITE_FRONTEND_URL=${VITE_FRONTEND_URL:-http://localhost:3000}
+
+      # Optional — safe to leave empty
+      - CLIENT_URL=${CLIENT_URL:-http://localhost:3000}
+      - SERVER_PORT=8080
+      - CLICKHOUSE_SKIP_ENSURES=true
+      - POSTHOG_API_KEY=${POSTHOG_API_KEY:-}
+      - SENTRY_DSN=${SENTRY_DSN:-}
+      - RESEND_API_KEY=${RESEND_API_KEY:-}
+      - LOOPS_API_KEY=${LOOPS_API_KEY:-}
+      - AXIOM_TOKEN=${AXIOM_TOKEN:-}
+      - AWS_REGION=${AWS_REGION:-us-east-1}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - SQS_QUEUE_URL=${SQS_QUEUE_URL:-}
+      - HATCHET_CLIENT_TOKEN=${HATCHET_CLIENT_TOKEN:-}
+      - STRIPE_SANDBOX_SECRET_KEY=${STRIPE_SANDBOX_SECRET_KEY:-}
+      - STRIPE_SANDBOX_WEBHOOK_SECRET=${STRIPE_SANDBOX_WEBHOOK_SECRET:-}
+    restart: unless-stopped
+
+volumes:
+  postgres-data:

--- a/docker/sandbox-drizzle.config.ts
+++ b/docker/sandbox-drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+// Container-only drizzle config used at build time to generate a fresh schema.
+// Output goes to /tmp/drizzle-gen inside the image — never touches the host.
+// DATABASE_URL is not needed for generate (only for push/migrate).
+export default defineConfig({
+	dialect: "postgresql",
+	out: "/tmp/drizzle-gen",
+	schema: "/app/shared/db/schema.ts",
+});

--- a/docker/sandbox-entrypoint.sh
+++ b/docker/sandbox-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+# ── 1. Apply generated schema to Postgres ────────────────────────────────────
+echo "[sandbox] Applying schema..."
+bun /app/docker/sandbox-schema-apply.ts
+echo "[sandbox] Schema ready"
+
+# ── 2. Start Vite dev server ──────────────────────────────────────────────────
+echo "[sandbox] Starting Vite dev server on port ${VITE_PORT:-3000}..."
+cd /app/vite
+bun dev &
+
+# ── 3. Start BullMQ workers ───────────────────────────────────────────────────
+echo "[sandbox] Starting workers..."
+cd /app/server
+bun src/workers.ts &
+
+# ── 4. Start API server (foreground) ─────────────────────────────────────────
+echo "[sandbox] Starting API server on port ${SERVER_PORT:-8080}..."
+cd /app/server
+exec bun src/index.ts

--- a/docker/sandbox-schema-apply.ts
+++ b/docker/sandbox-schema-apply.ts
@@ -1,0 +1,29 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { SQL } from "bun";
+
+const MIGRATIONS_DIR = "/tmp/drizzle-gen";
+const db = new SQL(process.env.DATABASE_URL!);
+
+// Apply all generated SQL files in order
+const files = readdirSync(MIGRATIONS_DIR)
+	.filter((f) => f.endsWith(".sql"))
+	.sort();
+
+for (const file of files) {
+	const path = join(MIGRATIONS_DIR, file);
+	console.log(`[sandbox] Applying ${file}...`);
+	try {
+		await db.file(path);
+	} catch (err: any) {
+		// 42P07 = relation already exists — schema already applied, safe to skip
+		if (err?.errno === "42P07") {
+			console.log(`[sandbox] Schema already exists, skipping`);
+		} else {
+			throw err;
+		}
+	}
+}
+
+await db.close();
+console.log("[sandbox] Schema applied");

--- a/docker/sandbox.dockerfile
+++ b/docker/sandbox.dockerfile
@@ -1,0 +1,47 @@
+# =============================================================================
+# Autumn Sandbox — dev mode, fully self-contained (except Postgres + Valkey
+# which are sidecars in docker-compose.sandbox.yml)
+# =============================================================================
+FROM oven/bun:latest
+
+WORKDIR /app
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
+# ── Install dependencies ──────────────────────────────────────────────────────
+COPY package.json bun.lock ./
+COPY shared/package.json         ./shared/
+COPY server/package.json         ./server/
+COPY vite/package.json           ./vite/
+COPY scripts/package.json        ./scripts/
+COPY apps/checkout/package.json  ./apps/checkout/
+COPY apps/docs/package.json      ./apps/docs/
+COPY apps/sdk-test/package.json  ./apps/sdk-test/
+COPY packages/sdk/package.json           ./packages/sdk/
+COPY packages/autumn-js/package.json     ./packages/autumn-js/
+COPY packages/openapi/package.json       ./packages/openapi/
+
+RUN bun install --ignore-scripts
+
+# ── Copy full source ──────────────────────────────────────────────────────────
+COPY . .
+
+# ── Generate fresh schema SQL into /tmp/drizzle-gen ──────────────────────────
+# Uses the container-only config (docker/sandbox-drizzle.config.ts) which
+# outputs to /tmp/drizzle-gen — your local shared/drizzle/ is never touched.
+RUN cp /app/docker/sandbox-drizzle.config.ts /app/shared/sandbox-drizzle.config.ts && \
+    cd /app/shared && NODE_OPTIONS="--import tsx" \
+      bun /app/shared/node_modules/.bin/drizzle-kit generate \
+      --config /app/shared/sandbox-drizzle.config.ts \
+      --name sandbox_init
+
+COPY docker/sandbox-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8080 3000
+
+ENV NODE_ENV=development
+ENV MOCK_MODE=true
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/server/src/honoMiddlewares/mockAuthMiddleware.ts
+++ b/server/src/honoMiddlewares/mockAuthMiddleware.ts
@@ -1,0 +1,57 @@
+import { AppEnv, AuthType } from "@autumn/shared";
+import type { Context, Next } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import {
+	getMockOrgContext,
+	MOCK_ORG_ID,
+} from "@/utils/mockMode/initMockOrg.js";
+
+/**
+ * Mock auth middleware for Hono routes (MOCK_MODE=true only).
+ *
+ * Bypasses all API key and session validation. Looks up the real mock org
+ * from the DB (populated on startup by initMockOrg) and injects it into
+ * the request context so all downstream handlers work normally against a
+ * real DB / Stripe sandbox.
+ *
+ * The env defaults to Sandbox; callers may override via the app_env header.
+ */
+export const mockAuthMiddleware = async (c: Context<HonoEnv>, next: Next) => {
+	const ctx = c.get("ctx");
+
+	// Prefer cached context; fall back to a fresh DB lookup if the cache
+	// was not populated yet (e.g. first request before startup hook ran)
+	let mockData = getMockOrgContext();
+
+	if (!mockData) {
+		const appEnv = (c.req.header("app_env") as AppEnv) ?? AppEnv.Sandbox;
+		mockData = await OrgService.getWithFeatures({
+			db: ctx.db,
+			orgId: MOCK_ORG_ID,
+			env: appEnv,
+			allowNotFound: true,
+		});
+	}
+
+	if (!mockData) {
+		return c.json(
+			{
+				message:
+					"Mock org not initialised yet — server may still be starting up",
+				code: "mock_org_not_ready",
+			},
+			503,
+		);
+	}
+
+	const appEnv = (c.req.header("app_env") as AppEnv) ?? AppEnv.Sandbox;
+
+	ctx.org = mockData.org;
+	ctx.features = mockData.features;
+	ctx.env = appEnv;
+	ctx.userId = "mock_test_user";
+	ctx.authType = AuthType.SecretKey;
+
+	await next();
+};

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -21,6 +21,7 @@ import { redirectToHono } from "./initHono.js";
 import { auth } from "./utils/auth.js";
 import { generateId } from "./utils/genUtils.js";
 import { checkEnvVars } from "./utils/initUtils.js";
+import { initMockOrg } from "./utils/mockMode/initMockOrg.js";
 
 checkEnvVars();
 // subscribeToOrgUpdates({ db });
@@ -108,6 +109,11 @@ const init = async () => {
 
 	// Initialize managers in parallel for faster startup
 	await Promise.all([ClickHouseManager.getInstance(), warmupRegionalRedis()]);
+
+	// Bootstrap mock org when running in mock mode
+	if (process.env.MOCK_MODE === "true") {
+		await initMockOrg();
+	}
 
 	app.use(async (req: any, res: any, next: any) => {
 		// Add Render region identifier headers for load balancer verification

--- a/server/src/internal/api/apiRouter.ts
+++ b/server/src/internal/api/apiRouter.ts
@@ -2,11 +2,14 @@ import { Router } from "express";
 import { analyticsMiddleware } from "@/middleware/analyticsMiddleware.js";
 import { apiAuthMiddleware } from "@/middleware/apiAuthMiddleware.js";
 import { expressApiVersionMiddleware } from "@/middleware/expressApiVersionMiddleware.js";
+import { mockAuthMiddleware } from "@/middleware/mockAuthMiddleware.js";
 import { refreshCacheMiddleware } from "@/middleware/refreshCacheMiddleware.js";
 
 const apiRouter: Router = Router();
 
-apiRouter.use(apiAuthMiddleware);
+apiRouter.use(
+	process.env.MOCK_MODE === "true" ? mockAuthMiddleware : apiAuthMiddleware,
+);
 apiRouter.use(analyticsMiddleware);
 apiRouter.use(expressApiVersionMiddleware as any);
 apiRouter.use(refreshCacheMiddleware);

--- a/server/src/middleware/mockAuthMiddleware.ts
+++ b/server/src/middleware/mockAuthMiddleware.ts
@@ -1,0 +1,50 @@
+import { AppEnv, AuthType } from "@autumn/shared";
+import type { NextFunction } from "express";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import {
+	getMockOrgContext,
+	MOCK_ORG_ID,
+} from "@/utils/mockMode/initMockOrg.js";
+
+/**
+ * Mock auth middleware for Express routes (MOCK_MODE=true only).
+ *
+ * Bypasses all API key and session validation. Looks up the real mock org
+ * from the DB (populated on startup by initMockOrg) and injects it into
+ * req so all downstream handlers work normally against a real DB / Stripe sandbox.
+ */
+export const mockAuthMiddleware = async (
+	req: any,
+	res: any,
+	next: NextFunction,
+) => {
+	let mockData = getMockOrgContext();
+
+	if (!mockData) {
+		const appEnv = (req.headers.app_env as AppEnv) ?? AppEnv.Sandbox;
+		mockData = await OrgService.getWithFeatures({
+			db: req.db,
+			orgId: MOCK_ORG_ID,
+			env: appEnv,
+			allowNotFound: true,
+		});
+	}
+
+	if (!mockData) {
+		return res.status(503).json({
+			message: "Mock org not initialised yet — server may still be starting up",
+			code: "mock_org_not_ready",
+		});
+	}
+
+	const appEnv = (req.headers.app_env as AppEnv) ?? AppEnv.Sandbox;
+
+	req.orgId = mockData.org.id;
+	req.env = appEnv;
+	req.org = mockData.org;
+	req.features = mockData.features;
+	req.authType = AuthType.SecretKey;
+	req.userId = "mock_test_user";
+
+	next();
+};

--- a/server/src/routers/apiRouter.ts
+++ b/server/src/routers/apiRouter.ts
@@ -7,6 +7,7 @@ import { configsRouter } from "@/internal/misc/configs/configsRouter.js";
 import { analyticsMiddleware } from "../honoMiddlewares/analyticsMiddleware.js";
 import { apiVersionMiddleware } from "../honoMiddlewares/apiVersionMiddleware.js";
 import { idempotencyMiddleware } from "../honoMiddlewares/idempotencyMiddleware.js";
+import { mockAuthMiddleware } from "../honoMiddlewares/mockAuthMiddleware.js";
 import { orgConfigMiddleware } from "../honoMiddlewares/orgConfigMiddleware.js";
 import { queryMiddleware } from "../honoMiddlewares/queryMiddleware.js";
 import { rateLimitMiddleware } from "../honoMiddlewares/rateLimitMiddleware.js";
@@ -39,7 +40,10 @@ import { rpcRouter } from "./rpcRouter.js";
 export const apiRouter = new Hono<HonoEnv>();
 
 apiRouter.use("*", responseFilterMiddleware);
-apiRouter.use("*", secretKeyMiddleware);
+apiRouter.use(
+	"*",
+	process.env.MOCK_MODE === "true" ? mockAuthMiddleware : secretKeyMiddleware,
+);
 apiRouter.use("*", orgConfigMiddleware);
 apiRouter.use("*", apiVersionMiddleware);
 apiRouter.use("*", refreshCacheMiddleware);

--- a/server/src/utils/mockMode/initMockOrg.ts
+++ b/server/src/utils/mockMode/initMockOrg.ts
@@ -1,0 +1,153 @@
+import { AppEnv, type Feature, type Organization } from "@autumn/shared";
+import { db } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { createSvixApp } from "@/external/svix/svixHelpers.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { createConnectAccount } from "@/internal/orgs/orgUtils/createConnectAccount.js";
+import { generatePublishableKey } from "@/utils/encryptUtils.js";
+
+export const MOCK_ORG_ID = "mock_test_org";
+export const MOCK_ORG_SLUG = "mock-test-org";
+export const MOCK_ORG_NAME = "Mock Test Org";
+
+const MOCK_USER = {
+	id: "mock_test_user",
+	email: "mock@test.local",
+	name: "Mock Test User",
+	emailVerified: true,
+	createdAt: new Date(),
+	updatedAt: new Date(),
+};
+
+let cachedMockOrg: { org: Organization; features: Feature[] } | null = null;
+
+/**
+ * Returns the cached mock org context (org + sandbox features).
+ * Call initMockOrg() first to ensure it is populated.
+ */
+export const getMockOrgContext = () => cachedMockOrg;
+
+/**
+ * Ensures the mock org exists in the DB and is fully ready.
+ * If STRIPE_SANDBOX_SECRET_KEY is present, creates a real Stripe Connect account.
+ * If SVIX_API_KEY is present, creates real Svix apps (safeSvix already guards this).
+ * All external calls are optional — the sandbox works without them.
+ * Idempotent — safe to call multiple times.
+ */
+export const initMockOrg = async () => {
+	logger.info("[mock] Initialising mock org...");
+
+	// Check if already exists
+	const existing = await OrgService.getWithFeatures({
+		db,
+		orgId: MOCK_ORG_ID,
+		env: AppEnv.Sandbox,
+		allowNotFound: true,
+	});
+
+	if (existing) {
+		logger.info(
+			`[mock] Mock org already exists (${MOCK_ORG_ID}), skipping creation`,
+		);
+		cachedMockOrg = existing;
+		return existing;
+	}
+
+	logger.info("[mock] Creating mock org in DB...");
+
+	// Insert the org row
+	await OrgService.create({
+		db,
+		id: MOCK_ORG_ID,
+		slug: MOCK_ORG_SLUG,
+		name: MOCK_ORG_NAME,
+	});
+
+	// ── Stripe Connect ────────────────────────────────────────────────────────
+	let testStripeConnect: Record<string, string> = {};
+	if (process.env.STRIPE_SANDBOX_SECRET_KEY) {
+		logger.info(
+			"[mock] STRIPE_SANDBOX_SECRET_KEY detected — creating Stripe Connect account...",
+		);
+		try {
+			const account = await createConnectAccount({
+				org: {
+					id: MOCK_ORG_ID,
+					slug: MOCK_ORG_SLUG,
+					name: MOCK_ORG_NAME,
+					createdAt: new Date(),
+				},
+				user: MOCK_USER as any,
+			});
+			testStripeConnect = { default_account_id: account.id };
+			logger.info(`[mock] Stripe Connect account created: ${account.id}`);
+		} catch (err: any) {
+			logger.warn(
+				`[mock] Stripe Connect creation failed (skipping): ${err?.message}`,
+			);
+		}
+	} else {
+		logger.info(
+			"[mock] No STRIPE_SANDBOX_SECRET_KEY — skipping Stripe Connect",
+		);
+	}
+
+	// ── Svix webhook apps ─────────────────────────────────────────────────────
+	// createSvixApp is wrapped in safeSvix which returns undefined when
+	// SVIX_API_KEY is not set, so this is safe to call unconditionally.
+	let svixConfig = { sandbox_app_id: "", live_app_id: "" };
+	if (process.env.SVIX_API_KEY) {
+		logger.info("[mock] SVIX_API_KEY detected — creating Svix apps...");
+		try {
+			const [sandboxApp, liveApp] = await Promise.all([
+				createSvixApp({
+					name: `${MOCK_ORG_SLUG}_${AppEnv.Sandbox}`,
+					orgId: MOCK_ORG_ID,
+					env: AppEnv.Sandbox,
+				}),
+				createSvixApp({
+					name: `${MOCK_ORG_SLUG}_${AppEnv.Live}`,
+					orgId: MOCK_ORG_ID,
+					env: AppEnv.Live,
+				}),
+			]);
+			svixConfig = {
+				sandbox_app_id: sandboxApp?.id ?? "",
+				live_app_id: liveApp?.id ?? "",
+			};
+			logger.info(
+				`[mock] Svix apps created (sandbox=${svixConfig.sandbox_app_id}, live=${svixConfig.live_app_id})`,
+			);
+		} catch (err: any) {
+			logger.warn(
+				`[mock] Svix app creation failed (skipping): ${err?.message}`,
+			);
+		}
+	} else {
+		logger.info("[mock] No SVIX_API_KEY — skipping Svix apps");
+	}
+
+	// ── Persist everything ────────────────────────────────────────────────────
+	await OrgService.update({
+		db,
+		orgId: MOCK_ORG_ID,
+		updates: {
+			created_at: Date.now(),
+			default_currency: "usd",
+			test_pkey: generatePublishableKey(AppEnv.Sandbox),
+			live_pkey: generatePublishableKey(AppEnv.Live),
+			svix_config: svixConfig,
+			test_stripe_connect: testStripeConnect,
+		},
+	});
+
+	const result = await OrgService.getWithFeatures({
+		db,
+		orgId: MOCK_ORG_ID,
+		env: AppEnv.Sandbox,
+	});
+
+	cachedMockOrg = result;
+	logger.info(`[mock] Mock org ready (${MOCK_ORG_ID})`);
+	return result;
+};

--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -85,8 +85,9 @@ export function MainLayout() {
 		);
 	}
 
-	// 2. If no user, redirect to sign in
-	if (!data) {
+	// 2. If no user, redirect to sign in (skipped in mock mode)
+	const isMockMode = import.meta.env.VITE_MOCK_MODE === "true";
+	if (!data && !isMockMode) {
 		navigate("/sign-in");
 		return;
 	}

--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -49,7 +49,12 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 		initialData: getInitialData(),
 	});
 
+	const isMockMode = import.meta.env.VITE_MOCK_MODE === "true";
+
 	useEffect(() => {
+		// In mock mode there is no real session, so skip setActive / signOut flows
+		if (isMockMode) return;
+
 		const handleNoActiveOrg = async () => {
 			// 1. If there's existing org, set as active
 			if (orgList && orgList.length > 0) {
@@ -67,7 +72,7 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 		if (!org && !isLoading) {
 			handleNoActiveOrg();
 		}
-	}, [org, orgList, isLoading]);
+	}, [org, orgList, isLoading, isMockMode]);
 
 	return { org: org as FrontendOrg, isLoading, error, mutate: refetch };
 };

--- a/vite/src/lib/auth-client.ts
+++ b/vite/src/lib/auth-client.ts
@@ -5,6 +5,7 @@ import {
 	organizationClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
+import { useMockSession } from "./mockSession";
 
 export const authClient = createAuthClient({
 	baseURL: import.meta.env.VITE_BACKEND_URL,
@@ -16,4 +17,12 @@ export const authClient = createAuthClient({
 	],
 });
 
-export const { useSession, signIn, useListOrganizations } = authClient;
+const isMockMode = import.meta.env.VITE_MOCK_MODE === "true";
+
+/**
+ * useSession — returns the mock session when VITE_MOCK_MODE=true,
+ * otherwise delegates to better-auth.
+ */
+export const useSession = isMockMode ? useMockSession : authClient.useSession;
+
+export const { signIn, useListOrganizations } = authClient;

--- a/vite/src/lib/mockSession.ts
+++ b/vite/src/lib/mockSession.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? "http://localhost:8080";
+
+/**
+ * Fetches the mock session from the server's /api/mock-session endpoint.
+ * Used in place of better-auth's useSession when VITE_MOCK_MODE=true.
+ */
+const fetchMockSession = async () => {
+	const res = await fetch(`${BACKEND_URL}/api/mock-session`, {
+		credentials: "include",
+	});
+	if (!res.ok) return null;
+	return res.json();
+};
+
+/**
+ * Drop-in replacement for better-auth's useSession hook.
+ * Returns a stable mock user + session so the frontend skips all auth flows.
+ */
+export const useMockSession = () => {
+	const { data, isPending } = useQuery({
+		queryKey: ["mock-session"],
+		queryFn: fetchMockSession,
+		staleTime: Number.POSITIVE_INFINITY,
+		retry: 3,
+	});
+
+	return { data, isPending };
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a self-contained sandbox Docker stack with mocked auth so the app runs locally without external services. It auto-generates the DB schema, starts API, workers, and Vite, and provides a fake session/org for the UI.

- **New Features**
  - Docker sandbox: compose file with Postgres + Valkey sidecars, dev image, schema generation, and entrypoint that starts Vite, workers, and API with hot reload.
  - Mock mode: server-wide mock auth (Hono + Express), /api/mock-session endpoint, and startup bootstrap for a mock org (optional Stripe Connect and Svix if keys are set).
  - Routing: secret/session auth is swapped for mockAuthMiddleware when MOCK_MODE=true; admin routes remain protected only outside mock mode.
  - Frontend: VITE_MOCK_MODE skips sign-in, uses a mock session hook, and bypasses active org handling.

- **Refactors**
  - Workers prefer BullMQ (QUEUE_URL) over SQS (SQS_QUEUE_URL) to ensure Redis queues in sandbox.

- **Migration**
  - Run: docker compose -f docker-compose.sandbox.yml up --build, then visit http://localhost:3000.
  - Optional: set STRIPE_SANDBOX_SECRET_KEY and SVIX_API_KEY to create real sandbox integrations; otherwise everything runs fully local.

<sup>Written for commit 6c84d47b17b4ef1716d80a4a595b08198be4b29f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements a fully self-contained Docker sandbox environment for Autumn, enabling AI agents and developers to spin up the entire stack locally without requiring external services like Stripe or Svix. The implementation introduces `MOCK_MODE` functionality that bypasses authentication and uses a pre-initialized mock organization.

**Key Changes:**

**Improvements:**
- Created comprehensive Docker Compose setup with Postgres, Valkey (Redis), and the Autumn stack with hot-reload support
- Implemented automatic schema migration at container startup using Drizzle-generated SQL
- Added mock authentication middleware for both Hono and Express routes that injects a cached mock organization context
- Created `/api/mock-session` endpoint and corresponding frontend hook to bypass Better Auth entirely in mock mode
- Made all external integrations (Stripe Connect, Svix) optional with graceful fallbacks
- Implemented idempotent mock org initialization with proper caching to avoid redundant database queries

**Bug fixes:**
- Changed worker queue detection to prioritize `QUEUE_URL` (BullMQ) over `SQS_QUEUE_URL` to prevent local environment variables from leaking into Docker sandbox

**API changes:**
- Added `/api/mock-session` endpoint (only available when `MOCK_MODE=true`)
- Modified authentication flow for all `/api/*` and `/internal/*` routes to use mock middleware when in mock mode

**Issues Found:**
- Both mock auth middleware files use `c.json()` and `res.status().json()` patterns for error responses instead of throwing `InternalError` as specified in CLAUDE.md
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor style improvements recommended
- The implementation is well-architected and follows good patterns (idempotent initialization, optional external services, proper caching). The code is clean and handles edge cases appropriately. Score reduced by 1 point due to error handling not following project guidelines in two middleware files - these use direct JSON responses instead of throwing `InternalError` as specified in CLAUDE.md
- Pay attention to `server/src/honoMiddlewares/mockAuthMiddleware.ts` and `server/src/middleware/mockAuthMiddleware.ts` - both should use `InternalError` instead of direct JSON error responses

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docker-compose.sandbox.yml | Added comprehensive Docker Compose configuration for fully self-contained sandbox environment with Postgres, Valkey (Redis), and hot-reload support |
| docker/sandbox.dockerfile | Created Dockerfile with Bun runtime, dependency installation, and automatic schema generation at build time |
| docker/sandbox-entrypoint.sh | Added entrypoint script that applies schema, starts Vite, workers, and API server in proper sequence |
| server/src/honoMiddlewares/mockAuthMiddleware.ts | Created Hono mock auth middleware that bypasses API key validation and injects mock org context for sandbox mode |
| server/src/middleware/mockAuthMiddleware.ts | Created Express mock auth middleware with same logic as Hono version for legacy routes |
| server/src/utils/mockMode/initMockOrg.ts | Implemented comprehensive mock org initialization with optional Stripe Connect and Svix integration, fully idempotent |
| server/src/workers.ts | Changed queue detection priority to prefer `QUEUE_URL` (BullMQ) over `SQS_QUEUE_URL` for sandbox environments |
| vite/src/lib/mockSession.ts | Created mock session hook that fetches fake session from `/api/mock-session` endpoint with infinite stale time |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Docker Compose Start] --> B[PostgreSQL Container]
    A --> C[Valkey/Redis Container]
    A --> D[Sandbox Container Build]
    
    D --> E[Install Bun Dependencies]
    E --> F[Generate Schema SQL to /tmp/drizzle-gen]
    F --> G[Container Ready]
    
    G --> H[Entrypoint: Apply Schema to Postgres]
    H --> I[Start Vite Dev Server :3000]
    H --> J[Start BullMQ Workers]
    H --> K[Start API Server :8080]
    
    K --> L{MOCK_MODE=true?}
    L -->|Yes| M[Initialize Mock Org in DB]
    M --> N[Create Stripe Connect Account]
    M --> O[Create Svix Apps]
    M --> P[Cache Mock Org Context]
    
    K --> Q[API Requests]
    Q --> R{Route Type?}
    
    R -->|/api/*| S{MOCK_MODE?}
    S -->|Yes| T[mockAuthMiddleware - Inject Mock Org]
    S -->|No| U[secretKeyMiddleware - Validate API Key]
    
    R -->|/internal/*| V{MOCK_MODE?}
    V -->|Yes| W[mockAuthMiddleware - Inject Mock Org]
    V -->|No| X[betterAuthMiddleware - Validate Session]
    
    I --> Y[Frontend Requests]
    Y --> Z{VITE_MOCK_MODE?}
    Z -->|Yes| AA[Fetch /api/mock-session]
    Z -->|No| AB[Better Auth useSession]
    
    AA --> AC[useMockSession Hook]
    AC --> AD[Skip Auth Flows]
```
</details>


<sub>Last reviewed commit: 6c84d47</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))

<!-- /greptile_comment -->