### PR TITLE
Fix type mismatch between autumn-js and autumn-js/react

### DIFF
--- a/packages/autumn-js/package.json
+++ b/packages/autumn-js/package.json
@@ -95,6 +95,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@useautumn/sdk": "workspace:*",
 		"query-string": "^9.2.2",
 		"rou3": "^0.6.1",
 		"zod": "^4.0.0"
@@ -105,7 +106,6 @@
 		"@types/node": "^22.15.32",
 		"@types/react": "^19",
 		"@typescript/native-preview": "catalog:",
-		"@useautumn/sdk": "workspace:*",
 		"esbuild-plugin-path-alias": "^1.0.7",
 		"hono": "^4.7.9",
 		"next": "^15.2.3",

--- a/packages/autumn-js/tsup.config.ts
+++ b/packages/autumn-js/tsup.config.ts
@@ -7,11 +7,7 @@ import { defineConfig, type Options } from "tsup";
 const pathAliases = {
 	"@": path.resolve("./src/libraries/react"),
 	"@sdk": path.resolve("./src/sdk"),
-	"@useautumn/sdk": path.resolve("../sdk/src"),
 };
-
-// Packages to bundle (not external) - workspace packages that should be inlined
-const noExternal = ["@useautumn/sdk"];
 
 const reactConfigs: Options[] = [
 	// New Backend (src/backend)
@@ -22,7 +18,6 @@ const reactConfigs: Options[] = [
 		clean: false,
 		outDir: "./dist/backend",
 		external: ["react", "react/jsx-runtime", "react-dom", "next", "hono"],
-		noExternal,
 		bundle: true,
 		skipNodeModulesBundle: true,
 		esbuildOptions(options) {
@@ -42,7 +37,6 @@ const reactConfigs: Options[] = [
 		clean: false,
 		outDir: "./dist/better-auth",
 		external: ["better-auth", "better-call"],
-		noExternal,
 		bundle: true,
 		skipNodeModulesBundle: true,
 		esbuildOptions(options) {
@@ -62,7 +56,7 @@ const reactConfigs: Options[] = [
 		clean: false,
 		outDir: "./dist/react",
 		external: ["react", "react/jsx-runtime", "react-dom"],
-		noExternal: [...noExternal, "@tanstack/react-query"],
+		noExternal: ["@tanstack/react-query"],
 		bundle: true,
 		skipNodeModulesBundle: false,
 		banner: {
@@ -86,7 +80,6 @@ export default defineConfig([
 		format: ["cjs", "esm"],
 		entry: ["./src/sdk/index.ts"],
 		skipNodeModulesBundle: true,
-		noExternal,
 		dts: true,
 		shims: true,
 		clean: false,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,6 +19,12 @@
       "./*": "./src/*.ts"
     }
   },
+  "files": [
+    "dist",
+    "src",
+    "FUNCTIONS.md",
+    "RUNTIMES.md"
+  ],
   "sideEffects": false,
   "scripts": {
     "lint": "eslint --cache --max-warnings=0 src",


### PR DESCRIPTION
## Problem

When you import types from both `autumn-js` and `autumn-js/react`, TypeScript thinks they're different types — even though they're structurally identical. (#1143)

```typescript
import type { Customer } from "autumn-js";
import { useCustomer } from "autumn-js/react";

const { data } = useCustomer();

// ❌ TS error: Type 'Customer' is not assignable to type 'Customer'
// "Two different types with this name exist, but they are unrelated"
const customer: Customer = data;
```

**Repro:** https://github.com/ramadanomar/autumn-type-repro (`main` branch has the bug, `fix/sdk-type-mismatch` branch has the fix applied)

## Root cause

tsup bundles `@useautumn/sdk` separately into each entry point (sdk, react, backend). Each copy gets its own `declare const __brand: unique symbol`. Since `unique symbol` is nominal in TypeScript, the two copies of `__brand` are different types — which breaks every type that uses `OpenEnum` (`Customer`, `Plan`, `Balance`, etc.).

## Fix

Make `@useautumn/sdk` a real dependency instead of inlining it. All entry points then import from the same package — one `__brand`, one type identity.

**3 changes:**
- `packages/autumn-js/package.json` — move `@useautumn/sdk` from devDependencies to dependencies
- `packages/autumn-js/tsup.config.ts` — remove `@useautumn/sdk` from `noExternal` and path aliases
- `packages/sdk/package.json` — add `files` field so `bun pm pack` includes `dist/`

**Requires:** publishing `@useautumn/sdk` to npm before the next `autumn-js` release.

## Benefits

- Permanently fixes the type mismatch — no workarounds needed
- Smaller published bundle (SDK code no longer duplicated across every entry)
- Standard approach — this is how `@tanstack/react-query` depends on `@tanstack/query-core`, how `@trpc/react-query` depends on `@trpc/client`, etc.

## Trade-offs

- `@useautumn/sdk` needs to be published to npm (it's already versioned at 0.10.17 and set up for publishing)
- Consumers get it as a transitive dependency (it's small — only depends on `zod`)
- Publishing order matters: SDK first, then autumn-js

## Test plan

- [x] `bun run build` succeeds in `packages/autumn-js`
- [x] Zero `declare const __brand: unique symbol` duplicates in `dist/`
- [x] All react/backend `.d.ts` files import from `@useautumn/sdk` instead of inlining
- [x] Type repro project passes `tsc --noEmit` with zero errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TypeScript type mismatch between `autumn-js` and `autumn-js/react` by using a single shared `@useautumn/sdk` package. Branded types now match across all entry points and SDK code is no longer duplicated.

- **Dependencies**
  - Moved `@useautumn/sdk` to `dependencies` in `autumn-js` and stopped bundling it via `tsup` (removed alias and `noExternal` entries).
  - Added `files` to `@useautumn/sdk` so `dist/` is included in the published package.

- **Migration**
  - Publish `@useautumn/sdk` to npm before releasing `autumn-js`.

<sup>Written for commit 5d1039b76730189f0835d9405c9793b5b8d9c108. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a TypeScript nominal type mismatch between `autumn-js` and `autumn-js/react` caused by tsup inlining `@useautumn/sdk` separately into each entry point, producing duplicate `declare const __brand: unique symbol` declarations that TypeScript considers structurally incompatible. The fix converts `@useautumn/sdk` from a dev-time inlined bundle into a proper published runtime dependency, so all entry points share a single type identity.

**Key changes:**

- **[Bug fix]** `packages/autumn-js/package.json` — moves `@useautumn/sdk` from `devDependencies` to `dependencies` with `workspace:*`, so it becomes a published transitive dependency of `autumn-js`. The `workspace:*` specifier is correctly resolved to the actual version by bun/pnpm during `publish`/`pack`.

- **[Bug fix / Improvements]** `packages/autumn-js/tsup.config.ts` — removes `@useautumn/sdk` from `noExternal` across all entry-point configs (backend, better-auth, react, main SDK) and removes the local path alias that pointed to `../sdk/src`. For configs with `skipNodeModulesBundle: true` (backend, better-auth, main SDK), this makes `@useautumn/sdk` a true external reference in both JS and `.d.ts` outputs. For the react config (`skipNodeModulesBundle: false`), removing it from `noExternal` stops tsup's declaration bundler (rollup-plugin-dts) from inlining the SDK types, so `dist/react/index.d.ts` now references `@useautumn/sdk` instead of embedding its own copy of `__brand`.

- **[Improvements]** `packages/sdk/package.json` — adds the `files` field (`dist`, `src`, `FUNCTIONS.md`, `RUNTIMES.md`), which is a prerequisite for `@useautumn/sdk` to be publishable to npm at all. Without this, `bun pm pack` would produce an empty tarball.

**Operational note:** `@useautumn/sdk` must be published to npm *before* the next `autumn-js` release, as noted in the PR description. CI/CD pipelines should enforce this publishing order.
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge once the publishing-order requirement is documented in the release process; no code correctness issues found.
- The three changes are well-scoped, follow standard monorepo patterns (TanStack Query, tRPC), and the author has verified the fix with a standalone tsc repro. The one risk is operational: autumn-js consumers will fail to install the package if @useautumn/sdk is published to npm after autumn-js. This isn't a code bug but is an external process dependency that merits attention before the release.
- packages/autumn-js/package.json — confirm the workspace:* → resolved-version substitution happens correctly in the actual publish pipeline (bun publish / pnpm publish).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/autumn-js/package.json | Moves @useautumn/sdk from devDependencies to dependencies so it's a published runtime dependency, which is the core fix for the type identity issue. |
| packages/autumn-js/tsup.config.ts | Removes @useautumn/sdk from noExternal and path alias across all entry-point configs, so declaration files reference the package rather than inlining its types (and thus its unique symbol). |
| packages/sdk/package.json | Adds a files field so that bun pm pack/npm publish correctly includes dist/ and src/ in the published tarball — without this, the package would be published empty. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Consumer imports<br/><code>autumn-js</code>"] --> B["dist/sdk/index.d.ts"]
    C["Consumer imports<br/><code>autumn-js/react</code>"] --> D["dist/react/index.d.ts"]
    E["Consumer imports<br/><code>autumn-js/backend</code>"] --> F["dist/backend/index.d.ts"]

    subgraph BEFORE["❌ Before (noExternal inlines SDK)"]
        B1["dist/sdk — inlines<br/>declare const __brand: unique symbol (copy 1)"]
        D1["dist/react — inlines<br/>declare const __brand: unique symbol (copy 2)"]
        F1["dist/backend — inlines<br/>declare const __brand: unique symbol (copy 3)"]
        B1 -.->|"TS error: types are<br/>nominally incompatible"| D1
    end

    subgraph AFTER["✅ After (SDK is external dependency)"]
        B2["dist/sdk/index.d.ts<br/>re-exports from @useautumn/sdk"]
        D2["dist/react/index.d.ts<br/>imports from @useautumn/sdk"]
        F2["dist/backend/index.d.ts<br/>imports from @useautumn/sdk"]
        G["@useautumn/sdk<br/>declare const __brand: unique symbol (one copy)"]
        B2 --> G
        D2 --> G
        F2 --> G
    end

    B --> B2
    D --> D2
    E --> F2
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve type mismatch between autum..."](https://github.com/useautumn/autumn/commit/5d1039b76730189f0835d9405c9793b5b8d9c108) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27168835)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->