### PR TITLE
working on rollout infra

### DIFF
--- a/.agents/skills/rolling-rollouts/SKILL.md
+++ b/.agents/skills/rolling-rollouts/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: rolling-rollouts
+description: Build and manage percentage-based rolling rollouts with cache staleness detection. Use when adding new rollout features, debugging rollout bucket routing, working with the rollout edge config, or handling cache staleness during forward/rollback migrations.
+---
+
+# Rolling Rollouts
+
+Percentage-based rolling rollout infrastructure for safely migrating infrastructure changes (cache layers, Redis instances, billing engines, etc.) customer-by-customer.
+
+## Architecture
+
+1. **S3 edge config** (`admin/rollout-config.json`) stores rollout definitions with per-org overrides
+2. **In-memory polling** via `createEdgeConfigStore` refreshes every 30s (fail-open to empty config)
+3. **Deterministic hashing** maps each `customerId` to a bucket 0-99 via `Bun.hash`
+4. **Per-request snapshot** on `ctx.rolloutSnapshot` prevents race conditions from mid-request config changes
+5. **Cache staleness detection** auto-evicts entries whose routing changed between `previousPercent` and `percent`
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `server/src/internal/misc/rollouts/rolloutSchemas.ts` | Zod schemas: `RolloutPercent`, `RolloutEntry`, `RolloutConfig` |
+| `server/src/internal/misc/rollouts/rolloutConfigStore.ts` | Edge config store + `updateRolloutPercent` + `removeRolloutOrg` |
+| `server/src/internal/misc/rollouts/rolloutUtils.ts` | `getCustomerBucket`, `isRolloutEnabled`, `isSnapshotCacheStale` |
+| `server/src/honoMiddlewares/rolloutMiddleware.ts` | Computes `ctx.rolloutSnapshot` once per request |
+| `server/src/honoMiddlewares/utils/resolveCustomerId.ts` | Extracts `customerId` from URL/body/query in `baseMiddleware` |
+| `server/src/honoUtils/HonoEnv.ts` | `RolloutSnapshot` and `RolloutSnapshotEntry` types on `RequestContext` |
+| `server/src/internal/admin/rollouts/` | Admin CRUD routes for rollout config |
+| `vite/src/views/admin/edge-config/EdgeConfigView.tsx` | Admin UI for managing rollouts |
+
+## Config shape
+
+```json
+{
+  "rollouts": {
+    "v2-cache": {
+      "percent": 50,
+      "previousPercent": 20,
+      "changedAt": 1711929600000,
+      "orgs": {
+        "org_abc": { "percent": 100, "previousPercent": 50, "changedAt": 1711929600000 }
+      }
+    }
+  }
+}
+```
+
+Each level (global + per-org) stores `percent`, `previousPercent`, `changedAt`. Per-org takes priority over global.
+
+## How to add a new rollout
+
+1. Add a rollout entry to the S3 config (via admin UI at `/admin/edge-config` or `updateRolloutPercent`)
+2. At the branch point in your code, read from the snapshot:
+
+```typescript
+const snapshot = ctx.rolloutSnapshot?.rollouts["my-rollout"];
+if (snapshot?.enabled) {
+  // new path
+} else {
+  // old path
+}
+```
+
+3. In cache read paths, check for staleness:
+
+```typescript
+const snapshot = ctx.rolloutSnapshot?.rollouts["my-rollout"];
+if (snapshot && isSnapshotCacheStale({ snapshot, customerBucket: ctx.rolloutSnapshot.customerBucket, cachedAt })) {
+  // evict and re-fetch
+}
+```
+
+## Cache staleness algorithm
+
+When a percentage changes, only customers whose bucket **crossed the boundary** are affected:
+
+```
+Example: 20% -> 50%
+  bucket 15: was enabled (< 20), still enabled (< 50)    -> NOT stale
+  bucket 35: was disabled (>= 20), now enabled (< 50)    -> STALE
+  bucket 70: was disabled (>= 20), still disabled (>= 50) -> NOT stale
+
+Example: 50% -> 20% (rollback)
+  bucket 15: was enabled (< 50), still enabled (< 20)     -> NOT stale
+  bucket 35: was enabled (< 50), now disabled (>= 20)     -> STALE
+  bucket 70: was disabled (>= 50), still disabled (>= 20) -> NOT stale
+```
+
+The check: `(bucket < previousPercent) !== (bucket < percent)` AND `cachedAt < changedAt`.
+
+Entries without `_cachedAt` (legacy) are conservatively treated as stale if routing changed.
+
+## updateRolloutPercent auto-manages staleness
+
+Always use `updateRolloutPercent` (or the admin UI) to change percentages. It automatically:
+- Sets `previousPercent` to the old `percent`
+- Sets `changedAt` to `Date.now()`
+- Writes to S3 + updates local cache
+
+Never manually edit `previousPercent` or `changedAt`.
+
+## Middleware chain order
+
+```
+baseMiddleware (sets ctx.customerId via resolveCustomerId)
+  -> auth middleware (sets ctx.org)
+    -> rolloutMiddleware (computes ctx.rolloutSnapshot)
+      -> handler
+```
+
+The rollout middleware must run after auth (needs `ctx.org.id`) and after base (needs `ctx.customerId`).
+
+## Testing rollouts
+
+Use `getCustomerBucket` to find customer IDs in specific bucket ranges:
+
+```typescript
+const findCustomerInBucketRange = (min: number, max: number): string => {
+  for (let i = 0; i < 10000; i++) {
+    const id = `cus_test_${i}`;
+    const bucket = getCustomerBucket({ customerId: id });
+    if (bucket >= min && bucket < max) return id;
+  }
+  throw new Error(`No customer found in range [${min}, ${max})`);
+};
+```
+
+Test staleness scenarios: forward migration, rollback, bump forward, full migration, full rollback, same-percent no-op, legacy entries without `_cachedAt`.

