### PR TITLE
fix: pass currency to atmnToStripeAmount in proration invoice line items

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams.ts
@@ -35,11 +35,11 @@ const toStripeCreateInvoiceItemParams = ({
 
 		amount: shouldUsePriceData
 			? undefined
-			: atmnToStripeAmount({ amount: lineAmount }),
+			: atmnToStripeAmount({ amount: lineAmount, currency }),
 
 		price_data: shouldUsePriceData
 			? {
-					unit_amount: atmnToStripeAmount({ amount: lineAmount }),
+					unit_amount: atmnToStripeAmount({ amount: lineAmount, currency }),
 					currency,
 					product: stripeProductId,
 				}

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToInvoiceAddLinesParams.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToInvoiceAddLinesParams.ts
@@ -28,10 +28,10 @@ const toStripeAddLineParams = ({
 		description,
 		amount: shouldUsePriceData
 			? undefined
-			: atmnToStripeAmount({ amount: lineAmount }),
+			: atmnToStripeAmount({ amount: lineAmount, currency }),
 		price_data: shouldUsePriceData
 			? {
-					unit_amount: atmnToStripeAmount({ amount: lineAmount }),
+					unit_amount: atmnToStripeAmount({ amount: lineAmount, currency }),
 					currency,
 					product: stripeProductId,
 				}


### PR DESCRIPTION
## Summary

Zero-decimal currencies (e.g. JPY, KRW) were being charged 100x the correct amount on proration invoices during plan upgrades.

## Root Cause

In `lineItemsToInvoiceAddLinesParams.ts` and `lineItemsToCreateInvoiceItemsParams.ts`, the `atmnToStripeAmount()` calls for the `amount` field did not pass a `currency` parameter. Without it, `atmnToStripeAmount` defaults to assuming USD (a non-zero-decimal currency) and multiplies the amount by 100.

The `currency` was already destructured from `lineItem.context` and correctly passed inside `price_data`, but the standalone `amount` field (used when `shouldUsePriceData` is false, e.g. for negative/credit line items) was missing it.

## Fix

Pass `currency` to all `atmnToStripeAmount()` calls in both files:

- `lineItemsToInvoiceAddLinesParams.ts` — lines 31, 34
- `lineItemsToCreateInvoiceItemsParams.ts` — lines 38, 42

Changed from:
```ts
atmnToStripeAmount({ amount: lineAmount })
```
To:
```ts
atmnToStripeAmount({ amount: lineAmount, currency })
```

## Impact

This fixes proration invoices for all zero-decimal currencies (JPY, KRW, VND, etc.) where upgrade charges were being inflated by 100x.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated proration charges for zero-decimal currencies by passing the currency to `atmnToStripeAmount`. Prevents 100x overcharges on plan upgrades (e.g., JPY, KRW, VND).

- **Bug Fixes**
  - Pass `currency` to `atmnToStripeAmount` for `amount` and `price_data.unit_amount` in `lineItemsToInvoiceAddLinesParams.ts` and `lineItemsToCreateInvoiceItemsParams.ts`.
  - Corrects amounts when `shouldUsePriceData` is false (e.g., credits/negative lines).

<sup>Written for commit fc5dc30db2d355907f31ecfdde0f8f3d0452586a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a critical billing bug where zero-decimal currencies (e.g. JPY, KRW, VND) were being charged 100× the correct amount on proration invoices. The root cause was that `atmnToStripeAmount()` was called without a `currency` argument, causing it to default to USD behaviour and always multiply by 100, even for currencies that Stripe expects as whole numbers.

**Key changes:**

- **Bug fixes** — `lineItemsToInvoiceAddLinesParams.ts`: Pass `currency` to both `atmnToStripeAmount` calls (`amount` field and `price_data.unit_amount`), ensuring the zero-decimal currency check in `atmnToStripeAmount` fires correctly.
- **Bug fixes** — `lineItemsToCreateInvoiceItemsParams.ts`: Same fix applied — `currency` is now forwarded to both `atmnToStripeAmount` call sites, covering both the standalone `amount` path (used for negative/credit line items) and the `price_data` path.
</details>

<h3>Confidence Score: 5/5</h3>

- Safe to merge — minimal, targeted fix with no side-effects for non-zero-decimal currencies.
- The change is a one-parameter addition across 4 call sites. The `atmnToStripeAmount` function already handles the `currency` parameter correctly (it's an optional arg defaulting to `"USD"`), so passing the already-destructured `currency` value simply enables the existing zero-decimal path. Non-zero-decimal currencies are unaffected since the multiplication by 100 still happens. The fix is consistent across both files and covers both code paths (`amount` and `price_data.unit_amount`).
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToInvoiceAddLinesParams.ts | Passes `currency` to both `atmnToStripeAmount` calls (amount and price_data.unit_amount), fixing 100x overcharge for zero-decimal currencies like JPY/KRW. |
| server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams.ts | Same fix applied here — `currency` now passed to both `atmnToStripeAmount` calls, ensuring zero-decimal currencies are handled correctly in invoice item creation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LineItem] --> B{shouldUsePriceData?}
    B -- "true (!isNegative && stripeProductId)" --> C["price_data.unit_amount\natmnToStripeAmount({ amount, currency })"]
    B -- "false (negative / no productId)" --> D["amount\natmnToStripeAmount({ amount, currency })"]
    C --> E{Zero-decimal currency?}
    D --> E
    E -- "Yes (JPY, KRW, VND...)" --> F[Return amount as-is]
    E -- "No (USD, EUR...)" --> G[Return amount × 100]
    F --> H[Stripe API]
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pass currency to atmnToStripeAmount..."](https://github.com/useautumn/autumn/commit/fc5dc30db2d355907f31ecfdde0f8f3d0452586a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27172730)</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->