### PR TITLE
fix: 🐛 a bug where the legacy prices in sub context werent made

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -1,5 +1,11 @@
 import type { AutumnBillingPlan, BillingContext } from "@autumn/shared";
-import { cusProductToProduct } from "@autumn/shared";
+import {
+	cusProductToProduct,
+	isCustomerProductOnStripeSubscription,
+	isCustomerProductOnStripeSubscriptionSchedule,
+	isPrepaidPrice,
+	type UsagePriceConfig,
+} from "@autumn/shared";
 import { createStripePriceIFNotExist } from "@/external/stripe/createStripePrice/createStripePrice";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { checkStripeProductExists } from "@/internal/products/productUtils";
@@ -15,8 +21,8 @@ export const initStripeResourcesForBillingPlan = async ({
 }) => {
 	const { db, org, env, logger } = ctx;
 
-	// For each insert customer product
-	const { fullCustomer } = billingContext;
+	const { fullCustomer, stripeSubscription, stripeSubscriptionSchedule } =
+		billingContext;
 	const { insertCustomerProducts } = autumnBillingPlan;
 
 	const newProducts = insertCustomerProducts.flatMap((cp) =>
@@ -55,5 +61,58 @@ export const initStripeResourcesForBillingPlan = async ({
 			);
 		}
 	}
+
+	// Also ensure V2 Stripe prices exist for existing customer products on the
+	// same subscription/schedule. The phase builder includes these products when
+	// constructing schedule items, so any prepaid price missing
+	// stripe_prepaid_price_v2_id would cause a failure.
+	const existingCusProducts = fullCustomer.customer_products.filter(
+		(customerProduct) => {
+			if (
+				stripeSubscription &&
+				isCustomerProductOnStripeSubscription({
+					customerProduct,
+					stripeSubscriptionId: stripeSubscription.id,
+				})
+			) {
+				return true;
+			}
+
+			if (
+				stripeSubscriptionSchedule &&
+				isCustomerProductOnStripeSubscriptionSchedule({
+					customerProduct,
+					stripeSubscriptionScheduleId: stripeSubscriptionSchedule.id,
+				})
+			) {
+				return true;
+			}
+
+			return false;
+		},
+	);
+
+	for (const cusProduct of existingCusProducts) {
+		const product = cusProductToProduct({ cusProduct });
+
+		for (const price of product.prices) {
+			if (!isPrepaidPrice(price)) continue;
+
+			const config = price.config as UsagePriceConfig;
+			if (config.stripe_prepaid_price_v2_id) continue;
+
+			batchPriceUpdates.push(
+				createStripePriceIFNotExist({
+					ctx,
+					price,
+					entitlements: product.entitlements,
+					product,
+					internalEntityId,
+					useCheckout: false,
+				}),
+			);
+		}
+	}
+
 	await Promise.all(batchPriceUpdates);
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing creation of Stripe V2 prepaid prices for existing customer products on the active subscription/schedule, which caused phase building to fail. We now backfill missing prepaid price IDs during billing plan initialization.

- **Bug Fixes**
  - Scan existing `customer_products` on the current subscription or schedule and create missing V2 prepaid prices.
  - Skip non-prepaid and already-initialized prices to avoid duplicates.
  - Prevents schedule phase construction failures when legacy products are present.

<sup>Written for commit 939bbc43207bd23b02ae10689954d92d38d61657. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where legacy prepaid Stripe V2 prices were not being created for existing `customer_products` already attached to the active subscription or schedule, causing phase construction to fail. The fix backfills missing `stripe_prepaid_price_v2_id` values during billing plan initialization by scanning existing customer products on the current subscription/schedule and calling `createStripePriceIFNotExist` for any prepaid prices that are missing the V2 price ID.

**Key changes:**

- **[Bug fix]** Scan `fullCustomer.customer_products` for products already on the active `stripeSubscription` or `stripeSubscriptionSchedule` and create missing Stripe V2 prepaid prices before phase building begins.
- **[Improvements]** Skip non-prepaid prices and prices that already have `stripe_prepaid_price_v2_id` set, keeping the backfill idempotent and avoiding duplicate Stripe price creation.
- **[Improvements]** Batch the backfill alongside existing `batchPriceUpdates` so all Stripe price creation calls are still resolved in a single `Promise.all`.
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fix is targeted, idempotent, and addresses a real phase-building failure with no functional regressions.
- The logic is correct: existing products are filtered to those on the active subscription/schedule, only missing prepaid V2 prices are created, and the "IF Not Exist" semantics of the creation helper make the operation idempotent. The only open items are two variable names that use the abbreviated `cus` prefix contrary to CLAUDE.md style guidelines — a minor cleanup that doesn't affect runtime behavior.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Backfills missing V2 prepaid Stripe prices for existing customer products on the current subscription/schedule. Logic is sound; two new variable names use the abbreviated `cus` prefix contrary to CLAUDE.md naming conventions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[initStripeResourcesForBillingPlan] --> B[Ensure Stripe products exist\nfor insertCustomerProducts]
    B --> C[Queue price creation for\nall new product prices]
    C --> D{stripeSubscription\nor stripeSubscriptionSchedule\npresent?}
    D -- No --> G[await Promise.all\nbatchPriceUpdates]
    D -- Yes --> E[Filter fullCustomer.customer_products\nto those on active sub/schedule]
    E --> F[For each existing customer product\nloop over prices]
    F --> F1{isPrepaidPrice?}
    F1 -- No --> F2[skip]
    F1 -- Yes --> F3{stripe_prepaid_price_v2_id\nalready set?}
    F3 -- Yes --> F2
    F3 -- No --> F4[Queue createStripePriceIFNotExist\nfor missing V2 prepaid price]
    F4 --> G
    G[await Promise.all\nbatchPriceUpdates] --> H[Done]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
Line: 69-93

Comment:
**Abbreviated variable names in new code**

Per `CLAUDE.md`, new code should spell out variable names in full form — `customerProduct` not `cusProduct`, etc. The variables introduced in this section (`existingCusProducts` and `cusProduct`) use the abbreviated `cus` prefix that the style guide explicitly calls out.

```suggestion
	const existingCustomerProducts = fullCustomer.customer_products.filter(
		(customerProduct) => {
			if (
				stripeSubscription &&
				isCustomerProductOnStripeSubscription({
					customerProduct,
					stripeSubscriptionId: stripeSubscription.id,
				})
			) {
				return true;
			}

			if (
				stripeSubscriptionSchedule &&
				isCustomerProductOnStripeSubscriptionSchedule({
					customerProduct,
					stripeSubscriptionScheduleId: stripeSubscriptionSchedule.id,
				})
			) {
				return true;
			}

			return false;
		},
	);
```

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
Line: 95-115

Comment:
**Abbreviated loop variable in new code**

Same naming convention: `cusProduct` and its derived `product` variable are fine, but the loop variable name should use the full form `customerProduct` per `CLAUDE.md`.

```suggestion
	for (const customerProduct of existingCustomerProducts) {
		const product = cusProductToProduct({ cusProduct: customerProduct });

		for (const price of product.prices) {
			if (!isPrepaidPrice(price)) continue;

			const config = price.config as UsagePriceConfig;
			if (config.stripe_prepaid_price_v2_id) continue;

			batchPriceUpdates.push(
				createStripePriceIFNotExist({
					ctx,
					price,
					entitlements: product.entitlements,
					product,
					internalEntityId,
					useCheckout: false,
				}),
			);
		}
	}
```

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 a bug where the legacy prices in..."](https://github.com/useautumn/autumn/commit/939bbc43207bd23b02ae10689954d92d38d61657) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26203037)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->