### PR TITLE
feat: add /v1/customers.get RPC endpoint

### DIFF
--- a/server/src/internal/customers/cusRouter.ts
+++ b/server/src/internal/customers/cusRouter.ts
@@ -11,6 +11,7 @@ import {
 	handleDeleteCustomerV2,
 } from "./handlers/handleDeleteCustomer.js";
 import { handleGetCustomerV2 } from "./handlers/handleGetCustomerV2.js";
+import { handleGetCustomerV3 } from "./handlers/handleGetCustomerV3.js";
 import { handlePostCustomer } from "./handlers/handleGetOrCreateCustomer/handleGetOrCreateCustomer.js";
 import { handleListCustomers } from "./handlers/handleListCustomers.js";
 import { handleListCustomersV2 } from "./handlers/handleListCustomersV2.js";
@@ -52,3 +53,4 @@ customerRpcRouter.post(
 customerRpcRouter.post("/customers.update", ...handleUpdateCustomerV2);
 customerRpcRouter.post("/customers.list", ...handleListCustomersV2);
 customerRpcRouter.post("/customers.delete", ...handleDeleteCustomerV2);
+customerRpcRouter.post("/customers.get", ...handleGetCustomerV3);

--- a/server/src/internal/customers/handlers/handleGetCustomerV3.ts
+++ b/server/src/internal/customers/handlers/handleGetCustomerV3.ts
@@ -1,0 +1,53 @@
+import {
+	AffectedResource,
+	ApiVersion,
+	backwardsChangeActive,
+	CustomerExpand,
+	GetCustomerParamsSchema,
+	V0_2_InvoicesAlwaysExpanded,
+} from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { getApiCustomer } from "../cusUtils/apiCusUtils/getApiCustomer.js";
+import { getOrSetCachedFullCustomer } from "../cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.js";
+
+export const handleGetCustomerV3 = createRoute({
+	body: GetCustomerParamsSchema,
+	resource: AffectedResource.Customer,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const body = c.req.valid("json");
+		const { customer_id, with_autumn_id } = body;
+		const { expand } = ctx;
+
+		// SIDE EFFECT: Auto-expand invoices for older API versions
+		if (
+			backwardsChangeActive({
+				apiVersion: ctx.apiVersion,
+				versionChange: V0_2_InvoicesAlwaysExpanded,
+			})
+		) {
+			expand.push(CustomerExpand.Invoices);
+		}
+
+		const start = Date.now();
+
+		// Get FullCustomer from cache or DB (throws CustomerNotFoundError if not found)
+		const fullCustomer = await getOrSetCachedFullCustomer({
+			ctx,
+			customerId: customer_id,
+			source: "handleGetCustomerV3",
+		});
+
+		// Transform to ApiCustomer with version changes
+		const customer = await getApiCustomer({
+			ctx,
+			fullCustomer,
+			withAutumnId: with_autumn_id,
+		});
+
+		const duration = Date.now() - start;
+		ctx.logger.debug(`[customers.get] getApiCustomer duration: ${duration}ms`);
+
+		return c.json(customer);
+	},
+});

--- a/shared/api/customers/crud/getCustomerParams.ts
+++ b/shared/api/customers/crud/getCustomerParams.ts
@@ -1,0 +1,16 @@
+import { CustomerIdSchema } from "@api/common/customerId";
+import { queryStringArray } from "@api/common/queryHelpers";
+import { CustomerExpandEnum } from "@api/customers/components/customerExpand/customerExpand";
+import { z } from "zod/v4";
+
+export const GetCustomerParamsSchema = z.object({
+	customer_id: CustomerIdSchema.describe("ID of the customer to fetch"),
+	expand: queryStringArray(CustomerExpandEnum).optional().meta({
+		description: "Fields to expand in the returned customer response",
+	}),
+	with_autumn_id: z.boolean().default(false).meta({
+		internal: true,
+	}),
+});
+
+export type GetCustomerParams = z.infer<typeof GetCustomerParamsSchema>;

--- a/shared/api/customers/crud/index.ts
+++ b/shared/api/customers/crud/index.ts
@@ -1,4 +1,5 @@
 export * from "./createCustomerParams";
 export * from "./deleteCustomerParams";
+export * from "./getCustomerParams";
 export * from "./listCustomersParamsV2";
 export * from "./updateCustomerParams";


### PR DESCRIPTION
## Summary
Adds `/v1/customers.get` RPC endpoint to fetch a customer by ID. Returns 404 if customer not found (no auto-creation, unlike `customers.get_or_create`).

## Changes

