### PR TITLE
feat: 🎸 API key expiry — schema, verification, and UI

### DIFF
--- a/server/src/internal/dev/ApiKeyService.ts
+++ b/server/src/internal/dev/ApiKeyService.ts
@@ -53,6 +53,7 @@ export class ApiKeyService {
 			env,
 			userId: data.user_id,
 			user: data.user || null,
+			expiresAt: data.expires_at as number | null,
 		};
 
 		return result;

--- a/server/src/internal/dev/api-keys/apiKeyUtils.ts
+++ b/server/src/internal/dev/api-keys/apiKeyUtils.ts
@@ -4,6 +4,7 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { generateId } from "@/utils/genUtils.js";
 import { ApiKeyService } from "../ApiKeyService.js";
 import {
+	clearSecretKeyCache,
 	getCachedSecretKeyVerification,
 	SECRET_KEY_CACHE_TTL_SECONDS,
 	setCachedSecretKeyVerification,
@@ -16,13 +17,11 @@ export enum ApiKeyPrefix {
 
 function generateApiKey(length = 32, prefix = "") {
 	try {
-		// Define allowed characters (alphanumeric only)
 		const allowedChars =
 			"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 		const array = new Uint8Array(length);
 		crypto.getRandomValues(array);
 
-		// Convert random bytes to alphanumeric string
 		const key = Array.from(array)
 			.map((byte) => allowedChars[byte % allowedChars.length])
 			.join("");
@@ -46,6 +45,7 @@ export const createKey = async ({
 	orgId,
 	prefix,
 	meta,
+	expiresAt,
 }: {
 	db: DrizzleCli;
 	env: AppEnv;
@@ -54,6 +54,7 @@ export const createKey = async ({
 	prefix: string;
 	meta: Record<string, unknown>;
 	userId?: string;
+	expiresAt?: number | null;
 }) => {
 	const apiKey = generateApiKey(42, prefix);
 	const hashedKey = hashApiKey(apiKey);
@@ -65,6 +66,7 @@ export const createKey = async ({
 		name,
 		prefix: apiKey.substring(0, 14),
 		created_at: Date.now(),
+		expires_at: expiresAt ?? null,
 		env,
 		hashed_key: hashedKey,
 		meta,
@@ -92,7 +94,6 @@ export const createHardcodedKey = async ({
 }): Promise<{ key: string; alreadyExists: boolean }> => {
 	const hashedKey = hashApiKey(hardcodedKey);
 
-	// Check if key already exists
 	const existing = await ApiKeyService.verifyAndFetch({
 		db,
 		hashedKey,
@@ -110,6 +111,7 @@ export const createHardcodedKey = async ({
 		name,
 		prefix: hardcodedKey.substring(0, 14),
 		created_at: Date.now(),
+		expires_at: null,
 		env,
 		hashed_key: hashedKey,
 		meta,
@@ -140,10 +142,12 @@ export const verifyKey = async ({
 	});
 
 	if (cached) {
-		return {
-			valid: true,
-			data: cached,
-		};
+		if (cached.expiresAt !== null && cached.expiresAt <= Date.now()) {
+			await clearSecretKeyCache({ hashedKey });
+			return { valid: false, data: null };
+		}
+
+		return { valid: true, data: cached };
 	}
 
 	const data = await ApiKeyService.verifyAndFetch({
@@ -153,20 +157,22 @@ export const verifyKey = async ({
 	});
 
 	if (!data) {
-		return {
-			valid: false,
-			data: null,
-		};
+		return { valid: false, data: null };
 	}
 
-	await setCachedSecretKeyVerification({
-		hashedKey,
-		data,
-		ttl: SECRET_KEY_CACHE_TTL_SECONDS,
-	});
+	if (data.expiresAt !== null && data.expiresAt <= Date.now()) {
+		return { valid: false, data: null };
+	}
 
-	return {
-		valid: true,
-		data: data,
-	};
+	let ttl = SECRET_KEY_CACHE_TTL_SECONDS;
+	if (data.expiresAt !== null) {
+		const secondsUntilExpiry = Math.floor((data.expiresAt - Date.now()) / 1000);
+		ttl = Math.min(SECRET_KEY_CACHE_TTL_SECONDS, secondsUntilExpiry);
+	}
+
+	if (ttl > 0) {
+		await setCachedSecretKeyVerification({ hashedKey, data, ttl });
+	}
+
+	return { valid: true, data };
 };

--- a/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
+++ b/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
@@ -113,6 +113,7 @@ export const handleCreateOAuthApiKeys = createRoute({
 				userId,
 				prefix: ApiKeyPrefix.Sandbox,
 				meta,
+				expiresAt: null,
 			}),
 			createKey({
 				db,
@@ -122,6 +123,7 @@ export const handleCreateOAuthApiKeys = createRoute({
 				userId,
 				prefix: ApiKeyPrefix.Live,
 				meta,
+				expiresAt: null,
 			}),
 		]);
 

--- a/server/src/internal/dev/handlers/handleCreateSecretKey.ts
+++ b/server/src/internal/dev/handlers/handleCreateSecretKey.ts
@@ -1,36 +1,68 @@
-import { AppEnv } from "@autumn/shared";
+import { AppEnv, ErrCode, RecaseError } from "@autumn/shared";
 import { z } from "zod/v4";
 import { auth } from "@/utils/auth";
 import { captureOrgEvent } from "@/utils/posthog.js";
 import { createRoute } from "../../../honoMiddlewares/routeHandler";
 import { ApiKeyPrefix, createKey } from "../api-keys/apiKeyUtils";
+
+const MS_30_DAYS = 30 * 24 * 60 * 60 * 1000;
+
 export const handleCreateSecretKey = createRoute({
 	body: z.object({
 		name: z.string().min(1),
+		expires_at: z.number().nullable().optional(),
 	}),
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, env, org } = ctx;
-		const { name } = c.req.valid("json");
+		const { name, expires_at } = c.req.valid("json");
 
-		// 1. Create API key
+		const session = await auth.api.getSession({
+			headers: c.req.raw.headers,
+		});
+
+		const isImpersonated = !!session?.session?.impersonatedBy;
+		const now = Date.now();
+		const maxImpersonatedExpiry = now + MS_30_DAYS;
+
+		if (expires_at !== undefined && expires_at !== null) {
+			if (expires_at <= now) {
+				throw new RecaseError({
+					message: "expires_at must be in the future",
+					code: ErrCode.InvalidInputs,
+					statusCode: 400,
+				});
+			}
+		}
+
+		if (isImpersonated) {
+			if (!expires_at) {
+				throw new RecaseError({
+					message: "expires_at is required for impersonated sessions",
+					code: ErrCode.InvalidInputs,
+					statusCode: 400,
+				});
+			}
+
+			if (expires_at > maxImpersonatedExpiry) {
+				throw new RecaseError({
+					message: "expires_at cannot exceed 30 days for impersonated sessions",
+					code: ErrCode.InvalidInputs,
+					statusCode: 400,
+				});
+			}
+		}
+
 		let prefix = ApiKeyPrefix.Sandbox;
 		if (env === AppEnv.Live) {
 			prefix = ApiKeyPrefix.Live;
 		}
 
-		// Get session to check for impersonation and author
-		const session = await auth.api.getSession({
-			headers: c.req.raw.headers,
-		});
-
 		const meta: Record<string, string> = {};
 
-		// Check if this is an impersonation session (Autumn Support)
-		if (session?.session?.impersonatedBy) {
+		if (isImpersonated) {
 			meta.created_via = "autumn_support";
 		} else if (session?.user?.name) {
-			// Regular user creation
 			meta.author = session.user.name;
 		}
 
@@ -42,6 +74,7 @@ export const handleCreateSecretKey = createRoute({
 			userId: ctx.user?.id,
 			prefix,
 			meta,
+			expiresAt: expires_at ?? null,
 		});
 
 		await captureOrgEvent({

--- a/server/src/internal/dev/handlers/handleGetOtp.ts
+++ b/server/src/internal/dev/handlers/handleGetOtp.ts
@@ -41,6 +41,7 @@ export const handleGetOtp = createRoute({
 				generatedAt: new Date().toISOString(),
 			},
 			userId: user?.id,
+			expiresAt: null,
 		});
 
 		const prodKey = await createKey({
@@ -54,6 +55,7 @@ export const handleGetOtp = createRoute({
 				generatedAt: new Date().toISOString(),
 			},
 			userId: user?.id,
+			expiresAt: null,
 		});
 
 		const org = await OrgService.get({

--- a/server/src/internal/misc/pricingAgent/handlers/handleSetupPreviewOrg.ts
+++ b/server/src/internal/misc/pricingAgent/handlers/handleSetupPreviewOrg.ts
@@ -101,6 +101,7 @@ export const handleSetupPreviewOrg = createRoute({
 			name: "Preview API Key",
 			prefix: "am_sk_test",
 			meta: { preview: true },
+			expiresAt: null,
 		});
 
 		return c.json({

--- a/server/src/internal/platform/platformBeta/handlers/handleCreatePlatformOrg.ts
+++ b/server/src/internal/platform/platformBeta/handlers/handleCreatePlatformOrg.ts
@@ -146,6 +146,7 @@ export const handleCreatePlatformOrg = createRoute({
 				name: "Platform API Key",
 				prefix: "am_sk_test",
 				meta: {},
+				expiresAt: null,
 			});
 		}
 
@@ -157,6 +158,7 @@ export const handleCreatePlatformOrg = createRoute({
 				name: "Platform API Key",
 				prefix: "am_sk_live",
 				meta: {},
+				expiresAt: null,
 			});
 		}
 

--- a/server/src/internal/platform/platformBeta/handlers/handleLegacyPlatformExchange.ts
+++ b/server/src/internal/platform/platformBeta/handlers/handleLegacyPlatformExchange.ts
@@ -170,6 +170,7 @@ export const handleLegacyPlatformExchange = createRoute({
 				name: "Platform API Key",
 				prefix: "am_sk_test",
 				meta: {},
+				expiresAt: null,
 			});
 		}
 
@@ -211,6 +212,7 @@ export const handleLegacyPlatformExchange = createRoute({
 				name: "Platform API Key",
 				prefix: "am_sk_live",
 				meta: {},
+				expiresAt: null,
 			});
 		}
 

--- a/shared/models/devModels/apiKeyModels.ts
+++ b/shared/models/devModels/apiKeyModels.ts
@@ -7,6 +7,7 @@ export type ApiKey = {
 	name: string;
 	prefix: string;
 	created_at: number;
+	expires_at: number | null;
 	env: AppEnv;
 	hashed_key: string;
 	meta: any;

--- a/shared/models/devModels/apiKeyTable.ts
+++ b/shared/models/devModels/apiKeyTable.ts
@@ -15,6 +15,7 @@ export const apiKeys = pgTable(
 	{
 		id: text().primaryKey().notNull(),
 		created_at: numeric({ mode: "number" }).notNull().default(sqlNow),
+		expires_at: numeric({ mode: "number" }),
 		name: text(),
 		prefix: text(),
 		org_id: text("org_id"),

--- a/vite/src/views/developer/api-keys/ApiKeysPage.tsx
+++ b/vite/src/views/developer/api-keys/ApiKeysPage.tsx
@@ -8,14 +8,28 @@ import { useProductTable } from "@/views/products/hooks/useProductTable";
 import { createAPIKeyTableColumns } from "./components/APIKeyTableColumns";
 import { CreateApiKeyDialog } from "./components/CreateApiKeyDialog";
 
+function sortApiKeys(
+	keys: NonNullable<ReturnType<typeof useDevQuery>["apiKeys"]>,
+) {
+	const now = Date.now();
+	const active = keys.filter((k) => !k.expires_at || k.expires_at > now);
+	const expired = keys.filter((k) => k.expires_at && k.expires_at <= now);
+	return [...active, ...expired];
+}
+
 export const ApiKeysPage = () => {
 	const { apiKeys } = useDevQuery();
 	const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
+	const sortedApiKeys = useMemo(
+		() => sortApiKeys(apiKeys || []),
+		[apiKeys],
+	);
+
 	const columns = useMemo(() => createAPIKeyTableColumns(), []);
 
 	const apiKeyTable = useProductTable({
-		data: apiKeys || [],
+		data: sortedApiKeys,
 		columns,
 		options: {
 			globalFilterFn: "includesString",
@@ -27,7 +41,6 @@ export const ApiKeysPage = () => {
 
 	const hasRows = apiKeyTable.getRowModel().rows.length > 0;
 
-	// Add keyboard shortcut: N to open create API key dialog
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (
@@ -114,3 +127,4 @@ export const ApiKeysPage = () => {
 		</div>
 	);
 };
+

--- a/vite/src/views/developer/api-keys/components/APIKeyTableColumns.tsx
+++ b/vite/src/views/developer/api-keys/components/APIKeyTableColumns.tsx
@@ -14,7 +14,6 @@ import {
 import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
 import { APIKeyToolbar } from "./APIKeyToolbar";
 
-// Parse meta to get source info
 function getSourceInfo(meta: ApiKey["meta"]): {
 	type: "cli" | "dashboard" | "autumn_support" | null;
 	author?: string;
@@ -36,16 +35,24 @@ function getSourceInfo(meta: ApiKey["meta"]): {
 	return { type: null };
 }
 
+function isExpired(expiresAt: number | null | undefined): boolean {
+	if (!expiresAt) return false;
+	return expiresAt <= Date.now();
+}
+
 export const createAPIKeyTableColumns = (): ColumnDef<ApiKey, unknown>[] => [
 	{
 		size: 120,
 		header: "Name",
 		accessorKey: "name",
 		cell: ({ row }: { row: Row<ApiKey> }) => {
+			const expired = isExpired(row.original.expires_at);
 			return (
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<div className="font-medium text-t1 truncate max-w-[150px]">
+						<div
+							className={`font-medium text-t1 truncate max-w-[150px] ${expired ? "opacity-50" : ""}`}
+						>
 							{row.original.name}
 						</div>
 					</TooltipTrigger>
@@ -60,8 +67,11 @@ export const createAPIKeyTableColumns = (): ColumnDef<ApiKey, unknown>[] => [
 		accessorKey: "prefix",
 		cell: ({ row }: { row: Row<ApiKey> }) => {
 			const apiKey = row.original;
+			const expired = isExpired(apiKey.expires_at);
 			return (
-				<div className="font-mono justify-start flex w-full group overflow-hidden">
+				<div
+					className={`font-mono justify-start flex w-full group overflow-hidden ${expired ? "opacity-50" : ""}`}
+				>
 					{apiKey.prefix ? (
 						<span className="text-tiny-id"> {apiKey.prefix}</span>
 					) : (
@@ -77,10 +87,11 @@ export const createAPIKeyTableColumns = (): ColumnDef<ApiKey, unknown>[] => [
 		accessorKey: "meta",
 		cell: ({ row }: { row: Row<ApiKey> }) => {
 			const source = getSourceInfo(row.original.meta);
+			const expired = isExpired(row.original.expires_at);
 
 			if (source.type === "cli") {
 				return (
-					<div className="flex justify-start items-center">
+					<div className={`flex justify-start items-center ${expired ? "opacity-50" : ""}`}>
 						<span className="text-tiny flex items-center gap-1 px-1.5 py-0.5 bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400 rounded-md">
 							<TerminalIcon size={12} />
 							CLI
@@ -91,7 +102,7 @@ export const createAPIKeyTableColumns = (): ColumnDef<ApiKey, unknown>[] => [
 
 			if (source.type === "autumn_support") {
 				return (
-					<div className="flex justify-start items-center">
+					<div className={`flex justify-start items-center ${expired ? "opacity-50" : ""}`}>
 						<span className="text-tiny flex items-center gap-1 px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded-md">
 							<ShieldCheckIcon size={12} />
 							Autumn Support
@@ -102,7 +113,7 @@ export const createAPIKeyTableColumns = (): ColumnDef<ApiKey, unknown>[] => [
 
 			if (source.type === "dashboard" && source.author) {
 				return (
-					<div className="flex justify-start items-center">
+					<div className={`flex justify-start items-center ${expired ? "opacity-50" : ""}`}>
 						<span className="text-tiny flex items-center gap-1 px-1.5 py-0.5 bg-muted text-t2 rounded-md">
 							<UserIcon size={12} className="shrink-0" />
 							{source.author}
@@ -125,6 +136,34 @@ export const createAPIKeyTableColumns = (): ColumnDef<ApiKey, unknown>[] => [
 		size: 120,
 		cell: ({ row }: { row: Row<ApiKey> }) => {
 			const { date, time } = formatUnixToDateTime(row.original.created_at);
+			return (
+				<div className="text-xs text-t3 pr-4 w-full">
+					{date} <span className="truncate">{time}</span>
+				</div>
+			);
+		},
+	},
+	{
+		header: () => (
+			<div className="flex items-center gap-1.5">
+				<CalendarIcon size={14} className="text-t4" />
+				<span>Expires</span>
+			</div>
+		),
+		accessorKey: "expires_at",
+		size: 120,
+		cell: ({ row }: { row: Row<ApiKey> }) => {
+			const expiresAt = row.original.expires_at;
+
+			if (!expiresAt) {
+				return <div className="text-xs text-t4">Never</div>;
+			}
+
+			if (expiresAt <= Date.now()) {
+				return <div className="text-xs text-t4">Expired</div>;
+			}
+
+			const { date, time } = formatUnixToDateTime(expiresAt);
 			return (
 				<div className="text-xs text-t3 pr-4 w-full">
 					{date} <span className="truncate">{time}</span>

--- a/vite/src/views/developer/api-keys/components/CreateApiKeyDialog.tsx
+++ b/vite/src/views/developer/api-keys/components/CreateApiKeyDialog.tsx
@@ -13,9 +13,49 @@ import {
 	DialogTitle,
 } from "@/components/v2/dialogs/Dialog";
 import { Input } from "@/components/v2/inputs/Input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+import { DateInputUnix } from "@/components/general/DateInputUnix";
 import { useDevQuery } from "@/hooks/queries/useDevQuery";
 import { DevService } from "@/services/DevService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+type ExpiryOption = "7d" | "30d" | "60d" | "90d" | "1y" | "custom" | "never";
+
+const EXPIRY_OPTIONS: { label: string; value: ExpiryOption }[] = [
+	{ label: "7 days", value: "7d" },
+	{ label: "30 days", value: "30d" },
+	{ label: "60 days", value: "60d" },
+	{ label: "90 days", value: "90d" },
+	{ label: "1 year", value: "1y" },
+	{ label: "Custom", value: "custom" },
+	{ label: "Never", value: "never" },
+];
+
+const MS_DAY = 24 * 60 * 60 * 1000;
+
+function computeExpiresAt({
+	expiryOption,
+	customDate,
+}: {
+	expiryOption: ExpiryOption;
+	customDate: number | null;
+}): number | null {
+	const now = Date.now();
+	if (expiryOption === "never") return null;
+	if (expiryOption === "custom") return customDate;
+	if (expiryOption === "7d") return now + 7 * MS_DAY;
+	if (expiryOption === "30d") return now + 30 * MS_DAY;
+	if (expiryOption === "60d") return now + 60 * MS_DAY;
+	if (expiryOption === "90d") return now + 90 * MS_DAY;
+	if (expiryOption === "1y") return now + 365 * MS_DAY;
+	return null;
+}
 
 const createApiKeySchema = z.object({
 	name: z.string().min(1, "Name is required"),
@@ -37,6 +77,8 @@ export const CreateApiKeyDialog = ({
 	const [copied, setCopied] = useState(false);
 	const [copiedEnv, setCopiedEnv] = useState(false);
 	const [validationError, setValidationError] = useState<string | null>(null);
+	const [expiryOption, setExpiryOption] = useState<ExpiryOption>("never");
+	const [customDate, setCustomDate] = useState<number | null>(null);
 
 	useEffect(() => {
 		if (open) {
@@ -45,6 +87,8 @@ export const CreateApiKeyDialog = ({
 			setCopied(false);
 			setCopiedEnv(false);
 			setValidationError(null);
+			setExpiryOption("never");
+			setCustomDate(null);
 		} else if (!open) {
 			refetch();
 			setTimeout(() => {
@@ -74,6 +118,8 @@ export const CreateApiKeyDialog = ({
 		}
 	}, [copiedEnv]);
 
+	const isCustomWithNoDate = expiryOption === "custom" && customDate === null;
+
 	const handleCreate = async () => {
 		const result = createApiKeySchema.safeParse({ name });
 		if (!result.success) {
@@ -81,10 +127,15 @@ export const CreateApiKeyDialog = ({
 			return;
 		}
 
+		if (isCustomWithNoDate) return;
+
 		setLoading(true);
 		try {
+			const expires_at = computeExpiresAt({ expiryOption, customDate });
+
 			const { api_key } = await DevService.createAPIKey(axiosInstance, {
-				name: name,
+				name,
+				expires_at,
 			});
 
 			setApiKey(api_key);
@@ -166,28 +217,76 @@ export const CreateApiKeyDialog = ({
 								bounce: 0.15,
 								duration: 0.3,
 							}}
+							className="flex flex-col gap-4"
 						>
-							<p className="mb-2 text-sm text-t3">Name</p>
-							<Input
-								placeholder="Name"
-								value={name}
-								onChange={(e) => setName(e.target.value)}
-								variant={validationError ? "destructive" : undefined}
-								onKeyDown={(e) => {
-									if (
-										e.key === "Enter" &&
-										name.trim() &&
-										!loading &&
-										!validationError
-									) {
-										e.preventDefault();
-										handleCreate();
-									}
-								}}
-							/>
-							{validationError && (
-								<p className="mt-2 text-sm text-red-500">{validationError}</p>
-							)}
+							<div>
+								<p className="mb-2 text-sm text-t3">Name</p>
+								<Input
+									placeholder="Name"
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									variant={validationError ? "destructive" : undefined}
+									onKeyDown={(e) => {
+										if (
+											e.key === "Enter" &&
+											name.trim() &&
+											!loading &&
+											!validationError &&
+											!isCustomWithNoDate
+										) {
+											e.preventDefault();
+											handleCreate();
+										}
+									}}
+								/>
+								{validationError && (
+									<p className="mt-2 text-sm text-red-500">{validationError}</p>
+								)}
+							</div>
+							<div>
+								<p className="mb-2 text-sm text-t3">Expiration</p>
+								{expiryOption === "custom" ? (
+									<div className="grid grid-cols-[auto_1fr] gap-2 items-center">
+										<Select
+											value={expiryOption}
+											onValueChange={(v) =>
+												setExpiryOption(v as ExpiryOption)
+											}
+										>
+											<SelectTrigger>
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{EXPIRY_OPTIONS.map((opt) => (
+													<SelectItem key={opt.value} value={opt.value}>
+														{opt.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+										<DateInputUnix
+											unixDate={customDate}
+											setUnixDate={setCustomDate}
+										/>
+									</div>
+								) : (
+									<Select
+										value={expiryOption}
+										onValueChange={(v) => setExpiryOption(v as ExpiryOption)}
+									>
+										<SelectTrigger className="w-full">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{EXPIRY_OPTIONS.map((opt) => (
+												<SelectItem key={opt.value} value={opt.value}>
+													{opt.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								)}
+							</div>
 						</motion.div>
 					)}
 				</AnimatePresence>
@@ -229,7 +328,7 @@ export const CreateApiKeyDialog = ({
 									onClick={handleCreate}
 									variant="primary"
 									className="cursor-pointer"
-									disabled={!!validationError || !name.trim()}
+									disabled={!!validationError || !name.trim() || isCustomWithNoDate}
 								>
 									Create
 								</Button>


### PR DESCRIPTION
- Add nullable expires_at (ms epoch) column to api_keys table
- Add expires_at: number | null to ApiKey shared type
- createKey() accepts expiresAt param; createHardcodedKey sets null
- All non-dashboard createKey callers pass expiresAt: null
- ApiKeyService.verifyAndFetch returns expiresAt in result
- verifyKey: checks cache/DB expiry, evicts stale cache, uses smart TTL
- handleCreateSecretKey: accepts expires_at, validates future timestamp, requires expiry for impersonated sessions (max 30 days)
- CreateApiKeyDialog: expiration select (7d/30d/60d/90d/1y/custom/never) with inline DateInputUnix for custom mode
- APIKeyTableColumns: Expires column with Never/Expired/date display, expired rows dimmed via opacity-50
- ApiKeysPage: sorts expired keys to bottom of table

<img width="980" height="1082" alt="image" src="https://github.com/user-attachments/assets/bb858e94-ea34-4cfd-9b20-d0d3de89561a" />

## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [x] I have tested my changes locally
- [x] I have linked relevant issues
- [x] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add API key expiration end-to-end. Keys now support an optional expires_at; expired keys are rejected and the dashboard lets you set and see expiry.

- **New Features**
  - Schema: add nullable expires_at (ms epoch) to `api_keys`; shared types updated.
  - Creation: API accepts expires_at; impersonated sessions require a future expiry ≤ 30 days; all other server-created keys pass null.
  - Verification: rejects expired keys; clears stale cache; cache TTL is capped to time-to-expiry.
  - UI: create dialog with presets (7d/30d/60d/90d/1y/custom/never) and custom date input; table shows Expires (Never/Expired/date), dims expired keys, and sorts expired to the bottom.

- **Migration**
  - Run the DB migration to add the `expires_at` column. No other steps required.

<sup>Written for commit 494ff65e2a70eed022c28c4cc0e1e501038380f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements end-to-end API key expiry: a nullable `expires_at` column in the DB schema, server-side validation and smart cache TTL management (capping the Redis TTL at `min(default, secondsUntilExpiry)` to avoid stale cache hits), and a UI with preset durations (7d–1y), a custom date picker, an Expires column in the key table, and expired rows sorted to the bottom.

**Key changes:**
- [Improvements] `verifyKey` now evicts stale cached entries on expiry check and sets a smart TTL so the cache never outlives a key's expiry timestamp
- [API changes] `handleCreateSecretKey` accepts `expires_at`, validates it is in the future, and enforces a maximum 30-day expiry for impersonated sessions
- [Improvements] All non-dashboard `createKey` callers (CLI, platform, preview org, OTP) explicitly pass `expiresAt: null`
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no blocking correctness issues.

The core expiry logic (smart TTL caching, server-side validation, impersonation cap) is correct and well-guarded. The two remaining findings are a stray console.log and a missing client-side past-date guard (the server already rejects invalid input), both P2.

CreateApiKeyDialog.tsx — minor: remove console.log and add client-side past-date guard for custom expiry.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The 30-day expiry cap for impersonated sessions is a good security guardrail, and the server-side `expires_at <= now` check prevents accepting expired timestamps on key creation.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/dev/api-keys/apiKeyUtils.ts | Adds expiresAt to createKey, expiry checks in verifyKey with smart cache TTL (min of default TTL vs seconds-until-expiry), and stale cache eviction — logic is correct and well-guarded. |
| server/src/internal/dev/handlers/handleCreateSecretKey.ts | Adds expires_at validation (must be future timestamp), enforces expiry requirement for impersonated sessions (max 30 days), and threads value through createKey — all guards are correct. |
| vite/src/views/developer/api-keys/components/CreateApiKeyDialog.tsx | Adds expiry select (preset durations + custom date picker) and wires expires_at into the API call; missing client-side past-date guard for custom mode, and has a stray console.log. |
| vite/src/views/developer/api-keys/components/APIKeyTableColumns.tsx | Adds Expires column with Never/Expired/date display and dims expired rows with opacity-50 — clean and consistent. |
| shared/models/devModels/apiKeyTable.ts | Adds nullable expires_at numeric column to the api_keys table schema — consistent with created_at column type. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as CreateApiKeyDialog
    participant API as handleCreateSecretKey
    participant DB as Database
    participant Cache as Redis Cache

    UI->>API: POST /dev/secret-key { name, expires_at }
    API->>API: Validate expires_at > now
    API->>API: If impersonated: enforce expires_at <= 30d
    API->>DB: INSERT api_keys (... expires_at)
    API-->>UI: { api_key }

    note over UI,Cache: On subsequent API requests using the key

    UI->>Cache: getCachedSecretKeyVerification(hashedKey)
    alt Cache hit
        Cache-->>UI: cached data
        UI->>UI: Check cached.expiresAt <= now?
        alt Expired in cache
            UI->>Cache: clearSecretKeyCache(hashedKey)
            UI-->>UI: { valid: false }
        else Still valid
            UI-->>UI: { valid: true, data: cached }
        end
    else Cache miss
        UI->>DB: verifyAndFetch(hashedKey)
        DB-->>UI: key data (with expires_at)
        UI->>UI: Check data.expiresAt <= now?
        alt Expired in DB
            UI-->>UI: { valid: false }
        else Still valid
            UI->>UI: ttl = min(DEFAULT_TTL, secondsUntilExpiry)
            UI->>Cache: setCachedSecretKeyVerification(ttl)
            UI-->>UI: { valid: true, data }
        end
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/developer/api-keys/components/CreateApiKeyDialog.tsx`, line 143 ([link](https://github.com/useautumn/autumn/blob/494ff65e2a70eed022c28c4cc0e1e501038380f6/vite/src/views/developer/api-keys/components/CreateApiKeyDialog.tsx#L143)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Remove `console.log` from production code**

   Per the project's code standards, `console.log` statements should be removed from production code. The error is already surfaced to the user via `toast.error`, so this log is redundant.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/developer/api-keys/components/CreateApiKeyDialog.tsx
   Line: 143

   Comment:
   **Remove `console.log` from production code**

   Per the project's code standards, `console.log` statements should be removed from production code. The error is already surfaced to the user via `toast.error`, so this log is redundant.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/views/developer/api-keys/components/CreateApiKeyDialog.tsx
Line: 143

Comment:
**Remove `console.log` from production code**

Per the project's code standards, `console.log` statements should be removed from production code. The error is already surfaced to the user via `toast.error`, so this log is redundant.

```suggestion
		} catch {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/developer/api-keys/components/CreateApiKeyDialog.tsx
Line: 130

Comment:
**No client-side validation for past custom dates**

`isCustomWithNoDate` prevents submitting when no date is selected, but if the user picks a date in the past, `computeExpiresAt` will return that past timestamp and the request will be rejected server-side with a generic `"Failed to create API key"` toast. A frontend guard here would give a clearer error message:

```suggestion
		if (isCustomWithNoDate) return;
		if (expiryOption === "custom" && customDate !== null && customDate <= Date.now()) {
			setValidationError("Expiration date must be in the future");
			return;
		}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: API key expiry — schema, verificat..."](https://github.com/useautumn/autumn/commit/494ff65e2a70eed022c28c4cc0e1e501038380f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27709981)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->