### PR TITLE
fix: prevent server crash when Redis is unavailable

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,22 @@
 // Instead of:
 import "dotenv/config";
 
+// Prevent BullMQ/ioredis connection errors from crashing the process when Redis is unavailable.
+// These are expected in degraded-mode operation and are handled at the call site.
+process.on("unhandledRejection", (reason) => {
+	const message = reason instanceof Error ? reason.message : String(reason);
+	if (
+		message.includes("maxRetriesPerRequest") ||
+		message.includes("enableOfflineQueue") ||
+		message.includes("Stream isn't writeable")
+	) {
+		console.warn("[queue] Redis unavailable, job dropped:", message);
+		return;
+	}
+	// Re-throw all other unhandled rejections so real bugs still crash the process
+	throw reason;
+});
+
 import cluster from "node:cluster";
 
 import { initInfisical } from "./external/infisical/initInfisical.js";

--- a/server/src/queue/bullmq/initBullMq.ts
+++ b/server/src/queue/bullmq/initBullMq.ts
@@ -17,14 +17,11 @@ export const queue = new Queue("autumn", {
 		url: process.env.QUEUE_URL,
 		tls: caText ? { ca: caText } : undefined,
 		enableOfflineQueue: false,
+		maxRetriesPerRequest: null,
 		retryStrategy: () => {
 			return 5000;
 		},
 	},
-});
-
-const queueRedis = new Redis(process.env.QUEUE_URL, {
-	tls: caText ? { ca: caText } : undefined,
 });
 
 // Separate Redis connection for BullMQ Workers (requires maxRetriesPerRequest: null)