- **Schema** (`shared/api/customers/crud/getCustomerParams.ts`): New `GetCustomerParamsSchema` with `customer_id`, optional `expand`, and internal `with_autumn_id`
- **Handler** (`server/src/internal/customers/handlers/handleGetCustomerV3.ts`): RPC-style handler using body validation, `getOrSetCachedFullCustomer` for non-autocreate fetch, and `getApiCustomer` for versioned response transformation
- **Router** (`server/src/internal/customers/cusRouter.ts`): Registered `POST /customers.get` on `customerRpcRouter`
- **Exports** (`shared/api/customers/crud/index.ts`): Added export for new params schema

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/pull/1195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/task/706e6451-c801-4655-a9f6-00e2fa9b13df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-7&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-7"><img alt="SCO-7 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-7"></picture></a>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds POST /v1/customers.get to fetch a customer by ID without auto-creating. Returns 404 if not found. Meets SCO-7 by providing a read-only fetch endpoint.

- New Features
  - Validates body with `GetCustomerParamsSchema` (`customer_id`, optional `expand`, internal `with_autumn_id`).
  - Version-aware behavior: auto-expands invoices for older API versions via `@autumn/shared` `V0_2_InvoicesAlwaysExpanded`.
  - Fetches via `getOrSetCachedFullCustomer` and returns a versioned customer with `getApiCustomer`; route registered on `customerRpcRouter` and schema exported.

<sup>Written for commit 5e92985f770b8f8a55f10006ac5a9a917b741787. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a `POST /v1/customers.get` RPC endpoint that fetches a customer by ID without auto-creation, returning 404 (via `CustomerNotFoundError`) if the customer does not exist.

- **API changes**: New `customers.get` route registered on `customerRpcRouter`, backed by `handleGetCustomerV3` which mirrors the existing V2 handler but reads all params from the POST body instead of URL path/query params.
- **API changes**: New `GetCustomerParamsSchema` schema with `customer_id`, optional `expand`, and internal `with_autumn_id`; exported from the shared CRUD index.
- **Improvements**: Version-aware invoice expansion is preserved via `backwardsChangeActive` / `V0_2_InvoicesAlwaysExpanded`, consistent with the V2 handler.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a clean additive endpoint that reuses well-tested utilities and follows the established RPC handler pattern.

The handler correctly delegates to getOrSetCachedFullCustomer (which throws CustomerNotFoundError on a miss) and getApiCustomer, both already used by V2. Error handling, 404 status, and backwards-compat expand logic are all wired correctly through the existing middleware chain.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/handlers/handleGetCustomerV3.ts | New RPC-style GET handler; mirrors V2 logic correctly using body instead of query params, 404 via CustomerNotFoundError is properly wired through the error middleware chain |
| shared/api/customers/crud/getCustomerParams.ts | New schema for customers.get body params; consistent with existing schema patterns but uses queryStringArray in a JSON body context (minor style note) |
| server/src/internal/customers/cusRouter.ts | Adds customers.get route to customerRpcRouter; straightforward addition consistent with other RPC registrations |
| shared/api/customers/crud/index.ts | Exports new GetCustomerParamsSchema; alphabetically ordered, no issues |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant customerRpcRouter
    participant expandMiddleware
    participant handleGetCustomerV3
    participant getOrSetCachedFullCustomer
    participant getApiCustomer

    Client->>customerRpcRouter: POST /customers.get
    customerRpcRouter->>expandMiddleware: runs (reads raw body.expand into ctx.expand)
    expandMiddleware->>handleGetCustomerV3: body validated by GetCustomerParamsSchema
    handleGetCustomerV3->>handleGetCustomerV3: backwardsChangeActive? push Invoices to ctx.expand
    handleGetCustomerV3->>getOrSetCachedFullCustomer: fetch by customer_id (cache or DB)
    alt customer not found
        getOrSetCachedFullCustomer-->>handleGetCustomerV3: throws CustomerNotFoundError
        handleGetCustomerV3-->>Client: 404 message and code
    else customer found
        getOrSetCachedFullCustomer-->>handleGetCustomerV3: FullCustomer
        handleGetCustomerV3->>getApiCustomer: transform to versioned ApiCustomer
        getApiCustomer-->>handleGetCustomerV3: ApiCustomer
        handleGetCustomerV3-->>Client: 200 ApiCustomer
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
shared/api/customers/crud/getCustomerParams.ts:8-10
**`queryStringArray` used in JSON body schema**

`queryStringArray` is designed for URL query parameters — it handles the single-string-to-array coercion that HTTP frameworks produce from `?expand=a&expand=b`. In a JSON body, clients send proper arrays directly, so using `z.array(CustomerExpandEnum)` would be more idiomatic. The practical difference is that `queryStringArray` also splits on commas (`"invoices,rewards"` → `["invoices", "rewards"]`), but the actual routing of the expand value goes through `expandMiddleware` which reads the raw body *without* comma-splitting, meaning `ctx.expand` ends up as `["invoices,rewards"]` while the Zod-validated field (which the handler discards) would be `["invoices", "rewards"]`. Sending comma-separated strings in a JSON body is an unusual pattern, but the inconsistency is worth noting.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add RPC endpoint for fetching cust..."](https://github.com/useautumn/autumn/commit/5e92985f770b8f8a55f10006ac5a9a917b741787) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27664220)</sub>

<!-- /greptile_comment -->