### PR TITLE
feat: 🎸 migrate reward/referrals to use action pattern

### DIFF
--- a/server/src/internal/api/rewards/handlers/referrals/handleGetReferralCode.ts
+++ b/server/src/internal/api/rewards/handlers/referrals/handleGetReferralCode.ts
@@ -7,7 +7,7 @@ import {
 } from "@autumn/shared";
 import { CusService } from "@/internal/customers/CusService.js";
 import { rewardProgramRepo, referralCodeRepo } from "@/internal/rewards/repos/index.js";
-import { generateReferralCode } from "@/internal/rewards/referralUtils.js";
+import { generateReferralCode } from "@/internal/rewards/rewardUtils.js";
 import { generateId } from "@/utils/genUtils.js";
 import { createRoute } from "../../../../../honoMiddlewares/routeHandler";
 

--- a/server/src/internal/api/rewards/handlers/referrals/handleRedeemReferral.ts
+++ b/server/src/internal/api/rewards/handlers/referrals/handleRedeemReferral.ts
@@ -11,8 +11,8 @@ import {
 } from "@autumn/shared";
 import { CusService } from "@/internal/customers/CusService.js";
 import { redemptionRepo, rewardRepo, referralCodeRepo } from "@/internal/rewards/repos/index.js";
-import { triggerFreeProduct } from "@/internal/rewards/referralUtils/triggerFreeProduct.js";
-import { triggerRedemption } from "@/internal/rewards/referralUtils.js";
+import { triggerFreeProduct } from "@/internal/rewards/actions/triggerFreeProduct.js";
+import { triggerDiscount } from "@/internal/rewards/actions/triggerDiscount.js";
 import { getRewardCat } from "@/internal/rewards/rewardUtils.js";
 import { generateId, notNullish } from "@/utils/genUtils.js";
 import { createRoute } from "../../../../../honoMiddlewares/routeHandler";
