### PR TITLE
Balance reset cron optimisation

### DIFF
--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -1,80 +1,77 @@
-import {
-	type CustomerEntitlement,
-	notNullish,
-	type ResetCusEnt,
-} from "@autumn/shared";
+import type { AppEnv } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
 import { format } from "date-fns";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
+import type { BatchResetCusEntsPayload } from "@/queue/workflows";
+import { workflows } from "@/queue/workflows";
 import type { CronContext } from "../utils/CronContext";
-import { clearCusEntsFromCache } from "./clearCusEntsFromCache";
-import { resetCustomerEntitlement } from "./resetCustomerEntitlement";
+
+const CUSTOMERS_PER_BATCH = 50;
 
 export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 	const { db } = ctx;
 
-	const maxIterations = 10;
-	const timeoutMs = 60_000; // 1 minute
-	const startTime = Date.now();
-
 	try {
-		let iteration = 0;
+		const customersToReset = await CusEntService.getCustomerIdsForReset({
+			db,
+		});
 
-		while (iteration < maxIterations && Date.now() - startTime < timeoutMs) {
-			iteration++;
-
-			const cusEnts = await CusEntService.getActiveResetPassed({
-				db,
-				batchSize: 5_000,
-				limit: 5_000,
-			});
-
-			if (cusEnts.length < 5_000) {
-				console.log(
-					`Reset cron: only ${cusEnts.length} entitlements to reset, skipping (lazy reset will handle)`,
-				);
-				break;
-			}
-
-			console.log(
-				`Reset cron iteration ${iteration}: processing ${cusEnts.length} entitlements`,
-			);
-
-			const batchSize = 1000;
-			for (let i = 0; i < cusEnts.length; i += batchSize) {
-				const batch = cusEnts.slice(i, i + batchSize);
-				const batchResets = [];
-				const updatedCusEnts: ResetCusEnt[] = [];
-				for (const cusEnt of batch) {
-					batchResets.push(
-						resetCustomerEntitlement({
-							ctx,
-							cusEnt: cusEnt,
-							updatedCusEnts,
-						}),
-					);
-				}
-
-				const results = await Promise.all(batchResets);
-
-				const toUpsert = results.filter(notNullish);
-				await CusEntService.upsert({
-					db,
-					data: toUpsert as CustomerEntitlement[],
-				});
-				console.log(`Upserted ${toUpsert.length} short entitlements`);
-
-				await clearCusEntsFromCache({ cusEnts: updatedCusEnts });
-			}
+		if (customersToReset.length === 0) {
+			console.log("Reset cron: no customers pending reset");
+			return;
 		}
 
 		console.log(
-			"FINISHED RESET CRON:",
-			format(new UTCDate(), "yyyy-MM-dd HH:mm:ss"),
+			`Reset cron: scheduling ${customersToReset.length} customers for reset`,
+		);
+
+		// Group customers by org + env so each SQS message has the right context
+		const groupedByOrgEnv = new Map<
+			string,
+			{
+				orgId: string;
+				env: string;
+				resets: BatchResetCusEntsPayload["resets"];
+			}
+		>();
+
+		for (const row of customersToReset) {
+			const key = `${row.orgId}:${row.env}`;
+			let group = groupedByOrgEnv.get(key);
+			if (!group) {
+				group = { orgId: row.orgId, env: row.env, resets: [] };
+				groupedByOrgEnv.set(key, group);
+			}
+			group.resets.push({
+				internalCustomerId: row.internalCustomerId,
+				customerId: row.customerId ?? "",
+				cusEntIds: [],
+			});
+		}
+
+		// Dispatch batches to SQS
+		const triggers: Promise<void>[] = [];
+
+		for (const group of groupedByOrgEnv.values()) {
+			for (let i = 0; i < group.resets.length; i += CUSTOMERS_PER_BATCH) {
+				const batch = group.resets.slice(i, i + CUSTOMERS_PER_BATCH);
+				triggers.push(
+					workflows.triggerBatchResetCusEnts({
+						orgId: group.orgId,
+						env: group.env as AppEnv,
+						resets: batch,
+					}),
+				);
+			}
+		}
+
+		await Promise.all(triggers);
+
+		console.log(
+			`Reset cron: dispatched ${triggers.length} SQS batches | ${format(new UTCDate(), "yyyy-MM-dd HH:mm:ss")}`,
 		);
 		console.log("----------------------------------\n");
 	} catch (error) {
-		console.error("Error getting entitlements for reset:", error);
-		return;
+		console.error("Error in reset cron scheduler:", error);
 	}
 };

