### PR TITLE
Fix Docker self-hosted build for current workspace structure

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Autumn: Start (Docker)",
+			"type": "node-terminal",
+			"request": "launch",
+			"command": "docker compose -f docker-compose.unix.yml up",
+			"preLaunchTask": "Autumn: Install Dependencies",
+			"env": {
+				"PATH": "${env:HOME}/.bun/bin:${env:PATH}"
+			}
+		},
+		{
+			"name": "Autumn: Start (Docker - Rebuild)",
+			"type": "node-terminal",
+			"request": "launch",
+			"command": "docker compose -f docker-compose.unix.yml up --build",
+			"env": {
+				"PATH": "${env:HOME}/.bun/bin:${env:PATH}"
+			}
+		},
+		{
+			"name": "Autumn: First Time Setup",
+			"type": "node-terminal",
+			"request": "launch",
+			"command": "bun setup && bun db:generate && bun db:migrate",
+			"preLaunchTask": "Autumn: Install Dependencies",
+			"env": {
+				"PATH": "${env:HOME}/.bun/bin:${env:PATH}"
+			}
+		},
+		{
+			"name": "Autumn: DB Migrate",
+			"type": "node-terminal",
+			"request": "launch",
+			"command": "bun db:generate && bun db:migrate",
+			"env": {
+				"PATH": "${env:HOME}/.bun/bin:${env:PATH}"
+			}
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,5 +1,10 @@
 {
 	"version": "2.0.0",
+	"options": {
+		"env": {
+			"PATH": "${env:HOME}/.bun/bin:${env:PATH}"
+		}
+	},
 	"tasks": [
 		{
 			"label": "Run Test Pattern",
@@ -17,6 +22,22 @@
 			"label": "Run Current Test File",
 			"type": "shell",
 			"command": "bun test ${relativeFile}",
+			"problemMatcher": []
+		},
+		{
+			"label": "Autumn: Install Dependencies",
+			"type": "shell",
+			"command": "bun install",
+			"problemMatcher": [],
+			"presentation": {
+				"reveal": "silent",
+				"revealProblems": "onProblem"
+			}
+		},
+		{
+			"label": "Autumn: Docker Compose Down",
+			"type": "shell",
+			"command": "docker compose -f docker-compose.unix.yml down",
 			"problemMatcher": []
 		}
 	],

--- a/docker-compose.unix.yml
+++ b/docker-compose.unix.yml
@@ -64,6 +64,7 @@ services:
     environment:
       - NODE_ENV=development
       - REDIS_URL=redis://valkey:6379
+      - CACHE_URL=redis://valkey:6379
     depends_on:
       - shared
     restart: unless-stopped
@@ -83,6 +84,7 @@ services:
     environment:
       - NODE_ENV=development
       - REDIS_URL=redis://valkey:6379
+      - CACHE_URL=redis://valkey:6379
     depends_on:
       - shared
     restart: unless-stopped

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -12,34 +12,55 @@ COPY bun.lock ./
 COPY shared/package*.json ./shared/
 COPY server/package*.json ./server/
 COPY vite/package*.json ./vite/
+COPY scripts/package*.json ./scripts/
+COPY apps/checkout/package*.json ./apps/checkout/
+COPY apps/docs/package*.json ./apps/docs/
+COPY apps/sdk-test/package*.json ./apps/sdk-test/
+COPY packages/atmn/package*.json ./packages/atmn/
+COPY packages/sdk/package*.json ./packages/sdk/
+COPY packages/autumn-js/package*.json ./packages/autumn-js/
+COPY packages/openapi/package*.json ./packages/openapi/
+COPY packages/ksuid/package*.json ./packages/ksuid/
 
 RUN bun install
 
-# Stage 1: /localtunnel
+# Stage 1: /shared
+FROM base AS shared
+COPY shared/ ./shared/
+COPY packages/ ./packages/
+WORKDIR /app/shared
+CMD ["bun", "run", "--watch", "index.ts"]
+
+# Stage 2: /localtunnel
 FROM base AS localtunnel
 WORKDIR /app
 COPY localtunnel-start.sh ./
 CMD ["sh", "localtunnel-start.sh"]
 
-# Stage 2: /vite
+# Stage 3: /vite
 FROM base AS vite
 COPY shared/ ./shared/
+COPY packages/ ./packages/
 WORKDIR /app/vite
 COPY vite/ ./
 EXPOSE 3000
 CMD ["bun", "dev"]
 
-# Stage 3: /server
+# Stage 4: /server
 FROM base AS server
 COPY shared/ ./shared/
+COPY packages/ ./packages/
+COPY scripts/ ./scripts/
 COPY server/ ./server/
 WORKDIR /app/server
 EXPOSE 8080
 CMD ["bun", "dev"]
 
-# Stage 4: Workers
+# Stage 5: Workers
 FROM base AS workers
 COPY shared/ ./shared/
+COPY packages/ ./packages/
+COPY scripts/ ./scripts/
 COPY server/ ./server/
 WORKDIR /app/server
 CMD ["bun", "workers:dev"]


### PR DESCRIPTION
## Summary
- Update `dev.dockerfile` to copy all 12 workspace `package.json` files (was only 3), add the missing `shared` build stage, and copy `packages/` and `scripts/` into runtime stages
- Add `CACHE_URL=redis://valkey:6379` to server and workers in `docker-compose.unix.yml` (server exits without it)
- Add VS Code launch/task configs for easier local onboarding

## Test plan
- [x] `docker compose -f docker-compose.unix.yml up --build` builds successfully
- [x] All services start (valkey, shared, vite, server, workers)
- [x] Server runs on port 8080, Vite on port 3000
- [x] Sign-in and org creation work end-to-end


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Docker self-hosted build by aligning the `dev.dockerfile` and `docker-compose.unix.yml` with the current 12-package bun workspace structure, and adds VS Code configs to streamline local onboarding.

**Key changes:**

- **Bug fixes** — `docker/dev.dockerfile`: All 12 workspace `package*.json` files are now explicitly copied in the base stage so `bun install` resolves the full dependency graph correctly (previously only 3 were copied, causing install failures).
- **Bug fixes** — `docker/dev.dockerfile`: Adds the missing `shared` build stage with `CMD ["bun", "run", "--watch", "index.ts"]` so the shared package compiles and hot-reloads on file changes.
- **Bug fixes** — `docker/dev.dockerfile`: `packages/` and `scripts/` are now copied into the `vite`, `server`, and `workers` stages where those source trees are needed.
- **Bug fixes** — `docker-compose.unix.yml`: Adds `CACHE_URL=redis://valkey:6379` to the `server` and `workers` services. `server/src/external/redis/initRedis.ts` reads `CACHE_URL` to establish the primary Redis connection; without it `primaryCacheUrl` is `undefined` and the server exits immediately.
- **Improvements** — `.vscode/launch.json` (new): Adds four VS Code launch configurations (Docker up/rebuild, first-time setup, DB migrate) for a smoother onboarding experience.
- **Improvements** — `.vscode/tasks.json`: Adds a global `PATH` entry for bun, plus `Autumn: Install Dependencies` and `Autumn: Docker Compose Down` task definitions referenced by the new launch configs.
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge — fixes genuine build breakage with no regressions; only minor style nit remains.
- All changes are clearly targeted bug fixes that have been manually end-to-end tested per the PR description. The CACHE_URL addition is confirmed necessary by reading the server Redis init code. The only finding is a missing trailing newline and a note that `packages/` edits require a full image rebuild (no bind-mount), which is likely an acceptable tradeoff for a dev setup.
- No files require special attention beyond the noted missing trailing newline in `docker/dev.dockerfile`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docker/dev.dockerfile | Adds all 12 workspace package.json COPY instructions to the base stage, adds the missing `shared` build stage, and copies `packages/` and `scripts/` into runtime stages that need them. Missing newline at end of file. |
| docker-compose.unix.yml | Adds `CACHE_URL=redis://valkey:6379` to both `server` and `workers` services, fixing the missing required env var that caused the server to exit on startup. |
| .vscode/launch.json | New file adding VS Code debug launch configurations for Docker compose, first-time setup, and DB migration — straightforward and well-structured for onboarding. |
| .vscode/tasks.json | Adds global `PATH` env for bun, plus new tasks for `bun install` and `docker compose down`, complementing the new launch configs. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph base["Base Stage (oven/bun:latest)"]
        B1["COPY root package.json + bun.lock"]
        B2["COPY all 12 workspace package*.json files"]
        B3["RUN bun install"]
        B1 --> B2 --> B3
    end

    base --> shared_stage
    base --> localtunnel_stage
    base --> vite_stage
    base --> server_stage
    base --> workers_stage

    subgraph shared_stage["Stage 1: shared"]
        S1["COPY shared/ packages/"]
        S2["WORKDIR /app/shared"]
        S3["CMD bun run --watch index.ts"]
        S1 --> S2 --> S3
    end

    subgraph localtunnel_stage["Stage 2: localtunnel"]
        L1["COPY localtunnel-start.sh"]
        L2["CMD sh localtunnel-start.sh"]
        L1 --> L2
    end

    subgraph vite_stage["Stage 3: vite"]
        V1["COPY shared/ packages/ vite/"]
        V2["WORKDIR /app/vite — EXPOSE 3000"]
        V3["CMD bun dev"]
        V1 --> V2 --> V3
    end

    subgraph server_stage["Stage 4: server"]
        SR1["COPY shared/ packages/ scripts/ server/"]
        SR2["WORKDIR /app/server — EXPOSE 8080"]
        SR3["CMD bun dev"]
        SR1 --> SR2 --> SR3
    end

    subgraph workers_stage["Stage 5: workers"]
        W1["COPY shared/ packages/ scripts/ server/"]
        W2["WORKDIR /app/server"]
        W3["CMD bun workers:dev"]
        W1 --> W2 --> W3
    end

    subgraph compose["docker-compose.unix.yml services"]
        valkey["valkey (Redis/Valkey 8.0)"]
        svc_shared["shared — mounts ./shared, shared-dist vol"]
        svc_vite["vite — mounts ./vite, shared-dist vol — :3000"]
        svc_server["server — mounts ./server, shared-dist vol — :8080\nREDIS_URL + CACHE_URL"]
        svc_workers["workers — mounts ./server, shared-dist vol\nREDIS_URL + CACHE_URL"]
        svc_lt["localtunnel"]

        valkey --> svc_shared
        svc_shared --> svc_vite
        svc_shared --> svc_server
        svc_shared --> svc_workers
        svc_server --> svc_lt
    end

    shared_stage -.->|"target: shared"| svc_shared
    vite_stage -.->|"target: vite"| svc_vite
    server_stage -.->|"target: server"| svc_server
    workers_stage -.->|"target: workers"| svc_workers
    localtunnel_stage -.->|"target: localtunnel"| svc_lt
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docker-compose.unix.yml`, line 19-31 ([link](https://github.com/useautumn/autumn/blob/9210742a4850c2851f7b082089421c5fbab2b75e/docker-compose.unix.yml#L19-L31)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`packages/` directory not volume-mounted in `shared` service**

   The `shared` Dockerfile stage now copies `packages/` at build time (`COPY packages/ ./packages/`), and `shared/index.ts` may import from packages in that directory (e.g. `packages/ksuid`). However, the `shared` service in docker-compose has no corresponding `./packages:/app/packages` bind-mount.

   This means local edits to any file under `packages/` won't be picked up by the `--watch` rebuild loop in the shared container — a full `docker compose up --build` would be required. The same applies to the `vite`, `server`, and `workers` services.

   If these packages are rarely edited during local development this is an acceptable trade-off, but it is worth documenting so contributors aren't surprised when a package change isn't reflected without a rebuild.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docker-compose.unix.yml
   Line: 19-31

   Comment:
   **`packages/` directory not volume-mounted in `shared` service**

   The `shared` Dockerfile stage now copies `packages/` at build time (`COPY packages/ ./packages/`), and `shared/index.ts` may import from packages in that directory (e.g. `packages/ksuid`). However, the `shared` service in docker-compose has no corresponding `./packages:/app/packages` bind-mount.

   This means local edits to any file under `packages/` won't be picked up by the `--watch` rebuild loop in the shared container — a full `docker compose up --build` would be required. The same applies to the `vite`, `server`, and `workers` services.

   If these packages are rarely edited during local development this is an acceptable trade-off, but it is worth documenting so contributors aren't surprised when a package change isn't reflected without a rebuild.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docker/dev.dockerfile
Line: 66

Comment:
**Missing newline at end of file**

The file is missing a trailing newline on the last line. Most editors and POSIX tools expect files to end with a newline, and this can produce noisy diffs in the future.

```suggestion
CMD ["bun", "workers:dev"]
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docker-compose.unix.yml
Line: 19-31

Comment:
**`packages/` directory not volume-mounted in `shared` service**

The `shared` Dockerfile stage now copies `packages/` at build time (`COPY packages/ ./packages/`), and `shared/index.ts` may import from packages in that directory (e.g. `packages/ksuid`). However, the `shared` service in docker-compose has no corresponding `./packages:/app/packages` bind-mount.

This means local edits to any file under `packages/` won't be picked up by the `--watch` rebuild loop in the shared container — a full `docker compose up --build` would be required. The same applies to the `vite`, `server`, and `workers` services.

If these packages are rarely edited during local development this is an acceptable trade-off, but it is worth documenting so contributors aren't surprised when a package change isn't reflected without a rebuild.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["Fix Docker self-host..."](https://github.com/useautumn/autumn/commit/9210742a4850c2851f7b082089421c5fbab2b75e)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Docker self-hosted build to match our 12‑package Bun workspace. All services now build and start; the server no longer exits on boot.

- **Bug Fixes**
  - `docker/dev.dockerfile`: Copy all workspace `package*.json` files so `bun install` resolves the full graph.
  - Add missing `shared` stage with `bun run --watch`; copy `packages/` and `scripts/` into `vite`, `server`, and `workers` stages.
  - `docker-compose.unix.yml`: Set `CACHE_URL=redis://valkey:6379` for `server` and `workers` to enable the Redis cache connection.

- **Developer Experience**
  - Add `.vscode/launch.json` and update `.vscode/tasks.json` with compose up/rebuild, first‑time setup, and DB migrate tasks, including `PATH` for `bun`.

<sup>Written for commit 9210742a4850c2851f7b082089421c5fbab2b75e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

