### PR TITLE
fix: windows dev script quoting and set trailing space

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -95,55 +95,56 @@ async function startDev() {
 		let shellArgs: string[];
 		if (serverOnly) {
 			// Only start server and workers (for test sandboxes)
-			if (isWindows) {
-				const serverCmd = `cd server && set SERVER_PORT=${SERVER_PORT} && bun start`;
-				const workersCmd = `cd server && bun workers`;
-				shellArgs = [
-					"cmd",
-					"/c",
-					`bunx concurrently -n server,workers -c green,yellow "${serverCmd}" "${workersCmd}"`,
-				];
-			} else {
-				shellArgs = [
-					"sh",
-					"-c",
-					`bunx concurrently -n server,workers -c green,yellow "cd server && SERVER_PORT=${SERVER_PORT} bun start" "cd server && bun workers"`,
-				];
-			}
+			const serverCmd = isWindows
+				? `cd server && set SERVER_PORT=${SERVER_PORT}&& bun start`
+				: `cd server && SERVER_PORT=${SERVER_PORT} bun start`;
+			const workersCmd = `cd server && bun workers`;
+			shellArgs = [
+				process.execPath,
+				"x",
+				"concurrently",
+				"-n",
+				"server,workers",
+				"-c",
+				"green,yellow",
+				serverCmd,
+				workersCmd,
+			];
 		} else {
 			const names = ["server"];
 			const colors = ["green"];
 			const cmds = [
 				isWindows
-					? `"cd server && set SERVER_PORT=${SERVER_PORT} && bun dev"`
-					: `"cd server && SERVER_PORT=${SERVER_PORT} bun dev"`,
+					? `cd server && set SERVER_PORT=${SERVER_PORT}&& bun dev`
+					: `cd server && SERVER_PORT=${SERVER_PORT} bun dev`,
 			];
 
 			if (!skipWorkers) {
 				names.push("workers");
 				colors.push("yellow");
-				cmds.push(
-					isWindows
-						? `"cd server && bun workers:dev"`
-						: `"cd server && bun workers:dev"`,
-				);
+				cmds.push(`cd server && bun workers:dev`);
 			}
 
 			names.push("vite", "checkout");
 			colors.push("blue", "magenta");
 			cmds.push(
 				isWindows
-					? `"cd vite && set VITE_PORT=${VITE_PORT} && bun dev"`
-					: `"cd vite && VITE_PORT=${VITE_PORT} bun dev"`,
+					? `cd vite && set VITE_PORT=${VITE_PORT}&& bun dev`
+					: `cd vite && VITE_PORT=${VITE_PORT} bun dev`,
 				isWindows
-					? `"cd apps/checkout && set VITE_PORT=${CHECKOUT_PORT} && bun dev"`
-					: `"cd apps/checkout && VITE_PORT=${CHECKOUT_PORT} bun dev"`,
+					? `cd apps/checkout && set VITE_PORT=${CHECKOUT_PORT}&& bun dev`
+					: `cd apps/checkout && VITE_PORT=${CHECKOUT_PORT} bun dev`,
 			);
 
 			shellArgs = [
-				isWindows ? "cmd" : "sh",
-				isWindows ? "/c" : "-c",
-				`bunx concurrently -n ${names.join(",")} -c ${colors.join(",")} ${cmds.join(" ")}`,
+				process.execPath,
+				"x",
+				"concurrently",
+				"-n",
+				names.join(","),
+				"-c",
+				colors.join(","),
+				...cmds,
 			];
 		}
 


### PR DESCRIPTION
## Summary
Fix Windows dev script quoting by passing commands as array args to concurrently instead of through cmd /c

Windows didn't like cmd /c mangling inner double quotes, causing `bun dev` to fail when setting up the repository.

## Related Issues
Follow-up to #397 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Additional Context
Tested on Windows 11 and WSL Ubuntu 24.04 where WSL had bunx not found from a fresh install so verifying on macOS is needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows dev script quoting by invoking bun x concurrently directly with array args instead of cmd/sh wrappers. Prevents bun dev, workers, Vite, and checkout dev servers from failing on Windows.

- **Bug Fixes**
  - Call bun x concurrently directly and pass each command as its own arg to avoid quote mangling and platform-specific duplication.
  - Remove spaces before && in Windows set to prevent trailing spaces in env values (SERVER_PORT, VITE_PORT, CHECKOUT_PORT).

<sup>Written for commit 5558002be99749e35fe4f86c59c928da84d9af93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two Windows-specific issues in the `bun dev` script: shell quote mangling caused by wrapping the `concurrently` invocation in `cmd /c`, and a trailing-space bug in Windows `set` variable assignments. The fix unifies both platforms by spawning `bunx concurrently` directly as an array argument to `Bun.spawn`, with each sub-command passed as its own element rather than as a single shell-escaped string.

**Key changes:**

- **Bug fixes** — Replaced `Bun.spawn(["cmd", "/c", `bunx concurrently ... "${cmd1}" "${cmd2}"`])` with `Bun.spawn(["bunx", "concurrently", ..., cmd1, cmd2])` on both Windows and Unix, eliminating `cmd /c` double-quote mangling that broke `bun dev` on Windows.
- **Bug fixes** — Changed `set SERVER_PORT=${SERVER_PORT} && bun dev` → `set SERVER_PORT=${SERVER_PORT}&& bun dev` (removing the space before `&&`). In Windows `cmd.exe` the `set` command captures all characters up to the next unescaped `&`, so the old form stored a trailing space in the variable value; the new form does not.
- **Improvements** — Removed the now-redundant duplication in the `workers:dev` push (`isWindows ? "..." : "..."` where both branches were identical) by using a single platform-agnostic string.

</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge after macOS/Linux verification; Windows fix is logically sound and tested.
- The architectural change (dropping `cmd /c` / `sh -c` wrappers in favour of direct `Bun.spawn` with array args) is correct and the Windows `set` trailing-space fix is valid cmd.exe syntax. The only gap is that the author explicitly noted macOS verification is still needed — the Unix path is simpler than before so failure is unlikely, but it has not been confirmed yet.
- scripts/dev.ts — needs a macOS/Linux smoke-test since the Unix spawn path also changed from `sh -c` to direct `bunx` invocation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/dev.ts | Refactors `Bun.spawn` call to invoke `bunx concurrently` directly with commands as separate array arguments, eliminating the `cmd /c` / `sh -c` wrapper that caused Windows quote mangling; also removes trailing spaces from `set VAR=value &&` → `set VAR=value&&` on Windows. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun dev / scripts/dev.ts] --> B{serverOnly?}

    B -- yes --> C{isWindows?}
    C -- yes --> D["serverCmd = 'cd server && set SERVER_PORT=PORT&& bun start'"]
    C -- no --> E["serverCmd = 'cd server && SERVER_PORT=PORT bun start'"]
    D & E --> F["Bun.spawn(['bunx','concurrently','-n','server,workers','-c','green,yellow', serverCmd, workersCmd])"]

    B -- no --> G{isWindows?}
    G -- yes --> H["cmds = ['cd server && set SERVER_PORT=PORT&& bun dev', ...]"]
    G -- no --> I["cmds = ['cd server && SERVER_PORT=PORT bun dev', ...]"]
    H & I --> J["Bun.spawn(['bunx','concurrently','-n',names,'-c',colors,...cmds])"]

    F --> K[concurrently spawns each cmd via system shell]
    J --> K
```
</details>

<sub>Last reviewed commit: 70d829b</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->