### PR TITLE
fix/clear cache after stripe cus

### DIFF
--- a/apps/docs/mintlify/documentation/modelling-pricing/proration.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/proration.mdx
@@ -93,12 +93,59 @@ When a customer switches between plans (upgrade or downgrade), Autumn prorates a
 <Info>
 **Example**
 
-A customer is on a $20/month plan and upgrades to a $50/month plan on day 15 of a 30-day cycle.
+A customer is on a \$20/month plan and upgrades to a \$50/month plan on day 15 of a 30-day cycle.
 
 - Old plan credit: $20 × (15/30) = $10 credit
 - New plan charge: $50 × (15/30) = $25 charge
 - Net charge: $25 - $10 = **$15**
 </Info>
+
+### Controlling proration in attach
+
+By default, plan switches prorate immediately. You can override this behavior using the `proration_behavior` parameter in `billing.attach`:
+
+| Value | Behavior |
+|-------|----------|
+| `prorate_immediately` | **(default)** Charges or credits the prorated difference immediately |
+| `none` | Skips proration — no charges or credits are created for the plan change |
+
+<CodeGroup>
+```typescript TypeScript
+await autumn.billing.attach({
+  customerId: "user_123",
+  planId: "enterprise",
+  prorationBehavior: "none",
+});
+```
+
+```python Python
+autumn.billing.attach(
+  customer_id="user_123",
+  plan_id="enterprise",
+  proration_behavior="none",
+)
+```
+
+```bash cURL
+curl -X POST https://api.useautumn.com/v2/billing/attach \
+  -H "Authorization: Bearer am_sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "user_123",
+    "plan_id": "enterprise",
+    "proration_behavior": "none"
+  }'
+```
+</CodeGroup>
+
+<Warning>
+`proration_behavior: "none"` cannot be used when:
+- Upgrading from a **free** plan to a **paid** plan
+- Removing an active **free trial**
+- Any transition that would result in a new charge
+
+In these cases, Autumn requires immediate billing and will return an error.
+</Warning>
 
 ## Usage-based proration
 

--- a/apps/docs/mintlify/documentation/modelling-pricing/proration.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/proration.mdx
@@ -147,6 +147,23 @@ curl -X POST https://api.useautumn.com/v2/billing/attach \
 In these cases, Autumn requires immediate billing and will return an error.
 </Warning>
 
+### Custom line items
+
+If you need full control over what the customer is charged during a plan switch, you can pass `custom_line_items` to replace the auto-generated proration invoice entirely. This is only valid for immediate plan changes (e.g. upgrades).
+
+```typescript
+await autumn.billing.attach({
+  customerId: "user_123",
+  planId: "enterprise",
+  customLineItems: [
+    { amount: 25, description: "Prorated upgrade credit" },
+    { amount: -10, description: "Loyalty discount" },
+  ],
+});
+```
+
+When `custom_line_items` is provided, Autumn skips its own proration calculation and creates an invoice with exactly the line items you specified. Amounts can be negative to represent credits.
+
 ## Usage-based proration
 
 For usage-based prices, when a plan change occurs mid-cycle:

--- a/server/src/external/stripe/customers/operations/createStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/createStripeCustomer.ts
@@ -1,5 +1,6 @@
-import type { Customer } from "@autumn/shared";
+import { type Customer, shouldForwardCustomerMetadata } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli";
+import { autumnToStripeCustomerMetadata } from "@/external/stripe/customers/utils/autumnToStripeMetadata";
 import { buildStripeCustomerIdempotencyKey } from "@/external/stripe/customers/utils/buildIdempotencyKey";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ExpandedStripeCustomer } from "./getExpandedStripeCustomer";
@@ -23,6 +24,10 @@ export const createStripeCustomer = async ({
 		customerId: customer.id || customer.internal_id,
 	});
 