--- a/.claude/skills/rolling-rollouts/SKILL.md
+++ b/.claude/skills/rolling-rollouts/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: rolling-rollouts
+description: Build and manage percentage-based rolling rollouts with cache staleness detection. Use when adding new rollout features, debugging rollout bucket routing, working with the rollout edge config, or handling cache staleness during forward/rollback migrations.
+---
+
+# Rolling Rollouts
+
+Percentage-based rolling rollout infrastructure for safely migrating infrastructure changes (cache layers, Redis instances, billing engines, etc.) customer-by-customer.
+
+## Architecture
+
+1. **S3 edge config** (`admin/rollout-config.json`) stores rollout definitions with per-org overrides
+2. **In-memory polling** via `createEdgeConfigStore` refreshes every 30s (fail-open to empty config)
+3. **Deterministic hashing** maps each `customerId` to a bucket 0-99 via `Bun.hash`
+4. **Per-request snapshot** on `ctx.rolloutSnapshot` prevents race conditions from mid-request config changes
+5. **Cache staleness detection** auto-evicts entries whose routing changed between `previousPercent` and `percent`
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `server/src/internal/misc/rollouts/rolloutSchemas.ts` | Zod schemas: `RolloutPercent`, `RolloutEntry`, `RolloutConfig` |
+| `server/src/internal/misc/rollouts/rolloutConfigStore.ts` | Edge config store + `updateRolloutPercent` + `removeRolloutOrg` |
+| `server/src/internal/misc/rollouts/rolloutUtils.ts` | `getCustomerBucket`, `isRolloutEnabled`, `isSnapshotCacheStale` |
+| `server/src/honoMiddlewares/rolloutMiddleware.ts` | Computes `ctx.rolloutSnapshot` once per request |
+| `server/src/honoMiddlewares/utils/resolveCustomerId.ts` | Extracts `customerId` from URL/body/query in `baseMiddleware` |
+| `server/src/honoUtils/HonoEnv.ts` | `RolloutSnapshot` and `RolloutSnapshotEntry` types on `RequestContext` |
+| `server/src/internal/admin/rollouts/` | Admin CRUD routes for rollout config |
+| `vite/src/views/admin/edge-config/EdgeConfigView.tsx` | Admin UI for managing rollouts |
+
+## Config shape
+
+```json
+{
+  "rollouts": {
+    "v2-cache": {
+      "percent": 50,
+      "previousPercent": 20,
+      "changedAt": 1711929600000,
+      "orgs": {
+        "org_abc": { "percent": 100, "previousPercent": 50, "changedAt": 1711929600000 }
+      }
+    }
+  }
+}
+```
+
+Each level (global + per-org) stores `percent`, `previousPercent`, `changedAt`. Per-org takes priority over global.
+
+## How to add a new rollout
+
+1. Add a rollout entry to the S3 config (via admin UI at `/admin/edge-config` or `updateRolloutPercent`)
+2. At the branch point in your code, read from the snapshot:
+
+```typescript
+const snapshot = ctx.rolloutSnapshot?.rollouts["my-rollout"];
+if (snapshot?.enabled) {
+  // new path
+} else {
+  // old path
+}
+```
+
+3. In cache read paths, check for staleness:
+
+```typescript
+const snapshot = ctx.rolloutSnapshot?.rollouts["my-rollout"];
+if (snapshot && isSnapshotCacheStale({ snapshot, customerBucket: ctx.rolloutSnapshot.customerBucket, cachedAt })) {
+  // evict and re-fetch
+}
+```
+
+## Cache staleness algorithm
+
+When a percentage changes, only customers whose bucket **crossed the boundary** are affected:
+
+```
+Example: 20% -> 50%
+  bucket 15: was enabled (< 20), still enabled (< 50)    -> NOT stale
+  bucket 35: was disabled (>= 20), now enabled (< 50)    -> STALE
+  bucket 70: was disabled (>= 20), still disabled (>= 50) -> NOT stale
+
+Example: 50% -> 20% (rollback)
+  bucket 15: was enabled (< 50), still enabled (< 20)     -> NOT stale
+  bucket 35: was enabled (< 50), now disabled (>= 20)     -> STALE
+  bucket 70: was disabled (>= 50), still disabled (>= 20) -> NOT stale
+```
+
+The check: `(bucket < previousPercent) !== (bucket < percent)` AND `cachedAt < changedAt`.
+
+Entries without `_cachedAt` (legacy) are conservatively treated as stale if routing changed.
+
+## updateRolloutPercent auto-manages staleness
+
+Always use `updateRolloutPercent` (or the admin UI) to change percentages. It automatically:
+- Sets `previousPercent` to the old `percent`
+- Sets `changedAt` to `Date.now()`
+- Writes to S3 + updates local cache
+
+Never manually edit `previousPercent` or `changedAt`.
+
+## Middleware chain order
+
+```
+baseMiddleware (sets ctx.customerId via resolveCustomerId)
+  -> auth middleware (sets ctx.org)
+    -> rolloutMiddleware (computes ctx.rolloutSnapshot)
+      -> handler
+```
+
+The rollout middleware must run after auth (needs `ctx.org.id`) and after base (needs `ctx.customerId`).
+
+## Testing rollouts
+
+Use `getCustomerBucket` to find customer IDs in specific bucket ranges:
+
+```typescript
+const findCustomerInBucketRange = (min: number, max: number): string => {
+  for (let i = 0; i < 10000; i++) {
+    const id = `cus_test_${i}`;
+    const bucket = getCustomerBucket({ customerId: id });
+    if (bucket >= min && bucket < max) return id;
+  }
+  throw new Error(`No customer found in range [${min}, ${max})`);
+};
+```
+
+Test staleness scenarios: forward migration, rollback, bump forward, full migration, full rollback, same-percent no-op, legacy entries without `_cachedAt`.

--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -1,4 +1,5 @@
 export const ADMIN_REQUEST_BLOCK_CONFIG_KEY = "admin/request-block-config.json";
+export const ADMIN_ROLLOUT_CONFIG_KEY = "admin/rollout-config.json";
 
 type AdminS3Target = "dev" | "prod";
 

--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -9,6 +9,7 @@ import {
 import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { CusService } from "@/internal/customers/CusService";
+import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { ProductService } from "@/internal/products/ProductService";
 import { getOrCreateCustomer } from "../../../internal/customers/cusUtils/getOrCreateCustomer";
 
@@ -87,8 +88,11 @@ export const resolveRevenuecatResources = async ({
 			cp.processor?.type === ProcessorType.RevenueCat || cp.product.is_default,
 	);
 
-	// Set customer ID in context for cache refresh middleware
 	ctx.customerId = customer.id ?? "";
+	ctx.rolloutSnapshot = computeRolloutSnapshot({
+		orgId: ctx.org.id,
+		customerId: ctx.customerId,
+	});
 
 	return { product, customer, cusProducts };
 };

--- a/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
@@ -1,5 +1,6 @@
 import { RELEVANT_STATUSES } from "@autumn/shared";
 import type { Context, Next } from "hono";
+import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { CusService } from "../../../internal/customers/CusService";
 import type {
 	StripeWebhookContext,
@@ -56,5 +57,14 @@ export const stripeToAutumnCustomerMiddleware = async (
 ) => {
 	const ctx = c.get("ctx") as StripeWebhookContext;
 	await getAutumnCustomerId({ ctx });
+
+	if (ctx.fullCustomer?.id) {
+		ctx.customerId = ctx.fullCustomer.id;
+		ctx.rolloutSnapshot = computeRolloutSnapshot({
+			orgId: ctx.org.id,
+			customerId: ctx.customerId,
+		});
+	}
+
 	await next();
 };

--- a/server/src/external/vercel/misc/vercelMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelMiddleware.ts
@@ -4,6 +4,7 @@ import type { Context, Next } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
+import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { addAppContextToLogs } from "@/utils/logging/addContextToLogs";
 
@@ -29,6 +30,11 @@ export const vercelSeederMiddleware = async (
 			env: ctx.env ?? AppEnv.Sandbox,
 		});
 	}