--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -21,6 +21,12 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 			return;
 		}
 
+		if (customersToReset.length === 10_000) {
+			console.warn(
+				"Reset cron: hit 10,000-customer limit — some customers may be deferred to the next run",
+			);
+		}
+
 		console.log(
 			`Reset cron: scheduling ${customersToReset.length} customers for reset`,
 		);
@@ -42,6 +48,7 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 				group = { orgId: row.orgId, env: row.env, resets: [] };
 				groupedByOrgEnv.set(key, group);
 			}
+			// cusEntIds left empty — the worker calls CusService.getFull which triggers lazy reset for all entitlements
 			group.resets.push({
 				internalCustomerId: row.internalCustomerId,
 				customerId: row.customerId ?? "",

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -225,7 +225,7 @@ export class CusEntService {
 
 	/**
 	 * Lightweight query: returns unique customers needing a reset, grouped by org/env.
-	 * No heavy joins — just customer_entitlements + customers.
+	 * Only includes loose entitlements (no product) or those attached to active products.
 	 */
 	static async getCustomerIdsForReset({
 		db,
@@ -248,8 +248,16 @@ export class CusEntService {
 				customers,
 				eq(customerEntitlements.internal_customer_id, customers.internal_id),
 			)
+			.leftJoin(
+				customerProducts,
+				sql`${customerEntitlements.customer_product_id} COLLATE "C" = ${customerProducts.id}`,
+			)
 			.where(
 				and(
+					or(
+						isNull(customerEntitlements.customer_product_id),
+						eq(customerProducts.status, CusProductStatus.Active),
+					),
 					lt(customerEntitlements.next_reset_at, now),
 					or(
 						isNull(customerEntitlements.expires_at),

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -223,6 +223,45 @@ export class CusEntService {
 		return allResults as ResetCusEnt[];
 	}
 
+	/**
+	 * Lightweight query: returns unique customers needing a reset, grouped by org/env.
+	 * No heavy joins — just customer_entitlements + customers.
+	 */
+	static async getCustomerIdsForReset({
+		db,
+		limit = 10_000,
+	}: {
+		db: DrizzleCli;
+		limit?: number;
+	}) {
+		const now = Date.now();
+
+		const rows = await db
+			.selectDistinctOn([customerEntitlements.internal_customer_id], {
+				internalCustomerId: customerEntitlements.internal_customer_id,
+				customerId: customers.id,
+				orgId: customers.org_id,
+				env: customers.env,
+			})
+			.from(customerEntitlements)
+			.innerJoin(
+				customers,
+				eq(customerEntitlements.internal_customer_id, customers.internal_id),
+			)
+			.where(
+				and(
+					lt(customerEntitlements.next_reset_at, now),
+					or(
+						isNull(customerEntitlements.expires_at),
+						gt(customerEntitlements.expires_at, now),
+					),
+				),
+			)
+			.limit(limit);
+
+		return rows;
+	}
+
 	static async update({
 		ctx,
 		id,

--- a/server/tests/integration/balances/reset/get-customer-ids-for-reset.test.ts
+++ b/server/tests/integration/balances/reset/get-customer-ids-for-reset.test.ts
@@ -1,0 +1,158 @@
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expireCusEntForReset } from "@tests/utils/cusProductUtils/resetTestUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+
+// ─────────────────────────────────────────────────────────────────
+// getCustomerIdsForReset — lightweight cron scheduler query
+// ─────────────────────────────────────────────────────────────────
+
+const PREFIX = "cron-reset-query";
+
+test.concurrent(`${chalk.yellowBright("getCustomerIdsForReset: returns only customers with expired next_reset_at")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const pro = products.pro({ items: [messagesItem] });
+
+	const staleId = `${PREFIX}-stale`;
+	const freshId = `${PREFIX}-fresh`;
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId: staleId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.otherCustomers([{ id: freshId }]),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({ productId: pro.id }),
+			s.attach({ productId: pro.id, customerId: freshId }),
+		],
+	});
+
+	// Track usage on both so they have active entitlements
+	await Promise.all([
+		autumnV1.track({
+			customer_id: staleId,
+			feature_id: TestFeature.Messages,
+			value: 10,
+		}),
+		autumnV1.track({
+			customer_id: freshId,
+			feature_id: TestFeature.Messages,
+			value: 20,
+		}),
+	]);
+	await new Promise((resolve) => setTimeout(resolve, 2000));
+
+	// Expire only the stale customer's entitlement
+	await expireCusEntForReset({
+		ctx,
+		customerId: staleId,
+		featureId: TestFeature.Messages,
+	});
+
+	const results = await CusEntService.getCustomerIdsForReset({
+		db: ctx.db,
+	});
+
+	// Stale customer should appear
+	const staleResult = results.find((r) => r.customerId === staleId);
+	expect(staleResult).toBeDefined();
+	expect(staleResult!.orgId).toBe(ctx.org.id);
+	expect(staleResult!.env).toBe(ctx.env);
+
+	// Fresh customer should NOT appear
+	const freshResult = results.find((r) => r.customerId === freshId);
+	expect(freshResult).toBeUndefined();
+}, 60_000);
+
+test.concurrent(`${chalk.yellowBright("getCustomerIdsForReset: returns unique customers even with multiple expired entitlements")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const wordsItem = items.monthlyWords({ includedUsage: 50 });
+	const pro = products.pro({ items: [messagesItem, wordsItem] });
+
+	const customerId = `${PREFIX}-multi-ent`;
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await Promise.all([
+		autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 10,
+		}),
+		autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Words,
+			value: 5,
+		}),
+	]);
+	await new Promise((resolve) => setTimeout(resolve, 2000));
+
+	// Expire both entitlements
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Words,
+	});
+
+	const results = await CusEntService.getCustomerIdsForReset({
+		db: ctx.db,
+	});
+
+	// Should appear exactly once despite two expired entitlements
+	const matches = results.filter((r) => r.customerId === customerId);
+	expect(matches.length).toBe(1);
+}, 60_000);
+
+test.concurrent(`${chalk.yellowBright("getCustomerIdsForReset: respects limit parameter")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const pro = products.pro({ items: [messagesItem] });
+
+	const customerId = `${PREFIX}-limit`;
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await autumnV1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 10,
+	});
+	await new Promise((resolve) => setTimeout(resolve, 2000));
+
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+
+	const results = await CusEntService.getCustomerIdsForReset({
+		db: ctx.db,
+		limit: 1,
+	});
+
+	expect(results.length).toBe(1);
+}, 60_000);

--- a/shared/models/cusProductModels/cusEntModels/cusEntTable.ts
+++ b/shared/models/cusProductModels/cusEntModels/cusEntTable.ts
@@ -89,6 +89,7 @@ export const customerEntitlements = pgTable(
 
 collatePgColumn(customerEntitlements.id, "C");
 collatePgColumn(customerEntitlements.internal_customer_id, "C");
+collatePgColumn(customerEntitlements.customer_product_id, "C");
 
 export type InsertCustomerEntitlement =
 	typeof customerEntitlements.$inferInsert;


### PR DESCRIPTION
## Summary

- Refactored runResetCron from a large executor (db updates + stripe API calls) into a lightweight scheduler that dispatches work to SQS workers (set and forget)
- Added getCustomerIdsForReset - a 2-table query replacing the 5-table join in the cron path
- Added C collation to customer_entitlements.customer_product_id to match customer_products.id - was missing
- Removed the 5,000 entitlement volume threshold - could cause reset backlogs

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
```text
Limit (cost=3.61..3.62 rows=1 width=87) (actual time=0.025..0.026 rows=3 loops=1)
-> Unique (cost=3.61..3.62 rows=1 width=87) (actual time=0.024..0.025 rows=3 loops=1)
-> Sort (cost=3.61..3.61 rows=1 width=87) (actual time=0.024..0.025 rows=3 loops=1)
Sort Key: customer_entitlements.internal_customer_id COLLATE "C"
Sort Method: quicksort Memory: 25kB
-> Hash Join (cost=1.18..3.60 rows=1 width=87) (actual time=0.015..0.016 rows=3 loops=1)
Hash Cond: (customers.internal_id = customer_entitlements.internal_customer_id)
-> Seq Scan on customers (cost=0.00..2.30 rows=30 width=87) (actual time=0.002..0.003 rows=28 loops=1)
-> Hash (cost=1.17..1.17 rows=1 width=32) (actual time=0.007..0.007 rows=3 loops=1)
Buckets: 1024 Batches: 1 Memory Usage: 9kB
-> Seq Scan on customer_entitlements (cost=0.00..1.17 rows=1 width=32) (actual time=0.004..0.005 rows=3 loops=1)
Filter: ((next_reset_at < '1773942578198'::numeric) AND ((expires_at IS NULL) OR (expires_at > '1773942578198'::numeric)))
Rows Removed by Filter: 18
Planning Time: 0.558 ms
Execution Time: 0.040 ms
```
SQL EXPLAIN ANALYZE took < 1ms on local machine. Because there's no complex joins it will likely take 50-100ms in a prod environment.

**Local schedular benchmarking (grouping + batching):**

| | customers | schedulerMs | sqsBatches | orgEnvGroups |
| :--- | :--- | :--- | :--- | :--- |
| 0 | 1000 | 0.17ms | 20 | 20 |
| 1 | 5000 | 0.48ms | 100 | 20 |
| 2 | 10000 | 0.93ms | 200 | 20 |
| 3 | 30000 | 2.09ms | 600 | 20 |
| 4 | 50000 | 3.13ms | 1000 | 20 |


OLD CRON (serial executor):
- 5-table join query: ~seconds (collation mismatch)
- Stripe API calls: ~1500 (5% hit anchor check)
- Stripe time (25 req/s): ~60s
- Serial DB updates: ~60s
- Total estimated time: ~120s (2.0 min)
- Parallelism: none (single process)
- Volume gate: skips if < 5,000 entitlements

NEW CRON (scheduler -> SQS workers):
- 2-table lightweight query: ~ms (indexed, no joins on products)
- Scheduler (group + batch): 1.15ms
- SQS batches dispatched: 600
- Stripe calls in cron: 0 (handled by workers)
- Parallelism: 600 concurrent SQS workers
- Volume gate: none (always processes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the balance reset cron into a lightweight scheduler that batches customers and dispatches work to SQS workers. This cuts cron time, removes the 5k volume gate, and prevents reset backlogs.

- **Refactors**
  - Added `getCustomerIdsForReset`: a fast distinct-customer query across `customer_entitlements` + `customers`, with a left join on `customer_products` for status checks.
  - Cron groups by org/env and sends SQS batches of 50 customers via `workflows.triggerBatchResetCusEnts`; Stripe calls moved to workers.
  - Added integration tests for `getCustomerIdsForReset` (expired-only, per-customer dedupe, respects limit).

- **Bug Fixes**
  - Excludes inactive `customer_products` in the reset query to avoid unnecessary SQS dispatches.
  - Logs a warning when the 10,000-customer default limit is hit.
  - Added `C` collation to `customer_entitlements.customer_product_id` to match `customer_products.id` and avoid slow joins.

<sup>Written for commit fd924f456e4a625472a8b61517d2b7edd4dcaddc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the old serial balance-reset cron (heavy 5-table join + inline Stripe calls) with a lightweight scheduler that runs a fast 2-table query, groups results by org/env, and fans out 50-customer batches to SQS workers — reducing cron wall-clock time from ~2 minutes to single-digit milliseconds. It also ships a collation fix and integration tests for the new query.

**Key changes:**

- **Improvements** — `runResetCron` is now a pure scheduler: it reads `getCustomerIdsForReset`, groups by org/env, and dispatches `triggerBatchResetCusEnts` SQS batches (`CUSTOMERS_PER_BATCH = 50`). All Stripe calls and DB writes are deferred to workers.
- **Improvements** — `getCustomerIdsForReset` replaces the 5-table join with a 2-table `SELECT DISTINCT ON (internal_customer_id)` query, filtered only on `next_reset_at` and `expires_at`, with a default limit of 10,000.
- **Improvements** — Removed the 5,000-entitlement volume gate that could cause reset backlogs; the cron now always processes.
- **Bug fixes** — Added `C` collation to `customer_entitlements.customer_product_id` to match `customer_products.id`, fixing the collation mismatch responsible for slow joins in `getActiveResetPassed`.
- **Improvements** — Added integration tests covering the three core behaviours of `getCustomerIdsForReset`: filtering by expired `next_reset_at`, per-customer deduplication, and the `limit` parameter.
</details>

<h3>Confidence Score: 3/5</h3>

- Safe to merge with awareness of the missing product-status filter, which may cause unnecessary — but not incorrect — SQS dispatches for customers with cancelled products.
- The architectural shift is well-structured and well-tested. The main concern is that `getCustomerIdsForReset` drops the `customer_products.status = Active` guard from the old query, meaning entitlements tied to cancelled products (with no `expires_at`) will match the filter and generate superfluous worker invocations on every cron tick. Workers handle this gracefully today, but at scale this could add non-trivial SQS and DB load. The silent 10,000-customer truncation is a secondary observability gap.
- Pay close attention to `server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts` — specifically the missing `customer_products.status` filter in `getCustomerIdsForReset`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/cron/resetCron/runResetCron.ts | Refactored from a serial executor to a lightweight scheduler that groups customers by org/env and fans out to SQS batches; two minor issues: no warning when the 10k limit is hit, and `cusEntIds` is always sent as an empty array. |
| server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts | Added `getCustomerIdsForReset` — a fast 2-table query; missing the `customer_products.status = Active` filter from the old query, which may cause unnecessary SQS dispatches for customers with only cancelled-product entitlements. |
| server/tests/integration/balances/reset/get-customer-ids-for-reset.test.ts | New integration tests covering the three key behaviours of `getCustomerIdsForReset`: filtering by expired `next_reset_at`, deduplication, and the `limit` parameter. |
| shared/models/cusProductModels/cusEntModels/cusEntTable.ts | Added `C` collation to `customer_product_id` to match `customer_products.id`, fixing the collation mismatch that was causing slow joins in the old cron query. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Cron as Reset Cron (scheduler)
    participant DB as Database<br/>(customer_entitlements + customers)
    participant SQS as SQS Queue
    participant Worker as SQS Worker<br/>(batchResetCusEnts)
    participant CusSvc as CusService.getFull<br/>(lazy reset)
    participant Stripe as Stripe API

    Cron->>DB: getCustomerIdsForReset()<br/>SELECT DISTINCT ON (internal_customer_id)<br/>WHERE next_reset_at < now AND not expired
    DB-->>Cron: rows (up to 10,000 customers)

    Cron->>Cron: Group by orgId:env<br/>Slice into batches of 50

    loop For each batch
        Cron->>SQS: triggerBatchResetCusEnts({orgId, env, resets[]})
    end

    Note over Cron: Cron finishes in ~ms

    loop SQS workers (parallel)
        SQS->>Worker: BatchResetCusEntsPayload
        loop For each customer (up to 100 at a time)
            Worker->>CusSvc: getFull(internalCustomerId)
            CusSvc->>DB: fetch entitlements & lazy reset
            CusSvc->>Stripe: Stripe API calls (if needed)
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
Line: 230-262

Comment:
**Missing active product status filter**

The new `getCustomerIdsForReset` query omits the `customer_products.status = Active` guard that existed in `getActiveResetPassed`. Entitlements attached to **cancelled or past-due** customer products will satisfy `next_reset_at < now AND (expires_at IS NULL OR expires_at > now)` because `expires_at` is only populated for loose (product-free) entitlements; product-backed entitlements typically leave it `NULL`.

This means the cron will dispatch SQS workers for customers whose only pending entitlements belong to inactive products, generating unnecessary worker invocations on every cron tick until those stale entitlement rows are cleaned up.

The previous query handled this with:
```sql
WHERE (customer_product_id IS NULL OR customer_products.status = 'active')
```

Consider adding an equivalent guard — either as a `LEFT JOIN` + status filter on `customer_products`, or by filtering only entitlements whose `customer_product_id IS NULL` at the query level and letting the worker re-derive per-product state via `CusService.getFull`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/cron/resetCron/runResetCron.ts
Line: 15-17

Comment:
**Silent truncation at default 10,000-customer limit**

`getCustomerIdsForReset` defaults to `limit = 10_000`. If more than 10,000 customers need a reset at the same time, the excess are silently skipped until the next cron tick. There is no log warning to indicate that truncation occurred, making this scenario invisible in observability tooling.

Consider logging a warning when the result count reaches the limit:

```suggestion
		const customersToReset = await CusEntService.getCustomerIdsForReset({
			db,
		});

		if (customersToReset.length === 10_000) {
			console.warn(
				"Reset cron: hit 10,000-customer limit — some customers may be deferred to the next run",
			);
		}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/cron/resetCron/runResetCron.ts
Line: 45-49

Comment:
**`cusEntIds` always dispatched as empty array**

Every reset message is sent with `cusEntIds: []`. The `BatchResetCusEntsPayload` type includes `cusEntIds: string[]` as a first-class field, and the worker (`batchResetCustomerEntitlements`) ignores it entirely — it calls `CusService.getFull` which triggers the lazy reset without consulting that list.

While this is harmless today, the dead field on the payload type could mislead future contributors into thinking the worker performs targeted per-entitlement resets when it actually does a full customer fetch. Consider either removing `cusEntIds` from `BatchResetCusEntsPayload` or adding a code comment explaining that the cron intentionally omits it and the worker relies on lazy reset.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["unit tests for getCu..."](https://github.com/useautumn/autumn/commit/2f24d3e11b595d90bdd3429ad0f77c999b8193f2)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->