### PR TITLE
fix: add CLIENT_URL to CORS allowed origins for self-hosted deployments

### DIFF
--- a/server/src/middleware/apiAuthMiddleware.ts
+++ b/server/src/middleware/apiAuthMiddleware.ts
@@ -1,6 +1,6 @@
 import { AuthType, ErrCode } from "@autumn/shared";
 import { verifyKey } from "@/internal/dev/api-keys/apiKeyUtils.js";
-import { dashboardOrigins } from "@/utils/constants.js";
+import { isDashboardOrigin } from "@/utils/constants.js";
 import RecaseError from "@/utils/errorUtils.js";
 import { withOrgAuth } from "./authMiddleware.js";
 import { verifyBearerPublishableKey } from "./publicAuthMiddleware.js";
@@ -15,7 +15,7 @@ const verifySecretKey = async (req: any, res: any, next: any) => {
 
 	if (!authHeader || !authHeader.startsWith("Bearer ")) {
 		const origin = req.get("origin");
-		if (dashboardOrigins.includes(origin)) {
+		if (isDashboardOrigin({ origin })) {
 			return withOrgAuth(req, res, next);
 		} else {
 			throw new RecaseError({
@@ -100,7 +100,7 @@ export const apiAuthMiddleware = async (req: any, res: any, next: any) => {
 	} catch (error: any) {
 		if (error instanceof RecaseError) {
 			if (error.code === ErrCode.InvalidSecretKey) {
-				const apiKey = req.headers["authorization"]?.split(" ")[1];
+				const apiKey = req.headers.authorization?.split(" ")[1];
 				error.message = `Invalid secret key: ${maskApiKey(apiKey)}`;
 			}
 

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -21,6 +21,7 @@ import sendOTPEmail from "@/internal/emails/sendOTPEmail.js";
 import { afterOrgCreated } from "./authUtils/afterOrgCreated.js";
 import { beforeSessionCreated } from "./authUtils/beforeSessionCreated.js";
 import { ADMIN_USER_IDs } from "./constants.js";
+import { getSelfHostedOrigins } from "./corsOrigins.js";
 
 export const auth = betterAuth({
 	baseURL: process.env.BETTER_AUTH_URL,
@@ -67,6 +68,8 @@ export const auth = betterAuth({
 			"https://staging.useautumn.com",
 			"https://*.useautumn.com",
 		];
+
+		origins.push(...getSelfHostedOrigins());
 
 		// Better Auth validates origins independently from app-level CORS.
 		// Allow local multi-port setups for any non-production runtime.

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { CusProductStatus } from "@autumn/shared";
+import { getClientOrigin } from "./corsOrigins.js";
 
 const BREAK_API_VERSION = 0.2;
 
@@ -20,13 +21,28 @@ export const ADMIN_USER_IDs = [
 	"K7NDwSwohMCV9BXJ3Yb5MxgeXhWcwj0L", // charlie sandbox
 ];
 
-export const dashboardOrigins = [
+const DEFAULT_DASHBOARD_ORIGINS = [
 	"http://localhost:3000",
 	"https://app.useautumn.com",
 	"https://staging.useautumn.com",
 	"https://dev.useautumn.com",
-	process.env.CLIENT_URL!,
 ];
+
+export const getDashboardOrigins = (): string[] => {
+	const clientOrigin = getClientOrigin();
+	const origins = [...DEFAULT_DASHBOARD_ORIGINS];
+	if (clientOrigin) {
+		origins.push(clientOrigin);
+	}
+
+	return [...new Set(origins)];
+};
+
+export const isDashboardOrigin = ({ origin }: { origin?: string }) => {
+	if (!origin) return false;
+
+	return getDashboardOrigins().includes(origin);
+};
 
 export const WEBHOOK_EVENTS = [
 	"checkout.session.completed",

--- a/server/src/utils/corsOrigins.ts
+++ b/server/src/utils/corsOrigins.ts
@@ -16,9 +16,42 @@ export const ALLOWED_ORIGINS = [
 	"https://localhost:8080",
 ];
 
+const toOrigin = ({ url }: { url?: string }): string | undefined => {
+	if (!url) return undefined;
+	const trimmedUrl = url.trim();
+	if (!trimmedUrl) return undefined;
+
+	try {
+		const parsedUrl = new URL(trimmedUrl);
+		if (!["http:", "https:"].includes(parsedUrl.protocol)) return undefined;
+		return parsedUrl.origin;
+	} catch {
+		return undefined;
+	}
+};
+
+export const getClientOrigin = (): string | undefined => {
+	return toOrigin({ url: process.env.CLIENT_URL });
+};
+
+export const getCheckoutBaseOrigin = (): string | undefined => {
+	return toOrigin({ url: process.env.CHECKOUT_BASE_URL });
+};
+
+export const getSelfHostedOrigins = (): string[] => {
+	const origins = [getClientOrigin(), getCheckoutBaseOrigin()];
+
+	return [
+		...new Set(origins.filter((origin): origin is string => Boolean(origin))),
+	];
+};
+
 /** Allow any localhost origin in dev for multi-worktree support */
 export const isAllowedOrigin = (origin: string): string | undefined => {
 	if (ALLOWED_ORIGINS.includes(origin)) return origin;
+	for (const selfHostedOrigin of getSelfHostedOrigins()) {
+		if (origin === selfHostedOrigin) return origin;
+	}
 	if (
 		process.env.NODE_ENV !== "production" &&
 		/^https?:\/\/localhost:\d+$/.test(origin)

--- a/server/tests/unit/corsOrigins.test.ts
+++ b/server/tests/unit/corsOrigins.test.ts
@@ -1,11 +1,33 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { ALLOWED_ORIGINS, isAllowedOrigin } from "@/utils/corsOrigins.js";
 
+const restoreEnvVar = ({
+	key,
+	value,
+}: {
+	key: "NODE_ENV" | "CLIENT_URL" | "CHECKOUT_BASE_URL";
+	value: string | undefined;
+}) => {
+	if (value === undefined) {
+		delete process.env[key];
+		return;
+	}
+
+	process.env[key] = value;
+};
+
 describe("isAllowedOrigin", () => {
 	const originalNodeEnv = process.env.NODE_ENV;
+	const originalClientUrl = process.env.CLIENT_URL;
+	const originalCheckoutBaseUrl = process.env.CHECKOUT_BASE_URL;
 
 	afterEach(() => {
-		process.env.NODE_ENV = originalNodeEnv;
+		restoreEnvVar({ key: "NODE_ENV", value: originalNodeEnv });
+		restoreEnvVar({ key: "CLIENT_URL", value: originalClientUrl });
+		restoreEnvVar({
+			key: "CHECKOUT_BASE_URL",
+			value: originalCheckoutBaseUrl,
+		});
 	});
 
 	describe("production", () => {
@@ -61,6 +83,102 @@ describe("isAllowedOrigin", () => {
 			process.env.NODE_ENV = "development";
 			expect(isAllowedOrigin("http://localhost:3000/evil")).toBeUndefined();
 			expect(isAllowedOrigin("http://localhost:3000?x=1")).toBeUndefined();
+		});
+	});
+
+	describe("self-hosted env URLs", () => {
+		test("allows CLIENT_URL in production", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CLIENT_URL =
+				"https://autumn-dashboard-production.up.railway.app";
+			expect(
+				isAllowedOrigin("https://autumn-dashboard-production.up.railway.app"),
+			).toBe("https://autumn-dashboard-production.up.railway.app");
+		});
+
+		test("allows CLIENT_URL origin when URL has path and trailing slash", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CLIENT_URL =
+				"https://autumn-dashboard-production.up.railway.app/app/";
+			expect(
+				isAllowedOrigin("https://autumn-dashboard-production.up.railway.app"),
+			).toBe("https://autumn-dashboard-production.up.railway.app");
+		});
+
+		test("allows CHECKOUT_BASE_URL in production", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CHECKOUT_BASE_URL =
+				"https://autumn-checkout-production.up.railway.app";
+			expect(
+				isAllowedOrigin("https://autumn-checkout-production.up.railway.app"),
+			).toBe("https://autumn-checkout-production.up.railway.app");
+		});
+
+		test("trims whitespace around self-hosted env URLs", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CLIENT_URL = "  https://dashboard.mycompany.com/app/  ";
+			expect(isAllowedOrigin("https://dashboard.mycompany.com")).toBe(
+				"https://dashboard.mycompany.com",
+			);
+		});
+
+		test("allows CHECKOUT_BASE_URL origin when URL has path", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CHECKOUT_BASE_URL =
+				"https://autumn-checkout-production.up.railway.app/c";
+			expect(
+				isAllowedOrigin("https://autumn-checkout-production.up.railway.app"),
+			).toBe("https://autumn-checkout-production.up.railway.app");
+		});
+
+		test("allows both CLIENT_URL and CHECKOUT_BASE_URL simultaneously", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CLIENT_URL = "https://dashboard.mycompany.com";
+			process.env.CHECKOUT_BASE_URL = "https://checkout.mycompany.com";
+			expect(isAllowedOrigin("https://dashboard.mycompany.com")).toBe(
+				"https://dashboard.mycompany.com",
+			);
+			expect(isAllowedOrigin("https://checkout.mycompany.com")).toBe(
+				"https://checkout.mycompany.com",
+			);
+		});
+
+		test("still rejects unrelated origins when env URLs are set", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CLIENT_URL = "https://dashboard.mycompany.com";
+			process.env.CHECKOUT_BASE_URL = "https://checkout.mycompany.com";
+			expect(isAllowedOrigin("https://evil.com")).toBeUndefined();
+			expect(
+				isAllowedOrigin("https://not-autumn.up.railway.app"),
+			).toBeUndefined();
+		});
+
+		test("ignores invalid self-hosted URL env values", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CLIENT_URL = "autumn-dashboard-production.up.railway.app";
+			process.env.CHECKOUT_BASE_URL = "not-a-url";
+
+			expect(
+				isAllowedOrigin("https://autumn-dashboard-production.up.railway.app"),
+			).toBeUndefined();
+		});
+
+		test("ignores non-http protocols in self-hosted env URLs", () => {
+			process.env.NODE_ENV = "production";
+			process.env.CLIENT_URL = "ftp://dashboard.mycompany.com";
+
+			expect(
+				isAllowedOrigin("https://dashboard.mycompany.com"),
+			).toBeUndefined();
+		});
+
+		test("rejects custom domains when env URLs are unset", () => {
+			process.env.NODE_ENV = "production";
+			delete process.env.CLIENT_URL;
+			delete process.env.CHECKOUT_BASE_URL;
+			expect(
+				isAllowedOrigin("https://autumn-dashboard-production.up.railway.app"),
+			).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
Fixes #857

`CLIENT_URL` (and `CHECKOUT_BASE_URL`) were not included in the CORS allowlist or Better Auth's `trustedOrigins` in production, blocking self-hosted deployments on custom domains (e.g. Railway).

**Changes:**
- `corsOrigins.ts` — allow `CLIENT_URL` and `CHECKOUT_BASE_URL` as valid origins unconditionally
- `auth.ts` — move `CLIENT_URL` out of the dev-only guard so `trustedOrigins` includes it in production; add `CHECKOUT_BASE_URL`
- `corsOrigins.test.ts` — add tests for self-hosted origin scenarios

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always allow CLIENT_URL and CHECKOUT_BASE_URL for self-hosted deployments by adding them to CORS and Better Auth trusted origins. Normalize env URLs to strict HTTP(S) origins so paths/trailing slashes match browser Origin headers.

- Bug Fixes
  - CORS/Auth: normalize env URLs and allow CLIENT_URL/CHECKOUT_BASE_URL; reuse shared helpers across CORS, Better Auth trustedOrigins, and API auth middleware.
  - Tests: correct env restoration and add cases for whitespace, path/trailing slash, invalid/non-HTTP protocols, and unset envs; unrelated origins remain rejected.

<sup>Written for commit e4748ea949867eb02e34fb6bde99455df2068c83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes CORS and Better Auth `trustedOrigins` misconfigurations that blocked self-hosted deployments (e.g. on Railway) from communicating with the server when using custom domains set via `CLIENT_URL` and `CHECKOUT_BASE_URL`.

**Key Changes:**
- **Bug fixes** — `corsOrigins.ts`: `CLIENT_URL` and `CHECKOUT_BASE_URL` are now checked unconditionally in `isAllowedOrigin`, allowing custom-domain self-hosted deployments through CORS in production.
- **Bug fixes** — `auth.ts`: `CLIENT_URL` is moved outside the `NODE_ENV !== "production"` guard so Better Auth's `trustedOrigins` includes it in production; `CHECKOUT_BASE_URL` is also added.
- **Improvements** — `corsOrigins.test.ts`: New `self-hosted env URLs` test suite covers production allowance, simultaneous use of both env vars, rejection of unrelated origins, and rejection when env vars are unset. The `afterEach` cleanup has a subtle issue where assigning `undefined` to a `process.env` key sets it to the string `"undefined"` rather than deleting it (see inline comment).
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge with a minor test-cleanup fix; the core CORS logic is correct and well-tested.
- The production logic changes in `corsOrigins.ts` and `auth.ts` are straightforward and well-scoped: they add exact-match allowances for two operator-configured env vars. The only notable issues are (1) a test `afterEach` cleanup bug that doesn't break current tests but is semantically incorrect, and (2) a robustness gap if env vars include a path component. Neither blocks the fix from working in the typical deployment scenario.
- server/tests/unit/corsOrigins.test.ts — afterEach cleanup incorrectly assigns undefined to process.env keys.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/utils/corsOrigins.ts | Adds runtime checks for CLIENT_URL and CHECKOUT_BASE_URL in isAllowedOrigin; correct approach but exact-string comparison may fail if env vars include a path or trailing slash. |
| server/src/utils/auth.ts | Moves CLIENT_URL and adds CHECKOUT_BASE_URL to trustedOrigins unconditionally; clean and correct change that unblocks self-hosted deployments in Better Auth. |
| server/tests/unit/corsOrigins.test.ts | Good coverage of self-hosted scenarios, but afterEach cleanup incorrectly assigns undefined to process.env keys, which sets them to the string "undefined" rather than deleting them. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming request with Origin header] --> B{isAllowedOrigin}
    B --> C{In ALLOWED_ORIGINS hardcoded list?}
    C -- Yes --> ALLOW[Return origin ✅]
    C -- No --> D{CLIENT_URL set AND origin matches?}
    D -- Yes --> ALLOW
    D -- No --> E{CHECKOUT_BASE_URL set AND origin matches?}
    E -- Yes --> ALLOW
    E -- No --> F{NODE_ENV !== production AND localhost:port pattern?}
    F -- Yes --> ALLOW
    F -- No --> REJECT[Return undefined ❌]

    G[Better Auth trustedOrigins IIFE] --> H[Hardcoded: localhost:3000, app/staging/*.useautumn.com]
    H --> I{CLIENT_URL set?}
    I -- Yes --> J[Push CLIENT_URL]
    I -- No --> K{CHECKOUT_BASE_URL set?}
    J --> K
    K -- Yes --> L[Push CHECKOUT_BASE_URL]
    K -- No --> M{NODE_ENV !== production?}
    L --> M
    M -- Yes --> N[Push localhost:3000–3010]
    M -- No --> O[Return origins array]
    N --> O
```
</details>


<sub>Last reviewed commit: 6ba9b35</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->