+	const forwardCustomerMetadata = shouldForwardCustomerMetadata({
+		org: ctx.org,
+	});
+
 	const stripeCustomer = await stripeCli.customers.create(
 		{
 			name: customer.name || undefined,
@@ -30,6 +35,8 @@ export const createStripeCustomer = async ({
 			metadata: {
 				autumn_id: customer.id || null,
 				autumn_internal_id: customer.internal_id,
+				...(forwardCustomerMetadata &&
+					autumnToStripeCustomerMetadata({ metadata: customer.metadata })),
 			},
 			test_clock: options.testClockId,
 			expand: [

--- a/server/src/external/stripe/customers/utils/autumnToStripeMetadata.ts
+++ b/server/src/external/stripe/customers/utils/autumnToStripeMetadata.ts
@@ -1,0 +1,34 @@
+const STRIPE_MAX_KEYS = 48; // leave 2 slots for autumn_id + autumn_internal_id
+const STRIPE_MAX_KEY_LENGTH = 40;
+const STRIPE_MAX_VALUE_LENGTH = 500;
+
+/**
+ * Safely converts Autumn metadata (Record<string, any>) to Stripe-compatible
+ * metadata (Record<string, string>), respecting Stripe's limits.
+ */
+export const autumnToStripeCustomerMetadata = ({
+	metadata,
+}: {
+	metadata: Record<string, unknown> | null | undefined;
+}): Record<string, string> => {
+	if (!metadata) return {};
+
+	const result: Record<string, string> = {};
+	let count = 0;
+
+	for (const [key, value] of Object.entries(metadata)) {
+		if (count >= STRIPE_MAX_KEYS) break;
+		if (key.startsWith("autumn_")) continue;
+		if (value === undefined || value === null) continue;
+
+		const stripeKey = key.slice(0, STRIPE_MAX_KEY_LENGTH);
+
+		const stripeValue =
+			typeof value === "object" ? JSON.stringify(value) : String(value);
+
+		result[stripeKey] = stripeValue.slice(0, STRIPE_MAX_VALUE_LENGTH);
+		count++;
+	}
+
+	return result;
+};

--- a/server/src/external/stripe/customers/utils/autumnToStripeMetadata.ts
+++ b/server/src/external/stripe/customers/utils/autumnToStripeMetadata.ts
@@ -1,5 +1,5 @@
 const STRIPE_MAX_KEYS = 48; // leave 2 slots for autumn_id + autumn_internal_id
-const STRIPE_MAX_KEY_LENGTH = 40;
+export const STRIPE_MAX_KEY_LENGTH = 40;
 const STRIPE_MAX_VALUE_LENGTH = 500;
 
 /**

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus.ts
@@ -16,24 +16,37 @@ import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/
 import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { trackCustomerProductUpdate } from "../../../common/trackCustomerProductUpdate";
-import type { StripeSubscriptionUpdatedContext } from "../../stripeSubscriptionUpdatedContext";
+import type {
+	StripeSubscriptionUpdatedContext,
+	SubscriptionPreviousAttributes,
+} from "../../stripeSubscriptionUpdatedContext";
 import { fixUnexpectedStatuses } from "./fixUnexpectedStatuses";
 
 /**
  * In cases where a manual invoice was created due to an upgrade, we don't want to treat it as a past due.
+ * Only applies when the subscription just transitioned to past_due from a healthy state.
+ * If the sub was already past_due before this event, it's a real past_due.
  */
 const handleFalsePositivePastDue = async ({
 	ctx,
 	stripeSubscription,
 	autumnStatus,
+	previousAttributes,
 }: {
 	ctx: StripeWebhookContext;
 	stripeSubscription: ExpandedStripeSubscription;
 	autumnStatus: CusProductStatus;
+	previousAttributes: SubscriptionPreviousAttributes;
 }): Promise<CusProductStatus> => {
 	if (!isStripeSubscriptionPastDue(stripeSubscription)) return autumnStatus;
 
-	// const latestInvoice = await get
+	// If the status didn't change in this event or was already past_due,
+	// the subscription was genuinely past_due — don't override.
+	const wasAlreadyPastDue =
+		previousAttributes.status === undefined ||
+		previousAttributes.status === "past_due";
+	if (wasAlreadyPastDue) return autumnStatus;
+
 	const latestInvoice = await getStripeInvoice({
 		stripeClient: ctx.stripeCli,
 		invoiceId: stripeSubscription.latest_invoice,
@@ -70,8 +83,12 @@ export const syncCustomerProductStatus = async ({
 	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
 }): Promise<void> => {
 	const { db, logger, org, env } = ctx;
-	const { stripeSubscription, customerProducts, fullCustomer } =
-		subscriptionUpdatedContext;
+	const {
+		stripeSubscription,
+		customerProducts,
+		fullCustomer,
+		previousAttributes,
+	} = subscriptionUpdatedContext;
 
 	// Map Stripe status to Autumn status
 	let autumnStatus = stripeSubscriptionToAutumnStatus({
@@ -82,6 +99,7 @@ export const syncCustomerProductStatus = async ({
 		ctx,
 		stripeSubscription,
 		autumnStatus,
+		previousAttributes,
 	});
 
 	// Don't transition autumn status to past_due if the stripe invoice has metadata: autumn_billing_update, and invoice_mode is false.

--- a/server/src/honoMiddlewares/refreshCacheMiddleware.ts
+++ b/server/src/honoMiddlewares/refreshCacheMiddleware.ts
@@ -39,6 +39,14 @@ const cusPrefixedUrls = [
 		method: "POST",
 		url: "/customers/:customer_id/transfer",
 	},
+	{
+		method: "POST",
+		url: "/customers/:customer_id/billing_portal",
+	},
+	{
+		method: "GET",
+		url: "/customers/:customer_id/billing_portal",
+	},
 ];
 
 /**
@@ -90,6 +98,10 @@ const coreUrls: { method: string; url: string; source?: string }[] = [
 		method: "POST",
 		url: "/billing.multi_attach",
 		source: "multiAttach",
+	},
+	{
+		method: "POST",
+		url: "/billing.open_customer_portal",
 	},
 
 	// BALANCES

--- a/server/src/internal/balances/autoTopUp/helpers/limits/recordAutoTopupAttempt.ts
+++ b/server/src/internal/balances/autoTopUp/helpers/limits/recordAutoTopupAttempt.ts
@@ -19,8 +19,10 @@ export const recordAutoTopupAttempt = async ({
 }) => {
 	const now = Date.now();
 	const { limitState: state, autoTopupConfig } = autoTopupContext;
+	const invoiceStatus = billingResult.stripe?.stripeInvoice?.status;
+	const isInvoiceMode = Boolean(autoTopupContext.invoiceMode);
 	const outcome =
-		billingResult.stripe?.stripeInvoice?.status === "paid"
+		invoiceStatus === "paid" || (isInvoiceMode && invoiceStatus === "open")
 			? "success"
 			: "failure";
 

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleFeatureQuantityErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleFeatureQuantityErrors.ts
@@ -1,86 +1,25 @@
-import type {
-	AutumnBillingPlan,
-	UpdateSubscriptionBillingContext,
-	UpdateSubscriptionV1Params,
-} from "@autumn/shared";
+import type { AutumnBillingPlan } from "@autumn/shared";
 import {
 	cusProductToPrices,
 	ErrCode,
+	isOneOffPrice,
 	isPrepaidPrice,
-	nullish,
-	priceToFeature,
 	RecaseError,
 	type UsagePriceConfig,
 } from "@autumn/shared";
-import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { billingPlanToNewActiveCustomerProduct } from "@/internal/billing/v2/utils/billingPlan/billingPlanToNewActiveCustomerProduct";
-
-const checkInputFeatureQuantitiesAreValid = ({
-	ctx,
-	params,
-	autumnBillingPlan,
-	billingContext,
-}: {
-	ctx: AutumnContext;
-	params: UpdateSubscriptionV1Params;
-	autumnBillingPlan: AutumnBillingPlan;
-	billingContext: UpdateSubscriptionBillingContext;
-}) => {
-	const targetCustomerProduct =
-		billingPlanToNewActiveCustomerProduct({
-			autumnBillingPlan,
-		}) ?? billingContext.customerProduct;
-
-	if (!targetCustomerProduct) return;
-
-	const prepaidPrices = cusProductToPrices({
-		cusProduct: targetCustomerProduct,
-	}).filter(isPrepaidPrice);
-
-	for (const option of params.feature_quantities ?? []) {
-		if (nullish(option.quantity)) continue;
-
-		const targetPrepaidPrice = prepaidPrices.find((p) => {
-			const priceFeature = priceToFeature({
-				price: p,
-				features: ctx.features,
-				errorOnNotFound: false,
-			});
-			return priceFeature?.id === option.feature_id;
-		});
-
-		if (!targetPrepaidPrice) {
-			throw new RecaseError({
-				message: `Invalid feature quantity passed in (feature ID: ${option.feature_id}). This feature has no prepaid price on the updated product.`,
-			});
-		}
-	}
-};
 
 export const handleFeatureQuantityErrors = ({
-	ctx,
-	billingContext,
 	autumnBillingPlan,
-	params,
 }: {
-	ctx: AutumnContext;
-	billingContext: UpdateSubscriptionBillingContext;
 	autumnBillingPlan: AutumnBillingPlan;
-	params: UpdateSubscriptionV1Params;
 }) => {
-	// 1. Check if param feature IDs are valid
-	checkInputFeatureQuantitiesAreValid({
-		ctx,
-		autumnBillingPlan,
-		billingContext,
-		params,
-	});
-
 	const newCustomerProduct = autumnBillingPlan.insertCustomerProducts?.[0];
 	if (!newCustomerProduct) return;
 
 	const newPrices = cusProductToPrices({ cusProduct: newCustomerProduct });
-	const prepaidPrices = newPrices.filter(isPrepaidPrice);
+	const prepaidPrices = newPrices.filter(
+		(p) => isPrepaidPrice(p) && !isOneOffPrice(p),
+	);
 
 	if (prepaidPrices.length === 0) return;
 

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -46,12 +46,9 @@ export const handleUpdateSubscriptionErrors = async ({
 	// 2. Product type transition errors
 	handleProductTypeTransitionErrors({ billingContext, autumnBillingPlan });
 
-	// 3. Feature quantity errors (prepaid prices must have options)
+	// 3. Feature quantity errors (recurring prepaid prices must have options)
 	handleFeatureQuantityErrors({
-		ctx,
-		billingContext,
 		autumnBillingPlan,
-		params,
 	});
 
 	// 4. Custom plan errors

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -10,7 +10,6 @@ import { handleExternalPSPErrors } from "@/internal/billing/v2/common/errors/han
 import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
 import { handleCurrentCustomerProductErrors } from "./handleCurrentCustomerProductErrors";
 import { handleCustomPlanErrors } from "./handleCustomPlanErrors";
-import { handleFeatureQuantityErrors } from "./handleFeatureQuantityErrors";
 import {
 	checkTrialRemovalWithOneOffItems,
 	handleOneOffErrors,
@@ -46,10 +45,10 @@ export const handleUpdateSubscriptionErrors = async ({
 	// 2. Product type transition errors
 	handleProductTypeTransitionErrors({ billingContext, autumnBillingPlan });
 
-	// 3. Feature quantity errors (recurring prepaid prices must have options)
-	handleFeatureQuantityErrors({
-		autumnBillingPlan,
-	});
+	// // 3. Feature quantity errors (recurring prepaid prices must have options)
+	// handleFeatureQuantityErrors({
+	// 	autumnBillingPlan,
+	// });
 
 	// 4. Custom plan errors
 	handleCustomPlanErrors({ ctx, billingContext, autumnBillingPlan, params });

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -5,10 +5,12 @@ import {
 	notNullish,
 	ProcessorType,
 	RecaseError,
+	shouldForwardCustomerMetadata,
 	type UpdateCustomerParamsV1,
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
+import { autumnToStripeCustomerMetadata } from "@/external/stripe/customers/utils/autumnToStripeMetadata";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusService } from "@/internal/customers/CusService";
 import { updateCachedCustomerData } from "../../cusUtils/fullCustomerCacheUtils/updateCachedCustomerData";
@@ -76,14 +78,26 @@ export const updateCustomer = async ({
 		);
 	}
 
-	// Check if customer email is being changed
 	const oldMetadata = originalCustomer.metadata || {};
 	const newMetadata = newCusData.metadata || {};
+	const deletedMetadataKeys: string[] = [];
 	for (const key in newMetadata) {
 		if (newMetadata[key] === null) {
+			deletedMetadataKeys.push(key);
 			delete newMetadata[key];
 			delete oldMetadata[key];
 		}
+	}
+	const mergedMetadata = { ...oldMetadata, ...newMetadata };
+
+	const hasMetadataChanges =
+		Object.keys(newMetadata).length > 0 || deletedMetadataKeys.length > 0;
+	const forwardMetadata =
+		shouldForwardCustomerMetadata({ org }) && hasMetadataChanges;
+
+	const stripeMetadataDeletions: Record<string, ""> = {};
+	for (const key of deletedMetadataKeys) {
+		if (!key.startsWith("autumn_")) stripeMetadataDeletions[key] = "";
 	}
 
 	const stripeUpdate: Stripe.CustomerUpdateParams = {
@@ -96,6 +110,12 @@ export const updateCustomer = async ({
 			originalCustomer.name !== newCusData.name && notNullish(newCusData.name)
 				? newCusData.name
 				: undefined,
+		...(forwardMetadata && {
+			metadata: {
+				...autumnToStripeCustomerMetadata({ metadata: mergedMetadata }),
+				...stripeMetadataDeletions,
+			},
+		}),
 	};
 
 	if (Object.keys(stripeUpdate).length > 0 && stripeId) {
@@ -107,10 +127,7 @@ export const updateCustomer = async ({
 	const updateData: Partial<Customer> = {
 		...newCusData,
 		id: newCustomerId,
-		metadata: {
-			...oldMetadata,
-			...newMetadata,
-		},
+		metadata: mergedMetadata,
 		...(billing_controls && {
 			auto_topups: billing_controls.auto_topups,
 			spend_limits: billing_controls.spend_limits,

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -127,17 +127,24 @@ export const updateCustomer = async ({
 		await stripeCli.customers.update(stripeId, stripeUpdate);
 	}
 
-	// Prepare update data
+	// Prepare update data — only include defined billing control fields
+	const billingControlUpdates: Partial<Customer> = {};
+	if (billing_controls) {
+		if (billing_controls.auto_topups !== undefined)
+			billingControlUpdates.auto_topups = billing_controls.auto_topups;
+		if (billing_controls.spend_limits !== undefined)
+			billingControlUpdates.spend_limits = billing_controls.spend_limits;
+		if (billing_controls.usage_alerts !== undefined)
+			billingControlUpdates.usage_alerts = billing_controls.usage_alerts;
+		if (billing_controls.overage_allowed !== undefined)
+			billingControlUpdates.overage_allowed = billing_controls.overage_allowed;
+	}
+
 	const updateData: Partial<Customer> = {
 		...newCusData,
 		id: newCustomerId,
 		metadata: mergedMetadata,
-		...(billing_controls && {
-			auto_topups: billing_controls.auto_topups,
-			spend_limits: billing_controls.spend_limits,
-			usage_alerts: billing_controls.usage_alerts,
-			overage_allowed: billing_controls.overage_allowed,
-		}),
+		...billingControlUpdates,
 	};
 
 	if (newStripeId) {

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -10,7 +10,10 @@ import {
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
-import { autumnToStripeCustomerMetadata } from "@/external/stripe/customers/utils/autumnToStripeMetadata";
+import {
+	autumnToStripeCustomerMetadata,
+	STRIPE_MAX_KEY_LENGTH,
+} from "@/external/stripe/customers/utils/autumnToStripeMetadata";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusService } from "@/internal/customers/CusService";
 import { updateCachedCustomerData } from "../../cusUtils/fullCustomerCacheUtils/updateCachedCustomerData";
@@ -97,7 +100,8 @@ export const updateCustomer = async ({
 
 	const stripeMetadataDeletions: Record<string, ""> = {};
 	for (const key of deletedMetadataKeys) {
-		if (!key.startsWith("autumn_")) stripeMetadataDeletions[key] = "";
+		if (!key.startsWith("autumn_"))
+			stripeMetadataDeletions[key.slice(0, STRIPE_MAX_KEY_LENGTH)] = "";
 	}
 
 	const stripeUpdate: Stripe.CustomerUpdateParams = {

--- a/server/tests/_groups/temp.ts
+++ b/server/tests/_groups/temp.ts
@@ -2,14 +2,10 @@ import type { TestGroup } from "./types";
 
 export const temp: TestGroup = {
 	name: "temp",
-	description: "Overage allowed billing control tests",
+	description: "Subscription updated past due tests",
 	tier: "domain",
 	paths: [
-		"integration/balances/check/overage-allowed/",
-		"integration/balances/track/overage-allowed/",
-		"integration/crud/customers/customer-billing-controls.test.ts",
-		"integration/crud/entities/update-entity-billing-controls.test.ts",
-		"integration/balances/reset/persist-free-overage-on.test.ts",
-		"integration/balances/reset/persist-free-overage-off.test.ts",
+		"integration/billing/stripe-webhooks/subscription-updated/subscription-updated-past-due.test.ts",
+		"integration/billing/update-subscription/custom-plan/update-oneoff-no-quantity.test.ts",
 	],
 };

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -1,488 +1,61 @@
-import { describe, expect, test } from "bun:test";
-import { AppEnv, type FullCustomer } from "@autumn/shared";
-import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements";
-import { customerProducts } from "@tests/utils/fixtures/db/customerProducts";
-import { customers } from "@tests/utils/fixtures/db/customers";
-import { entities as entityFixtures } from "@tests/utils/fixtures/db/entities";
-import chalk from "chalk";
-import { redis } from "@/external/redis/initRedis.js";
-import { buildPathIndex } from "@/internal/customers/cache/pathIndex/buildPathIndex.js";
-import { buildPathIndexKey } from "@/internal/customers/cache/pathIndex/pathIndexConfig.js";
+import { test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
 import {
-	buildFullCustomerCacheKey,
-	FULL_CUSTOMER_CACHE_TTL_SECONDS,
-} from "@/internal/customers/cusUtils/fullCustomerCacheUtils/fullCustomerCacheConfig.js";
+	expectCustomerProducts,
+	expectProductPastDue,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
 
-const ENTITY_COUNT = 100;
-const CUS_ENTS_PER_PRODUCT = 10;
-const ORG_ID = "org_perf_test";
-const ENV = AppEnv.Sandbox;
-const CUSTOMER_ID = "cus_perf_large";
+test.concurrent(`${chalk.yellowBright("sub.updated 3: upgrade from premium to ultra while past_due, product stays past_due")}`, async () => {
+	const customerId = "sub-updated-past-due-upgrade";
 
-const buildLargeFullCustomer = (): FullCustomer => {
-	const entitiesList = Array.from({ length: ENTITY_COUNT }, (_, i) =>
-		entityFixtures.create({
-			id: `entity_${i}`,
-			featureId: `entity_feature_${i}`,
-		}),
-	);
+	const messagesItem = items.monthlyMessages({ includedUsage: 10 });
 
-	const cusProducts = entitiesList.map((entity, entityIdx) => {
-		const cusEnts = Array.from({ length: CUS_ENTS_PER_PRODUCT }, (_, ceIdx) =>
-			customerEntitlements.create({
-				id: `cus_ent_${entityIdx}_${ceIdx}`,
-				featureId: `feature_${ceIdx}`,
-				featureName: `Feature ${ceIdx}`,
-				allowance: 1000,
-				balance: 500,
-				customerProductId: `cus_prod_entity_${entityIdx}`,
-				entityFeatureId: entity.feature_id,
-				entities: {
-					[entity.id!]: { id: entity.id!, balance: 500, adjustment: 0 },
-				},
-			}),
-		);
-
-		return customerProducts.create({
-			id: `cus_prod_entity_${entityIdx}`,
-			productId: `prod_entity_${entityIdx}`,
-			customerEntitlements: cusEnts,
-			internalEntityId: entity.internal_id,
-			entityId: entity.id!,
-		});
+	const premium = products.premium({
+		id: "premium",
+		items: [messagesItem],
 	});
 
-	const fullCustomer: FullCustomer = {
-		...customers.create({ customerProducts: cusProducts }),
-		id: CUSTOMER_ID,
-		org_id: ORG_ID,
-		env: ENV,
-		entities: entitiesList,
-		extra_customer_entitlements: [],
-	};
-
-	return fullCustomer;
-};
-
-const cacheKey = buildFullCustomerCacheKey({
-	orgId: ORG_ID,
-	env: ENV,
-	customerId: CUSTOMER_ID,
-});
-
-const pathIdxKey = buildPathIndexKey({
-	orgId: ORG_ID,
-	env: ENV,
-	customerId: CUSTOMER_ID,
-});
-
-const formatStats = (
-	timings: number[],
-): { min: number; avg: number; p95: number; max: number } => {
-	const sorted = [...timings].sort((a, b) => a - b);
-	const sum = sorted.reduce((acc, t) => acc + t, 0);
-	const p95Index = Math.floor(sorted.length * 0.95);
-	return {
-		min: sorted[0],
-		avg: sum / sorted.length,
-		p95: sorted[p95Index],
-		max: sorted[sorted.length - 1],
-	};
-};
-
-const printStats = (label: string, stats: ReturnType<typeof formatStats>) => {
-	console.log(
-		`  ${label}: min=${stats.min.toFixed(2)}ms  avg=${stats.avg.toFixed(2)}ms  p95=${stats.p95.toFixed(2)}ms  max=${stats.max.toFixed(2)}ms`,
-	);
-};
-
-// ═══════════════════════════════════════════════════════════════════
-// Block 1: Setup — seed large FullCustomer into Redis
-// ═══════════════════════════════════════════════════════════════════
-describe(chalk.blueBright("setup: seed large FullCustomer"), () => {
-	test("seed large FullCustomer in Redis", async () => {
-		const fullCustomer = buildLargeFullCustomer();
-		const serialized = JSON.stringify(fullCustomer);
-		console.log(
-			`  Serialized FullCustomer size: ${(serialized.length / 1024 / 1024).toFixed(2)} MB`,
-		);
-		console.log(
-			`  Customer products: ${fullCustomer.customer_products.length}`,
-		);
-		console.log(
-			`  Total cusEnts: ${fullCustomer.customer_products.reduce((sum, cp) => sum + cp.customer_entitlements.length, 0)}`,
-		);
-		console.log(`  Entities: ${fullCustomer.entities.length}`);
-
-		const pathIndexEntries = buildPathIndex({ fullCustomer });
-		const pathIndexJson = JSON.stringify(pathIndexEntries);
-		console.log(
-			`  Path index entries: ${Object.keys(pathIndexEntries).length}`,
-		);
-		console.log(
-			`  Path index size: ${(pathIndexJson.length / 1024).toFixed(2)} KB`,
-		);
-
-		const result = await redis.setFullCustomerCache(
-			cacheKey,
-			ORG_ID,
-			ENV,
-			CUSTOMER_ID,
-			String(Date.now()),
-			String(FULL_CUSTOMER_CACHE_TTL_SECONDS),
-			serialized,
-			"true",
-			pathIndexJson,
-		);
-
-		expect(result).toBe("OK");
-
-		const exists = await redis.call("EXISTS", cacheKey);
-		expect(exists).toBe(1);
-
-		const pathExists = await redis.call("EXISTS", pathIdxKey);
-		expect(pathExists).toBe(1);
-
-		console.log(chalk.green("  FullCustomer seeded successfully"));
-	});
-});
-
-// ═══════════════════════════════════════════════════════════════════
-// Helpers for building deduction params
-// ═══════════════════════════════════════════════════════════════════
-
-const buildDeductionParams = ({
-	iteration,
-	entitlementCount = 1,
-}: {
-	iteration: number;
-	entitlementCount?: number;
-}) => {
-	const sortedEntitlements = Array.from(
-		{ length: entitlementCount },
-		(_, idx) => {
-			const entIdx = (iteration * entitlementCount + idx) % ENTITY_COUNT;
-			const ceIdx = (iteration * entitlementCount + idx) % CUS_ENTS_PER_PRODUCT;
-			return {
-				customer_entitlement_id: `cus_ent_${entIdx}_${ceIdx}`,
-				credit_cost: 1,
-				feature_id: `feature_${ceIdx}`,
-				entity_feature_id: `entity_feature_${entIdx}`,
-				usage_allowed: true,
-				min_balance: null,
-				max_balance: null,
-			};
-		},
-	);
-
-	const entityIdx = iteration % ENTITY_COUNT;
-	const ceIdx = iteration % CUS_ENTS_PER_PRODUCT;
-	return {
-		org_id: ORG_ID,
-		env: ENV,
-		customer_id: CUSTOMER_ID,
-		sorted_entitlements: sortedEntitlements,
-		spend_limit_by_feature_id: null,
-		usage_based_cus_ent_ids_by_feature_id: null,
-		amount_to_deduct: 1,
-		target_balance: null,
-		target_entity_id: `entity_${entityIdx}`,
-		rollovers: null,
-		skip_additional_balance: false,
-		alter_granted_balance: false,
-		overage_behaviour: "allow",
-		feature_id: `feature_${ceIdx}`,
-		lock: null,
-		unwind_value: null,
-		lock_receipt_key: null,
-	};
-};
-
-type SlowlogEntry = [
-	id: number,
-	timestamp: number,
-	durationMicros: number,
-	command: string[],
-	clientIp: string,
-	clientName: string,
-];
-
-/**
- * Runs a batch of deductions and measures server-side execution time via SLOWLOG.
- * SLOWLOG records commands that exceed the threshold (in microseconds).
- * By setting the threshold to 0, every command is logged.
- */
-const runSlowlogBenchmark = async ({
-	iterations,
-	label,
-	entitlementCount = 1,
-}: {
-	iterations: number;
-	label: string;
-	entitlementCount?: number;
-}) => {
-	// Set threshold to 0 to capture ALL commands, keep enough entries
-	await redis.call("CONFIG", "SET", "slowlog-log-slower-than", "0");
-	await redis.call("CONFIG", "SET", "slowlog-max-len", "1024");
-	await redis.call("SLOWLOG", "RESET");
-
-	const e2eTimings: number[] = [];
-
-	for (let i = 0; i < iterations; i++) {
-		const luaParams = buildDeductionParams({ iteration: i, entitlementCount });
-		const start = performance.now();
-		const result = await redis.deductFromCustomerEntitlements(
-			cacheKey,
-			JSON.stringify(luaParams),
-		);
-		e2eTimings.push(performance.now() - start);
-
-		const parsed = JSON.parse(result);
-		expect(parsed.error).toBeNull();
-	}
-
-	// Collect slowlog entries for EVALSHA commands (our Lua scripts)
-	const rawEntries = (await redis.call(
-		"SLOWLOG",
-		"GET",
-		"1024",
-	)) as SlowlogEntry[];
-
-	const evalEntries = rawEntries.filter(
-		(entry) =>
-			entry[3] && (entry[3][0] === "evalsha" || entry[3][0] === "EVALSHA"),
-	);
-
-	// Duration is in microseconds (entry[2])
-	const serverTimings = evalEntries.map((entry) => entry[2] / 1000);
-
-	// Restore default slowlog config
-	await redis.call("CONFIG", "SET", "slowlog-log-slower-than", "10000");
-
-	const e2eStats = formatStats(e2eTimings);
-	const serverStats =
-		serverTimings.length > 0 ? formatStats(serverTimings) : null;
-
-	console.log(chalk.bold(`\n  ${label} (${iterations} iterations):`));
-	printStats("End-to-end (TS)", e2eStats);
-	if (serverStats) {
-		printStats("Server-side (SLOWLOG)", serverStats);
-		const avgRtt = e2eStats.avg - serverStats.avg;
-		console.log(`  Network RTT (avg): ~${avgRtt.toFixed(2)}ms`);
-	} else {
-		console.log("  (no SLOWLOG entries captured for EVALSHA)");
-	}
-
-	return { e2eStats, serverStats };
-};
-
-// ═══════════════════════════════════════════════════════════════════
-// Block 2: Benchmark — re-runnable against seeded data
-// ═══════════════════════════════════════════════════════════════════
-describe(chalk.yellowBright("benchmark: Redis operations"), () => {
-	const ITERATIONS = 50;
-
-	test("benchmark JSON.GET full read (TS-side getCachedFullCustomer cost)", async () => {
-		// Also measure server-side via SLOWLOG
-		await redis.call("CONFIG", "SET", "slowlog-log-slower-than", "0");
-		await redis.call("CONFIG", "SET", "slowlog-max-len", "256");
-		await redis.call("SLOWLOG", "RESET");
-
-		const timings: number[] = [];
-		for (let i = 0; i < ITERATIONS; i++) {
-			const start = performance.now();
-			const raw = (await redis.call("JSON.GET", cacheKey)) as string | null;
-			expect(raw).toBeTruthy();
-			JSON.parse(raw!);
-			const elapsed = performance.now() - start;
-			timings.push(elapsed);
-		}
-
-		const rawEntries = (await redis.call(
-			"SLOWLOG",
-			"GET",
-			"256",
-		)) as SlowlogEntry[];
-		const jsonGetEntries = rawEntries.filter(
-			(entry) =>
-				entry[3] && (entry[3][0] === "JSON.GET" || entry[3][0] === "json.get"),
-		);
-		const serverTimings = jsonGetEntries.map((entry) => entry[2] / 1000);
-
-		await redis.call("CONFIG", "SET", "slowlog-log-slower-than", "10000");
-
-		const e2eStats = formatStats(timings);
-		const serverStats =
-			serverTimings.length > 0 ? formatStats(serverTimings) : null;
-
-		console.log(
-			chalk.cyan(`\n  JSON.GET '.' + JSON.parse (${ITERATIONS} iterations):`),
-		);
-		printStats("End-to-end (TS)", e2eStats);
-		if (serverStats) {
-			printStats("Server-side (SLOWLOG)", serverStats);
-			console.log(
-				`  Network + JSON.parse (avg): ~${(e2eStats.avg - serverStats.avg).toFixed(2)}ms`,
-			);
-		}
+	const ultra = products.ultra({
+		id: "ultra",
+		items: [messagesItem],
 	});
 
-	const entitlementCounts = [1, 5, 10, 20];
-
-	for (const count of entitlementCounts) {
-		test(`benchmark deduction WITH path index — ${count} entitlement(s)`, async () => {
-			// Re-seed to reset balances
-			const fullCustomer = buildLargeFullCustomer();
-			const pathIndexEntries = buildPathIndex({ fullCustomer });
-			await redis.setFullCustomerCache(
-				cacheKey,
-				ORG_ID,
-				ENV,
-				CUSTOMER_ID,
-				String(Date.now()),
-				String(FULL_CUSTOMER_CACHE_TTL_SECONDS),
-				JSON.stringify(fullCustomer),
-				"true",
-				JSON.stringify(pathIndexEntries),
-			);
-
-			const exists = await redis.call("EXISTS", pathIdxKey);
-			expect(exists).toBe(1);
-
-			const { e2eStats, serverStats } = await runSlowlogBenchmark({
-				iterations: ITERATIONS,
-				label: chalk.green(`Fast path — ${count} entitlement(s)`),
-				entitlementCount: count,
-			});
-
-			(globalThis as Record<string, unknown>)[`__fastPathStats_${count}`] = {
-				e2eStats,
-				serverStats,
-			};
-		});
-	}
-
-	for (const count of entitlementCounts) {
-		test(`benchmark deduction WITHOUT path index — ${count} entitlement(s)`, async () => {
-			// Re-seed to reset balances, then delete path index
-			const fullCustomer = buildLargeFullCustomer();
-			const pathIndexEntries = buildPathIndex({ fullCustomer });
-			await redis.setFullCustomerCache(
-				cacheKey,
-				ORG_ID,
-				ENV,
-				CUSTOMER_ID,
-				String(Date.now()),
-				String(FULL_CUSTOMER_CACHE_TTL_SECONDS),
-				JSON.stringify(fullCustomer),
-				"true",
-				JSON.stringify(pathIndexEntries),
-			);
-			await redis.call("DEL", pathIdxKey);
-
-			const { e2eStats, serverStats } = await runSlowlogBenchmark({
-				iterations: ITERATIONS,
-				label: chalk.red(`Fallback — ${count} entitlement(s)`),
-				entitlementCount: count,
-			});
-
-			(globalThis as Record<string, unknown>)[`__fallbackStats_${count}`] = {
-				e2eStats,
-				serverStats,
-			};
-		});
-	}
-
-	test("comparison table", async () => {
-		// Re-seed for subsequent runs
-		const fullCustomer = buildLargeFullCustomer();
-		const pathIndexEntries = buildPathIndex({ fullCustomer });
-		await redis.setFullCustomerCache(
-			cacheKey,
-			ORG_ID,
-			ENV,
-			CUSTOMER_ID,
-			String(Date.now()),
-			String(FULL_CUSTOMER_CACHE_TTL_SECONDS),
-			JSON.stringify(fullCustomer),
-			"true",
-			JSON.stringify(pathIndexEntries),
-		);
-
-		type Stats = {
-			e2eStats: ReturnType<typeof formatStats>;
-			serverStats: ReturnType<typeof formatStats> | null;
-		};
-		const g = globalThis as Record<string, unknown>;
-
-		console.log(chalk.bold("\n  ─── Comparison: Fast path vs Fallback ───"));
-		console.log("  │ Ents │ Fast (server) │ Fallback (server) │ Speedup │");
-		console.log("  │──────│───────────────│───────────────────│─────────│");
-
-		for (const count of entitlementCounts) {
-			const fast = g[`__fastPathStats_${count}`] as Stats | undefined;
-			const slow = g[`__fallbackStats_${count}`] as Stats | undefined;
-			if (fast?.serverStats && slow?.serverStats) {
-				const speedup = slow.serverStats.avg / fast.serverStats.avg;
-				console.log(
-					`  │ ${String(count).padStart(4)} │ ${fast.serverStats.avg.toFixed(2).padStart(9)}ms   │ ${slow.serverStats.avg.toFixed(2).padStart(13)}ms   │ ${speedup.toFixed(1).padStart(5)}x  │`,
-				);
-			}
-		}
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [premium, ultra] }),
+		],
+		actions: [
+			s.attach({ productId: premium.id }),
+			s.removePaymentMethod(),
+			s.attachPaymentMethod({ type: "fail" }),
+			s.advanceTestClock({ toNextInvoice: true }),
+		],
 	});
 
-	test("benchmark setFullCustomerCache", async () => {
-		const fullCustomer = buildLargeFullCustomer();
-		const serialized = JSON.stringify(fullCustomer);
-		const pathIndexEntries = buildPathIndex({ fullCustomer });
-		const pathIndexJson = JSON.stringify(pathIndexEntries);
+	const customerBeforeUpgrade =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductPastDue({
+		customer: customerBeforeUpgrade,
+		productId: premium.id,
+	});
 
-		await redis.call("CONFIG", "SET", "slowlog-log-slower-than", "0");
-		await redis.call("CONFIG", "SET", "slowlog-max-len", "256");
-		await redis.call("SLOWLOG", "RESET");
+	await autumnV1.billing.attach({
+		customer_id: customerId,
+		product_id: ultra.id,
+	});
 
-		const timings: number[] = [];
-		for (let i = 0; i < ITERATIONS; i++) {
-			const start = performance.now();
-			const result = await redis.setFullCustomerCache(
-				cacheKey,
-				ORG_ID,
-				ENV,
-				CUSTOMER_ID,
-				String(Date.now()),
-				String(FULL_CUSTOMER_CACHE_TTL_SECONDS),
-				serialized,
-				"true",
-				pathIndexJson,
-			);
-			const elapsed = performance.now() - start;
-			timings.push(elapsed);
-			expect(result).toBe("OK");
-		}
+	const customerAfterUpgrade =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-		const rawEntries = (await redis.call(
-			"SLOWLOG",
-			"GET",
-			"256",
-		)) as SlowlogEntry[];
-		const evalEntries = rawEntries.filter(
-			(entry) =>
-				entry[3] && (entry[3][0] === "evalsha" || entry[3][0] === "EVALSHA"),
-		);
-		const serverTimings = evalEntries.map((entry) => entry[2] / 1000);
-
-		await redis.call("CONFIG", "SET", "slowlog-log-slower-than", "10000");
-
-		const e2eStats = formatStats(timings);
-		const serverStats =
-			serverTimings.length > 0 ? formatStats(serverTimings) : null;
-
-		console.log(
-			chalk.magenta(`\n  setFullCustomerCache (${ITERATIONS} iterations):`),
-		);
-		printStats("End-to-end (TS)", e2eStats);
-		if (serverStats) {
-			printStats("Server-side (SLOWLOG)", serverStats);
-		}
+	await expectCustomerProducts({
+		customer: customerAfterUpgrade,
+		pastDue: [ultra.id],
+		notPresent: [premium.id],
 	});
 });

--- a/server/tests/_temp/temp2.test.ts
+++ b/server/tests/_temp/temp2.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService";
+
+test(`${chalk.yellowBright("check where default payment method lives after attach")}`, async () => {
+	const customerId = "pm-location-check";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const pro = products.pro({
+		id: "pro-pm-check",
+		items: [messagesItem],
+	});
+
+	const { ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+
+	const stripeCustomerId = fullCustomer.processor?.id;
+	expect(stripeCustomerId).toBeDefined();
+
+	const subs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCustomerId!,
+		status: "all",
+	});
+
+	const subscription = subs.data.find(
+		(sub) => sub.status === "active" || sub.status === "trialing",
+	);
+	expect(subscription).toBeDefined();
+
+	const subDefaultPm = subscription!.default_payment_method;
+	console.log(`Subscription default_payment_method: ${JSON.stringify(subDefaultPm)}`);
+
+	const stripeCustomer = await ctx.stripeCli.customers.retrieve(stripeCustomerId!);
+	const customerDefaultPm = "deleted" in stripeCustomer
+		? null
+		: stripeCustomer.invoice_settings?.default_payment_method;
+	console.log(`Customer invoice_settings.default_payment_method: ${JSON.stringify(customerDefaultPm)}`);
+
+	const customerDefaultSource = "deleted" in stripeCustomer
+		? null
+		: stripeCustomer.default_source;
+	console.log(`Customer default_source: ${JSON.stringify(customerDefaultSource)}`);
+
+	if (subDefaultPm) {
+		console.log(chalk.green("Payment method is set at the SUBSCRIPTION level"));
+	} else if (customerDefaultPm) {
+		console.log(chalk.green("Payment method is set at the CUSTOMER level (invoice_settings)"));
+	} else if (customerDefaultSource) {
+		console.log(chalk.green("Payment method is set at the CUSTOMER level (default_source)"));
+	} else {
+		console.log(chalk.red("No default payment method found on subscription or customer"));
+	}
+});

--- a/server/tests/integration/balances/auto-topup/auto-topup-invoice-mode.test.ts
+++ b/server/tests/integration/balances/auto-topup/auto-topup-invoice-mode.test.ts
@@ -9,6 +9,7 @@ import { timeout } from "@tests/utils/genUtils.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { Decimal } from "decimal.js";
+import { autoTopupLimitRepo } from "@/internal/balances/autoTopUp/repos";
 import { makeAutoTopupConfig } from "./utils/makeAutoTopupConfig.js";
 
 const AUTO_TOPUP_WAIT_MS = 20000;
@@ -134,4 +135,100 @@ test.concurrent(`${chalk.yellowBright("auto-topup invoice-mode: disabled invoice
 		latestStatus: "paid",
 		latestInvoiceProductId: oneOffProd.id,
 	});
+});
+
+test.concurrent(`${chalk.yellowBright("auto-topup invoice-mode: multiple sequential top-ups record as successes")}`, async () => {
+	const oneOffItem = items.oneOffMessages({
+		includedUsage: 0,
+		billingUnits: 100,
+		price: 10,
+	});
+	const oneOffProd = products.oneOffAddOn({
+		id: "topup-im3",
+		items: [oneOffItem],
+	});
+
+	const { customerId, autumnV2_1, ctx, customer } = await initScenario({
+		customerId: "auto-topup-im3",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [oneOffProd] }),
+		],
+		actions: [
+			s.attach({
+				productId: oneOffProd.id,
+				options: [{ feature_id: TestFeature.Messages, quantity: 100 }],
+			}),
+		],
+	});
+
+	await autumnV2_1.customers.update(customerId, {
+		billing_controls: makeAutoTopupConfig({
+			threshold: 20,
+			quantity: 100,
+			invoiceMode: true,
+		}),
+	});
+
+	// Round 1: Track 85 → balance = 15 → top-up fires → balance = 115
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 85,
+	});
+
+	await timeout(AUTO_TOPUP_WAIT_MS);
+
+	const mid = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	const expectedMid = new Decimal(100).sub(85).add(100).toNumber();
+	expectBalanceCorrect({
+		customer: mid,
+		featureId: TestFeature.Messages,
+		remaining: expectedMid,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customerId,
+		count: 2,
+		latestTotal: 10,
+		latestStatus: "open",
+		latestInvoiceProductId: oneOffProd.id,
+	});
+
+	// Round 2: Track 100 → balance = 15 → second top-up fires → balance = 115
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 100,
+	});
+
+	await timeout(AUTO_TOPUP_WAIT_MS);
+
+	const after = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	const expectedAfter = new Decimal(115).sub(100).add(100).toNumber();
+	expectBalanceCorrect({
+		customer: after,
+		featureId: TestFeature.Messages,
+		remaining: expectedAfter,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customerId,
+		count: 3,
+		latestTotal: 10,
+		latestStatus: "open",
+		latestInvoiceProductId: oneOffProd.id,
+	});
+
+	// Verify limit state recorded both as successes, not failures
+	expect(Boolean(customer?.internal_id)).toBe(true);
+	const limitState = await autoTopupLimitRepo.findByScope({
+		ctx,
+		internalCustomerId: customer?.internal_id || "",
+		featureId: TestFeature.Messages,
+	});
+
+	expect(limitState).toBeDefined();
+	expect(limitState?.attempt_count).toBe(2);
+	expect(limitState?.failed_attempt_count).toBe(0);
 });

--- a/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-past-due.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-updated/subscription-updated-past-due.test.ts
@@ -15,7 +15,10 @@
 import { test } from "bun:test";
 import type { ApiCustomerV3 } from "@autumn/shared";
 import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
-import { expectProductPastDue } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import {
+	expectCustomerProducts,
+	expectProductPastDue,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { advanceTestClock } from "@tests/utils/stripeUtils";
@@ -129,5 +132,60 @@ test.concurrent(`${chalk.yellowBright("sub.updated 2: invoice mode upgrade, prod
 	await expectProductPastDue({
 		customer,
 		productId: premium.id,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: Upgrade while past_due keeps product in past_due
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("sub.updated 3: upgrade from premium to ultra while past_due, product stays past_due")}`, async () => {
+	const customerId = "sub-updated-past-due-upgrade";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 10 });
+
+	const premium = products.premium({
+		id: "premium",
+		items: [messagesItem],
+	});
+
+	const ultra = products.ultra({
+		id: "ultra",
+		items: [messagesItem],
+	});
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [premium, ultra] }),
+		],
+		actions: [
+			s.attach({ productId: premium.id }),
+			s.removePaymentMethod(),
+			s.attachPaymentMethod({ type: "fail" }),
+			s.advanceToNextInvoice(),
+		],
+	});
+
+	const customerBeforeUpgrade =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductPastDue({
+		customer: customerBeforeUpgrade,
+		productId: premium.id,
+	});
+
+	await autumnV1.billing.attach({
+		customer_id: customerId,
+		product_id: ultra.id,
+	});
+
+	const customerAfterUpgrade =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	await expectCustomerProducts({
+		customer: customerAfterUpgrade,
+		pastDue: [premium.id],
+		notPresent: [ultra.id],
 	});
 });

--- a/server/tests/integration/billing/update-subscription/custom-plan/update-oneoff-no-quantity.test.ts
+++ b/server/tests/integration/billing/update-subscription/custom-plan/update-oneoff-no-quantity.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ONE-OFF PREPAID WITH NO QUANTITY ON CUSTOM PLAN UPDATE
+//
+// When a product has both monthly metered items and a one-off prepaid item,
+// updating the plan (e.g. increasing monthly included usage) should NOT require
+// passing feature_quantities for the one-off prepaid.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("custom-plan: increase monthly usage with one-off prepaid present (no quantity)")}`, async () => {
+	const monthlyMessagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const oneOffMessagesItem = items.oneOffMessages({
+		includedUsage: 0,
+		billingUnits: 100,
+		price: 10,
+	});
+
+	const pro = products.pro({
+		items: [monthlyMessagesItem, oneOffMessagesItem],
+	});
+
+	const { customerId, autumnV1, ctx } = await initScenario({
+		customerId: "oneoff-no-qty-update",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.billing.attach({ productId: pro.id })],
+	});
+
+	const updatedMonthlyMessagesItem = items.monthlyMessages({
+		includedUsage: 200,
+	});
+	const monthlyPriceItem = items.monthlyPrice();
+
+	const updateParams = {
+		customer_id: customerId,
+		product_id: pro.id,
+		items: [updatedMonthlyMessagesItem, monthlyPriceItem, oneOffMessagesItem],
+	};
+
+	const preview = await autumnV1.subscriptions.previewUpdate(updateParams);
+
+	expect(preview.total).toBe(0);
+
+	await autumnV1.subscriptions.update(updateParams);
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	expectCustomerFeatureCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		includedUsage: 200,
+		balance: 200,
+		usage: 0,
+	});
+
+	await expectStripeSubscriptionCorrect({ ctx, customerId });
+});

--- a/server/tests/integration/org-config/forward-customer-metadata.test.ts
+++ b/server/tests/integration/org-config/forward-customer-metadata.test.ts
@@ -1,0 +1,294 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { db } from "@/db/initDrizzle";
+import { CusService } from "@/internal/customers/CusService";
+import { OrgService } from "@/internal/orgs/OrgService";
+
+const retrieveStripeCustomer = async ({
+	stripeCustomerId,
+}: {
+	stripeCustomerId: string;
+}) => {
+	const stripeCustomer =
+		await defaultCtx.stripeCli.customers.retrieve(stripeCustomerId);
+	if ("deleted" in stripeCustomer) throw new Error("Stripe customer deleted");
+	return stripeCustomer;
+};
+
+describe("forward_customer_metadata", () => {
+	beforeAll(async () => {
+		await OrgService.update({
+			db,
+			orgId: defaultCtx.org.id,
+			updates: {
+				config: {
+					...defaultCtx.org.config,
+					forward_customer_metadata: true,
+				},
+			},
+		});
+	});
+
+	afterAll(async () => {
+		await OrgService.update({
+			db,
+			orgId: defaultCtx.org.id,
+			updates: {
+				config: {
+					...defaultCtx.org.config,
+					forward_customer_metadata: false,
+				},
+			},
+		});
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// CREATE: metadata forwarded when Stripe customer created via attach
+	// ═══════════════════════════════════════════════════════════════════
+
+	test.concurrent(`${chalk.yellowBright("create: metadata forwarded to Stripe via attach (handleAttachV2)")}`, async () => {
+		const customerId = "create-fwd-meta-attach";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const pro = products.pro({ id: "pro-fwd-meta", items: [messagesItem] });
+
+		const { autumnV1, ctx } = await initScenario({
+			setup: [s.deleteCustomer({ customerId }), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		await autumnV1.customers.create({
+			id: customerId,
+			name: "Metadata Forward Test",
+			email: `${customerId}@example.com`,
+			metadata: { plan: "enterprise", team_size: "50" },
+		});
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerId = fullCustomer.processor?.id;
+		expect(stripeCustomerId).toBeDefined();
+
+		const stripeCustomer = await retrieveStripeCustomer({
+			stripeCustomerId: stripeCustomerId!,
+		});
+
+		expect(stripeCustomer.metadata.plan).toBe("enterprise");
+		expect(stripeCustomer.metadata.team_size).toBe("50");
+		expect(stripeCustomer.metadata.autumn_id).toBe(customerId);
+		expect(stripeCustomer.metadata.autumn_internal_id).toBeDefined();
+	});
+
+	test.concurrent(`${chalk.yellowBright("create: autumn_ prefix keys are not forwarded to Stripe")}`, async () => {
+		const customerId = "create-fwd-meta-filter";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const pro = products.pro({ id: "pro-fwd-filter", items: [messagesItem] });
+
+		const { autumnV1, ctx } = await initScenario({
+			setup: [s.deleteCustomer({ customerId }), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		await autumnV1.customers.create({
+			id: customerId,
+			name: "Metadata Filter Test",
+			email: `${customerId}@example.com`,
+			metadata: {
+				valid_key: "should_appear",
+				autumn_custom: "should_not_appear",
+			},
+		});
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerId = fullCustomer.processor?.id;
+		expect(stripeCustomerId).toBeDefined();
+
+		const stripeCustomer = await retrieveStripeCustomer({
+			stripeCustomerId: stripeCustomerId!,
+		});
+
+		expect(stripeCustomer.metadata.valid_key).toBe("should_appear");
+		expect(stripeCustomer.metadata.autumn_custom).toBeUndefined();
+		expect(stripeCustomer.metadata.autumn_id).toBe(customerId);
+	});
+
+	test.concurrent(`${chalk.yellowBright("create: non-string metadata values stringified for Stripe")}`, async () => {
+		const customerId = "create-fwd-meta-types";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const pro = products.pro({ id: "pro-fwd-types", items: [messagesItem] });
+
+		const { autumnV1, ctx } = await initScenario({
+			setup: [s.deleteCustomer({ customerId }), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		await autumnV1.customers.create({
+			id: customerId,
+			name: "Type Coercion Test",
+			email: `${customerId}@example.com`,
+			metadata: {
+				string_val: "hello",
+				number_val: 42,
+				bool_val: true,
+				object_val: { nested: "data" },
+			},
+		});
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerId = fullCustomer.processor?.id;
+		expect(stripeCustomerId).toBeDefined();
+
+		const stripeCustomer = await retrieveStripeCustomer({
+			stripeCustomerId: stripeCustomerId!,
+		});
+
+		expect(stripeCustomer.metadata.string_val).toBe("hello");
+		expect(stripeCustomer.metadata.number_val).toBe("42");
+		expect(stripeCustomer.metadata.bool_val).toBe("true");
+		expect(stripeCustomer.metadata.object_val).toBe('{"nested":"data"}');
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// UPDATE: metadata forwarded to existing Stripe customer
+	// ═══════════════════════════════════════════════════════════════════
+
+	test.concurrent(`${chalk.yellowBright("update: metadata forwarded to Stripe")}`, async () => {
+		const customerId = "update-fwd-meta";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const pro = products.pro({ id: "pro-upd-fwd", items: [messagesItem] });
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		await autumnV1.customers.update(customerId, {
+			metadata: { plan: "enterprise", team_size: "25" },
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerId = fullCustomer.processor?.id;
+		expect(stripeCustomerId).toBeDefined();
+
+		const stripeCustomer = await retrieveStripeCustomer({
+			stripeCustomerId: stripeCustomerId!,
+		});
+
+		expect(stripeCustomer.metadata.plan).toBe("enterprise");
+		expect(stripeCustomer.metadata.team_size).toBe("25");
+	});
+
+	test.concurrent(`${chalk.yellowBright("update: delete metadata key removes from Stripe")}`, async () => {
+		const customerId = "update-del-meta-key";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const pro = products.pro({ id: "pro-upd-del", items: [messagesItem] });
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		await autumnV1.customers.update(customerId, {
+			metadata: { keep_me: "value", delete_me: "gone_soon" },
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerId = fullCustomer.processor?.id;
+		expect(stripeCustomerId).toBeDefined();
+
+		let stripeCustomer = await retrieveStripeCustomer({
+			stripeCustomerId: stripeCustomerId!,
+		});
+		expect(stripeCustomer.metadata.keep_me).toBe("value");
+		expect(stripeCustomer.metadata.delete_me).toBe("gone_soon");
+
+		await autumnV1.customers.update(customerId, {
+			metadata: { delete_me: null } as Record<string, unknown>,
+		});
+
+		stripeCustomer = await retrieveStripeCustomer({
+			stripeCustomerId: stripeCustomerId!,
+		});
+		expect(stripeCustomer.metadata.keep_me).toBe("value");
+		expect("delete_me" in stripeCustomer.metadata).toBe(false);
+	});
+
+	test.concurrent(`${chalk.yellowBright("update: autumn_ prefix keys not forwarded on update")}`, async () => {
+		const customerId = "update-fwd-meta-filter";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const pro = products.pro({
+			id: "pro-upd-fwd-filter",
+			items: [messagesItem],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		await autumnV1.customers.update(customerId, {
+			metadata: {
+				valid_key: "forwarded",
+				autumn_reserved: "should_not_appear",
+			},
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomerId = fullCustomer.processor?.id;
+		expect(stripeCustomerId).toBeDefined();
+
+		const stripeCustomer = await retrieveStripeCustomer({
+			stripeCustomerId: stripeCustomerId!,
+		});
+
+		expect(stripeCustomer.metadata.valid_key).toBe("forwarded");
+		expect(stripeCustomer.metadata.autumn_reserved).toBeUndefined();
+	});
+});

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -34,6 +34,8 @@ export const OrgConfigSchema = z.object({
 	disabled_auto_topup: z.boolean().default(false),
 	persist_free_overage: z.boolean().default(false),
 	dryrun_autotopups: z.boolean().default(false),
+
+	forward_customer_metadata: z.boolean().default(false),
 });
 
 export type OrgConfig = z.infer<typeof OrgConfigSchema>;

--- a/shared/utils/orgUtils/convertOrgUtils.ts
+++ b/shared/utils/orgUtils/convertOrgUtils.ts
@@ -45,3 +45,11 @@ export const orgDisableStripeWrites = ({ ctx }: { ctx: SharedContext }) => {
 export const orgPersistFreeOverage = ({ org }: { org: Organization }) => {
 	return org.config.persist_free_overage ?? false;
 };
+
+export const shouldForwardCustomerMetadata = ({
+	org,
+}: {
+	org: Organization;
+}) => {
+	return org.config.forward_customer_metadata;
+};

--- a/vite/src/components/general/table/table-body-virtualized.tsx
+++ b/vite/src/components/general/table/table-body-virtualized.tsx
@@ -52,6 +52,7 @@ const VirtualRowInner = <T,>({
 				"text-t3 transition-none h-10 relative border-b",
 				rowClassName,
 				isSelected ? "z-100" : "hover:bg-interactive-secondary-hover",
+				(onRowClick || rowHref) && "cursor-pointer",
 			)}
 			onClick={handleClick}
 			onDoubleClick={onRowDoubleClick ? handleDoubleClick : undefined}

--- a/vite/src/components/general/table/table-body.tsx
+++ b/vite/src/components/general/table/table-body.tsx
@@ -49,6 +49,7 @@ export function TableBody() {
 							"text-t3 transition-none h-12 py-4 relative",
 							rowClassName,
 							isSelected ? "z-100" : "hover:bg-interactive-secondary-hover",
+							(onRowClick || rowHref) && "cursor-pointer",
 						)}
 						data-state={row.getIsSelected() && "selected"}
 						key={row.id}

--- a/vite/src/components/ui/table.tsx
+++ b/vite/src/components/ui/table.tsx
@@ -64,7 +64,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
 		<tr
 			data-slot="table-row"
 			className={cn(
-				" data-[state=selected]:bg-zinc-100 dark:hover:bg-zinc-800/50 dark:data-[state=selected]:bg-zinc-800 ",
+				"data-[state=selected]:bg-zinc-100 dark:data-[state=selected]:bg-zinc-800",
 				className,
 			)}
 			{...props}

--- a/vite/src/components/v2/dropdowns/FeatureSearchDropdown.tsx
+++ b/vite/src/components/v2/dropdowns/FeatureSearchDropdown.tsx
@@ -1,0 +1,119 @@
+import type { Feature } from "@autumn/shared";
+import { CaretDownIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
+import type React from "react";
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { getFeatureIcon } from "@/views/products/features/utils/getFeatureIcon";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "./DropdownMenu";
+
+export function FeatureSearchDropdown({
+	features,
+	value,
+	onSelect,
+	placeholder = "Select a feature",
+	open,
+	onOpenChange,
+	renderExtra,
+	footer,
+}: {
+	features: Feature[];
+	value: string | null;
+	onSelect: (featureId: string) => void;
+	placeholder?: string;
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	renderExtra?: (feature: Feature) => React.ReactNode;
+	footer?: React.ReactNode;
+}) {
+	const [internalOpen, setInternalOpen] = useState(false);
+	const [search, setSearch] = useState("");
+
+	const isControlled = open !== undefined;
+	const isOpen = isControlled ? open : internalOpen;
+	const setIsOpen = (next: boolean) => {
+		if (!isControlled) setInternalOpen(next);
+		onOpenChange?.(next);
+		if (!next) setSearch("");
+	};
+
+	const selectedFeature = features.find((f) => f.id === value);
+
+	const filteredFeatures = useMemo(
+		() =>
+			features.filter((f) =>
+				f.name.toLowerCase().includes(search.toLowerCase()),
+			),
+		[features, search],
+	);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					className={cn(
+						"flex items-center justify-between w-full rounded-lg border bg-transparent text-sm outline-none h-input input-base input-shadow-default input-state-open p-2",
+					)}
+				>
+					{selectedFeature ? (
+						<div className="flex items-center gap-2">
+							<div className="shrink-0">
+								{getFeatureIcon({ feature: selectedFeature })}
+							</div>
+							<span className="truncate">{selectedFeature.name}</span>
+						</div>
+					) : (
+						<span className="text-t4">{placeholder}</span>
+					)}
+					<CaretDownIcon className="size-4 opacity-50" />
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="start"
+				className="w-(--radix-dropdown-menu-trigger-width)"
+			>
+				<div className="flex items-center gap-2 px-2 py-1.5 border-b border-border">
+					<MagnifyingGlassIcon className="size-4 text-t4" />
+					<input
+						type="text"
+						placeholder="Search features..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						onKeyDown={(e) => e.stopPropagation()}
+						className="flex-1 bg-transparent text-sm outline-none placeholder:text-t4"
+					/>
+				</div>
+				<div className="max-h-60 overflow-y-auto">
+					{filteredFeatures.length === 0 ? (
+						<div className="py-4 text-center text-sm text-t4">
+							No features found.
+						</div>
+					) : (
+						filteredFeatures.map((feature: Feature) => (
+							<DropdownMenuItem
+								key={feature.id}
+								onClick={() => {
+									onSelect(feature.id);
+									setIsOpen(false);
+								}}
+								className="py-2 px-2.5"
+							>
+								<div className="flex items-center gap-2 w-full">
+									<div className="shrink-0">{getFeatureIcon({ feature })}</div>
+									<span className="truncate flex-1">{feature.name}</span>
+									{renderExtra?.(feature)}
+								</div>
+							</DropdownMenuItem>
+						))
+					)}
+				</div>
+				{footer}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -3,6 +3,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { authClient, useListOrganizations } from "@/lib/auth-client";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useEnv } from "@/utils/envUtils";
 
 let lastSwitchedOrgId: string | null = null;
 export const setLastSwitchedOrgId = (id: string) => {
@@ -11,6 +12,7 @@ export const setLastSwitchedOrgId = (id: string) => {
 export const getLastSwitchedOrgId = () => lastSwitchedOrgId;
 
 export const useOrg = (params?: { env?: AppEnv }) => {
+	const currentEnv = useEnv();
 	const axiosInstance = useAxiosInstance({ env: params?.env });
 	const { data: orgList } = useListOrganizations();
 
@@ -29,7 +31,7 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 		error,
 		refetch,
 	} = useQuery({
-		queryKey: params?.env ? ["org", params.env] : ["org"],
+		queryKey: params?.env ? ["org", params.env] : ["org", currentEnv],
 		queryFn: fetcher,
 		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: true,

--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -18,6 +18,7 @@ export type SheetType =
 	| "subscription-uncancel"
 	| "balance-edit"
 	| "balance-delete"
+	| "balance-create"
 	| "invoice-detail"
 	| null;
 

--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -20,6 +20,16 @@ export type SheetType =
 	| "balance-delete"
 	| "balance-create"
 	| "invoice-detail"
+	| "billing-auto-topup-add"
+	| "billing-auto-topup-edit"
+	| "billing-spend-limit-add"
+	| "billing-spend-limit-edit"
+	| "billing-usage-alert-add"
+	| "billing-usage-alert-edit"
+	| "billing-overage-allowed-add"
+	| "billing-overage-allowed-edit"
+	| "record-usage"
+	| "check-balance"
 	| null;
 
 // Store state interface

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -1,3 +1,8 @@
+import type {
+	DbOverageAllowed,
+	DbSpendLimit,
+	DbUsageAlert,
+} from "@autumn/shared";
 import type { AxiosInstance } from "axios";
 
 export class CusService {
@@ -37,9 +42,9 @@ export class CusService {
 		customerId: string;
 		entityId: string;
 		billingControls: {
-			spend_limits?: any[];
-			usage_alerts?: any[];
-			overage_allowed?: any[];
+			spend_limits?: DbSpendLimit[];
+			usage_alerts?: DbUsageAlert[];
+			overage_allowed?: DbOverageAllowed[];
 		};
 	}) {
 		return await axios.post("/v1/entities.update", {

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -27,6 +27,28 @@ export class CusService {
 		return await axios.post(`/v1/customers/${customer_id}`, data);
 	}
 
+	static async updateEntity({
+		axios,
+		customerId,
+		entityId,
+		billingControls,
+	}: {
+		axios: AxiosInstance;
+		customerId: string;
+		entityId: string;
+		billingControls: {
+			spend_limits?: any[];
+			usage_alerts?: any[];
+			overage_allowed?: any[];
+		};
+	}) {
+		return await axios.post("/v1/entities.update", {
+			customer_id: customerId,
+			entity_id: entityId,
+			billing_controls: billingControls,
+		});
+	}
+
 	static async getProductOptions(axios: AxiosInstance, data: any) {
 		return await axios.post(`/customers/product_options`, {
 			...data,

--- a/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
+++ b/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
@@ -7,10 +7,18 @@ import type {
 	Feature,
 	FullCustomer,
 } from "@autumn/shared";
-import { FadersHorizontalIcon, GavelIcon } from "@phosphor-icons/react";
+import { GavelIcon, PlusIcon } from "@phosphor-icons/react";
 import { type ReactNode, useMemo } from "react";
 import { Table } from "@/components/general/table";
 import { SectionTag } from "@/components/v2/badges/SectionTag";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/v2/dropdowns/DropdownMenu";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { cn } from "@/lib/utils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerContext } from "../customer/CustomerContext";
@@ -19,7 +27,7 @@ import { EmptyState } from "./table/EmptyState";
 const pillClassName =
 	"rounded-md bg-muted px-1.5 py-0.5 text-xs text-t3 whitespace-nowrap";
 const rowClassName =
-	"flex items-center gap-2 rounded-lg border bg-interactive-secondary h-12 px-3 min-w-0";
+	"flex items-center gap-2 rounded-lg border h-12 px-3 min-w-0 cursor-pointer transition-none bg-interactive-secondary hover:bg-interactive-secondary-hover";
 
 const getFeatureLabel = ({
 	featureId,
@@ -75,14 +83,16 @@ const BillingControlsGroup = ({
 const AutoTopupRow = ({
 	autoTopup,
 	featureNameById,
+	onClick,
 }: {
 	autoTopup: AutoTopup;
 	featureNameById: Map<string, string>;
+	onClick: () => void;
 }) => {
 	const purchaseLimit = autoTopup.purchase_limit;
 
 	return (
-		<div className={rowClassName}>
+		<button type="button" className={rowClassName} onClick={onClick}>
 			<StatusPill enabled={autoTopup.enabled} />
 			<span className="truncate text-sm text-t1 font-medium">
 				{getFeatureLabel({
@@ -99,18 +109,20 @@ const AutoTopupRow = ({
 					</Pill>
 				)}
 			</div>
-		</div>
+		</button>
 	);
 };
 
 const SpendLimitRow = ({
 	spendLimit,
 	featureNameById,
+	onClick,
 }: {
 	spendLimit: DbSpendLimit;
 	featureNameById: Map<string, string>;
+	onClick: () => void;
 }) => (
-	<div className={rowClassName}>
+	<button type="button" className={rowClassName} onClick={onClick}>
 		<StatusPill enabled={spendLimit.enabled} />
 		<span className="truncate text-sm text-t1 font-medium">
 			{getFeatureLabel({
@@ -126,15 +138,17 @@ const SpendLimitRow = ({
 					: spendLimit.overage_limit.toLocaleString()}
 			</Pill>
 		</div>
-	</div>
+	</button>
 );
 
 const UsageAlertRow = ({
 	usageAlert,
 	featureNameById,
+	onClick,
 }: {
 	usageAlert: DbUsageAlert;
 	featureNameById: Map<string, string>;
+	onClick: () => void;
 }) => {
 	const thresholdLabel =
 		usageAlert.threshold_type === "usage_percentage"
@@ -142,7 +156,7 @@ const UsageAlertRow = ({
 			: usageAlert.threshold.toLocaleString();
 
 	return (
-		<div className={rowClassName}>
+		<button type="button" className={rowClassName} onClick={onClick}>
 			<StatusPill enabled={usageAlert.enabled} />
 			<span className="truncate text-sm text-t1 font-medium">
 				{getFeatureLabel({
@@ -163,18 +177,20 @@ const UsageAlertRow = ({
 						: "absolute usage"}
 				</Pill>
 			</div>
-		</div>
+		</button>
 	);
 };
 
 const OverageAllowedRow = ({
 	overageAllowed,
 	featureNameById,
+	onClick,
 }: {
 	overageAllowed: DbOverageAllowed;
 	featureNameById: Map<string, string>;
+	onClick: () => void;
 }) => (
-	<div className={rowClassName}>
+	<button type="button" className={rowClassName} onClick={onClick}>
 		<StatusPill enabled={overageAllowed.enabled} />
 		<span className="truncate text-sm text-t1 font-medium">
 			{getFeatureLabel({
@@ -182,12 +198,13 @@ const OverageAllowedRow = ({
 				featureNameById,
 			})}
 		</span>
-	</div>
+	</button>
 );
 
 export function CustomerBillingControlsSection() {
 	const { customer, features, isLoading } = useCusQuery();
 	const { entityId } = useCustomerContext();
+	const setSheet = useSheetStore((s) => s.setSheet);
 
 	const fullCustomer = customer as FullCustomer | undefined;
 
@@ -233,12 +250,64 @@ export function CustomerBillingControlsSection() {
 				(entity.overage_allowed?.length ?? 0) > 0,
 		).length ?? 0;
 
-	if (!isLoading && !hasAnyControls && selectedEntity) return null;
+	const isEntityView = !!selectedEntity;
 
-	const customerEmptyText =
-		entitiesWithControlsCount > 0
-			? `No customer-level billing controls — billing controls exist on ${entitiesWithControlsCount} ${entitiesWithControlsCount === 1 ? "entity" : "entities"}`
-			: "No billing controls configured";
+	if (!isLoading && !hasAnyControls && !isEntityView) {
+		const customerEmptyText =
+			entitiesWithControlsCount > 0
+				? `No customer-level billing controls — billing controls exist on ${entitiesWithControlsCount} ${entitiesWithControlsCount === 1 ? "entity" : "entities"}`
+				: "No billing controls configured";
+
+		return (
+			<Table.Container>
+				<Table.Toolbar>
+					<Table.Heading>
+						<GavelIcon size={16} weight="fill" className="text-subtle" />
+						Billing controls
+					</Table.Heading>
+					<Table.Actions>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="secondary"
+									size="mini"
+									className="gap-2 font-medium"
+								>
+									<PlusIcon className="size-3.5" />
+									Add Control
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								<DropdownMenuItem
+									onClick={() => setSheet({ type: "billing-auto-topup-add" })}
+								>
+									Auto top-up
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									onClick={() => setSheet({ type: "billing-spend-limit-add" })}
+								>
+									Spend limit
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									onClick={() => setSheet({ type: "billing-usage-alert-add" })}
+								>
+									Usage alert
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									onClick={() =>
+										setSheet({ type: "billing-overage-allowed-add" })
+									}
+								>
+									Overage allowed
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</Table.Actions>
+				</Table.Toolbar>
+				<EmptyState text={customerEmptyText} />
+			</Table.Container>
+		);
+	}
 
 	return (
 		<Table.Container>
@@ -247,22 +316,74 @@ export function CustomerBillingControlsSection() {
 					<GavelIcon size={16} weight="fill" className="text-subtle" />
 					Billing controls
 				</Table.Heading>
+				<Table.Actions>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								variant="secondary"
+								size="mini"
+								className="gap-2 font-medium"
+							>
+								<PlusIcon className="size-3.5" />
+								Add Control
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							{!selectedEntity && (
+								<DropdownMenuItem
+									onClick={() => setSheet({ type: "billing-auto-topup-add" })}
+								>
+									Auto top-up
+								</DropdownMenuItem>
+							)}
+							<DropdownMenuItem
+								onClick={() => setSheet({ type: "billing-spend-limit-add" })}
+							>
+								Spend limit
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => setSheet({ type: "billing-usage-alert-add" })}
+							>
+								Usage alert
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() =>
+									setSheet({ type: "billing-overage-allowed-add" })
+								}
+							>
+								Overage allowed
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</Table.Actions>
 			</Table.Toolbar>
 
 			{isLoading ? (
 				<EmptyState text="Loading billing controls" />
 			) : !hasAnyControls ? (
-				<EmptyState text={customerEmptyText} />
+				<EmptyState
+					text={
+						isEntityView
+							? "No billing controls set on this entity"
+							: "No billing controls configured"
+					}
+				/>
 			) : (
 				<div className="flex flex-col gap-4">
 					{autoTopups.length > 0 && (
 						<BillingControlsGroup title="Auto top-ups" emptyText="" hasItems>
-							<div className="flex flex-col gap-1.5">
-								{autoTopups.map((autoTopup) => (
+							<div className="flex flex-col gap-1.5 rounded-lg">
+								{autoTopups.map((autoTopup, index) => (
 									<AutoTopupRow
 										key={`auto-topup-${autoTopup.feature_id}`}
 										autoTopup={autoTopup}
 										featureNameById={featureNameById}
+										onClick={() =>
+											setSheet({
+												type: "billing-auto-topup-edit",
+												data: { index, item: autoTopup },
+											})
+										}
 									/>
 								))}
 							</div>
@@ -271,12 +392,18 @@ export function CustomerBillingControlsSection() {
 
 					{spendLimits.length > 0 && (
 						<BillingControlsGroup title="Spend limits" emptyText="" hasItems>
-							<div className="flex flex-col gap-1.5">
+							<div className="flex flex-col gap-1.5 rounded-lg">
 								{spendLimits.map((spendLimit, index) => (
 									<SpendLimitRow
 										key={`spend-limit-${spendLimit.feature_id ?? "global"}-${index}`}
 										spendLimit={spendLimit}
 										featureNameById={featureNameById}
+										onClick={() =>
+											setSheet({
+												type: "billing-spend-limit-edit",
+												data: { index, item: spendLimit },
+											})
+										}
 									/>
 								))}
 							</div>
@@ -285,12 +412,18 @@ export function CustomerBillingControlsSection() {
 
 					{usageAlerts.length > 0 && (
 						<BillingControlsGroup title="Usage alerts" emptyText="" hasItems>
-							<div className="flex flex-col gap-1.5">
+							<div className="flex flex-col gap-1.5 rounded-lg">
 								{usageAlerts.map((usageAlert, index) => (
 									<UsageAlertRow
 										key={`usage-alert-${usageAlert.feature_id ?? "global"}-${usageAlert.name ?? index}`}
 										usageAlert={usageAlert}
 										featureNameById={featureNameById}
+										onClick={() =>
+											setSheet({
+												type: "billing-usage-alert-edit",
+												data: { index, item: usageAlert },
+											})
+										}
 									/>
 								))}
 							</div>
@@ -298,13 +431,19 @@ export function CustomerBillingControlsSection() {
 					)}
 
 					{overageAllowed.length > 0 && (
-						<BillingControlsGroup title="Overage enabled" emptyText="" hasItems>
-							<div className="flex flex-col gap-1.5">
-								{overageAllowed.map((item) => (
+						<BillingControlsGroup title="Overage allowed" emptyText="" hasItems>
+							<div className="flex flex-col gap-1.5 rounded-lg">
+								{overageAllowed.map((item, index) => (
 									<OverageAllowedRow
 										key={`overage-allowed-${item.feature_id}`}
 										overageAllowed={item}
 										featureNameById={featureNameById}
+										onClick={() =>
+											setSheet({
+												type: "billing-overage-allowed-edit",
+												data: { index, item },
+											})
+										}
 									/>
 								))}
 							</div>

--- a/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
@@ -1,0 +1,256 @@
+import { type Feature, FeatureType, ResetInterval } from "@autumn/shared";
+import { CalendarXIcon, InfinityIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { DateInputUnix } from "@/components/general/DateInputUnix";
+import { Button } from "@/components/v2/buttons/Button";
+import { IconCheckbox } from "@/components/v2/checkboxes/IconCheckbox";
+import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+import {
+	LayoutGroup,
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerContext } from "../../customer/CustomerContext";
+
+const RESET_INTERVAL_LABELS: Record<string, string> = {
+	[ResetInterval.Minute]: "Minute",
+	[ResetInterval.Hour]: "Hour",
+	[ResetInterval.Day]: "Day",
+	[ResetInterval.Week]: "Week",
+	[ResetInterval.Month]: "Month",
+	[ResetInterval.Quarter]: "Quarter",
+	[ResetInterval.SemiAnnual]: "Semi-annual",
+	[ResetInterval.Year]: "Year",
+};
+
+export function BalanceCreateSheet() {
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const { customer, refetch } = useCusQuery();
+	const { entityId } = useCustomerContext();
+	const { features } = useFeaturesQuery();
+	const axiosInstance = useAxiosInstance();
+
+	const [isCreating, setIsCreating] = useState(false);
+	const [featureId, setFeatureId] = useState<string>("");
+	const [balanceId, setBalanceId] = useState("");
+	const [includedGrant, setIncludedGrant] = useState("");
+	const [unlimited, setUnlimited] = useState(false);
+	const [resetInterval, setResetInterval] = useState<string>("");
+	const [oneOff, setOneOff] = useState(false);
+	const [expiresAt, setExpiresAt] = useState<number | null>(null);
+
+	const nonArchivedFeatures = features.filter((f: Feature) => !f.archived);
+	const selectedFeature = nonArchivedFeatures.find(
+		(f: Feature) => f.id === featureId,
+	);
+	const isMetered =
+		selectedFeature?.type === FeatureType.Metered ||
+		selectedFeature?.type === FeatureType.CreditSystem;
+
+	const handleCreate = async () => {
+		const customerId = customer?.id || customer?.internal_id;
+		if (!customerId || !featureId) return;
+
+		const params: Record<string, unknown> = {
+			customer_id: customerId,
+			feature_id: featureId,
+		};
+
+		if (entityId) params.entity_id = entityId;
+		if (balanceId.trim()) params.balance_id = balanceId.trim();
+
+		if (isMetered) {
+			if (unlimited) {
+				params.unlimited = true;
+			} else if (includedGrant.trim()) {
+				const grant = parseFloat(includedGrant);
+				if (Number.isNaN(grant)) {
+					toast.error("Please enter a valid number for included grant");
+					return;
+				}
+				params.included_grant = grant;
+			} else {
+				toast.error("Please provide an included grant or mark as unlimited");
+				return;
+			}
+		}
+
+		if (resetInterval && !oneOff && !unlimited) {
+			params.reset = { interval: resetInterval };
+		}
+
+		if (expiresAt) {
+			params.expires_at = expiresAt;
+		}
+
+		setIsCreating(true);
+		try {
+			await axiosInstance.post("/v1/balances.create", params);
+			await refetch();
+			closeSheet();
+			toast.success("Balance created");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to create balance"));
+		} finally {
+			setIsCreating(false);
+		}
+	};
+
+	return (
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-y-auto">
+				<SheetHeader
+					title="Create Balance"
+					description="Create a new, standalone balance for this customer that's not associated with any plan."
+				/>
+
+				<SheetSection withSeparator>
+					<FormLabel>Feature</FormLabel>
+					<FeatureSearchDropdown
+						features={nonArchivedFeatures}
+						value={featureId || null}
+						onSelect={setFeatureId}
+					/>
+				</SheetSection>
+
+				{selectedFeature && (
+					<SheetSection withSeparator={false}>
+						<div className="flex flex-col gap-3">
+							<div>
+								<FormLabel>Balance ID</FormLabel>
+								<Input
+									placeholder="Optional unique identifier"
+									value={balanceId}
+									onChange={(e) => setBalanceId(e.target.value)}
+								/>
+							</div>
+
+							{isMetered && (
+								<div>
+									<FormLabel>Grant Amount</FormLabel>
+									<div className="flex items-center gap-2">
+										<Input
+											placeholder="eg, 100"
+											type="number"
+											value={unlimited ? "Unlimited" : includedGrant}
+											disabled={unlimited}
+											onChange={(e) => setIncludedGrant(e.target.value)}
+										/>
+										<IconCheckbox
+											icon={<InfinityIcon />}
+											iconOrientation="left"
+											variant="muted"
+											size="default"
+											checked={unlimited}
+											onCheckedChange={(checked) => {
+												setUnlimited(checked);
+												if (checked) {
+													setIncludedGrant("");
+													setResetInterval("");
+													setOneOff(false);
+												}
+											}}
+											className="py-1 w-26 text-t4 gap-2"
+										>
+											Unlimited
+										</IconCheckbox>
+									</div>
+								</div>
+							)}
+
+							{isMetered && !unlimited && (
+								<div>
+									<FormLabel>Interval</FormLabel>
+									<div className="flex items-center gap-2">
+										<Select
+											value={oneOff ? undefined : resetInterval}
+											onValueChange={setResetInterval}
+											disabled={oneOff}
+										>
+											<SelectTrigger className="w-full">
+												<SelectValue placeholder="None" />
+											</SelectTrigger>
+											<SelectContent>
+												{Object.entries(RESET_INTERVAL_LABELS).map(
+													([value, label]) => (
+														<SelectItem key={value} value={value}>
+															{label}
+														</SelectItem>
+													),
+												)}
+											</SelectContent>
+										</Select>
+										<IconCheckbox
+											icon={<CalendarXIcon />}
+											iconOrientation="left"
+											variant="secondary"
+											size="default"
+											checked={oneOff}
+											onCheckedChange={(checked) => {
+												setOneOff(checked);
+												if (checked) setResetInterval("");
+											}}
+											className="py-1 w-26 text-t4 gap-2 justify-start"
+										>
+											One-off
+										</IconCheckbox>
+									</div>
+								</div>
+							)}
+
+							{isMetered && (
+								<div className="flex flex-col shrink-0 w-full">
+									<FormLabel>Expires At</FormLabel>
+									<DateInputUnix
+										unixDate={expiresAt}
+										setUnixDate={setExpiresAt}
+										withTime
+										use24Hour
+									/>
+								</div>
+							)}
+						</div>
+					</SheetSection>
+				)}
+
+				<div className="flex-1" />
+
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={closeSheet}
+						disabled={isCreating}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={handleCreate}
+						isLoading={isCreating}
+						disabled={!featureId}
+					>
+						Create
+					</Button>
+				</SheetFooter>
+			</div>
+		</LayoutGroup>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
@@ -117,7 +117,7 @@ export function BalanceCreateSheet() {
 			<div className="flex h-full flex-col overflow-y-auto">
 				<SheetHeader
 					title="Create Balance"
-					description="Create a new, standalone balance for this customer that's not associated with any plan."
+					description="Create a separate balance for this customer that is not associated with any plan."
 				/>
 
 				<SheetSection withSeparator>

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -203,9 +203,6 @@ export function BillingAutoTopupSheet() {
 				data: {
 					billing_controls: {
 						auto_topups: currentAutoTopups,
-						spend_limits: fullCustomer?.spend_limits,
-						usage_alerts: fullCustomer?.usage_alerts,
-						overage_allowed: fullCustomer?.overage_allowed,
 					},
 				},
 			});
@@ -236,9 +233,6 @@ export function BillingAutoTopupSheet() {
 				data: {
 					billing_controls: {
 						auto_topups: currentAutoTopups,
-						spend_limits: fullCustomer?.spend_limits,
-						usage_alerts: fullCustomer?.usage_alerts,
-						overage_allowed: fullCustomer?.overage_allowed,
 					},
 				},
 			});

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -203,6 +203,9 @@ export function BillingAutoTopupSheet() {
 				data: {
 					billing_controls: {
 						auto_topups: currentAutoTopups,
+						spend_limits: fullCustomer?.spend_limits,
+						usage_alerts: fullCustomer?.usage_alerts,
+						overage_allowed: fullCustomer?.overage_allowed,
 					},
 				},
 			});
@@ -233,6 +236,9 @@ export function BillingAutoTopupSheet() {
 				data: {
 					billing_controls: {
 						auto_topups: currentAutoTopups,
+						spend_limits: fullCustomer?.spend_limits,
+						usage_alerts: fullCustomer?.usage_alerts,
+						overage_allowed: fullCustomer?.overage_allowed,
 					},
 				},
 			});

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -1,0 +1,489 @@
+import {
+	type AutoTopup,
+	cusEntToCusPrice,
+	type Feature,
+	FeatureType,
+	FeatureUsageType,
+	type FullCusEntWithFullCusProduct,
+	type FullCustomer,
+	formatAmount,
+	fullCustomerToCustomerEntitlements,
+	isPrepaidCustomerEntitlement,
+	PurchaseLimitInterval,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import FieldLabel from "@/components/general/modal-components/FieldLabel";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/v2/buttons/Button";
+import { Checkbox } from "@/components/v2/checkboxes/Checkbox";
+import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+import {
+	LayoutGroup,
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { useOrg } from "@/hooks/common/useOrg";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { CusService } from "@/services/customers/CusService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
+
+const INTERVAL_LABELS: Record<string, string> = {
+	[PurchaseLimitInterval.Hour]: "Hour",
+	[PurchaseLimitInterval.Day]: "Day",
+	[PurchaseLimitInterval.Week]: "Week",
+	[PurchaseLimitInterval.Month]: "Month",
+};
+
+export function BillingAutoTopupSheet() {
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const sheetData = useSheetStore((s) => s.data);
+	const sheetType = useSheetStore((s) => s.type);
+	const { customer, refetch } = useCusQuery();
+	const { features } = useFeaturesQuery();
+	const { org } = useOrg();
+	const axiosInstance = useAxiosInstance();
+
+	const isEdit = sheetType === "billing-auto-topup-edit";
+	const existingItem = sheetData?.item as AutoTopup | undefined;
+	const existingIndex = sheetData?.index as number | undefined;
+
+	const [isSaving, setIsSaving] = useState(false);
+	const [featureId, setFeatureId] = useState(existingItem?.feature_id ?? "");
+	const [enabled, setEnabled] = useState(existingItem?.enabled ?? true);
+	const [threshold, setThreshold] = useState(
+		existingItem?.threshold?.toString() ?? "",
+	);
+	const [quantity, setQuantity] = useState(
+		existingItem?.quantity?.toString() ?? "",
+	);
+	const [hasPurchaseLimit, setHasPurchaseLimit] = useState(
+		!!existingItem?.purchase_limit,
+	);
+	const [purchaseLimitInterval, setPurchaseLimitInterval] = useState(
+		existingItem?.purchase_limit?.interval ?? "",
+	);
+	const [purchaseLimitIntervalCount, setPurchaseLimitIntervalCount] = useState(
+		existingItem?.purchase_limit?.interval_count?.toString() ?? "1",
+	);
+	const [purchaseLimitLimit, setPurchaseLimitLimit] = useState(
+		existingItem?.purchase_limit?.limit?.toString() ?? "",
+	);
+	const [invoiceMode, setInvoiceMode] = useState(
+		existingItem?.invoice_mode ?? false,
+	);
+
+	const fullCustomer = customer as FullCustomer | undefined;
+	const consumableFeatures = (features ?? []).filter(
+		(f: Feature) =>
+			!f.archived &&
+			f.type !== FeatureType.Boolean &&
+			f.config?.usage_type !== FeatureUsageType.Continuous,
+	);
+
+	const topupPriceInfo = useMemo(() => {
+		if (!featureId || !fullCustomer) return null;
+
+		const cusEnts = fullCustomerToCustomerEntitlements({
+			fullCustomer,
+			featureId,
+		});
+
+		const prepaidCusEnt = cusEnts.find((cusEnt: FullCusEntWithFullCusProduct) =>
+			isPrepaidCustomerEntitlement(cusEnt),
+		);
+
+		if (!prepaidCusEnt) return { hasPrice: false as const };
+
+		const cusPrice = cusEntToCusPrice({ cusEnt: prepaidCusEnt });
+		if (!cusPrice) return { hasPrice: false as const };
+
+		const config = cusPrice.price.config as UsagePriceConfig;
+		const billingUnits = config.billing_units || 1;
+		const tiers = config.usage_tiers;
+
+		return {
+			hasPrice: true as const,
+			isTiered: tiers.length > 1,
+			unitAmount: tiers[0].amount,
+			billingUnits,
+		};
+	}, [featureId, fullCustomer]);
+
+	const buildItem = (): AutoTopup | null => {
+		if (!featureId) {
+			toast.error("Please select a feature");
+			return null;
+		}
+		const parsedThreshold = Number.parseFloat(threshold);
+		if (Number.isNaN(parsedThreshold) || parsedThreshold < 0) {
+			toast.error("Please enter a valid threshold");
+			return null;
+		}
+		const parsedQuantity = Number.parseInt(quantity, 10);
+		if (Number.isNaN(parsedQuantity) || parsedQuantity < 1) {
+			toast.error("Please enter a valid quantity (min 1)");
+			return null;
+		}
+
+		const item: AutoTopup = {
+			feature_id: featureId,
+			enabled,
+			threshold: parsedThreshold,
+			quantity: parsedQuantity,
+		};
+
+		if (hasPurchaseLimit && purchaseLimitInterval && purchaseLimitLimit) {
+			const parsedLimit = Number.parseInt(purchaseLimitLimit, 10);
+			const parsedIntervalCount = Number.parseInt(
+				purchaseLimitIntervalCount,
+				10,
+			);
+			if (Number.isNaN(parsedLimit) || parsedLimit < 1) {
+				toast.error("Please enter a valid purchase limit");
+				return null;
+			}
+			item.purchase_limit = {
+				interval: purchaseLimitInterval as PurchaseLimitInterval,
+				interval_count:
+					Number.isNaN(parsedIntervalCount) || parsedIntervalCount < 1
+						? 1
+						: parsedIntervalCount,
+				limit: parsedLimit,
+			};
+		}
+
+		if (invoiceMode) {
+			item.invoice_mode = true;
+		}
+
+		return item;
+	};
+
+	const handleSave = async () => {
+		const item = buildItem();
+		if (!item) return;
+
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		const currentAutoTopups = [...(fullCustomer?.auto_topups ?? [])];
+
+		if (isEdit && existingIndex !== undefined) {
+			currentAutoTopups[existingIndex] = item;
+		} else {
+			currentAutoTopups.push(item);
+		}
+
+		setIsSaving(true);
+		try {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: {
+						auto_topups: currentAutoTopups,
+					},
+				},
+			});
+			await refetch();
+			closeSheet();
+			toast.success(isEdit ? "Auto top-up updated" : "Auto top-up added");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to save auto top-up"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (existingIndex === undefined) return;
+
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		const currentAutoTopups = [...(fullCustomer?.auto_topups ?? [])];
+		currentAutoTopups.splice(existingIndex, 1);
+
+		setIsSaving(true);
+		try {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: {
+						auto_topups: currentAutoTopups,
+					},
+				},
+			});
+			await refetch();
+			closeSheet();
+			toast.success("Auto top-up deleted");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to delete auto top-up"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-y-auto">
+				<SheetHeader
+					title={isEdit ? "Edit Auto Top-up" : "Add Auto Top-up"}
+					description="Configure automatic credit top-ups when a feature balance drops below a threshold."
+				/>
+
+				<SheetSection withSeparator>
+					<FormLabel>Feature</FormLabel>
+					{isEdit ? (
+						<div className="text-sm text-t2">
+							{consumableFeatures.find((f: Feature) => f.id === featureId)
+								?.name ?? featureId}
+						</div>
+					) : (
+						<FeatureSearchDropdown
+							features={consumableFeatures}
+							value={featureId || null}
+							onSelect={setFeatureId}
+						/>
+					)}
+				</SheetSection>
+
+				{featureId && topupPriceInfo && (
+					<SheetSection withSeparator>
+						{topupPriceInfo.hasPrice ? (
+							<InfoBox variant="note">
+								{topupPriceInfo.isTiered
+									? "Pricing for this feature is tiered — the charge per top-up depends on current usage."
+									: `Customer will be charged ${formatAmount({ org, amount: topupPriceInfo.unitAmount })} per ${topupPriceInfo.billingUnits === 1 ? "unit" : `${topupPriceInfo.billingUnits} units`}.`}
+							</InfoBox>
+						) : (
+							<InfoBox variant="warning">
+								No prepaid price found for this feature. This auto top-up won't
+								take effect until the customer has a product with a prepaid
+								price for this feature.
+							</InfoBox>
+						)}
+					</SheetSection>
+				)}
+
+				<SheetSection withSeparator>
+					<div className="flex flex-col gap-3">
+						<div className="flex items-center justify-between">
+							<FormLabel className="mb-0">Enabled</FormLabel>
+							<Switch checked={enabled} onCheckedChange={setEnabled} />
+						</div>
+
+						<div>
+							<FormLabel>Threshold</FormLabel>
+							<Input
+								placeholder="Balance threshold to trigger top-up"
+								type="number"
+								value={threshold}
+								onChange={(e) => setThreshold(e.target.value)}
+							/>
+						</div>
+
+						<div>
+							<FormLabel>Quantity</FormLabel>
+							<Input
+								placeholder="Credits to add per top-up"
+								type="number"
+								value={quantity}
+								onChange={(e) => setQuantity(e.target.value)}
+							/>
+						</div>
+
+						<div className="flex items-center justify-between">
+							<FormLabel className="mb-0">Invoice mode</FormLabel>
+							<Switch checked={invoiceMode} onCheckedChange={setInvoiceMode} />
+						</div>
+					</div>
+				</SheetSection>
+
+				<SheetSection withSeparator={false}>
+					<div className="flex items-center gap-2 mb-2">
+						<Checkbox
+							checked={hasPurchaseLimit}
+							onCheckedChange={(checked) =>
+								setHasPurchaseLimit(checked === true)
+							}
+						/>
+						<FormLabel className="mb-0">Purchase limit</FormLabel>
+					</div>
+
+					{hasPurchaseLimit && (
+						<div className="flex flex-col gap-3">
+							<div>
+								<FormLabel>Interval</FormLabel>
+								<Select
+									value={purchaseLimitInterval}
+									onValueChange={setPurchaseLimitInterval}
+								>
+									<SelectTrigger className="w-full">
+										<SelectValue placeholder="Select interval" />
+									</SelectTrigger>
+									<SelectContent>
+										{Object.entries(INTERVAL_LABELS).map(([value, label]) => {
+											const count = Number.parseInt(
+												purchaseLimitIntervalCount,
+												10,
+											);
+											const displayLabel =
+												count > 1
+													? `Every ${count} ${label.toLowerCase()}s`
+													: label;
+											return (
+												<SelectItem key={value} value={value}>
+													{displayLabel}
+												</SelectItem>
+											);
+										})}
+										<PurchaseLimitIntervalPopover
+											intervalCount={purchaseLimitIntervalCount}
+											onSave={setPurchaseLimitIntervalCount}
+											disabled={!purchaseLimitInterval}
+										/>
+									</SelectContent>
+								</Select>
+							</div>
+
+							<div>
+								<FormLabel>Max top-ups</FormLabel>
+								<Input
+									placeholder="Max top-ups in interval"
+									type="number"
+									value={purchaseLimitLimit}
+									onChange={(e) => setPurchaseLimitLimit(e.target.value)}
+								/>
+							</div>
+						</div>
+					)}
+				</SheetSection>
+
+				<div className="flex-1" />
+
+				{isEdit && (
+					<div className="px-4 pb-2">
+						<Button
+							variant="ghost"
+							className="text-destructive hover:text-destructive w-full"
+							onClick={handleDelete}
+							disabled={isSaving}
+						>
+							Delete auto top-up
+						</Button>
+					</div>
+				)}
+
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={closeSheet}
+						disabled={isSaving}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={handleSave}
+						isLoading={isSaving}
+						disabled={!featureId}
+					>
+						{isEdit ? "Save" : "Add"}
+					</Button>
+				</SheetFooter>
+			</div>
+		</LayoutGroup>
+	);
+}
+
+function PurchaseLimitIntervalPopover({
+	intervalCount,
+	onSave,
+	disabled,
+}: {
+	intervalCount: string;
+	onSave: (value: string) => void;
+	disabled: boolean;
+}) {
+	const [open, setOpen] = useState(false);
+	const [localCount, setLocalCount] = useState(intervalCount || "1");
+
+	const handleSave = () => {
+		onSave(localCount);
+		setOpen(false);
+	};
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					className="w-full justify-start px-2 group-hover:text-primary active:border-0"
+					variant="skeleton"
+					disabled={disabled}
+				>
+					<p className="text-t3 group-hover/btn:text-primary">
+						Customize Interval
+					</p>
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="start"
+				className="p-3 w-[200px] z-101"
+				sideOffset={-1}
+				onOpenAutoFocus={(e) => e.preventDefault()}
+				onCloseAutoFocus={(e) => e.preventDefault()}
+			>
+				<div className="mb-2">
+					<FieldLabel>Interval Count</FieldLabel>
+				</div>
+				<div className="flex items-center gap-2">
+					<Input
+						className="flex-1"
+						type="number"
+						value={localCount}
+						onChange={(e) => setLocalCount(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "-" || e.key === "Minus") {
+								e.preventDefault();
+							}
+							if (e.key === "Enter") {
+								handleSave();
+							}
+							if (e.key === "Escape") {
+								setOpen(false);
+							}
+						}}
+					/>
+					<Button variant="secondary" className="px-4 h-7" onClick={handleSave}>
+						Save
+					</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/BillingOverageAllowedSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingOverageAllowedSheet.tsx
@@ -71,8 +71,6 @@ export function BillingOverageAllowedSheet() {
 				customerId,
 				entityId: selectedEntity.id || selectedEntity.internal_id,
 				billingControls: {
-					spend_limits: selectedEntity.spend_limits ?? undefined,
-					usage_alerts: selectedEntity.usage_alerts ?? undefined,
 					overage_allowed: overageAllowed,
 				},
 			});
@@ -82,9 +80,6 @@ export function BillingOverageAllowedSheet() {
 				customer_id: customerId,
 				data: {
 					billing_controls: {
-						auto_topups: fullCustomer?.auto_topups,
-						spend_limits: fullCustomer?.spend_limits,
-						usage_alerts: fullCustomer?.usage_alerts,
 						overage_allowed: overageAllowed,
 					},
 				},

--- a/vite/src/views/customers2/components/sheets/BillingOverageAllowedSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingOverageAllowedSheet.tsx
@@ -1,0 +1,223 @@
+import {
+	type DbOverageAllowed,
+	type Feature,
+	FeatureType,
+	type FullCustomer,
+} from "@autumn/shared";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/v2/buttons/Button";
+import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import {
+	LayoutGroup,
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { CusService } from "@/services/customers/CusService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerContext } from "../../customer/CustomerContext";
+
+export function BillingOverageAllowedSheet() {
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const sheetData = useSheetStore((s) => s.data);
+	const sheetType = useSheetStore((s) => s.type);
+	const { customer, refetch } = useCusQuery();
+	const { entityId } = useCustomerContext();
+	const { features } = useFeaturesQuery();
+	const axiosInstance = useAxiosInstance();
+
+	const isEdit = sheetType === "billing-overage-allowed-edit";
+	const existingItem = sheetData?.item as DbOverageAllowed | undefined;
+	const existingIndex = sheetData?.index as number | undefined;
+
+	const fullCustomer = customer as FullCustomer | undefined;
+	const selectedEntity = entityId
+		? fullCustomer?.entities?.find(
+				(e) => e.id === entityId || e.internal_id === entityId,
+			)
+		: null;
+
+	const [isSaving, setIsSaving] = useState(false);
+	const [featureId, setFeatureId] = useState(existingItem?.feature_id ?? "");
+	const [enabled, setEnabled] = useState(existingItem?.enabled ?? true);
+
+	const nonArchivedFeatures = (features ?? []).filter(
+		(f: Feature) => !f.archived && f.type !== FeatureType.Boolean,
+	);
+
+	const getCurrentOverageAllowed = () => {
+		if (selectedEntity) return [...(selectedEntity.overage_allowed ?? [])];
+		return [...(fullCustomer?.overage_allowed ?? [])];
+	};
+
+	const buildBillingControls = ({
+		overageAllowed,
+	}: {
+		overageAllowed: DbOverageAllowed[];
+	}) => {
+		if (selectedEntity) {
+			return {
+				spend_limits: selectedEntity.spend_limits,
+				usage_alerts: selectedEntity.usage_alerts,
+				overage_allowed: overageAllowed,
+			};
+		}
+		return {
+			auto_topups: fullCustomer?.auto_topups,
+			spend_limits: fullCustomer?.spend_limits,
+			usage_alerts: fullCustomer?.usage_alerts,
+			overage_allowed: overageAllowed,
+		};
+	};
+
+	const handleSave = async () => {
+		if (!featureId) {
+			toast.error("Please select a feature");
+			return;
+		}
+
+		const item: DbOverageAllowed = {
+			feature_id: featureId,
+			enabled,
+		};
+
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		const currentOverageAllowed = getCurrentOverageAllowed();
+
+		if (isEdit && existingIndex !== undefined) {
+			currentOverageAllowed[existingIndex] = item;
+		} else {
+			currentOverageAllowed.push(item);
+		}
+
+		setIsSaving(true);
+		try {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: buildBillingControls({
+						overageAllowed: currentOverageAllowed,
+					}),
+				},
+			});
+			await refetch();
+			closeSheet();
+			toast.success(
+				isEdit ? "Overage allowed updated" : "Overage allowed added",
+			);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to save overage allowed"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (existingIndex === undefined) return;
+
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		const currentOverageAllowed = getCurrentOverageAllowed();
+		currentOverageAllowed.splice(existingIndex, 1);
+
+		setIsSaving(true);
+		try {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: buildBillingControls({
+						overageAllowed: currentOverageAllowed,
+					}),
+				},
+			});
+			await refetch();
+			closeSheet();
+			toast.success("Overage allowed deleted");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to delete overage allowed"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-y-auto">
+				<SheetHeader
+					title={isEdit ? "Edit Overage Allowed" : "Add Overage Allowed"}
+					description="Control whether usage can exceed the granted balance for a feature."
+				/>
+
+				<SheetSection withSeparator>
+					<FormLabel>Feature</FormLabel>
+					{isEdit ? (
+						<div className="text-sm text-t2">
+							{nonArchivedFeatures.find((f: Feature) => f.id === featureId)
+								?.name ?? featureId}
+						</div>
+					) : (
+						<FeatureSearchDropdown
+							features={nonArchivedFeatures}
+							value={featureId || null}
+							onSelect={setFeatureId}
+						/>
+					)}
+				</SheetSection>
+
+				<SheetSection withSeparator={false}>
+					<div className="flex items-center justify-between">
+						<FormLabel className="mb-0">Enabled</FormLabel>
+						<Switch checked={enabled} onCheckedChange={setEnabled} />
+					</div>
+				</SheetSection>
+
+				<div className="flex-1" />
+
+				{isEdit && (
+					<div className="px-4 pb-2">
+						<Button
+							variant="ghost"
+							className="text-destructive hover:text-destructive w-full"
+							onClick={handleDelete}
+							disabled={isSaving}
+						>
+							Delete overage allowed
+						</Button>
+					</div>
+				)}
+
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={closeSheet}
+						disabled={isSaving}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={handleSave}
+						isLoading={isSaving}
+						disabled={!featureId}
+					>
+						{isEdit ? "Save" : "Add"}
+					</Button>
+				</SheetFooter>
+			</div>
+		</LayoutGroup>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/BillingOverageAllowedSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingOverageAllowedSheet.tsx
@@ -57,24 +57,39 @@ export function BillingOverageAllowedSheet() {
 		return [...(fullCustomer?.overage_allowed ?? [])];
 	};
 
-	const buildBillingControls = ({
+	const saveBillingControls = async ({
 		overageAllowed,
 	}: {
 		overageAllowed: DbOverageAllowed[];
 	}) => {
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
 		if (selectedEntity) {
-			return {
-				spend_limits: selectedEntity.spend_limits,
-				usage_alerts: selectedEntity.usage_alerts,
-				overage_allowed: overageAllowed,
-			};
+			await CusService.updateEntity({
+				axios: axiosInstance,
+				customerId,
+				entityId: selectedEntity.id || selectedEntity.internal_id,
+				billingControls: {
+					spend_limits: selectedEntity.spend_limits ?? undefined,
+					usage_alerts: selectedEntity.usage_alerts ?? undefined,
+					overage_allowed: overageAllowed,
+				},
+			});
+		} else {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: {
+						auto_topups: fullCustomer?.auto_topups,
+						spend_limits: fullCustomer?.spend_limits,
+						usage_alerts: fullCustomer?.usage_alerts,
+						overage_allowed: overageAllowed,
+					},
+				},
+			});
 		}
-		return {
-			auto_topups: fullCustomer?.auto_topups,
-			spend_limits: fullCustomer?.spend_limits,
-			usage_alerts: fullCustomer?.usage_alerts,
-			overage_allowed: overageAllowed,
-		};
 	};
 
 	const handleSave = async () => {
@@ -88,9 +103,6 @@ export function BillingOverageAllowedSheet() {
 			enabled,
 		};
 
-		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
-		if (!customerId) return;
-
 		const currentOverageAllowed = getCurrentOverageAllowed();
 
 		if (isEdit && existingIndex !== undefined) {
@@ -101,15 +113,7 @@ export function BillingOverageAllowedSheet() {
 
 		setIsSaving(true);
 		try {
-			await CusService.updateCustomer({
-				axios: axiosInstance,
-				customer_id: customerId,
-				data: {
-					billing_controls: buildBillingControls({
-						overageAllowed: currentOverageAllowed,
-					}),
-				},
-			});
+			await saveBillingControls({ overageAllowed: currentOverageAllowed });
 			await refetch();
 			closeSheet();
 			toast.success(
@@ -125,23 +129,12 @@ export function BillingOverageAllowedSheet() {
 	const handleDelete = async () => {
 		if (existingIndex === undefined) return;
 
-		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
-		if (!customerId) return;
-
 		const currentOverageAllowed = getCurrentOverageAllowed();
 		currentOverageAllowed.splice(existingIndex, 1);
 
 		setIsSaving(true);
 		try {
-			await CusService.updateCustomer({
-				axios: axiosInstance,
-				customer_id: customerId,
-				data: {
-					billing_controls: buildBillingControls({
-						overageAllowed: currentOverageAllowed,
-					}),
-				},
-			});
+			await saveBillingControls({ overageAllowed: currentOverageAllowed });
 			await refetch();
 			closeSheet();
 			toast.success("Overage allowed deleted");

--- a/vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx
@@ -61,24 +61,39 @@ export function BillingSpendLimitSheet() {
 		return [...(fullCustomer?.spend_limits ?? [])];
 	};
 
-	const buildBillingControls = ({
+	const saveBillingControls = async ({
 		spendLimits,
 	}: {
 		spendLimits: DbSpendLimit[];
 	}) => {
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
 		if (selectedEntity) {
-			return {
-				spend_limits: spendLimits,
-				usage_alerts: selectedEntity.usage_alerts,
-				overage_allowed: selectedEntity.overage_allowed,
-			};
+			await CusService.updateEntity({
+				axios: axiosInstance,
+				customerId,
+				entityId: selectedEntity.id || selectedEntity.internal_id,
+				billingControls: {
+					spend_limits: spendLimits,
+					usage_alerts: selectedEntity.usage_alerts ?? undefined,
+					overage_allowed: selectedEntity.overage_allowed ?? undefined,
+				},
+			});
+		} else {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: {
+						auto_topups: fullCustomer?.auto_topups,
+						spend_limits: spendLimits,
+						usage_alerts: fullCustomer?.usage_alerts,
+						overage_allowed: fullCustomer?.overage_allowed,
+					},
+				},
+			});
 		}
-		return {
-			auto_topups: fullCustomer?.auto_topups,
-			spend_limits: spendLimits,
-			usage_alerts: fullCustomer?.usage_alerts,
-			overage_allowed: fullCustomer?.overage_allowed,
-		};
 	};
 
 	const handleSave = async () => {
@@ -102,9 +117,6 @@ export function BillingSpendLimitSheet() {
 			overage_limit: parsedOverageLimit,
 		};
 
-		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
-		if (!customerId) return;
-
 		const currentSpendLimits = getCurrentSpendLimits();
 
 		if (isEdit && existingIndex !== undefined) {
@@ -115,15 +127,7 @@ export function BillingSpendLimitSheet() {
 
 		setIsSaving(true);
 		try {
-			await CusService.updateCustomer({
-				axios: axiosInstance,
-				customer_id: customerId,
-				data: {
-					billing_controls: buildBillingControls({
-						spendLimits: currentSpendLimits,
-					}),
-				},
-			});
+			await saveBillingControls({ spendLimits: currentSpendLimits });
 			await refetch();
 			closeSheet();
 			toast.success(isEdit ? "Spend limit updated" : "Spend limit added");
@@ -137,23 +141,12 @@ export function BillingSpendLimitSheet() {
 	const handleDelete = async () => {
 		if (existingIndex === undefined) return;
 
-		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
-		if (!customerId) return;
-
 		const currentSpendLimits = getCurrentSpendLimits();
 		currentSpendLimits.splice(existingIndex, 1);
 
 		setIsSaving(true);
 		try {
-			await CusService.updateCustomer({
-				axios: axiosInstance,
-				customer_id: customerId,
-				data: {
-					billing_controls: buildBillingControls({
-						spendLimits: currentSpendLimits,
-					}),
-				},
-			});
+			await saveBillingControls({ spendLimits: currentSpendLimits });
 			await refetch();
 			closeSheet();
 			toast.success("Spend limit deleted");

--- a/vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx
@@ -1,0 +1,249 @@
+import {
+	type DbSpendLimit,
+	type Feature,
+	FeatureType,
+	type FullCustomer,
+} from "@autumn/shared";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/v2/buttons/Button";
+import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	LayoutGroup,
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { CusService } from "@/services/customers/CusService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerContext } from "../../customer/CustomerContext";
+
+export function BillingSpendLimitSheet() {
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const sheetData = useSheetStore((s) => s.data);
+	const sheetType = useSheetStore((s) => s.type);
+	const { customer, refetch } = useCusQuery();
+	const { entityId } = useCustomerContext();
+	const { features } = useFeaturesQuery();
+	const axiosInstance = useAxiosInstance();
+
+	const isEdit = sheetType === "billing-spend-limit-edit";
+	const existingItem = sheetData?.item as DbSpendLimit | undefined;
+	const existingIndex = sheetData?.index as number | undefined;
+
+	const fullCustomer = customer as FullCustomer | undefined;
+	const selectedEntity = entityId
+		? fullCustomer?.entities?.find(
+				(e) => e.id === entityId || e.internal_id === entityId,
+			)
+		: null;
+
+	const [isSaving, setIsSaving] = useState(false);
+	const [featureId, setFeatureId] = useState(existingItem?.feature_id ?? "");
+	const [enabled, setEnabled] = useState(existingItem?.enabled ?? true);
+	const [overageLimit, setOverageLimit] = useState(
+		existingItem?.overage_limit?.toString() ?? "",
+	);
+
+	const nonArchivedFeatures = (features ?? []).filter(
+		(f: Feature) => !f.archived && f.type !== FeatureType.Boolean,
+	);
+
+	const getCurrentSpendLimits = () => {
+		if (selectedEntity) return [...(selectedEntity.spend_limits ?? [])];
+		return [...(fullCustomer?.spend_limits ?? [])];
+	};
+
+	const buildBillingControls = ({
+		spendLimits,
+	}: {
+		spendLimits: DbSpendLimit[];
+	}) => {
+		if (selectedEntity) {
+			return {
+				spend_limits: spendLimits,
+				usage_alerts: selectedEntity.usage_alerts,
+				overage_allowed: selectedEntity.overage_allowed,
+			};
+		}
+		return {
+			auto_topups: fullCustomer?.auto_topups,
+			spend_limits: spendLimits,
+			usage_alerts: fullCustomer?.usage_alerts,
+			overage_allowed: fullCustomer?.overage_allowed,
+		};
+	};
+
+	const handleSave = async () => {
+		const parsedOverageLimit =
+			overageLimit.trim() === "" ? undefined : Number.parseFloat(overageLimit);
+
+		if (parsedOverageLimit !== undefined) {
+			if (Number.isNaN(parsedOverageLimit) || parsedOverageLimit < 0) {
+				toast.error("Please enter a valid overage limit");
+				return;
+			}
+			if (!featureId) {
+				toast.error("Feature is required when overage limit is set");
+				return;
+			}
+		}
+
+		const item: DbSpendLimit = {
+			feature_id: featureId || undefined,
+			enabled,
+			overage_limit: parsedOverageLimit,
+		};
+
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		const currentSpendLimits = getCurrentSpendLimits();
+
+		if (isEdit && existingIndex !== undefined) {
+			currentSpendLimits[existingIndex] = item;
+		} else {
+			currentSpendLimits.push(item);
+		}
+
+		setIsSaving(true);
+		try {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: buildBillingControls({
+						spendLimits: currentSpendLimits,
+					}),
+				},
+			});
+			await refetch();
+			closeSheet();
+			toast.success(isEdit ? "Spend limit updated" : "Spend limit added");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to save spend limit"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (existingIndex === undefined) return;
+
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		const currentSpendLimits = getCurrentSpendLimits();
+		currentSpendLimits.splice(existingIndex, 1);
+
+		setIsSaving(true);
+		try {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: buildBillingControls({
+						spendLimits: currentSpendLimits,
+					}),
+				},
+			});
+			await refetch();
+			closeSheet();
+			toast.success("Spend limit deleted");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to delete spend limit"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-y-auto">
+				<SheetHeader
+					title={isEdit ? "Edit Spend Limit" : "Add Spend Limit"}
+					description="Set an overage spend limit for a feature or globally."
+				/>
+
+				<SheetSection withSeparator>
+					<FormLabel>Feature</FormLabel>
+					{isEdit ? (
+						<div className="text-sm text-t2">
+							{featureId
+								? (nonArchivedFeatures.find((f: Feature) => f.id === featureId)
+										?.name ?? featureId)
+								: "All features"}
+						</div>
+					) : (
+						<FeatureSearchDropdown
+							features={nonArchivedFeatures}
+							value={featureId || null}
+							onSelect={setFeatureId}
+							placeholder="Optional — leave empty for global"
+						/>
+					)}
+				</SheetSection>
+
+				<SheetSection withSeparator>
+					<div className="flex flex-col gap-3">
+						<div className="flex items-center justify-between">
+							<FormLabel className="mb-0">Enabled</FormLabel>
+							<Switch checked={enabled} onCheckedChange={setEnabled} />
+						</div>
+
+						<div>
+							<FormLabel>Overage limit</FormLabel>
+							<Input
+								placeholder="Optional — leave empty for no limit"
+								type="number"
+								value={overageLimit}
+								onChange={(e) => setOverageLimit(e.target.value)}
+							/>
+						</div>
+					</div>
+				</SheetSection>
+
+				<div className="flex-1" />
+
+				{isEdit && (
+					<div className="px-4 pb-2">
+						<Button
+							variant="ghost"
+							className="text-destructive hover:text-destructive w-full"
+							onClick={handleDelete}
+							disabled={isSaving}
+						>
+							Delete spend limit
+						</Button>
+					</div>
+				)}
+
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={closeSheet}
+						disabled={isSaving}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={handleSave}
+						isLoading={isSaving}
+					>
+						{isEdit ? "Save" : "Add"}
+					</Button>
+				</SheetFooter>
+			</div>
+		</LayoutGroup>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingSpendLimitSheet.tsx
@@ -76,8 +76,6 @@ export function BillingSpendLimitSheet() {
 				entityId: selectedEntity.id || selectedEntity.internal_id,
 				billingControls: {
 					spend_limits: spendLimits,
-					usage_alerts: selectedEntity.usage_alerts ?? undefined,
-					overage_allowed: selectedEntity.overage_allowed ?? undefined,
 				},
 			});
 		} else {
@@ -86,10 +84,7 @@ export function BillingSpendLimitSheet() {
 				customer_id: customerId,
 				data: {
 					billing_controls: {
-						auto_topups: fullCustomer?.auto_topups,
 						spend_limits: spendLimits,
-						usage_alerts: fullCustomer?.usage_alerts,
-						overage_allowed: fullCustomer?.overage_allowed,
 					},
 				},
 			});

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -72,24 +72,39 @@ export function BillingUsageAlertSheet() {
 		return [...(fullCustomer?.usage_alerts ?? [])];
 	};
 
-	const buildBillingControls = ({
+	const saveBillingControls = async ({
 		usageAlerts,
 	}: {
 		usageAlerts: DbUsageAlert[];
 	}) => {
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
 		if (selectedEntity) {
-			return {
-				spend_limits: selectedEntity.spend_limits,
-				usage_alerts: usageAlerts,
-				overage_allowed: selectedEntity.overage_allowed,
-			};
+			await CusService.updateEntity({
+				axios: axiosInstance,
+				customerId,
+				entityId: selectedEntity.id || selectedEntity.internal_id,
+				billingControls: {
+					spend_limits: selectedEntity.spend_limits ?? undefined,
+					usage_alerts: usageAlerts,
+					overage_allowed: selectedEntity.overage_allowed ?? undefined,
+				},
+			});
+		} else {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: {
+						auto_topups: fullCustomer?.auto_topups,
+						spend_limits: fullCustomer?.spend_limits,
+						usage_alerts: usageAlerts,
+						overage_allowed: fullCustomer?.overage_allowed,
+					},
+				},
+			});
 		}
-		return {
-			auto_topups: fullCustomer?.auto_topups,
-			spend_limits: fullCustomer?.spend_limits,
-			usage_alerts: usageAlerts,
-			overage_allowed: fullCustomer?.overage_allowed,
-		};
 	};
 
 	const handleSave = async () => {
@@ -112,9 +127,6 @@ export function BillingUsageAlertSheet() {
 			name: name.trim() || undefined,
 		};
 
-		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
-		if (!customerId) return;
-
 		const currentUsageAlerts = getCurrentUsageAlerts();
 
 		if (isEdit && existingIndex !== undefined) {
@@ -125,15 +137,7 @@ export function BillingUsageAlertSheet() {
 
 		setIsSaving(true);
 		try {
-			await CusService.updateCustomer({
-				axios: axiosInstance,
-				customer_id: customerId,
-				data: {
-					billing_controls: buildBillingControls({
-						usageAlerts: currentUsageAlerts,
-					}),
-				},
-			});
+			await saveBillingControls({ usageAlerts: currentUsageAlerts });
 			await refetch();
 			closeSheet();
 			toast.success(isEdit ? "Usage alert updated" : "Usage alert added");
@@ -147,23 +151,12 @@ export function BillingUsageAlertSheet() {
 	const handleDelete = async () => {
 		if (existingIndex === undefined) return;
 
-		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
-		if (!customerId) return;
-
 		const currentUsageAlerts = getCurrentUsageAlerts();
 		currentUsageAlerts.splice(existingIndex, 1);
 
 		setIsSaving(true);
 		try {
-			await CusService.updateCustomer({
-				axios: axiosInstance,
-				customer_id: customerId,
-				data: {
-					billing_controls: buildBillingControls({
-						usageAlerts: currentUsageAlerts,
-					}),
-				},
-			});
+			await saveBillingControls({ usageAlerts: currentUsageAlerts });
 			await refetch();
 			closeSheet();
 			toast.success("Usage alert deleted");
@@ -224,10 +217,10 @@ export function BillingUsageAlertSheet() {
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-									<SelectItem value="usage">Absolute usage</SelectItem>
-									<SelectItem value="usage_percentage">
-										Percentage of allowance
-									</SelectItem>
+								<SelectItem value="usage">Absolute usage</SelectItem>
+								<SelectItem value="usage_percentage">
+									% of allowance used
+								</SelectItem>
 								</SelectContent>
 							</Select>
 						</div>

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -86,9 +86,7 @@ export function BillingUsageAlertSheet() {
 				customerId,
 				entityId: selectedEntity.id || selectedEntity.internal_id,
 				billingControls: {
-					spend_limits: selectedEntity.spend_limits ?? undefined,
 					usage_alerts: usageAlerts,
-					overage_allowed: selectedEntity.overage_allowed ?? undefined,
 				},
 			});
 		} else {
@@ -97,10 +95,7 @@ export function BillingUsageAlertSheet() {
 				customer_id: customerId,
 				data: {
 					billing_controls: {
-						auto_topups: fullCustomer?.auto_topups,
-						spend_limits: fullCustomer?.spend_limits,
 						usage_alerts: usageAlerts,
-						overage_allowed: fullCustomer?.overage_allowed,
 					},
 				},
 			});
@@ -217,10 +212,10 @@ export function BillingUsageAlertSheet() {
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-								<SelectItem value="usage">Absolute usage</SelectItem>
-								<SelectItem value="usage_percentage">
-									% of allowance used
-								</SelectItem>
+									<SelectItem value="usage">Absolute usage</SelectItem>
+									<SelectItem value="usage_percentage">
+										% of allowance used
+									</SelectItem>
 								</SelectContent>
 							</Select>
 						</div>

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -1,0 +1,288 @@
+import {
+	type DbUsageAlert,
+	type Feature,
+	FeatureType,
+	type FullCustomer,
+} from "@autumn/shared";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/v2/buttons/Button";
+import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+import {
+	LayoutGroup,
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { CusService } from "@/services/customers/CusService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerContext } from "../../customer/CustomerContext";
+
+export function BillingUsageAlertSheet() {
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const sheetData = useSheetStore((s) => s.data);
+	const sheetType = useSheetStore((s) => s.type);
+	const { customer, refetch } = useCusQuery();
+	const { entityId } = useCustomerContext();
+	const { features } = useFeaturesQuery();
+	const axiosInstance = useAxiosInstance();
+
+	const isEdit = sheetType === "billing-usage-alert-edit";
+	const existingItem = sheetData?.item as DbUsageAlert | undefined;
+	const existingIndex = sheetData?.index as number | undefined;
+
+	const fullCustomer = customer as FullCustomer | undefined;
+	const selectedEntity = entityId
+		? fullCustomer?.entities?.find(
+				(e) => e.id === entityId || e.internal_id === entityId,
+			)
+		: null;
+
+	const [isSaving, setIsSaving] = useState(false);
+	const [featureId, setFeatureId] = useState(existingItem?.feature_id ?? "");
+	const [enabled, setEnabled] = useState(existingItem?.enabled ?? true);
+	const [name, setName] = useState(existingItem?.name ?? "");
+	const [threshold, setThreshold] = useState(
+		existingItem?.threshold?.toString() ?? "",
+	);
+	const [thresholdType, setThresholdType] = useState<string>(
+		existingItem?.threshold_type ?? "usage",
+	);
+
+	const nonArchivedFeatures = (features ?? []).filter(
+		(f: Feature) => !f.archived && f.type !== FeatureType.Boolean,
+	);
+
+	const getCurrentUsageAlerts = () => {
+		if (selectedEntity) return [...(selectedEntity.usage_alerts ?? [])];
+		return [...(fullCustomer?.usage_alerts ?? [])];
+	};
+
+	const buildBillingControls = ({
+		usageAlerts,
+	}: {
+		usageAlerts: DbUsageAlert[];
+	}) => {
+		if (selectedEntity) {
+			return {
+				spend_limits: selectedEntity.spend_limits,
+				usage_alerts: usageAlerts,
+				overage_allowed: selectedEntity.overage_allowed,
+			};
+		}
+		return {
+			auto_topups: fullCustomer?.auto_topups,
+			spend_limits: fullCustomer?.spend_limits,
+			usage_alerts: usageAlerts,
+			overage_allowed: fullCustomer?.overage_allowed,
+		};
+	};
+
+	const handleSave = async () => {
+		const parsedThreshold = Number.parseFloat(threshold);
+		if (Number.isNaN(parsedThreshold) || parsedThreshold < 0) {
+			toast.error("Please enter a valid threshold");
+			return;
+		}
+
+		if (thresholdType === "usage_percentage" && parsedThreshold > 100) {
+			toast.error("Percentage threshold must be between 0 and 100");
+			return;
+		}
+
+		const item: DbUsageAlert = {
+			feature_id: featureId || undefined,
+			enabled,
+			threshold: parsedThreshold,
+			threshold_type: thresholdType as "usage" | "usage_percentage",
+			name: name.trim() || undefined,
+		};
+
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		const currentUsageAlerts = getCurrentUsageAlerts();
+
+		if (isEdit && existingIndex !== undefined) {
+			currentUsageAlerts[existingIndex] = item;
+		} else {
+			currentUsageAlerts.push(item);
+		}
+
+		setIsSaving(true);
+		try {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: buildBillingControls({
+						usageAlerts: currentUsageAlerts,
+					}),
+				},
+			});
+			await refetch();
+			closeSheet();
+			toast.success(isEdit ? "Usage alert updated" : "Usage alert added");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to save usage alert"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (existingIndex === undefined) return;
+
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		const currentUsageAlerts = getCurrentUsageAlerts();
+		currentUsageAlerts.splice(existingIndex, 1);
+
+		setIsSaving(true);
+		try {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: {
+					billing_controls: buildBillingControls({
+						usageAlerts: currentUsageAlerts,
+					}),
+				},
+			});
+			await refetch();
+			closeSheet();
+			toast.success("Usage alert deleted");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to delete usage alert"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-y-auto">
+				<SheetHeader
+					title={isEdit ? "Edit Usage Alert" : "Add Usage Alert"}
+					description="Configure alerts that notify when usage reaches a threshold."
+				/>
+
+				<SheetSection withSeparator>
+					<FormLabel>Feature</FormLabel>
+					{isEdit ? (
+						<div className="text-sm text-t2">
+							{featureId
+								? (nonArchivedFeatures.find((f: Feature) => f.id === featureId)
+										?.name ?? featureId)
+								: "All features"}
+						</div>
+					) : (
+						<FeatureSearchDropdown
+							features={nonArchivedFeatures}
+							value={featureId || null}
+							onSelect={setFeatureId}
+							placeholder="Optional — leave empty for global"
+						/>
+					)}
+				</SheetSection>
+
+				<SheetSection withSeparator>
+					<div className="flex flex-col gap-3">
+						<div className="flex items-center justify-between">
+							<FormLabel className="mb-0">Enabled</FormLabel>
+							<Switch checked={enabled} onCheckedChange={setEnabled} />
+						</div>
+
+						<div>
+							<FormLabel>Name</FormLabel>
+							<Input
+								placeholder="Optional label for this alert"
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+							/>
+						</div>
+
+						<div>
+							<FormLabel>Threshold type</FormLabel>
+							<Select value={thresholdType} onValueChange={setThresholdType}>
+								<SelectTrigger className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="usage">Absolute usage</SelectItem>
+									<SelectItem value="usage_percentage">
+										Percentage of allowance
+									</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div>
+							<FormLabel>
+								Threshold
+								{thresholdType === "usage_percentage" ? " (%)" : ""}
+							</FormLabel>
+							<Input
+								placeholder={
+									thresholdType === "usage_percentage" ? "eg, 80" : "eg, 1000"
+								}
+								type="number"
+								value={threshold}
+								onChange={(e) => setThreshold(e.target.value)}
+							/>
+						</div>
+					</div>
+				</SheetSection>
+
+				<div className="flex-1" />
+
+				{isEdit && (
+					<div className="px-4 pb-2">
+						<Button
+							variant="ghost"
+							className="text-destructive hover:text-destructive w-full"
+							onClick={handleDelete}
+							disabled={isSaving}
+						>
+							Delete usage alert
+						</Button>
+					</div>
+				)}
+
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={closeSheet}
+						disabled={isSaving}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={handleSave}
+						isLoading={isSaving}
+					>
+						{isEdit ? "Save" : "Add"}
+					</Button>
+				</SheetFooter>
+			</div>
+		</LayoutGroup>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -1,7 +1,6 @@
 import { LATEST_VERSION } from "@autumn/shared";
 import { Spinner } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "react-router";
 import {
 	CodeGroup,
 	CodeGroupCode,
@@ -10,46 +9,40 @@ import {
 	CodeGroupTab,
 } from "@/components/v2/CodeGroup";
 import {
-	Sheet,
-	SheetContent,
+	LayoutGroup,
 	SheetHeader,
-	SheetTitle,
-} from "@/components/v2/sheets/Sheet";
+} from "@/components/v2/sheets/SharedSheetComponents";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerContext } from "../../customer/CustomerContext";
 
-interface ShowCustomerObjectSheetProps {
-	open: boolean;
-	setOpen: (open: boolean) => void;
-}
-
-const EXPAND_PARAMS = [
-	"invoices",
-	"trials_used",
-	"rewards",
-	"entities",
-	"referrals",
-	"payment_method",
-].join(",");
-
-export function ShowCustomerObjectSheet({
-	open,
-	setOpen,
-}: ShowCustomerObjectSheetProps) {
-	const { customer_id } = useParams();
+export function CheckBalanceSheet() {
+	const sheetData = useSheetStore((s) => s.data);
+	const { customer } = useCusQuery();
+	const { entityId } = useCustomerContext();
 	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
 	const buildKey = useQueryKeyFactory();
 
+	const featureId = sheetData?.featureId as string | undefined;
+	const featureName = sheetData?.featureName as string | undefined;
+	const customerId = customer?.id || customer?.internal_id;
+
 	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["customer-object", customer_id, "expanded"]),
+		queryKey: buildKey(["check-balance", customerId, featureId, entityId]),
 		queryFn: async () => {
-			const { data } = await axiosInstance.get(
-				`/v1/customers/${customer_id}?expand=${EXPAND_PARAMS}`,
-			);
+			const params: Record<string, unknown> = {
+				customer_id: customerId,
+				feature_id: featureId,
+			};
+			if (entityId) params.entity_id = entityId;
+
+			const { data } = await axiosInstance.post("/v1/check", params);
 			return data;
 		},
-		enabled: open && !!customer_id,
+		enabled: !!customerId && !!featureId,
 		gcTime: 0,
 		staleTime: 0,
 	});
@@ -57,14 +50,12 @@ export function ShowCustomerObjectSheet({
 	const formattedJson = data ? JSON.stringify(data, null, 2) : "";
 
 	return (
-		<Sheet open={open} onOpenChange={setOpen}>
-			<SheetContent className="flex flex-col overflow-hidden bg-background min-w-xl">
-				<SheetHeader>
-					<SheetTitle>Customer Object</SheetTitle>
-					<p className="text-t3 text-sm">
-						Customer state from GET /customers/{customer_id}
-					</p>
-				</SheetHeader>
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-hidden">
+				<SheetHeader
+					title="Check Balance"
+					description={`POST /check for ${featureName ?? featureId}`}
+				/>
 
 				<div className="flex-1 overflow-hidden flex flex-col px-4 pb-4">
 					{isLoading && (
@@ -75,7 +66,7 @@ export function ShowCustomerObjectSheet({
 
 					{error && (
 						<div className="p-4 rounded-md bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-sm">
-							{getBackendErr(error, "Failed to fetch customer")}
+							{getBackendErr(error, "Failed to check balance")}
 						</div>
 					)}
 
@@ -93,7 +84,7 @@ export function ShowCustomerObjectSheet({
 						</CodeGroup>
 					)}
 				</div>
-			</SheetContent>
-		</Sheet>
+			</div>
+		</LayoutGroup>
 	);
 }

--- a/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
@@ -1,0 +1,211 @@
+import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/v2/buttons/Button";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	LayoutGroup,
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerContext } from "../../customer/CustomerContext";
+
+export function RecordUsageSheet() {
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const sheetData = useSheetStore((s) => s.data);
+	const { customer } = useCusQuery();
+	const { entityId } = useCustomerContext();
+	const axiosInstance = useAxiosInstance();
+	const queryClient = useQueryClient();
+
+	const featureId = sheetData?.featureId as string | undefined;
+	const featureName = sheetData?.featureName as string | undefined;
+
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [value, setValue] = useState("1");
+	const [properties, setProperties] = useState<
+		{ key: string; value: string }[]
+	>([]);
+
+	const handleAddProperty = () => {
+		setProperties((prev) => [...prev, { key: "", value: "" }]);
+	};
+
+	const handleRemoveProperty = ({ index }: { index: number }) => {
+		setProperties((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	const handlePropertyChange = ({
+		index,
+		field,
+		fieldValue,
+	}: {
+		index: number;
+		field: "key" | "value";
+		fieldValue: string;
+	}) => {
+		setProperties((prev) =>
+			prev.map((property, i) =>
+				i === index ? { ...property, [field]: fieldValue } : property,
+			),
+		);
+	};
+
+	const handleSubmit = async () => {
+		const customerId = customer?.id || customer?.internal_id;
+		if (!customerId || !featureId) return;
+
+		const parsedValue = value.trim() === "" ? 1 : Number.parseFloat(value);
+		if (Number.isNaN(parsedValue)) {
+			toast.error("Please enter a valid number for value");
+			return;
+		}
+
+		const duplicateKeys = properties
+			.filter((p) => p.key.trim())
+			.map((p) => p.key.trim());
+		if (new Set(duplicateKeys).size !== duplicateKeys.length) {
+			toast.error("Property keys must be unique");
+			return;
+		}
+
+		const params: Record<string, unknown> = {
+			customer_id: customerId,
+			feature_id: featureId,
+			value: parsedValue,
+		};
+
+		if (entityId) params.entity_id = entityId;
+
+		const filteredProperties = properties.filter((p) => p.key.trim());
+		if (filteredProperties.length > 0) {
+			params.properties = Object.fromEntries(
+				filteredProperties.map((p) => [p.key.trim(), p.value]),
+			);
+		}
+
+		setIsSubmitting(true);
+		try {
+			await axiosInstance.post("/v1/track", params);
+			closeSheet();
+			toast.success("Usage recorded");
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			await queryClient.invalidateQueries({ queryKey: ["customer"] });
+			await queryClient.invalidateQueries({
+				queryKey: ["customer-timeseries-events"],
+			});
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to record usage"));
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-y-auto">
+				<SheetHeader
+					title="Record Usage"
+					description={`Record usage for ${featureName ?? featureId}`}
+				/>
+
+				<SheetSection withSeparator>
+					<FormLabel>Value</FormLabel>
+					<Input
+						placeholder="1"
+						type="number"
+						value={value}
+						onChange={(e) => setValue(e.target.value)}
+					/>
+				</SheetSection>
+
+				<SheetSection withSeparator={false}>
+					<div className="flex flex-col gap-3">
+						<div className="flex items-center justify-between">
+							<FormLabel className="mb-0">Properties</FormLabel>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={handleAddProperty}
+								className="h-6 gap-1 text-xs text-t3"
+							>
+								<PlusIcon size={12} />
+								Add
+							</Button>
+						</div>
+
+						{properties.length === 0 && (
+							<p className="text-xs text-t3">
+								No properties added. Click "Add" to attach metadata.
+							</p>
+						)}
+
+						{properties.map((property, index) => (
+							<div key={index} className="flex items-center gap-2">
+								<Input
+									placeholder="Key"
+									value={property.key}
+									onChange={(e) =>
+										handlePropertyChange({
+											index,
+											field: "key",
+											fieldValue: e.target.value,
+										})
+									}
+									className="flex-1"
+								/>
+								<Input
+									placeholder="Value"
+									value={property.value}
+									onChange={(e) =>
+										handlePropertyChange({
+											index,
+											field: "value",
+											fieldValue: e.target.value,
+										})
+									}
+									className="flex-1"
+								/>
+								<button
+									type="button"
+									onClick={() => handleRemoveProperty({ index })}
+									className="shrink-0 p-1 text-t3 hover:text-destructive transition-colors"
+								>
+									<TrashIcon size={14} />
+								</button>
+							</div>
+						))}
+					</div>
+				</SheetSection>
+
+				<div className="flex-1" />
+
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={closeSheet}
+						disabled={isSubmitting}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={handleSubmit}
+						isLoading={isSubmitting}
+					>
+						Record
+					</Button>
+				</SheetFooter>
+			</div>
+		</LayoutGroup>
+	);
+}

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -59,6 +59,22 @@ export function CustomerBalanceTable({
 							balance,
 						},
 					}),
+				onRecordUsageClick: (balance) =>
+					setSheet({
+						type: "record-usage",
+						data: {
+							featureId: balance.entitlement.feature.id,
+							featureName: balance.entitlement.feature.name,
+						},
+					}),
+				onCheckBalanceClick: (balance) =>
+					setSheet({
+						type: "check-balance",
+						data: {
+							featureId: balance.entitlement.feature.id,
+							featureName: balance.entitlement.feature.name,
+						},
+					}),
 			}),
 		[customer, entityId, setSheet],
 	);

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -15,8 +15,10 @@ import {
 } from "@autumn/shared";
 import {
 	BoxArrowDownIcon,
+	BracketsSquareIcon,
 	CaretRightIcon,
 	MoneyWavyIcon,
+	PulseIcon,
 	WalletIcon,
 } from "@phosphor-icons/react";
 import type { Row } from "@tanstack/react-table";
@@ -189,8 +191,6 @@ function SubRowUsageCell({
 		return <span className="text-t4">Unlimited</span>;
 	}
 
-	
-
 	const { balance, allowance, rolloverBalance } = getIndividualEntValues({
 		ent,
 		entityId,
@@ -361,17 +361,21 @@ function BarCell({
 function BalanceActionsCell({
 	row,
 	onDeleteClick,
+	onRecordUsageClick,
+	onCheckBalanceClick,
 }: {
 	row: Row<CustomerBalanceRowData>;
 	onDeleteClick?: (balance: FullCusEntWithFullCusProduct) => void;
+	onRecordUsageClick?: (balance: FullCusEntWithFullCusProduct) => void;
+	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) {
+	const isParentRow = row.depth === 0;
 	const canDelete =
-		!row.getCanExpand() &&
-		canDeleteCustomerBalance({
-			balance: row.original,
-		});
+		!row.getCanExpand() && canDeleteCustomerBalance({ balance: row.original });
+	const canRecordUsage = isParentRow && !!onRecordUsageClick;
+	const canCheckBalance = isParentRow && !!onCheckBalanceClick;
 
-	if (!canDelete || !onDeleteClick) return null;
+	if (!canDelete && !canRecordUsage && !canCheckBalance) return null;
 
 	return (
 		<div className="flex justify-end">
@@ -384,17 +388,45 @@ function BalanceActionsCell({
 					align="end"
 					onClick={(event) => event.stopPropagation()}
 				>
-					<DropdownMenuItem
-						onClick={(event) => {
-							event.stopPropagation();
-							onDeleteClick(row.original);
-						}}
-					>
-						<div className="flex w-full items-center justify-between gap-2 text-sm">
-							Delete
-							<Trash size={12} className="text-t3" />
-						</div>
-					</DropdownMenuItem>
+					{canRecordUsage && (
+						<DropdownMenuItem
+							onClick={(event) => {
+								event.stopPropagation();
+								onRecordUsageClick(row.original);
+							}}
+						>
+							<div className="flex w-full items-center justify-between gap-2 text-sm">
+								Record usage
+								<PulseIcon size={12} className="text-t3" />
+							</div>
+						</DropdownMenuItem>
+					)}
+					{canCheckBalance && (
+						<DropdownMenuItem
+							onClick={(event) => {
+								event.stopPropagation();
+								onCheckBalanceClick(row.original);
+							}}
+						>
+							<div className="flex w-full items-center justify-between gap-2 text-sm">
+								Check balance
+								<BracketsSquareIcon size={12} className="text-t3" />
+							</div>
+						</DropdownMenuItem>
+					)}
+					{canDelete && onDeleteClick && (
+						<DropdownMenuItem
+							onClick={(event) => {
+								event.stopPropagation();
+								onDeleteClick(row.original);
+							}}
+						>
+							<div className="flex w-full items-center justify-between gap-2 text-sm">
+								Delete
+								<Trash size={12} className="text-t3" />
+							</div>
+						</DropdownMenuItem>
+					)}
 				</DropdownMenuContent>
 			</DropdownMenu>
 		</div>
@@ -408,11 +440,15 @@ export const CustomerBalanceTableColumns = ({
 	entityId,
 	entities = [],
 	onDeleteClick,
+	onRecordUsageClick,
+	onCheckBalanceClick,
 }: {
 	fullCustomer: FullCustomer | null | undefined;
 	entityId: string | null;
 	entities?: Entity[];
 	onDeleteClick?: (balance: FullCusEntWithFullCusProduct) => void;
+	onRecordUsageClick?: (balance: FullCusEntWithFullCusProduct) => void;
+	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) => [
 	{
 		header: "Feature",
@@ -530,7 +566,12 @@ export const CustomerBalanceTableColumns = ({
 		header: "",
 		size: 44,
 		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => (
-			<BalanceActionsCell row={row} onDeleteClick={onDeleteClick} />
+			<BalanceActionsCell
+				row={row}
+				onDeleteClick={onDeleteClick}
+				onRecordUsageClick={onRecordUsageClick}
+				onCheckBalanceClick={onCheckBalanceClick}
+			/>
 		),
 	},
 ];

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -4,11 +4,13 @@ import type {
 	FullCustomerEntitlement,
 } from "@autumn/shared";
 import { FeatureType, type FullCusProduct } from "@autumn/shared";
-import { CubeIcon } from "@phosphor-icons/react";
-import { SectionTag } from "@/components/v2/badges/SectionTag";
+import { CubeIcon, PlusIcon } from "@phosphor-icons/react";
 import { type ExpandedState, getExpandedRowModel } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import { Table } from "@/components/general/table";
+import { SectionTag } from "@/components/v2/badges/SectionTag";
+import { Button } from "@/components/v2/buttons/Button";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useEntity } from "@/hooks/stores/useSubscriptionStore";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
@@ -27,6 +29,7 @@ import {
 
 export function CustomerFeatureUsageTable() {
 	const { customer, features, isLoading } = useCusQuery();
+	const { setSheet } = useSheetStore();
 
 	const { entityId } = useEntity();
 
@@ -173,13 +176,20 @@ export function CustomerFeatureUsageTable() {
 				<Table.Container>
 					<Table.Toolbar>
 						<Table.Heading>
-							<CubeIcon
-								size={16}
-								weight="fill"
-								className="text-subtle"
-							/>
+							<CubeIcon size={16} weight="fill" className="text-subtle" />
 							Features
 						</Table.Heading>
+						<Table.Actions>
+							<Button
+								variant="secondary"
+								size="mini"
+								className="gap-2 font-medium"
+								onClick={() => setSheet({ type: "balance-create" })}
+							>
+								<PlusIcon className="size-3.5" />
+								Create Balance
+							</Button>
+						</Table.Actions>
 					</Table.Toolbar>
 					{hasBooleanFlags && <SectionTag>Balances</SectionTag>}
 					{hasMeteredBalances ? (
@@ -190,7 +200,8 @@ export function CustomerFeatureUsageTable() {
 							isLoading={isLoading}
 						/>
 					) : (
-						!isLoading && !hasBooleanFlags && (
+						!isLoading &&
+						!hasBooleanFlags && (
 							<EmptyState text="Enable a plan to grant access to features" />
 						)
 					)}

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
@@ -16,7 +16,7 @@ export function CustomerFlagsSection({
 				{booleanEnts.map((ent) => (
 					<div
 						key={ent.entitlement.feature.id}
-						className="text-sm text-t2 bg-interactive-secondary border h-8 flex items-center px-4 rounded-lg"
+						className="text-sm text-t2 bg-interactive-secondary border h-12 flex items-center px-4 rounded-lg"
 					>
 						<span>{ent.entitlement.feature.name}</span>
 					</div>

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
@@ -169,9 +169,11 @@ export const createCustomerListColumns = (): ColumnDef<
 		accessorKey: "email",
 		size: 120,
 		cell: ({ row }: { row: Row<CustomerWithProducts> }) => {
+			const email = row.original.email;
+			if (!email) return null;
 			return (
 				<div className="truncate">
-					<MiniCopyButton text={row.original.email ?? ""} />
+					<MiniCopyButton text={email} />
 				</div>
 			);
 		},

--- a/vite/src/views/customers2/components/table/customer-usage-analytics/CustomerUsageAnalyticsChart.tsx
+++ b/vite/src/views/customers2/components/table/customer-usage-analytics/CustomerUsageAnalyticsChart.tsx
@@ -78,15 +78,16 @@ export function CustomerUsageAnalyticsChart({
 					isLoading && "animate-pulse")}
 				barCategoryGap={4}
 			>
+				{eventNames.length > 0 && !isLoading && (
 				<CartesianGrid
 					vertical={false}
 					className="fill-white dark:fill-gray-900"
 					stroke="var(--chart-grid-stroke)"
 					strokeWidth={1}
 					strokeDasharray="2 2"
-					// verticalPoints={[20]}
 					horizontalPoints={[5, 50, 100, 150, 200]}
 				/>
+			)}
 				<XAxis
 					dataKey="date"
 					tickLine={false}

--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -16,7 +16,13 @@ import { AttachProductSheetV2 } from "../components/sheets/AttachProductSheetV2"
 import { BalanceCreateSheet } from "../components/sheets/BalanceCreateSheet";
 import { BalanceDeleteSheet } from "../components/sheets/BalanceDeleteSheet";
 import { BalanceEditSheet } from "../components/sheets/BalanceEditSheet";
+import { BillingAutoTopupSheet } from "../components/sheets/BillingAutoTopupSheet";
+import { BillingOverageAllowedSheet } from "../components/sheets/BillingOverageAllowedSheet";
+import { BillingSpendLimitSheet } from "../components/sheets/BillingSpendLimitSheet";
+import { BillingUsageAlertSheet } from "../components/sheets/BillingUsageAlertSheet";
+import { CheckBalanceSheet } from "../components/sheets/CheckBalanceSheet";
 import { InvoiceDetailSheet } from "../components/sheets/InvoiceDetailSheet";
+import { RecordUsageSheet } from "../components/sheets/RecordUsageSheet";
 import { SubscriptionDetailSheet } from "../components/sheets/SubscriptionDetailSheet";
 import { SubscriptionUpdateSheet } from "../components/sheets/SubscriptionUpdateSheet";
 import { SHEET_ANIMATION } from "./customerAnimations";
@@ -62,6 +68,22 @@ export function CustomerSheets() {
 				if (!invoice) return null;
 				return <InvoiceDetailSheet invoice={invoice} lineItems={lineItems} />;
 			}
+			case "billing-auto-topup-add":
+			case "billing-auto-topup-edit":
+				return <BillingAutoTopupSheet />;
+			case "billing-spend-limit-add":
+			case "billing-spend-limit-edit":
+				return <BillingSpendLimitSheet />;
+			case "billing-usage-alert-add":
+			case "billing-usage-alert-edit":
+				return <BillingUsageAlertSheet />;
+			case "billing-overage-allowed-add":
+			case "billing-overage-allowed-edit":
+				return <BillingOverageAllowedSheet />;
+			case "record-usage":
+				return <RecordUsageSheet />;
+			case "check-balance":
+				return <CheckBalanceSheet />;
 			default:
 				return null;
 		}

--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -13,6 +13,7 @@ import { SubscriptionUncancelSheet } from "@/views/customers2/components/sheets/
 import { SubscriptionUpdateSheet2 } from "@/views/customers2/components/sheets/SubscriptionUpdateSheet2";
 import { AttachProductSheet } from "../components/sheets/AttachProductSheet";
 import { AttachProductSheetV2 } from "../components/sheets/AttachProductSheetV2";
+import { BalanceCreateSheet } from "../components/sheets/BalanceCreateSheet";
 import { BalanceDeleteSheet } from "../components/sheets/BalanceDeleteSheet";
 import { BalanceEditSheet } from "../components/sheets/BalanceEditSheet";
 import { InvoiceDetailSheet } from "../components/sheets/InvoiceDetailSheet";
@@ -53,6 +54,8 @@ export function CustomerSheets() {
 				return <BalanceEditSheet />;
 			case "balance-delete":
 				return <BalanceDeleteSheet />;
+			case "balance-create":
+				return <BalanceCreateSheet />;
 			case "invoice-detail": {
 				const invoice = sheetData?.invoice as Invoice | undefined;
 				const lineItems = (sheetData?.lineItems as InvoiceLineItem[]) ?? [];

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -143,7 +143,7 @@ export default function CustomerView2() {
 								</div>
 								<SelectedEntityDetails />
 							</div>
-							<div className="flex flex-col gap-12 w-full">
+							<div className="flex flex-col gap-16 w-full">
 								<CustomerPlansSection />
 								<CustomerFeatureUsageTable />
 								{!entityId && <CustomerUsageAnalyticsTable />}

--- a/vite/src/views/main-sidebar/components/OrgDropdown.tsx
+++ b/vite/src/views/main-sidebar/components/OrgDropdown.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useEnv } from "@/utils/envUtils";
 import { OrgLogo } from "../org-dropdown/components/OrgLogo";
 import { useMemberships } from "../org-dropdown/hooks/useMemberships";
 import { useSidebarContext } from "../SidebarContext";
@@ -239,6 +240,7 @@ export const useOrgSwitch = () => {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 	const axiosInstance = useAxiosInstance();
+	const env = useEnv();
 
 	return async ({
 		orgId,
@@ -257,7 +259,7 @@ export const useOrgSwitch = () => {
 
 			if (newOrg?.id) setLastSwitchedOrgId(newOrg.id);
 
-			queryClient.setQueryData(["org"], newOrg);
+			queryClient.setQueryData(["org", env], newOrg);
 			queryClient.invalidateQueries({ queryKey: ["org"] });
 
 			if (

--- a/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
@@ -4,19 +4,10 @@ import {
 	FeatureType,
 	type ProductItem,
 } from "@autumn/shared";
-import {
-	CaretDownIcon,
-	MagnifyingGlassIcon,
-	PlusIcon,
-} from "@phosphor-icons/react";
+import { PlusIcon } from "@phosphor-icons/react";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/v2/buttons/Button";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/v2/dropdowns/DropdownMenu";
+import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import { FormLabel } from "@/components/v2/form/FormLabel";
 import {
 	useProduct,
@@ -24,9 +15,7 @@ import {
 } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetHeader, SheetSection } from "@/components/v2/sheets/InlineSheet";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
-import { cn } from "@/lib/utils";
 import { getItemId } from "@/utils/product/productItemUtils";
-import { getFeatureIcon } from "@/views/products/features/utils/getFeatureIcon";
 import { getDefaultItem } from "../utils/getDefaultItem";
 
 /** Get all feature IDs already in the plan, including underlying features from credit systems */
@@ -64,33 +53,21 @@ export function SelectFeatureSheet({
 	isOnboarding?: boolean;
 }) {
 	const [selectOpen, setSelectOpen] = useState(false);
-	const [searchValue, setSearchValue] = useState("");
 
 	const { features } = useFeaturesQuery();
 	const { product, setProduct, initialProduct } = useProduct();
 	const { setSheet } = useSheet();
 
+	const nonArchivedFeatures = useMemo(
+		() => features.filter((f: Feature) => !f.archived),
+		[features],
+	);
+
 	useEffect(() => {
-		// Always delay to let sheet animate in (300ms animation + buffer)
 		const timer = setTimeout(() => setSelectOpen(true), 350);
 		return () => clearTimeout(timer);
 	}, []);
 
-	// Reset search when dropdown closes
-	useEffect(() => {
-		if (!selectOpen) {
-			setSearchValue("");
-		}
-	}, [selectOpen]);
-
-	// Filter features based on search and exclude archived features
-	const filteredFeatures = features.filter(
-		(feature: Feature) =>
-			!feature.archived &&
-			feature.name.toLowerCase().includes(searchValue.toLowerCase()),
-	);
-
-	// Get features already in the plan (for showing "Already in plan" tag)
 	const featuresInPlan = useMemo(
 		() =>
 			getFeaturesAlreadyInPlan({
@@ -143,63 +120,20 @@ export function SelectFeatureSheet({
 			<div className="flex-1 overflow-y-auto">
 				<SheetSection withSeparator={false}>
 					<FormLabel>Select a feature</FormLabel>
-					<DropdownMenu open={selectOpen} onOpenChange={setSelectOpen}>
-						<DropdownMenuTrigger asChild>
-							<button
-								type="button"
-								className={cn(
-									"flex items-center justify-between w-full rounded-lg border bg-transparent text-sm outline-none h-input input-base input-shadow-default input-state-open p-2",
-								)}
-							>
-								<span className="text-t4">Select a feature</span>
-								<CaretDownIcon className="size-4 opacity-50" />
-							</button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent
-							align="start"
-							className="w-(--radix-dropdown-menu-trigger-width)"
-						>
-							{/* Search input */}
-							<div className="flex items-center gap-2 px-2 py-1.5 border-b border-border">
-								<MagnifyingGlassIcon className="size-4 text-t4" />
-								<input
-									type="text"
-									placeholder="Search features..."
-									value={searchValue}
-									onChange={(e) => setSearchValue(e.target.value)}
-									onKeyDown={(e) => e.stopPropagation()}
-									className="flex-1 bg-transparent text-sm outline-none placeholder:text-t4"
-								/>
-							</div>
-
-							<div className="max-h-60 overflow-y-auto">
-								{filteredFeatures.length === 0 ? (
-									<div className="py-4 text-center text-sm text-t4">
-										No features found.
-									</div>
-								) : (
-									filteredFeatures.map((feature: Feature) => (
-										<DropdownMenuItem
-											key={feature.id}
-											onClick={() => handleFeatureSelect(feature.id)}
-											className="py-2 px-2.5"
-										>
-											<div className="flex items-center gap-2 w-full">
-												<div className="shrink-0">
-													{getFeatureIcon({ feature })}
-												</div>
-												<span className="truncate flex-1">{feature.name}</span>
-												{featuresInPlan.has(feature.id) && (
-													<span className="shrink-0 text-xs text-t3 bg-muted px-1 py-0 rounded-md">
-														Already in plan
-													</span>
-												)}
-											</div>
-										</DropdownMenuItem>
-									))
-								)}
-							</div>
-
+					<FeatureSearchDropdown
+						features={nonArchivedFeatures}
+						value={null}
+						onSelect={handleFeatureSelect}
+						open={selectOpen}
+						onOpenChange={setSelectOpen}
+						renderExtra={(feature) =>
+							featuresInPlan.has(feature.id) ? (
+								<span className="shrink-0 text-xs text-t3 bg-muted px-1 py-0 rounded-md">
+									Already in plan
+								</span>
+							) : null
+						}
+						footer={
 							<div className="border-t pt-2 pb-1 px-2">
 								<Button
 									variant="muted"
@@ -210,8 +144,8 @@ export function SelectFeatureSheet({
 									Create new feature
 								</Button>
 							</div>
-						</DropdownMenuContent>
-					</DropdownMenu>
+						}
+					/>
 				</SheetSection>
 			</div>
 		</div>


### PR DESCRIPTION
- **feat: add Create Balance sheet and extract shared FeatureSearchDropdown**
- **docs: add proration_behavior and custom_line_items to proration docs**
- **feat: add billing control sheets and improve entity-level billing controls**
- **fix: billing control sheets update entity instead of customer when on entity view**
- **fix: forward metadata stripe**
- **fix: deleting long stripe keys**
- **sync status past due false positive**
- **removed feature quantity check in error handler for update sub**
- **fix bug**
- **fix: use proper shared types instead of any[] for entity billing controls**
- **fix stale stripe bug**
- **fix: 🐛 clear cache on customer portal creation**

## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears cached customer data after creating or opening the Stripe billing portal so UIs and APIs see fresh billing state. Also adds opt‑in customer metadata forwarding to Stripe, fixes billing edge cases, and ships new customer billing control sheets.

- New Features
  - Clear cache on `POST/GET /customers/:customer_id/billing_portal` and `POST /billing.open_customer_portal`.
  - Add org-config flag `forward_customer_metadata`; safely map and truncate metadata to Stripe limits.
  - New customer sheets: Create Balance, Auto Topup, Spend Limit, Usage Alert, Overage Allowed, Check Balance, Record Usage.
  - Extract shared `FeatureSearchDropdown`; improve entity-level billing controls via `/v1/entities.update`.
  - Docs: add `proration_behavior` and `custom_line_items` to proration guide.

- Bug Fixes
  - Prevent false past_due on upgrades that issue manual invoices; only transition when truly past_due.
  - Auto-topup invoice mode: treat `open` invoices as success; record sequential successes correctly.
  - Forwarding to Stripe: handle deletion of long keys and use shared types.
  - Remove one-off feature quantity validation during plan updates.
  - Small UX fixes: clickable table rows when actionable, safe email copy, avoid stale Stripe org state, conditional chart grid, and non-cached customer object sheet.

<sup>Written for commit d56d027e6a854fab1b225baf56346a1873e4c1ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bundles multiple bug fixes, a new metadata-forwarding feature, and a set of new billing-control UI sheets for the customer view.

**Key changes:**

- **Bug fixes** — Clear the customer cache after billing portal creation; fix false-positive `past_due` webhook status by checking `previousAttributes.status`; fix entity-level billing controls updating the parent customer instead of the entity; fix invoice-mode auto-topup recording `"failure"` for open invoices.
- **Improvements** — New `BalanceCreateSheet`, `BillingAutoTopupSheet`, `BillingSpendLimitSheet`, `BillingUsageAlertSheet`, `BillingOverageAllowedSheet`, `RecordUsageSheet`, and `CheckBalanceSheet` components; billing-controls section now supports add/edit flows; extracted shared `FeatureSearchDropdown`; billing-control updates now apply only defined fields, avoiding unintended nullification.
- **API changes** — New `forward_customer_metadata` org config flag; when enabled, Autumn customer metadata is synced to the corresponding Stripe customer on create and update, with key/value length clamping and `autumn_` prefix filtering.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/cleanup items with no impact on correctness.

All three inline comments are P2: the commented-out dead code is cosmetic, the key-collision on truncation requires keys sharing a 40-character prefix which is extremely unlikely in practice, and the unreachable previousAttributes.status === 'past_due' branch is harmless. No P0 or P1 issues found.

server/src/external/stripe/customers/utils/autumnToStripeMetadata.ts (key-collision on truncation) and server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts (commented-out block).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/customers/utils/autumnToStripeMetadata.ts | New utility that converts Autumn metadata to Stripe-compatible format, respecting Stripe's 50-key/40-char-key/500-char-value limits; silent overwrite occurs if two keys share the same 40-char prefix after truncation. |
| server/src/external/stripe/customers/operations/createStripeCustomer.ts | Correctly gates metadata forwarding to Stripe behind the new forward_customer_metadata org config flag during customer creation. |
| server/src/internal/customers/actions/update/updateCustomer.ts | Refactored to surgically apply only defined billing control fields and to forward metadata deletes to Stripe as empty-string overrides; logic is correct. |
| server/src/honoMiddlewares/refreshCacheMiddleware.ts | Adds /customers/:customer_id/billing_portal (GET + POST) and /billing.open_customer_portal to the cache-invalidation URL list, fixing stale-cache after portal creation. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus.ts | Fixes false-positive past_due detection by skipping the override when the status didn't change in the event; the previousAttributes.status === 'past_due' branch is unreachable given the outer guard clause but is harmless. |
| server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts | Feature quantity validation call commented out rather than removed, leaving dead code in production; the underlying function file is now unreachable. |
| server/src/internal/billing/v2/actions/updateSubscription/errors/handleFeatureQuantityErrors.ts | Slimmed down to only enforce recurring prepaid price options by excluding one-off prices from the validation filter; checkInputFeatureQuantitiesAreValid removed entirely. |
| server/src/internal/balances/autoTopUp/helpers/limits/recordAutoTopupAttempt.ts | Records invoice-mode auto-topup as 'success' when the invoice is open (not just paid), fixing incorrect failure recording for invoice-mode top-ups. |
| shared/models/orgModels/orgConfig.ts | Adds forward_customer_metadata boolean flag (defaulting to false) to OrgConfigSchema. |
| shared/utils/orgUtils/convertOrgUtils.ts | Adds shouldForwardCustomerMetadata helper that reads the new org config flag; straightforward and correctly typed. |
| vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx | New sheet for adding/editing auto-topup billing controls per customer; handles both create and edit modes with full form state management. |
| vite/src/views/customers2/components/CustomerBillingControlsSection.tsx | Extended to support click-through editing of billing controls and a dropdown for adding new control types; entity vs. customer routing handled correctly via CusService.updateEntity. |
| server/tests/integration/org-config/forward-customer-metadata.test.ts | Comprehensive integration tests covering metadata creation, update, deletion, autumn_ prefix filtering, long-key/value truncation, and null-value handling for the metadata forwarding feature. |
| vite/src/services/customers/CusService.tsx | Adds updateEntity static method to route billing-control updates to the entity-level endpoint when viewing an entity, fixing the bug where entity views updated the parent customer instead. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Customer create / update API"] -->|forward_customer_metadata = true| B["shouldForwardCustomerMetadata"]
    B -->|true| C["autumnToStripeCustomerMetadata\n(clamp keys ≤40, values ≤500,\nskip autumn_ prefix, max 48 keys)"]
    C --> D["stripeCli.customers.create / update\n(merged metadata + deletions as empty strings)"]
    B -->|false| E["No Stripe metadata sync"]
    F["billing.open_customer_portal POST"] --> G["refreshCacheMiddleware\n(cache invalidated)"]
    H["/customers/:id/billing_portal GET/POST"] --> G
    I["Stripe subscription.updated webhook"] --> J{"isStripeSubscriptionPastDue?"}
    J -->|No| K["Return autumnStatus as-is"]
    J -->|Yes| L{"previousAttributes.status === undefined?"}
    L -->|Yes: status did not change, was already past_due| M["Return autumnStatus (genuine past_due)"]
    L -->|No: just transitioned to past_due| N["Check latest invoice for false-positive logic"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
Line: 48-51

Comment:
**Commented-out dead code**

The call to `handleFeatureQuantityErrors` is commented out rather than removed. The function in `handleFeatureQuantityErrors.ts` also appears to no longer be invoked anywhere. If this check is intentionally disabled (as indicated by the PR description), the commented block should be removed to keep the production code clean.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/syncCustomerProductStatus/syncCustomerProductStatus.ts
Line: 33-40

Comment:
**`previousAttributes.status === "past_due"` is unreachable**

The outer guard `if (!isStripeSubscriptionPastDue(stripeSubscription)) return autumnStatus` ensures the current subscription status IS `past_due`. In Stripe webhooks, `previous_attributes` only includes fields that actually changed. If `previousAttributes.status === "past_due"`, it means the status changed FROM `past_due` to something else — but that contradicts the outer check confirming the current status is `past_due`. This branch is dead code and the comment describing it as "was already past_due" is misleading. The real fix — the `undefined` check — is correct and sufficient.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/external/stripe/customers/utils/autumnToStripeMetadata.ts
Line: 19-30

Comment:
**Silent key collision on truncation**

If two metadata keys share the same first 40 characters, `stripeKey` will be identical for both entries. The second assignment silently overwrites the first in `result` while `count` is still incremented for both, causing one value to be lost without any warning or error. A guard before the assignment (e.g. `if (stripeKey in result) skip the entry`) would surface this conflict rather than silently dropping data.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 clear cache on customer portal c..."](https://github.com/useautumn/autumn/commit/d56d027e6a854fab1b225baf56346a1873e4c1ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27300739)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->