### PR TITLE
chore: fix update sub version with no prepaid options bug

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleProductTypeTransitionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleProductTypeTransitionErrors.ts
@@ -1,6 +1,13 @@
-import { cusProductToPrices, ErrCode, RecaseError } from "@autumn/shared";
-import type { UpdateSubscriptionBillingContext } from "@autumn/shared";
-import type { AutumnBillingPlan } from "@autumn/shared";
+import type {
+	AutumnBillingPlan,
+	UpdateSubscriptionBillingContext,
+} from "@autumn/shared";
+import {
+	cusProductToPrices,
+	ErrCode,
+	isFreeProduct,
+	RecaseError,
+} from "@autumn/shared";
 import { isOneOff } from "@/internal/products/productUtils";
 
 export const handleProductTypeTransitionErrors = ({
@@ -22,10 +29,14 @@ export const handleProductTypeTransitionErrors = ({
 	});
 	const newPrices = cusProductToPrices({ cusProduct: newCustomerProduct });
 
+	const currentIsFree = isFreeProduct({ prices: currentPrices });
+	const newIsFree = isFreeProduct({ prices: newPrices });
 	const currentIsOneOff = isOneOff(currentPrices);
 	const newIsOneOff = isOneOff(newPrices);
+	const currentIsPaidRecurring = !currentIsFree && !currentIsOneOff;
+	const newIsPaidRecurring = !newIsFree && !newIsOneOff;
 
-	if (!currentIsOneOff && newIsOneOff) {
+	if (currentIsPaidRecurring && newIsOneOff) {
 		throw new RecaseError({
 			message:
 				"Cannot update a subscription from a recurring product to a one-off product",
@@ -34,7 +45,7 @@ export const handleProductTypeTransitionErrors = ({
 		});
 	}
 
-	if (currentIsOneOff && !newIsOneOff) {
+	if (currentIsOneOff && newIsPaidRecurring) {
 		throw new RecaseError({
 			message:
 				"Cannot update a subscription from a one-off product to a recurring product",

--- a/server/tests/integration/billing/update-subscription/errors/update-errors-basic.test.ts
+++ b/server/tests/integration/billing/update-subscription/errors/update-errors-basic.test.ts
@@ -1,5 +1,7 @@
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 import { ErrCode, type UpdateSubscriptionV1ParamsInput } from "@autumn/shared";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { expectProductActive } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -195,11 +197,58 @@ test.concurrent(`${chalk.yellowBright("error: one-off to paid recurring transiti
 	});
 });
 
+// 5. Free product can update to a free one-off product
+test.concurrent(`${chalk.yellowBright("free update: free to free one-off stays allowed")}`, async () => {
+	const free = products.base({
+		id: "free-to-oneoff-free",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const oneOffFreeMessagesItem = constructPrepaidItem({
+		featureId: TestFeature.Messages,
+		price: 0,
+		billingUnits: 100,
+		includedUsage: 200,
+		isOneOff: true,
+	});
+
+	const { customerId, autumnV1 } = await initScenario({
+		customerId: "free-to-oneoff-free",
+		setup: [s.customer({}), s.products({ list: [free] })],
+		actions: [s.attach({ productId: free.id })],
+	});
+
+	const preview = await autumnV1.subscriptions.previewUpdate({
+		customer_id: customerId,
+		product_id: free.id,
+		items: [oneOffFreeMessagesItem],
+		options: [{ feature_id: TestFeature.Messages, quantity: 0 }],
+	});
+
+	expect(preview.total).toBe(0);
+
+	await autumnV1.subscriptions.update({
+		customer_id: customerId,
+		product_id: free.id,
+		items: [oneOffFreeMessagesItem],
+		options: [{ feature_id: TestFeature.Messages, quantity: 0 }],
+	});
+
+	const customer = await autumnV1.customers.get(customerId);
+	await expectProductActive({ customer, productId: free.id });
+	expectCustomerFeatureCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		includedUsage: 200,
+		balance: 200,
+		usage: 0,
+	});
+});
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // INVOICE MODE ERRORS
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// 5. Cannot use invoice mode when there's no billing change
+// 6. Cannot use invoice mode when there's no billing change
 test.concurrent(`${chalk.yellowBright("error: invoice mode with no billing change")}`, async () => {
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
 	const priceItem = items.monthlyPrice({ price: 20 });

--- a/vite/src/components/forms/update-subscription-v2/components/SectionTitle.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SectionTitle.tsx
@@ -7,6 +7,7 @@ import {
 	TooltipTrigger,
 } from "@/components/v2/tooltips/Tooltip";
 import { cn } from "@/lib/utils";
+import { useUpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 import type { UseTrialStateReturn } from "../hooks/useTrialState";
 import type { UseUpdateSubscriptionForm } from "../hooks/useUpdateSubscriptionForm";
 
@@ -25,6 +26,7 @@ export function SectionTitle({
 	currentVersion,
 	trialState,
 }: SectionTitleProps) {
+	const { handleVersionChange } = useUpdateSubscriptionFormContext();
 	const showTrialToggle = !trialState.isCurrentlyTrialing;
 	const trialIsActive =
 		(trialState.isCurrentlyTrialing || trialState.isTrialExpanded) &&
@@ -70,7 +72,7 @@ export function SectionTitle({
 					hasCustomizations={hasCustomizations}
 					numVersions={numVersions}
 					selectedVersion={field.state.value ?? currentVersion}
-					onVersionChange={(v) => field.handleChange(v)}
+					onVersionChange={(v) => void handleVersionChange({ version: v })}
 					trialAction={trialAction}
 				/>
 			)}

--- a/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionFooter.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionFooter.tsx
@@ -15,6 +15,7 @@ export function UpdateSubscriptionFooter() {
 	const {
 		isPending,
 		hasChanges,
+		isVersionLoading,
 		previewQuery,
 		handleConfirm,
 		handleInvoiceUpdate,
@@ -22,7 +23,7 @@ export function UpdateSubscriptionFooter() {
 
 	const isLoading = previewQuery.isLoading;
 	const hasError = !!previewQuery.error;
-	const isReady = hasChanges && !isLoading && !hasError;
+	const isReady = hasChanges && !isLoading && !hasError && !isVersionLoading;
 
 	const [showFooter, setShowFooter] = useState(false);
 
@@ -46,7 +47,11 @@ export function UpdateSubscriptionFooter() {
 			>
 				<Popover>
 					<PopoverTrigger asChild>
-						<Button variant="secondary" className="w-full" disabled={isPending}>
+						<Button
+							variant="secondary"
+							className="w-full"
+							disabled={isPending || isVersionLoading}
+						>
 							Send an Invoice
 						</Button>
 					</PopoverTrigger>
@@ -86,6 +91,7 @@ export function UpdateSubscriptionFooter() {
 					className="w-full"
 					onClick={handleConfirm}
 					isLoading={isPending}
+					disabled={isVersionLoading}
 				>
 					Confirm Update
 				</Button>

--- a/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
+++ b/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
@@ -14,6 +14,7 @@ import {
 	useCallback,
 	useContext,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 import { applyDefinedFormPatchFields } from "@/components/forms/shared/utils/formPatchUtils";
@@ -25,6 +26,8 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductVersionQuery } from "@/hooks/queries/useProductVersionQuery";
 import type { PrepaidItemWithFeature } from "@/hooks/stores/useProductStore";
 import { useHasBillingChanges } from "@/hooks/stores/useProductStore";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getPrepaidItems } from "@/utils/product/productItemUtils";
 import { useHasSubscriptionChanges } from "../hooks/useHasSubscriptionChanges";
 import {
 	type UseTrialStateReturn,
@@ -37,6 +40,7 @@ import {
 import { useUpdateSubscriptionMutation } from "../hooks/useUpdateSubscriptionMutation";
 import { useUpdateSubscriptionRequestBody } from "../hooks/useUpdateSubscriptionRequestBody";
 import type { UpdateSubscriptionForm } from "../updateSubscriptionFormSchema";
+import { mergePrepaidOptionsByFeatureIdentity } from "../utils/prepaidOptionUtils";
 import {
 	getProductWithSupportedFormValues,
 	getSupportedFormPatchFromDraftProduct,
@@ -68,6 +72,7 @@ interface UpdateSubscriptionFormContextValue {
 	changedPrepaidOptions: Record<string, number> | undefined;
 	productWithFormItems: FrontendProduct | undefined;
 	isVersionReady: boolean;
+	isVersionLoading: boolean;
 	hasChanges: boolean;
 	hasNoBillingChanges: boolean;
 
@@ -76,6 +81,7 @@ interface UpdateSubscriptionFormContextValue {
 
 	// Plan editor state
 	showPlanEditor: boolean;
+	handleVersionChange: (params: { version: number }) => Promise<void>;
 	handleEditPlan: () => void;
 	handlePlanEditorSave: (product: FrontendProduct) => void;
 	handlePlanEditorCancel: () => void;
@@ -135,8 +141,10 @@ export function UpdateSubscriptionFormProvider({
 }: UpdateSubscriptionFormProviderProps) {
 	const { customerProduct, prepaidItems, currentVersion, product } =
 		formContext;
+	const axiosInstance = useAxiosInstance();
 
 	const [showPlanEditor, setShowPlanEditor] = useState(false);
+	const requestedVersionRef = useRef(currentVersion);
 
 	const form = useUpdateSubscriptionForm({
 		updateSubscriptionFormContext: formContext,
@@ -145,7 +153,9 @@ export function UpdateSubscriptionFormProvider({
 	const { features } = useFeaturesQuery();
 	const trialState = useTrialState({ form, customerProduct });
 
-	const formValues = useStore(form.store, (state) => state.values);
+	const formValues = useStore(form.store, (state) =>
+		structuredClone(state.values),
+	);
 	const { prepaidOptions } = formValues;
 
 	// Fetch the target version's product data when version differs from current
@@ -164,7 +174,6 @@ export function UpdateSubscriptionFormProvider({
 		}
 		return product;
 	}, [product, isVersionReady, versionProductQuery.data]);
-
 	const defaultValues = form.options.defaultValues;
 	const initialPrepaidOptions = defaultValues?.prepaidOptions ?? {};
 	const initialBillingBehavior = defaultValues?.billingBehavior ?? null;
@@ -226,8 +235,8 @@ export function UpdateSubscriptionFormProvider({
 		newProduct: newProduct as FrontendProduct,
 	});
 
-	const hasPrepaidQuantityChanges = changedPrepaidOptions !== undefined;
 	const isVersionLoading = isVersionChanged && !isVersionReady;
+	const hasPrepaidQuantityChanges = changedPrepaidOptions !== undefined;
 	const hasNoBillingChanges =
 		hasChanges &&
 		!hasBillingChanges &&
@@ -237,6 +246,7 @@ export function UpdateSubscriptionFormProvider({
 	const { buildRequestBody } = useUpdateSubscriptionRequestBody({
 		updateSubscriptionFormContext: formContext,
 		form,
+		effectiveProduct,
 	});
 
 	// Build the preview body reactively — formValues triggers recomputation,
@@ -248,7 +258,8 @@ export function UpdateSubscriptionFormProvider({
 
 	const previewQuery = useUpdateSubscriptionPreview({
 		body: previewBody,
-		enabled: !!(formContext.customerId && formContext.product),
+		enabled:
+			!!(formContext.customerId && formContext.product) && !isVersionLoading,
 	});
 
 	const { handleConfirm, handleInvoiceUpdate, isPending } =
@@ -265,6 +276,49 @@ export function UpdateSubscriptionFormProvider({
 		setShowPlanEditor(true);
 		onPlanEditorOpen?.();
 	}, [productWithFormItems, onPlanEditorOpen]);
+
+	const getMergedPrepaidOptions = useCallback(
+		({
+			nextItems,
+		}: {
+			nextItems: {
+				feature_id?: string | null;
+				feature?: { internal_id?: string | null } | null;
+			}[];
+		}) =>
+			mergePrepaidOptionsByFeatureIdentity({
+				currentItems: getPrepaidItems(effectiveProduct),
+				currentPrepaidOptions: prepaidOptions,
+				nextItems,
+			}),
+		[effectiveProduct, prepaidOptions],
+	);
+
+	const handleVersionChange = useCallback(
+		async ({ version }: { version: number }) => {
+			requestedVersionRef.current = version;
+			form.setFieldValue("version", version);
+
+			const targetProduct =
+				version === currentVersion
+					? product
+					: (
+							await axiosInstance.get<{ product: ProductV2 }>(
+								`/products/${product?.id}/data`,
+								{ params: { version } },
+							)
+						).data.product;
+
+			if (requestedVersionRef.current !== version) return;
+
+			const { nextPrepaidOptions } = getMergedPrepaidOptions({
+				nextItems: getPrepaidItems(targetProduct),
+			});
+
+			form.setFieldValue("prepaidOptions", nextPrepaidOptions);
+		},
+		[axiosInstance, currentVersion, form, getMergedPrepaidOptions, product],
+	);
 
 	const handlePlanEditorSave = useCallback(
 		(draftProduct: FrontendProduct) => {
@@ -301,23 +355,14 @@ export function UpdateSubscriptionFormProvider({
 				},
 			});
 
-			const currentPrepaidOptions = form.store.state.values.prepaidOptions;
-			const updatedPrepaidOptions = { ...currentPrepaidOptions };
-			let hasNewPrepaidItems = false;
+			const { nextPrepaidOptions, didChange } = getMergedPrepaidOptions({
+				nextItems: draftProduct.items.filter(
+					(item) => item.usage_model === "prepaid",
+				),
+			});
 
-			for (const item of draftProduct.items) {
-				if (
-					item.usage_model === "prepaid" &&
-					item.feature_id &&
-					updatedPrepaidOptions[item.feature_id] === undefined
-				) {
-					updatedPrepaidOptions[item.feature_id] = 0;
-					hasNewPrepaidItems = true;
-				}
-			}
-
-			if (hasNewPrepaidItems) {
-				form.setFieldValue("prepaidOptions", updatedPrepaidOptions);
+			if (didChange) {
+				form.setFieldValue("prepaidOptions", nextPrepaidOptions);
 			}
 
 			setShowPlanEditor(false);
@@ -325,6 +370,7 @@ export function UpdateSubscriptionFormProvider({
 		},
 		[
 			form,
+			getMergedPrepaidOptions,
 			onPlanEditorClose,
 			productWithFormItems,
 			trialState.isCurrentlyTrialing,
@@ -348,10 +394,12 @@ export function UpdateSubscriptionFormProvider({
 			changedPrepaidOptions,
 			productWithFormItems,
 			isVersionReady,
+			isVersionLoading,
 			hasChanges,
 			hasNoBillingChanges,
 			previewQuery,
 			showPlanEditor,
+			handleVersionChange,
 			handleEditPlan,
 			handlePlanEditorSave,
 			handlePlanEditorCancel,
@@ -370,10 +418,12 @@ export function UpdateSubscriptionFormProvider({
 			changedPrepaidOptions,
 			productWithFormItems,
 			isVersionReady,
+			isVersionLoading,
 			hasChanges,
 			hasNoBillingChanges,
 			previewQuery,
 			showPlanEditor,
+			handleVersionChange,
 			handleEditPlan,
 			handlePlanEditorSave,
 			handlePlanEditorCancel,

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
@@ -1,18 +1,20 @@
 import {
 	type ProductItem,
+	type ProductV2,
 	type UpdateSubscriptionV0Params,
 	UsageModel,
 } from "@autumn/shared";
 import { useCallback } from "react";
+import { getPrepaidItems } from "@/utils/product/productItemUtils";
 import type { UpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 import { getFreeTrial } from "../utils/getFreeTrial";
+import { getPrepaidOptionQuantity } from "../utils/prepaidOptionUtils";
 import type { UseUpdateSubscriptionForm } from "./useUpdateSubscriptionForm";
 
 /** Pure function to build update subscription options from prepaid form values. Extracted for testability. */
 export function buildUpdateSubscriptionOptions({
 	prepaidItems,
 	prepaidOptions,
-	initialPrepaidOptions,
 	items,
 }: {
 	prepaidItems: {
@@ -21,23 +23,32 @@ export function buildUpdateSubscriptionOptions({
 		included_usage?: number | "inf" | null;
 	}[];
 	prepaidOptions: Record<string, number>;
-	initialPrepaidOptions: Record<string, number>;
 	items?: ProductItem[] | null;
 }): { feature_id: string; quantity: number }[] {
+	const updatedItemsByFeatureId = new Map(
+		(items ?? [])
+			.filter((item) => item.feature_id)
+			.map((item) => [item.feature_id as string, item]),
+	);
+
 	const options = prepaidItems
 		.map((item) => {
 			const featureId = item.feature_id ?? item.feature?.internal_id ?? "";
-			const inputQuantity = prepaidOptions[featureId];
-			const initialQuantity = initialPrepaidOptions[featureId];
+			const updatedItem = featureId
+				? updatedItemsByFeatureId.get(featureId)
+				: undefined;
+			const inputQuantity = getPrepaidOptionQuantity({
+				item,
+				prepaidOptions,
+			});
 			const includedUsage =
 				typeof item.included_usage === "number" ? item.included_usage : 0;
 
-			if (
-				inputQuantity !== undefined &&
-				inputQuantity !== null &&
-				featureId &&
-				inputQuantity !== initialQuantity
-			) {
+			if (updatedItem && updatedItem.usage_model !== UsageModel.Prepaid) {
+				return null;
+			}
+
+			if (inputQuantity !== undefined && inputQuantity !== null && featureId) {
 				return {
 					feature_id: featureId,
 					quantity: inputQuantity + includedUsage,
@@ -76,15 +87,14 @@ export function buildUpdateSubscriptionOptions({
 export function useUpdateSubscriptionRequestBody({
 	updateSubscriptionFormContext,
 	form,
+	effectiveProduct,
 }: {
 	updateSubscriptionFormContext: UpdateSubscriptionFormContext;
 	form: UseUpdateSubscriptionForm;
+	effectiveProduct?: ProductV2;
 }) {
-	const { customerId, product, entityId, customerProduct, prepaidItems } =
+	const { customerId, product, entityId, customerProduct } =
 		updateSubscriptionFormContext;
-
-	const initialPrepaidOptions =
-		form.options.defaultValues?.prepaidOptions ?? {};
 	const initialVersion = form.options.defaultValues?.version;
 
 	const buildRequestBody = useCallback((): UpdateSubscriptionV0Params => {
@@ -122,10 +132,10 @@ export function useUpdateSubscriptionRequestBody({
 			};
 		}
 
+		const prepaidItems = getPrepaidItems(effectiveProduct);
 		const options = buildUpdateSubscriptionOptions({
 			prepaidItems,
 			prepaidOptions,
-			initialPrepaidOptions,
 			items,
 		});
 
@@ -153,8 +163,7 @@ export function useUpdateSubscriptionRequestBody({
 		customerProduct.id,
 		customerProduct.internal_product_id,
 		initialVersion,
-		prepaidItems,
-		initialPrepaidOptions,
+		effectiveProduct,
 	]);
 
 	return { buildRequestBody };

--- a/vite/src/components/forms/update-subscription-v2/utils/prepaidOptionUtils.ts
+++ b/vite/src/components/forms/update-subscription-v2/utils/prepaidOptionUtils.ts
@@ -1,0 +1,72 @@
+export interface PrepaidOptionItem {
+	feature_id?: string | null;
+	feature?: (Record<string, unknown> & { internal_id?: string | null }) | null;
+}
+
+export const getPrepaidOptionQuantity = ({
+	item,
+	prepaidOptions,
+}: {
+	item: PrepaidOptionItem;
+	prepaidOptions: Record<string, number>;
+}) => {
+	if (item.feature_id && prepaidOptions[item.feature_id] !== undefined) {
+		return prepaidOptions[item.feature_id];
+	}
+
+	const internalFeatureId = item.feature?.internal_id;
+	if (internalFeatureId && prepaidOptions[internalFeatureId] !== undefined) {
+		return prepaidOptions[internalFeatureId];
+	}
+
+	return undefined;
+};
+
+export const mergePrepaidOptionsByFeatureIdentity = ({
+	currentItems,
+	currentPrepaidOptions,
+	nextItems,
+}: {
+	currentItems: PrepaidOptionItem[];
+	currentPrepaidOptions: Record<string, number>;
+	nextItems: PrepaidOptionItem[];
+}) => {
+	const nextPrepaidOptions = { ...currentPrepaidOptions };
+	const quantityByIdentity = new Map<string, number>();
+
+	for (const item of currentItems) {
+		const quantity = getPrepaidOptionQuantity({
+			item,
+			prepaidOptions: currentPrepaidOptions,
+		});
+
+		if (quantity === undefined) continue;
+		if (item.feature_id) {
+			quantityByIdentity.set(item.feature_id, quantity);
+		}
+		if (item.feature?.internal_id) {
+			quantityByIdentity.set(item.feature.internal_id, quantity);
+		}
+	}
+
+	let didChange = false;
+
+	for (const item of nextItems) {
+		const nextFeatureId = item.feature_id ?? item.feature?.internal_id;
+		if (!nextFeatureId) continue;
+
+		const matchedQuantity =
+			quantityByIdentity.get(nextFeatureId) ??
+			(item.feature?.internal_id
+				? quantityByIdentity.get(item.feature.internal_id)
+				: undefined);
+		const nextQuantity = matchedQuantity ?? 0;
+
+		if (nextPrepaidOptions[nextFeatureId] !== nextQuantity) {
+			nextPrepaidOptions[nextFeatureId] = nextQuantity;
+			didChange = true;
+		}
+	}
+
+	return { nextPrepaidOptions, didChange };
+};

--- a/vite/src/utils/billing/prepaidQuantityUtils.ts
+++ b/vite/src/utils/billing/prepaidQuantityUtils.ts
@@ -12,12 +12,23 @@ export function backendToDisplayQuantity({
 	backendOptions,
 	prepaidItems,
 }: {
-	backendOptions: { feature_id: string; quantity: number }[];
-	prepaidItems: { feature_id?: string | null; billing_units?: number | null }[];
+	backendOptions: {
+		feature_id: string;
+		quantity: number;
+		internal_feature_id?: string | null;
+	}[];
+	prepaidItems: {
+		feature_id?: string | null;
+		billing_units?: number | null;
+		feature?: { internal_id?: string | null } | null;
+	}[];
 }): Record<string, number> {
 	const backendLookup = backendOptions.reduce(
 		(acc, option) => {
 			acc[option.feature_id] = option.quantity;
+			if (option.internal_feature_id) {
+				acc[option.internal_feature_id] = option.quantity;
+			}
 			return acc;
 		},
 		{} as Record<string, number>,
@@ -25,10 +36,16 @@ export function backendToDisplayQuantity({
 
 	return prepaidItems.reduce(
 		(acc, item) => {
-			if (!item.feature_id) return acc;
+			const featureId = item.feature_id;
+			const internalFeatureId = item.feature?.internal_id;
+			const optionKey = featureId ?? internalFeatureId;
+			if (!optionKey) return acc;
 
-			const backendQuantity = backendLookup[item.feature_id] ?? 0;
-			acc[item.feature_id] = getPrepaidDisplayQuantity({
+			const backendQuantity =
+				(featureId ? backendLookup[featureId] : undefined) ??
+				(internalFeatureId ? backendLookup[internalFeatureId] : undefined) ??
+				0;
+			acc[optionKey] = getPrepaidDisplayQuantity({
 				quantity: backendQuantity,
 				billingUnits: item.billing_units,
 			});

--- a/vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-options.test.ts
+++ b/vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-options.test.ts
@@ -7,7 +7,6 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [{ feature_id: "messages", included_usage: 0 }],
 			prepaidOptions: { messages: 5000 },
-			initialPrepaidOptions: { messages: 1000 },
 		});
 
 		expect(result).toEqual([{ feature_id: "messages", quantity: 5000 }]);
@@ -17,7 +16,6 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [{ feature_id: "messages", included_usage: 0 }],
 			prepaidOptions: { messages: 5000 },
-			initialPrepaidOptions: { messages: 1000 },
 		});
 
 		// Must NOT be 5,000,000 (5000 * 1000) or 5 (5000 / 1000)
@@ -28,20 +26,18 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [{ feature_id: "messages", included_usage: 200 }],
 			prepaidOptions: { messages: 5000 },
-			initialPrepaidOptions: { messages: 1000 },
 		});
 
 		expect(result).toEqual([{ feature_id: "messages", quantity: 5200 }]);
 	});
 
-	test("should skip items where quantity has not changed", () => {
+	test("should include existing prepaid quantities even when unchanged", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [{ feature_id: "messages", included_usage: 0 }],
 			prepaidOptions: { messages: 1000 },
-			initialPrepaidOptions: { messages: 1000 },
 		});
 
-		expect(result).toEqual([]);
+		expect(result).toEqual([{ feature_id: "messages", quantity: 1000 }]);
 	});
 
 	test("should handle multiple features with different billing_units", () => {
@@ -51,7 +47,6 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 				{ feature_id: "tokens", included_usage: 100 },
 			],
 			prepaidOptions: { messages: 10000, tokens: 2500 },
-			initialPrepaidOptions: { messages: 5000, tokens: 1000 },
 		});
 
 		expect(result).toEqual([
@@ -64,7 +59,6 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [{ feature_id: "messages", included_usage: 0 }],
 			prepaidOptions: { messages: 5000, tokens: 3000 },
-			initialPrepaidOptions: { messages: 1000 },
 			items: [
 				{
 					feature_id: "tokens",
@@ -84,7 +78,6 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [{ feature_id: "messages", included_usage: 0 }],
 			prepaidOptions: { messages: 5000 },
-			initialPrepaidOptions: { messages: 1000 },
 			items: [
 				{
 					feature_id: "messages",
@@ -97,11 +90,26 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 		expect(result).toEqual([{ feature_id: "messages", quantity: 5000 }]);
 	});
 
+	test("should skip quantities for features changed from prepaid to non-prepaid", () => {
+		const result = buildUpdateSubscriptionOptions({
+			prepaidItems: [{ feature_id: "ai_credits", included_usage: 0 }],
+			prepaidOptions: { ai_credits: 200 },
+			items: [
+				{
+					feature_id: "ai_credits",
+					usage_model: undefined,
+					included_usage: "inf",
+				},
+			],
+		});
+
+		expect(result).toEqual([]);
+	});
+
 	test("should skip non-prepaid items from items array", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [],
 			prepaidOptions: { storage: 100 },
-			initialPrepaidOptions: {},
 			items: [
 				{
 					feature_id: "storage",
@@ -114,24 +122,25 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 		expect(result).toEqual([]);
 	});
 
-	test("should return empty array when no quantities changed", () => {
+	test("should return all existing quantities when no values changed", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [
 				{ feature_id: "messages", included_usage: 0 },
 				{ feature_id: "tokens", included_usage: 0 },
 			],
 			prepaidOptions: { messages: 1000, tokens: 500 },
-			initialPrepaidOptions: { messages: 1000, tokens: 500 },
 		});
 
-		expect(result).toEqual([]);
+		expect(result).toEqual([
+			{ feature_id: "messages", quantity: 1000 },
+			{ feature_id: "tokens", quantity: 500 },
+		]);
 	});
 
 	test("should handle included_usage as 'inf' by treating as 0", () => {
 		const result = buildUpdateSubscriptionOptions({
 			prepaidItems: [{ feature_id: "messages", included_usage: "inf" }],
 			prepaidOptions: { messages: 5000 },
-			initialPrepaidOptions: { messages: 1000 },
 		});
 
 		// typeof "inf" !== "number", so includedUsage defaults to 0
@@ -148,9 +157,23 @@ describe("buildUpdateSubscriptionOptions — billing_units handling", () => {
 				},
 			],
 			prepaidOptions: { int_messages: 3000 },
-			initialPrepaidOptions: { int_messages: 1000 },
 		});
 
 		expect(result).toEqual([{ feature_id: "int_messages", quantity: 3000 }]);
+	});
+
+	test("should preserve renamed prepaid quantities via internal feature identity", () => {
+		const result = buildUpdateSubscriptionOptions({
+			prepaidItems: [
+				{
+					feature_id: "messages_v2",
+					feature: { internal_id: "int_messages" },
+					included_usage: 100,
+				},
+			],
+			prepaidOptions: { int_messages: 5000 },
+		});
+
+		expect(result).toEqual([{ feature_id: "messages_v2", quantity: 5100 }]);
 	});
 });

--- a/vite/tests/components/forms/update-subscription-v2/utils/prepaid-option-utils.test.ts
+++ b/vite/tests/components/forms/update-subscription-v2/utils/prepaid-option-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { mergePrepaidOptionsByFeatureIdentity } from "@/components/forms/update-subscription-v2/utils/prepaidOptionUtils";
+
+describe("mergePrepaidOptionsByFeatureIdentity", () => {
+	test("should preserve quantities when feature_id changes but internal_id stays the same", () => {
+		const result = mergePrepaidOptionsByFeatureIdentity({
+			currentItems: [
+				{
+					feature_id: "messages_v1",
+					feature: { internal_id: "int_messages" },
+				},
+			],
+			currentPrepaidOptions: { messages_v1: 5000 },
+			nextItems: [
+				{
+					feature_id: "messages_v2",
+					feature: { internal_id: "int_messages" },
+				},
+			],
+		});
+
+		expect(result.nextPrepaidOptions).toEqual({
+			messages_v1: 5000,
+			messages_v2: 5000,
+		});
+		expect(result.didChange).toBe(true);
+	});
+
+	test("should seed zero only for genuinely new prepaid items", () => {
+		const result = mergePrepaidOptionsByFeatureIdentity({
+			currentItems: [],
+			currentPrepaidOptions: {},
+			nextItems: [{ feature_id: "tokens_v2" }],
+		});
+
+		expect(result.nextPrepaidOptions).toEqual({ tokens_v2: 0 });
+		expect(result.didChange).toBe(true);
+	});
+});

--- a/vite/tests/utils/billing/prepaid-quantity-utils.test.ts
+++ b/vite/tests/utils/billing/prepaid-quantity-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	AppEnv,
 	getPrepaidDisplayQuantity,
 	type ProductV2,
 	UsageModel,
@@ -17,7 +18,7 @@ function makeProduct({ items }: { items: ProductV2["items"] }): ProductV2 {
 		is_default: false,
 		version: 1,
 		group: null,
-		env: "sandbox" as any,
+		env: AppEnv.Sandbox,
 		items,
 		created_at: Date.now(),
 	};
@@ -85,6 +86,27 @@ describe("backendToDisplayQuantity", () => {
 		});
 
 		expect(result).toEqual({});
+	});
+
+	test("should match backend options by internal_feature_id", () => {
+		const result = backendToDisplayQuantity({
+			backendOptions: [
+				{
+					feature_id: "messages",
+					internal_feature_id: "feat_internal_messages",
+					quantity: 3,
+				},
+			],
+			prepaidItems: [
+				{
+					feature_id: "messages",
+					feature: { internal_id: "feat_internal_messages" },
+					billing_units: 1000,
+				},
+			],
+		});
+
+		expect(result).toEqual({ messages: 3000 });
 	});
 });
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes subscription updates when changing product versions by correctly handling prepaid options (including none or renamed features) and preventing actions during version loads. Also allows free-to-free one-off transitions while keeping paid recurring ↔ one-off transitions blocked.

- **Bug Fixes**
  - Merge prepaid options across version changes using feature identity (`feature_id` or internal `feature.internal_id`), seeding 0 for new items and preserving quantities for renamed features.
  - Build update request using the effective product’s prepaid items, include existing prepaid quantities even if unchanged, and skip features that are no longer prepaid.
  - Match backend options by `internal_feature_id` when converting quantities for display.
  - Disable Confirm and Send Invoice while the target version is loading; version changes now go through form context to sync options.
  - Server: refine product-type transition checks to allow free → free one-off updates; keep paid recurring → one-off and one-off → paid recurring blocked.

<sup>Written for commit e64cde7abb1a7027fb0b46d44b33d84b335d6f95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs in the update-subscription flow: (1) a server-side error that incorrectly blocked free-product-to-free-one-off subscription updates by treating free products as paid recurring, and (2) a client-side issue where switching to a different product version left the prepaid options uninitialized (defaulting to zero) because no merging logic existed to carry over quantities to the new version's feature set.

**Key changes:**

- 🐛 **Bug fix** — `handleProductTypeTransitionErrors`: Introduces `isFreeProduct` checks so only true paid-recurring ↔ one-off transitions are blocked; free→one-off and one-off→free transitions are now permitted.
- 🐛 **Bug fix** — `UpdateSubscriptionFormProvider`: Adds `handleVersionChange` async handler that fetches the target version's product data and merges existing prepaid quantities into the new version's feature list via `mergePrepaidOptionsByFeatureIdentity`, solving the "no prepaid options after version switch" bug.
- 🔧 **Improvement** — `useUpdateSubscriptionRequestBody`: Removes the `initialPrepaidOptions` diff-guard from `buildUpdateSubscriptionOptions`; all current prepaid quantities are now always included in the request body rather than only those that changed from the initial state.
- 🔧 **Improvement** — `prepaidQuantityUtils.ts` / `prepaidOptionUtils.ts`: Two new utility helpers enable resolving prepaid quantities by `internal_feature_id` fallback, so renamed features across product versions don't lose their stored quantities.
- 🔧 **Improvement** — `UpdateSubscriptionFooter`: Disables action buttons while `isVersionLoading` is true, preventing submission with a stale request body during the async version-change fetch.
</details>

<h3>Confidence Score: 3/5</h3>

- Unsafe to merge without addressing missing error handling in async version-change fetch.
- The core bug fixes are correct and well-tested (server-side free-product transition guard, prepaid options merge on version change). However, `handleVersionChange` has a critical gap: no try/catch on the axios fetch. If the network request fails, the version field is already updated in the form state but prepaidOptions remain unmerged for the new version, leaving the form in an inconsistent state that could result in an incorrect request body being sent. This doesn't affect server-side data integrity (the server validates independently), but it creates confusing UX and potential request failures. Additionally, a minor redundant map lookup in prepaidOptionUtils clarifies intent but doesn't affect correctness.
- `vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx` — add try/catch to `handleVersionChange` to synchronize version and prepaidOptions on fetch failure.

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SectionTitle
    participant handleVersionChange
    participant AxiosInstance
    participant FormStore

    User->>SectionTitle: Select new version
    SectionTitle->>handleVersionChange: onVersionChange(v)
    handleVersionChange->>FormStore: setFieldValue("version", v)
    Note over handleVersionChange: requestedVersionRef = v

    alt version == currentVersion
        handleVersionChange->>handleVersionChange: use existing product
    else version != currentVersion
        handleVersionChange->>AxiosInstance: GET /products/{id}/data?version=v
        AxiosInstance-->>handleVersionChange: { product: ProductV2 }
    end

    Note over handleVersionChange: Check requestedVersionRef == v (cancel if stale)

    handleVersionChange->>handleVersionChange: getMergedPrepaidOptions(targetProduct.items)
    Note over handleVersionChange: mergePrepaidOptionsByFeatureIdentity<br/>carries quantities across feature renames<br/>via internal_id
    handleVersionChange->>FormStore: setFieldValue("prepaidOptions", nextPrepaidOptions)

    Note over FormStore: isVersionLoading = false → buttons re-enabled
```
</details>

<sub>Last reviewed commit: e64cde7</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->