@@ -33,10 +30,6 @@ export const workerRedis = new Redis(process.env.QUEUE_URL, {
 	maxRetriesPerRequest: null,
 	enableReadyCheck: false,
 	enableOfflineQueue: false,
-});
-
-queueRedis.on("error", (error) => {
-	// logger.error(`redis (queue) error: ${error.message}`);
 });
 
 workerRedis.on("error", (error) => {

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -132,10 +132,17 @@ export const addTaskToQueue = async <T extends keyof Payloads>({
 
 		// BullMQ dedup: if a stable dedup ID is provided, use it as the jobId.
 		// BullMQ ignores jobs whose jobId already exists in the queue (not yet completed).
-		await queue.add(jobName as string, payload, {
-			delay: delayMs,
-			...(messageDeduplicationId && { jobId: messageDeduplicationId }),
-		});
+		try {
+			await queue.add(jobName as string, payload, {
+				delay: delayMs,
+				...(messageDeduplicationId && { jobId: messageDeduplicationId }),
+			});
+		} catch (error) {
+			console.warn(
+				`[BullMQ] Failed to enqueue job ${jobName} — Redis may be unavailable:`,
+				(error as Error).message,
+			);
+		}
 		return;
 	}
 


### PR DESCRIPTION
- Wrap BullMQ queue.add() in try/catch so Redis outages drop jobs with a warning instead of crashing the request handler
- Remove unused queueRedis connection that was crashing the process after 20 connection retries
- Add maxRetriesPerRequest: null to BullMQ queue connection to prevent MaxRetriesPerRequestError from internal connections
- Add process-level unhandledRejection handler to catch any remaining BullMQ/ioredis errors that escape through internal connections

## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents server crashes when Redis is down by making `BullMQ` enqueue resilient and handling `ioredis` errors safely. Jobs are dropped with a warning so the server stays up in degraded mode.

- **Bug Fixes**
  - Wrap `queue.add()` in try/catch to drop jobs with a warning if Redis is unavailable.
  - Remove unused `queueRedis` connection that crashed after retrying.
  - Set `maxRetriesPerRequest: null` on the `queue` connection to avoid `MaxRetriesPerRequestError`.
  - Add `process.on('unhandledRejection')` handler to log known Redis connectivity errors and rethrow others.

<sup>Written for commit 98d046eb59cb8870c31bcab609a0555f21b34710. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the server against Redis unavailability by wrapping `queue.add()` in a try/catch, removing an unused `queueRedis` connection that was triggering process crashes after 20 reconnect retries, and adding a global `unhandledRejection` guard for any BullMQ/ioredis errors that escape call-site handling.

**Key changes:**
- [Bug fixes] Remove unused `queueRedis` Redis connection that caused process crashes after exhausting reconnect retries
- [Bug fixes] Add `maxRetriesPerRequest: null` to the BullMQ Queue connection to prevent `MaxRetriesPerRequestError` from internal BullMQ connections
- [Improvements] Wrap `queue.add()` in try/catch so Redis outages drop jobs with a warning instead of crashing the request handler
- [Improvements] Add process-level `unhandledRejection` handler as a last-resort safety net for Redis errors escaping internal BullMQ connections
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/observability suggestions that do not affect correctness or reliability of the fix.

The three concrete bugs (unused crashing connection, missing maxRetriesPerRequest, unguarded queue.add) are all addressed correctly. Remaining comments are about the fragility of string-based error matching and silent job drops, both of which are P2 improvement suggestions rather than present defects.

server/src/index.ts — the unhandledRejection string-matching could be made more robust, but is not blocking.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The changes only affect error handling and connection management for an internal Redis/BullMQ queue; no user input, auth boundaries, or data exposure paths are modified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/index.ts | Adds a process-level unhandledRejection guard that swallows known ioredis/BullMQ error messages; string-based matching is fragile across library versions. |
| server/src/queue/bullmq/initBullMq.ts | Removes the unused queueRedis connection that was crashing the process; adds maxRetriesPerRequest: null to the Queue connection to suppress internal BullMQ MaxRetriesPerRequestError. |
| server/src/queue/queueUtils.ts | Wraps queue.add() in try/catch so Redis outages produce a console.warn instead of propagating; job drops are silent to callers. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[addTaskToQueue called] --> B{SQS_QUEUE_URL set?}
    B -- Yes --> C[Send via SQS]
    B -- No --> D{QUEUE_URL set?}
    D -- No --> E[throw: No queue configured]
    D -- Yes --> F[queue.add via BullMQ]
    F -- Success --> G[Job enqueued ✓]
    F -- Redis error --> H[catch: console.warn, job silently dropped]

    I[BullMQ internal connection] -- MaxRetriesPerRequestError / ioredis errors --> J[process unhandledRejection handler]
    J -- message matches Redis pattern --> K[console.warn, swallow error]
    J -- message does NOT match --> L[throw reason → uncaughtException → crash]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/index.ts
Line: 7-18

Comment:
**Fragile string-based error filtering**

The handler filters Redis errors by matching substrings of error messages (`"maxRetriesPerRequest"`, `"enableOfflineQueue"`, `"Stream isn't writeable"`). These strings are internal to ioredis and can change silently in a patch or minor version bump — causing either real Redis errors to start crashing the process again, or (worse) non-Redis errors that happen to share these substrings being silently swallowed.

A more durable approach is to match on the error's constructor name or a stable `code` property:

```typescript
process.on("unhandledRejection", (reason) => {
  if (reason instanceof Error) {
    const name = reason.constructor.name;
    // ioredis throws MaxRetriesPerRequestError; enableOfflineQueue rejections come as ReplyError
    if (name === "MaxRetriesPerRequestError" || name === "ReplyError") {
      console.warn("[queue] Redis unavailable, job dropped:", reason.message);
      return;
    }
  }
  throw reason;
});
```

If matching by class is not feasible (e.g. the error comes through without prototype), at minimum document the exact ioredis version these strings were captured from so future maintainers know when to re-verify.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/queue/queueUtils.ts
Line: 135-145

Comment:
**Silent job drops are invisible to callers**

`addTaskToQueue` always resolves to `void` — both on success and on Redis failure. Callers that schedule critical background work (balance syncs, reward migrations, lock expiry) have no way to know their job was quietly dropped. If observability or alerting is added later, the hook point is gone.

Consider returning a typed result, or at a minimum logging the `jobName` alongside the warning so operators can correlate dropped jobs from logs:

```typescript
console.warn(
  `[BullMQ] Failed to enqueue job "${String(jobName)}" — Redis may be unavailable. Job dropped silently.`,
  (error as Error).message,
);
```

This won't change behaviour but makes post-incident reconstruction easier.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent server crash when Redis is ..."](https://github.com/useautumn/autumn/commit/98d046eb59cb8870c31bcab609a0555f21b34710) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27839635)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->