### PR TITLE
fix: full customer limits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -253,6 +253,14 @@
         "typescript-eslint": "^8.26.0",
       },
     },
+    "packages/stripe-sync": {
+      "name": "@autumn/stripe-sync",
+      "version": "1.0.0",
+      "dependencies": {
+        "@supabase/stripe-sync-engine": "^0.48.5",
+        "stripe": "catalog:",
+      },
+    },
     "scripts": {
       "name": "@autumn/scripts",
       "version": "1.0.0",
@@ -282,6 +290,7 @@
         "@anthropic-ai/sdk": "^0.32.1",
         "@autumn/ksuid": "workspace:*",
         "@autumn/shared": "workspace:*",
+        "@autumn/stripe-sync": "workspace:*",
         "@aws-sdk/client-s3": "^3.1017.0",
         "@aws-sdk/client-scheduler": "^3.1004.0",
         "@aws-sdk/client-sqs": "^3.958.0",
@@ -602,6 +611,8 @@
     "@autumn/server": ["@autumn/server@workspace:server"],
 
     "@autumn/shared": ["@autumn/shared@workspace:shared"],
+
+    "@autumn/stripe-sync": ["@autumn/stripe-sync@workspace:packages/stripe-sync"],
 
     "@autumn/vite": ["@autumn/vite@workspace:vite"],
 
@@ -1920,6 +1931,8 @@
     "@supabase/realtime-js": ["@supabase/realtime-js@2.102.1", "", { "dependencies": { "@supabase/phoenix": "^0.4.0", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-h2fCumib/v6u7XMwSPgxnpfimjX4xCEayUHrxWLC7UurfQjUZJ0pmJDgm6yj80DnUerxuulRghwm5zXYysFG/Q=="],
 
     "@supabase/storage-js": ["@supabase/storage-js@2.102.1", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-eCL9T4Xpe40nmKlkUJ7Zq/hk34db1xPiT0WL3Iv5MbJqHuCAe5TxhV8Rjqd6DNZrzjtfYObZtYl9jKJaHrivqw=="],
+
+    "@supabase/stripe-sync-engine": ["@supabase/stripe-sync-engine@0.48.5", "", { "dependencies": { "pg": "^8.20.0", "pg-node-migrations": "0.0.8", "yesql": "^7.0.0" }, "peerDependencies": { "stripe": "> 18" } }, "sha512-+LbtJH8n5Xiu289AL3FuWFdKXd0K7kDF0z4Lm+zMYoImWmOuGd3TgSx9gm/nv4nzLooOmIxGZh6LojoYBcJM+g=="],
 
     "@supabase/supabase-js": ["@supabase/supabase-js@2.102.1", "", { "dependencies": { "@supabase/auth-js": "2.102.1", "@supabase/functions-js": "2.102.1", "@supabase/postgrest-js": "2.102.1", "@supabase/realtime-js": "2.102.1", "@supabase/storage-js": "2.102.1" } }, "sha512-bChxPVeLDnYN9M2d/u4fXsvylwSQG5grAl+HN8f+ZD9a9PuVU+Ru+xGmEsk+b9Iz3rJC9ZQnQUJYQ28fApdWYA=="],
 
@@ -4369,6 +4382,8 @@
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
 
+    "pg-node-migrations": ["pg-node-migrations@0.0.8", "", { "dependencies": { "pg": "^8.6.0", "sql-template-strings": "^2.2.2" }, "bin": { "pg-validate-migrations": "dist/bin/validate.js" } }, "sha512-44cMl9umOmCv0hzZyEcvjEq8Bm8u7mrzggZ06qXTJVSsMMB4j2OsjG+rSp+uzeKWyP2Vu0K9Ye2wKtjFUJwrdw=="],
+
     "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
 
     "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
@@ -4866,6 +4881,8 @@
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "sql-template-strings": ["sql-template-strings@2.2.2", "", {}, "sha512-UXhXR2869FQaD+GMly8jAMCRZ94nU5KcrFetZfWEMd+LVVG6y0ExgHAhatEcKZ/wk8YcKPdi+hiD2wm75lq3/Q=="],
 
     "sqs-consumer": ["sqs-consumer@6.0.2", "", { "dependencies": { "@aws-sdk/client-sqs": "^3.226.0", "debug": "^4.3.4" } }, "sha512-Y8ztFBc1VPj4q72j9Uji4XR6n2O88n9X83aOUaCvz9zZqjpGJaI4PBHBPnE8RDBgD0EQR8Dh+sQwH/+8mzr+Bg=="],
 
@@ -5376,6 +5393,8 @@
     "yargs-unparser": ["yargs-unparser@2.0.0", "", { "dependencies": { "camelcase": "^6.0.0", "decamelize": "^4.0.0", "flat": "^5.0.2", "is-plain-obj": "^2.1.0" } }, "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA=="],
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
+    "yesql": ["yesql@7.0.0", "", {}, "sha512-sosfr7agy4ibLM7BvXBkM6BpBmKMGuBO8DUYQEuey+QqaqrgW+2bsSg6D050ocBYIz0PuHxUyehyzEztZTU4pw=="],
 
     "yn": ["yn@3.1.1", "", {}, "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 			"packages/sdk",
 			"packages/autumn-js",
 			"packages/openapi",
-			"packages/ksuid"
+			"packages/ksuid",
+			"packages/stripe-sync"
 		],
 		"catalog": {
 			"stripe": "19.3.0-beta.1",
@@ -107,7 +108,9 @@
 		"js:publish": "bun js:build && cd packages/autumn-js && npm publish",
 		"js:publish-beta": "bun js:build && cd packages/autumn-js && npm publish --tag beta",
 		"js:publish-dry": "bun js:build && cd packages/autumn-js && npm publish --dry-run",
-		"js:version": "git fetch --tags origin && git tag -l 'autumn-js-v*' --sort=-v:refname | head -1"
+		"js:version": "git fetch --tags origin && git tag -l 'autumn-js-v*' --sort=-v:refname | head -1",
+		"stripe-sync:migrate": "bun packages/stripe-sync/scripts/migrate.ts",
+		"stripe-sync:migrate:prod": "NODE_ENV=production infisical run --env=prod -- bun packages/stripe-sync/scripts/migrate.ts"
 	},
 	"dependencies": {
 		"@aws-sdk/client-sqs": "^3.985.0",

--- a/packages/stripe-sync/package.json
+++ b/packages/stripe-sync/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@autumn/stripe-sync",
+	"version": "1.0.0",
+	"description": "Stripe-to-Postgres sync engine wrapper for Autumn",
+	"type": "module",
+	"main": "./src/index.ts",
+	"types": "./src/index.ts",
+	"exports": {
+		".": {
+			"types": "./src/index.ts",
+			"import": "./src/index.ts",
+			"default": "./src/index.ts"
+		}
+	},
+	"private": true,
+	"dependencies": {
+		"@supabase/stripe-sync-engine": "^0.48.5",
+		"stripe": "catalog:"
+	}
+}

--- a/packages/stripe-sync/scripts/migrate.ts
+++ b/packages/stripe-sync/scripts/migrate.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { config } from "dotenv";
+import { addAutumnColumns, runStripeSyncMigrations } from "../src/index.js";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../../..");
+
+config({ path: path.join(repoRoot, "server/.env"), override: true });
+
+const databaseUrl = process.env.STRIPE_SYNC_DATABASE_URL;
+
+if (!databaseUrl) {
+	console.error("STRIPE_SYNC_DATABASE_URL is required");
+	process.exit(1);
+}
+
+console.log("Running stripe sync migrations...");
+await runStripeSyncMigrations({ databaseUrl });
+console.log("Stripe sync migrations complete");
+
+console.log(
+	"Adding Autumn columns (stripe_account_id, org_id) to synced tables...",
+);
+await addAutumnColumns({ databaseUrl });
+console.log("Autumn columns added");

--- a/packages/stripe-sync/src/addAccountIdColumn.ts
+++ b/packages/stripe-sync/src/addAccountIdColumn.ts
@@ -20,7 +20,8 @@ export const addAutumnColumns = async ({
 			await client.query(`
 				ALTER TABLE "${schema}"."${table}"
 				ADD COLUMN IF NOT EXISTS stripe_account_id TEXT,
-				ADD COLUMN IF NOT EXISTS org_id TEXT
+				ADD COLUMN IF NOT EXISTS org_id TEXT,
+				ADD COLUMN IF NOT EXISTS env TEXT
 			`);
 			await client.query(`
 				CREATE INDEX IF NOT EXISTS idx_${table}_stripe_account_id

--- a/packages/stripe-sync/src/addAccountIdColumn.ts
+++ b/packages/stripe-sync/src/addAccountIdColumn.ts
@@ -1,0 +1,37 @@
+import pg from "pg";
+import { SYNCED_TABLES } from "./eventTypeToTable.js";
+
+/**
+ * Adds `stripe_account_id` and `org_id` columns + indexes to all synced tables.
+ * Idempotent -- safe to run multiple times.
+ */
+export const addAutumnColumns = async ({
+	databaseUrl,
+	schema = "stripe",
+}: {
+	databaseUrl: string;
+	schema?: string;
+}): Promise<void> => {
+	const client = new pg.Client({ connectionString: databaseUrl });
+	await client.connect();
+
+	try {
+		for (const table of SYNCED_TABLES) {
+			await client.query(`
+				ALTER TABLE "${schema}"."${table}"
+				ADD COLUMN IF NOT EXISTS stripe_account_id TEXT,
+				ADD COLUMN IF NOT EXISTS org_id TEXT
+			`);
+			await client.query(`
+				CREATE INDEX IF NOT EXISTS idx_${table}_stripe_account_id
+				ON "${schema}"."${table}" (stripe_account_id)
+			`);
+			await client.query(`
+				CREATE INDEX IF NOT EXISTS idx_${table}_org_id
+				ON "${schema}"."${table}" (org_id)
+			`);
+		}
+	} finally {
+		await client.end();
+	}
+};

--- a/packages/stripe-sync/src/eventTypeToTable.ts
+++ b/packages/stripe-sync/src/eventTypeToTable.ts
@@ -1,0 +1,61 @@
+/**
+ * Maps a Stripe event type to the sync DB table that stores the object.
+ * Returns undefined for event types that don't map to a known table.
+ */
+export const eventTypeToTable = ({
+	eventType,
+}: {
+	eventType: string;
+}): string | undefined => {
+	if (eventType.startsWith("charge.dispute.")) return "disputes";
+	if (eventType.startsWith("charge.")) return "charges";
+	if (eventType.startsWith("checkout.session.")) return "checkout_sessions";
+	if (eventType.startsWith("customer.subscription.")) return "subscriptions";
+	if (eventType.startsWith("customer.tax_id.")) return "tax_ids";
+	if (eventType.startsWith("customer.")) return "customers";
+	if (eventType.startsWith("invoice.")) return "invoices";
+	if (eventType.startsWith("product.")) return "products";
+	if (eventType.startsWith("price.")) return "prices";
+	if (eventType.startsWith("plan.")) return "plans";
+	if (eventType.startsWith("setup_intent.")) return "setup_intents";
+	if (eventType.startsWith("subscription_schedule."))
+		return "subscription_schedules";
+	if (eventType.startsWith("payment_method.")) return "payment_methods";
+	if (eventType.startsWith("payment_intent.")) return "payment_intents";
+	if (eventType.startsWith("credit_note.")) return "credit_notes";
+	if (eventType.startsWith("radar.early_fraud_warning."))
+		return "early_fraud_warnings";
+	if (eventType.startsWith("refund.")) return "refunds";
+	if (eventType.startsWith("review.")) return "reviews";
+	if (eventType === "invoice_payment.paid") return "invoice_payments";
+
+	return undefined;
+};
+
+/** All tables in the stripe sync schema that store Stripe objects. */
+export const SYNCED_TABLES = [
+	"charges",
+	"checkout_sessions",
+	"checkout_session_line_items",
+	"coupons",
+	"credit_notes",
+	"customers",
+	"disputes",
+	"early_fraud_warnings",
+	"events",
+	"invoices",
+	"invoice_payments",
+	"payment_intents",
+	"payment_methods",
+	"payouts",
+	"plans",
+	"prices",
+	"products",
+	"refunds",
+	"reviews",
+	"setup_intents",
+	"subscription_items",
+	"subscription_schedules",
+	"subscriptions",
+	"tax_ids",
+] as const;

--- a/packages/stripe-sync/src/index.ts
+++ b/packages/stripe-sync/src/index.ts
@@ -1,0 +1,12 @@
+export { addAutumnColumns } from "./addAccountIdColumn.js";
+export { eventTypeToTable, SYNCED_TABLES } from "./eventTypeToTable.js";
+export {
+	closeStripeSyncEngine,
+	getStripeSyncEngine,
+	processStripeSyncEvent,
+} from "./initStripeSync.js";
+export { runStripeSyncMigrations } from "./runStripeSyncMigrations.js";
+export {
+	isSyncableEvent,
+	SYNCABLE_EVENT_PREFIXES,
+} from "./syncableResources.js";

--- a/packages/stripe-sync/src/initStripeSync.ts
+++ b/packages/stripe-sync/src/initStripeSync.ts
@@ -52,10 +52,12 @@ export const processStripeSyncEvent = async ({
 	event,
 	stripeAccountId,
 	orgId,
+	env,
 }: {
 	event: Stripe.Event;
 	stripeAccountId?: string;
 	orgId?: string;
+	env?: string;
 }): Promise<void> => {
 	const engine = getStripeSyncEngine();
 	if (!engine) return;
@@ -74,12 +76,12 @@ export const processStripeSyncEvent = async ({
 
 	const accountId = stripeAccountId ?? event.account ?? null;
 
-	if (!accountId && !orgId) return;
+	if (!accountId && !orgId && !env) return;
 
 	try {
 		await engine.postgresClient.pool.query(
-			`UPDATE "${SCHEMA}"."${table}" SET stripe_account_id = COALESCE($1, stripe_account_id), org_id = COALESCE($2, org_id) WHERE id = $3`,
-			[accountId, orgId, objectId],
+			`UPDATE "${SCHEMA}"."${table}" SET stripe_account_id = COALESCE($1, stripe_account_id), org_id = COALESCE($2, org_id), env = COALESCE($3, env) WHERE id = $4`,
+			[accountId, orgId, env, objectId],
 		);
 	} catch {
 		// Fail-open: metadata stamp is best-effort

--- a/packages/stripe-sync/src/initStripeSync.ts
+++ b/packages/stripe-sync/src/initStripeSync.ts
@@ -1,0 +1,99 @@
+import { StripeSync } from "@supabase/stripe-sync-engine";
+import type Stripe from "stripe";
+import { eventTypeToTable } from "./eventTypeToTable.js";
+
+const SCHEMA = "stripe";
+
+let instance: StripeSync | null = null;
+let initAttempted = false;
+
+/**
+ * Lazily creates a singleton StripeSync instance.
+ * Returns null if STRIPE_SYNC_DATABASE_URL is not configured or init fails.
+ */
+export const getStripeSyncEngine = (): StripeSync | null => {
+	if (instance) return instance;
+	if (initAttempted) return null;
+
+	initAttempted = true;
+
+	const databaseUrl = process.env.STRIPE_SYNC_DATABASE_URL;
+	const stripeSecretKey =
+		process.env.STRIPE_LIVE_SECRET_KEY || process.env.STRIPE_SANDBOX_SECRET_KEY;
+
+	if (!databaseUrl || !stripeSecretKey) return null;
+
+	try {
+		instance = new StripeSync({
+			poolConfig: {
+				connectionString: databaseUrl,
+				max: 5,
+				keepAlive: true,
+				connectionTimeoutMillis: 5_000,
+				idleTimeoutMillis: 30_000,
+			},
+			stripeSecretKey,
+			stripeWebhookSecret: "unused-processEvent-only",
+			schema: SCHEMA,
+		});
+	} catch {
+		instance = null;
+	}
+
+	return instance;
+};
+
+/**
+ * Upserts the Stripe event into the sync DB, then stamps the row
+ * with the originating Stripe account ID and org ID for multi-tenancy.
+ * Fully fail-open: any error is swallowed and returns silently.
+ */
+export const processStripeSyncEvent = async ({
+	event,
+	stripeAccountId,
+	orgId,
+}: {
+	event: Stripe.Event;
+	stripeAccountId?: string;
+	orgId?: string;
+}): Promise<void> => {
+	const engine = getStripeSyncEngine();
+	if (!engine) return;
+
+	try {
+		await engine.processEvent(event);
+	} catch {
+		return;
+	}
+
+	const table = eventTypeToTable({ eventType: event.type });
+	if (!table) return;
+
+	const objectId = (event.data.object as { id?: string }).id;
+	if (!objectId) return;
+
+	const accountId = stripeAccountId ?? event.account ?? null;
+
+	if (!accountId && !orgId) return;
+
+	try {
+		await engine.postgresClient.pool.query(
+			`UPDATE "${SCHEMA}"."${table}" SET stripe_account_id = COALESCE($1, stripe_account_id), org_id = COALESCE($2, org_id) WHERE id = $3`,
+			[accountId, orgId, objectId],
+		);
+	} catch {
+		// Fail-open: metadata stamp is best-effort
+	}
+};
+
+/** Gracefully close the sync engine's PG pool (call on server shutdown). */
+export const closeStripeSyncEngine = async (): Promise<void> => {
+	if (!instance) return;
+	try {
+		await instance.close();
+	} catch {
+		// Best-effort cleanup
+	}
+	instance = null;
+	initAttempted = false;
+};

--- a/packages/stripe-sync/src/runStripeSyncMigrations.ts
+++ b/packages/stripe-sync/src/runStripeSyncMigrations.ts
@@ -1,0 +1,15 @@
+import { runMigrations } from "@supabase/stripe-sync-engine";
+
+/**
+ * Run stripe-sync-engine migrations against the sync DB.
+ * Idempotent -- safe to run multiple times.
+ */
+export const runStripeSyncMigrations = async ({
+	databaseUrl,
+	schema = "stripe",
+}: {
+	databaseUrl: string;
+	schema?: string;
+}): Promise<void> => {
+	await runMigrations({ databaseUrl, schema });
+};

--- a/packages/stripe-sync/src/syncableResources.ts
+++ b/packages/stripe-sync/src/syncableResources.ts
@@ -1,0 +1,16 @@
+export const SYNCABLE_EVENT_PREFIXES = [
+	"customer.subscription.",
+	"payment_intent.",
+	"invoice.",
+	"customer.",
+	"product.",
+	"price.",
+] as const;
+
+export const isSyncableEvent = ({
+	eventType,
+}: {
+	eventType: string;
+}): boolean => {
+	return SYNCABLE_EVENT_PREFIXES.some((prefix) => eventType.startsWith(prefix));
+};

--- a/packages/stripe-sync/tsconfig.json
+++ b/packages/stripe-sync/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"composite": true,
+		"declaration": true,
+		"declarationMap": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"module": "Preserve",
+		"moduleResolution": "bundler",
+		"target": "ES2020",
+		"outDir": "./dist",
+		"rootDir": "."
+	},
+	"include": ["src/**/*"]
+}

--- a/server/experiments/explainGetFull.ts
+++ b/server/experiments/explainGetFull.ts
@@ -24,17 +24,18 @@ const main = async () => {
 
 	const { db } = initDrizzle();
 
-	const query = getFullCusQuery(
-		customerId,
+	const query = getFullCusQuery({
+		idOrInternalId: customerId,
 		orgId,
 		env,
-		RELEVANT_STATUSES,
-		true, // includeInvoices
-		true, // withEntities
-		false, // withTrialsUsed
-		true, // withSubs
-		false, // withEvents
-	);
+		inStatuses: RELEVANT_STATUSES,
+		includeInvoices: true,
+		withEntities: true,
+		withTrialsUsed: false,
+		withSubs: true,
+		withEvents: false,
+		cusProductLimit: 15,
+	});
 
 	// Run the actual query to measure wall-clock time
 	console.log("--- Running query ---");

--- a/server/experiments/explainListCustomersV2.ts
+++ b/server/experiments/explainListCustomersV2.ts
@@ -108,6 +108,7 @@ const main = async () => {
 		limit: config.limit,
 		offset: config.offset,
 		search: config.search,
+		cusProductLimit: 15,
 	});
 	const filteredCountQuery = getFilteredCountQuery({
 		orgId: config.orgId,

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,7 @@
 		"@anthropic-ai/sdk": "^0.32.1",
 		"@autumn/ksuid": "workspace:*",
 		"@autumn/shared": "workspace:*",
+		"@autumn/stripe-sync": "workspace:*",
 		"@aws-sdk/client-s3": "^3.1017.0",
 		"@aws-sdk/client-scheduler": "^3.1004.0",
 		"@aws-sdk/client-sqs": "^3.958.0",

--- a/server/register.ts
+++ b/server/register.ts
@@ -1,29 +1,23 @@
 import "dotenv/config";
 import { loadLocalEnv } from "./src/utils/envUtils";
 import Stripe from "stripe";
+import {
+	MAIN_STRIPE_EVENT_TYPES,
+	SYNC_STRIPE_EVENT_TYPES,
+} from "./src/external/stripe/common/stripeConstants";
 
 loadLocalEnv();
 
+const allEventTypes = [
+	...new Set([...MAIN_STRIPE_EVENT_TYPES, ...SYNC_STRIPE_EVENT_TYPES]),
+] as Stripe.WebhookEndpointCreateParams.EnabledEvent[];
+
 const main = async () => {
 	const stripe = new Stripe(process.env.STRIPE_SANDBOX_SECRET_KEY || "");
-	
 
 	const result = await stripe.webhookEndpoints.create({
 		url: `${process.env.STRIPE_WEBHOOK_URL}/webhooks/connect/sandbox`,
-		enabled_events: [
-			"checkout.session.completed",
-			"customer.subscription.created",
-			"customer.subscription.updated",
-			"customer.subscription.deleted",
-			"customer.discount.deleted",
-			"invoice.paid",
-			"invoice.upcoming",
-			"invoice.created",
-			"invoice.finalized",
-			"invoice.updated",
-			"subscription_schedule.canceled",
-			"subscription_schedule.updated",
-		],
+		enabled_events: allEventTypes,
 		connect: true,
 	});
 

--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -2,6 +2,7 @@ export const ADMIN_REQUEST_BLOCK_CONFIG_KEY = "admin/request-block-config.json";
 export const ADMIN_FEATURE_FLAGS_CONFIG_KEY = "admin/feature-flags-config.json";
 export const ADMIN_CUSTOMER_BLOCK_CONFIG_KEY =
 	"admin/customer-block-config.json";
+export const ADMIN_ORG_LIMITS_CONFIG_KEY = "admin/org-limits-config.json";
 
 type AdminS3Target = "dev" | "prod";
 

--- a/server/src/external/stripe/common/stripeConstants.ts
+++ b/server/src/external/stripe/common/stripeConstants.ts
@@ -1,0 +1,64 @@
+import type Stripe from "stripe";
+
+type StripeEventType = Stripe.WebhookEndpointCreateParams.EnabledEvent;
+
+/** Events Autumn actively handles in its webhook handler. */
+export const MAIN_STRIPE_EVENT_TYPES: StripeEventType[] = [
+	"checkout.session.completed",
+	"customer.subscription.created",
+	"customer.subscription.updated",
+	"customer.subscription.deleted",
+	"customer.discount.deleted",
+	"invoice.paid",
+	"invoice.upcoming",
+	"invoice.created",
+	"invoice.finalized",
+	"invoice.updated",
+	"subscription_schedule.canceled",
+	"subscription_schedule.updated",
+];
+
+/** Additional events needed to keep the stripe-sync DB up to date. */
+export const SYNC_STRIPE_EVENT_TYPES: StripeEventType[] = [
+	// customers
+	"customer.created",
+	"customer.updated",
+	"customer.deleted",
+
+	// subscriptions (extras beyond main)
+	"customer.subscription.paused",
+	"customer.subscription.resumed",
+
+	// subscription schedules (extras beyond main)
+	"subscription_schedule.created",
+	"subscription_schedule.completed",
+	"subscription_schedule.released",
+
+	// payment methods
+	"payment_method.attached",
+	"payment_method.detached",
+	"payment_method.updated",
+
+	// products
+	"product.created",
+	"product.updated",
+	"product.deleted",
+
+	// prices
+	"price.created",
+	"price.updated",
+	"price.deleted",
+
+	// invoices (extras beyond main)
+	"invoice.deleted",
+	"invoice.payment_failed",
+	"invoice.payment_succeeded",
+	"invoice.voided",
+	"invoice.marked_uncollectible",
+
+	// payment intents
+	"payment_intent.created",
+	"payment_intent.succeeded",
+	"payment_intent.payment_failed",
+	"payment_intent.canceled",
+];

--- a/server/src/external/stripe/stripeOnboardingUtils.ts
+++ b/server/src/external/stripe/stripeOnboardingUtils.ts
@@ -1,6 +1,10 @@
 import { type AppEnv, ErrCode } from "@autumn/shared";
 import Stripe from "stripe";
 import RecaseError from "@/utils/errorUtils.js";
+import {
+	MAIN_STRIPE_EVENT_TYPES,
+	SYNC_STRIPE_EVENT_TYPES,
+} from "./common/stripeConstants";
 
 export const checkKeyValid = async (apiKey: string) => {
 	const stripe = new Stripe(apiKey);
@@ -29,20 +33,22 @@ export const createWebhookEndpoint = async (
 
 	const endpoint = await stripe.webhookEndpoints.create({
 		url: `${webhookBaseUrl}/webhooks/stripe/${orgId}/${env}`,
-		enabled_events: [
-			"customer.subscription.created",
-			"customer.subscription.updated",
-			"customer.subscription.deleted",
-			"checkout.session.completed",
-			"invoice.paid",
-			"invoice.upcoming",
-			"invoice.created",
-			"invoice.finalized",
-			"invoice.updated",
-			"subscription_schedule.canceled",
-			"subscription_schedule.updated",
-			"customer.discount.deleted",
-		],
+		enabled_events: [...MAIN_STRIPE_EVENT_TYPES, ...SYNC_STRIPE_EVENT_TYPES],
+
+		// [
+		// 	"customer.subscription.created",
+		// 	"customer.subscription.updated",
+		// 	"customer.subscription.deleted",
+		// 	"checkout.session.completed",
+		// 	"invoice.paid",
+		// 	"invoice.upcoming",
+		// 	"invoice.created",
+		// 	"invoice.finalized",
+		// 	"invoice.updated",
+		// 	"subscription_schedule.canceled",
+		// 	"subscription_schedule.updated",
+		// 	"customer.discount.deleted",
+		// ],
 	});
 
 	return endpoint;

--- a/server/src/external/stripe/stripeWebhookRouter.ts
+++ b/server/src/external/stripe/stripeWebhookRouter.ts
@@ -4,6 +4,7 @@ import { handleStripeWebhookEvent } from "./handleStripeWebhookEvent.js";
 import { stripeConnectSeederMiddleware } from "./webhookMiddlewares/stripeConnectSeederMiddleware.js";
 import { stripeIdempotencyMiddleware } from "./webhookMiddlewares/stripeIdempotencyMiddleware.js";
 import { stripeLegacySeederMiddleware } from "./webhookMiddlewares/stripeLegacySeederMiddleware.js";
+import { stripeSyncMiddleware } from "./webhookMiddlewares/stripeSyncMiddleware.js";
 import { stripeToAutumnCustomerMiddleware } from "./webhookMiddlewares/stripeToAutumnCustomerMiddleware.js";
 import type { StripeWebhookHonoEnv } from "./webhookMiddlewares/stripeWebhookContext.js";
 import { stripeWebhookRefreshMiddleware } from "./webhookMiddlewares/stripeWebhookRefreshMiddleware.js";
@@ -15,6 +16,7 @@ stripeWebhookRouter.post(
 	"/webhooks/stripe/:orgId/:env",
 	stripeLegacySeederMiddleware,
 	stripeWebhookRefreshMiddleware,
+	stripeSyncMiddleware,
 	stripeToAutumnCustomerMiddleware,
 	stripeLoggerMiddleware,
 	stripeIdempotencyMiddleware,
@@ -26,6 +28,7 @@ stripeWebhookRouter.post(
 	"/webhooks/connect/:env",
 	stripeConnectSeederMiddleware,
 	stripeWebhookRefreshMiddleware,
+	stripeSyncMiddleware,
 	stripeToAutumnCustomerMiddleware,
 	stripeLoggerMiddleware,
 	stripeIdempotencyMiddleware,

--- a/server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts
@@ -1,0 +1,57 @@
+import { isSyncableEvent, processStripeSyncEvent } from "@autumn/stripe-sync";
+import type { Context, Next } from "hono";
+import { isStripeSyncEnabled } from "@/internal/misc/stripeSync/stripeSyncStore.js";
+import type {
+	StripeWebhookContext,
+	StripeWebhookHonoEnv,
+} from "./stripeWebhookContext.js";
+
+/**
+ * Post-handler middleware that syncs Stripe events to the sync DB.
+ * Fire-and-forget -- errors are caught and logged, never propagated.
+ */
+export const stripeSyncMiddleware = async (
+	c: Context<StripeWebhookHonoEnv>,
+	next: Next,
+) => {
+	await next();
+
+	const ctx = c.get("ctx") as StripeWebhookContext;
+	const { logger, org, stripeEvent } = ctx;
+
+	if (!org || !stripeEvent) return;
+	if (
+		process.env.NODE_ENV === "production" &&
+		!isStripeSyncEnabled({ orgId: org.id })
+	)
+		return;
+
+	if (!isSyncableEvent({ eventType: stripeEvent.type })) return;
+
+	try {
+		const stripeAccountId = stripeEvent.account ?? undefined;
+
+		void processStripeSyncEvent({
+			event: stripeEvent,
+			stripeAccountId,
+			orgId: org.id,
+		}).catch((error) => {
+			logger.error(`Stripe sync failed for event ${stripeEvent.id}: ${error}`, {
+				error: {
+					message: error instanceof Error ? error.message : String(error),
+				},
+				data: {
+					eventId: stripeEvent.id,
+					eventType: stripeEvent.type,
+					orgId: org.id,
+				},
+			});
+		});
+	} catch (error) {
+		logger.error(`Stripe sync middleware error: ${error}`, {
+			error: {
+				message: error instanceof Error ? error.message : String(error),
+			},
+		});
+	}
+};

--- a/server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts
@@ -35,6 +35,7 @@ export const stripeSyncMiddleware = async (
 			event: stripeEvent,
 			stripeAccountId,
 			orgId: org.id,
+			env: ctx.env,
 		}).catch((error) => {
 			logger.error(`Stripe sync failed for event ${stripeEvent.id}: ${error}`, {
 				error: {
@@ -48,10 +49,6 @@ export const stripeSyncMiddleware = async (
 			});
 		});
 	} catch (error) {
-		logger.error(`Stripe sync middleware error: ${error}`, {
-			error: {
-				message: error instanceof Error ? error.message : String(error),
-			},
-		});
+		logger.error(`Stripe sync middleware error: ${error}`);
 	}
 };

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -20,6 +20,7 @@ import {
 import "./internal/misc/requestBlocks/requestBlockStore.js";
 import "./internal/misc/featureFlags/featureFlagStore.js";
 import "./internal/misc/customerBlocks/customerBlockStore.js";
+import "./internal/misc/edgeConfig/orgLimitsStore.js";
 import "./internal/misc/stripeSync/stripeSyncStore.js";
 import { closeStripeSyncEngine } from "@autumn/stripe-sync";
 import { warmupRegionalRedis } from "./external/redis/initRedis.js";

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -20,6 +20,8 @@ import {
 import "./internal/misc/requestBlocks/requestBlockStore.js";
 import "./internal/misc/featureFlags/featureFlagStore.js";
 import "./internal/misc/customerBlocks/customerBlockStore.js";
+import "./internal/misc/stripeSync/stripeSyncStore.js";
+import { closeStripeSyncEngine } from "@autumn/stripe-sync";
 import { warmupRegionalRedis } from "./external/redis/initRedis.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
@@ -117,6 +119,7 @@ async function gracefulShutdown() {
 			client.end(),
 			clientCritical.end(),
 			clientReplica?.end(),
+			closeStripeSyncEngine(),
 		]);
 		console.log("Shutdown complete. Exiting process.");
 		process.exit(0);

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { HonoEnv } from "../../honoUtils/HonoEnv";
 import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
 import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsConfig";
+import { handleGetAdminOrgLimitsConfig } from "./handleGetAdminOrgLimitsConfig";
 import { handleGetAdminOrgRequestBlock } from "./handleGetAdminOrgRequestBlock";
 import { handleGetAdminRequestBlockConfig } from "./handleGetAdminRequestBlockConfig";
 import { handleGetInvoiceLineItems } from "./handleGetInvoiceLineItems";
@@ -12,6 +13,7 @@ import { handleListAdminUsers } from "./handleListAdminUsers";
 import { handleListOAuthClients } from "./handleListOAuthClients";
 import { handleUpsertAdminCustomerBlockConfig } from "./handleUpsertAdminCustomerBlockConfig";
 import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureFlagsConfig";
+import { handleUpsertAdminOrgLimitsConfig } from "./handleUpsertAdminOrgLimitsConfig";
 import { handleUpsertAdminOrgRequestBlock } from "./handleUpsertAdminOrgRequestBlock";
 import { handleUpsertAdminRequestBlockConfig } from "./handleUpsertAdminRequestBlockConfig";
 
@@ -51,6 +53,8 @@ honoAdminRouter.put(
 	"/customer-block-config",
 	...handleUpsertAdminCustomerBlockConfig,
 );
+honoAdminRouter.get("/org-limits-config", ...handleGetAdminOrgLimitsConfig);
+honoAdminRouter.put("/org-limits-config", ...handleUpsertAdminOrgLimitsConfig);
 honoAdminRouter.get("/org-member", ...handleGetOrgMember);
 honoAdminRouter.get("/master-stripe-account", ...handleGetMasterStripeAccount);
 honoAdminRouter.get("/oauth-clients", ...handleListOAuthClients);

--- a/server/src/internal/admin/handleGetAdminOrgLimitsConfig.ts
+++ b/server/src/internal/admin/handleGetAdminOrgLimitsConfig.ts
@@ -1,0 +1,20 @@
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getOrgLimitsConfigFromSource,
+	getRuntimeOrgLimitsStatus,
+} from "@/internal/misc/edgeConfig/orgLimitsStore.js";
+
+export const handleGetAdminOrgLimitsConfig = createRoute({
+	handler: async (c) => {
+		const status = getRuntimeOrgLimitsStatus();
+		const config = await getOrgLimitsConfigFromSource();
+
+		return c.json({
+			...config,
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminOrgLimitsConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminOrgLimitsConfig.ts
@@ -1,0 +1,14 @@
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { OrgLimitsConfigSchema } from "@/internal/misc/edgeConfig/orgLimitsSchemas.js";
+import { updateFullOrgLimitsConfig } from "@/internal/misc/edgeConfig/orgLimitsStore.js";
+
+export const handleUpsertAdminOrgLimitsConfig = createRoute({
+	body: OrgLimitsConfigSchema,
+	handler: async (c) => {
+		const body = c.req.valid("json");
+
+		await updateFullOrgLimitsConfig({ config: body });
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -11,6 +11,7 @@ import {
 } from "@autumn/shared";
 import * as Sentry from "@sentry/bun";
 import type { AutumnContext, RequestContext } from "@/honoUtils/HonoEnv.js";
+import { getOrgCusProductLimit } from "../misc/edgeConfig/orgLimitsStore.js";
 import { triggerBatchResetCustomerEntitlements } from "./actions/resetCustomerEntitlements/triggerBatchResetCustomerEntitlements.js";
 import { getApiCustomerBase } from "./cusUtils/apiCusUtils/getApiCustomerBase.js";
 import { getPaginatedFullCusQuery } from "./getFullCusQuery.js";
@@ -24,6 +25,11 @@ export class CusBatchService {
 		internalCustomerIds: string[];
 	}) {
 		const { org, env, db } = ctx;
+		const cusProductLimit = getOrgCusProductLimit({
+			orgId: ctx.org.id,
+			orgSlug: ctx.org.slug,
+		});
+
 		const query = getPaginatedFullCusQuery({
 			orgId: ctx.org.id,
 			env: ctx.env,
@@ -34,6 +40,7 @@ export class CusBatchService {
 			limit: internalCustomerIds.length || 100,
 			offset: 0,
 			internalCustomerIds,
+			cusProductLimit,
 		});
 		const results = await db.execute(query);
 		const fullCustomers = results as unknown as FullCustomer[];
@@ -66,6 +73,10 @@ export class CusBatchService {
 
 		const { limit, offset, plans, subscription_status, search } = query;
 
+		const cusProductLimit = getOrgCusProductLimit({
+			orgId: ctx.org.id,
+			orgSlug: ctx.org.slug,
+		});
 		const sqlQuery = getPaginatedFullCusQuery({
 			orgId: ctx.org.id,
 			env: ctx.env,
@@ -80,6 +91,7 @@ export class CusBatchService {
 			offset,
 			search,
 			plans,
+			cusProductLimit,
 		});
 		const results = await ctx.db.execute(sqlQuery);
 		const finals = [];

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -8,6 +8,7 @@ import {
 
 import {
 	and,
+	asc,
 	desc,
 	eq,
 	gt,
@@ -21,6 +22,7 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { getOrgCusProductLimit } from "../misc/edgeConfig/orgLimitsStore.js";
 
 // Create alias for subquery
 const customerProductsAlias = alias(customerProducts, "cp_alias");
@@ -47,6 +49,7 @@ const productFields = {
 	id: products.id,
 	name: products.name,
 	version: products.version,
+	is_add_on: products.is_add_on,
 };
 
 interface SearchFilters {
@@ -60,25 +63,21 @@ export class CusSearchService {
 	static async searchByProduct({
 		db,
 		orgId,
+		orgSlug,
 		env,
 		search,
 		filters,
 		pageSize = 50,
 		pageNumber,
-		// lastItem,
 	}: {
 		db: DrizzleCli;
 		orgId: string;
+		orgSlug?: string;
 		env: AppEnv;
 		search: string;
 		filters: SearchFilters;
 		pageSize?: number;
 		pageNumber: number;
-		// lastItem?: {
-		//   internal_id: string;
-		//   created_at?: string;
-		//   name?: string;
-		// } | null;
 	}) {
 		// If we have a lastItem with only internal_id, fetch the full customer data for cursor pagination
 		// let resolvedLastItem = lastItem;
@@ -304,14 +303,14 @@ export class CusSearchService {
 			const offset = (pageNumber - 1) * pageSize;
 			productQueryResult = buildQuery()
 				.where(whereClause)
-				.orderBy(desc(customers.internal_id))
+				.orderBy(desc(customers.internal_id), asc(products.is_add_on))
 				.offset(offset)
 				.limit(pageSize);
 		} else {
 			// Use cursor-based pagination
 			productQueryResult = buildQuery()
 				.where(whereClause)
-				.orderBy(desc(customers.internal_id))
+				.orderBy(desc(customers.internal_id), asc(products.is_add_on))
 				.limit(pageSize);
 		}
 
@@ -375,7 +374,14 @@ export class CusSearchService {
 			}
 		}
 
+		const cusProductLimit = getOrgCusProductLimit({ orgId, orgSlug });
 		const processedData = Array.from(customerMap.values());
+		for (const customer of processedData) {
+			customer.customer_products = customer.customer_products.slice(
+				0,
+				cusProductLimit,
+			);
+		}
 
 		const totalCount = totalCountResult[0]?.totalCount || 0;
 
@@ -495,9 +501,7 @@ export class CusSearchService {
 												return sql`(${customers.processors}->>'vercel' IS NOT NULL)`;
 											return undefined;
 										})
-										.filter(
-											(c): c is NonNullable<typeof c> => c !== undefined,
-										),
+										.filter((c): c is NonNullable<typeof c> => c !== undefined),
 								)
 							: undefined,
 					),
@@ -510,6 +514,7 @@ export class CusSearchService {
 	static async search({
 		db,
 		orgId,
+		orgSlug,
 		env,
 		search,
 		pageSize = 50,
@@ -519,6 +524,7 @@ export class CusSearchService {
 	}: {
 		db: DrizzleCli;
 		orgId: string;
+		orgSlug?: string;
 		env: AppEnv;
 		search: string;
 		lastItem?: {
@@ -570,7 +576,6 @@ export class CusSearchService {
 				search,
 				filters,
 				pageSize,
-				// lastItem: resolvedLastItem,
 				pageNumber,
 			});
 		}
@@ -583,11 +588,11 @@ export class CusSearchService {
 			return await CusSearchService.searchByProduct({
 				db,
 				orgId,
+				orgSlug,
 				env,
 				search,
 				filters,
 				pageSize,
-				// lastItem: resolvedLastItem,
 				pageNumber,
 			});
 		}
@@ -685,7 +690,7 @@ export class CusSearchService {
 					products,
 					eq(customerProducts.internal_product_id, products.internal_id),
 				)
-				.orderBy(desc(baseQuery.internal_id)),
+				.orderBy(desc(baseQuery.internal_id), asc(products.is_add_on)),
 			totalCountQuery,
 		]);
 
@@ -718,7 +723,14 @@ export class CusSearchService {
 			}
 		}
 
+		const cusProductLimit = getOrgCusProductLimit({ orgId, orgSlug });
 		const finalResults = Array.from(customerMap.values());
+		for (const customer of finalResults) {
+			customer.customer_products = customer.customer_products.slice(
+				0,
+				cusProductLimit,
+			);
+		}
 
 		return { data: finalResults, count: totalCount };
 	}

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -6,6 +6,7 @@ import {
 	CustomerNotFoundError,
 	customerProducts,
 	customers,
+	type Entity,
 	type EntityExpand,
 	ErrCode,
 	type FullCusProduct,
@@ -33,6 +34,7 @@ import { executeWithHealthTracking } from "@/db/pgHealthMonitor.js";
 import type { RepoContext } from "@/db/repoContext.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { withSpan } from "../analytics/tracer/spanUtils.js";
+import { getOrgCusProductLimit } from "../misc/edgeConfig/orgLimitsStore.js";
 import { resetCustomerEntitlements } from "./actions/resetCustomerEntitlements/resetCustomerEntitlements.js";
 import {
 	ACTIVE_STATUSES,
@@ -84,7 +86,11 @@ export class CusService {
 				withSubs,
 			},
 			fn: async () => {
-				const query = getFullCusQuery(
+				const cusProductLimit = getOrgCusProductLimit({
+					orgId,
+					orgSlug: org.slug,
+				});
+				const query = getFullCusQuery({
 					idOrInternalId,
 					orgId,
 					env,
@@ -95,7 +101,8 @@ export class CusService {
 					withSubs,
 					withEvents,
 					entityId,
-				);
+					cusProductLimit,
+				});
 
 				if (explain) {
 					const explainQuery = sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) ${query}`;
@@ -142,9 +149,18 @@ export class CusService {
 						.slice(0, 5);
 				}
 
-				// Skip reset only when executeWithHealthTracking explicitly chose the
-				// replica. Lazy reset writes themselves go through dbGeneral.
+				if (orgId === "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF") {
+					fullCus.customer_products = (
+						fullCus.customer_products as FullCusProduct[]
+					)
+						.sort((a, b) => b.customer_prices.length - a.customer_prices.length)
+						.slice(0, 5);
+
+					fullCus.entities = (fullCus.entities as Entity[]).slice(0, 50);
+				}
 				if (!usedReplica) {
+					// Skip reset only when executeWithHealthTracking explicitly chose the
+					// replica. Lazy reset writes themselves go through dbGeneral.
 					await resetCustomerEntitlements({
 						fullCus,
 						ctx,
@@ -315,22 +331,21 @@ export class CusService {
 			? [query.subscription_status as CusProductStatus]
 			: ACTIVE_STATUSES;
 
-		const processorFilter =
-			query?.processors?.length
-				? or(
-						...query.processors
-							.map((proc) => {
-								if (proc === "stripe")
-									return sql`(${customers.processor}->>'id' IS NOT NULL)`;
-								if (proc === "revenuecat")
-									return sql`(${customers.processors}->>'revenuecat' IS NOT NULL)`;
-								if (proc === "vercel")
-									return sql`(${customers.processors}->>'vercel' IS NOT NULL)`;
-								return undefined;
-							})
-							.filter((c): c is NonNullable<typeof c> => c !== undefined),
-					)
-				: undefined;
+		const processorFilter = query?.processors?.length
+			? or(
+					...query.processors
+						.map((proc) => {
+							if (proc === "stripe")
+								return sql`(${customers.processor}->>'id' IS NOT NULL)`;
+							if (proc === "revenuecat")
+								return sql`(${customers.processors}->>'revenuecat' IS NOT NULL)`;
+							if (proc === "vercel")
+								return sql`(${customers.processors}->>'vercel' IS NOT NULL)`;
+							return undefined;
+						})
+						.filter((c): c is NonNullable<typeof c> => c !== undefined),
+				)
+			: undefined;
 
 		if (!query?.plans?.length) {
 			const [result] = await ctx.db

--- a/server/src/internal/customers/cancel/handleCancelV2.ts
+++ b/server/src/internal/customers/cancel/handleCancelV2.ts
@@ -8,10 +8,27 @@ import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBilling
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
 import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
+import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan";
 
 export const handleCancelV2 = createRoute({
-	// body: CancelBodySchema,
+	lock:
+		process.env.NODE_ENV !== "development"
+			? {
+					ttlMs: 120000,
+					errorMessage:
+						"Cancel already in progress for this customer, try again in a few seconds",
+					getKey: (c) => {
+						const ctx = c.get("ctx");
+						if (!ctx.customerId) return null;
+						return buildBillingLockKey({
+							orgId: ctx.org.id,
+							env: ctx.env,
+							customerId: ctx.customerId,
+						});
+					},
+				}
+			: undefined,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts
@@ -149,6 +149,10 @@ export const getCachedFullCustomer = async ({
 		data: JSON.parse(cached),
 	});
 
+	// if (fullCustomer.entities?.[0] === null) {
+	// 	fullCustomer.entities = fullCustomer.entities?.filter((e) => e !== null);
+	// }
+
 	if (entityId) {
 		fullCustomer.entity = fullCustomer.entities?.find((e) => e.id === entityId);
 	} else {

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -6,7 +6,13 @@ import {
 } from "@autumn/shared";
 import { type SQL, sql } from "drizzle-orm";
 
-const buildOptimizedCusProductsCTE = (inStatuses?: CusProductStatus[]) => {
+const buildOptimizedCusProductsCTE = ({
+	inStatuses,
+	cusProductLimit,
+}: {
+	inStatuses?: CusProductStatus[];
+	cusProductLimit: number;
+}) => {
 	const withStatusFilter = () => {
 		return inStatuses
 			? sql`AND cp.status = ANY(ARRAY[${sql.join(
@@ -86,8 +92,8 @@ const buildOptimizedCusProductsCTE = (inStatuses?: CusProductStatus[]) => {
       ) ft_data ON true
       WHERE cp.internal_customer_id = (SELECT internal_id FROM customer_record)
       ${withStatusFilter()}
-      ORDER BY ${relevantStatusFirst}, cp.created_at DESC
-      LIMIT 15
+      ORDER BY ${relevantStatusFirst}, prod.is_add_on ASC, cp.created_at DESC
+      LIMIT ${cusProductLimit}
     )
   `;
 };
@@ -101,7 +107,7 @@ const buildEntitiesCTE = (withEntities: boolean) => {
     customer_entities AS (
       SELECT 
         COALESCE(
-          json_agg(row_to_json(e) ORDER BY e.internal_id DESC),
+          json_agg(row_to_json(e) ORDER BY e.internal_id DESC) FILTER (WHERE e.internal_id IS NOT NULL),
           '[]'::json
         ) AS entities
       FROM (
@@ -266,18 +272,31 @@ const buildInvoicesCTE = (hasEntityCTE: boolean) => {
   `;
 };
 
-export const getFullCusQuery = (
-	idOrInternalId: string,
-	orgId: string,
-	env: AppEnv,
-	inStatuses: CusProductStatus[],
-	includeInvoices: boolean,
-	withEntities: boolean,
-	withTrialsUsed: boolean,
-	withSubs: boolean,
-	withEvents: boolean,
-	entityId?: string,
-) => {
+export const getFullCusQuery = ({
+	idOrInternalId,
+	orgId,
+	env,
+	inStatuses,
+	includeInvoices,
+	withEntities,
+	withTrialsUsed,
+	withSubs,
+	withEvents,
+	entityId,
+	cusProductLimit,
+}: {
+	idOrInternalId: string;
+	orgId: string;
+	env: AppEnv;
+	inStatuses: CusProductStatus[];
+	includeInvoices: boolean;
+	withEntities: boolean;
+	withTrialsUsed: boolean;
+	withSubs: boolean;
+	withEvents: boolean;
+	entityId?: string;
+	cusProductLimit: number;
+}) => {
 	const sqlChunks: SQL[] = [];
 
 	// Step 1: Get customer record
@@ -309,7 +328,7 @@ export const getFullCusQuery = (
 	// Add customer products CTE
 	sqlChunks.push(sql`, `);
 	// sqlChunks.push(buildCusProductsCTE(inStatuses));
-	sqlChunks.push(buildOptimizedCusProductsCTE(inStatuses));
+	sqlChunks.push(buildOptimizedCusProductsCTE({ inStatuses, cusProductLimit }));
 
 	// Conditionally add trials used CTE
 	if (withTrialsUsed) {
@@ -429,6 +448,7 @@ export const getPaginatedFullCusQuery = ({
 	internalCustomerIds,
 	plans,
 	search,
+	cusProductLimit,
 }: {
 	orgId: string;
 	env: AppEnv;
@@ -444,6 +464,7 @@ export const getPaginatedFullCusQuery = ({
 	internalCustomerIds?: string[];
 	plans?: ListCustomersV2Params["plans"];
 	search?: string;
+	cusProductLimit: number;
 }) => {
 	const withStatusFilter = () => {
 		return inStatuses?.length
@@ -539,8 +560,8 @@ export const getPaginatedFullCusQuery = ({
         FROM customer_products cp
         WHERE cp.internal_customer_id = cr.internal_id
         ${withStatusFilter()}
-        ORDER BY cp.created_at DESC
-        LIMIT 15
+        ORDER BY (SELECT p.is_add_on FROM products p WHERE p.internal_id = cp.internal_product_id) ASC, cp.created_at DESC
+        LIMIT ${cusProductLimit}
       ) cp ON true
       JOIN products prod ON cp.internal_product_id = prod.internal_id
       LEFT JOIN LATERAL (
@@ -659,7 +680,7 @@ export const getPaginatedFullCusQuery = ({
       SELECT 
         cr.internal_id AS internal_customer_id,
         COALESCE(
-          json_agg(row_to_json(e) ORDER BY e.internal_id DESC),
+          json_agg(row_to_json(e) ORDER BY e.internal_id DESC) FILTER (WHERE e.internal_id IS NOT NULL),
           '[]'::json
         ) AS entities
       FROM customer_records cr

--- a/server/src/internal/customers/internalHandlers/handleSearchCustomers.ts
+++ b/server/src/internal/customers/internalHandlers/handleSearchCustomers.ts
@@ -24,6 +24,7 @@ export const handleSearchCustomers = createRoute({
 		const { data: customers, count } = await CusSearchService.search({
 			db,
 			orgId: org.id,
+			orgSlug: org.slug,
 			env,
 			search: search ?? "",
 			filters,

--- a/server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts
@@ -1,0 +1,14 @@
+import { z } from "zod/v4";
+
+export const OrgLimitsConfigSchema = z.object({
+	orgs: z
+		.record(
+			z.string(),
+			z.object({
+				maxCusProducts: z.number().min(1).optional(),
+			}),
+		)
+		.default({}),
+});
+
+export type OrgLimitsConfig = z.infer<typeof OrgLimitsConfigSchema>;

--- a/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
@@ -1,0 +1,65 @@
+import { ADMIN_ORG_LIMITS_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type OrgLimitsConfig,
+	OrgLimitsConfigSchema,
+} from "./orgLimitsSchemas.js";
+
+export const DEFAULT_CUS_PRODUCT_LIMIT = 15;
+
+const store = createEdgeConfigStore<OrgLimitsConfig>({
+	s3Key: ADMIN_ORG_LIMITS_CONFIG_KEY,
+	schema: OrgLimitsConfigSchema,
+	defaultValue: () => ({ orgs: {} }),
+	pollIntervalMs: 30_000,
+});
+
+registerEdgeConfig({ store });
+
+export const getRuntimeOrgLimitsStatus = () => store.getStatus();
+
+export const getOrgCusProductLimit = ({
+	orgId,
+	orgSlug,
+}: {
+	orgId?: string;
+	orgSlug?: string;
+}): number => {
+	const orgs = store.get().orgs;
+	const orgConfig =
+		(orgId ? orgs[orgId] : undefined) ??
+		(orgSlug ? orgs[orgSlug] : undefined);
+	return orgConfig?.maxCusProducts ?? DEFAULT_CUS_PRODUCT_LIMIT;
+};
+
+export const getOrgLimitsConfigFromSource = async () => {
+	return await store.readFromSource();
+};
+
+export const updateOrgLimitsInSource = async ({
+	orgId,
+	maxCusProducts,
+}: {
+	orgId: string;
+	maxCusProducts?: number;
+}) => {
+	const config = await store.readFromSource();
+
+	if (maxCusProducts === undefined) {
+		delete config.orgs[orgId];
+	} else {
+		config.orgs[orgId] = { maxCusProducts };
+	}
+
+	await store.writeToSource({ config });
+	return config.orgs[orgId];
+};
+
+export const updateFullOrgLimitsConfig = async ({
+	config,
+}: {
+	config: OrgLimitsConfig;
+}) => {
+	await store.writeToSource({ config });
+};

--- a/server/src/internal/misc/stripeSync/stripeSyncSchemas.ts
+++ b/server/src/internal/misc/stripeSync/stripeSyncSchemas.ts
@@ -1,0 +1,7 @@
+import { z } from "zod/v4";
+
+export const StripeSyncConfigSchema = z.object({
+	enabledOrgIds: z.array(z.string()).default([]),
+});
+
+export type StripeSyncConfig = z.infer<typeof StripeSyncConfigSchema>;

--- a/server/src/internal/misc/stripeSync/stripeSyncStore.ts
+++ b/server/src/internal/misc/stripeSync/stripeSyncStore.ts
@@ -1,0 +1,20 @@
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type StripeSyncConfig,
+	StripeSyncConfigSchema,
+} from "./stripeSyncSchemas.js";
+
+const store = createEdgeConfigStore<StripeSyncConfig>({
+	s3Key: "admin/stripe-sync-config.json",
+	schema: StripeSyncConfigSchema,
+	defaultValue: () => ({ enabledOrgIds: [] }),
+	pollIntervalMs: 60_000,
+});
+
+registerEdgeConfig({ store });
+
+/** Pure in-memory lookup -- zero I/O, sync. */
+export const isStripeSyncEnabled = ({ orgId }: { orgId: string }): boolean => {
+	return store.get().enabledOrgIds.includes(orgId);
+};

--- a/server/tests/_temp/temp2.test.ts
+++ b/server/tests/_temp/temp2.test.ts
@@ -1,67 +1,106 @@
-import { expect, test } from "bun:test";
+import { test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
+import {
+	applySubscriptionDiscount,
+	createPercentCoupon,
+	getStripeSubscription,
+} from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
-import { CusService } from "@/internal/customers/CusService";
 
-test(`${chalk.yellowBright("check where default payment method lives after attach")}`, async () => {
-	const customerId = "pm-location-check";
+/**
+ * Repro for Mintlify multi-entity discount bug.
+ *
+ * Production sequence (from Axiom logs):
+ *  1. Entity 1 attaches pro (upgrade from Hobby) — creates subscription
+ *  2. Discount applied to subscription
+ *  3. Entity 1 cancels pro (end_of_cycle) — creates subscription schedule
+ *  4. Entity 1 uncancels pro — schedule modified
+ *  5. Entity 2 attaches pro — subscription update succeeds but schedule
+ *     creation/update fails: "Discount di_xxx has exceeded its maximum
+ *     number of applications and cannot be reused"
+ *
+ * The error is in stripeDiscountsToPhaseDiscounts which passes
+ * { discount: "di_xxx" } to schedule phases — but the discount is bound
+ * to the subscription, not the schedule.
+ */
+test(`${chalk.yellowBright("bug repro: entity 2 attach after cancel+uncancel with discount on sub")}`, async () => {
+	const customerId = "multi-ent-cancel-uncancel";
 
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+
 	const pro = products.pro({
-		id: "pro-pm-check",
+		id: "pro",
 		items: [messagesItem],
 	});
 
-	const { ctx } = await initScenario({
+	// Step 1: Entity 1 attaches pro
+	const { autumnV2_2, autumnV1, entities } = await initScenario({
 		customerId,
 		setup: [
 			s.customer({ paymentMethod: "success" }),
 			s.products({ list: [pro] }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
 		],
-		actions: [s.attach({ productId: pro.id })],
+		actions: [
+			s.billing.attach({ productId: pro.id, entityIndex: 0 }),
+		],
 	});
 
-	const fullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: customerId,
+	// Step 2: Apply a discount to entity 1's subscription
+	const { stripeCli, subscription } = await getStripeSubscription({
+		customerId,
 	});
 
-	const stripeCustomerId = fullCustomer.processor?.id;
-	expect(stripeCustomerId).toBeDefined();
-
-	const subs = await ctx.stripeCli.subscriptions.list({
-		customer: stripeCustomerId!,
-		status: "all",
+	const coupon = await createPercentCoupon({
+		stripeCli,
+		percentOff: 10,
 	});
 
-	const subscription = subs.data.find(
-		(sub) => sub.status === "active" || sub.status === "trialing",
-	);
-	expect(subscription).toBeDefined();
+	await applySubscriptionDiscount({
+		stripeCli,
+		subscriptionId: subscription.id,
+		couponIds: [coupon.id],
+	});
 
-	const subDefaultPm = subscription!.default_payment_method;
-	console.log(`Subscription default_payment_method: ${JSON.stringify(subDefaultPm)}`);
+	// Step 3: Entity 1 cancels pro (end_of_cycle) — creates subscription schedule
+	console.log("Canceling entity 1 pro (end of cycle)...");
+	await autumnV2_2.subscriptions.update({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: pro.id,
+		cancel_action: "cancel_end_of_cycle",
+	});
 
-	const stripeCustomer = await ctx.stripeCli.customers.retrieve(stripeCustomerId!);
-	const customerDefaultPm = "deleted" in stripeCustomer
-		? null
-		: stripeCustomer.invoice_settings?.default_payment_method;
-	console.log(`Customer invoice_settings.default_payment_method: ${JSON.stringify(customerDefaultPm)}`);
+	await new Promise((resolve) => setTimeout(resolve, 3000));
 
-	const customerDefaultSource = "deleted" in stripeCustomer
-		? null
-		: stripeCustomer.default_source;
-	console.log(`Customer default_source: ${JSON.stringify(customerDefaultSource)}`);
+	// Step 4: Entity 1 uncancels pro — schedule released/modified
+	console.log("Uncanceling entity 1 pro...");
+	await autumnV2_2.subscriptions.update({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		plan_id: pro.id,
+		cancel_action: "uncancel",
+	});
 
-	if (subDefaultPm) {
-		console.log(chalk.green("Payment method is set at the SUBSCRIPTION level"));
-	} else if (customerDefaultPm) {
-		console.log(chalk.green("Payment method is set at the CUSTOMER level (invoice_settings)"));
-	} else if (customerDefaultSource) {
-		console.log(chalk.green("Payment method is set at the CUSTOMER level (default_source)"));
-	} else {
-		console.log(chalk.red("No default payment method found on subscription or customer"));
+	await new Promise((resolve) => setTimeout(resolve, 3000));
+
+	// Step 5: Entity 2 attaches pro
+	console.log("Attaching pro to entity 2...");
+	try {
+		const result = await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: pro.id,
+			redirect_mode: "if_required",
+		});
+		console.log("Entity 2 result:", JSON.stringify(result, null, 2));
+		console.log(chalk.red("BUG NOT REPRODUCED — entity 2 attach succeeded"));
+	} catch (error: any) {
+		console.log(chalk.green("BUG REPRODUCED — entity 2 attach failed:"));
+		console.log("Error:", JSON.stringify(error, null, 2));
 	}
 });

--- a/server/tests/integration/billing/attach/new-plan/schedule-addon-attach.test.ts
+++ b/server/tests/integration/billing/attach/new-plan/schedule-addon-attach.test.ts
@@ -1,0 +1,113 @@
+import { test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import {
+	applySubscriptionDiscount,
+	createPercentCoupon,
+	getStripeSubscription,
+} from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import {
+	expectProductCanceling,
+	expectProductScheduled,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+/**
+ * Reproduces: attaching a one-off add-on to a subscription that already
+ * has a schedule (from a prior downgrade) fails with Stripe error
+ * "You cannot migrate a subscription that is already attached to a schedule".
+ *
+ * The root cause is that setupStripeBillingContext skips fetching the schedule
+ * when targetCustomerProduct is undefined (new attachment, no transition).
+ * buildStripeSubscriptionScheduleAction then sees hasSchedule=false and emits
+ * type:"create" instead of type:"update", which Stripe rejects.
+ */
+test.concurrent(`${chalk.yellowBright("bug-repro: attach one-off add-on after scheduled downgrade hits 'subscription already attached to schedule'")}`, async () => {
+	const customerId = "repro-schedule-addon-attach";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+
+	const premium = products.premium({
+		id: "premium",
+		items: [messagesItem],
+	});
+
+	const pro = products.pro({
+		id: "pro",
+		items: [messagesItem],
+	});
+
+	const topupAddon = products.base({
+		id: "topup-addon",
+		items: [
+			items.oneOffWords({
+				includedUsage: 0,
+				billingUnits: 100,
+				price: 25,
+			}),
+		],
+	});
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [premium, pro, topupAddon] }),
+		],
+		actions: [s.billing.attach({ productId: premium.id })],
+	});
+
+	// Apply a 20% discount to the subscription (matches production scenario)
+	const { stripeCli, subscription: subBefore } = await getStripeSubscription({
+		customerId,
+	});
+
+	const coupon = await createPercentCoupon({
+		stripeCli,
+		percentOff: 20,
+	});
+
+	await applySubscriptionDiscount({
+		stripeCli,
+		subscriptionId: subBefore.id,
+		couponIds: [coupon.id],
+	});
+
+	// Schedule downgrade: Premium -> Pro (creates a subscription schedule)
+	await autumnV1.billing.attach({
+		customer_id: customerId,
+		product_id: pro.id,
+		redirect_mode: "if_required",
+	});
+
+	// Verify the downgrade was scheduled correctly
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductCanceling({ customer, productId: premium.id });
+	await expectProductScheduled({ customer, productId: pro.id });
+
+	await autumnV1.billing.attach({
+		customer_id: customerId,
+		product_id: topupAddon.id,
+		redirect_mode: "if_required",
+		options: [{ feature_id: TestFeature.Words, quantity: 100 }],
+	});
+
+	const customerAfter = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	expectCustomerFeatureCorrect({
+		customer: customerAfter,
+		featureId: TestFeature.Words,
+		balance: 100,
+		usage: 0,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfter,
+		count: 2,
+		latestTotal: 25,
+	});
+});

--- a/vite/src/hooks/stores/useSubscriptionStore.ts
+++ b/vite/src/hooks/stores/useSubscriptionStore.ts
@@ -21,10 +21,15 @@ export const useEntity = () => {
 	const { customer } = useCusQuery();
 	const entities = (customer as FullCustomer)?.entities || [];
 
+	// #region agent log
+	fetch('http://127.0.0.1:7322/ingest/302190cd-01f7-494e-9c36-a1625f5cf969',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'0967f4'},body:JSON.stringify({sessionId:'0967f4',location:'useSubscriptionStore.ts:useEntity',message:'entities debug',data:{customerExists:!!customer,entitiesRaw:(customer as any)?.entities,entitiesIsArray:Array.isArray((customer as any)?.entities),entitiesLength:entities.length,entitiesNullCount:entities.filter((e:any) => e == null).length,firstFewEntities:entities.slice(0,3).map((e:any) => e == null ? 'NULL' : {id:e?.id,internal_id:e?.internal_id}),selectedEntityId},timestamp:Date.now()})}).catch(()=>{});
+	// #endregion
+
 	// Find the full entity object
 	const entity = entities.find(
 		(e: Entity) =>
-			e.id === selectedEntityId || e.internal_id === selectedEntityId,
+			e != null &&
+			(e.id === selectedEntityId || e.internal_id === selectedEntityId),
 	);
 
 	// Sync query param to store on mount/change

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/v2/buttons/Button";
 import { CustomerBlockDialog } from "./CustomerBlockDialog";
 import { EdgeConfigDialog } from "./EdgeConfigDialog";
 import { FeatureFlagsDialog } from "./FeatureFlagsDialog";
+import { OrgLimitsDialog } from "./OrgLimitsDialog";
 import { RawEdgeConfigDialog } from "./RawEdgeConfigDialog";
 
 export function EdgeConfigTab() {
@@ -10,6 +11,7 @@ export function EdgeConfigTab() {
 	const [requestBlockRawOpen, setRequestBlockRawOpen] = useState(false);
 	const [featureFlagsOpen, setFeatureFlagsOpen] = useState(false);
 	const [customerBlockOpen, setCustomerBlockOpen] = useState(false);
+	const [orgLimitsOpen, setOrgLimitsOpen] = useState(false);
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -71,6 +73,23 @@ export function EdgeConfigTab() {
 						Edit
 					</Button>
 				</div>
+
+				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
+					<div className="flex flex-col gap-0.5">
+						<div className="text-sm font-medium text-t1">Org Limits</div>
+						<div className="text-xs text-t3">
+							Per-org overrides for max customer products returned in queries
+							(default 15).
+						</div>
+					</div>
+					<Button
+						variant="primary"
+						size="sm"
+						onClick={() => setOrgLimitsOpen(true)}
+					>
+						Edit
+					</Button>
+				</div>
 			</div>
 
 			<FeatureFlagsDialog
@@ -95,6 +114,8 @@ export function EdgeConfigTab() {
 				onOpenChange={setRequestBlockRawOpen}
 				configId="request-block"
 			/>
+
+			<OrgLimitsDialog open={orgLimitsOpen} onOpenChange={setOrgLimitsOpen} />
 		</div>
 	);
 }

--- a/vite/src/views/admin/components/OrgLimitsDialog.tsx
+++ b/vite/src/views/admin/components/OrgLimitsDialog.tsx
@@ -1,0 +1,342 @@
+import Editor from "@monaco-editor/react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/v2/badges/Badge";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { Input } from "@/components/v2/inputs/Input";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+
+const DEFAULT_CUS_PRODUCT_LIMIT = 15;
+
+type OrgLimitsEntry = {
+	maxCusProducts?: number;
+};
+
+type OrgLimitsConfig = {
+	orgs: Record<string, OrgLimitsEntry>;
+	configHealthy: boolean;
+	configConfigured: boolean;
+	lastSuccessAt: string | null;
+	error: string | null;
+};
+
+const DEFAULT_CONFIG: OrgLimitsConfig = {
+	orgs: {},
+	configHealthy: false,
+	configConfigured: false,
+	lastSuccessAt: null,
+	error: null,
+};
+
+const getEditableConfig = ({ config }: { config: OrgLimitsConfig }) => ({
+	orgs: config.orgs,
+});
+
+const getEntryRows = ({ config }: { config: OrgLimitsConfig }) => {
+	return Object.entries(config.orgs)
+		.map(([orgId, entry]) => ({
+			orgId,
+			maxCusProducts: entry.maxCusProducts ?? DEFAULT_CUS_PRODUCT_LIMIT,
+		}))
+		.sort((a, b) => a.orgId.localeCompare(b.orgId));
+};
+
+export function OrgLimitsDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const [loading, setLoading] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [config, setConfig] = useState<OrgLimitsConfig>(DEFAULT_CONFIG);
+	const [jsonText, setJsonText] = useState("");
+	const [jsonError, setJsonError] = useState<string | null>(null);
+	const [syncSource, setSyncSource] = useState<"form" | "json">("form");
+	const [newOrgId, setNewOrgId] = useState("");
+	const [newLimit, setNewLimit] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+
+		let cancelled = false;
+		setLoading(true);
+
+		void axiosInstance
+			.get<OrgLimitsConfig>("/admin/org-limits-config")
+			.then(({ data }) => {
+				if (cancelled) return;
+				const mergedConfig: OrgLimitsConfig = {
+					...DEFAULT_CONFIG,
+					...data,
+				};
+				setConfig(mergedConfig);
+				setJsonText(
+					JSON.stringify(getEditableConfig({ config: mergedConfig }), null, 2),
+				);
+				setJsonError(null);
+				setSyncSource("form");
+			})
+			.catch((error) => {
+				if (!cancelled) {
+					toast.error(getBackendErr(error, "Failed to load org limits config"));
+				}
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [axiosInstance, open]);
+
+	useEffect(() => {
+		if (syncSource !== "form") return;
+		setJsonText(JSON.stringify(getEditableConfig({ config }), null, 2));
+		setJsonError(null);
+	}, [config, syncSource]);
+
+	const entryRows = useMemo(() => getEntryRows({ config }), [config]);
+
+	const handleJsonChange = (value: string | undefined) => {
+		const text = value ?? "";
+		setJsonText(text);
+		setSyncSource("json");
+
+		try {
+			const parsed = JSON.parse(text) as {
+				orgs?: Record<string, OrgLimitsEntry>;
+			};
+			setConfig((current) => ({
+				...current,
+				orgs: parsed.orgs ?? {},
+			}));
+			setJsonError(null);
+		} catch {
+			setJsonError("Invalid JSON");
+		}
+	};
+
+	const addEntry = () => {
+		const orgId = newOrgId.trim();
+		const limit = parseInt(newLimit.trim(), 10);
+
+		if (!orgId || Number.isNaN(limit) || limit < 1) return;
+
+		setSyncSource("form");
+		setConfig((current) => ({
+			...current,
+			orgs: {
+				...current.orgs,
+				[orgId]: { maxCusProducts: limit },
+			},
+		}));
+		setNewOrgId("");
+		setNewLimit("");
+	};
+
+	const removeEntry = ({ orgId }: { orgId: string }) => {
+		setSyncSource("form");
+		setConfig((current) => {
+			const nextOrgs = { ...current.orgs };
+			delete nextOrgs[orgId];
+			return { ...current, orgs: nextOrgs };
+		});
+	};
+
+	const handleSave = async () => {
+		if (jsonError) {
+			toast.error("Fix JSON errors before saving");
+			return;
+		}
+
+		let payload: unknown;
+		try {
+			payload = JSON.parse(jsonText);
+		} catch {
+			toast.error("Invalid JSON");
+			return;
+		}
+
+		setSaving(true);
+		try {
+			await axiosInstance.put("/admin/org-limits-config", payload);
+			toast.success("Org limits config saved");
+			onOpenChange(false);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to save org limits config"));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-5xl bg-card">
+				<DialogHeader>
+					<DialogTitle>Org Limits</DialogTitle>
+					<DialogDescription>
+						Configure per-org limits such as max customer products returned in
+						queries. Default is {DEFAULT_CUS_PRODUCT_LIMIT}.
+					</DialogDescription>
+				</DialogHeader>
+
+				{loading ? (
+					<div className="py-8 text-center text-sm text-t3">Loading...</div>
+				) : (
+					<div className="grid grid-cols-[320px_1fr] gap-6">
+						<div className="flex flex-col gap-4">
+							<div className="text-xs font-medium uppercase tracking-wide text-t3">
+								Org Overrides
+							</div>
+
+							<div className="rounded-lg border border-border p-3">
+								<div className="mb-3 flex flex-col gap-2">
+									<Input
+										placeholder="Org ID or slug"
+										value={newOrgId}
+										onChange={(event) => setNewOrgId(event.target.value)}
+									/>
+									<Input
+										placeholder="Max cusProducts (e.g. 30)"
+										type="number"
+										min={1}
+										value={newLimit}
+										onChange={(event) => setNewLimit(event.target.value)}
+									/>
+									<Button
+										variant="secondary"
+										size="sm"
+										onClick={addEntry}
+										disabled={
+											!newOrgId.trim() ||
+											!newLimit.trim() ||
+											Number.isNaN(parseInt(newLimit, 10)) ||
+											parseInt(newLimit, 10) < 1
+										}
+									>
+										Add org limit
+									</Button>
+								</div>
+
+								<div className="flex flex-col gap-2 border-t border-border pt-3">
+									{entryRows.length === 0 ? (
+										<div className="text-xs italic text-t3">
+											No org overrides — all orgs use default (
+											{DEFAULT_CUS_PRODUCT_LIMIT})
+										</div>
+									) : (
+										entryRows.map((entry) => (
+											<div
+												key={entry.orgId}
+												className="flex items-start justify-between gap-3 rounded-lg border border-border p-2"
+											>
+												<div className="min-w-0 flex-1">
+													<div className="truncate font-mono text-xs text-t1">
+														{entry.orgId}
+													</div>
+													<div className="text-xs text-t2">
+														maxCusProducts: {entry.maxCusProducts}
+													</div>
+												</div>
+												<Button
+													variant="secondary"
+													size="sm"
+													onClick={() => removeEntry({ orgId: entry.orgId })}
+												>
+													Remove
+												</Button>
+											</div>
+										))
+									)}
+								</div>
+							</div>
+
+							<div className="rounded-lg border border-border p-3 text-xs text-t3">
+								<div className="mb-2 flex items-center gap-2">
+									<Badge
+										variant="muted"
+										className={
+											config.configHealthy
+												? "border-emerald-200 bg-emerald-50 text-emerald-700"
+												: "border-amber-200 bg-amber-50 text-amber-700"
+										}
+									>
+										{config.configHealthy
+											? "Config healthy"
+											: "Config unavailable"}
+									</Badge>
+									{config.lastSuccessAt && (
+										<span>
+											Last refresh:{" "}
+											{new Date(config.lastSuccessAt).toLocaleString()}
+										</span>
+									)}
+								</div>
+								<div>
+									{config.configConfigured === false
+										? "S3 org limits config is not configured."
+										: config.error ||
+											"Limits update within 5 minutes of saving."}
+								</div>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-2">
+							<div className="text-xs font-medium uppercase tracking-wide text-t3">
+								Raw JSON
+							</div>
+							<div className="overflow-hidden rounded-md border border-border">
+								<Editor
+									height="420px"
+									language="json"
+									value={jsonText}
+									onChange={handleJsonChange}
+									options={{
+										minimap: { enabled: false },
+										scrollBeyondLastLine: false,
+										fontSize: 12,
+										tabSize: 2,
+										wordWrap: "on",
+										formatOnPaste: true,
+										formatOnType: true,
+									}}
+									theme="vs-dark"
+								/>
+							</div>
+							{jsonError && (
+								<div className="text-xs text-red-500">{jsonError}</div>
+							)}
+						</div>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button variant="secondary" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						onClick={handleSave}
+						isLoading={saving}
+						disabled={loading || !!jsonError}
+					>
+						Save
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/main-sidebar/org-dropdown/components/OrgLogo.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/components/OrgLogo.tsx
@@ -9,13 +9,13 @@ export const OrgLogo = ({ org }: { org: FrontendOrg }) => {
 				"rounded-md overflow-hidden flex items-center justify-center scale-100 translate-x-px bg-zinc-200 w-5 h-5 min-w-5 min-h-5",
 			)}
 		>
-			{org.logo ? (
+			{/* {org.logo ? (
 				<img src={org.logo} alt={org.name} className="w-full h-full" />
-			) : (
-				<span className="w-5 h-5 flex items-center justify-center bg-linear-to-r from-purple-600 via-purple-500 to-purple-gradient text-white text-xs">
-					{firstLetter}
-				</span>
-			)}
+			) : ( */}
+			<span className="w-5 h-5 flex items-center justify-center bg-linear-to-r from-purple-600 via-purple-500 to-purple-gradient text-white text-xs">
+				{firstLetter}
+			</span>
+			{/* )} */}
 		</div>
 	);
 };

--- a/vite/src/views/products/plan/components/EditPlanHeader.tsx
+++ b/vite/src/views/products/plan/components/EditPlanHeader.tsx
@@ -194,7 +194,10 @@ export const EditPlanHeader = () => {
 						{hasRCMapping && (
 							<Tooltip>
 								<TooltipTrigger>
-									<IconBadge variant="muted" icon={<RevenueCatIcon size={14} />}>
+									<IconBadge
+										variant="muted"
+										icon={<RevenueCatIcon size={14} />}
+									>
 										RC
 									</IconBadge>
 								</TooltipTrigger>
@@ -209,8 +212,7 @@ export const EditPlanHeader = () => {
 									<IconBadge
 										variant="muted"
 										icon={<TriangleIcon size={12} weight="fill" />}
-									>
-									</IconBadge>
+									></IconBadge>
 								</TooltipTrigger>
 								<TooltipContent>
 									This plan is linked to Vercel Marketplace


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Stripe-to-Postgres sync engine and per‑org limits on returned customer products to improve customer queries and prepare for multi-tenant Stripe analytics.

- **New Features**
  - Introduced `@autumn/stripe-sync` (wraps `@supabase/stripe-sync-engine`) with migrations and an `addAutumnColumns` step to add `stripe_account_id`, `org_id`, and `env` to synced tables.
  - Added `stripeSyncMiddleware` to webhook routes to upsert relevant Stripe events into the sync DB and stamp account/org/env; unified event lists in `stripeConstants` and used for webhook registration.
  - Edge-config driven per‑org limits for full customer results (default 15). New admin routes `GET/PUT /admin/org-limits-config` and an “Org Limits” admin dialog to manage overrides.
  - Customer queries (`getFullCusQuery`, paginated/search/batch services) now accept `cusProductLimit`, cap `customer_products`, and sort non add‑ons first for better relevance.

- **Migration**
  - Set `STRIPE_SYNC_DATABASE_URL` and run:
    - `bun stripe-sync:migrate`
    - Optionally `bun stripe-sync:migrate:prod`
  - Ensure Stripe secrets are configured; webhook registration now uses unified event constants.
  - To enable syncing per org, populate `admin/stripe-sync-config.json` with `enabledOrgIds`.
  - To customize customer product limits, configure `admin/org-limits-config.json` via the new admin UI or API.

<sup>Written for commit 558a52abf071b164a74f9e1192fbf23f8d906234. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a configurable per-org `cusProductLimit` mechanism (backed by an S3-polled edge config store) that replaces the hardcoded `LIMIT 15` in customer-product SQL queries, adds ordering by `is_add_on ASC` so base plans surface first, fixes a null-entity bug in `json_agg`, adds a billing lock to `handleCancelV2`, and wires in a new `stripe-sync` package that mirrors Stripe webhook events to a secondary DB.

**Key changes:**
- [Bug fixes] Fixed null entity aggregation in `getFullCusQuery` using `FILTER (WHERE e.internal_id IS NOT NULL)`, and null guard in entity `.find()` in `useSubscriptionStore`
- [Improvements] Per-org `maxCusProducts` override via `orgLimitsStore` with admin UI (`OrgLimitsDialog`), `DEFAULT_CUS_PRODUCT_LIMIT = 15` constant replacing magic numbers
- [Improvements] New `packages/stripe-sync` package mirroring Stripe events to a sync DB via `processStripeSyncEvent`, registered as a fire-and-forget post-handler middleware
- [Improvements] `handleCancelV2` now acquires a billing lock to prevent duplicate concurrent cancels
- [Bug fixes] Hardcoded webhook event list replaced by typed `MAIN_STRIPE_EVENT_TYPES` / `SYNC_STRIPE_EVENT_TYPES` constants

Two items need to be resolved before merging: a debug telemetry `fetch` call was left in `useSubscriptionStore.ts`, and a hardcoded org ID guard in `CusService.ts` should be removed now that the general limit mechanism exists.
</details>


<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — two P1 regressions (commented-out logo rendering, leftover debug telemetry fetch) and one P1 code-smell (hardcoded org ID) need to be resolved first.

Three P1-severity issues are present: a debug `fetch` to localhost left in `useSubscriptionStore.ts` that fires on every render, the `OrgLogo` conditional fully commented out causing a UI regression for all orgs with logos, and a hardcoded org-ID guard in `CusService` that should be replaced by the new edge-config mechanism. Core logic of the `cusProductLimit` feature, stripe-sync middleware, and billing lock are otherwise sound.

`vite/src/hooks/stores/useSubscriptionStore.ts`, `vite/src/views/main-sidebar/org-dropdown/components/OrgLogo.tsx`, and `server/src/internal/customers/CusService.ts` all require changes before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/hooks/stores/useSubscriptionStore.ts | Adds null guard to entity `.find()` (correct fix) but also contains a leftover debug `fetch` call that posts entity data to localhost on every render — must be removed before merging. |
| server/src/internal/customers/CusService.ts | Wires `getOrgCusProductLimit` into the single-customer query path correctly, but retains a hardcoded org-ID guard that special-cases one org with `slice(0,5)` — should be replaced by the new edge-config mechanism. |
| server/src/internal/customers/getFullCusQuery.ts | Refactors positional params to named object params, passes configurable `cusProductLimit` to both `buildOptimizedCusProductsCTE` and `getPaginatedFullCusQuery`, adds `is_add_on ASC` ordering, and fixes null-entity aggregation with a `FILTER` clause. |
| server/src/internal/misc/edgeConfig/orgLimitsStore.ts | New S3-polled edge-config store providing `getOrgCusProductLimit` with org-ID/slug fallback and admin CRUD helpers; `DEFAULT_CUS_PRODUCT_LIMIT = 15` constant properly replaces magic numbers. |
| vite/src/views/main-sidebar/org-dropdown/components/OrgLogo.tsx | Logo conditional accidentally commented out — all orgs render only the first-letter fallback, regressing orgs with a configured logo. |
| server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts | New post-handler middleware that fire-and-forgets Stripe events to the sync DB; correctly gates on `isStripeSyncEnabled` in production and swallows errors to remain fail-open. |
| packages/stripe-sync/src/initStripeSync.ts | Lazy singleton `StripeSync` engine with graceful shutdown; stamps each synced row with `stripe_account_id`, `org_id`, and `env` for multi-tenancy via a direct pool query — fail-open on all errors. |
| server/src/internal/customers/cancel/handleCancelV2.ts | Adds a billing lock (120 s TTL) to prevent duplicate concurrent cancellations; lock is skipped in development for convenience. |
| vite/src/views/admin/components/OrgLimitsDialog.tsx | New admin dialog for managing per-org product limits with dual form/JSON editing and health badge; UI message incorrectly states "5 minutes" refresh when the actual poll interval is 30 seconds. |
| server/src/internal/customers/CusBatchService.ts | Correctly threads `cusProductLimit` from `getOrgCusProductLimit` into both paginated and batch full-customer queries. |
| server/src/internal/customers/CusSearchService.ts | Adds `orgSlug` propagation for limit lookups, applies in-memory `slice(0, cusProductLimit)` after both `searchByProduct` and `search` aggregation, and adds `is_add_on ASC` ordering. |
| .cursor/debug-0967f4.log | Debug session log from Cursor agent accidentally committed; contains telemetry payloads and should not be tracked in git. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stripe Webhook Received] --> B[stripeSyncMiddleware]
    B --> C{isStripeSyncEnabled?}
    C -- No / dev --> D[Skip sync]
    C -- Yes --> E{isSyncableEvent?}
    E -- No --> D
    E -- Yes --> F[processStripeSyncEvent]
    F --> G[engine.processEvent - upsert row]
    G --> H[Stamp row with stripe_account_id / org_id / env]
    H --> I[(stripe-sync DB)]

    J[API: GET /full-customer] --> K[CusService.getFullCustomer]
    K --> L[getOrgCusProductLimit]
    L --> M[(orgLimitsStore S3 poll 30s)]
    M --> L
    L --> N[getFullCusQuery with cusProductLimit]
    N --> O[(Autumn DB)]

    P[Admin PUT /org-limits-config] --> Q[handleUpsertAdminOrgLimitsConfig]
    Q --> R[store.writeToSource]
    R --> M
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.cursor/debug-0967f4.log`, line 1 ([link](https://github.com/useautumn/autumn/blob/558a52abf071b164a74f9e1192fbf23f8d906234/.cursor/debug-0967f4.log#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Debug log file committed to repo**

   This file contains session telemetry from a Cursor debug agent and should not be tracked in git. It should be deleted and `.cursor/` should be added to `.gitignore` to prevent future debug files from being committed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .cursor/debug-0967f4.log
   Line: 1

   Comment:
   **Debug log file committed to repo**

   This file contains session telemetry from a Cursor debug agent and should not be tracked in git. It should be deleted and `.cursor/` should be added to `.gitignore` to prevent future debug files from being committed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/hooks/stores/useSubscriptionStore.ts
Line: 24

Comment:
**Debug telemetry fetch left in production code**

This line fires an HTTP POST to `http://127.0.0.1:7322/ingest/…` on every render of `useEntity`, sending customer entity data (IDs, counts) to a localhost debug agent. It will silently fail in any environment that isn't the original developer's machine, adding unnecessary network noise. The `// #region agent log … // #endregion` block and the `.cursor/debug-0967f4.log` file committed alongside it confirm this is leftover debug instrumentation and should be removed before merging.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/customers/CusService.ts
Line: 149-157

Comment:
**Hardcoded org ID should be removed**

This block hard-codes special-case limits (`slice(0, 5)` for products, `slice(0, 50)` for entities) for a single org ID. The whole point of this PR is the new `getOrgCusProductLimit` / `orgLimitsStore` mechanism — the org-specific product cap should be set through that config instead. This workaround bypasses the general path and will silently continue to override whatever value is set in the edge config for this org.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/main-sidebar/org-dropdown/components/OrgLogo.tsx
Line: 12-20

Comment:
**Logo rendering accidentally commented out**

The `org.logo` conditional is wrapped in comments, so every org now renders only the first-letter fallback regardless of whether a logo is configured. This regresses orgs that have a logo set.

```suggestion
			{org.logo ? (
				<img src={org.logo} alt={org.name} className="w-full h-full" />
			) : (
				<span className="w-5 h-5 flex items-center justify-center bg-linear-to-r from-purple-600 via-purple-500 to-purple-gradient text-white text-xs">
					{firstLetter}
				</span>
			)}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/admin/components/OrgLimitsDialog.tsx
Line: 290-293

Comment:
**Inaccurate poll-interval message**

The message says "Limits update within 5 minutes of saving" but `orgLimitsStore.ts` polls every 30 seconds (`pollIntervalMs: 30_000`). Consider updating the copy to match the actual refresh cadence.

```suggestion
								config.error ||
								"Limits update within ~30 seconds of saving."}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/external/stripe/stripeOnboardingUtils.ts
Line: 35-52

Comment:
**Stale commented-out event list**

The old `enabled_events` array is left as a comment block. Now that it's been replaced by `[...MAIN_STRIPE_EVENT_TYPES, ...SYNC_STRIPE_EVENT_TYPES]` the comment serves no purpose and can be deleted.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .cursor/debug-0967f4.log
Line: 1

Comment:
**Debug log file committed to repo**

This file contains session telemetry from a Cursor debug agent and should not be tracked in git. It should be deleted and `.cursor/` should be added to `.gitignore` to prevent future debug files from being committed.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: full customer limits PER org"](https://github.com/useautumn/autumn/commit/558a52abf071b164a74f9e1192fbf23f8d906234) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27987589)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->