### PR TITLE
fix: cusProduct updateDbAndCache

### DIFF
--- a/server/src/internal/customers/cusProducts/actions/updateDbAndCache.ts
+++ b/server/src/internal/customers/cusProducts/actions/updateDbAndCache.ts
@@ -1,6 +1,5 @@
 import type { InsertCustomerProduct } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getOrSetCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.js";
 import { CusProductService } from "../CusProductService.js";
 import { updateCachedCustomerProduct } from "./cache/updateCachedCustomerProduct.js";
 
@@ -41,10 +40,5 @@ export const updateCustomerProductDbAndCache = async ({
 		ctx.logger.info(
 			`[updateCustomerProductDbAndCache] cache_miss for cusProduct ${cusProductId}, rebuilding cache from DB`,
 		);
-		await getOrSetCachedFullCustomer({
-			ctx,
-			customerId,
-			source: "updateDbAndCache:cache_miss_fallback",
-		});
 	}
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop rebuilding the full customer cache on cusProduct update cache misses. `updateCustomerProductDbAndCache` now only updates the product cache and logs the miss, reducing unnecessary work and side effects.

<sup>Written for commit 35989dfe9400b36cde599873dad0167f8b27b6db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the eager cache-rebuild fallback (`getOrSetCachedFullCustomer`) that was previously triggered on a `cache_miss` inside `updateCustomerProductDbAndCache`. On a miss the function now only logs and returns, leaving the cache to be repopulated lazily.

**Key changes**

- **Bug fixes** — Removes the `getOrSetCachedFullCustomer` call in the `cache_miss` branch of `updateCustomerProductDbAndCache`, which was presumably causing unintended side-effects or unnecessary DB round-trips.
- **Improvements** — Eliminates an unused import (`getOrSetCachedFullCustomer`) from the file.

**Note**: The JSDoc comment still describes the old eager-rebuild behavior and should be updated to match the new lazy-repopulation semantics.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the only code change is a deliberate removal of a cache-rebuild call; the sole issue is a stale JSDoc comment.

The diff is minimal (removing 5 lines + one import). Logic is straightforward: on a cache_miss the function now logs and exits instead of triggering a full-customer cache rebuild. No new code paths are introduced. The only issue is that the JSDoc comment still describes the old eager-rebuild behavior, which is misleading but not a runtime defect.

server/src/internal/customers/cusProducts/actions/updateDbAndCache.ts — JSDoc comment needs to be updated to reflect the new lazy-repopulation semantics.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/actions/updateDbAndCache.ts | Removes the `getOrSetCachedFullCustomer` cache-rebuild fallback on `cache_miss`; the JSDoc comment still describes the old (now-removed) behavior and needs updating. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant updateCustomerProductDbAndCache
    participant CusProductService
    participant updateCachedCustomerProduct
    participant Redis

    Caller->>updateCustomerProductDbAndCache: { ctx, customerId, cusProductId, updates }
    updateCustomerProductDbAndCache->>CusProductService: update({ ctx, cusProductId, updates })
    CusProductService-->>updateCustomerProductDbAndCache: ok

    updateCustomerProductDbAndCache->>updateCachedCustomerProduct: { ctx, customerId, cusProductId, updates }
    updateCachedCustomerProduct->>Redis: Lua atomic patch
    alt cache hit
        Redis-->>updateCachedCustomerProduct: { ok: true, updated_count: N }
        updateCachedCustomerProduct-->>updateCustomerProductDbAndCache: { ok: true }
    else cache miss
        Redis-->>updateCachedCustomerProduct: { ok: false, error: "cache_miss" }
        updateCachedCustomerProduct-->>updateCustomerProductDbAndCache: { ok: false, error: "cache_miss" }
        Note over updateCustomerProductDbAndCache: Log cache_miss and return (cache left cold)
    end
    updateCustomerProductDbAndCache-->>Caller: done
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/customers/cusProducts/actions/updateDbAndCache.ts`, line 6-14 ([link](https://github.com/useautumn/autumn/blob/35989dfe9400b36cde599873dad0167f8b27b6db/server/src/internal/customers/cusProducts/actions/updateDbAndCache.ts#L6-L14)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale JSDoc comment after cache-rebuild removal**

   The JSDoc block still describes the removed `getOrSetCachedFullCustomer` fallback behavior:

   > "we fall back to a full DB fetch and re-populate the cache before returning. This ensures the cache is warm and correct before the 200 response goes out, preventing stale reads immediately after the update."

   This is now factually incorrect — on a `cache_miss` the function only logs and returns, it no longer rebuilds the cache. A future reader relying on this comment would have a wrong mental model of the behavior.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/cusProducts/actions/updateDbAndCache.ts
   Line: 6-14

   Comment:
   **Stale JSDoc comment after cache-rebuild removal**

   The JSDoc block still describes the removed `getOrSetCachedFullCustomer` fallback behavior:

   > "we fall back to a full DB fetch and re-populate the cache before returning. This ensures the cache is warm and correct before the 200 response goes out, preventing stale reads immediately after the update."

   This is now factually incorrect — on a `cache_miss` the function only logs and returns, it no longer rebuilds the cache. A future reader relying on this comment would have a wrong mental model of the behavior.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/customers/cusProducts/actions/updateDbAndCache.ts
Line: 6-14

Comment:
**Stale JSDoc comment after cache-rebuild removal**

The JSDoc block still describes the removed `getOrSetCachedFullCustomer` fallback behavior:

> "we fall back to a full DB fetch and re-populate the cache before returning. This ensures the cache is warm and correct before the 200 response goes out, preventing stale reads immediately after the update."

This is now factually incorrect — on a `cache_miss` the function only logs and returns, it no longer rebuilds the cache. A future reader relying on this comment would have a wrong mental model of the behavior.

```suggestion
/**
 * Updates a customer product in both Postgres and the Redis FullCustomer cache.
 *
 * If the Lua atomic patch finds a cache_miss (e.g. because a concurrent Stripe
 * webhook deleted the key mid-flight), the miss is logged and the cache is left
 * cold to be repopulated on the next natural read.
 */
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: cusProduct update db and cache"](https://github.com/useautumn/autumn/commit/35989dfe9400b36cde599873dad0167f8b27b6db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27358907)</sub>

<!-- /greptile_comment -->