### PR TITLE
feat: 🎸 introduce redeem promo code route + tests

### DIFF
--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -763,6 +763,20 @@ export class AutumnInt {
 			const data = await this.delete(`/rewards/${rewardId}`);
 			return data;
 		},
+
+		redeem: async ({
+			code,
+			customerId,
+		}: {
+			code: string;
+			customerId: string;
+		}) => {
+			const data = await this.post("/rewards.redeem", {
+				code,
+				customer_id: customerId,
+			});
+			return data;
+		},
 	};
 
 	rewardPrograms = {

--- a/server/src/honoMiddlewares/refreshCacheConfigs.ts
+++ b/server/src/honoMiddlewares/refreshCacheConfigs.ts
@@ -116,6 +116,11 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 
 	route({
 		method: "POST",
+		url: "/rewards.redeem",
+	}),
+
+	route({
+		method: "POST",
 		url: "/balances.delete",
 	}),
 

--- a/server/src/internal/api/rewards/handlers/handleRedeemReward.ts
+++ b/server/src/internal/api/rewards/handlers/handleRedeemReward.ts
@@ -1,0 +1,24 @@
+import { Scopes } from "@autumn/shared";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { rewardActions } from "@/internal/rewards/actions/index.js";
+
+export const handleRedeemReward = createRoute({
+	scopes: [Scopes.Rewards.Write],
+	body: z.object({
+		code: z.string().min(1),
+		customer_id: z.string().min(1),
+	}),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { code, customer_id } = c.req.valid("json");
+
+		const result = await rewardActions.redeemPromoCode({
+			ctx,
+			code,
+			customerId: customer_id,
+		});
+
+		return c.json(result);
+	},
+});

--- a/server/src/internal/api/rewards/handlers/referrals/handleGetReferralCode.ts
+++ b/server/src/internal/api/rewards/handlers/referrals/handleGetReferralCode.ts
@@ -6,7 +6,10 @@ import {
 	Scopes,
 } from "@autumn/shared";
 import { CusService } from "@/internal/customers/CusService.js";
-import { rewardProgramRepo, referralCodeRepo } from "@/internal/rewards/repos/index.js";
+import {
+	referralCodeRepo,
+	rewardProgramRepo,
+} from "@/internal/rewards/repos/index.js";
 import { generateReferralCode } from "@/internal/rewards/rewardUtils.js";
 import { generateId } from "@/utils/genUtils.js";
 import { createRoute } from "../../../../../honoMiddlewares/routeHandler";
