### PR TITLE
feat: 🎸 initialise db schemas and indexes for feature grants

### DIFF
--- a/server/src/internal/rewards/repos/getRedemptionsByCustomer.ts
+++ b/server/src/internal/rewards/repos/getRedemptionsByCustomer.ts
@@ -42,7 +42,11 @@ export const getRedemptionsByCustomer = async ({
 		with: {
 			reward_program: {
 				with: {
-					reward: true,
+					reward: {
+						with: {
+							entitlements: true,
+						},
+					},
 				},
 			},
 			referral_code: true,

--- a/server/src/internal/rewards/repos/getReferralCode.ts
+++ b/server/src/internal/rewards/repos/getReferralCode.ts
@@ -33,7 +33,11 @@ export const getReferralCode = async ({
 			? {
 					reward_program: {
 						with: {
-							reward: true,
+							reward: {
+								with: {
+									entitlements: true,
+								},
+							},
 						},
 					},
 				}

--- a/server/src/internal/rewards/repos/getReward.ts
+++ b/server/src/internal/rewards/repos/getReward.ts
@@ -23,6 +23,9 @@ export const getReward = async ({
 			eq(rewards.org_id, orgId),
 			eq(rewards.env, env),
 		),
+		with: {
+			entitlements: true,
+		},
 	});
 
 	if (!result) {

--- a/server/src/internal/rewards/repos/getRewardsByIdOrCode.ts
+++ b/server/src/internal/rewards/repos/getRewardsByIdOrCode.ts
@@ -28,6 +28,9 @@ export const getRewardsByIdOrCode = async ({
 				),
 			),
 		),
+		with: {
+			entitlements: true,
+		},
 	});
 
 	return reward as Reward[];

--- a/server/src/internal/rewards/repos/getRewardsInIds.ts
+++ b/server/src/internal/rewards/repos/getRewardsInIds.ts
@@ -20,5 +20,8 @@ export const getRewardsInIds = async ({
 			eq(rewards.org_id, orgId),
 			eq(rewards.env, env),
 		),
+		with: {
+			entitlements: true,
+		},
 	})) as Reward[];
 };

