### PR TITLE
feat: 🎸 allow overrides in billingAction.migrate()

### DIFF
--- a/server/src/internal/billing/v2/actions/migrate/migrate.ts
+++ b/server/src/internal/billing/v2/actions/migrate/migrate.ts
@@ -2,15 +2,18 @@ import {
 	type AttachBillingContext,
 	type BillingPlan,
 	type BillingResult,
+	type CustomizePlanV1,
 	type FullCusProduct,
 	type FullCustomer,
 	type FullProduct,
 	featureUtils,
+	hasCustomItems,
 	type UpdateSubscriptionV1Params,
 } from "@autumn/shared";
 import type { TransitionRules } from "@shared/api/billing/common/transitionRules";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { billingActions } from "@/internal/billing/v2/actions";
+import { setupCustomFullProduct } from "@/internal/billing/v2/setup/setupCustomFullProduct";
 
 export interface AttachResult {
 	billingContext: AttachBillingContext;
@@ -24,34 +27,57 @@ export async function migrate({
 	fullCustomer,
 	currentCustomerProduct,
 	newProduct,
+	overrides,
 }: {
 	ctx: AutumnContext;
 	fullCustomer: FullCustomer;
 	currentCustomerProduct: FullCusProduct;
 	newProduct: FullProduct;
+	overrides?: {
+		customize?: CustomizePlanV1;
+		noBillingChanges?: boolean;
+	};
 }) {
-	// 1. Build update subscription params
 	const entity = fullCustomer.entities.find(
 		(e) => e.internal_id === currentCustomerProduct.internal_entity_id,
 	);
 
 	const features = newProduct.entitlements.map((e) => e.feature);
 
-	// Reset all features after trial ends
 	const transitionRules: TransitionRules = {
 		reset_after_trial_end: features
 			.filter((f) => !featureUtils.isAllocated(f))
 			.map((f) => f.id),
 	};
 
+	// Build the product context: if customize is provided, pre-build custom
+	// prices/ents from the target product so updateSubscription receives a
+	// fully-resolved productContext pointing at the *target* product (not the
+	// source). Without this, updateSubscription would resolve the product from
+	// the source customer_product_id and ignore the target product entirely.
+	let resolvedFullProduct = newProduct;
+	let customPrices: any[] = [];
+	let customEnts: any[] = [];
+
+	if (hasCustomItems(overrides?.customize)) {
+		const customResult = await setupCustomFullProduct({
+			ctx,
+			currentFullProduct: newProduct,
+			customizePlan: overrides!.customize,
+		});
+		resolvedFullProduct = customResult.fullProduct;
+		customPrices = customResult.customPrices;
+		customEnts = customResult.customEnts;
+	}
+
 	const updateSubscriptionParams: UpdateSubscriptionV1Params = {
 		customer_id: fullCustomer.id || fullCustomer.internal_id,
 		customer_product_id: currentCustomerProduct.id,
 		entity_id: entity?.id ?? undefined,
-
+		customize: overrides?.customize,
+		no_billing_changes: overrides?.noBillingChanges ?? false,
 		proration_behavior: "none",
-		version: newProduct.version, // to trigger update custom plan intent
-
+		version: newProduct.version,
 		transition_rules: transitionRules,
 		redirect_mode: "if_required",
 	};
@@ -59,18 +85,17 @@ export async function migrate({
 	ctx.logger.info(
 		`----- RUNNING MIGRATION FOR CUSTOMER ${fullCustomer.id}, ENTITY ${entity?.id} -----`,
 	);
+
 	await billingActions.updateSubscription({
 		ctx,
 		params: updateSubscriptionParams,
 		contextOverride: {
 			productContext: {
 				customerProduct: currentCustomerProduct,
-				fullProduct: newProduct,
-
-				customPrices: [],
-				customEnts: [],
+				fullProduct: resolvedFullProduct,
+				customPrices,
+				customEnts,
 			},
-
 			billingVersion: currentCustomerProduct.billing_version,
 		},
 	});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add optional overrides to `billingActions.migrate()` to support custom plan migrations and no-billing-changes. We now prebuild the target product context so `updateSubscription` applies the customized target plan, not the source.

- **New Features**
  - Added `overrides?: { customize?: CustomizePlanV1; noBillingChanges?: boolean }`, forwarded to `updateSubscription` as `customize` and `no_billing_changes`.
  - When `customize` has items, use `setupCustomFullProduct` to resolve the target `fullProduct` and pass `customPrices`/`customEnts` via `contextOverride`.
  - Backwards compatible: existing calls work unchanged.

<sup>Written for commit 3b2142e5f0e74eb99b3caba34aaf87ce8ea13b4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enhances `billingAction.migrate()` to accept an optional `overrides` parameter, enabling callers to supply a `customize` plan (custom prices/items) and a `noBillingChanges` flag during a product migration. Without this change, `updateSubscription` would resolve the product context from the *source* `customer_product_id` and silently ignore any customisation targeting the *destination* product.

**Key changes:**
- **Improvements** — Added an `overrides?: { customize?: CustomizePlanV1; noBillingChanges?: boolean }` parameter to `migrate()`, giving callers fine-grained control over how the target subscription is configured at migration time.
- **Improvements** — When `overrides.customize` contains custom prices or items (`hasCustomItems` returns `true`), the function now pre-resolves the custom product context via `setupCustomFullProduct` and injects it as `contextOverride.productContext`. Because `setupUpdateSubscriptionProductContext` early-returns when `productContext` is already present, there is no risk of double-applying the customisation.
- **Improvements** — `no_billing_changes` and `customize` are forwarded into `updateSubscriptionParams` so that the downstream billing context (`skipBillingChanges`, `isCustom`, intent logic) correctly reflects the caller's intent.
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge — logic is correct and the override mechanism is well-integrated with the existing billing context pipeline.
- The core change correctly pre-builds the custom product context so `updateSubscription` targets the destination product instead of the source. The early-return guard in `setupUpdateSubscriptionProductContext` prevents double-application. The only non-critical concern is the use of `any[]` for `customPrices`/`customEnts`, which erases the specific `Price[]`/`Entitlement[]` types expected by `UpdateSubscriptionBillingContextOverride`.
- No files require special attention beyond the `any[]` typing note in `migrate.ts`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/migrate/migrate.ts | Extends `migrate()` to accept an `overrides` parameter (with `customize` and `noBillingChanges` options). When `customize` contains custom items/price, it pre-builds the full product context via `setupCustomFullProduct` and passes it through `contextOverride`, correctly preventing `setupUpdateSubscriptionProductContext` from re-resolving against the source product. Logic is sound; minor type safety concern with `any[]` for `customPrices`/`customEnts`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant migrate
    participant setupCustomFullProduct
    participant updateSubscription
    participant setupUpdateSubscriptionProductContext

    Caller->>migrate: migrate({ ctx, fullCustomer, currentCustomerProduct, newProduct, overrides? })

    alt overrides.customize has custom items/price
        migrate->>setupCustomFullProduct: setupCustomFullProduct({ ctx, currentFullProduct: newProduct, customizePlan })
        setupCustomFullProduct-->>migrate: { fullProduct: resolvedFullProduct, customPrices, customEnts }
    else no custom items
        Note over migrate: resolvedFullProduct = newProduct, customPrices=[], customEnts=[]
    end

    migrate->>updateSubscription: updateSubscription({ params: { ..., customize, no_billing_changes, version }, contextOverride: { productContext: { customerProduct, fullProduct: resolvedFullProduct, customPrices, customEnts } } })

    updateSubscription->>setupUpdateSubscriptionProductContext: setupUpdateSubscriptionProductContext({ params, contextOverride })

    alt contextOverride.productContext is set (always true in migrate)
        setupUpdateSubscriptionProductContext-->>updateSubscription: early return productContext (no re-resolve)
    end

    updateSubscription-->>migrate: done
    migrate-->>Caller: (void)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/actions/migrate/migrate.ts
Line: 59-60

Comment:
**Weak `any[]` typing for `customPrices` and `customEnts`**

`customPrices` and `customEnts` are declared as `any[]`, losing the type safety provided by `setupCustomFullProduct`'s return type. The `contextOverride.productContext` interface expects `Price[]` and `Entitlement[]` respectively (see `billingContextOverride.ts`). Keeping `any[]` means TypeScript won't catch accidental mismatches between what `setupCustomFullProduct` returns and what the context override expects.

Consider inferring the types from the helper's return:

```typescript
// Derive types from the helper to stay in sync automatically
type CustomProductResult = Awaited<ReturnType<typeof setupCustomFullProduct>>;

let resolvedFullProduct: FullProduct = newProduct;
let customPrices: CustomProductResult["customPrices"] = [];
let customEnts: CustomProductResult["customEnts"] = [];
```

Or simply use the explicit imported types `Price[]` and `Entitlement[]`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat: 🎸 allow overr..."](https://github.com/useautumn/autumn/commit/3b2142e5f0e74eb99b3caba34aaf87ce8ea13b4e)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->