### PR TITLE
feat: 🎸 frontend for reward feature grants + more tests

### DIFF
--- a/server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts
@@ -63,7 +63,10 @@ export const handleCreateCoupon = createRoute({
 			});
 		}
 
-		if (getRewardCat(newReward) === RewardCategory.FreeProduct) {
+		if (
+			getRewardCat(newReward) === RewardCategory.FreeProduct &&
+			newReward.free_product_id
+		) {
 			const fullProduct = await ProductService.getFull({
 				db,
 				idOrInternalId: newReward.free_product_id!,

--- a/server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts
+++ b/server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts
@@ -20,7 +20,6 @@ test(`${chalk.yellowBright("feature-grant-1: redeem simple 10 message promo code
 		actions: [s.rewards.redeem({ code: "MESSAGES10" })],
 	});
 
-	// Verify customer got 10 messages balance
 	const check = await autumnV1.check({
 		customer_id: customerId,
 		feature_id: TestFeature.Messages,
@@ -55,7 +54,6 @@ test(`${chalk.yellowBright("feature-grant-2: promo code with max 5 redemptions a
 			customerId: allCustomerIds[i],
 		});
 
-		// Verify each redeemer got 10 messages
 		const check = await autumnV1.check({
 			customer_id: allCustomerIds[i],
 			feature_id: TestFeature.Messages,
@@ -78,10 +76,128 @@ test(`${chalk.yellowBright("feature-grant-2: promo code with max 5 redemptions a
 		);
 	}
 
-	// Verify 6th customer has no balance (balance is undefined or 0 when no entitlements exist)
 	const check6 = await autumnV1.check({
 		customer_id: allCustomerIds[5],
 		feature_id: TestFeature.Messages,
 	});
 	expect(check6.balance ?? 0).toBe(0);
+});
+
+test(`${chalk.yellowBright("feature-grant-3: multiple entitlements per reward (messages + words)")}`, async () => {
+	const customerId = "feature-grant-3";
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.featureGrant({
+				entitlements: [
+					{ feature_id: TestFeature.Messages, allowance: 50 },
+					{ feature_id: TestFeature.Words, allowance: 1000 },
+				],
+				promoCodes: [{ code: "MULTIFEATURE" }],
+			}),
+		],
+		actions: [s.rewards.redeem({ code: "MULTIFEATURE" })],
+	});
+
+	const checkMessages = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(checkMessages.allowed).toBe(true);
+	expect(checkMessages.balance).toBe(50);
+
+	const checkWords = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Words,
+	});
+	expect(checkWords.allowed).toBe(true);
+	expect(checkWords.balance).toBe(1000);
+});
+
+test(`${chalk.yellowBright("feature-grant-4: duplicate redemption blocked")}`, async () => {
+	const customerId = "feature-grant-4";
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.featureGrant({
+				entitlements: [{ feature_id: TestFeature.Messages, allowance: 10 }],
+				promoCodes: [{ code: "NODUPE" }],
+			}),
+		],
+		actions: [s.rewards.redeem({ code: "NODUPE" })],
+	});
+
+	// First redemption worked
+	const check = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(check.allowed).toBe(true);
+	expect(check.balance).toBe(10);
+
+	// Second redemption by same customer should fail
+	try {
+		await autumnV1.rewards.redeem({
+			code: "NODUPE",
+			customerId,
+		});
+		throw new Error("Should have failed — already redeemed");
+	} catch (error) {
+		expect(error).toBeInstanceOf(AutumnError);
+		expect((error as AutumnError).code).toBe(
+			ErrCode.CustomerAlreadyRedeemedReferralCode,
+		);
+	}
+
+	// Balance should still be 10, not 20
+	const checkAfter = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(checkAfter.balance).toBe(10);
+});
+
+test(`${chalk.yellowBright("feature-grant-5: multiple promo codes on one reward")}`, async () => {
+	const customer1 = "feature-grant-5a";
+	const customer2 = "feature-grant-5b";
+
+	const { autumnV1 } = await initScenario({
+		customerId: customer1,
+		setup: [
+			s.customer({ testClock: false }),
+			s.otherCustomers([{ id: customer2 }]),
+			s.featureGrant({
+				entitlements: [{ feature_id: TestFeature.Messages, allowance: 25 }],
+				promoCodes: [
+					{ code: "CODEAAA", max_redemptions: 1 },
+					{ code: "CODEBBB", max_redemptions: 1 },
+				],
+			}),
+		],
+		actions: [],
+	});
+
+	// Customer 1 redeems CODEAAA
+	await autumnV1.rewards.redeem({ code: "CODEAAA", customerId: customer1 });
+
+	const check1 = await autumnV1.check({
+		customer_id: customer1,
+		feature_id: TestFeature.Messages,
+	});
+	expect(check1.allowed).toBe(true);
+	expect(check1.balance).toBe(25);
+
+	// Customer 2 redeems CODEBBB (different code, same reward)
+	await autumnV1.rewards.redeem({ code: "CODEBBB", customerId: customer2 });
+
+	const check2 = await autumnV1.check({
+		customer_id: customer2,
+		feature_id: TestFeature.Messages,
+	});
+	expect(check2.allowed).toBe(true);
+	expect(check2.balance).toBe(25);
 });

--- a/vite/index.html
+++ b/vite/index.html
@@ -37,6 +37,12 @@
         }
       })();
     </script>
+
+    <script type="module">
+      if (import.meta.env.DEV) {
+        import("react-grab");
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/vite/package.json
+++ b/vite/package.json
@@ -76,6 +76,7 @@
 		"react": "^18.2.0",
 		"react-day-picker": "^8.10.1",
 		"react-dom": "^18.2.0",
+		"react-grab": "^0.1.29",
 		"react-hotkeys-hook": "^4.6.1",
 		"react-router": "^7.3.0",
 		"react-router-dom": "^7.6.2",

--- a/vite/src/components/v2/buttons/ShortcutButton.tsx
+++ b/vite/src/components/v2/buttons/ShortcutButton.tsx
@@ -30,6 +30,7 @@ export const ShortcutButton = ({
 				? [singleShortcut]
 				: [],
 		(e) => {
+			if (props.disabled || isLoading) return;
 			e.preventDefault();
 			props?.onClick?.(e as unknown as React.MouseEvent<HTMLButtonElement>);
 		},

--- a/vite/src/hooks/stores/useRewardStore.ts
+++ b/vite/src/hooks/stores/useRewardStore.ts
@@ -11,6 +11,7 @@ const DEFAULT_REWARD: FrontendReward = {
 	free_product_id: null,
 	discount_config: defaultDiscountConfig,
 	free_product_config: null,
+	featureGrantEntitlements: [],
 };
 
 interface RewardState {

--- a/vite/src/views/products/rewards/components/RewardsTableColumns.tsx
+++ b/vite/src/views/products/rewards/components/RewardsTableColumns.tsx
@@ -42,9 +42,11 @@ export const createRewardsTableColumns = (): ColumnDef<Reward, unknown>[] => {
 			accessorKey: "type",
 			cell: ({ row }: { row: Row<Reward> }) => {
 				const typeLabels: Record<RewardType, string> = {
-					[RewardType.AmountDiscount]: "Amount Discount",
+					[RewardType.FixedDiscount]: "Fixed Discount",
 					[RewardType.PercentageDiscount]: "Percentage Discount",
 					[RewardType.FreeProduct]: "Free Product",
+					[RewardType.InvoiceCredits]: "Invoice Credits",
+					[RewardType.FeatureGrant]: "Feature Grant",
 				};
 				return (
 					<div className="text-t2">
@@ -90,6 +92,18 @@ const RewardValueCell = ({ reward }: { reward: Reward }) => {
 			(p: ProductV2) => p.id === reward.free_product_id,
 		);
 		return <div className="text-t2">{product?.name || "—"}</div>;
+	}
+
+	if (reward.type === RewardType.FeatureGrant) {
+		const grantCount = reward.entitlements?.length ?? 0;
+
+		return (
+			<div className="text-t2">
+				{grantCount > 0
+					? `${grantCount} feature grant${grantCount === 1 ? "" : "s"}`
+					: "—"}
+			</div>
+		);
 	}
 
 	return (

--- a/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
@@ -56,57 +56,52 @@ export function CreateRewardSheet({
 		}
 	}, [open, reset]);
 
-	const handleCreate = async () => {
-		// Validation
-		if (!reward.name || !reward.id) {
-			toast.error("Name and ID are required");
-			return;
-		}
-
-		if (!reward.rewardCategory) {
-			toast.error("Please select a reward type");
-			return;
-		}
+	const isFormValid = () => {
+		if (!reward.name || !reward.id) return false;
+		if (!reward.rewardCategory) return false;
 
 		if (reward.rewardCategory === "discount") {
-			if (!reward.discountType) {
-				toast.error("Please select a discount type");
-				return;
-			}
-
+			if (!reward.discountType) return false;
 			const config = reward.discount_config;
 			if (
 				!config?.apply_to_all &&
 				(!config?.price_ids || config.price_ids.length === 0)
 			) {
-				toast.error("Please select price(s) to apply this reward to");
-				return;
+				return false;
 			}
 		}
 
 		if (reward.rewardCategory === "free_product" && !reward.free_product_id) {
-			toast.error("Please select a free plan");
-			return;
+			return false;
 		}
 
 		if (reward.rewardCategory === "feature_grant") {
-			const validEntitlements = reward.featureGrantEntitlements.filter(
-				(e) => e.feature_id && e.allowance > 0,
-			);
-			if (validEntitlements.length === 0) {
-				toast.error(
-					"Please add at least one entitlement with a feature and balance",
-				);
-				return;
-			}
+			if (reward.featureGrantEntitlements.length === 0) return false;
+			const featureIds = features.map((f) => f.id);
+			if (
+				reward.featureGrantEntitlements.some(
+					(e) => !e.feature_id || !featureIds.includes(e.feature_id),
+				)
+			)
+				return false;
+			if (
+				reward.featureGrantEntitlements.some(
+					(e) => !e.allowance || e.allowance <= 0,
+				)
+			)
+				return false;
 			if (
 				!reward.promo_codes?.length ||
 				!reward.promo_codes.some((pc) => pc.code)
-			) {
-				toast.error("Please add at least one promo code");
-				return;
-			}
+			)
+				return false;
 		}
+
+		return true;
+	};
+
+	const handleCreate = async () => {
+		if (!isFormValid()) return;
 
 		setLoading(true);
 		try {
@@ -180,6 +175,7 @@ export function CreateRewardSheet({
 						onClick={handleCreate}
 						metaShortcut="enter"
 						isLoading={loading}
+						disabled={!isFormValid()}
 					>
 						Create reward
 					</ShortcutButton>

--- a/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
@@ -12,6 +12,7 @@ import {
 	SheetContent,
 	SheetTrigger,
 } from "@/components/v2/sheets/Sheet";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useRewardsQuery } from "@/hooks/queries/useRewardsQuery";
 import { useRewardStore } from "@/hooks/stores/useRewardStore";
 import { RewardService } from "@/services/products/RewardService";
@@ -19,6 +20,7 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { mapFrontendToApiReward } from "../../utils/rewardMappers";
 import { DiscountRewardConfig } from "./DiscountRewardConfig";
+import { FeatureGrantRewardConfig } from "./FeatureGrantRewardConfig";
 import { FreeProductRewardConfig } from "./FreeProductRewardConfig";
 import { RewardDetails } from "./RewardDetails";
 import { SelectRewardType } from "./SelectRewardType";
@@ -34,6 +36,7 @@ export function CreateRewardSheet({
 }: CreateRewardSheetProps = {}) {
 	const axiosInstance = useAxiosInstance();
 	const { refetch } = useRewardsQuery();
+	const { features } = useFeaturesQuery();
 
 	const [loading, setLoading] = useState(false);
 	const [internalOpen, setInternalOpen] = useState(false);
@@ -86,9 +89,31 @@ export function CreateRewardSheet({
 			return;
 		}
 
+		if (reward.rewardCategory === "feature_grant") {
+			const validEntitlements = reward.featureGrantEntitlements.filter(
+				(e) => e.feature_id && e.allowance > 0,
+			);
+			if (validEntitlements.length === 0) {
+				toast.error(
+					"Please add at least one entitlement with a feature and balance",
+				);
+				return;
+			}
+			if (
+				!reward.promo_codes?.length ||
+				!reward.promo_codes.some((pc) => pc.code)
+			) {
+				toast.error("Please add at least one promo code");
+				return;
+			}
+		}
+
 		setLoading(true);
 		try {
-			const apiReward = mapFrontendToApiReward(reward);
+			const apiReward = mapFrontendToApiReward({
+				frontendReward: reward,
+				features,
+			});
 
 			await RewardService.createReward({
 				axiosInstance,
@@ -134,6 +159,10 @@ export function CreateRewardSheet({
 
 					{reward.rewardCategory === "free_product" && (
 						<FreeProductRewardConfig reward={reward} setReward={setReward} />
+					)}
+
+					{reward.rewardCategory === "feature_grant" && (
+						<FeatureGrantRewardConfig reward={reward} setReward={setReward} />
 					)}
 				</div>
 

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -1,0 +1,347 @@
+import {
+	type Feature,
+	FeatureGrantDuration,
+	FeatureType,
+} from "@autumn/shared";
+import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/v2/buttons/Button";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import type {
+	FrontendReward,
+	FrontendRewardEntitlement,
+} from "../../types/frontendReward";
+
+interface FeatureGrantRewardConfigProps {
+	reward: FrontendReward;
+	setReward: (reward: FrontendReward) => void;
+}
+
+export function FeatureGrantRewardConfig({
+	reward,
+	setReward,
+}: FeatureGrantRewardConfigProps) {
+	const { features } = useFeaturesQuery();
+
+	// Filter to metered, non-boolean features only
+	const meteredFeatures = features.filter(
+		(f) => f.type === FeatureType.Metered,
+	);
+
+	const entitlements = reward.featureGrantEntitlements;
+
+	const updateEntitlement = ({
+		index,
+		updates,
+	}: {
+		index: number;
+		updates: Partial<FrontendRewardEntitlement>;
+	}) => {
+		const updated = [...entitlements];
+		updated[index] = { ...updated[index], ...updates };
+		setReward({ ...reward, featureGrantEntitlements: updated });
+	};
+
+	const addEntitlement = () => {
+		// Infer expiry from the first entitlement that has one
+		const existingExpiry = entitlements.find((e) => e.expiry)?.expiry;
+		setReward({
+			...reward,
+			featureGrantEntitlements: [
+				...entitlements,
+				{
+					feature_id: "",
+					allowance: 0,
+					expiry: existingExpiry ? { ...existingExpiry } : undefined,
+				},
+			],
+		});
+	};
+
+	const removeEntitlement = ({ index }: { index: number }) => {
+		setReward({
+			...reward,
+			featureGrantEntitlements: entitlements.filter((_, i) => i !== index),
+		});
+	};
+
+	const updatePromoCode = ({
+		index,
+		code,
+	}: {
+		index: number;
+		code: string;
+	}) => {
+		const updated = [...(reward.promo_codes || [])];
+		updated[index] = { ...updated[index], code };
+		setReward({ ...reward, promo_codes: updated });
+	};
+
+	const updateMaxRedemptions = ({
+		index,
+		value,
+	}: {
+		index: number;
+		value: number | undefined;
+	}) => {
+		const updated = [...(reward.promo_codes || [])];
+		updated[index] = { ...updated[index], max_redemptions: value };
+		setReward({ ...reward, promo_codes: updated });
+	};
+
+	const addPromoCode = () => {
+		// Infer max_redemptions from first promo code
+		const existingMax = reward.promo_codes?.find(
+			(pc) => pc.max_redemptions,
+		)?.max_redemptions;
+		setReward({
+			...reward,
+			promo_codes: [
+				...(reward.promo_codes || []),
+				{ code: "", max_redemptions: existingMax },
+			],
+		});
+	};
+
+	const removePromoCode = ({ index }: { index: number }) => {
+		setReward({
+			...reward,
+			promo_codes: (reward.promo_codes || []).filter((_, i) => i !== index),
+		});
+	};
+
+	// Exclude features already selected in other entitlements
+	const getAvailableFeatures = ({ currentIndex }: { currentIndex: number }) => {
+		const selectedIds = entitlements
+			.filter((_, i) => i !== currentIndex)
+			.map((e) => e.feature_id);
+		return meteredFeatures.filter((f) => !selectedIds.includes(f.id));
+	};
+
+	return (
+		<>
+			{/* Promo Codes Section */}
+			<SheetSection title="Promo Codes">
+				<div className="space-y-3">
+					{(reward.promo_codes || []).map((promoCode, index) => (
+						<div key={index} className="flex items-end gap-2">
+							<div className="flex-1">
+								{index === 0 && <FormLabel>Code</FormLabel>}
+								<Input
+									value={promoCode.code}
+									onChange={(e) =>
+										updatePromoCode({
+											index,
+											code: e.target.value
+												.toUpperCase()
+												.replace(/[^A-Z0-9]/g, ""),
+										})
+									}
+									placeholder="PROMO2024"
+								/>
+							</div>
+							<div className="w-32">
+								{index === 0 && <FormLabel>Max Uses</FormLabel>}
+								<Input
+									type="number"
+									value={promoCode.max_redemptions ?? ""}
+									onChange={(e) =>
+										updateMaxRedemptions({
+											index,
+											value: e.target.value
+												? Number(e.target.value)
+												: undefined,
+										})
+									}
+									placeholder="Unlimited"
+								/>
+							</div>
+							{(reward.promo_codes || []).length > 1 && (
+								<button
+									type="button"
+									onClick={() => removePromoCode({ index })}
+									className="p-2 text-t4 hover:text-t1 transition-colors"
+								>
+									<TrashIcon size={14} />
+								</button>
+							)}
+						</div>
+					))}
+					<Button variant="secondary" size="sm" onClick={addPromoCode}>
+						<PlusIcon size={12} className="mr-1" />
+						Add Code
+					</Button>
+				</div>
+			</SheetSection>
+
+			{/* Entitlements Section */}
+			<SheetSection title="Feature Grants">
+				<div className="space-y-4">
+					{entitlements.map((ent, index) => (
+						<div
+							key={index}
+							className="relative space-y-3 rounded-lg border border-border p-3"
+						>
+							{entitlements.length > 1 && (
+								<button
+									type="button"
+									onClick={() => removeEntitlement({ index })}
+									className="absolute top-2 right-2 p-1 text-t4 hover:text-t1 transition-colors cursor-pointer"
+								>
+									<TrashIcon size={12} />
+								</button>
+							)}
+
+							{/* Feature selector */}
+							<div>
+								<FormLabel>Feature</FormLabel>
+								<SearchableSelect<Feature>
+									value={ent.feature_id || null}
+									onValueChange={(value) =>
+										updateEntitlement({
+											index,
+											updates: { feature_id: value },
+										})
+									}
+									options={getAvailableFeatures({
+										currentIndex: index,
+									})}
+									getOptionValue={(f) => f.id}
+									getOptionLabel={(f) => f.name}
+									placeholder="Select a metered feature..."
+									searchable
+									searchPlaceholder="Search features..."
+									emptyText="No metered features found"
+									triggerClassName="cursor-pointer"
+								/>
+							</div>
+
+							{/* Allowance */}
+							<div>
+								<FormLabel>Balance Grant</FormLabel>
+								<Input
+									type="number"
+									value={ent.allowance || ""}
+									onChange={(e) =>
+										updateEntitlement({
+											index,
+											updates: {
+												allowance: Number(e.target.value),
+											},
+										})
+									}
+									placeholder="0"
+								/>
+							</div>
+
+							{/* Expiry */}
+							<div>
+								<FormLabel>Expiry</FormLabel>
+								{ent.expiry ? (
+									<div className="flex items-center gap-2">
+										<Input
+											type="number"
+											value={ent.expiry.length || ""}
+											onChange={(e) =>
+												updateEntitlement({
+													index,
+													updates: {
+														expiry: {
+															duration:
+																ent.expiry?.duration ??
+																FeatureGrantDuration.Month,
+															length: Number(e.target.value),
+														},
+													},
+												})
+											}
+											placeholder="30"
+											className="w-20"
+										/>
+										<Select
+											value={ent.expiry.duration}
+											onValueChange={(value) =>
+												updateEntitlement({
+													index,
+													updates: {
+														expiry: {
+															duration: value as FeatureGrantDuration,
+															length: ent.expiry?.length ?? 1,
+														},
+													},
+												})
+											}
+										>
+											<SelectTrigger className="flex-1">
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												<SelectItem value={FeatureGrantDuration.Day}>
+													Day(s)
+												</SelectItem>
+												<SelectItem value={FeatureGrantDuration.Week}>
+													Week(s)
+												</SelectItem>
+												<SelectItem value={FeatureGrantDuration.Month}>
+													Month(s)
+												</SelectItem>
+												<SelectItem value={FeatureGrantDuration.Year}>
+													Year(s)
+												</SelectItem>
+											</SelectContent>
+										</Select>
+										<button
+											type="button"
+											onClick={() =>
+												updateEntitlement({
+													index,
+													updates: { expiry: undefined },
+												})
+											}
+											className="text-xs text-t4 hover:text-t1 transition-colors whitespace-nowrap"
+										>
+											Clear
+										</button>
+									</div>
+								) : (
+									<button
+										type="button"
+										onClick={() =>
+											updateEntitlement({
+												index,
+												updates: {
+													expiry: {
+														duration: FeatureGrantDuration.Month,
+														length: 1,
+													},
+												},
+											})
+										}
+									className="text-xs text-t4 hover:text-t1 transition-colors cursor-pointer"
+								>
+									No expiry (permanent). Click to set one.
+									</button>
+								)}
+							</div>
+						</div>
+					))}
+
+					<Button variant="secondary" size="sm" onClick={addEntitlement}>
+						<PlusIcon size={12} className="mr-1" />
+						Add Entitlement
+					</Button>
+				</div>
+			</SheetSection>
+		</>
+	);
+}

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -1,9 +1,8 @@
-import {
-	type Feature,
-	FeatureGrantDuration,
-	FeatureType,
-} from "@autumn/shared";
+import { EntitlementDuration, type Feature, FeatureType } from "@autumn/shared";
 import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
+import { CheckIcon } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { cloneElement, isValidElement } from "react";
 import { Button } from "@/components/v2/buttons/Button";
 import { FormLabel } from "@/components/v2/form/FormLabel";
 import { Input } from "@/components/v2/inputs/Input";
@@ -15,8 +14,11 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/v2/selects/Select";
+import { Separator } from "@/components/v2/separator";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { cn } from "@/lib/utils";
+import { getFeatureIconConfig } from "@/views/products/features/utils/getFeatureIcon";
 import type {
 	FrontendReward,
 	FrontendRewardEntitlement,
@@ -33,12 +35,16 @@ export function FeatureGrantRewardConfig({
 }: FeatureGrantRewardConfigProps) {
 	const { features } = useFeaturesQuery();
 
-	// Filter to metered, non-boolean features only
-	const meteredFeatures = features.filter(
-		(f) => f.type === FeatureType.Metered,
+	// Keep existing metered filtering, but allow credit systems too
+	const availableGrantTargets = features.filter(
+		(f) =>
+			f.type === FeatureType.Metered || f.type === FeatureType.CreditSystem,
 	);
 
 	const entitlements = reward.featureGrantEntitlements;
+	const getGlobalMaxRedemption = (
+		promoCode: NonNullable<FrontendReward["promo_codes"]>[number],
+	) => promoCode.global_max_redemption ?? promoCode.max_redemptions;
 
 	const updateEntitlement = ({
 		index,
@@ -53,7 +59,6 @@ export function FeatureGrantRewardConfig({
 	};
 
 	const addEntitlement = () => {
-		// Infer expiry from the first entitlement that has one
 		const existingExpiry = entitlements.find((e) => e.expiry)?.expiry;
 		setReward({
 			...reward,
@@ -95,20 +100,23 @@ export function FeatureGrantRewardConfig({
 		value: number | undefined;
 	}) => {
 		const updated = [...(reward.promo_codes || [])];
-		updated[index] = { ...updated[index], max_redemptions: value };
+		const promoCode = updated[index] ?? { code: "" };
+		updated[index] = {
+			code: promoCode.code,
+			global_max_redemption: value,
+		};
 		setReward({ ...reward, promo_codes: updated });
 	};
 
 	const addPromoCode = () => {
-		// Infer max_redemptions from first promo code
-		const existingMax = reward.promo_codes?.find(
-			(pc) => pc.max_redemptions,
-		)?.max_redemptions;
+		const existingMax = reward.promo_codes
+			?.map((pc) => getGlobalMaxRedemption(pc))
+			.find((max) => max !== undefined);
 		setReward({
 			...reward,
 			promo_codes: [
 				...(reward.promo_codes || []),
-				{ code: "", max_redemptions: existingMax },
+				{ code: "", global_max_redemption: existingMax },
 			],
 		});
 	};
@@ -120,18 +128,32 @@ export function FeatureGrantRewardConfig({
 		});
 	};
 
-	// Exclude features already selected in other entitlements
 	const getAvailableFeatures = ({ currentIndex }: { currentIndex: number }) => {
 		const selectedIds = entitlements
 			.filter((_, i) => i !== currentIndex)
 			.map((e) => e.feature_id);
-		return meteredFeatures.filter((f) => !selectedIds.includes(f.id));
+		return availableGrantTargets.filter((f) => !selectedIds.includes(f.id));
+	};
+
+	const getGrantTargetIcon = ({ feature }: { feature: Feature }) => {
+		const iconConfig = getFeatureIconConfig(
+			feature.type,
+			feature.config?.usage_type,
+		);
+
+		if (isValidElement<{ className?: string }>(iconConfig.icon)) {
+			return cloneElement(iconConfig.icon, {
+				className: cn(iconConfig.icon.props.className, iconConfig.color),
+			});
+		}
+
+		return iconConfig.icon;
 	};
 
 	return (
 		<>
 			{/* Promo Codes Section */}
-			<SheetSection title="Promo Codes">
+			<SheetSection title="Promo Codes" withSeparator={false}>
 				<div className="space-y-3">
 					{(reward.promo_codes || []).map((promoCode, index) => (
 						<div key={index} className="flex items-end gap-2">
@@ -154,7 +176,7 @@ export function FeatureGrantRewardConfig({
 								{index === 0 && <FormLabel>Max Uses</FormLabel>}
 								<Input
 									type="number"
-									value={promoCode.max_redemptions ?? ""}
+									value={getGlobalMaxRedemption(promoCode) ?? ""}
 									onChange={(e) =>
 										updateMaxRedemptions({
 											index,
@@ -183,162 +205,197 @@ export function FeatureGrantRewardConfig({
 					</Button>
 				</div>
 			</SheetSection>
+			<div className="px-4">
+				<Separator />
+			</div>
 
 			{/* Entitlements Section */}
-			<SheetSection title="Feature Grants">
+			<SheetSection title="Feature Grants" withSeparator={false}>
 				<div className="space-y-4">
-					{entitlements.map((ent, index) => (
-						<div
-							key={index}
-							className="relative space-y-3 rounded-lg border border-border p-3"
-						>
-							{entitlements.length > 1 && (
-								<button
-									type="button"
-									onClick={() => removeEntitlement({ index })}
-									className="absolute top-2 right-2 p-1 text-t4 hover:text-t1 transition-colors cursor-pointer"
-								>
-									<TrashIcon size={12} />
-								</button>
-							)}
+					<AnimatePresence initial={false}>
+						{entitlements.map((ent, index) => (
+							<motion.div
+								key={`${ent.feature_id || "new"}-${index}`}
+								initial={{ opacity: 0, scaleY: 0.95, originY: 0 }}
+								animate={{ opacity: 1, scaleY: 1 }}
+								exit={{ opacity: 0, scaleY: 0.95 }}
+								transition={{ duration: 0.2, ease: "easeOut" }}
+							>
+								<div className="relative space-y-3 rounded-lg border border-border p-3">
+									{entitlements.length > 1 && (
+										<button
+											type="button"
+											onClick={() => removeEntitlement({ index })}
+											className="absolute top-2 right-2 p-1 text-t4 hover:text-t1 transition-colors cursor-pointer"
+										>
+											<TrashIcon size={12} />
+										</button>
+									)}
 
-							{/* Feature selector */}
-							<div>
-								<FormLabel>Feature</FormLabel>
-								<SearchableSelect<Feature>
-									value={ent.feature_id || null}
-									onValueChange={(value) =>
-										updateEntitlement({
-											index,
-											updates: { feature_id: value },
-										})
-									}
-									options={getAvailableFeatures({
-										currentIndex: index,
-									})}
-									getOptionValue={(f) => f.id}
-									getOptionLabel={(f) => f.name}
-									placeholder="Select a metered feature..."
-									searchable
-									searchPlaceholder="Search features..."
-									emptyText="No metered features found"
-									triggerClassName="cursor-pointer"
-								/>
-							</div>
-
-							{/* Allowance */}
-							<div>
-								<FormLabel>Balance Grant</FormLabel>
-								<Input
-									type="number"
-									value={ent.allowance || ""}
-									onChange={(e) =>
-										updateEntitlement({
-											index,
-											updates: {
-												allowance: Number(e.target.value),
-											},
-										})
-									}
-									placeholder="0"
-								/>
-							</div>
-
-							{/* Expiry */}
-							<div>
-								<FormLabel>Expiry</FormLabel>
-								{ent.expiry ? (
-									<div className="flex items-center gap-2">
-										<Input
-											type="number"
-											value={ent.expiry.length || ""}
-											onChange={(e) =>
-												updateEntitlement({
-													index,
-													updates: {
-														expiry: {
-															duration:
-																ent.expiry?.duration ??
-																FeatureGrantDuration.Month,
-															length: Number(e.target.value),
-														},
-													},
-												})
-											}
-											placeholder="30"
-											className="w-20"
-										/>
-										<Select
-											value={ent.expiry.duration}
+									{/* Feature selector */}
+									<div>
+										<FormLabel>Feature</FormLabel>
+										<SearchableSelect<Feature>
+											value={ent.feature_id || null}
 											onValueChange={(value) =>
 												updateEntitlement({
 													index,
-													updates: {
-														expiry: {
-															duration: value as FeatureGrantDuration,
-															length: ent.expiry?.length ?? 1,
-														},
-													},
+													updates: { feature_id: value },
 												})
 											}
-										>
-											<SelectTrigger className="flex-1">
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												<SelectItem value={FeatureGrantDuration.Day}>
-													Day(s)
-												</SelectItem>
-												<SelectItem value={FeatureGrantDuration.Week}>
-													Week(s)
-												</SelectItem>
-												<SelectItem value={FeatureGrantDuration.Month}>
-													Month(s)
-												</SelectItem>
-												<SelectItem value={FeatureGrantDuration.Year}>
-													Year(s)
-												</SelectItem>
-											</SelectContent>
-										</Select>
-										<button
-											type="button"
-											onClick={() =>
+											options={getAvailableFeatures({ currentIndex: index })}
+											getOptionValue={(f) => f.id}
+											getOptionLabel={(f) => f.name}
+											renderOption={(feature, isSelected) => (
+												<>
+													{getGrantTargetIcon({ feature })}
+													<span className="flex-1 truncate min-w-0">
+														{feature.name}
+													</span>
+													{isSelected && (
+														<CheckIcon className="size-4 shrink-0" />
+													)}
+												</>
+											)}
+											renderValue={(feature) => {
+												if (!feature) {
+													return (
+														<span className="text-t3 leading-none">
+															Select a feature or credit system...
+														</span>
+													);
+												}
+
+												return (
+													<span className="flex items-center gap-2 min-w-0 max-w-full leading-none">
+														{getGrantTargetIcon({ feature })}
+														<span className="truncate">{feature.name}</span>
+													</span>
+												);
+											}}
+											placeholder="Select a feature or credit system..."
+											searchable
+											searchPlaceholder="Search features and credit systems..."
+											emptyText="No eligible features found"
+											triggerClassName="cursor-pointer h-input"
+											contentClassName="[&_[cmdk-group]]:py-0"
+										/>
+									</div>
+
+									{/* Allowance */}
+									<div>
+										<FormLabel>Balance Grant</FormLabel>
+										<Input
+											type="number"
+											value={ent.allowance || ""}
+											onChange={(e) =>
 												updateEntitlement({
 													index,
-													updates: { expiry: undefined },
+													updates: { allowance: Number(e.target.value) },
 												})
 											}
-											className="text-xs text-t4 hover:text-t1 transition-colors whitespace-nowrap"
-										>
-											Clear
-										</button>
+											placeholder="0"
+											className="w-full [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+										/>
 									</div>
-								) : (
-									<button
-										type="button"
-										onClick={() =>
-											updateEntitlement({
-												index,
-												updates: {
-													expiry: {
-														duration: FeatureGrantDuration.Month,
-														length: 1,
-													},
-												},
-											})
-										}
-									className="text-xs text-t4 hover:text-t1 transition-colors cursor-pointer"
-								>
-									No expiry (permanent). Click to set one.
-									</button>
-								)}
-							</div>
-						</div>
-					))}
+
+									{/* Expiry */}
+									<div>
+										<FormLabel>Expiry</FormLabel>
+										{ent.expiry ? (
+											<div className="flex items-center gap-2">
+												<Input
+													type="number"
+													value={ent.expiry.length || ""}
+													onChange={(e) =>
+														updateEntitlement({
+															index,
+															updates: {
+																expiry: {
+																	duration:
+																		ent.expiry?.duration ??
+																		EntitlementDuration.Month,
+																	length: Number(e.target.value),
+																},
+															},
+														})
+													}
+													placeholder="30"
+													className="w-20"
+												/>
+												<Select
+													value={ent.expiry.duration}
+													onValueChange={(value) =>
+														updateEntitlement({
+															index,
+															updates: {
+																expiry: {
+																	duration: value as EntitlementDuration,
+																	length: ent.expiry?.length ?? 1,
+																},
+															},
+														})
+													}
+												>
+													<SelectTrigger className="flex-1">
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														<SelectItem value={EntitlementDuration.Day}>
+															Day(s)
+														</SelectItem>
+														<SelectItem value={EntitlementDuration.Week}>
+															Week(s)
+														</SelectItem>
+														<SelectItem value={EntitlementDuration.Month}>
+															Month(s)
+														</SelectItem>
+														<SelectItem value={EntitlementDuration.Year}>
+															Year(s)
+														</SelectItem>
+													</SelectContent>
+												</Select>
+												<button
+													type="button"
+													onClick={() =>
+														updateEntitlement({
+															index,
+															updates: { expiry: undefined },
+														})
+													}
+													className="text-xs text-t4 hover:text-t1 transition-colors whitespace-nowrap"
+												>
+													Clear
+												</button>
+											</div>
+										) : (
+											<button
+												type="button"
+												onClick={() =>
+													updateEntitlement({
+														index,
+														updates: {
+															expiry: {
+																duration: EntitlementDuration.Month,
+																length: 1,
+															},
+														},
+													})
+												}
+												className="text-xs text-t4 hover:text-t1 transition-colors cursor-pointer"
+											>
+												No expiry (permanent). Click to set one.
+											</button>
+										)}
+									</div>
+								</div>
+							</motion.div>
+						))}
+					</AnimatePresence>
 
 					<Button variant="secondary" size="sm" onClick={addEntitlement}>
 						<PlusIcon size={12} className="mr-1" />
-						Add Entitlement
+						Add Grant
 					</Button>
 				</div>
 			</SheetSection>

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -1,4 +1,4 @@
-import { GiftIcon, PercentIcon } from "@phosphor-icons/react";
+import { LightningIcon, PercentIcon } from "@phosphor-icons/react";
 import { PanelButton } from "@/components/v2/buttons/PanelButton";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import {
@@ -23,13 +23,12 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 						onClick={() =>
 							setReward({
 								...reward,
-
 								rewardCategory: FrontendRewardCategory.Discount,
 								discountType: FrontendDiscountType.Percentage,
-
 								discount_config: defaultDiscountConfig,
 								free_product_id: null,
 								free_product_config: null,
+								featureGrantEntitlements: [],
 							})
 						}
 						icon={<PercentIcon size={16} color="currentColor" />}
@@ -45,23 +44,25 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 
 				<div className="flex w-full items-center gap-4">
 					<PanelButton
-						isSelected={reward.rewardCategory === "free_product"}
+						isSelected={reward.rewardCategory === "feature_grant"}
 						onClick={() =>
 							setReward({
 								...reward,
-								rewardCategory: FrontendRewardCategory.FreeProduct,
+								rewardCategory: FrontendRewardCategory.FeatureGrant,
 								discountType: null,
 								discount_config: null,
 								free_product_id: null,
 								free_product_config: null,
+								featureGrantEntitlements: [{ feature_id: "", allowance: 0 }],
 							})
 						}
-						icon={<GiftIcon size={16} color="currentColor" />}
+						icon={<LightningIcon size={16} color="currentColor" />}
 					/>
 					<div className="flex-1">
-						<div className="text-body-highlight mb-1">Free Product</div>
+						<div className="text-body-highlight mb-1">Feature Grant</div>
 						<div className="text-body-secondary leading-tight">
-							Used to give away products in a referral program
+							Give your users a metered feature balance grant upon promo code
+							redemption
 						</div>
 					</div>
 				</div>

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -1,4 +1,4 @@
-import { LightningIcon, PercentIcon } from "@phosphor-icons/react";
+import { GiftIcon, LightningIcon, PercentIcon } from "@phosphor-icons/react";
 import { PanelButton } from "@/components/v2/buttons/PanelButton";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import {
@@ -19,7 +19,9 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 			<div className="space-y-4">
 				<div className="flex w-full items-center gap-4">
 					<PanelButton
-						isSelected={reward.rewardCategory === "discount"}
+						isSelected={
+							reward.rewardCategory === FrontendRewardCategory.Discount
+						}
 						onClick={() =>
 							setReward({
 								...reward,
@@ -44,7 +46,35 @@ export function SelectRewardType({ reward, setReward }: SelectRewardTypeProps) {
 
 				<div className="flex w-full items-center gap-4">
 					<PanelButton
-						isSelected={reward.rewardCategory === "feature_grant"}
+						isSelected={
+							reward.rewardCategory === FrontendRewardCategory.FreeProduct
+						}
+						onClick={() =>
+							setReward({
+								...reward,
+								rewardCategory: FrontendRewardCategory.FreeProduct,
+								discountType: null,
+								discount_config: null,
+								free_product_id: null,
+								free_product_config: null,
+								featureGrantEntitlements: [],
+							})
+						}
+						icon={<GiftIcon size={16} color="currentColor" />}
+					/>
+					<div className="flex-1">
+						<div className="text-body-highlight mb-1">Free Product</div>
+						<div className="text-body-secondary leading-tight">
+							Used to give away products in a referral program
+						</div>
+					</div>
+				</div>
+
+				<div className="flex w-full items-center gap-4">
+					<PanelButton
+						isSelected={
+							reward.rewardCategory === FrontendRewardCategory.FeatureGrant
+						}
 						onClick={() =>
 							setReward({
 								...reward,

--- a/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
@@ -58,40 +58,52 @@ export function UpdateRewardSheet({
 		}
 	}, [open, selectedReward, setReward, setBaseReward]);
 
-	const handleUpdate = async () => {
-		if (!selectedReward) return;
-
-		// Validation
-		if (!reward.name || !reward.id) {
-			toast.error("Name and ID are required");
-			return;
-		}
-
-		if (!reward.rewardCategory) {
-			toast.error("Please select a reward type");
-			return;
-		}
+	const isFormValid = () => {
+		if (!reward.name || !reward.id) return false;
+		if (!reward.rewardCategory) return false;
 
 		if (reward.rewardCategory === "discount") {
-			if (!reward.discountType) {
-				toast.error("Please select a discount type");
-				return;
-			}
-
+			if (!reward.discountType) return false;
 			const config = reward.discount_config;
 			if (
 				!config?.apply_to_all &&
 				(!config?.price_ids || config.price_ids.length === 0)
 			) {
-				toast.error("Please select price(s) to apply this reward to");
-				return;
+				return false;
 			}
 		}
 
 		if (reward.rewardCategory === "free_product" && !reward.free_product_id) {
-			toast.error("Please select a free plan");
-			return;
+			return false;
 		}
+
+		if (reward.rewardCategory === "feature_grant") {
+			if (reward.featureGrantEntitlements.length === 0) return false;
+			const featureIds = features.map((f) => f.id);
+			if (
+				reward.featureGrantEntitlements.some(
+					(e) => !e.feature_id || !featureIds.includes(e.feature_id),
+				)
+			)
+				return false;
+			if (
+				reward.featureGrantEntitlements.some(
+					(e) => !e.allowance || e.allowance <= 0,
+				)
+			)
+				return false;
+			if (
+				!reward.promo_codes?.length ||
+				!reward.promo_codes.some((pc) => pc.code)
+			)
+				return false;
+		}
+
+		return true;
+	};
+
+	const handleUpdate = async () => {
+		if (!selectedReward || !isFormValid()) return;
 
 		setLoading(true);
 		try {
@@ -161,6 +173,7 @@ export function UpdateRewardSheet({
 						onClick={handleUpdate}
 						metaShortcut="enter"
 						isLoading={loading}
+						disabled={!isFormValid()}
 					>
 						Update reward
 					</ShortcutButton>

--- a/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
@@ -8,6 +8,7 @@ import {
 	SheetHeader,
 } from "@/components/v2/sheets/SharedSheetComponents";
 import { Sheet, SheetContent } from "@/components/v2/sheets/Sheet";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useRewardsQuery } from "@/hooks/queries/useRewardsQuery";
 import { useRewardStore } from "@/hooks/stores/useRewardStore";
 import { RewardService } from "@/services/products/RewardService";
@@ -18,6 +19,7 @@ import {
 	mapFrontendToApiReward,
 } from "../../utils/rewardMappers";
 import { DiscountRewardConfig } from "./DiscountRewardConfig";
+import { FeatureGrantRewardConfig } from "./FeatureGrantRewardConfig";
 import { FreeProductRewardConfig } from "./FreeProductRewardConfig";
 import { RewardDetails } from "./RewardDetails";
 import { SelectRewardType } from "./SelectRewardType";
@@ -35,6 +37,7 @@ export function UpdateRewardSheet({
 }: UpdateRewardSheetProps) {
 	const axiosInstance = useAxiosInstance();
 	const { refetch } = useRewardsQuery();
+	const { features } = useFeaturesQuery();
 
 	const [loading, setLoading] = useState(false);
 
@@ -45,7 +48,10 @@ export function UpdateRewardSheet({
 	// Initialize reward store when selectedReward changes
 	useEffect(() => {
 		if (open && selectedReward) {
-			const frontendReward = mapApiToFrontendReward(selectedReward);
+			const frontendReward = mapApiToFrontendReward({
+				apiReward: selectedReward,
+				features,
+			});
 
 			setReward(frontendReward);
 			setBaseReward(frontendReward);
@@ -89,7 +95,10 @@ export function UpdateRewardSheet({
 
 		setLoading(true);
 		try {
-			const apiReward = mapFrontendToApiReward(reward);
+			const apiReward = mapFrontendToApiReward({
+				frontendReward: reward,
+				features,
+			});
 
 			await RewardService.updateReward({
 				axiosInstance,
@@ -131,6 +140,10 @@ export function UpdateRewardSheet({
 
 					{reward.rewardCategory === "free_product" && (
 						<FreeProductRewardConfig reward={reward} setReward={setReward} />
+					)}
+
+					{reward.rewardCategory === "feature_grant" && (
+						<FeatureGrantRewardConfig reward={reward} setReward={setReward} />
 					)}
 				</div>
 

--- a/vite/src/views/products/rewards/types/frontendReward.ts
+++ b/vite/src/views/products/rewards/types/frontendReward.ts
@@ -1,4 +1,4 @@
-import type { CreateReward } from "@autumn/shared";
+import type { CreateReward, FeatureGrantDuration } from "@autumn/shared";
 
 /**
  * Frontend-only reward category to separate UI concerns from API types
@@ -6,6 +6,7 @@ import type { CreateReward } from "@autumn/shared";
 export enum FrontendRewardCategory {
 	Discount = "discount",
 	FreeProduct = "free_product",
+	FeatureGrant = "feature_grant",
 }
 
 /**
@@ -17,6 +18,16 @@ export enum FrontendDiscountType {
 	InvoiceCredits = "invoice_credits",
 }
 
+/** Frontend entitlement config for feature grant rewards */
+export interface FrontendRewardEntitlement {
+	feature_id: string;
+	allowance: number;
+	expiry?: {
+		duration: FeatureGrantDuration;
+		length: number;
+	};
+}
+
 /**
  * Extended reward type for frontend with separated concerns
  */
@@ -24,4 +35,6 @@ export interface FrontendReward extends Omit<CreateReward, "type"> {
 	// Frontend-specific fields
 	rewardCategory: FrontendRewardCategory | null;
 	discountType: FrontendDiscountType | null;
+	// Feature grant entitlements (frontend uses feature_id, mapped to internal_feature_id on submit)
+	featureGrantEntitlements: FrontendRewardEntitlement[];
 }

--- a/vite/src/views/products/rewards/types/frontendReward.ts
+++ b/vite/src/views/products/rewards/types/frontendReward.ts
@@ -1,4 +1,4 @@
-import type { CreateReward, FeatureGrantDuration } from "@autumn/shared";
+import type { CreateReward, EntitlementDuration } from "@autumn/shared";
 
 /**
  * Frontend-only reward category to separate UI concerns from API types
@@ -23,7 +23,7 @@ export interface FrontendRewardEntitlement {
 	feature_id: string;
 	allowance: number;
 	expiry?: {
-		duration: FeatureGrantDuration;
+		duration: EntitlementDuration;
 		length: number;
 	};
 }

--- a/vite/src/views/products/rewards/utils/rewardMappers.ts
+++ b/vite/src/views/products/rewards/utils/rewardMappers.ts
@@ -1,4 +1,4 @@
-import { type CreateReward, RewardType } from "@autumn/shared";
+import { type CreateReward, type Feature, RewardType } from "@autumn/shared";
 import type {
 	FrontendDiscountType,
 	FrontendReward,
@@ -8,15 +8,26 @@ import type {
 /**
  * Maps frontend reward to API reward type
  */
-export function mapFrontendToApiReward(
-	frontendReward: FrontendReward,
-): CreateReward {
-	const { rewardCategory, discountType, ...baseReward } = frontendReward;
+export function mapFrontendToApiReward({
+	frontendReward,
+	features,
+}: {
+	frontendReward: FrontendReward;
+	features?: Feature[];
+}): CreateReward {
+	const {
+		rewardCategory,
+		discountType,
+		featureGrantEntitlements,
+		...baseReward
+	} = frontendReward;
 
 	// Determine the API reward type based on frontend category and discount type
 	let type: RewardType;
 
-	if (rewardCategory === "free_product") {
+	if (rewardCategory === "feature_grant") {
+		type = RewardType.FeatureGrant;
+	} else if (rewardCategory === "free_product") {
 		type = RewardType.FreeProduct;
 	} else if (discountType === "percentage") {
 		type = RewardType.PercentageDiscount;
@@ -25,26 +36,47 @@ export function mapFrontendToApiReward(
 	} else if (discountType === "invoice_credits") {
 		type = RewardType.InvoiceCredits;
 	} else {
-		// Default fallback
 		type = RewardType.PercentageDiscount;
 	}
 
-	return {
+	const result: CreateReward = {
 		...baseReward,
 		type,
 	};
+
+	// Map frontend feature_id → internal_feature_id for feature grant entitlements
+	if (rewardCategory === "feature_grant" && featureGrantEntitlements?.length) {
+		result.entitlements = featureGrantEntitlements
+			.filter((e) => e.feature_id && e.allowance > 0)
+			.map((e) => {
+				const feature = features?.find((f) => f.id === e.feature_id);
+				return {
+					internal_feature_id: feature?.internal_id ?? e.feature_id,
+					allowance: e.allowance,
+					expiry: e.expiry,
+				};
+			});
+	}
+
+	return result;
 }
 
 /**
  * Maps API reward to frontend reward
  */
-export function mapApiToFrontendReward(
-	apiReward: CreateReward,
-): FrontendReward {
+export function mapApiToFrontendReward({
+	apiReward,
+	features,
+}: {
+	apiReward: CreateReward;
+	features?: Feature[];
+}): FrontendReward {
 	let rewardCategory: FrontendRewardCategory | null = null;
 	let discountType: FrontendDiscountType | null = null;
 
-	if (apiReward.type === RewardType.FreeProduct) {
+	if (apiReward.type === RewardType.FeatureGrant) {
+		rewardCategory = "feature_grant";
+	} else if (apiReward.type === RewardType.FreeProduct) {
 		rewardCategory = "free_product";
 	} else {
 		rewardCategory = "discount";
@@ -57,11 +89,24 @@ export function mapApiToFrontendReward(
 		}
 	}
 
-	const { type, ...baseReward } = apiReward;
+	const { type, entitlements, ...baseReward } = apiReward;
+
+	// Map internal_feature_id → feature_id for display
+	const featureGrantEntitlements = (entitlements ?? []).map((e) => {
+		const feature = features?.find(
+			(f) => f.internal_id === e.internal_feature_id,
+		);
+		return {
+			feature_id: feature?.id ?? e.internal_feature_id,
+			allowance: e.allowance,
+			expiry: e.expiry,
+		};
+	});
 
 	return {
 		...baseReward,
 		rewardCategory,
 		discountType,
+		featureGrantEntitlements,
 	};
 }

--- a/vite/src/views/products/rewards/utils/rewardMappers.ts
+++ b/vite/src/views/products/rewards/utils/rewardMappers.ts
@@ -1,9 +1,55 @@
-import { type CreateReward, type Feature, RewardType } from "@autumn/shared";
-import type {
+import {
+	type CreateReward,
+	type Feature,
+	findFeatureById,
+	findFeatureByInternalId,
+	type Reward,
+	RewardType,
+} from "@autumn/shared";
+import {
 	FrontendDiscountType,
-	FrontendReward,
+	type FrontendReward,
 	FrontendRewardCategory,
 } from "../types/frontendReward";
+
+type ApiRewardEntitlement =
+	| NonNullable<CreateReward["entitlements"]>[number]
+	| NonNullable<Reward["entitlements"]>[number];
+type ApiPromoCode = CreateReward["promo_codes"][number];
+
+const normalizePromoCode = ({
+	code,
+	global_max_redemption,
+	max_redemptions,
+}: ApiPromoCode): ApiPromoCode => {
+	const globalMaxRedemption = global_max_redemption ?? max_redemptions;
+
+	return {
+		code,
+		...(globalMaxRedemption !== undefined
+			? { global_max_redemption: globalMaxRedemption }
+			: {}),
+	};
+};
+
+const getFrontendExpiry = (entitlement: ApiRewardEntitlement) => {
+	if ("expiry" in entitlement && entitlement.expiry) {
+		return entitlement.expiry;
+	}
+
+	if (
+		"expiry_duration" in entitlement &&
+		entitlement.expiry_duration &&
+		entitlement.expiry_length != null
+	) {
+		return {
+			duration: entitlement.expiry_duration,
+			length: entitlement.expiry_length,
+		};
+	}
+
+	return undefined;
+};
 
 /**
  * Maps frontend reward to API reward type
@@ -25,15 +71,15 @@ export function mapFrontendToApiReward({
 	// Determine the API reward type based on frontend category and discount type
 	let type: RewardType;
 
-	if (rewardCategory === "feature_grant") {
+	if (rewardCategory === FrontendRewardCategory.FeatureGrant) {
 		type = RewardType.FeatureGrant;
-	} else if (rewardCategory === "free_product") {
+	} else if (rewardCategory === FrontendRewardCategory.FreeProduct) {
 		type = RewardType.FreeProduct;
-	} else if (discountType === "percentage") {
+	} else if (discountType === FrontendDiscountType.Percentage) {
 		type = RewardType.PercentageDiscount;
-	} else if (discountType === "fixed") {
+	} else if (discountType === FrontendDiscountType.Fixed) {
 		type = RewardType.FixedDiscount;
-	} else if (discountType === "invoice_credits") {
+	} else if (discountType === FrontendDiscountType.InvoiceCredits) {
 		type = RewardType.InvoiceCredits;
 	} else {
 		type = RewardType.PercentageDiscount;
@@ -41,21 +87,25 @@ export function mapFrontendToApiReward({
 
 	const result: CreateReward = {
 		...baseReward,
+		promo_codes: (baseReward.promo_codes ?? []).map(normalizePromoCode),
 		type,
 	};
 
 	// Map frontend feature_id → internal_feature_id for feature grant entitlements
-	if (rewardCategory === "feature_grant" && featureGrantEntitlements?.length) {
-		result.entitlements = featureGrantEntitlements
-			.filter((e) => e.feature_id && e.allowance > 0)
-			.map((e) => {
-				const feature = features?.find((f) => f.id === e.feature_id);
-				return {
-					internal_feature_id: feature?.internal_id ?? e.feature_id,
-					allowance: e.allowance,
-					expiry: e.expiry,
-				};
-			});
+	if (
+		rewardCategory === FrontendRewardCategory.FeatureGrant &&
+		featureGrantEntitlements?.length
+	) {
+		result.entitlements = featureGrantEntitlements.map((e) => {
+			const feature = features
+				? findFeatureById({ features, featureId: e.feature_id })
+				: undefined;
+			return {
+				internal_feature_id: feature?.internal_id ?? e.feature_id,
+				allowance: e.allowance,
+				expiry: e.expiry,
+			};
+		});
 	}
 
 	return result;
@@ -68,24 +118,24 @@ export function mapApiToFrontendReward({
 	apiReward,
 	features,
 }: {
-	apiReward: CreateReward;
+	apiReward: CreateReward | Reward;
 	features?: Feature[];
 }): FrontendReward {
 	let rewardCategory: FrontendRewardCategory | null = null;
 	let discountType: FrontendDiscountType | null = null;
 
 	if (apiReward.type === RewardType.FeatureGrant) {
-		rewardCategory = "feature_grant";
+		rewardCategory = FrontendRewardCategory.FeatureGrant;
 	} else if (apiReward.type === RewardType.FreeProduct) {
-		rewardCategory = "free_product";
+		rewardCategory = FrontendRewardCategory.FreeProduct;
 	} else {
-		rewardCategory = "discount";
+		rewardCategory = FrontendRewardCategory.Discount;
 		if (apiReward.type === RewardType.PercentageDiscount) {
-			discountType = "percentage";
+			discountType = FrontendDiscountType.Percentage;
 		} else if (apiReward.type === RewardType.FixedDiscount) {
-			discountType = "fixed";
+			discountType = FrontendDiscountType.Fixed;
 		} else if (apiReward.type === RewardType.InvoiceCredits) {
-			discountType = "invoice_credits";
+			discountType = FrontendDiscountType.InvoiceCredits;
 		}
 	}
 
@@ -93,13 +143,16 @@ export function mapApiToFrontendReward({
 
 	// Map internal_feature_id → feature_id for display
 	const featureGrantEntitlements = (entitlements ?? []).map((e) => {
-		const feature = features?.find(
-			(f) => f.internal_id === e.internal_feature_id,
-		);
+		const feature = features
+			? findFeatureByInternalId({
+					features,
+					internalId: e.internal_feature_id,
+				})
+			: undefined;
 		return {
 			feature_id: feature?.id ?? e.internal_feature_id,
-			allowance: e.allowance,
-			expiry: e.expiry,
+			allowance: e.allowance ?? 0,
+			expiry: getFrontendExpiry(e),
 		};
 	});
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the frontend UI for the feature-grant reward type alongside three new integration tests and several bug fixes to the existing reward flow.

- **Improvements**: New `FeatureGrantRewardConfig` component lets users define multi-feature entitlements with optional expiry, promo codes, and max-redemption limits; `RewardsTableColumns` extended with `FixedDiscount`, `InvoiceCredits`, and `FeatureGrant` entries; keyboard shortcut in `ShortcutButton` now respects `disabled`/`isLoading` state.
- **Bug fixes**: `handleCreateCoupon` no longer attempts a product lookup when `free_product_id` is absent on a `FreeProduct` reward; `mapFrontendToApiReward` switched from positional to object-argument signature.
- **API changes**: Both `mapFrontendToApiReward` and `mapApiToFrontendReward` now accept object parameters instead of bare reward arguments; all call sites in this PR are updated accordingly.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with minor UX and dependency-placement issues to address.

The core feature grant flow is well-structured and covered by new integration tests. The `react-grab` dependency placement is incorrect but won't reach the production bundle. The shift to a silent `isFormValid()` guard removes per-field error toasts, degrading UX for the more complex feature-grant form without causing data loss.

`vite/package.json` (dependency category), `CreateRewardSheet.tsx` and `UpdateRewardSheet.tsx` (validation feedback), `FeatureGrantRewardConfig.tsx` (animation key stability).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts | Added null guard on `free_product_id` before the FreeProduct DB/Stripe lookup — prevents a crash when the field is missing. |
| server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts | Added three new integration tests (multi-entitlement grants, duplicate redemption blocking, and multi-code rewards). |
| vite/package.json | Added `react-grab` (a dev inspector tool) to `dependencies` instead of `devDependencies`. |
| vite/index.html | Added DEV-only dynamic import of `react-grab` via an inline module script. |
| vite/src/components/v2/buttons/ShortcutButton.tsx | Keyboard shortcut handler now early-returns when the button is `disabled` or loading. |
| vite/src/views/products/rewards/utils/rewardMappers.ts | Refactored both mapper functions to accept an object parameter with feature-grant entitlement mapping support. |
| vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx | New component for configuring feature grant rewards; animation key instability may cause exit animations to skip. |
| vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx | Validation refactored to boolean `isFormValid()`; specific error messages removed. |
| vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx | Same validation refactor as CreateRewardSheet plus feature grant support. |
| vite/src/views/products/rewards/types/frontendReward.ts | Added `FeatureGrant` enum value, `FrontendRewardEntitlement` interface, and `featureGrantEntitlements` field. |
| vite/src/views/products/rewards/components/RewardsTableColumns.tsx | Updated type labels and added FeatureGrant value cell renderer. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Create/Update Reward Sheet] --> B[SelectRewardType]
    B --> C{rewardCategory}
    C -->|discount| D[DiscountRewardConfig]
    C -->|free_product| E[FreeProductRewardConfig]
    C -->|feature_grant| F[FeatureGrantRewardConfig]
    F --> G[Define Promo Codes]
    F --> H[Define Entitlements]
    G & H --> I[isFormValid]
    D --> I
    E --> I
    I -->|valid| J[mapFrontendToApiReward]
    I -->|invalid| K[Button disabled]
    J --> L[RewardService]
    L --> M[handleCreateCoupon]
    M -->|FreeProduct + free_product_id| N[ProductService + Stripe]
    M -->|FeatureGrant| O[rewardRepo.insert]
    M -->|Discount| P[createStripeCoupon]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx`, line 143-145 ([link](https://github.com/useautumn/autumn/blob/f91788faaae89cfe2cff23508df33da03e7ddad1/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx#L143-L145)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Sheet description still mentions only discount/free plan.** The `description` prop on `SheetHeader` reads `"Create a discount or free plan reward"` but the sheet now also supports Feature Grant rewards. Minor copy issue that could confuse users.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
   Line: 143-145

   Comment:
   **Sheet description still mentions only discount/free plan.** The `description` prop on `SheetHeader` reads `"Create a discount or free plan reward"` but the sheet now also supports Feature Grant rewards. Minor copy issue that could confuse users.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
vite/package.json:79
`react-grab` is a dev-time inspector tool and should be in `devDependencies`, not `dependencies`. Listing it under `dependencies` means it is installed in any production/CI environment that runs `npm install --production`, even though it is only dynamically imported inside a `if (import.meta.env.DEV)` guard.

```suggestion
		"react-grab": "^0.1.29",
```

### Issue 2 of 4
vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx:59-101
**Lost validation feedback on form errors.** The refactor replaced per-rule `toast.error("…")` calls with a silent `return false`, so when the form is invalid and the user interacts (e.g., via keyboard shortcut before the disabled state propagates), they get no explanation of what is wrong. The same pattern is duplicated in `UpdateRewardSheet`. Consider returning a descriptive message from `isFormValid` (or keeping the toast calls inside `handleCreate` as a fallback) so users know which field to fix.

### Issue 3 of 4
vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx:217-219
**Unstable animation key causes exit animations to skip.** The key `${ent.feature_id || "new"}-${index}` appends the list index, so when an item is removed from the middle the indices of all subsequent items shift and `AnimatePresence` sees them as entirely new elements rather than the same items moving. This means exit animations for removed cards will not play. A stable UUID generated at `addEntitlement` time, stored on the entitlement object, would fix this.

### Issue 4 of 4
vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx:143-145
**Sheet description still mentions only discount/free plan.** The `description` prop on `SheetHeader` reads `"Create a discount or free plan reward"` but the sheet now also supports Feature Grant rewards. Minor copy issue that could confuse users.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 fix some frontend bugs and add ..."](https://github.com/useautumn/autumn/commit/f91788faaae89cfe2cff23508df33da03e7ddad1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31369111)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->