### PR TITLE
fix: exclude archived products from check preview and related flows

### DIFF
--- a/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getCusAndProducts.ts
+++ b/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getCusAndProducts.ts
@@ -37,6 +37,14 @@ const getProductsForAttach = async ({
 		version,
 	});
 
+	const archivedProducts = products.filter((prod) => prod.archived);
+	if (archivedProducts.length > 0) {
+		throw new RecaseError({
+			message: `Cannot attach archived product${archivedProducts.length > 1 ? "s" : ""}: ${archivedProducts.map((p) => p.id).join(", ")}`,
+			code: ErrCode.InvalidRequest,
+		});
+	}
+
 	if (notNullish(product_ids)) {
 		const freeTrialProds = products.filter((prod) =>
 			notNullish(prod.free_trial),

--- a/server/src/internal/misc/components/handlers/handleGetPricingTable.ts
+++ b/server/src/internal/misc/components/handlers/handleGetPricingTable.ts
@@ -23,7 +23,7 @@ export const handleGetPricingTable = createRoute({
 		const { customer_id: customerId } = c.req.valid("query");
 
 		const [products, customer] = await Promise.all([
-			ProductService.listFull({ db, orgId: org.id, env }),
+			ProductService.listFull({ db, orgId: org.id, env, archived: false }),
 			(async () => {
 				if (!customerId) {
 					return undefined;

--- a/server/src/internal/product/actions/createProduct.ts
+++ b/server/src/internal/product/actions/createProduct.ts
@@ -36,8 +36,8 @@ export const createProduct = async ({
 		id: data.id,
 	});
 
-	// 1. If existing product, throw error
-	if (existing) throw new ProductAlreadyExistsError({ productId: data.id });
+	// 1. If existing non-archived product, throw error
+	if (existing && !existing.archived) throw new ProductAlreadyExistsError({ productId: data.id });
 
 	await validateDefaultFlag({
 		ctx,

--- a/server/src/internal/products/ProductService.ts
+++ b/server/src/internal/products/ProductService.ts
@@ -63,16 +63,19 @@ export class ProductService {
 		internalFeatureId: string;
 	}) {
 		const fullProducts = (await db.query.products.findMany({
-			where: exists(
-				db
-					.select()
-					.from(entitlements)
-					.where(
-						and(
-							eq(entitlements.internal_product_id, products.internal_id),
-							eq(entitlements.internal_feature_id, internalFeatureId),
+			where: and(
+				ne(products.archived, true),
+				exists(
+					db
+						.select()
+						.from(entitlements)
+						.where(
+							and(
+								eq(entitlements.internal_product_id, products.internal_id),
+								eq(entitlements.internal_feature_id, internalFeatureId),
+							),
 						),
-					),
+				),
 			),
 			with: {
 				entitlements: {

--- a/server/src/internal/products/handlers/handleCreateProduct/handleCreatePlan.ts
+++ b/server/src/internal/products/handlers/handleCreateProduct/handleCreatePlan.ts
@@ -59,8 +59,8 @@ export const handleCreatePlan = createRoute({
 			id: body.id,
 		});
 
-		// 1. If existing product, throw error
-		if (existing) throw new ProductAlreadyExistsError({ productId: body.id });
+		// 1. If existing non-archived product, throw error
+		if (existing && !existing.archived) throw new ProductAlreadyExistsError({ productId: body.id });
 
 		await validateDefaultFlag({
 			ctx,


### PR DESCRIPTION
## Summary
- **`ProductService.getByFeature`**: Added `ne(products.archived, true)` to the query so archived products are never included in the `/check` `withPreview` response. This was the root cause of paywall dialogs incorrectly suggesting upgrades to retired/archived plans as the upgrade target.
- **`handleGetPricingTable`**: Pass `archived: false` to `listFull` so archived products are excluded from the customer-facing pricing table component.
- **`getCusAndProducts`**: Reject attach requests that target an archived product with a clear error message, preventing archived products from being attached to customers.
- **`createProduct` / `handleCreatePlan`**: Allow reusing an archived product's ID for a new product — don't treat an archived product as a conflict when checking for duplicate IDs.

## Related Issues
No existing issue - bug found during code review

## Type of Change
- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
Other `ProductService` methods (`listDefault`, `handleListPlans`, `handleListBillingPlans`) already filtered archived products correctly using `ne(products.archived, true)` or `archived: false`. This PR brings the remaining callers in line with that existing pattern - `getByFeature` was the only query method missing the filter entirely, and the other three fixes address the downstream consequences of archived products leaking through.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Archived products are now fully excluded from previews and customer-facing flows to prevent upgrade prompts to retired plans and invalid attachments. Creating new products can reuse IDs from archived products.

- **Bug Fixes**
  - Filtered archived products in ProductService.getByFeature so /check withPreview returns only active plans.
  - Excluded archived products from the pricing table by passing archived: false to listFull.
  - Blocked attach requests targeting archived products with a clear error.
  - Allowed reusing IDs of archived products when creating products/plans; only non-archived products cause conflicts.

<sup>Written for commit 3f5d01bd76e58f60af4281c3dd7c7b0325d73a2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR systematically excludes archived products from customer-facing flows to prevent upgrade prompts to retired plans.

**Bug Fixes**
- Fixed `/check` endpoint's `withPreview` response incorrectly suggesting upgrades to archived/retired products by adding archived filter to `ProductService.getByFeature` at server/src/internal/products/ProductService.ts:67
- Prevented archived products from appearing in customer-facing pricing tables at server/src/internal/misc/components/handlers/handleGetPricingTable.ts:26
- Blocked attach requests targeting archived products with validation error at server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getCusAndProducts.ts:40-46

**Improvements**
- Allowed reusing product IDs from archived products when creating new products by updating duplicate checks in `createProduct` and `handleCreatePlan` to only reject non-archived duplicates

The changes are consistent with existing patterns throughout the codebase. Other `ProductService` methods (`listDefault`, `handleListBillingPlans`) already filter archived products using the same approach. The fix brings `getByFeature` in line with these existing patterns.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes follow established patterns already used elsewhere in the codebase. The archived product filtering using `ne(products.archived, true)` and `archived: false` is consistent with existing code in `listDefault`, `handleListBillingPlans`, and other methods. The validation logic is defensive and prevents potential runtime errors. The changes are minimal, focused, and directly address the stated bug.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/ProductService.ts | Added `ne(products.archived, true)` filter to `getByFeature` method to exclude archived products from check preview results |
| server/src/internal/misc/components/handlers/handleGetPricingTable.ts | Added `archived: false` parameter to `listFull` call to exclude archived products from customer-facing pricing table |
| server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getCusAndProducts.ts | Added validation to reject attach requests targeting archived products with clear error message |
| server/src/internal/product/actions/createProduct.ts | Updated duplicate check to only throw error for non-archived products, allowing ID reuse from archived products |
| server/src/internal/products/handlers/handleCreateProduct/handleCreatePlan.ts | Updated duplicate check to only throw error for non-archived products, allowing ID reuse from archived products |

</details>



<sub>Last reviewed commit: 3f5d01b</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->