--- a/server/src/internal/rewards/repos/insertReward.ts
+++ b/server/src/internal/rewards/repos/insertReward.ts
@@ -1,5 +1,9 @@
-import { type Reward, rewards } from "@autumn/shared";
+import { entitlements, type Reward, rewards } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	type RewardWithEntitlementInputs,
+	rewardToEntitlementRows,
+} from "./rewardEntitlementRows.js";
 
 /** Insert one or many rewards */
 export const insertReward = async ({
@@ -7,8 +11,30 @@ export const insertReward = async ({
 	data,
 }: {
 	db: DrizzleCli;
-	data: Reward | Reward[];
+	data: RewardWithEntitlementInputs | RewardWithEntitlementInputs[];
 }) => {
-	const results = await db.insert(rewards).values(data as Reward);
-	return results as Reward[];
+	const rewardsToInsert = Array.isArray(data) ? data : [data];
+	const rewardData = rewardsToInsert.map((reward) => {
+		const { entitlements: _entitlements, ...rewardRow } = reward;
+		return rewardRow;
+	});
+	const entitlementRows = rewardsToInsert.flatMap((reward) =>
+		rewardToEntitlementRows({ reward }),
+	);
+
+	const insertedRewards = await db
+		.insert(rewards)
+		.values(rewardData)
+		.returning();
+
+	if (entitlementRows.length > 0) {
+		await db.insert(entitlements).values(entitlementRows);
+	}
+
+	return insertedRewards.map((reward) => ({
+		...reward,
+		entitlements: entitlementRows.filter(
+			(entitlement) => entitlement.internal_reward_id === reward.internal_id,
+		),
+	})) as Reward[];
 };

--- a/server/src/internal/rewards/repos/listRewards.ts
+++ b/server/src/internal/rewards/repos/listRewards.ts
@@ -25,6 +25,9 @@ export const listRewards = async ({
 			eq(rewards.env, env),
 			inTypes ? inArray(rewards.type, inTypes) : undefined,
 		),
+		with: {
+			entitlements: true,
+		},
 		orderBy: [desc(rewards.internal_id)],
 	});
 

--- a/server/src/internal/rewards/repos/rewardEntitlementRows.ts
+++ b/server/src/internal/rewards/repos/rewardEntitlementRows.ts
@@ -1,0 +1,59 @@
+import {
+	AllowanceType,
+	type Entitlement,
+	type Reward,
+	type RewardEntitlement,
+} from "@autumn/shared";
+import { generateId } from "@/utils/genUtils.js";
+
+export type RewardWithEntitlementInputs = Partial<
+	Omit<Reward, "entitlements">
+> & {
+	internal_id: string;
+	org_id: string;
+	entitlements?: (RewardEntitlement | Entitlement)[] | null;
+};
+
+export const rewardToEntitlementRows = ({
+	reward,
+}: {
+	reward: RewardWithEntitlementInputs;
+}): Entitlement[] => {
+	const entitlements = reward.entitlements ?? [];
+
+	return entitlements.map((entitlement) => {
+		const expiry = "expiry" in entitlement ? entitlement.expiry : undefined;
+
+		return {
+			id:
+				"id" in entitlement && entitlement.id
+					? entitlement.id
+					: generateId("ent"),
+			created_at:
+				"created_at" in entitlement && entitlement.created_at
+					? entitlement.created_at
+					: Date.now(),
+			internal_feature_id: entitlement.internal_feature_id,
+			internal_product_id: null,
+			internal_reward_id: reward.internal_id,
+			is_custom: false,
+			allowance_type: AllowanceType.Fixed,
+			allowance: entitlement.allowance ?? null,
+			interval: null,
+			interval_count: 1,
+			carry_from_previous: false,
+			entity_feature_id: null,
+			org_id: reward.org_id,
+			feature_id:
+				"feature_id" in entitlement ? entitlement.feature_id : undefined,
+			usage_limit: null,
+			expiry_duration:
+				expiry?.duration ??
+				("expiry_duration" in entitlement ? entitlement.expiry_duration : null),
+			expiry_length:
+				expiry?.length ??
+				("expiry_length" in entitlement ? entitlement.expiry_length : null),
+			rollover: null,
+		};
+	});
+};

--- a/server/src/internal/rewards/repos/updateReward.ts
+++ b/server/src/internal/rewards/repos/updateReward.ts
@@ -1,12 +1,17 @@
 import {
 	type AppEnv,
 	ErrCode,
+	entitlements,
 	RecaseError,
 	type Reward,
 	rewards,
 } from "@autumn/shared";
 import { and, eq } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	type RewardWithEntitlementInputs,
+	rewardToEntitlementRows,
+} from "./rewardEntitlementRows.js";
 
 /** Update a reward by internal_id. Throws if not found. */
 export const updateReward = async ({
@@ -20,11 +25,13 @@ export const updateReward = async ({
 	internalId: string;
 	env: AppEnv;
 	orgId: string;
-	update: Partial<Reward>;
+	update: Partial<RewardWithEntitlementInputs>;
 }) => {
+	const { entitlements: entitlementInputs, ...rewardUpdate } = update;
+
 	const result = await db
 		.update(rewards)
-		.set(update)
+		.set(rewardUpdate)
 		.where(
 			and(
 				eq(rewards.internal_id, internalId),
@@ -39,6 +46,29 @@ export const updateReward = async ({
 			message: `Reward ${internalId} not found`,
 			code: ErrCode.InvalidRequest,
 		});
+	}
+
+	if (entitlementInputs !== undefined) {
+		await db
+			.delete(entitlements)
+			.where(eq(entitlements.internal_reward_id, internalId));
+
+		const entitlementRows = rewardToEntitlementRows({
+			reward: {
+				internal_id: internalId,
+				entitlements: entitlementInputs,
+				org_id: orgId,
+			},
+		});
+
+		if (entitlementRows.length > 0) {
+			await db.insert(entitlements).values(entitlementRows);
+		}
+
+		return {
+			...result[0],
+			entitlements: entitlementRows,
+		} as Reward;
 	}
 
 	return result[0] as Reward;

--- a/server/tests/integration/db/full-subject/utils/fullSubjectScenarioBuilders.ts
+++ b/server/tests/integration/db/full-subject/utils/fullSubjectScenarioBuilders.ts
@@ -184,6 +184,9 @@ const buildEntitlement = ({
 	org_id: ctx.org.id,
 	feature_id: feature.id,
 	usage_limit: null,
+	expiry_duration: null,
+	expiry_length: null,
+	internal_reward_id: null,
 	rollover: null,
 });
 

--- a/shared/db/schema.ts
+++ b/shared/db/schema.ts
@@ -61,6 +61,7 @@ import { rewardRedemptions } from "../models/rewardModels/referralModels/rewardR
 // Reward Tables
 import { rewards } from "../models/rewardModels/rewardModels/rewardTable.js";
 // Reward Relations
+import { rewardRelations } from "../models/rewardModels/rewardModels/rewardRelations.js";
 import { rewardProgramRelations } from "../models/rewardModels/rewardProgramModels/rewardProgramRelations.js";
 import { rewardPrograms } from "../models/rewardModels/rewardProgramModels/rewardProgramTable.js";
 import {
@@ -148,6 +149,7 @@ export {
 	customersRelations,
 	entitiesRelations,
 	apiKeyRelations,
+	rewardRelations,
 	rewardProgramRelations,
 	referralCodeRelations,
 	rewardRedemptionRelations,

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -176,6 +176,7 @@ export * from "./models/rewardModels/referralModels/rewardRedemptionTable";
 export * from "./models/rewardModels/rewardModels/rewardEnums";
 // Reward Models
 export * from "./models/rewardModels/rewardModels/rewardModels";
+export * from "./models/rewardModels/rewardModels/rewardRelations";
 export * from "./models/rewardModels/rewardModels/rewardResponseModels";
 export * from "./models/rewardModels/rewardModels/rewardTable";
 export * from "./models/rewardModels/rewardProgramModels/rewardProgramEnums";

--- a/shared/models/productModels/entModels/entModels.ts
+++ b/shared/models/productModels/entModels/entModels.ts
@@ -9,12 +9,25 @@ export enum AllowanceType {
 	None = "none",
 }
 
+export enum EntitlementDuration {
+	Day = "day",
+	Week = "week",
+	Month = "month",
+	Year = "year",
+}
+
+export const EntitlementExpirySchema = z.object({
+	duration: z.nativeEnum(EntitlementDuration),
+	length: z.number(),
+});
+
 export const EntitlementSchema = z.object({
 	// Required fields - no .optional()
 	id: z.string(),
 	created_at: z.number(),
 	internal_feature_id: z.string(),
 	internal_product_id: z.string().nullable(),
+	internal_reward_id: z.string().nullish(),
 	is_custom: z.boolean().default(false),
 
 	allowance_type: z.nativeEnum(AllowanceType).optional().nullable(),
@@ -29,6 +42,8 @@ export const EntitlementSchema = z.object({
 	org_id: z.string().optional(),
 	feature_id: z.string().optional(),
 	usage_limit: z.number().nullable().optional().default(null),
+	expiry_duration: z.nativeEnum(EntitlementDuration).nullish(),
+	expiry_length: z.number().nullish(),
 
 	rollover: RolloverConfigSchema.nullish(),
 });
@@ -50,6 +65,7 @@ export const CreateEntitlementSchema = z.object({
 export type CreateEntitlement = z.infer<typeof CreateEntitlementSchema>;
 
 export type Entitlement = z.infer<typeof EntitlementSchema>;
+export type EntitlementExpiry = z.infer<typeof EntitlementExpirySchema>;
 
 export const EntitlementWithFeatureSchema = EntitlementSchema.extend({
 	feature: FeatureSchema,

--- a/shared/models/productModels/entModels/entRelations.ts
+++ b/shared/models/productModels/entModels/entRelations.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm";
 
 import { features } from "../../featureModels/featureTable";
+import { rewards } from "../../rewardModels/rewardModels/rewardTable";
 import { products } from "../productTable";
 import { entitlements } from "./entTable";
 
@@ -12,5 +13,9 @@ export const entitlementsRelations = relations(entitlements, ({ one }) => ({
 	product: one(products, {
 		fields: [entitlements.internal_product_id],
 		references: [products.internal_id],
+	}),
+	reward: one(rewards, {
+		fields: [entitlements.internal_reward_id],
+		references: [rewards.internal_id],
 	}),
 }));

--- a/shared/models/productModels/entModels/entTable.ts
+++ b/shared/models/productModels/entModels/entTable.ts
@@ -11,6 +11,7 @@ import {
 } from "drizzle-orm/pg-core";
 import type { RolloverConfig } from "../../../index";
 import { features } from "../../featureModels/featureTable";
+import { rewards } from "../../rewardModels/rewardModels/rewardTable";
 import { products } from "../productTable";
 
 export const entitlements = pgTable(
@@ -20,6 +21,7 @@ export const entitlements = pgTable(
 		created_at: numeric({ mode: "number" }).notNull(),
 		internal_feature_id: text().notNull(),
 		internal_product_id: text(),
+		internal_reward_id: text("internal_reward_id"),
 		is_custom: boolean().default(false),
 
 		allowance_type: text(),
@@ -34,6 +36,8 @@ export const entitlements = pgTable(
 		org_id: text("org_id"),
 		feature_id: text("feature_id"),
 		usage_limit: numeric({ mode: "number" }),
+		expiry_duration: text("expiry_duration"),
+		expiry_length: numeric({ mode: "number" }),
 
 		rollover: jsonb().$type<RolloverConfig>(),
 	},
@@ -50,8 +54,20 @@ export const entitlements = pgTable(
 		})
 			.onUpdate("cascade")
 			.onDelete("cascade"),
+		foreignKey({
+			columns: [table.internal_reward_id],
+			foreignColumns: [rewards.internal_id],
+			name: "entitlements_internal_reward_id_fkey",
+		})
+			.onUpdate("cascade")
+			.onDelete("cascade"),
 		unique("entitlements_id_key").on(table.id),
 		index("idx_entitlements_internal_product_id").on(table.internal_product_id),
+		index("idx_entitlements_internal_reward_id").on(table.internal_reward_id),
+		index("idx_entitlements_reward_feature").on(
+			table.internal_reward_id,
+			table.internal_feature_id,
+		),
 	],
 );
 

--- a/shared/models/rewardModels/referralModels/rewardRedemptionTable.ts
+++ b/shared/models/rewardModels/referralModels/rewardRedemptionTable.ts
@@ -23,6 +23,7 @@ export const rewardRedemptions = pgTable(
 		applied: boolean().default(false),
 		redeemer_applied: boolean().default(false),
 		referral_code_id: text("referral_code_id"),
+		reward_internal_id: text("reward_internal_id"),
 	},
 	(table) => [
 		foreignKey({
@@ -41,6 +42,15 @@ export const rewardRedemptions = pgTable(
 			name: "reward_redemptions_referral_code_id_fkey",
 		}).onDelete("cascade"),
 		index("idx_reward_redemptions_referral_code_id").on(table.referral_code_id),
+		// For counting promo code redemptions per reward (limit enforcement)
+		index("idx_reward_redemptions_reward_internal_id").on(
+			table.reward_internal_id,
+		),
+		// For checking if a customer already redeemed a specific reward
+		index("idx_reward_redemptions_customer_reward").on(
+			table.internal_customer_id,
+			table.reward_internal_id,
+		),
 	],
 );
 

--- a/shared/models/rewardModels/rewardModels/rewardEnums.ts
+++ b/shared/models/rewardModels/rewardModels/rewardEnums.ts
@@ -19,4 +19,12 @@ export enum RewardType {
 	FixedDiscount = "fixed_discount",
 	FreeProduct = "free_product",
 	InvoiceCredits = "invoice_credits",
+	FeatureGrant = "feature_grant",
+}
+
+export enum FeatureGrantDuration {
+	Day = "day",
+	Week = "week",
+	Month = "month",
+	Year = "year",
 }

--- a/shared/models/rewardModels/rewardModels/rewardEnums.ts
+++ b/shared/models/rewardModels/rewardModels/rewardEnums.ts
@@ -21,10 +21,3 @@ export enum RewardType {
 	InvoiceCredits = "invoice_credits",
 	FeatureGrant = "feature_grant",
 }
-
-export enum FeatureGrantDuration {
-	Day = "day",
-	Week = "week",
-	Month = "month",
-	Year = "year",
-}

--- a/shared/models/rewardModels/rewardModels/rewardModels.ts
+++ b/shared/models/rewardModels/rewardModels/rewardModels.ts
@@ -1,8 +1,24 @@
 import { z } from "zod/v4";
-import { CouponDurationType, RewardType } from "./rewardEnums";
+import {
+	CouponDurationType,
+	FeatureGrantDuration,
+	RewardType,
+} from "./rewardEnums";
 
 const PromoCodeSchema = z.object({
 	code: z.string(),
+	max_redemptions: z.number().optional(),
+});
+
+const RewardEntitlementExpirySchema = z.object({
+	duration: z.nativeEnum(FeatureGrantDuration),
+	length: z.number(),
+});
+
+const RewardEntitlementSchema = z.object({
+	internal_feature_id: z.string(),
+	allowance: z.number(),
+	expiry: RewardEntitlementExpirySchema.optional(),
 });
 
 export const DiscountConfigSchema = z.object({
@@ -29,6 +45,7 @@ const RewardSchema = z.object({
 	free_product_id: z.string().nullish(),
 	discount_config: DiscountConfigSchema.nullish(),
 	free_product_config: FreeProductConfigSchema.nullish(),
+	entitlements: z.array(RewardEntitlementSchema).nullish(),
 
 	internal_id: z.string(),
 	org_id: z.string(),
@@ -44,6 +61,7 @@ export const CreateRewardSchema = z.object({
 	discount_config: DiscountConfigSchema.nullish(),
 	free_product_config: FreeProductConfigSchema.nullish(),
 	free_product_id: z.string().nullish(),
+	entitlements: z.array(RewardEntitlementSchema).nullish(),
 });
 
 export type PromoCode = z.infer<typeof PromoCodeSchema>;
@@ -51,3 +69,7 @@ export type CreateReward = z.infer<typeof CreateRewardSchema>;
 export type Reward = z.infer<typeof RewardSchema>;
 export type DiscountConfig = z.infer<typeof DiscountConfigSchema>;
 export type FreeProductConfig = z.infer<typeof FreeProductConfigSchema>;
+export type RewardEntitlement = z.infer<typeof RewardEntitlementSchema>;
+export type RewardEntitlementExpiry = z.infer<
+	typeof RewardEntitlementExpirySchema
+>;

--- a/shared/models/rewardModels/rewardModels/rewardModels.ts
+++ b/shared/models/rewardModels/rewardModels/rewardModels.ts
@@ -1,24 +1,19 @@
 import { z } from "zod/v4";
 import {
-	CouponDurationType,
-	FeatureGrantDuration,
-	RewardType,
-} from "./rewardEnums";
+	EntitlementExpirySchema,
+	EntitlementSchema,
+} from "../../productModels/entModels/entModels";
+import { CouponDurationType, RewardType } from "./rewardEnums";
 
 const PromoCodeSchema = z.object({
 	code: z.string(),
 	max_redemptions: z.number().optional(),
 });
 
-const RewardEntitlementExpirySchema = z.object({
-	duration: z.nativeEnum(FeatureGrantDuration),
-	length: z.number(),
-});
-
 const RewardEntitlementSchema = z.object({
 	internal_feature_id: z.string(),
 	allowance: z.number(),
-	expiry: RewardEntitlementExpirySchema.optional(),
+	expiry: EntitlementExpirySchema.optional(),
 });
 
 export const DiscountConfigSchema = z.object({
@@ -45,7 +40,7 @@ const RewardSchema = z.object({
 	free_product_id: z.string().nullish(),
 	discount_config: DiscountConfigSchema.nullish(),
 	free_product_config: FreeProductConfigSchema.nullish(),
-	entitlements: z.array(RewardEntitlementSchema).nullish(),
+	entitlements: z.array(EntitlementSchema).nullish(),
 
 	internal_id: z.string(),
 	org_id: z.string(),
@@ -70,6 +65,3 @@ export type Reward = z.infer<typeof RewardSchema>;
 export type DiscountConfig = z.infer<typeof DiscountConfigSchema>;
 export type FreeProductConfig = z.infer<typeof FreeProductConfigSchema>;
 export type RewardEntitlement = z.infer<typeof RewardEntitlementSchema>;
-export type RewardEntitlementExpiry = z.infer<
-	typeof RewardEntitlementExpirySchema
->;

--- a/shared/models/rewardModels/rewardModels/rewardRelations.ts
+++ b/shared/models/rewardModels/rewardModels/rewardRelations.ts
@@ -1,0 +1,7 @@
+import { relations } from "drizzle-orm";
+import { entitlements } from "../../productModels/entModels/entTable";
+import { rewards } from "./rewardTable";
+
+export const rewardRelations = relations(rewards, ({ many }) => ({
+	entitlements: many(entitlements),
+}));

--- a/shared/models/rewardModels/rewardModels/rewardTable.ts
+++ b/shared/models/rewardModels/rewardModels/rewardTable.ts
@@ -5,6 +5,7 @@ import type {
 	DiscountConfig,
 	FreeProductConfig,
 	PromoCode,
+	RewardEntitlement,
 } from "./rewardModels";
 
 export const rewards = pgTable(
@@ -22,6 +23,7 @@ export const rewards = pgTable(
 		).$type<FreeProductConfig>(),
 		free_product_id: text("free_product_id"),
 		promo_codes: jsonb("promo_codes").$type<PromoCode[]>().array(),
+		entitlements: jsonb("entitlements").$type<RewardEntitlement[]>(),
 		type: text(),
 	},
 	(table) => [

--- a/shared/models/rewardModels/rewardModels/rewardTable.ts
+++ b/shared/models/rewardModels/rewardModels/rewardTable.ts
@@ -5,7 +5,6 @@ import type {
 	DiscountConfig,
 	FreeProductConfig,
 	PromoCode,
-	RewardEntitlement,
 } from "./rewardModels";
 
 export const rewards = pgTable(
@@ -23,7 +22,6 @@ export const rewards = pgTable(
 		).$type<FreeProductConfig>(),
 		free_product_id: text("free_product_id"),
 		promo_codes: jsonb("promo_codes").$type<PromoCode[]>().array(),
-		entitlements: jsonb("entitlements").$type<RewardEntitlement[]>(),
 		type: text(),
 	},
 	(table) => [


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces the DB schema and repo layer for **feature grants** as a new reward type, wiring `entitlements` to `rewards` via a new FK column (`internal_reward_id`) and cascading indexes, and adding `expiry_duration`/`expiry_length` to entitlements for time-bounded grants.

- **[Improvements]** New `rewardRelations` / updated `entitlementsRelations` wire up Drizzle ORM relations so `getReward`, `listRewards`, and the referral/redemption query paths all eagerly load entitlements with `with: { entitlements: true }`.
- **[Improvements]** `rewardEntitlementRows.ts` provides a reusable helper that normalises `RewardEntitlement | Entitlement` union inputs into DB-ready rows, and `insertReward`/`updateReward` are updated to call it.
- **[API changes]** `RewardType.FeatureGrant` is added to the enum; `PromoCodeSchema` gains `max_redemptions`; `reward_internal_id` is added to `reward_redemptions` for per-reward redemption counting.
</details>

<h3>Confidence Score: 3/5</h3>

Two multi-statement write paths lack transactions, meaning a partial failure can corrupt reward-entitlement state; additionally a new FK-style column in reward_redemptions has no referential integrity constraint.

Both insertReward and updateReward perform multiple separate DB statements without a wrapping transaction. A failure mid-way leaves persistent data in a broken state. The reward_internal_id column in reward_redemptions is also missing a FK, so reward deletions will silently produce orphaned redemption rows that break the limit-enforcement logic the index comment describes.

server/src/internal/rewards/repos/insertReward.ts, server/src/internal/rewards/repos/updateReward.ts, and shared/models/rewardModels/referralModels/rewardRedemptionTable.ts all need attention before this lands.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/rewards/repos/updateReward.ts | Adds delete-then-insert of entitlements when updating a reward, but without a DB transaction — a failed insert leaves the reward with no entitlements. |
| server/src/internal/rewards/repos/insertReward.ts | Splits reward and entitlement inserts into two separate statements without a transaction; a failed entitlement insert leaves orphaned reward rows with no entitlements. |
| shared/models/rewardModels/referralModels/rewardRedemptionTable.ts | Adds reward_internal_id column and indexes, but is missing a foreign key to rewards.internal_id and uses a reversed naming convention. |
| server/src/internal/rewards/repos/rewardEntitlementRows.ts | New helper that maps RewardEntitlement/Entitlement inputs to DB rows; logic is sound but always hard-codes AllowanceType.Fixed. |
| shared/models/productModels/entModels/entTable.ts | Adds internal_reward_id FK, expiry_duration/expiry_length columns, and matching indexes cleanly. |
| shared/models/rewardModels/rewardModels/rewardModels.ts | Adds RewardEntitlementSchema, max_redemptions to PromoCodeSchema, and entitlements field to RewardSchema and CreateRewardSchema. |
| shared/models/rewardModels/rewardModels/rewardRelations.ts | New file defining the one-to-many relation from rewards to entitlements; correctly wired into db/schema.ts and shared/index.ts. |

</details>

<details><summary><h3>Entity Relationship Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    rewards {
        text internal_id PK
        text id
        text org_id
        text env
        text type
    }
    entitlements {
        text id PK
        text internal_feature_id FK
        text internal_product_id FK
        text internal_reward_id FK
        text expiry_duration
        numeric expiry_length
    }
    reward_redemptions {
        text id PK
        text internal_customer_id FK
        text internal_reward_program_id FK
        text referral_code_id FK
        text reward_internal_id
    }
    rewards ||--o{ entitlements : "internal_reward_id (new FK)"
    rewards ||--o{ reward_redemptions : "reward_internal_id (no FK)"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/internal/rewards/repos/updateReward.ts:51-66
**Non-atomic delete-then-insert for entitlements**

The delete on line 53 and the subsequent insert on line 65 run as separate statements with no transaction. If the insert throws (e.g., a constraint violation or transient DB error), the reward's entitlements are permanently deleted while the new ones are never written — leaving the reward in an entitlement-less state with no way to recover. Wrap the `db.delete` + `db.insert` block (and ideally the `db.update` that precedes it) in a single `db.transaction(...)` call.

### Issue 2 of 4
server/src/internal/rewards/repos/insertReward.ts:25-32
**Reward and entitlements inserted without a transaction**

The reward rows are committed on line 28, and the entitlement rows are inserted separately on line 31. If the entitlement insert fails (e.g., a duplicate `id`, a constraint violation, or a transient error), the rewards already exist in the database but carry no entitlements. Any subsequent `getReward` / `listRewards` call would return rewards with an empty `entitlements` array, silently breaking the feature-grant flow. Wrap both inserts in a `db.transaction(...)` so they succeed or fail atomically.

### Issue 3 of 4
shared/models/rewardModels/referralModels/rewardRedemptionTable.ts:26
**`reward_internal_id` column has no foreign key constraint**

The column is indexed (lines 46–53) but has no `foreignKey(...)` referencing `rewards.internal_id`, unlike every other relational column in this table (`internal_customer_id`, `internal_reward_program_id`, `referral_code_id`). Without the FK, deleting a reward leaves orphaned redemption rows that point to a non-existent reward, breaking any limit-enforcement query that counts redemptions by reward. Add a `foreignKey` with `.onDelete("set null")` (or `"cascade"` depending on desired semantics) to match the pattern used for the other columns.

### Issue 4 of 4
shared/models/rewardModels/referralModels/rewardRedemptionTable.ts:26
**Column name breaks the established `internal_*_id` naming convention**

Every other FK-style column in this table and across the schema follows the pattern `internal_<entity>_id` (e.g., `internal_customer_id`, `internal_reward_program_id`). The new column uses the reversed form `reward_internal_id`, which will require callers to remember a different pattern and will look out of place in JOIN conditions and query logs.

```suggestion
		internal_reward_id: text("internal_reward_id"),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Normalize reward entitlements"](https://github.com/useautumn/autumn/commit/3cec084e901b67b20620900bc0ca6bd6eb89cdde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31369062)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->