### PR TITLE
fix: import createAuthEndpoint from better-auth/api instead of better-auth/plugins

### DIFF
--- a/packages/autumn-js/src/better-auth/utils/createAutumnEndpoint.ts
+++ b/packages/autumn-js/src/better-auth/utils/createAutumnEndpoint.ts
@@ -1,4 +1,4 @@
-import { createAuthEndpoint } from "better-auth/plugins";
+import { createAuthEndpoint } from "better-auth/api";
 
 import { routeConfigs } from "../../backend/core/routes/routeConfigs";
 import type { RouteName } from "../../backend/core/types";


### PR DESCRIPTION
## Problem

`better-auth/plugins` no longer exports `createAuthEndpoint` in recent versions of better-auth. This causes a runtime error when using `autumn-js/better-auth` plugin:

```
Error: Cannot find module 'better-auth/plugins'
```

## Fix

Import `createAuthEndpoint` from `better-auth/api` instead, which is where it's exported in current better-auth versions.

## Impact

Without this fix, users on recent versions of better-auth (v1.x) cannot use the `autumn-js/better-auth` plugin. The published `autumn-js@1.2.2` package still contains the broken import, requiring consumers to apply a bun/npm patch as a workaround.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix import to use `better-auth/api` instead of `better-auth/plugins`, aligning with `better-auth` v1.x and removing runtime errors. Restores compatibility for the `autumn-js/better-auth` plugin without requiring consumer patches.

<sup>Written for commit 2887e03843d6e6e9212d1d5df500db05293c773c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a broken import of `createAuthEndpoint` in the `autumn-js/better-auth` plugin by updating the import source from `better-auth/plugins` to `better-auth/api`, which is where the function is currently exported in better-auth v1.x. This is a correct one-line fix confirmed by the official better-auth plugin documentation.

**Key Changes:**

- [Bug fixes] Updated the import of `createAuthEndpoint` in `createAutumnEndpoint.ts` from `better-auth/plugins` to `better-auth/api`, resolving a runtime `Cannot find module 'better-auth/plugins'` error that blocked users of `autumn-js@1.2.2` from using the `autumn-js/better-auth` plugin with recent better-auth versions.
</details>

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a correct one-line import path fix with no side effects.

The change is a single import path correction confirmed correct by the official better-auth documentation. No logic changes, no new dependencies, no risk of regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/autumn-js/src/better-auth/utils/createAutumnEndpoint.ts | Single-line import path fix: `createAuthEndpoint` moved from `better-auth/plugins` to `better-auth/api`, which is the correct export location in better-auth v1.x per the official documentation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[autumnPlugin initialized] --> B[createAutumnEndpoint called]
    B --> C{Import createAuthEndpoint}
    C -->|Before fix| D["better-auth/plugins ❌ Module not found"]
    C -->|After fix| E["better-auth/api ✅ Module resolved"]
    E --> F[Endpoint registered with better-auth]
    F --> G[Plugin works correctly]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: import createAuthEndpoint from bett..."](https://github.com/useautumn/autumn/commit/2887e03843d6e6e9212d1d5df500db05293c773c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26778697)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->