@@ -49,14 +52,13 @@ export const handleGetReferralCode = createRoute({
 		}
 
 		// Get referral code by customer and reward trigger
-		let referralCode =
-			await referralCodeRepo.getByCustomerAndProgram({
-				db,
-				orgId: org.id,
-				env,
-				internalCustomerId: customer.internal_id,
-				internalRewardProgramId: rewardProgram.internal_id,
-			});
+		let referralCode = await referralCodeRepo.getByCustomerAndProgram({
+			db,
+			orgId: org.id,
+			env,
+			internalCustomerId: customer.internal_id,
+			internalRewardProgramId: rewardProgram.internal_id,
+		});
 
 		if (!referralCode) {
 			const code = generateReferralCode();

--- a/server/src/internal/api/rewards/handlers/referrals/handleRedeemReferral.ts
+++ b/server/src/internal/api/rewards/handlers/referrals/handleRedeemReferral.ts
@@ -10,9 +10,13 @@ import {
 	Scopes,
 } from "@autumn/shared";
 import { CusService } from "@/internal/customers/CusService.js";
-import { redemptionRepo, rewardRepo, referralCodeRepo } from "@/internal/rewards/repos/index.js";
-import { triggerFreeProduct } from "@/internal/rewards/actions/triggerFreeProduct.js";
 import { triggerDiscount } from "@/internal/rewards/actions/triggerDiscount.js";
+import { triggerFreeProduct } from "@/internal/rewards/actions/triggerFreeProduct.js";
+import {
+	redemptionRepo,
+	referralCodeRepo,
+	rewardRepo,
+} from "@/internal/rewards/repos/index.js";
 import { getRewardCat } from "@/internal/rewards/rewardUtils.js";
 import { generateId, notNullish } from "@/utils/genUtils.js";
 import { createRoute } from "../../../../../honoMiddlewares/routeHandler";
@@ -106,6 +110,8 @@ export const handleRedeemReferral = createRoute({
 			referral_code_id: referralCode.id,
 			internal_customer_id: customer.internal_id, // redeemed by customer
 			internal_reward_program_id: referralCode.internal_reward_program_id,
+			reward_internal_id: null,
+			promo_code: null,
 			created_at: Date.now(),
 			triggered:
 				referralCode.reward_program.when ===

--- a/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
+++ b/server/src/internal/api/rewards/handlers/rewardPrograms/handleCreateRewardProgram.ts
@@ -6,7 +6,10 @@ import {
 	Scopes,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
-import { rewardRepo, rewardProgramRepo } from "@/internal/rewards/repos/index.js";
+import {
+	rewardProgramRepo,
+	rewardRepo,
+} from "@/internal/rewards/repos/index.js";
 import { constructRewardProgram } from "@/internal/rewards/rewardUtils.js";
 import { nullish } from "@/utils/genUtils.js";
 

--- a/server/src/internal/api/rewards/referralRouter.ts
+++ b/server/src/internal/api/rewards/referralRouter.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { HonoEnv } from "../../../honoUtils/HonoEnv.js";
+import { handleRedeemReward } from "./handlers/handleRedeemReward.js";
 import { handleGetRedemption } from "./handlers/referrals/handleGetRedemption.js";
 import { handleGetReferralCode } from "./handlers/referrals/handleGetReferralCode.js";
 import { handleRedeemReferral } from "./handlers/referrals/handleRedeemReferral.js";
@@ -15,3 +16,4 @@ referralRouter.post("/redeem", ...handleRedeemReferral);
 export const referralRpcRouter = new Hono<HonoEnv>();
 referralRpcRouter.post("referrals.create_code", ...handleGetReferralCode);
 referralRpcRouter.post("referrals.redeem_code", ...handleRedeemReferral);
+referralRpcRouter.post("rewards.redeem", ...handleRedeemReward);

--- a/server/src/internal/customers/handlers/handleAddCouponToCusV2.ts
+++ b/server/src/internal/customers/handlers/handleAddCouponToCusV2.ts
@@ -1,22 +1,30 @@
 import {
 	AffectedResource,
 	CustomerNotFoundError,
+	ErrCode,
 	RecaseError,
+	RewardType,
 	Scopes,
 } from "@autumn/shared";
+import { z } from "zod/v4";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { getOrCreateStripeCustomer } from "@/external/stripe/customers";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { rewardActions } from "@/internal/rewards/actions/index.js";
 import { rewardRepo } from "@/internal/rewards/repos/index.js";
 import { CusService } from "../CusService.js";
 
 export const handleAddCouponToCusV2 = createRoute({
 	scopes: [Scopes.Billing.Write],
 	resource: AffectedResource.Customer,
+	body: z.object({
+		promo_code: z.string().min(1).optional(),
+	}),
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const { db, org, env, logger } = ctx;
+		const { db, org, env } = ctx;
 		const { customer_id, coupon_id } = c.req.param();
+		const { promo_code } = c.req.valid("json");
 
 		const [customer, coupon] = await Promise.all([
 			CusService.get({
@@ -33,7 +41,7 @@ export const handleAddCouponToCusV2 = createRoute({
 			}),
 		]);
 
-		if (!customer) {
+		if (!customer?.id) {
 			throw new CustomerNotFoundError({ customerId: customer_id });
 		}
 
@@ -41,6 +49,25 @@ export const handleAddCouponToCusV2 = createRoute({
 			throw new RecaseError({
 				message: `Coupon ${coupon_id} not found`,
 			});
+		}
+
+		if (coupon.type === RewardType.FeatureGrant) {
+			if (!promo_code) {
+				throw new RecaseError({
+					message: "Promo code is required for feature grant rewards",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+
+			await rewardActions.redeemPromoCode({
+				ctx,
+				code: promo_code,
+				customerId: customer.id,
+				rewardInternalId: coupon.internal_id,
+			});
+
+			return c.json({ customer, coupon });
 		}
 
 		const stripeCli = createStripeCli({

--- a/server/src/internal/rewards/actions/index.ts
+++ b/server/src/internal/rewards/actions/index.ts
@@ -1,3 +1,4 @@
+import { redeemPromoCode } from "./redeemPromoCode.js";
 import { runTriggerCheckoutReward } from "./triggerCheckoutReward.js";
 import { triggerDiscount } from "./triggerDiscount.js";
 import { triggerFreePaidProduct } from "./triggerFreePaidProduct.js";
@@ -12,4 +13,6 @@ export const rewardActions = {
 	triggerDiscount,
 	/** Process checkout-triggered reward redemptions (called from job queue) */
 	triggerCheckoutReward: runTriggerCheckoutReward,
+	/** Redeem a promo code and grant loose entitlements */
+	redeemPromoCode,
 };

--- a/server/src/internal/rewards/actions/redeemPromoCode.ts
+++ b/server/src/internal/rewards/actions/redeemPromoCode.ts
@@ -1,0 +1,234 @@
+import {
+	addDuration,
+	type CustomerEntitlement,
+	type Entitlement,
+	ErrCode,
+	findFeatureByInternalId,
+	RecaseError,
+	RewardType,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { prepareNewBalanceForInsertion } from "@/internal/balances/createBalance/prepareNewBalanceForInsertion.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
+import { EntitlementService } from "@/internal/products/entitlements/EntitlementService.js";
+import { redemptionRepo, rewardRepo } from "@/internal/rewards/repos/index.js";
+import { generateId } from "@/utils/genUtils.js";
+
+/** Redeem a promo code and grant loose entitlements to a customer */
+export const redeemPromoCode = async ({
+	ctx,
+	code,
+	customerId,
+	rewardInternalId,
+}: {
+	ctx: AutumnContext;
+	code: string;
+	customerId: string;
+	rewardInternalId?: string;
+}) => {
+	const { db, org, env, logger } = ctx;
+
+	// 1. Find the reward matching this promo code
+	const reward = await rewardRepo.getByCode({
+		db,
+		code,
+		orgId: org.id,
+		env,
+		rewardInternalId,
+	});
+
+	if (!reward) {
+		throw new RecaseError({
+			message: rewardInternalId
+				? `Promo code "${code}" not found on reward "${rewardInternalId}"`
+				: `No reward found for code "${code}"`,
+			code: ErrCode.RewardNotFound,
+			statusCode: 404,
+		});
+	}
+
+	if (reward.type !== RewardType.FeatureGrant) {
+		throw new RecaseError({
+			message: `Reward "${reward.id}" is not a feature grant reward`,
+			code: ErrCode.InvalidReward,
+			statusCode: 400,
+		});
+	}
+
+	if (!reward.entitlements?.length) {
+		throw new RecaseError({
+			message: `Reward "${reward.id}" has no entitlements configured`,
+			code: ErrCode.InvalidReward,
+			statusCode: 400,
+		});
+	}
+
+	// 2. Find the matching promo code and check its global redemption limit
+	const promoCode = reward.promo_codes?.flat().find((pc) => pc.code === code);
+	if (!promoCode) {
+		throw new RecaseError({
+			message: `Promo code "${code}" not found on reward "${reward.id}"`,
+			code: ErrCode.RewardNotFound,
+			statusCode: 404,
+		});
+	}
+
+	const globalMaxRedemption =
+		promoCode.global_max_redemption ?? promoCode.max_redemptions;
+
+	if (globalMaxRedemption) {
+		const redemptionCount = await redemptionRepo.getPromoCodeRedemptionCount({
+			db,
+			rewardInternalId: reward.internal_id,
+			promoCode: code,
+		});
+
+		if (redemptionCount >= globalMaxRedemption) {
+			throw new RecaseError({
+				message: `Promo code "${code}" has reached its maximum redemptions`,
+				code: ErrCode.ReferralCodeMaxRedemptionsReached,
+				statusCode: 400,
+			});
+		}
+	}
+
+	// 3. Fetch customer
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+
+	// 4. Check if customer already redeemed this reward
+	const existingRedemption = await redemptionRepo.getByCustomerAndReward({
+		db,
+		internalCustomerId: fullCustomer.internal_id,
+		rewardInternalId: reward.internal_id,
+	});
+
+	if (existingRedemption) {
+		throw new RecaseError({
+			message: `Customer "${customerId}" has already redeemed this reward`,
+			code: ErrCode.CustomerAlreadyRedeemedReferralCode,
+			statusCode: 400,
+		});
+	}
+
+	// 5. Create entitlements for each reward entitlement config
+	const newEntitlements: Entitlement[] = [];
+	const newCustomerEntitlements: CustomerEntitlement[] = [];
+
+	for (const rewardEnt of reward.entitlements) {
+		const feature = findFeatureByInternalId({
+			features: ctx.features,
+			internalId: rewardEnt.internal_feature_id,
+		});
+
+		if (!feature) {
+			logger.warn(
+				`Feature with internal_id "${rewardEnt.internal_feature_id}" not found, skipping`,
+			);
+			continue;
+		}
+
+		const allowance = rewardEnt.allowance;
+		if (!allowance || allowance <= 0) {
+			throw new RecaseError({
+				message: `Reward entitlement for feature "${feature.id}" must have a positive allowance`,
+				code: ErrCode.InvalidReward,
+				statusCode: 400,
+			});
+		}
+
+		const expiresAt =
+			rewardEnt.expiry_duration && rewardEnt.expiry_length != null
+				? addDuration({
+						now: Date.now(),
+						durationType: rewardEnt.expiry_duration,
+						durationLength: rewardEnt.expiry_length,
+					})
+				: undefined;
+
+		const { newEntitlement, newCustomerEntitlement } =
+			await prepareNewBalanceForInsertion({
+				ctx,
+				fullCustomer,
+				feature,
+				params: {
+					customer_id: customerId,
+					feature_id: feature.id,
+					included_grant: allowance,
+					expires_at: expiresAt,
+					balance_id: `reward_${code}_${new Date().toISOString().slice(0, 10).replace(/-/g, "_")}`,
+				},
+			});
+
+		newEntitlements.push(newEntitlement);
+		newCustomerEntitlements.push(newCustomerEntitlement);
+	}
+
+	if (!newEntitlements.length) {
+		throw new RecaseError({
+			message:
+				"No valid entitlements could be created from reward configuration",
+			code: ErrCode.InvalidReward,
+			statusCode: 400,
+		});
+	}
+
+	// 6. Insert entitlements and customer_entitlements
+	await EntitlementService.insert({
+		db,
+		data: newEntitlements,
+	});
+
+	await CusEntService.insert({
+		ctx,
+		data: newCustomerEntitlements,
+	});
+
+	// 6.5. Clear cached customer so subsequent /check calls see the new entitlements
+	await deleteCachedFullCustomer({
+		customerId,
+		ctx,
+		source: "redeemPromoCode",
+	});
+
+	logger.info(
+		`Granted ${newEntitlements.length} entitlement(s) to customer "${customerId}" via promo code "${code}"`,
+	);
+
+	// 7. Record the redemption
+	await redemptionRepo.insert({
+		db,
+		rewardRedemption: {
+			id: generateId("rr"),
+			internal_customer_id: fullCustomer.internal_id,
+			reward_internal_id: reward.internal_id,
+			promo_code: code,
+			referral_code_id: null,
+			internal_reward_program_id: null,
+			triggered: true,
+			applied: true,
+			redeemer_applied: true,
+			created_at: Date.now(),
+			updated_at: Date.now(),
+		},
+	});
+
+	// 8. Return result
+	return {
+		reward_id: reward.id,
+		entitlements_granted: reward.entitlements.map((ent) => {
+			const feature = findFeatureByInternalId({
+				features: ctx.features,
+				internalId: ent.internal_feature_id,
+			});
+			return {
+				feature_id: feature?.id ?? ent.internal_feature_id,
+				balance: ent.allowance ?? 0,
+			};
+		}),
+	};
+};

--- a/server/src/internal/rewards/repos/getCustomerRewardRedemption.ts
+++ b/server/src/internal/rewards/repos/getCustomerRewardRedemption.ts
@@ -1,0 +1,23 @@
+import { type RewardRedemption, rewardRedemptions } from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+/** Check if a customer has already redeemed a specific reward (promo code) */
+export const getCustomerRewardRedemption = async ({
+	db,
+	internalCustomerId,
+	rewardInternalId,
+}: {
+	db: DrizzleCli;
+	internalCustomerId: string;
+	rewardInternalId: string;
+}) => {
+	const result = await db.query.rewardRedemptions.findFirst({
+		where: and(
+			eq(rewardRedemptions.internal_customer_id, internalCustomerId),
+			eq(rewardRedemptions.reward_internal_id, rewardInternalId),
+		),
+	});
+
+	return (result as RewardRedemption) ?? null;
+};

--- a/server/src/internal/rewards/repos/getPromoCodeRedemptionCount.ts
+++ b/server/src/internal/rewards/repos/getPromoCodeRedemptionCount.ts
@@ -1,0 +1,27 @@
+import { rewardRedemptions } from "@autumn/shared";
+import { and, count, eq, isNull } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+/** Count redemptions for a specific promo code on a reward */
+export const getPromoCodeRedemptionCount = async ({
+	db,
+	rewardInternalId,
+	promoCode,
+}: {
+	db: DrizzleCli;
+	rewardInternalId: string;
+	promoCode: string;
+}) => {
+	const result = await db
+		.select({ count: count() })
+		.from(rewardRedemptions)
+		.where(
+			and(
+				eq(rewardRedemptions.reward_internal_id, rewardInternalId),
+				eq(rewardRedemptions.promo_code, promoCode),
+				isNull(rewardRedemptions.referral_code_id),
+			),
+		);
+
+	return result[0].count;
+};

--- a/server/src/internal/rewards/repos/getRewardByCode.ts
+++ b/server/src/internal/rewards/repos/getRewardByCode.ts
@@ -1,0 +1,40 @@
+import { type AppEnv, type FullReward, rewards } from "@autumn/shared";
+import { and, desc, eq, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+/** Fetch one reward by promo code */
+export const getRewardByCode = async ({
+	db,
+	code,
+	orgId,
+	env,
+	rewardInternalId,
+}: {
+	db: DrizzleCli;
+	code: string;
+	orgId: string;
+	env: AppEnv;
+	rewardInternalId?: string;
+}) => {
+	const result = await db.query.rewards.findFirst({
+		where: and(
+			eq(rewards.org_id, orgId),
+			eq(rewards.env, env),
+			rewardInternalId ? eq(rewards.internal_id, rewardInternalId) : undefined,
+			sql`EXISTS (
+				SELECT 1 FROM unnest(${rewards.promo_codes}) AS elem
+				WHERE elem->>'code' = ${code}
+			)`,
+		),
+		orderBy: desc(rewards.created_at),
+		with: {
+			entitlements: true,
+		},
+	});
+
+	if (!result) {
+		return null;
+	}
+
+	return result as FullReward;
+};

--- a/server/src/internal/rewards/repos/index.ts
+++ b/server/src/internal/rewards/repos/index.ts
@@ -1,6 +1,8 @@
 import { deleteReward } from "./deleteReward.js";
 import { deleteRewardProgram } from "./deleteRewardProgram.js";
 import { deleteRewardsByOrgId } from "./deleteRewardsByOrgId.js";
+import { getCustomerRewardRedemption } from "./getCustomerRewardRedemption.js";
+import { getPromoCodeRedemptionCount } from "./getPromoCodeRedemptionCount.js";
 import { getRedemptionById } from "./getRedemptionById.js";
 import { getRedemptionsByCustomer } from "./getRedemptionsByCustomer.js";
 import { getRedemptionsByReferrer } from "./getRedemptionsByReferrer.js";
@@ -8,6 +10,7 @@ import { getReferralCode } from "./getReferralCode.js";
 import { getReferralCodeByCustomerAndProgram } from "./getReferralCodeByCustomerAndProgram.js";
 import { getReferralCodeRedemptionCount } from "./getReferralCodeRedemptionCount.js";
 import { getReward } from "./getReward.js";
+import { getRewardByCode } from "./getRewardByCode.js";
 import { getRewardProgram } from "./getRewardProgram.js";
 import { getRewardProgramsByProductId } from "./getRewardProgramsByProductId.js";
 import { getRewardsByIdOrCode } from "./getRewardsByIdOrCode.js";
@@ -26,6 +29,7 @@ import { updateRewardProgram } from "./updateRewardProgram.js";
 
 export const rewardRepo = {
 	get: getReward,
+	getByCode: getRewardByCode,
 	getByIdOrCode: getRewardsByIdOrCode,
 	getInIds: getRewardsInIds,
 	list: listRewards,
@@ -55,6 +59,8 @@ export const redemptionRepo = {
 	getById: getRedemptionById,
 	getByCustomer: getRedemptionsByCustomer,
 	getByReferrer: getRedemptionsByReferrer,
+	getByCustomerAndReward: getCustomerRewardRedemption,
+	getPromoCodeRedemptionCount: getPromoCodeRedemptionCount,
 	insert: insertRedemption,
 	update: updateRedemption,
 	getUnapplied: getUnappliedRedemptions,

--- a/server/src/internal/rewards/rewardUtils.ts
+++ b/server/src/internal/rewards/rewardUtils.ts
@@ -46,13 +46,47 @@ export const constructReward = ({
 		});
 	}
 
+	if (reward.type === RewardType.FeatureGrant) {
+		if (!reward.entitlements?.length) {
+			throw new RecaseError({
+				message: "Feature grant reward requires at least one entitlement",
+				code: ErrCode.InvalidReward,
+			});
+		}
+		for (const ent of reward.entitlements) {
+			if (!ent.internal_feature_id) {
+				throw new RecaseError({
+					message: "Each entitlement must have a feature",
+					code: ErrCode.InvalidReward,
+				});
+			}
+			if (!ent.allowance || ent.allowance <= 0) {
+				throw new RecaseError({
+					message: "Each entitlement must have a positive allowance",
+					code: ErrCode.InvalidReward,
+				});
+			}
+		}
+	}
+
 	if (getRewardCat(reward as Reward) === RewardCategory.Discount) {
 		DiscountConfigSchema.parse(reward.discount_config);
 	}
 
-	const promoCodes = reward.promo_codes.filter((promoCode) => {
-		return promoCode.code.length > 0;
-	});
+	const promoCodes = reward.promo_codes
+		.filter((promoCode) => {
+			return promoCode.code.length > 0;
+		})
+		.map(({ max_redemptions, global_max_redemption, ...promoCode }) => {
+			const globalMaxRedemption = global_max_redemption ?? max_redemptions;
+
+			return {
+				...promoCode,
+				...(globalMaxRedemption !== undefined
+					? { global_max_redemption: globalMaxRedemption }
+					: {}),
+			};
+		});
 
 	// Validate promo codes - Stripe only allows alphanumeric characters (a-z, A-Z, 0-9)
 	for (const promoCode of promoCodes) {
@@ -76,11 +110,20 @@ export const constructReward = ({
 		configData = {
 			free_product_id: reward.free_product_id,
 			discount_config: null,
+			entitlements: null,
+		};
+	} else if (reward.type === RewardType.FeatureGrant) {
+		configData = {
+			entitlements: reward.entitlements,
+			discount_config: null,
+			free_product_id: null,
+			free_product_config: null,
 		};
 	} else if (reward.type === RewardType.PercentageDiscount) {
 		configData = {
 			discount_config: reward.discount_config,
 			free_product_id: null,
+			entitlements: null,
 		};
 	}
 
@@ -98,7 +141,10 @@ export const constructReward = ({
 };
 
 export const getRewardCat = (reward: Reward) => {
-	if (reward.type === RewardType.FreeProduct) {
+	if (
+		reward.type === RewardType.FreeProduct ||
+		reward.type === RewardType.FeatureGrant
+	) {
 		return RewardCategory.FreeProduct;
 	}
 	return RewardCategory.Discount;

--- a/server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts
+++ b/server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test";
+import { ErrCode } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import AutumnError from "@/external/autumn/autumnCli.js";
+
+test(`${chalk.yellowBright("feature-grant-1: redeem simple 10 message promo code")}`, async () => {
+	const customerId = "feature-grant-1";
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.featureGrant({
+				entitlements: [{ feature_id: TestFeature.Messages, allowance: 10 }],
+				promoCodes: [{ code: "MESSAGES10" }],
+			}),
+		],
+		actions: [s.rewards.redeem({ code: "MESSAGES10" })],
+	});
+
+	// Verify customer got 10 messages balance
+	const check = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
+
+	expect(check.allowed).toBe(true);
+	expect(check.balance).toBe(10);
+});
+
+test(`${chalk.yellowBright("feature-grant-2: promo code with max 5 redemptions across 6 customers")}`, async () => {
+	const mainCustomerId = "feature-grant-2";
+	const otherIds = ["fg2-c1", "fg2-c2", "fg2-c3", "fg2-c4", "fg2-c5"];
+
+	const { autumnV1 } = await initScenario({
+		customerId: mainCustomerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.otherCustomers(otherIds.map((id) => ({ id }))),
+			s.featureGrant({
+				entitlements: [{ feature_id: TestFeature.Messages, allowance: 10 }],
+				promoCodes: [{ code: "LIMITEDMSG", max_redemptions: 5 }],
+			}),
+		],
+		actions: [],
+	});
+
+	// First 5 customers redeem successfully
+	const allCustomerIds = [mainCustomerId, ...otherIds];
+	for (let i = 0; i < 5; i++) {
+		await autumnV1.rewards.redeem({
+			code: "LIMITEDMSG",
+			customerId: allCustomerIds[i],
+		});
+
+		// Verify each redeemer got 10 messages
+		const check = await autumnV1.check({
+			customer_id: allCustomerIds[i],
+			feature_id: TestFeature.Messages,
+		});
+		expect(check.allowed).toBe(true);
+		expect(check.balance).toBe(10);
+	}
+
+	// 6th customer should fail — max redemptions reached
+	try {
+		await autumnV1.rewards.redeem({
+			code: "LIMITEDMSG",
+			customerId: allCustomerIds[5],
+		});
+		throw new Error("Should have failed — max redemptions reached");
+	} catch (error) {
+		expect(error).toBeInstanceOf(AutumnError);
+		expect((error as AutumnError).code).toBe(
+			ErrCode.ReferralCodeMaxRedemptionsReached,
+		);
+	}
+
+	// Verify 6th customer has no balance (balance is undefined or 0 when no entitlements exist)
+	const check6 = await autumnV1.check({
+		customer_id: allCustomerIds[5],
+		feature_id: TestFeature.Messages,
+	});
+	expect(check6.balance ?? 0).toBe(0);
+});

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -3,12 +3,15 @@ import {
 	ApiVersion,
 	type CreateReward,
 	type CreateRewardProgram,
+	type EntitlementDuration,
 	type OrgConfig,
 	type PlanTiming,
 	type ProductItem,
 	type ProductV2,
 	type ReferralCode,
+	type RewardEntitlement,
 	type RewardRedemption,
+	RewardType,
 } from "@autumn/shared";
 import { resetAndGetCusEnt } from "@tests/balances/track/rollovers/rolloverTestUtils.js";
 import { addHours, addMonths } from "date-fns";
@@ -16,6 +19,8 @@ import type Stripe from "stripe";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { removeAllPaymentMethods } from "@/external/stripe/customers/paymentMethods/operations/removeAllPaymentMethods.js";
 import { CusService } from "@/internal/customers/CusService.js";
+import { rewardRepo } from "@/internal/rewards/repos/index.js";
+import { generateId } from "@/utils/genUtils.js";
 import { attachPaymentMethod as attachPaymentMethodFn } from "@/utils/scriptUtils/initCustomer.js";
 import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
 import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
@@ -65,6 +70,19 @@ type ReferralProgramConfig = {
 type RewardConfig = {
 	reward: CreateReward;
 	productId: string;
+};
+
+type FeatureGrantEntitlement = {
+	feature_id: string;
+	allowance: number;
+	expiry?: { duration: EntitlementDuration; length: number };
+};
+
+type FeatureGrantConfig = {
+	id?: string;
+	name?: string;
+	entitlements: FeatureGrantEntitlement[];
+	promoCodes: { code: string; max_redemptions?: number }[];
 };
 
 // Discriminated union for all action types
@@ -174,6 +192,12 @@ type ResetFeatureAction = {
 	timeout?: number;
 };
 
+type RedeemRewardAction = {
+	type: "redeemReward";
+	code: string;
+	customerId?: string;
+};
+
 type ScenarioAction =
 	| AttachAction
 	| CancelAction
@@ -188,7 +212,8 @@ type ScenarioAction =
 	| CreateReferralCodeAction
 	| RedeemReferralCodeAction
 	| CreateAndRedeemReferralCodeAction
-	| ResetFeatureAction;
+	| ResetFeatureAction
+	| RedeemRewardAction;
 
 type CleanupConfig = {
 	customerIdsToDelete: string[];
@@ -225,6 +250,7 @@ type ScenarioConfig = {
 	referralProgram?: ReferralProgramConfig;
 	rewards: RewardConfig[];
 	platformConfig?: PlatformCreateConfig;
+	featureGrants: FeatureGrantConfig[];
 };
 
 type ConfigFn = (config: ScenarioConfig) => ScenarioConfig;
@@ -742,6 +768,43 @@ const billingMultiAttach = ({
 /** Top-level alias for billing multi-attach. */
 const multiAttach = billingMultiAttach;
 
+/**
+ * Define a feature grant reward for this test scenario.
+ * Inserts a reward of type `feature_grant` with entitlements and promo codes.
+ * Feature IDs are external (e.g., TestFeature.Messages) and resolved to internal IDs during setup.
+ * @param config - Feature grant configuration
+ * @example s.featureGrant({ entitlements: [{ feature_id: TestFeature.Messages, allowance: 10 }], promoCodes: [{ code: "MSG10" }] })
+ */
+const featureGrant = (config: FeatureGrantConfig): ConfigFn => {
+	return (scenarioConfig) => ({
+		...scenarioConfig,
+		featureGrants: [...scenarioConfig.featureGrants, config],
+	});
+};
+
+/**
+ * Redeem a reward promo code for a customer.
+ * @param code - The promo code to redeem
+ * @param customerId - Optional: use this customer instead of primary
+ * @example s.rewards.redeem({ code: "MSG10" })
+ * @example s.rewards.redeem({ code: "MSG10", customerId: "other-customer" })
+ */
+const redeemReward = ({
+	code,
+	customerId,
+}: {
+	code: string;
+	customerId?: string;
+}): ConfigFn => {
+	return (config) => ({
+		...config,
+		actions: [
+			...config.actions,
+			{ type: "redeemReward" as const, code, customerId },
+		],
+	});
+};
+
 // ═══════════════════════════════════════════════════════════════════
 // REFERRAL ACTIONS
 // ═══════════════════════════════════════════════════════════════════
@@ -831,6 +894,7 @@ export const s = {
 		multiAttach: billingMultiAttach,
 	},
 	multiAttach,
+	featureGrant,
 	referral: {
 		createCode: createReferralCode,
 		redeem: redeemReferralCode,
@@ -838,6 +902,9 @@ export const s = {
 	},
 	platform: {
 		create: platformCreate,
+	},
+	rewards: {
+		redeem: redeemReward,
 	},
 } as const;
 
@@ -859,6 +926,7 @@ const defaultConfig: ScenarioConfig = {
 	otherCustomers: [],
 	referralProgram: undefined,
 	rewards: [],
+	featureGrants: [],
 };
 
 /**
@@ -1082,6 +1150,46 @@ export async function initScenario({
 			autumn: cleanupAutumn,
 			reward,
 			productId: prefixedProductId,
+		});
+	}
+
+	// 1.7. Insert feature grant rewards (if configured)
+	for (const fg of config.featureGrants) {
+		const rewardId = fg.id ?? `feature-grant-${Date.now()}`;
+
+		// Resolve external feature_ids to internal_feature_ids
+		const resolvedEntitlements: RewardEntitlement[] = fg.entitlements.map(
+			(ent) => {
+				const feature = ctx.features.find((f) => f.id === ent.feature_id);
+				if (!feature) {
+					throw new Error(
+						`Feature "${ent.feature_id}" not found in ctx.features for feature grant reward`,
+					);
+				}
+				return {
+					internal_feature_id: feature.internal_id!,
+					allowance: ent.allowance,
+					expiry: ent.expiry,
+				};
+			},
+		);
+
+		await rewardRepo.insert({
+			db: ctx.db,
+			data: {
+				internal_id: generateId("rew"),
+				id: rewardId,
+				org_id: ctx.org.id,
+				env: ctx.env,
+				type: RewardType.FeatureGrant,
+				name: fg.name ?? rewardId,
+				entitlements: resolvedEntitlements,
+				promo_codes: fg.promoCodes.map((pc) => ({
+					code: pc.code,
+					max_redemptions: pc.max_redemptions,
+				})),
+				created_at: Date.now(),
+			},
 		});
 	}
 
@@ -1531,6 +1639,17 @@ export async function initScenario({
 			// Wait for cache to clear.
 			const waitTime = action.timeout ?? 2000;
 			await new Promise((resolve) => setTimeout(resolve, waitTime));
+		} else if (action.type === "redeemReward") {
+			const targetCustomerId = action.customerId ?? customerId;
+			if (!targetCustomerId) {
+				throw new Error(
+					"Cannot redeem reward: customerId is required when using s.rewards.redeem()",
+				);
+			}
+			await autumnV1.rewards.redeem({
+				code: action.code,
+				customerId: targetCustomerId,
+			});
 		}
 	}
 

--- a/shared/models/rewardModels/referralModels/referralModels.ts
+++ b/shared/models/rewardModels/referralModels/referralModels.ts
@@ -19,18 +19,17 @@ const RewardRedemptionSchema = z.object({
 	created_at: z.number(),
 	updated_at: z.number(),
 
-	// Customer who signed up / paid
-	internal_customer_id: z.string(), // customer who redeemed the code...
-	internal_reward_program_id: z.string(), // reward scheme that was redeemed
+	internal_customer_id: z.string(),
 
-	// Referral code used
-	// code: z.string(),
-	referral_code_id: z.string(),
+	// Referral redemptions: these are set, reward_internal_id may be null
+	internal_reward_program_id: z.string().nullable(),
+	referral_code_id: z.string().nullable(),
 
-	// Whether the reward was triggered
+	// Promo code redemptions: these are set, referral fields are null
+	reward_internal_id: z.string().nullable(),
+	promo_code: z.string().nullable(),
+
 	triggered: z.boolean(),
-
-	// Whether the (coupon) was applied
 	applied: z.boolean(),
 	redeemer_applied: z.boolean(),
 });

--- a/shared/models/rewardModels/referralModels/rewardRedemptionTable.ts
+++ b/shared/models/rewardModels/referralModels/rewardRedemptionTable.ts
@@ -24,6 +24,7 @@ export const rewardRedemptions = pgTable(
 		redeemer_applied: boolean().default(false),
 		referral_code_id: text("referral_code_id"),
 		reward_internal_id: text("reward_internal_id"),
+		promo_code: text("promo_code"),
 	},
 	(table) => [
 		foreignKey({

--- a/shared/models/rewardModels/rewardModels/rewardModels.ts
+++ b/shared/models/rewardModels/rewardModels/rewardModels.ts
@@ -7,12 +7,14 @@ import { CouponDurationType, RewardType } from "./rewardEnums";
 
 const PromoCodeSchema = z.object({
 	code: z.string(),
-	max_redemptions: z.number().optional(),
+	global_max_redemption: z.number().positive().optional(),
+	/** @deprecated Use global_max_redemption. */
+	max_redemptions: z.number().positive().optional(),
 });
 
 const RewardEntitlementSchema = z.object({
-	internal_feature_id: z.string(),
-	allowance: z.number(),
+	internal_feature_id: z.string().min(1),
+	allowance: z.number().positive(),
 	expiry: EntitlementExpirySchema.optional(),
 });
 
@@ -48,20 +50,40 @@ const RewardSchema = z.object({
 	created_at: z.number(),
 });
 
-export const CreateRewardSchema = z.object({
-	name: z.string(),
-	promo_codes: z.array(PromoCodeSchema),
-	id: z.string(),
-	type: z.nativeEnum(RewardType).nullish(),
-	discount_config: DiscountConfigSchema.nullish(),
-	free_product_config: FreeProductConfigSchema.nullish(),
-	free_product_id: z.string().nullish(),
-	entitlements: z.array(RewardEntitlementSchema).nullish(),
+const FullRewardSchema = RewardSchema.extend({
+	entitlements: z.array(EntitlementSchema),
 });
+
+export const CreateRewardSchema = z
+	.object({
+		name: z.string(),
+		promo_codes: z.array(PromoCodeSchema),
+		id: z.string(),
+		type: z.nativeEnum(RewardType).nullish(),
+		discount_config: DiscountConfigSchema.nullish(),
+		free_product_config: FreeProductConfigSchema.nullish(),
+		free_product_id: z.string().nullish(),
+		entitlements: z.array(RewardEntitlementSchema).nullish(),
+	})
+	.refine(
+		(data) => {
+			if (data.type !== RewardType.FeatureGrant) return true;
+			return data.entitlements && data.entitlements.length > 0;
+		},
+		{ message: "Feature grant rewards require at least one entitlement" },
+	)
+	.refine(
+		(data) => {
+			if (data.type !== RewardType.FeatureGrant) return true;
+			return data.promo_codes.some((pc) => pc.code.length > 0);
+		},
+		{ message: "Feature grant rewards require at least one promo code" },
+	);
 
 export type PromoCode = z.infer<typeof PromoCodeSchema>;
 export type CreateReward = z.infer<typeof CreateRewardSchema>;
 export type Reward = z.infer<typeof RewardSchema>;
+export type FullReward = z.infer<typeof FullRewardSchema>;
 export type DiscountConfig = z.infer<typeof DiscountConfigSchema>;
 export type FreeProductConfig = z.infer<typeof FreeProductConfigSchema>;
 export type RewardEntitlement = z.infer<typeof RewardEntitlementSchema>;

--- a/shared/utils/billingUtils/intervalUtils/addDuration.ts
+++ b/shared/utils/billingUtils/intervalUtils/addDuration.ts
@@ -1,5 +1,6 @@
+import { EntitlementDuration } from "@models/productModels/entModels/entModels";
 import { FreeTrialDuration } from "@models/productModels/freeTrialModels/freeTrialEnums";
-import { addDays, addMonths, addYears } from "date-fns";
+import { addDays, addMonths, addWeeks, addYears } from "date-fns";
 
 export const addDuration = ({
 	now,
@@ -7,12 +8,14 @@ export const addDuration = ({
 	durationLength = 1,
 }: {
 	now: number;
-	durationType: FreeTrialDuration;
+	durationType: FreeTrialDuration | EntitlementDuration;
 	durationLength?: number;
 }) => {
 	switch (durationType) {
 		case FreeTrialDuration.Day:
 			return addDays(now, durationLength).getTime();
+		case EntitlementDuration.Week:
+			return addWeeks(now, durationLength).getTime();
 		case FreeTrialDuration.Month:
 			return addMonths(now, durationLength).getTime();
 		case FreeTrialDuration.Year:


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `POST /rewards.redeem` endpoint that lets customers redeem feature-grant promo codes to receive loose entitlements (balance grants), along with two integration tests and supporting repos/utilities.

- **[API changes, Improvements]** New `rewards.redeem` RPC route, handler, `redeemPromoCode` action, and matching `AutumnInt.rewards.redeem` SDK method wired end-to-end.
- **[Improvements]** Three new repo helpers (`getRewardByCode`, `getPromoCodeRedemptionCount`, `getCustomerRewardRedemption`) and an `addDuration` utility used for expiry calculation.
- **[Improvements]** `initScenario` test harness extended with `s.featureGrant()` setup and `s.rewards.redeem()` action; two integration tests cover the happy path and the global-redemption-limit guard.
</details>

<h3>Confidence Score: 3/5</h3>

The new redemption flow has correctness gaps in redeemPromoCode.ts that should be resolved before the endpoint goes to production.

The central action file (redeemPromoCode.ts) has three issues affecting correctness: all entitlements in a multi-entitlement reward share the same balance_id which will likely cause a constraint violation; entitlements and the cache are updated before the redemption record is written so a crash in between allows a second redemption; and the global max-redemption check and the redemption write are not atomic so concurrent requests can both slip past the cap.

server/src/internal/rewards/actions/redeemPromoCode.ts and server/src/internal/rewards/repos/getCustomerRewardRedemption.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/rewards/actions/redeemPromoCode.ts | Core redemption logic with three issues: duplicate balance_id for multi-entitlement rewards, entitlements granted before the redemption row is written, and a TOCTOU race on the global max-redemption check. |
| server/src/internal/rewards/repos/getCustomerRewardRedemption.ts | Deduplication check operates at reward level, not promo-code level — all codes on the same reward are blocked after the first redemption; intent should be clarified. |
| server/src/internal/api/rewards/handlers/handleRedeemReward.ts | Thin route handler that validates input, delegates to redeemPromoCode, and returns the result — straightforward and correct. |
| server/src/internal/rewards/repos/getPromoCodeRedemptionCount.ts | Counts promo-code redemptions by reward + code with a referral_code_id IS NULL filter; logic is correct but results are consumed without any DB-level lock. |
| server/src/internal/rewards/repos/getRewardByCode.ts | Queries rewards using a raw SQL EXISTS sub-select over the promo_codes JSONB array; correct and returns at most one row. |
| server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts | Two integration tests cover the happy path and global-redemption-limit enforcement; multi-entitlement rewards and per-code vs per-reward deduplication semantics are not yet tested. |
| server/tests/utils/testInitUtils/initScenario.ts | Adds featureGrant setup step and redeemReward action to the scenario harness; wiring is clean and consistent with the existing pattern. |
| server/src/internal/api/rewards/referralRouter.ts | Mounts the new rewards.redeem RPC route alongside existing referral routes; no issues. |
| server/src/external/autumn/autumnCli.ts | Adds rewards.redeem client method that POSTs to /rewards.redeem; implementation matches the server-side contract. |
| shared/utils/billingUtils/intervalUtils/addDuration.ts | New utility that delegates to date-fns for duration arithmetic; straightforward with no issues. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as handleRedeemReward
    participant Action as redeemPromoCode
    participant DB

    Client->>Handler: "POST /rewards.redeem { code, customer_id }"
    Handler->>Action: "redeemPromoCode({ ctx, code, customerId })"
    Action->>DB: getRewardByCode (find reward with matching promo code)
    DB-->>Action: reward (or null 404)
    Action->>DB: getPromoCodeRedemptionCount (check global limit)
    DB-->>Action: count
    Action->>DB: CusService.getFull (fetch customer)
    DB-->>Action: fullCustomer
    Action->>DB: getCustomerRewardRedemption (duplicate check)
    DB-->>Action: existing redemption (or null)
    loop For each reward entitlement
        Action->>DB: prepareNewBalanceForInsertion
    end
    Action->>DB: EntitlementService.insert (new entitlements)
    Action->>DB: CusEntService.insert (customer entitlements)
    Action->>DB: deleteCachedFullCustomer
    Action->>DB: redemptionRepo.insert (record redemption)
    Action-->>Handler: "{ reward_id, entitlements_granted }"
    Handler-->>Client: 200 JSON response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/internal/rewards/actions/redeemPromoCode.ts:163-165
**Duplicate `balance_id` for multi-entitlement rewards**

When a reward is configured with two or more entitlements (e.g., messages + API credits), every iteration of the loop produces the same `balance_id` string — same `code` and same date prefix. If `balance_id` is subject to a uniqueness constraint or is used as a deduplication key in `prepareNewBalanceForInsertion`, the second insert will fail with a constraint violation. The tests only exercise single-entitlement rewards so this is not caught yet.

### Issue 2 of 4
server/src/internal/rewards/actions/redeemPromoCode.ts:181-218
**Entitlements granted before redemption is recorded — crash leaves customer redeemable again**

Steps 6 and 6.5 (entitlement insertion + cache invalidation) succeed before step 7 (redemption row insert). If the process crashes between these two points the customer already holds the granted entitlements but there is no `reward_redemptions` row, so the duplicate-redemption guard at step 4 will pass and they can redeem a second time. Inserting the redemption record first (or wrapping both in a single database transaction) would close this window.

### Issue 3 of 4
server/src/internal/rewards/actions/redeemPromoCode.ts:81-94
**TOCTOU race on global max-redemption limit**

The redemption count is read at step 2 and the redemption row is written at step 7 with no lock between them. Two simultaneous requests for the same promo code can both see a count below the limit and both proceed, resulting in more redemptions than `global_max_redemption` permits. For high-value promo codes this can silently exceed the cap. A database-level check (e.g. a conditional insert or a `SELECT … FOR UPDATE`) would be needed to enforce the limit atomically.

### Issue 4 of 4
server/src/internal/rewards/repos/getCustomerRewardRedemption.ts:16-20
**Per-reward deduplication blocks all codes on the same reward**

The query checks `reward_internal_id` only, not `promo_code`. If one reward carries multiple distinct promo codes (e.g., `GIFT10` and `GIFT20`) and a customer redeems `GIFT10`, they are permanently blocked from also redeeming `GIFT20`, even though they are separate codes. If the intended semantics are "one code per reward", this is correct and worth a comment; if the intent is "one redemption per code", the query should also filter on `promo_code`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 redeem promo code route, + test..."](https://github.com/useautumn/autumn/commit/f551ebb9c44c0f144e457276a83ef047e36e9031) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31369088)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->