+
+	ctx.rolloutSnapshot = computeRolloutSnapshot({
+		orgId: ctx.org?.id,
+		customerId: ctx.customerId,
+	});
 
 	ctx.logger = addAppContextToLogs({
 		logger: ctx.logger,

--- a/server/src/honoMiddlewares/analyticsMiddleware.ts
+++ b/server/src/honoMiddlewares/analyticsMiddleware.ts
@@ -7,69 +7,6 @@ import {
 } from "@/utils/logging/addContextToLogs";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
 
-export const parseCustomerIdFromUrl = ({
-	url,
-}: {
-	url: string;
-}): string | undefined => {
-	if (!url.startsWith("/v1")) {
-		return undefined;
-	}
-
-	const cleanUrl = url.split("?")[0].replace(/^\/+|\/+$/g, "");
-	const segments = cleanUrl.split("/");
-	const customersIndex = segments.indexOf("customers");
-
-	if (customersIndex !== -1 && segments[customersIndex + 1]) {
-		return segments[customersIndex + 1];
-	}
-
-	return undefined;
-};
-
-const extractCustomerIdFromBody = ({
-	body,
-	path,
-	method,
-}: {
-	body: Record<string, unknown>;
-	path: string;
-	method: string;
-}): string | undefined => {
-	const isCreateCustomerPath =
-		(path.startsWith("/v1/customers") && method === "POST" && !path.includes("customers.get_or_create"));
-	return (isCreateCustomerPath ? body?.id : body?.customer_id) as
-		| string
-		| undefined;
-};
-
-export const parseCustomerIdFromBody = async (
-	c: Context<HonoEnv>,
-): Promise<
-	{ customerId: string | undefined; sendEvent: boolean | undefined } | undefined
-> => {
-	const method = c.req.method;
-	if (method === "POST" || method === "PUT" || method === "PATCH") {
-		try {
-			const body = await c.req.json();
-
-			return {
-				customerId: extractCustomerIdFromBody({
-					body,
-					path: c.req.path,
-					method,
-				}),
-				sendEvent: body?.send_event,
-			};
-		} catch (_error) {
-			// Body might not be JSON, that's okay
-			return undefined;
-		}
-	}
-
-	return undefined;
-};
-
 /**
  * Logs response details asynchronously without blocking
  */
@@ -85,17 +22,13 @@ const logResponse = async ({
 	durationMs: number;
 }) => {
 	try {
-		// Skip logging for certain URLs
-		if (skipUrls.includes(c.req.path)) {
-			return;
-		}
+		if (skipUrls.includes(c.req.path)) return;
 
 		ctx.logger = addExtrasToLogs({
 			logger: ctx.logger,
 			extras: ctx.extraLogs,
 		});
 
-		// Only clone and log response body for /v1 API routes (saves memory on webhooks, health checks, etc.)
 		let responseBody: Record<string, unknown> | null = null;
 		if (c.req.path.includes("/v1")) {
 			const contentType = c.res.headers.get("content-type");
@@ -103,14 +36,10 @@ const logResponse = async ({
 				try {
 					const clonedResponse = c.res.clone();
 					responseBody = await clonedResponse.json();
-				} catch (_error) {
-					// Response might not be JSON or already consumed
-				}
+				} catch (_error) {}
 			}
 		}
 
-		// Log response in non-development environments
-		// if (process.env.NODE_ENV !== "development") {
 		const log = c.res.status === 200 ? ctx.logger.info : ctx.logger.warn;
 		const statusColor = c.res.status === 200 ? chalk.green : chalk.yellow;
 
@@ -144,14 +73,8 @@ export const analyticsMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 	const ctx = c.get("ctx");
 	const skipUrls = ["/v1/customers/all/search"];
 
-	let { customerId } = (await parseCustomerIdFromBody(c)) || {};
-	if (!customerId) {
-		customerId = parseCustomerIdFromUrl({ url: c.req.path });
-	}
+	const customerId = ctx.customerId;
 
-	ctx.customerId = customerId;
-
-	// Update logger with enriched context
 	ctx.logger = addAppContextToLogs({
 		logger: ctx.logger,
 		appContext: {
@@ -170,14 +93,11 @@ export const analyticsMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		`${c.req.method} ${c.req.path} (${ctx.org?.slug}) [${ctx.id}]`,
 	);
 
-	// Execute the request
 	await next();
 
-	// Re-fetch ctx after next() since handlers may have replaced it via c.set("ctx", {...})
 	const finalCtx = c.get("ctx");
 	const durationMs = Date.now() - finalCtx.timestamp;
 
-	// Log response asynchronously without blocking (runs after response is sent)
 	Promise.resolve()
 		.then(() => logResponse({ ctx: finalCtx, c, skipUrls, durationMs }))
 		.catch((error) => {

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -11,6 +11,7 @@ import { logger } from "@/external/logtail/logtailUtils.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { generateId } from "@/utils/genUtils.js";
 import { addRequestToLogs } from "@/utils/logging/addContextToLogs";
+import { resolveCustomerId } from "./utils/resolveCustomerId.js";
 
 /**
  * Base middleware that sets up the request context
@@ -31,7 +32,12 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 			? await tryCatch(c.req.json())
 			: { data: undefined };
 
-	// const { data: body } = await tryCatch(c.req.json());
+	const customerId = resolveCustomerId({
+		method: c.req.method,
+		path: c.req.path,
+		body,
+		query: c.req.query(),
+	});
 
 	const childLogger = addRequestToLogs({
 		logger,
@@ -66,6 +72,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		org: undefined as any,
 		features: [],
 		userId: undefined,
+		customerId,
 		authType: AuthType.Unknown,
 		env: AppEnv.Sandbox, // maybe use app_env headers
 

--- a/server/src/honoMiddlewares/rateLimitMiddleware.ts
+++ b/server/src/honoMiddlewares/rateLimitMiddleware.ts
@@ -31,7 +31,7 @@ export const rateLimitMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		}
 
 		// 2. Get rate limit key based on type
-		const rateLimitKey = await getRateLimitKey({ c, rateLimitType });
+		const rateLimitKey = getRateLimitKey({ c, rateLimitType });
 
 		// 3. Store key in context for keyGenerator to access
 		setRateLimitKeyInContext(c as Context, rateLimitKey);

--- a/server/src/honoMiddlewares/rolloutMiddleware.ts
+++ b/server/src/honoMiddlewares/rolloutMiddleware.ts
@@ -1,0 +1,21 @@
+import type { Context, Next } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
+
+/**
+ * Computes the rollout snapshot once per request and stores it on ctx.
+ * Must run after auth (ctx.org available) and baseMiddleware (ctx.customerId set).
+ * Downstream code reads ctx.rolloutSnapshot instead of the global store,
+ * guaranteeing consistent decisions for the entire request lifetime.
+ */
+export const rolloutMiddleware = async (
+	c: Context<HonoEnv>,
+	next: Next,
+): Promise<void> => {
+	const ctx = c.get("ctx");
+	ctx.rolloutSnapshot = computeRolloutSnapshot({
+		orgId: ctx.org?.id,
+		customerId: ctx.customerId,
+	});
+	await next();
+};

--- a/server/src/honoMiddlewares/utils/resolveCustomerId.ts
+++ b/server/src/honoMiddlewares/utils/resolveCustomerId.ts
@@ -1,0 +1,53 @@
+/**
+ * Centralized customer ID resolution from all possible request sources.
+ * Called once in baseMiddleware so ctx.customerId is available early
+ * in the middleware chain (before rollout routing, analytics, rate limiting).
+ */
+export const resolveCustomerId = ({
+	method,
+	path,
+	body,
+	query,
+}: {
+	method: string;
+	path: string;
+	body?: Record<string, unknown>;
+	query?: Record<string, string>;
+}): string | undefined => {
+	const urlCustomerId = parseCustomerIdFromPath({ path });
+	if (urlCustomerId) return urlCustomerId;
+
+	if (body && (method === "POST" || method === "PUT" || method === "PATCH")) {
+		const isCreateCustomerPath =
+			path.startsWith("/v1/customers") &&
+			method === "POST" &&
+			!path.includes("customers.get_or_create");
+
+		const bodyCustomerId = isCreateCustomerPath
+			? (body.id as string | undefined)
+			: (body.customer_id as string | undefined);
+
+		if (bodyCustomerId) return bodyCustomerId;
+	}
+
+	if (query?.customer_id) return query.customer_id;
+
+	return undefined;
+};
+
+const parseCustomerIdFromPath = ({
+	path,
+}: {
+	path: string;
+}): string | undefined => {
+	if (!path.startsWith("/v1")) return undefined;
+
+	const cleanPath = path.split("?")[0].replace(/^\/+|\/+$/g, "");
+	const segments = cleanPath.split("/");
+	const customersIndex = segments.indexOf("customers");
+
+	if (customersIndex !== -1 && segments[customersIndex + 1])
+		return segments[customersIndex + 1];
+
+	return undefined;
+};

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -11,6 +11,15 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type { OidcClaims } from "@/external/vercel/misc/vercelAuth.js";
 
+export type RolloutSnapshot = {
+	rolloutId: string | null;
+	enabled: boolean;
+	percent: number;
+	previousPercent: number;
+	changedAt: number;
+	customerBucket: number | null;
+};
+
 export type RequestContext = {
 	// Variables
 	org: Organization;
@@ -39,6 +48,7 @@ export type RequestContext = {
 	extraLogs: Record<string, unknown>;
 
 	fullCustomer?: FullCustomer;
+	rolloutSnapshot?: RolloutSnapshot;
 
 	testOptions?: {
 		skipCacheDeletion?: boolean;

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -18,6 +18,7 @@ import {
 
 // Edge config modules self-register on import
 import "./internal/misc/requestBlocks/requestBlockStore.js";
+import "./internal/misc/rollouts/rolloutConfigStore.js";
 import { warmupRegionalRedis } from "./external/redis/initRedis.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -8,6 +8,10 @@ import { handleListAdminOrgs } from "./handleListAdminOrgs";
 import { handleListAdminUsers } from "./handleListAdminUsers";
 import { handleListOAuthClients } from "./handleListOAuthClients";
 import { handleUpsertAdminOrgRequestBlock } from "./handleUpsertAdminOrgRequestBlock";
+import { handleDeleteRolloutOrg } from "./rollouts/handleDeleteRolloutOrg";
+import { handleGetRollouts } from "./rollouts/handleGetRollouts";
+import { handleUpdateRollout } from "./rollouts/handleUpdateRollout";
+import { handleUpdateRolloutOrg } from "./rollouts/handleUpdateRolloutOrg";
 
 export const honoAdminRouter = new Hono<HonoEnv>();
 
@@ -19,3 +23,14 @@ honoAdminRouter.get("/org-member", ...handleGetOrgMember);
 honoAdminRouter.get("/master-stripe-account", ...handleGetMasterStripeAccount);
 honoAdminRouter.get("/oauth-clients", ...handleListOAuthClients);
 honoAdminRouter.post("/invoice-line-items", ...handleGetInvoiceLineItems);
+
+honoAdminRouter.get("/rollouts", ...handleGetRollouts);
+honoAdminRouter.put("/rollouts/:rollout_id", ...handleUpdateRollout);
+honoAdminRouter.put(
+	"/rollouts/:rollout_id/orgs/:org_id",
+	...handleUpdateRolloutOrg,
+);
+honoAdminRouter.delete(
+	"/rollouts/:rollout_id/orgs/:org_id",
+	...handleDeleteRolloutOrg,
+);

--- a/server/src/internal/admin/rollouts/handleDeleteRolloutOrg.ts
+++ b/server/src/internal/admin/rollouts/handleDeleteRolloutOrg.ts
@@ -1,0 +1,17 @@
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { removeRolloutOrg } from "@/internal/misc/rollouts/rolloutConfigStore.js";
+
+export const handleDeleteRolloutOrg = createRoute({
+	params: z.object({
+		rollout_id: z.string().min(1),
+		org_id: z.string().min(1),
+	}),
+	handler: async (c) => {
+		const { rollout_id: rolloutId, org_id: orgId } = c.req.param();
+
+		await removeRolloutOrg({ rolloutId, orgId });
+
+		return c.json({ success: true, rolloutId, orgId });
+	},
+});

--- a/server/src/internal/admin/rollouts/handleGetRollouts.ts
+++ b/server/src/internal/admin/rollouts/handleGetRollouts.ts
@@ -1,0 +1,20 @@
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getRolloutConfigFromSource,
+	getRolloutConfigStatus,
+} from "@/internal/misc/rollouts/rolloutConfigStore.js";
+
+export const handleGetRollouts = createRoute({
+	handler: async (c) => {
+		const status = getRolloutConfigStatus();
+		const config = await getRolloutConfigFromSource();
+
+		return c.json({
+			rollouts: config.rollouts,
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/rollouts/handleUpdateRollout.ts
+++ b/server/src/internal/admin/rollouts/handleUpdateRollout.ts
@@ -1,0 +1,27 @@
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { updateRolloutPercent } from "@/internal/misc/rollouts/rolloutConfigStore.js";
+
+export const handleUpdateRollout = createRoute({
+	params: z.object({
+		rollout_id: z.string().min(1),
+	}),
+	body: z.object({
+		percent: z.number().min(0).max(100),
+	}),
+	handler: async (c) => {
+		const { rollout_id: rolloutId } = c.req.param();
+		const { percent } = c.req.valid("json");
+
+		const config = await updateRolloutPercent({ rolloutId, percent });
+		const entry = config.rollouts[rolloutId];
+
+		return c.json({
+			success: true,
+			rolloutId,
+			percent: entry?.percent ?? 0,
+			previousPercent: entry?.previousPercent ?? 0,
+			changedAt: entry?.changedAt ?? 0,
+		});
+	},
+});

--- a/server/src/internal/admin/rollouts/handleUpdateRolloutOrg.ts
+++ b/server/src/internal/admin/rollouts/handleUpdateRolloutOrg.ts
@@ -1,0 +1,29 @@
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { updateRolloutPercent } from "@/internal/misc/rollouts/rolloutConfigStore.js";
+
+export const handleUpdateRolloutOrg = createRoute({
+	params: z.object({
+		rollout_id: z.string().min(1),
+		org_id: z.string().min(1),
+	}),
+	body: z.object({
+		percent: z.number().min(0).max(100),
+	}),
+	handler: async (c) => {
+		const { rollout_id: rolloutId, org_id: orgId } = c.req.param();
+		const { percent } = c.req.valid("json");
+
+		const config = await updateRolloutPercent({ rolloutId, orgId, percent });
+		const orgEntry = config.rollouts[rolloutId]?.orgs[orgId];
+
+		return c.json({
+			success: true,
+			rolloutId,
+			orgId,
+			percent: orgEntry?.percent ?? 0,
+			previousPercent: orgEntry?.previousPercent ?? 0,
+			changedAt: orgEntry?.changedAt ?? 0,
+		});
+	},
+});

--- a/server/src/internal/checkouts/middleware/checkoutMiddleware.ts
+++ b/server/src/internal/checkouts/middleware/checkoutMiddleware.ts
@@ -14,6 +14,7 @@ import { rateLimiter } from "hono-rate-limiter";
 import { StatusCodes } from "http-status-codes";
 import type { HonoEnv } from "@/honoUtils/HonoEnv";
 import { checkoutActions } from "@/internal/checkouts/actions";
+import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { OrgService } from "@/internal/orgs/OrgService";
 import { deleteCheckoutCache } from "../actions/cache";
 import { checkoutRepo } from "../repos/checkoutRepo";
@@ -124,6 +125,10 @@ export const checkoutMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		features: orgWithFeatures.features,
 		isPublic: true,
 		customerId: validCheckout.customer_id,
+		rolloutSnapshot: computeRolloutSnapshot({
+			orgId: orgWithFeatures.org.id,
+			customerId: validCheckout.customer_id,
+		}),
 	});
 
 	// Attach checkout to context for handlers

--- a/server/src/internal/customers/cache/fullSubject/getCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/getCachedFullSubject.ts
@@ -11,8 +11,10 @@ import { getDbHealth, PgHealth } from "@/db/pgHealthMonitor.js";
 import { redis } from "@/external/redis/initRedis.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { resetCustomerEntitlements } from "@/internal/customers/actions/resetCustomerEntitlements/resetCustomerEntitlements.js";
+import { isSnapshotCacheStale } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { tryRedisRead } from "@/utils/cacheUtils/cacheUtils.js";
 import { normalizeFromSchema } from "@/utils/cacheUtils/normalizeFromSchema.js";
+import { deleteCachedFullSubject } from "./deleteCachedFullSubject.js";
 import { buildFullSubjectCacheKey } from "./fullSubjectCacheConfig.js";
 
 const roundBalance = (value: number | null | undefined): number => {
@@ -116,9 +118,33 @@ export const getCachedFullSubject = async ({
 
 	if (!cached) return undefined;
 
+	const parsed = JSON.parse(cached);
+	const cachedAt = parsed._cachedAt as number | undefined;
+	delete parsed._cachedAt;
+
+	if (
+		ctx.rolloutSnapshot &&
+		isSnapshotCacheStale({
+			snapshot: ctx.rolloutSnapshot,
+			cachedAt,
+		})
+	) {
+		ctx.logger.warn(
+			`[getCachedFullSubject] Stale rollout cache for ${customerId}, evicting`,
+		);
+		await deleteCachedFullSubject({
+			ctx,
+			customerId,
+			entityId,
+			source: "stale-rollout",
+			skipGuard: true,
+		});
+		return undefined;
+	}
+
 	const fullSubject = normalizeFromSchema<FullSubject>({
 		schema: FullSubjectSchema,
-		data: JSON.parse(cached),
+		data: parsed,
 	});
 
 	if (!fullSubject.extra_customer_entitlements) {

--- a/server/src/internal/customers/cache/fullSubject/setCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/setCachedFullSubject.ts
@@ -48,6 +48,8 @@ export const setCachedFullSubject = async ({
 	});
 	const pathIndexJson = JSON.stringify(pathIndexEntries);
 
+	const payload = { ...fullSubject, _cachedAt: Date.now() };
+
 	const result = await tryRedisWrite(async () => {
 		return await redis.setFullCustomerCache(
 			cacheKey,
@@ -56,7 +58,7 @@ export const setCachedFullSubject = async ({
 			fullSubject.customerId,
 			String(fetchTimeMs),
 			String(FULL_SUBJECT_CACHE_TTL_SECONDS),
-			JSON.stringify(fullSubject),
+			JSON.stringify(payload),
 			String(overwrite),
 			pathIndexJson,
 		);

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts
@@ -10,9 +10,11 @@ import type { Redis } from "ioredis";
 import { getDbHealth, PgHealth } from "@/db/pgHealthMonitor.js";
 import { redis } from "@/external/redis/initRedis.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { isSnapshotCacheStale } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { tryRedisRead } from "@/utils/cacheUtils/cacheUtils.js";
 import { normalizeFromSchema } from "@/utils/cacheUtils/normalizeFromSchema.js";
 import { resetCustomerEntitlements } from "../../actions/resetCustomerEntitlements/resetCustomerEntitlements.js";
+import { deleteCachedFullCustomer } from "./deleteCachedFullCustomer.js";
 import { buildFullCustomerCacheKey } from "./fullCustomerCacheConfig.js";
 
 /**
@@ -144,9 +146,32 @@ export const getCachedFullCustomer = async ({
 
 	if (!cached) return undefined;
 
+	const parsed = JSON.parse(cached);
+	const cachedAt = parsed._cachedAt as number | undefined;
+	delete parsed._cachedAt;
+
+	if (
+		ctx.rolloutSnapshot &&
+		isSnapshotCacheStale({
+			snapshot: ctx.rolloutSnapshot,
+			cachedAt,
+		})
+	) {
+		ctx.logger.warn(
+			`[getCachedFullCustomer] Stale rollout cache for ${customerId}, evicting`,
+		);
+		await deleteCachedFullCustomer({
+			ctx,
+			customerId,
+			source: "stale-rollout",
+			skipGuard: true,
+		});
+		return undefined;
+	}
+
 	const fullCustomer = normalizeFromSchema<FullCustomer>({
 		schema: FullCustomerSchema,
-		data: JSON.parse(cached),
+		data: parsed,
 	});
 
 	if (entityId) {

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/setCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/setCachedFullCustomer.ts
@@ -32,9 +32,15 @@ export const setCachedFullCustomer = async ({
 }): Promise<SetCacheResult> => {
 	const { org, env, logger } = ctx;
 
-	const cacheKey = buildFullCustomerCacheKey({ orgId: org.id, env, customerId });
+	const cacheKey = buildFullCustomerCacheKey({
+		orgId: org.id,
+		env,
+		customerId,
+	});
 	const pathIndexEntries = buildPathIndex({ fullCustomer });
 	const pathIndexJson = JSON.stringify(pathIndexEntries);
+
+	const payload = { ...fullCustomer, _cachedAt: Date.now() };
 
 	const result = await tryRedisWrite(async () => {
 		return await redis.setFullCustomerCache(
@@ -44,7 +50,7 @@ export const setCachedFullCustomer = async ({
 			customerId,
 			String(fetchTimeMs),
 			String(FULL_CUSTOMER_CACHE_TTL_SECONDS),
-			JSON.stringify(fullCustomer),
+			JSON.stringify(payload),
 			String(overwrite),
 			pathIndexJson,
 		);

--- a/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
@@ -2,10 +2,6 @@ import { RedisStore } from "@hono-rate-limiter/redis";
 import type { Context } from "hono";
 import { rateLimiter } from "hono-rate-limiter";
 import { redis } from "@/external/redis/initRedis";
-import {
-	parseCustomerIdFromBody,
-	parseCustomerIdFromUrl,
-} from "@/honoMiddlewares/analyticsMiddleware";
 import type { HonoEnv } from "@/honoUtils/HonoEnv";
 import {
 	RATE_LIMIT_CONFIGS,
@@ -71,13 +67,13 @@ const limiters = Object.fromEntries(
 
 export const getLimiterForType = (type: RateLimitType) => limiters[type];
 
-export const getRateLimitKey = async ({
+export const getRateLimitKey = ({
 	c,
 	rateLimitType,
 }: {
 	c: Context<HonoEnv>;
 	rateLimitType: RateLimitType;
-}): Promise<string> => {
+}): string => {
 	const ctx = c.get("ctx");
 	const orgId = ctx.org?.id;
 	const env = ctx.env;
@@ -89,16 +85,8 @@ export const getRateLimitKey = async ({
 		case RateLimitScope.Org:
 			return baseKey;
 
-		case RateLimitScope.Customer: {
-			const res = await parseCustomerIdFromBody(c);
-			return `${baseKey}:${res?.customerId}`;
-		}
-
-		case RateLimitScope.CustomerWithUrlFallback: {
-			const res = await parseCustomerIdFromBody(c);
-			const urlCustomerId = parseCustomerIdFromUrl({ url: c.req.path });
-			const customerId = res?.customerId || urlCustomerId;
-			return `${baseKey}:${customerId}`;
-		}
+		case RateLimitScope.Customer:
+		case RateLimitScope.CustomerWithUrlFallback:
+			return `${baseKey}:${ctx.customerId}`;
 	}
 };

--- a/server/src/internal/misc/rollouts/rolloutConfigStore.ts
+++ b/server/src/internal/misc/rollouts/rolloutConfigStore.ts
@@ -1,0 +1,83 @@
+import { ADMIN_ROLLOUT_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type RolloutConfig,
+	RolloutConfigSchema,
+	type RolloutPercent,
+} from "./rolloutSchemas.js";
+
+const store = createEdgeConfigStore<RolloutConfig>({
+	s3Key: ADMIN_ROLLOUT_CONFIG_KEY,
+	schema: RolloutConfigSchema,
+	defaultValue: () => ({ rollouts: {} }),
+});
+
+registerEdgeConfig({ store });
+
+export const getRolloutConfig = () => store.get();
+export const getRolloutConfigStatus = () => store.getStatus();
+export const getRolloutConfigFromSource = async () => store.readFromSource();
+
+/**
+ * Update a rollout percentage (global or per-org). Auto-manages
+ * previousPercent and changedAt for cache staleness tracking.
+ */
+export const updateRolloutPercent = async ({
+	rolloutId,
+	orgId,
+	percent,
+}: {
+	rolloutId: string;
+	orgId?: string;
+	percent: number;
+}) => {
+	const config = await store.readFromSource();
+
+	const entry = config.rollouts[rolloutId] ?? {
+		percent: 0,
+		previousPercent: 0,
+		changedAt: 0,
+		orgs: {},
+	};
+
+	if (orgId) {
+		const orgEntry: RolloutPercent = entry.orgs[orgId] ?? {
+			percent: 0,
+			previousPercent: 0,
+			changedAt: 0,
+		};
+		entry.orgs[orgId] = {
+			previousPercent: orgEntry.percent,
+			percent,
+			changedAt: Date.now(),
+		};
+	} else {
+		entry.previousPercent = entry.percent;
+		entry.percent = percent;
+		entry.changedAt = Date.now();
+	}
+
+	config.rollouts[rolloutId] = entry;
+	await store.writeToSource({ config });
+
+	return config;
+};
+
+/** Remove an org override from a rollout. */
+export const removeRolloutOrg = async ({
+	rolloutId,
+	orgId,
+}: {
+	rolloutId: string;
+	orgId: string;
+}) => {
+	const config = await store.readFromSource();
+	const entry = config.rollouts[rolloutId];
+	if (!entry) return config;
+
+	delete entry.orgs[orgId];
+	await store.writeToSource({ config });
+
+	return config;
+};

--- a/server/src/internal/misc/rollouts/rolloutSchemas.ts
+++ b/server/src/internal/misc/rollouts/rolloutSchemas.ts
@@ -1,0 +1,19 @@
+import { z } from "zod/v4";
+
+export const RolloutPercentSchema = z.object({
+	percent: z.number().min(0).max(100).default(0),
+	previousPercent: z.number().min(0).max(100).default(0),
+	changedAt: z.number().default(0),
+});
+
+export const RolloutEntrySchema = RolloutPercentSchema.extend({
+	orgs: z.record(z.string(), RolloutPercentSchema).default({}),
+});
+
+export const RolloutConfigSchema = z.object({
+	rollouts: z.record(z.string(), RolloutEntrySchema).default({}),
+});
+
+export type RolloutPercent = z.infer<typeof RolloutPercentSchema>;
+export type RolloutEntry = z.infer<typeof RolloutEntrySchema>;
+export type RolloutConfig = z.infer<typeof RolloutConfigSchema>;

--- a/server/src/internal/misc/rollouts/rolloutUtils.ts
+++ b/server/src/internal/misc/rollouts/rolloutUtils.ts
@@ -1,0 +1,111 @@
+import type { RolloutSnapshot } from "@/honoUtils/HonoEnv.js";
+import { getRolloutConfig } from "./rolloutConfigStore.js";
+import type { RolloutPercent } from "./rolloutSchemas.js";
+
+/** Deterministic bucket (0-99) for a customer ID. */
+export const getCustomerBucket = ({
+	customerId,
+}: {
+	customerId: string;
+}): number => Number(BigInt(Bun.hash(customerId)) % 100n);
+
+/** Resolves the effective percent config for a rollout (org override > global). */
+export const resolveRolloutPercent = ({
+	rolloutId,
+	orgId,
+}: {
+	rolloutId: string;
+	orgId: string;
+}): RolloutPercent | undefined => {
+	const config = getRolloutConfig();
+	const entry = config.rollouts[rolloutId];
+	if (!entry) return undefined;
+	return entry.orgs[orgId] ?? entry;
+};
+
+/** Checks whether a rollout is enabled for a given customer. */
+export const isRolloutEnabled = ({
+	rolloutId,
+	orgId,
+	customerId,
+}: {
+	rolloutId: string;
+	orgId: string;
+	customerId?: string;
+}): boolean => {
+	const resolved = resolveRolloutPercent({ rolloutId, orgId });
+	if (!resolved) return false;
+	if (resolved.percent >= 100) return true;
+	if (resolved.percent <= 0) return false;
+	if (!customerId) return false;
+
+	const bucket = getCustomerBucket({ customerId });
+	return bucket < resolved.percent;
+};
+
+/**
+ * Computes a flat rollout snapshot for the first active rollout.
+ * Used by middleware and worker context factories to freeze the rollout
+ * decision for the lifetime of a request/job.
+ */
+export const computeRolloutSnapshot = ({
+	orgId,
+	customerId,
+}: {
+	orgId?: string;
+	customerId?: string;
+}): RolloutSnapshot => {
+	const customerBucket = customerId ? getCustomerBucket({ customerId }) : null;
+	const config = getRolloutConfig();
+	const entries = Object.entries(config.rollouts);
+
+	if (entries.length === 0) {
+		return {
+			rolloutId: null,
+			enabled: false,
+			percent: 0,
+			previousPercent: 0,
+			changedAt: 0,
+			customerBucket,
+		};
+	}
+
+	const [rolloutId, entry] = entries[0];
+	const resolved = orgId && entry.orgs[orgId] ? entry.orgs[orgId] : entry;
+
+	return {
+		rolloutId,
+		enabled:
+			resolved.percent >= 100 ||
+			(customerBucket !== null && customerBucket < resolved.percent),
+		percent: resolved.percent,
+		previousPercent: resolved.previousPercent,
+		changedAt: resolved.changedAt,
+		customerBucket,
+	};
+};
+
+/**
+ * Checks if a cache entry is stale due to a rollout percentage change.
+ * Works with the per-request rollout snapshot to avoid race conditions.
+ *
+ * Returns true only when:
+ * 1. The customer's routing actually changed between previousPercent and percent
+ * 2. The cache entry was written before changedAt (or has no _cachedAt -- legacy conservative mode)
+ */
+export const isSnapshotCacheStale = ({
+	snapshot,
+	cachedAt,
+}: {
+	snapshot: RolloutSnapshot;
+	cachedAt?: number;
+}): boolean => {
+	if (!snapshot.changedAt || snapshot.customerBucket === null) return false;
+
+	const wasEnabled = snapshot.customerBucket < snapshot.previousPercent;
+	const isEnabled = snapshot.customerBucket < snapshot.percent;
+	if (wasEnabled === isEnabled) return false;
+
+	if (!cachedAt) return true;
+	return cachedAt < snapshot.changedAt;
+};

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -3,6 +3,7 @@ import { addAppContextToLogs } from "@/utils/logging/addContextToLogs.js";
 import type { DrizzleCli } from "../db/initDrizzle.js";
 import type { Logger } from "../external/logtail/logtailUtils.js";
 import type { AutumnContext } from "../honoUtils/HonoEnv.js";
+import { computeRolloutSnapshot } from "../internal/misc/rollouts/rolloutUtils.js";
 import { OrgService } from "../internal/orgs/OrgService.js";
 import { generateId } from "../utils/genUtils.js";
 
@@ -68,6 +69,10 @@ export const createWorkerContext = async ({
 		expand: [],
 		skipCache: true,
 		extraLogs: {},
+		rolloutSnapshot: computeRolloutSnapshot({
+			orgId: org.id,
+			customerId,
+		}),
 	};
 
 	return ctx;

--- a/server/src/utils/workerUtils/createAutumnContext.ts
+++ b/server/src/utils/workerUtils/createAutumnContext.ts
@@ -9,6 +9,7 @@ import {
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 
 export const createWorkerAutumnContext = async ({
@@ -63,5 +64,6 @@ export const createWorkerAutumnContext = async ({
 		timestamp: Date.now(),
 		skipCache: false,
 		extraLogs: {},
+		rolloutSnapshot: computeRolloutSnapshot({ orgId: org.id }),
 	} satisfies AutumnContext;
 };

--- a/vite/src/App.tsx
+++ b/vite/src/App.tsx
@@ -10,6 +10,7 @@ import { useSession } from "./lib/auth-client";
 import { identifyUser } from "./utils/posthogTracking";
 import { AdminView } from "./views/admin/AdminView";
 import { ImpersonateRedirect } from "./views/admin/ImpersonateRedirect";
+import { EdgeConfigView } from "./views/admin/edge-config/EdgeConfigView";
 import { OAuthClientsView } from "./views/admin/oauth/OAuthClientsView";
 import { AcceptInvitation } from "./views/auth/AcceptInvitation";
 import { Consent } from "./views/auth/Consent";
@@ -72,6 +73,7 @@ export default function App() {
 					<Route path="/settings" element={<OrgSettingsView />} />
 					<Route path="/admin" element={<AdminView />} />
 					<Route path="/admin/oauth" element={<OAuthClientsView />} />
+					<Route path="/admin/edge-config" element={<EdgeConfigView />} />
 					<Route
 						path="/impersonate-redirect"
 						element={<ImpersonateRedirect />}

--- a/vite/src/views/admin/AdminView.tsx
+++ b/vite/src/views/admin/AdminView.tsx
@@ -1,4 +1,4 @@
-import { Globe } from "@phosphor-icons/react";
+import { Globe, Sliders } from "@phosphor-icons/react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -41,6 +41,15 @@ export const AdminView = () => {
 		<div className="flex flex-col p-6 gap-8">
 			<div className="flex justify-end absolute top-10 right-10 gap-2">
 				<CreateUser />
+				<Button
+					onClick={() => navigate("/admin/edge-config")}
+					variant="outline"
+					size="sm"
+					className="w-fit"
+				>
+					<Sliders className="w-4 h-4 mr-1.5" />
+					Rollouts
+				</Button>
 				<Button
 					onClick={() => navigate("/admin/oauth")}
 					variant="outline"

--- a/vite/src/views/admin/edge-config/EdgeConfigView.tsx
+++ b/vite/src/views/admin/edge-config/EdgeConfigView.tsx
@@ -1,0 +1,361 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+	ArrowLeft,
+	ChevronDown,
+	ChevronRight,
+	Plus,
+	RefreshCw,
+	Trash2,
+} from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { toast } from "sonner";
+import { IconButton } from "@/components/v2/buttons/IconButton";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { DefaultView } from "../../DefaultView";
+import LoadingScreen from "../../general/LoadingScreen";
+import { useAdmin } from "../hooks/useAdmin";
+
+type RolloutPercent = {
+	percent: number;
+	previousPercent: number;
+	changedAt: number;
+};
+
+type RolloutEntry = RolloutPercent & {
+	orgs: Record<string, RolloutPercent>;
+};
+
+type RolloutsResponse = {
+	rollouts: Record<string, RolloutEntry>;
+	configHealthy: boolean;
+	configConfigured: boolean;
+	lastSuccessAt: string | null;
+	error: string | null;
+};
+
+const formatTimestamp = (timestamp: number) => {
+	if (!timestamp) return "Never";
+	return new Date(timestamp).toLocaleString();
+};
+
+const RolloutOrgRow = ({
+	rolloutId,
+	orgId,
+	orgEntry,
+	onUpdate,
+	onDelete,
+}: {
+	rolloutId: string;
+	orgId: string;
+	orgEntry: RolloutPercent;
+	onUpdate: ({
+		rolloutId,
+		orgId,
+		percent,
+	}: { rolloutId: string; orgId: string; percent: number }) => void;
+	onDelete: ({
+		rolloutId,
+		orgId,
+	}: { rolloutId: string; orgId: string }) => void;
+}) => {
+	const [editPercent, setEditPercent] = useState(orgEntry.percent);
+
+	return (
+		<div className="flex items-center gap-3 py-2 px-3 bg-t1 rounded-md">
+			<code className="text-xs flex-1 font-mono">{orgId}</code>
+			<input
+				type="number"
+				min={0}
+				max={100}
+				value={editPercent}
+				onChange={(e) => setEditPercent(Number(e.target.value))}
+				className="w-16 px-2 py-1 text-xs border rounded bg-background"
+			/>
+			<span className="text-xs text-t3">%</span>
+			<button
+				type="button"
+				onClick={() => onUpdate({ rolloutId, orgId, percent: editPercent })}
+				disabled={editPercent === orgEntry.percent}
+				className="text-xs px-2 py-1 bg-primary text-primary-foreground rounded disabled:opacity-40"
+			>
+				Save
+			</button>
+			<IconButton
+				icon={<Trash2 className="w-3.5 h-3.5" />}
+				variant="ghost"
+				size="sm"
+				onClick={() => onDelete({ rolloutId, orgId })}
+			/>
+			<span className="text-[10px] text-t3">
+				prev: {orgEntry.previousPercent}% | changed:{" "}
+				{formatTimestamp(orgEntry.changedAt)}
+			</span>
+		</div>
+	);
+};
+
+const RolloutCard = ({
+	rolloutId,
+	entry,
+	onUpdateGlobal,
+	onUpdateOrg,
+	onDeleteOrg,
+	onAddOrg,
+}: {
+	rolloutId: string;
+	entry: RolloutEntry;
+	onUpdateGlobal: ({
+		rolloutId,
+		percent,
+	}: { rolloutId: string; percent: number }) => void;
+	onUpdateOrg: ({
+		rolloutId,
+		orgId,
+		percent,
+	}: { rolloutId: string; orgId: string; percent: number }) => void;
+	onDeleteOrg: ({
+		rolloutId,
+		orgId,
+	}: { rolloutId: string; orgId: string }) => void;
+	onAddOrg: ({ rolloutId }: { rolloutId: string }) => void;
+}) => {
+	const [expanded, setExpanded] = useState(true);
+	const [globalPercent, setGlobalPercent] = useState(entry.percent);
+
+	const orgEntries = Object.entries(entry.orgs);
+
+	return (
+		<div className="border rounded-lg overflow-hidden">
+			<div className="flex items-center gap-3 p-4 bg-t1/50">
+				<button
+					type="button"
+					onClick={() => setExpanded(!expanded)}
+					className="text-t3"
+				>
+					{expanded ? (
+						<ChevronDown className="w-4 h-4" />
+					) : (
+						<ChevronRight className="w-4 h-4" />
+					)}
+				</button>
+				<h3 className="font-mono font-medium text-sm flex-1">{rolloutId}</h3>
+				<div className="flex items-center gap-2">
+					<span className="text-xs text-t3">Global:</span>
+					<input
+						type="number"
+						min={0}
+						max={100}
+						value={globalPercent}
+						onChange={(e) => setGlobalPercent(Number(e.target.value))}
+						className="w-16 px-2 py-1 text-xs border rounded bg-background"
+					/>
+					<span className="text-xs text-t3">%</span>
+					<button
+						type="button"
+						onClick={() =>
+							onUpdateGlobal({ rolloutId, percent: globalPercent })
+						}
+						disabled={globalPercent === entry.percent}
+						className="text-xs px-2 py-1 bg-primary text-primary-foreground rounded disabled:opacity-40"
+					>
+						Save
+					</button>
+				</div>
+			</div>
+
+			{expanded && (
+				<div className="p-4 flex flex-col gap-3">
+					<div className="text-[10px] text-t3">
+						prev: {entry.previousPercent}% | changed:{" "}
+						{formatTimestamp(entry.changedAt)}
+					</div>
+
+					<div className="flex items-center justify-between">
+						<h4 className="text-xs font-medium text-t2">Org Overrides</h4>
+						<button
+							type="button"
+							onClick={() => onAddOrg({ rolloutId })}
+							className="flex items-center gap-1 text-xs text-primary hover:underline"
+						>
+							<Plus className="w-3 h-3" />
+							Add Org
+						</button>
+					</div>
+
+					{orgEntries.length === 0 && (
+						<p className="text-xs text-t3 italic">
+							No org overrides. Global percent applies to all.
+						</p>
+					)}
+
+					<div className="flex flex-col gap-2">
+						{orgEntries.map(([orgId, orgEntry]) => (
+							<RolloutOrgRow
+								key={orgId}
+								rolloutId={rolloutId}
+								orgId={orgId}
+								orgEntry={orgEntry}
+								onUpdate={onUpdateOrg}
+								onDelete={onDeleteOrg}
+							/>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export const EdgeConfigView = () => {
+	const navigate = useNavigate();
+	const { isAdmin, isPending } = useAdmin();
+	const axiosInstance = useAxiosInstance();
+
+	const { data, isLoading, refetch } = useQuery<RolloutsResponse>({
+		queryKey: ["admin-rollouts"],
+		queryFn: async () => {
+			const { data } = await axiosInstance.get("/admin/rollouts");
+			return data;
+		},
+	});
+
+	const updateGlobalMutation = useMutation({
+		mutationFn: async ({
+			rolloutId,
+			percent,
+		}: { rolloutId: string; percent: number }) => {
+			await axiosInstance.put(`/admin/rollouts/${rolloutId}`, { percent });
+		},
+		onSuccess: () => {
+			toast.success("Global rollout updated");
+			refetch();
+		},
+		onError: (error) =>
+			toast.error(getBackendErr(error, "Failed to update rollout")),
+	});
+
+	const updateOrgMutation = useMutation({
+		mutationFn: async ({
+			rolloutId,
+			orgId,
+			percent,
+		}: { rolloutId: string; orgId: string; percent: number }) => {
+			await axiosInstance.put(
+				`/admin/rollouts/${rolloutId}/orgs/${orgId}`,
+				{ percent },
+			);
+		},
+		onSuccess: () => {
+			toast.success("Org override updated");
+			refetch();
+		},
+		onError: (error) =>
+			toast.error(getBackendErr(error, "Failed to update org override")),
+	});
+
+	const deleteOrgMutation = useMutation({
+		mutationFn: async ({
+			rolloutId,
+			orgId,
+		}: { rolloutId: string; orgId: string }) => {
+			await axiosInstance.delete(
+				`/admin/rollouts/${rolloutId}/orgs/${orgId}`,
+			);
+		},
+		onSuccess: () => {
+			toast.success("Org override removed");
+			refetch();
+		},
+		onError: (error) =>
+			toast.error(getBackendErr(error, "Failed to remove org override")),
+	});
+
+	const handleAddOrg = ({ rolloutId }: { rolloutId: string }) => {
+		const orgId = prompt("Enter org ID:");
+		if (!orgId?.trim()) return;
+
+		const percentStr = prompt("Enter rollout percentage (0-100):", "0");
+		const percent = Number(percentStr);
+		if (Number.isNaN(percent) || percent < 0 || percent > 100) {
+			toast.error("Invalid percentage");
+			return;
+		}
+
+		updateOrgMutation.mutate({ rolloutId, orgId: orgId.trim(), percent });
+	};
+
+	const handleDeleteOrg = ({
+		rolloutId,
+		orgId,
+	}: { rolloutId: string; orgId: string }) => {
+		if (!confirm(`Remove org override for ${orgId}?`)) return;
+		deleteOrgMutation.mutate({ rolloutId, orgId });
+	};
+
+	if (isPending || isLoading) {
+		return (
+			<div className="h-screen w-screen">
+				<LoadingScreen />
+			</div>
+		);
+	}
+
+	if (!isAdmin) return <DefaultView />;
+
+	const rollouts = data?.rollouts ?? {};
+	const rolloutEntries = Object.entries(rollouts);
+
+	return (
+		<div className="flex flex-col p-6 gap-6 max-w-4xl mx-auto">
+			<div className="flex items-center gap-3">
+				<IconButton
+					icon={<ArrowLeft className="w-4 h-4" />}
+					variant="ghost"
+					size="sm"
+					onClick={() => navigate("/admin")}
+				/>
+				<h1 className="text-lg font-semibold">Rollout Edge Config</h1>
+				<div className="flex-1" />
+				<IconButton
+					icon={<RefreshCw className="w-4 h-4" />}
+					variant="ghost"
+					size="sm"
+					onClick={() => refetch()}
+				/>
+				{data && (
+					<span className="text-[10px] text-t3">
+						{data.configHealthy ? "Healthy" : "Unhealthy"} | Last sync:{" "}
+						{data.lastSuccessAt ?? "never"}
+					</span>
+				)}
+			</div>
+
+			{rolloutEntries.length === 0 && (
+				<p className="text-sm text-t3 italic">
+					No rollouts configured. Add a rollout entry to the S3 config to get
+					started.
+				</p>
+			)}
+
+			<div className="flex flex-col gap-4">
+				{rolloutEntries.map(([rolloutId, entry]) => (
+					<RolloutCard
+						key={rolloutId}
+						rolloutId={rolloutId}
+						entry={entry}
+						onUpdateGlobal={({ rolloutId, percent }) =>
+							updateGlobalMutation.mutate({ rolloutId, percent })
+						}
+						onUpdateOrg={({ rolloutId, orgId, percent }) =>
+							updateOrgMutation.mutate({ rolloutId, orgId, percent })
+						}
+						onDeleteOrg={handleDeleteOrg}
+						onAddOrg={handleAddOrg}
+					/>
+				))}
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds percentage-based rolling rollout infrastructure with per-org overrides and request-scoped routing, plus automatic cache staleness handling on percent changes. Includes an admin API and UI to manage `admin/rollout-config.json`, and wires rollout snapshots into webhooks, workers, and checkouts.

- **New Features**
  - S3-backed edge config at `admin/rollout-config.json` with 30s polling; admin routes `GET /admin/rollouts`, `PUT /admin/rollouts/:rollout_id`, `PUT/DELETE /admin/rollouts/:rollout_id/orgs/:org_id`, and UI at `/admin/edge-config`.
  - Request-scoped rollout snapshot via `rolloutMiddleware` using deterministic 0–99 buckets; utils `computeRolloutSnapshot`, `isSnapshotCacheStale`, `getCustomerBucket`.
  - Cache staleness: `_cachedAt` added on set; `getCachedFullCustomer`/`getCachedFullSubject` evict when routing crosses the boundary; centralized `customerId` resolution in `baseMiddleware`; Stripe/RevenueCat/Vercel/checkout/worker contexts now compute `rolloutSnapshot`.

- **Migration**
  - Ensure middleware order: `baseMiddleware` (sets `customerId`) → auth (sets `org`) → `rolloutMiddleware` (sets `rolloutSnapshot`).
  - Gate new code paths with `ctx.rolloutSnapshot.enabled`, and change percentages via the admin UI or `updateRolloutPercent` only.
  - Seed S3 with initial rollout entries; empty config is safe (rollouts default to off).

<sup>Written for commit 9489cf90e909672f15b0cf46cc89f61d1f3b94bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces S3-backed percentage-based rollout infrastructure with per-org overrides, request-scoped rollout snapshots, automatic cache staleness eviction, and an admin API/UI. The cache staleness design (`_cachedAt` + `isSnapshotCacheStale`) is well-reasoned. One P1 bug: `resolveCustomerId` returns non-customer-ID path segments for routes like `/v1/customers/all/search`, causing incorrect rollout routing for those endpoints.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the resolveCustomerId path-segment extraction bug

One P1 issue in resolveCustomerId that causes incorrect rollout bucketing for multi-segment routes; remaining findings are P2

server/src/honoMiddlewares/utils/resolveCustomerId.ts (P1), server/src/internal/misc/rollouts/rolloutUtils.ts (P2), server/src/internal/misc/rollouts/rolloutConfigStore.ts (P2)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/utils/resolveCustomerId.ts | Incorrectly returns non-ID segments for routes like /v1/customers/all/search, breaking per-customer rollout routing |
| server/src/internal/misc/rollouts/rolloutUtils.ts | Core rollout logic with BigInt precision concern for large hash values |
| server/src/internal/misc/rollouts/rolloutConfigStore.ts | S3-backed config store with read-modify-write race on concurrent admin writes |
| server/src/honoMiddlewares/rolloutMiddleware.ts | Clean per-request snapshot freeze, correctly ordered after auth/baseMiddleware |
| server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts | Correctly adds _cachedAt extraction and rollout staleness eviction |
| server/src/internal/customers/cache/fullSubject/getCachedFullSubject.ts | Mirrors getCachedFullCustomer staleness eviction consistently |
| vite/src/views/admin/edge-config/EdgeConfigView.tsx | Functional admin UI but uses prompt()/confirm() for org management |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/honoMiddlewares/utils/resolveCustomerId.ts
Line: 38-53

Comment:
**Non-customer ID segments returned for multi-segment routes**

`parseCustomerIdFromPath` blindly returns the segment immediately after `"customers"` in the URL. The analytics middleware already has `/v1/customers/all/search` in its `skipUrls` list, confirming this route exists. For that path, `segments[customersIndex + 1]` is `"all"`, so `ctx.customerId` is set to `"all"` for every search request. `computeRolloutSnapshot` then computes a single deterministic bucket for the string `"all"`, meaning **every** search request is consistently routed to the same code path (all-on or all-off) instead of per-customer routing.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/misc/rollouts/rolloutConfigStore.ts
Line: 26-65

Comment:
**Read-modify-write race condition on S3**

`updateRolloutPercent` reads the full config, edits it in memory, and then writes it back. Two concurrent admin calls will each read the same stale state and the second write will silently clobber the first. Consider a Redis mutex or ETag-based conditional S3 write to prevent this.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/admin/edge-config/EdgeConfigView.tsx
Line: 276-287

Comment:
**`prompt()` / `confirm()` usage in admin UI**

`window.prompt()` and `window.confirm()` block the main thread and are generally bad practice in React. Consider replacing with a small dialog/inline form with proper validation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/misc/rollouts/rolloutUtils.ts
Line: 6-10

Comment:
**Potential BigInt precision loss for large hash values**

`Bun.hash()` returns a `number` (float64); for values > 2^53, `BigInt(number)` loses precision and can map distinct customer IDs to the same bucket. Use `Bun.hash.wyhash(customerId, 0n)` (returns `BigInt` directly) to avoid the float64 round-trip.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["working on rollout infra"](https://github.com/useautumn/autumn/commit/9489cf90e909672f15b0cf46cc89f61d1f3b94bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28905625)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->