@@ -151,7 +151,7 @@ export const handleRedeemReferral = createRoute({
 					redemption,
 				});
 			} else {
-				await triggerRedemption({
+				await triggerDiscount({
 					ctx,
 					referralCode,
 					reward,

--- a/server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts
+++ b/server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts
@@ -22,8 +22,8 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { redemptionRepo, referralCodeRepo } from "@/internal/rewards/repos/index.js";
-import { triggerFreeProduct } from "@/internal/rewards/referralUtils/triggerFreeProduct.js";
-import { triggerRedemption } from "@/internal/rewards/referralUtils.js";
+import { triggerFreeProduct } from "@/internal/rewards/actions/triggerFreeProduct.js";
+import { triggerDiscount } from "@/internal/rewards/actions/triggerDiscount.js";
 import { getRewardCat } from "@/internal/rewards/rewardUtils.js";
 
 export type GrantCheckoutRewardPayload = {
@@ -256,7 +256,7 @@ const applyReward = async ({
 			redemption,
 		});
 	} else {
-		await triggerRedemption({
+		await triggerDiscount({
 			ctx,
 			referralCode: { ...referralCode, reward_program: rewardProgram },
 			reward,

--- a/server/src/internal/rewards/actions/index.ts
+++ b/server/src/internal/rewards/actions/index.ts
@@ -1,0 +1,15 @@
+import { runTriggerCheckoutReward } from "./triggerCheckoutReward.js";
+import { triggerDiscount } from "./triggerDiscount.js";
+import { triggerFreePaidProduct } from "./triggerFreePaidProduct.js";
+import { triggerFreeProduct } from "./triggerFreeProduct.js";
+
+export const rewardActions = {
+	/** Grant a free product to referrer/redeemer */
+	triggerFreeProduct,
+	/** Grant a paid product with 100% coupon to referrer/redeemer */
+	triggerFreePaidProduct,
+	/** Apply a Stripe coupon discount to customer */
+	triggerDiscount,
+	/** Process checkout-triggered reward redemptions (called from job queue) */
+	triggerCheckoutReward: runTriggerCheckoutReward,
+};

--- a/server/src/internal/rewards/actions/triggerCheckoutReward.ts
+++ b/server/src/internal/rewards/actions/triggerCheckoutReward.ts
@@ -10,11 +10,15 @@ import {
 } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { redemptionRepo, referralCodeRepo } from "./repos/index.js";
-import { triggerFreeProduct } from "./referralUtils/triggerFreeProduct.js";
-import { triggerRedemption } from "./referralUtils.js";
-import { getRewardCat } from "./rewardUtils.js";
+import {
+	redemptionRepo,
+	referralCodeRepo,
+} from "@/internal/rewards/repos/index.js";
+import { getRewardCat } from "@/internal/rewards/rewardUtils.js";
+import { triggerDiscount } from "./triggerDiscount.js";
+import { triggerFreeProduct } from "./triggerFreeProduct.js";
 
+/** Process checkout-triggered reward redemptions (called from job queue) */
 export const runTriggerCheckoutReward = async ({
 	ctx,
 	payload,
@@ -29,17 +33,16 @@ export const runTriggerCheckoutReward = async ({
 	const { db, org, env, logger } = ctx;
 
 	try {
-		// Customer redeeming code, product they're buying
 		const { customer, product, subId } = payload;
 		const stripeCli = createStripeCli({
 			org,
 			env,
 		});
 
-		// 1. Check if redemption exists
+		// Check if redemption exists
 		const redemptions = await redemptionRepo.getByCustomer({
 			db,
-			internalCustomerId: customer.internal_id, // customer that redeemed code
+			internalCustomerId: customer.internal_id,
 			triggered: false,
 		});
 
@@ -48,10 +51,11 @@ export const runTriggerCheckoutReward = async ({
 				!redemption ||
 				redemption.reward_program.when !== RewardTriggerEvent.Checkout
 			) {
-				console.info(
+				logger.info(
 					"No redemption found or reward program not set to checkout, skipping",
 				);
-				return;
+				// BUG FIX: was `return` which exited the entire function — should be `continue`
+				continue;
 			}
 
 			const { reward_program, referral_code: referralCode } =
@@ -76,7 +80,8 @@ export const runTriggerCheckoutReward = async ({
 					`Product ${product.name} (${product.id}) not included in referral program, skipping`,
 				);
 				if (reward_program.reward.free_product_id !== product.id) {
-					return;
+					// BUG FIX: was `return` which exited the entire function — should be `continue`
+					continue;
 				}
 			}
 
@@ -84,28 +89,27 @@ export const runTriggerCheckoutReward = async ({
 			let hasTrial = false;
 			if (subId) {
 				const sub = await stripeCli.subscriptions.retrieve(subId);
-				// hasTrial = Boolean(sub.trial_end && sub.trial_end > Date.now());
 				hasTrial = sub.status === "trialing";
 			}
 
 			if (hasTrial) {
 				logger.info(`Subscription is on trial, not triggering reward`);
-				return;
+				// BUG FIX: was `return` which exited the entire function — should be `continue`
+				continue;
 			}
 
 			// Get redemption count
-		const redemptionCount = await referralCodeRepo.getRedemptionCount(
-			{
+			const redemptionCount = await referralCodeRepo.getRedemptionCount({
 				db,
 				referralCodeId: referralCode.id,
-			},
-		);
+			});
 
 			if (redemptionCount >= reward_program.max_redemptions!) {
 				logger.info(
 					`Max redemptions reached, not triggering latest redemption`,
 				);
-				return;
+				// BUG FIX: was `return` which exited the entire function — should be `continue`
+				continue;
 			}
 
 			const rewardCat = getRewardCat(reward);
@@ -118,7 +122,7 @@ export const runTriggerCheckoutReward = async ({
 					redemption,
 				});
 			} else {
-				await triggerRedemption({
+				await triggerDiscount({
 					ctx,
 					referralCode: {
 						...referralCode,
@@ -130,7 +134,6 @@ export const runTriggerCheckoutReward = async ({
 			}
 		}
 	} catch (error) {
-		console.error("Failed to trigger checkout reward");
-		console.error(error);
+		logger.error(`Failed to trigger checkout reward: ${error}`);
 	}
 };

--- a/server/src/internal/rewards/actions/triggerDiscount.ts
+++ b/server/src/internal/rewards/actions/triggerDiscount.ts
@@ -1,5 +1,6 @@
 import {
 	ErrCode,
+	RecaseError,
 	type ReferralCode,
 	type Reward,
 	type RewardProgram,
@@ -10,37 +11,15 @@ import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { getOrCreateStripeCustomer } from "@/external/stripe/customers";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import RecaseError from "@/utils/errorUtils.js";
-import { CusService } from "../customers/CusService.js";
+import { CusService } from "@/internal/customers/CusService.js";
 import { redemptionRepo } from "@/internal/rewards/repos/index.js";
 import {
 	receivedByRedeemer,
 	receivedByReferrer,
-} from "./referralUtils/triggerFreePaidProduct.js";
+} from "@/internal/rewards/rewardUtils.js";
 
-export const ReferralResponseCodes = {
-	OwnsProduct: "has_product_already",
-	Success: "success",
-	Unknown: "unknown",
-	NotConfigured: "not_configured",
-	InternalError: "internal_error",
-};
-
-export const generateReferralCode = () => {
-	const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-	const codeLength = 6;
-
-	let code = "";
-
-	for (let i = 0; i < codeLength; i++) {
-		code += chars.charAt(Math.floor(Math.random() * chars.length));
-	}
-
-	return code;
-};
-
-// Trigger reward
-export const triggerRedemption = async ({
+/** Apply a Stripe coupon discount to referrer/redeemer */
+export const triggerDiscount = async ({
 	ctx,
 	referralCode,
 	reward,
@@ -114,7 +93,8 @@ export const triggerRedemption = async ({
 
 		if (!stripeCus.discount) {
 			await stripeCli.customers.update(stripeCusId, {
-				// @ts-expect-error
+				// Stripe legacy API accepts coupon as string but types don't reflect this
+				// @ts-expect-error — legacy Stripe API accepts coupon ID as string
 				coupon: reward.id,
 			});
 

--- a/server/src/internal/rewards/actions/triggerFreePaidProduct.ts
+++ b/server/src/internal/rewards/actions/triggerFreePaidProduct.ts
@@ -4,37 +4,29 @@ import {
 	ErrCode,
 	type FullProduct,
 	type FullRewardProgram,
+	RecaseError,
 	type ReferralCode,
 	type Reward,
-	RewardReceivedBy,
 	type RewardRedemption,
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { getOrCreateStripeCustomer } from "@/external/stripe/customers";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { handleAddProduct } from "@/internal/customers/attach/attachFunctions/addProductFlow/handleAddProduct.js";
 import { rewardProgramToAttachParams } from "@/internal/customers/attach/attachUtils/attachParams/convertToParams.js";
 import { getCustomerSub } from "@/internal/customers/attach/attachUtils/convertAttachParams.js";
 import { getDefaultAttachConfig } from "@/internal/customers/attach/attachUtils/getAttachConfig.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { isStripeConnected } from "@/internal/orgs/orgUtils.js";
-import RecaseError from "@/utils/errorUtils.js";
-import type { ExtendedRequest } from "@/utils/models/Request.js";
-import type { AutumnContext } from "../../../honoUtils/HonoEnv.js";
 import { redemptionRepo } from "@/internal/rewards/repos/index.js";
-import { ReferralResponseCodes } from "../referralUtils.js";
-
-export const receivedByReferrer = (received_by: RewardReceivedBy) => {
-	return (
-		received_by === RewardReceivedBy.Referrer ||
-		received_by === RewardReceivedBy.All
-	);
-};
-
-export const receivedByRedeemer = (received_by: RewardReceivedBy) => {
-	return received_by === RewardReceivedBy.All;
-};
+import {
+	ReferralResponseCodes,
+	receivedByRedeemer,
+	receivedByReferrer,
+} from "@/internal/rewards/rewardUtils.js";
+import type { ExtendedRequest } from "@/utils/models/Request.js";
 
 export const triggerFreePaidProduct = async ({
 	ctx,
@@ -83,7 +75,6 @@ export const triggerFreePaidProduct = async ({
 		});
 	}
 
-	// Add to referrer / redeemer
 	const stripeCli = createStripeCli({ org, env });
 
 	const applied = [false, false]; // [referrerApplied, redeemerApplied]
@@ -108,14 +99,16 @@ export const triggerFreePaidProduct = async ({
 		const { sub } = await getCustomerSub({ attachParams });
 
 		if (sub) {
-			console.log("Detected sub", !!sub);
+			logger.info(
+				`Detected existing subscription for ${i === 0 ? "referrer" : "redeemer"}`,
+			);
 			const curDiscounts = (sub.discounts as Stripe.Discount[]) || [];
 
 			// If coupon already applied, don't add it again
 			if (
 				!curDiscounts.some((d: any) => d.coupon?.id === rewardProgram.reward.id)
 			) {
-				console.log("Detected no discount, adding it");
+				logger.info(`No existing discount, adding coupon`);
 				try {
 					await stripeCli.subscriptions.update(sub.id, {
 						discounts: [
@@ -128,7 +121,7 @@ export const triggerFreePaidProduct = async ({
 						],
 					});
 				} catch (error) {
-					console.log("Error adding discount", error);
+					logger.error(`Error adding discount: ${error}`);
 				}
 				applied[i] = true;
 			}

--- a/server/src/internal/rewards/actions/triggerFreeProduct.ts
+++ b/server/src/internal/rewards/actions/triggerFreeProduct.ts
@@ -3,32 +3,35 @@ import {
 	ErrCode,
 	type FullRewardProgram,
 	ProductNotFoundError,
+	RecaseError,
 	type ReferralCode,
 	type Reward,
 	RewardReceivedBy,
 	type RewardRedemption,
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { createFullCusProduct } from "@/internal/customers/add-product/createFullCusProduct.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import type { InsertCusProductParams } from "@/internal/customers/cusProducts/AttachParams.js";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { isFreeProduct, isOneOff } from "@/internal/products/productUtils.js";
-import RecaseError from "@/utils/errorUtils.js";
-import type { AutumnContext } from "../../../honoUtils/HonoEnv.js";
 import { redemptionRepo } from "@/internal/rewards/repos/index.js";
-import { deleteCachedFullCustomer } from "../../customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
-import { ReferralResponseCodes } from "../referralUtils.js";
+import { ReferralResponseCodes } from "@/internal/rewards/rewardUtils.js";
+import type { ExtendedRequest } from "@/utils/models/Request.js";
 import { triggerFreePaidProduct } from "./triggerFreePaidProduct.js";
 
 export const triggerFreeProduct = async ({
 	ctx,
+	req,
 	referralCode,
 	redeemer,
 	redemption,
 	rewardProgram,
 }: {
 	ctx: AutumnContext;
+	req?: ExtendedRequest;
 	referralCode: ReferralCode;
 	redeemer: Customer;
 	redemption: RewardRedemption;
@@ -52,23 +55,21 @@ export const triggerFreeProduct = async ({
 		env,
 	});
 
+	// BUG FIX: moved null check before first use (was unreachable at line 74 in original)
+	if (!fullProduct) {
+		throw new ProductNotFoundError({ productId });
+	}
+
 	if (!isFreeProduct(fullProduct.prices) && !isOneOff(fullProduct.prices)) {
 		return await triggerFreePaidProduct({
 			ctx,
+			req,
 			referralCode,
 			redeemer,
 			rewardProgram,
 			fullProduct,
 			redemption,
 		});
-	}
-
-	// const isPaidProduct = !isFreeProduct(fullProduct.prices);
-	// const isRecurring =
-	//   !isOneOff(fullProduct.prices) && !itemsAreOneOff(fullProduct.entitlements);
-
-	if (!fullProduct) {
-		throw new ProductNotFoundError({ productId: productId });
 	}
 
 	const [fullReferrer, fullRedeemer] = await Promise.all([
@@ -118,7 +119,7 @@ export const triggerFreeProduct = async ({
 			attachParams: redeemerAttachParams,
 			logger,
 		});
-		logger.info(`✅ Added ${fullProduct.name} to redeemer`);
+		logger.info(`Added ${fullProduct.name} to redeemer`);
 
 		await deleteCachedFullCustomer({
 			customerId: fullRedeemer.id!,
@@ -143,7 +144,7 @@ export const triggerFreeProduct = async ({
 			ctx,
 			source: `triggerFreeProduct, deleting referrer cache`,
 		});
-		logger.info(`✅ Added ${fullProduct.name} to referrer`);
+		logger.info(`Added ${fullProduct.name} to referrer`);
 	}
 
 	await redemptionRepo.update({

--- a/server/src/internal/rewards/rewardUtils.ts
+++ b/server/src/internal/rewards/rewardUtils.ts
@@ -10,6 +10,7 @@ import {
 	type Reward,
 	RewardCategory,
 	type RewardProgram,
+	RewardReceivedBy,
 	RewardType,
 	stripeToAtmnAmount,
 } from "@autumn/shared";
@@ -355,4 +356,41 @@ export const constructRewardProgram = ({
 	};
 
 	return rewardProgram;
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// Referral helpers (moved from referralUtils.ts)
+// ═══════════════════════════════════════════════════════════════════
+
+export const ReferralResponseCodes = {
+	OwnsProduct: "has_product_already",
+	Success: "success",
+	Unknown: "unknown",
+	NotConfigured: "not_configured",
+	InternalError: "internal_error",
+};
+
+/** Generate a random 6-character alphanumeric referral code */
+export const generateReferralCode = () => {
+	const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+	const codeLength = 6;
+
+	let code = "";
+	for (let i = 0; i < codeLength; i++) {
+		code += chars.charAt(Math.floor(Math.random() * chars.length));
+	}
+	return code;
+};
+
+/** Whether the referrer receives the reward */
+export const receivedByReferrer = (receivedBy: RewardReceivedBy) => {
+	return (
+		receivedBy === RewardReceivedBy.Referrer ||
+		receivedBy === RewardReceivedBy.All
+	);
+};
+
+/** Whether the redeemer receives the reward */
+export const receivedByRedeemer = (receivedBy: RewardReceivedBy) => {
+	return receivedBy === RewardReceivedBy.All;
 };

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -25,7 +25,7 @@ import { generateFeatureDisplay } from "@/internal/features/workflows/generateFe
 import { runMigrationTask } from "@/internal/migrations/runMigrationTask.js";
 import { runRewardMigrationTask } from "@/internal/migrations/runRewardMigrationTask.js";
 import { detectBaseVariant } from "@/internal/products/productUtils/detectProductVariant.js";
-import { runTriggerCheckoutReward } from "@/internal/rewards/triggerCheckoutReward.js";
+import { runTriggerCheckoutReward } from "@/internal/rewards/actions/triggerCheckoutReward.js";
 import { generateId } from "@/utils/genUtils.js";
 import { addWorkflowToLogs } from "@/utils/logging/addContextToLogs.js";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restructures the reward/referral system by consolidating all trigger functions into a new `actions/` directory and renaming `referralUtils.ts` → `rewardUtils.ts`, `triggerRedemption` → `triggerDiscount`, making the codebase easier to navigate. It also fixes a real bug in `triggerCheckoutReward.ts` where `return` statements inside a loop were exiting the entire function instead of continuing to the next redemption.

- **Improvements**: Extracted `generateReferralCode`, `receivedByReferrer`, `receivedByRedeemer`, and `ReferralResponseCodes` into `rewardUtils.ts`; renamed functions to better reflect intent (`triggerRedemption` → `triggerDiscount`); added a barrel `actions/index.ts` with JSDoc.
- **Bug fixes**: Replaced four incorrect `return` statements with `continue` inside `runTriggerCheckoutReward`'s redemption loop; moved the `!fullProduct` null-guard in `triggerFreeProduct` before its first use (was unreachable after the `isFreeProduct` check).
- **Improvements**: Replaced `console.log`/`console.error` calls with structured `logger` calls throughout the actions layer.
</details>


<h3>Confidence Score: 3/5</h3>

Safe to merge the structural cleanup, but triggerFreePaidProduct has two defects that will produce wrong API responses and incorrect DB state for paid-product rewards.

The triggerFreePaidProduct return value reports redeemer/referrer cause fields using swapped applied indices, so callers receive inverted success/failure signals, and skipped iterations incorrectly set applied[i] = true, causing the DB to record the reward as applied even though no Stripe coupon was ever issued.

server/src/internal/rewards/actions/triggerFreePaidProduct.ts needs a close look — both the return value block and the early-continue logic contain defects.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/rewards/actions/triggerFreePaidProduct.ts | Renamed from referralUtils/triggerFreePaidProduct.ts; has two logic bugs: return value swaps redeemer/referrer cause indices, and skipped slots incorrectly set applied=true before continue |
| server/src/internal/rewards/actions/triggerCheckoutReward.ts | Renamed from triggerCheckoutReward.ts; fixes critical return-vs-continue bugs in loop, replaces console.* with structured logger, cleans up imports |
| server/src/internal/rewards/actions/triggerDiscount.ts | Renamed from referralUtils.ts; extracts only the triggerRedemption (now triggerDiscount) logic, removes unrelated helpers that moved to rewardUtils.ts |
| server/src/internal/rewards/actions/triggerFreeProduct.ts | Renamed and updated; correctly moves null-check before isFreeProduct guard, adds optional req parameter forwarded to triggerFreePaidProduct |
| server/src/internal/rewards/rewardUtils.ts | Consolidates referral helpers (generateReferralCode, receivedByReferrer, receivedByRedeemer, ReferralResponseCodes) from the old referralUtils.ts into this shared utilities file |
| server/src/internal/rewards/actions/index.ts | New barrel file exposing all reward actions as a rewardActions namespace with inline documentation |
| server/src/internal/api/rewards/handlers/referrals/handleRedeemReferral.ts | Updated imports to use new actions paths; triggerRedemption correctly replaced with triggerDiscount |
| server/src/internal/api/rewards/handlers/referrals/handleGetReferralCode.ts | Import path for generateReferralCode updated from referralUtils.ts to rewardUtils.ts; no logic changes |
| server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts | Updated imports to use new actions paths; triggerRedemption correctly replaced with triggerDiscount |
| server/src/queue/processMessage.ts | Import path for runTriggerCheckoutReward updated to new actions directory; no logic changes |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `server/src/internal/rewards/actions/triggerFreePaidProduct.ts`, line 160-179 ([link](https://github.com/useautumn/autumn/blob/631a461c1258bc5f77f77f452396b3a154e21126/server/src/internal/rewards/actions/triggerFreePaidProduct.ts#L160-L179)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The `cause` fields in the return value use the wrong `applied` indices. `applied[0]` tracks whether the **referrer** received the discount, and `applied[1]` tracks the **redeemer**, but the object assigns them to the opposite keys. If a referrer received a discount but the redeemer did not, the response would report the opposite — success for redeemer, failure for referrer.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/rewards/actions/triggerFreePaidProduct.ts
   Line: 160-179

   Comment:
   The `cause` fields in the return value use the wrong `applied` indices. `applied[0]` tracks whether the **referrer** received the discount, and `applied[1]` tracks the **redeemer**, but the object assigns them to the opposite keys. If a referrer received a discount but the redeemer did not, the response would report the opposite — success for redeemer, failure for referrer.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/rewards/actions/triggerFreePaidProduct.ts`, line 81-89 ([link](https://github.com/useautumn/autumn/blob/631a461c1258bc5f77f77f452396b3a154e21126/server/src/internal/rewards/actions/triggerFreePaidProduct.ts#L81-L89)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> Marking a skipped slot as `applied = true` corrupts the DB record. When a customer is not eligible to receive the reward (e.g., only the redeemer receives it, so referrer is skipped), `applied[0]` is still set to `true` before `continue`. The subsequent `redemptionRepo.update` then persists `applied: true` even though no Stripe coupon was ever applied to that customer, making the record unfixable on retry.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/rewards/actions/triggerFreePaidProduct.ts
   Line: 81-89

   Comment:
   Marking a skipped slot as `applied = true` corrupts the DB record. When a customer is not eligible to receive the reward (e.g., only the redeemer receives it, so referrer is skipped), `applied[0]` is still set to `true` before `continue`. The subsequent `redemptionRepo.update` then persists `applied: true` even though no Stripe coupon was ever applied to that customer, making the record unfixable on retry.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `server/src/internal/rewards/actions/triggerFreePaidProduct.ts`, line 31-41 ([link](https://github.com/useautumn/autumn/blob/631a461c1258bc5f77f77f452396b3a154e21126/server/src/internal/rewards/actions/triggerFreePaidProduct.ts#L31-L41)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The `req` parameter is accepted in both `triggerFreePaidProduct` and the calling `triggerFreeProduct` but is never read inside `triggerFreePaidProduct`'s function body. If it is genuinely unused, removing it avoids confusing future callers about whether passing it has any effect.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/rewards/actions/triggerFreePaidProduct.ts
   Line: 31-41

   Comment:
   The `req` parameter is accepted in both `triggerFreePaidProduct` and the calling `triggerFreeProduct` but is never read inside `triggerFreePaidProduct`'s function body. If it is genuinely unused, removing it avoids confusing future callers about whether passing it has any effect.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/rewards/actions/triggerFreePaidProduct.ts:160-179
The `cause` fields in the return value use the wrong `applied` indices. `applied[0]` tracks whether the **referrer** received the discount, and `applied[1]` tracks the **redeemer**, but the object assigns them to the opposite keys. If a referrer received a discount but the redeemer did not, the response would report the opposite — success for redeemer, failure for referrer.

```suggestion
	return {
		redeemer: {
			applied: true,
			cause: applied?.[1]
				? ReferralResponseCodes.Success
				: ReferralResponseCodes.OwnsProduct,
			meta: {
				id: fullRedeemer.id,
				name: fullRedeemer.name,
				email: fullRedeemer.email,
				created_at: fullRedeemer.created_at,
			},
		},
		referrer: {
			applied: true,
			cause: applied?.[0]
				? ReferralResponseCodes.Success
				: ReferralResponseCodes.OwnsProduct,
		},
	};
```

### Issue 2 of 3
server/src/internal/rewards/actions/triggerFreePaidProduct.ts:81-89
Marking a skipped slot as `applied = true` corrupts the DB record. When a customer is not eligible to receive the reward (e.g., only the redeemer receives it, so referrer is skipped), `applied[0]` is still set to `true` before `continue`. The subsequent `redemptionRepo.update` then persists `applied: true` even though no Stripe coupon was ever applied to that customer, making the record unfixable on retry.

### Issue 3 of 3
server/src/internal/rewards/actions/triggerFreePaidProduct.ts:31-41
The `req` parameter is accepted in both `triggerFreePaidProduct` and the calling `triggerFreeProduct` but is never read inside `triggerFreePaidProduct`'s function body. If it is genuinely unused, removing it avoids confusing future callers about whether passing it has any effect.

```suggestion
export const triggerFreePaidProduct = async ({
	ctx,
	referralCode,
	redeemer,
	rewardProgram,
	fullProduct,
	redemption,
}: {
	ctx: AutumnContext;
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 phase 2; rewards are now in act..."](https://github.com/useautumn/autumn/commit/631a461c1258bc5f77f77f452396b3a154e21126) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31369058)</sub>

<!-- /greptile_comment -->