### PR TITLE
feat: 🎸 add reward redemption to ui

### DIFF
--- a/server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts
+++ b/server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts
@@ -201,3 +201,56 @@ test(`${chalk.yellowBright("feature-grant-5: multiple promo codes on one reward"
 	expect(check2.allowed).toBe(true);
 	expect(check2.balance).toBe(25);
 });
+
+test(`${chalk.yellowBright("feature-grant-6: add customer coupon requires promo code on selected reward")}`, async () => {
+	const customerId = "feature-grant-6";
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.featureGrant({
+				id: "feature-grant-6-messages",
+				entitlements: [{ feature_id: TestFeature.Messages, allowance: 10 }],
+				promoCodes: [{ code: "FG6_MESSAGES" }],
+			}),
+			s.featureGrant({
+				id: "feature-grant-6-words",
+				entitlements: [{ feature_id: TestFeature.Words, allowance: 100 }],
+				promoCodes: [{ code: "FG6_WORDS" }],
+			}),
+		],
+		actions: [],
+	});
+
+	try {
+		await autumnV1.post(
+			`/customers/${customerId}/coupons/feature-grant-6-messages`,
+			{ promo_code: "FG6_WORDS" },
+		);
+		throw new Error(
+			"Should have failed — promo code belongs to another reward",
+		);
+	} catch (error) {
+		expect(error).toBeInstanceOf(AutumnError);
+		expect((error as AutumnError).code).toBe(ErrCode.RewardNotFound);
+	}
+
+	const wordsAfterMismatch = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Words,
+	});
+	expect(wordsAfterMismatch.balance ?? 0).toBe(0);
+
+	await autumnV1.post(
+		`/customers/${customerId}/coupons/feature-grant-6-messages`,
+		{ promo_code: "FG6_MESSAGES" },
+	);
+
+	const messagesAfterMatch = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(messagesAfterMatch.allowed).toBe(true);
+	expect(messagesAfterMatch.balance).toBe(10);
+});

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -87,13 +87,16 @@ export class CusService {
 		axios,
 		customer_id,
 		coupon_id,
+		promo_code,
 	}: {
 		axios: AxiosInstance;
 		customer_id: string;
 		coupon_id: string;
+		promo_code?: string;
 	}) {
 		return await axios.post(
 			`/v1/customers/${customer_id}/coupons/${coupon_id}`,
+			promo_code ? { promo_code } : {},
 		);
 	}
 

--- a/vite/src/views/customers2/customer/components/AddCouponDialog.tsx
+++ b/vite/src/views/customers2/customer/components/AddCouponDialog.tsx
@@ -40,7 +40,6 @@ export const AddCouponDialog = ({
 	const [promoCodeSelected, setPromoCodeSelected] = useState<string | null>(
 		null,
 	);
-	const [promoCodeDialogOpen, setPromoCodeDialogOpen] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const axiosInstance = useAxiosInstance();
 
@@ -49,7 +48,6 @@ export const AddCouponDialog = ({
 	const resetSelection = () => {
 		setCouponSelected(null);
 		setPromoCodeSelected(null);
-		setPromoCodeDialogOpen(false);
 	};
 
 	const handleDialogOpenChange = (nextOpen: boolean) => {
@@ -62,10 +60,8 @@ export const AddCouponDialog = ({
 
 	const handleAddClicked = async () => {
 		if (!couponSelected) return;
-		if (couponSelected.type === RewardType.FeatureGrant && !promoCodeSelected) {
-			setPromoCodeDialogOpen(true);
+		if (couponSelected.type === RewardType.FeatureGrant && !promoCodeSelected)
 			return;
-		}
 
 		try {
 			setLoading(true);
@@ -76,7 +72,6 @@ export const AddCouponDialog = ({
 				promo_code: promoCodeSelected ?? undefined,
 			});
 			setOpen(false);
-			setPromoCodeDialogOpen(false);
 			await Promise.all([refetch(), cusRewardRefetch()]);
 			toast.success("Reward added to customer");
 			resetSelection();
@@ -106,121 +101,94 @@ export const AddCouponDialog = ({
 	);
 
 	return (
-		<>
-			<Dialog open={open} onOpenChange={handleDialogOpenChange}>
-				<DialogContent className="w-[400px] bg-card">
-					<DialogHeader>
-						<DialogTitle>Add Reward</DialogTitle>
-					</DialogHeader>
-					{getExistingCoupon() && (
-						<InfoBox variant="warning">
-							Reward {getExistingCoupon()?.name} already applied. Adding a new
-							one will replace the existing one.
-						</InfoBox>
-					)}
-					<div>
+		<Dialog open={open} onOpenChange={handleDialogOpenChange}>
+			<DialogContent className="w-[400px] bg-card">
+				<DialogHeader>
+					<DialogTitle>Add Reward</DialogTitle>
+				</DialogHeader>
+				{getExistingCoupon() && (
+					<InfoBox variant="warning">
+						Reward {getExistingCoupon()?.name} already applied. Adding a new one
+						will replace the existing one.
+					</InfoBox>
+				)}
+				<div className="space-y-3">
+					<Select
+						value={couponSelected?.internal_id}
+						onValueChange={(value) => {
+							const coupon = rewards.find(
+								(c: Reward) => c.internal_id === value,
+							);
+
+							if (!coupon) return;
+
+							setCouponSelected(coupon);
+							setPromoCodeSelected(null);
+						}}
+					>
+						<SelectTrigger className="w-full">
+							<SelectValue placeholder="Select Reward" />
+						</SelectTrigger>
+						<SelectContent>
+							{rewards && rewards.length > 0 ? (
+								rewards.map((coupon: Reward) => {
+									if (coupon.type === RewardType.FreeProduct) return null;
+									return (
+										<SelectItem
+											key={coupon.internal_id}
+											value={coupon.internal_id}
+										>
+											{coupon.name}
+										</SelectItem>
+									);
+								})
+							) : (
+								<SelectItem value="none" disabled>
+									No coupons found
+								</SelectItem>
+							)}
+						</SelectContent>
+					</Select>
+
+					{couponSelected?.type === RewardType.FeatureGrant && (
 						<Select
-							value={couponSelected?.internal_id}
-							onValueChange={(value) => {
-								const coupon = rewards.find(
-									(c: Reward) => c.internal_id === value,
-								);
-
-								if (!coupon) return;
-
-								setCouponSelected(coupon);
-								setPromoCodeSelected(null);
-								setPromoCodeDialogOpen(coupon.type === RewardType.FeatureGrant);
-							}}
+							value={promoCodeSelected || undefined}
+							onValueChange={setPromoCodeSelected}
 						>
 							<SelectTrigger className="w-full">
-								<SelectValue placeholder="Select Reward" />
+								<SelectValue placeholder="Select Promo Code" />
 							</SelectTrigger>
 							<SelectContent>
-								{rewards && rewards.length > 0 ? (
-									rewards.map((coupon: Reward) => {
-										if (coupon.type === RewardType.FreeProduct) return null;
-										return (
-											<SelectItem
-												key={coupon.internal_id}
-												value={coupon.internal_id}
-											>
-												{coupon.name}
-											</SelectItem>
-										);
-									})
+								{promoCodeOptions.length > 0 ? (
+									promoCodeOptions.map((promoCode) => (
+										<SelectItem key={promoCode.code} value={promoCode.code}>
+											{promoCode.code}
+										</SelectItem>
+									))
 								) : (
 									<SelectItem value="none" disabled>
-										No coupons found
+										No promo codes found
 									</SelectItem>
 								)}
 							</SelectContent>
 						</Select>
-					</div>
-					<DialogFooter>
-						<Button
-							variant="primary"
-							onClick={handleAddClicked}
-							disabled={!couponSelected}
-							isLoading={loading}
-						>
-							Add Reward
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
-
-			{couponSelected?.type === RewardType.FeatureGrant && (
-				<Dialog
-					open={promoCodeDialogOpen}
-					onOpenChange={setPromoCodeDialogOpen}
-				>
-					<DialogContent className="w-[400px] bg-card">
-						<DialogHeader>
-							<DialogTitle>Select Promo Code</DialogTitle>
-						</DialogHeader>
-						<div>
-							<Select
-								value={promoCodeSelected || undefined}
-								onValueChange={setPromoCodeSelected}
-							>
-								<SelectTrigger className="w-full">
-									<SelectValue placeholder="Select Promo Code" />
-								</SelectTrigger>
-								<SelectContent>
-									{promoCodeOptions.length > 0 ? (
-										promoCodeOptions.map((promoCode) => (
-											<SelectItem key={promoCode.code} value={promoCode.code}>
-												{promoCode.code}
-											</SelectItem>
-										))
-									) : (
-										<SelectItem value="none" disabled>
-											No promo codes found
-										</SelectItem>
-									)}
-								</SelectContent>
-							</Select>
-						</div>
-						<DialogFooter>
-							<Button
-								variant="secondary"
-								onClick={() => setPromoCodeDialogOpen(false)}
-							>
-								Back
-							</Button>
-							<Button
-								variant="primary"
-								onClick={handleAddClicked}
-								disabled={!promoCodeSelected}
-								isLoading={loading}
-							>
-								Add Reward
-							</Button>
-						</DialogFooter>
-					</DialogContent>
-				</Dialog>
-			)}
-		</>
+					)}
+				</div>
+				<DialogFooter>
+					<Button
+						variant="primary"
+						onClick={handleAddClicked}
+						disabled={
+							!couponSelected ||
+							(couponSelected.type === RewardType.FeatureGrant &&
+								!promoCodeSelected)
+						}
+						isLoading={loading}
+					>
+						Add Reward
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
 	);
 };

--- a/vite/src/views/customers2/customer/components/AddCouponDialog.tsx
+++ b/vite/src/views/customers2/customer/components/AddCouponDialog.tsx
@@ -37,13 +37,35 @@ export const AddCouponDialog = ({
 	const { customer, refetch } = useCusQuery();
 
 	const [couponSelected, setCouponSelected] = useState<Reward | null>(null);
+	const [promoCodeSelected, setPromoCodeSelected] = useState<string | null>(
+		null,
+	);
+	const [promoCodeDialogOpen, setPromoCodeDialogOpen] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const axiosInstance = useAxiosInstance();
 
 	const { rewards } = useRewardsQuery();
 
+	const resetSelection = () => {
+		setCouponSelected(null);
+		setPromoCodeSelected(null);
+		setPromoCodeDialogOpen(false);
+	};
+
+	const handleDialogOpenChange = (nextOpen: boolean) => {
+		if (!nextOpen) {
+			resetSelection();
+		}
+
+		setOpen(nextOpen);
+	};
+
 	const handleAddClicked = async () => {
 		if (!couponSelected) return;
+		if (couponSelected.type === RewardType.FeatureGrant && !promoCodeSelected) {
+			setPromoCodeDialogOpen(true);
+			return;
+		}
 
 		try {
 			setLoading(true);
@@ -51,12 +73,13 @@ export const AddCouponDialog = ({
 				axios: axiosInstance,
 				customer_id: customer.id,
 				coupon_id: couponSelected.internal_id,
+				promo_code: promoCodeSelected ?? undefined,
 			});
 			setOpen(false);
+			setPromoCodeDialogOpen(false);
 			await Promise.all([refetch(), cusRewardRefetch()]);
 			toast.success("Reward added to customer");
-			// Reset selection after success
-			setCouponSelected(null);
+			resetSelection();
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to create coupon"));
 		} finally {
@@ -78,65 +101,126 @@ export const AddCouponDialog = ({
 
 	if (!rewards) return null;
 
+	const promoCodeOptions = (couponSelected?.promo_codes || []).filter(
+		(promoCode) => promoCode.code,
+	);
+
 	return (
-		<Dialog open={open} onOpenChange={setOpen}>
-			<DialogContent className="w-[400px] bg-card">
-				<DialogHeader>
-					<DialogTitle>Add Reward</DialogTitle>
-				</DialogHeader>
-				{getExistingCoupon() && (
-					<InfoBox variant="warning">
-						Reward {getExistingCoupon()?.name} already applied. Adding a new one
-						will replace the existing one.
-					</InfoBox>
-				)}
-				<div>
-					<Select
-						value={couponSelected?.internal_id}
-						onValueChange={(value) => {
-							const coupon = rewards.find(
-								(c: Reward) => c.internal_id === value,
-							);
-							if (coupon) {
+		<>
+			<Dialog open={open} onOpenChange={handleDialogOpenChange}>
+				<DialogContent className="w-[400px] bg-card">
+					<DialogHeader>
+						<DialogTitle>Add Reward</DialogTitle>
+					</DialogHeader>
+					{getExistingCoupon() && (
+						<InfoBox variant="warning">
+							Reward {getExistingCoupon()?.name} already applied. Adding a new
+							one will replace the existing one.
+						</InfoBox>
+					)}
+					<div>
+						<Select
+							value={couponSelected?.internal_id}
+							onValueChange={(value) => {
+								const coupon = rewards.find(
+									(c: Reward) => c.internal_id === value,
+								);
+
+								if (!coupon) return;
+
 								setCouponSelected(coupon);
-							}
-						}}
-					>
-						<SelectTrigger className="w-full">
-							<SelectValue placeholder="Select Reward" />
-						</SelectTrigger>
-						<SelectContent>
-							{rewards && rewards.length > 0 ? (
-								rewards.map((coupon: Reward) => {
-									if (coupon.type === RewardType.FreeProduct) return null;
-									return (
-										<SelectItem
-											key={coupon.internal_id}
-											value={coupon.internal_id}
-										>
-											{coupon.name}
+								setPromoCodeSelected(null);
+								setPromoCodeDialogOpen(coupon.type === RewardType.FeatureGrant);
+							}}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Select Reward" />
+							</SelectTrigger>
+							<SelectContent>
+								{rewards && rewards.length > 0 ? (
+									rewards.map((coupon: Reward) => {
+										if (coupon.type === RewardType.FreeProduct) return null;
+										return (
+											<SelectItem
+												key={coupon.internal_id}
+												value={coupon.internal_id}
+											>
+												{coupon.name}
+											</SelectItem>
+										);
+									})
+								) : (
+									<SelectItem value="none" disabled>
+										No coupons found
+									</SelectItem>
+								)}
+							</SelectContent>
+						</Select>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="primary"
+							onClick={handleAddClicked}
+							disabled={!couponSelected}
+							isLoading={loading}
+						>
+							Add Reward
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{couponSelected?.type === RewardType.FeatureGrant && (
+				<Dialog
+					open={promoCodeDialogOpen}
+					onOpenChange={setPromoCodeDialogOpen}
+				>
+					<DialogContent className="w-[400px] bg-card">
+						<DialogHeader>
+							<DialogTitle>Select Promo Code</DialogTitle>
+						</DialogHeader>
+						<div>
+							<Select
+								value={promoCodeSelected || undefined}
+								onValueChange={setPromoCodeSelected}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder="Select Promo Code" />
+								</SelectTrigger>
+								<SelectContent>
+									{promoCodeOptions.length > 0 ? (
+										promoCodeOptions.map((promoCode) => (
+											<SelectItem key={promoCode.code} value={promoCode.code}>
+												{promoCode.code}
+											</SelectItem>
+										))
+									) : (
+										<SelectItem value="none" disabled>
+											No promo codes found
 										</SelectItem>
-									);
-								})
-							) : (
-								<SelectItem value="none" disabled>
-									No coupons found
-								</SelectItem>
-							)}
-						</SelectContent>
-					</Select>
-				</div>
-				<DialogFooter>
-					<Button
-						variant="primary"
-						onClick={handleAddClicked}
-						disabled={!couponSelected}
-						isLoading={loading}
-					>
-						Add Reward
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+									)}
+								</SelectContent>
+							</Select>
+						</div>
+						<DialogFooter>
+							<Button
+								variant="secondary"
+								onClick={() => setPromoCodeDialogOpen(false)}
+							>
+								Back
+							</Button>
+							<Button
+								variant="primary"
+								onClick={handleAddClicked}
+								disabled={!promoCodeSelected}
+								isLoading={loading}
+							>
+								Add Reward
+							</Button>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
+			)}
+		</>
 	);
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds promo code redemption support for FeatureGrant rewards in the customer UI, requiring users to select a matching promo code before applying a FeatureGrant reward, and validates the behaviour with a new integration test.

- **Improvements** — `AddCouponDialog` now shows a second `Select` for promo codes when a `FeatureGrant` reward is chosen, guards the submit button until a valid code is selected, and properly resets all state on dialog close or success.
- **Improvements** — `CusService.addCouponToCustomer` accepts an optional `promo_code` parameter and forwards it in the POST body only when present.
- **Improvements** — Integration test `feature-grant-6` verifies that a mismatched promo code returns `RewardNotFound` and the correct code grants the expected entitlement balance.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new promo-code flow is correctly gated in both the UI and the service layer.

The new promo-code selection and state reset logic are sound. The only concerns are a minor timing gap where stale dialog state persists during an async refetch, and a small wire-format change (empty body vs no body) in CusService — neither affects correctness in typical usage.

AddCouponDialog.tsx is worth a quick second look for the resetSelection() ordering relative to the async refetch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts | Adds feature-grant-6 integration test validating that a mismatched promo code returns RewardNotFound and the correct code grants the entitlement. |
| vite/src/services/customers/CusService.tsx | Adds optional promo_code to addCouponToCustomer; now always sends a body (empty object {} vs no body previously). |
| vite/src/views/customers2/customer/components/AddCouponDialog.tsx | Adds promo code selection for FeatureGrant rewards; resetSelection() is invoked after an awaited refetch rather than immediately after setOpen(false). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant D as AddCouponDialog
    participant S as CusService
    participant API as Backend API

    U->>D: Select FeatureGrant reward
    D->>D: setCouponSelected(reward), setPromoCodeSelected(null)
    D-->>U: Show promo code Select

    U->>D: Select promo code
    D->>D: setPromoCodeSelected(code)
    D-->>U: Enable Add Reward button

    U->>D: Click Add Reward
    D->>D: setLoading(true)
    D->>S: "addCouponToCustomer({ customer_id, coupon_id, promo_code })"
    S->>API: "POST /v1/customers/{id}/coupons/{coupon_id} { promo_code }"
    API-->>S: 200 OK / 4xx Error
    alt Success
        S-->>D: Response OK
        D->>D: setOpen(false), resetSelection()
        D->>D: refetch() + cusRewardRefetch()
        D->>D: toast.success
    else Error
        S-->>D: throws AutumnError
        D->>D: toast.error(getBackendErr(...))
    end
    D->>D: setLoading(false)

    U->>D: Close dialog (ESC / backdrop)
    D->>D: "handleDialogOpenChange(false) -> resetSelection(), setOpen(false)"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/services/customers/CusService.tsx:97-100
Previously the endpoint was called with no request body. Now an empty object `{}` is always sent when `promo_code` is absent. For most Express/Hono servers this is harmless, but it changes the `Content-Type` header from absent to `application/json`. Omitting the second argument when there is no promo code keeps behaviour identical to the pre-PR state.

```suggestion
		return await axios.post(
			`/v1/customers/${customer_id}/coupons/${coupon_id}`,
			...(promo_code ? [{ promo_code }] : []),
		);
```

### Issue 2 of 2
vite/src/views/customers2/customer/components/AddCouponDialog.tsx:68-77
State reset happens after the awaited `refetch()` calls rather than immediately after `setOpen(false)`. If the parent re-opens the dialog before both fetches complete, the user will briefly see the previously-selected coupon and promo code still populated. Moving `resetSelection()` immediately after `setOpen(false)` eliminates this window.

```suggestion
			await CusService.addCouponToCustomer({
				axios: axiosInstance,
				customer_id: customer.id,
				coupon_id: couponSelected.internal_id,
				promo_code: promoCodeSelected ?? undefined,
			});
			setOpen(false);
			resetSelection();
			await Promise.all([refetch(), cusRewardRefetch()]);
			toast.success("Reward added to customer");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 misc fixes for rewards"](https://github.com/useautumn/autumn/commit/b9e19d5bcd7446948c86ee9d3603519abf6a3712) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31368977)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->