### PR TITLE
fix: bun lock

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ COPY packages/atmn/package.json ./packages/atmn/package.json
 COPY packages/atmn-tests/package.json ./packages/atmn-tests/package.json
 COPY packages/openapi/package.json ./packages/openapi/package.json
 COPY packages/ksuid/package.json ./packages/ksuid/package.json
+COPY packages/stripe-sync/package.json ./packages/stripe-sync/package.json
 COPY packages/sdk/package.json ./packages/sdk/package.json
 COPY apps/sdk-test/package.json ./apps/sdk-test/package.json
 COPY apps/docs/package.json ./apps/docs/package.json


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Docker build by copying `packages/stripe-sync/package.json` so Bun installs all workspace deps and the lockfile stays accurate. Prevents missing `stripe-sync` dependencies during image build.

<sup>Written for commit ff841d3385588da19ff64663b2218bfa4209d9e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `packages/stripe-sync/package.json` to the Docker layer-caching COPY section so that `bun install --ignore-scripts` can resolve the workspace package referenced in `bun.lock`. Without this line, the Docker build would fail because `bun install` expects every workspace member listed in the lock file to have its `package.json` present.

**Key changes:**
- [Bug fixes] Added `COPY packages/stripe-sync/package.json` to `docker/Dockerfile` so the `stripe-sync` workspace is visible during the dependency installation layer.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line Dockerfile fix with no logic changes.

The change is minimal, correct, and follows the established pattern of the Dockerfile. The stripe-sync package is a registered workspace in package.json, and its package.json was simply missing from the Docker COPY step that precedes bun install. No other concerns.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Added COPY for packages/stripe-sync/package.json so the new workspace is included before bun install runs; straightforward and correct. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant D as Docker Build
    participant FS as Filesystem Layer
    participant B as bun install

    D->>FS: COPY bun.lock (references stripe-sync workspace)
    D->>FS: COPY packages/stripe-sync/package.json ✅ (added by this PR)
    D->>FS: COPY all other workspace package.jsons
    D->>B: RUN bun install --ignore-scripts
    B-->>D: ✅ Resolves all workspace packages from lock file
    D->>FS: COPY . . (rest of source)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: dockerfile"](https://github.com/useautumn/autumn/commit/ff841d3385588da19ff64663b2218bfa4209d9e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27988501)</sub>

<!-- /greptile_comment -->