### PR TITLE
fix: stripe sync

### DIFF
--- a/packages/stripe-sync/src/initStripeSync.ts
+++ b/packages/stripe-sync/src/initStripeSync.ts
@@ -18,6 +18,7 @@ export const getStripeSyncEngine = (): StripeSync | null => {
 	initAttempted = true;
 
 	const databaseUrl = process.env.STRIPE_SYNC_DATABASE_URL;
+
 	const stripeSecretKey =
 		process.env.STRIPE_LIVE_SECRET_KEY || process.env.STRIPE_SANDBOX_SECRET_KEY;
 

--- a/server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts
@@ -22,7 +22,7 @@ export const stripeSyncMiddleware = async (
 	if (!org || !stripeEvent) return;
 	if (
 		process.env.NODE_ENV === "production" &&
-		!isStripeSyncEnabled({ orgId: org.id })
+		!isStripeSyncEnabled({ orgId: org.id, orgSlug: org.slug })
 	)
 		return;
 

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -5,6 +5,8 @@ import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsCo
 import { handleGetAdminOrgLimitsConfig } from "./handleGetAdminOrgLimitsConfig";
 import { handleGetAdminOrgRequestBlock } from "./handleGetAdminOrgRequestBlock";
 import { handleGetAdminRequestBlockConfig } from "./handleGetAdminRequestBlockConfig";
+import { handleGetAdminStripeSyncConfig } from "./handleGetAdminStripeSyncConfig";
+
 import { handleGetInvoiceLineItems } from "./handleGetInvoiceLineItems";
 import { handleGetMasterStripeAccount } from "./handleGetMasterStripeAccount";
 import { handleGetOrgMember } from "./handleGetOrgMember";
@@ -16,6 +18,7 @@ import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureF
 import { handleUpsertAdminOrgLimitsConfig } from "./handleUpsertAdminOrgLimitsConfig";
 import { handleUpsertAdminOrgRequestBlock } from "./handleUpsertAdminOrgRequestBlock";
 import { handleUpsertAdminRequestBlockConfig } from "./handleUpsertAdminRequestBlockConfig";
+import { handleUpsertAdminStripeSyncConfig } from "./handleUpsertAdminStripeSyncConfig";
 
 export const honoAdminRouter = new Hono<HonoEnv>();
 
@@ -55,6 +58,11 @@ honoAdminRouter.put(
 );
 honoAdminRouter.get("/org-limits-config", ...handleGetAdminOrgLimitsConfig);
 honoAdminRouter.put("/org-limits-config", ...handleUpsertAdminOrgLimitsConfig);
+honoAdminRouter.get("/stripe-sync-config", ...handleGetAdminStripeSyncConfig);
+honoAdminRouter.put(
+	"/stripe-sync-config",
+	...handleUpsertAdminStripeSyncConfig,
+);
 honoAdminRouter.get("/org-member", ...handleGetOrgMember);
 honoAdminRouter.get("/master-stripe-account", ...handleGetMasterStripeAccount);
 honoAdminRouter.get("/oauth-clients", ...handleListOAuthClients);

--- a/server/src/internal/admin/handleGetAdminStripeSyncConfig.ts
+++ b/server/src/internal/admin/handleGetAdminStripeSyncConfig.ts
@@ -1,0 +1,20 @@
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getRuntimeStripeSyncStatus,
+	getStripeSyncConfigFromSource,
+} from "@/internal/misc/stripeSync/stripeSyncStore.js";
+
+export const handleGetAdminStripeSyncConfig = createRoute({
+	handler: async (c) => {
+		const status = getRuntimeStripeSyncStatus();
+		const config = await getStripeSyncConfigFromSource();
+
+		return c.json({
+			...config,
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminStripeSyncConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminStripeSyncConfig.ts
@@ -1,0 +1,14 @@
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { StripeSyncConfigSchema } from "@/internal/misc/stripeSync/stripeSyncSchemas.js";
+import { updateFullStripeSyncConfig } from "@/internal/misc/stripeSync/stripeSyncStore.js";
+
+export const handleUpsertAdminStripeSyncConfig = createRoute({
+	body: StripeSyncConfigSchema,
+	handler: async (c) => {
+		const body = c.req.valid("json");
+
+		await updateFullStripeSyncConfig({ config: body });
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/misc/stripeSync/stripeSyncStore.ts
+++ b/server/src/internal/misc/stripeSync/stripeSyncStore.ts
@@ -14,7 +14,26 @@ const store = createEdgeConfigStore<StripeSyncConfig>({
 
 registerEdgeConfig({ store });
 
-/** Pure in-memory lookup -- zero I/O, sync. */
-export const isStripeSyncEnabled = ({ orgId }: { orgId: string }): boolean => {
-	return store.get().enabledOrgIds.includes(orgId);
+/** Pure in-memory lookup -- zero I/O, sync. Matches on org ID or slug. */
+export const isStripeSyncEnabled = ({
+	orgId,
+	orgSlug,
+}: {
+	orgId: string;
+	orgSlug?: string;
+}): boolean => {
+	const enabled = store.get().enabledOrgIds;
+	return enabled.includes(orgId) || (!!orgSlug && enabled.includes(orgSlug));
+};
+
+export const getRuntimeStripeSyncStatus = () => store.getStatus();
+
+export const getStripeSyncConfigFromSource = async () => store.readFromSource();
+
+export const updateFullStripeSyncConfig = async ({
+	config,
+}: {
+	config: StripeSyncConfig;
+}) => {
+	await store.writeToSource({ config });
 };

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -5,6 +5,7 @@ import { EdgeConfigDialog } from "./EdgeConfigDialog";
 import { FeatureFlagsDialog } from "./FeatureFlagsDialog";
 import { OrgLimitsDialog } from "./OrgLimitsDialog";
 import { RawEdgeConfigDialog } from "./RawEdgeConfigDialog";
+import { StripeSyncDialog } from "./StripeSyncDialog";
 
 export function EdgeConfigTab() {
 	const [requestBlockEditOpen, setRequestBlockEditOpen] = useState(false);
@@ -12,6 +13,7 @@ export function EdgeConfigTab() {
 	const [featureFlagsOpen, setFeatureFlagsOpen] = useState(false);
 	const [customerBlockOpen, setCustomerBlockOpen] = useState(false);
 	const [orgLimitsOpen, setOrgLimitsOpen] = useState(false);
+	const [stripeSyncOpen, setStripeSyncOpen] = useState(false);
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -90,6 +92,22 @@ export function EdgeConfigTab() {
 						Edit
 					</Button>
 				</div>
+
+				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
+					<div className="flex flex-col gap-0.5">
+						<div className="text-sm font-medium text-t1">Stripe Sync</div>
+						<div className="text-xs text-t3">
+							Enable Stripe webhook event syncing to the sync DB per org.
+						</div>
+					</div>
+					<Button
+						variant="primary"
+						size="sm"
+						onClick={() => setStripeSyncOpen(true)}
+					>
+						Edit
+					</Button>
+				</div>
 			</div>
 
 			<FeatureFlagsDialog
@@ -116,6 +134,11 @@ export function EdgeConfigTab() {
 			/>
 
 			<OrgLimitsDialog open={orgLimitsOpen} onOpenChange={setOrgLimitsOpen} />
+
+			<StripeSyncDialog
+				open={stripeSyncOpen}
+				onOpenChange={setStripeSyncOpen}
+			/>
 		</div>
 	);
 }

--- a/vite/src/views/admin/components/StripeSyncDialog.tsx
+++ b/vite/src/views/admin/components/StripeSyncDialog.tsx
@@ -1,0 +1,306 @@
+import Editor from "@monaco-editor/react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/v2/badges/Badge";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { Input } from "@/components/v2/inputs/Input";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+
+type StripeSyncConfig = {
+	enabledOrgIds: string[];
+	configHealthy: boolean;
+	configConfigured: boolean;
+	lastSuccessAt: string | null;
+	error: string | null;
+};
+
+const DEFAULT_CONFIG: StripeSyncConfig = {
+	enabledOrgIds: [],
+	configHealthy: false,
+	configConfigured: false,
+	lastSuccessAt: null,
+	error: null,
+};
+
+export function StripeSyncDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const [loading, setLoading] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [config, setConfig] = useState<StripeSyncConfig>(DEFAULT_CONFIG);
+	const [jsonText, setJsonText] = useState("");
+	const [jsonError, setJsonError] = useState<string | null>(null);
+	const [syncSource, setSyncSource] = useState<"form" | "json">("form");
+	const [newOrgId, setNewOrgId] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+
+		let cancelled = false;
+		setLoading(true);
+
+		void axiosInstance
+			.get<StripeSyncConfig>("/admin/stripe-sync-config")
+			.then(({ data }) => {
+				if (cancelled) return;
+				const merged = { ...DEFAULT_CONFIG, ...data };
+				setConfig(merged);
+				setJsonText(
+					JSON.stringify({ enabledOrgIds: merged.enabledOrgIds }, null, 2),
+				);
+				setJsonError(null);
+				setSyncSource("form");
+			})
+			.catch((error) => {
+				if (!cancelled) {
+					toast.error(
+						getBackendErr(error, "Failed to load stripe sync config"),
+					);
+				}
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [axiosInstance, open]);
+
+	useEffect(() => {
+		if (syncSource !== "form") return;
+		setJsonText(
+			JSON.stringify({ enabledOrgIds: config.enabledOrgIds }, null, 2),
+		);
+		setJsonError(null);
+	}, [config, syncSource]);
+
+	const sortedOrgIds = useMemo(
+		() => [...config.enabledOrgIds].sort(),
+		[config.enabledOrgIds],
+	);
+
+	const handleJsonChange = (value: string | undefined) => {
+		const text = value ?? "";
+		setJsonText(text);
+		setSyncSource("json");
+
+		try {
+			const parsed = JSON.parse(text) as { enabledOrgIds?: string[] };
+			setConfig((current) => ({
+				...current,
+				enabledOrgIds: parsed.enabledOrgIds ?? [],
+			}));
+			setJsonError(null);
+		} catch {
+			setJsonError("Invalid JSON");
+		}
+	};
+
+	const addOrg = () => {
+		const orgId = newOrgId.trim();
+		if (!orgId) return;
+		if (config.enabledOrgIds.includes(orgId)) {
+			toast.error("Org already in list");
+			return;
+		}
+
+		setSyncSource("form");
+		setConfig((current) => ({
+			...current,
+			enabledOrgIds: [...current.enabledOrgIds, orgId],
+		}));
+		setNewOrgId("");
+	};
+
+	const removeOrg = ({ orgId }: { orgId: string }) => {
+		setSyncSource("form");
+		setConfig((current) => ({
+			...current,
+			enabledOrgIds: current.enabledOrgIds.filter((id) => id !== orgId),
+		}));
+	};
+
+	const handleSave = async () => {
+		if (jsonError) {
+			toast.error("Fix JSON errors before saving");
+			return;
+		}
+
+		let payload: unknown;
+		try {
+			payload = JSON.parse(jsonText);
+		} catch {
+			toast.error("Invalid JSON");
+			return;
+		}
+
+		setSaving(true);
+		try {
+			await axiosInstance.put("/admin/stripe-sync-config", payload);
+			toast.success("Stripe sync config saved");
+			onOpenChange(false);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to save stripe sync config"));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-5xl bg-card">
+				<DialogHeader>
+					<DialogTitle>Stripe Sync</DialogTitle>
+					<DialogDescription>
+						Manage which orgs have Stripe webhook events synced to the sync DB.
+						Changes take effect within 60 seconds.
+					</DialogDescription>
+				</DialogHeader>
+
+				{loading ? (
+					<div className="py-8 text-center text-sm text-t3">Loading...</div>
+				) : (
+					<div className="grid grid-cols-[320px_1fr] gap-6">
+						<div className="flex flex-col gap-4">
+							<div className="text-xs font-medium uppercase tracking-wide text-t3">
+								Enabled Orgs
+							</div>
+
+							<div className="rounded-lg border border-border p-3">
+								<div className="mb-3 flex gap-2">
+									<Input
+										placeholder="Org ID or slug"
+										value={newOrgId}
+										onChange={(event) => setNewOrgId(event.target.value)}
+										onKeyDown={(event) => {
+											if (event.key === "Enter") addOrg();
+										}}
+									/>
+									<Button
+										variant="secondary"
+										size="sm"
+										onClick={addOrg}
+										disabled={!newOrgId.trim()}
+									>
+										Add
+									</Button>
+								</div>
+
+								<div className="flex flex-col gap-2 border-t border-border pt-3">
+									{sortedOrgIds.length === 0 ? (
+										<div className="text-xs italic text-t3">
+											No orgs enabled — sync is disabled for all orgs.
+										</div>
+									) : (
+										sortedOrgIds.map((orgId) => (
+											<div
+												key={orgId}
+												className="flex items-center justify-between gap-3 rounded-lg border border-border p-2"
+											>
+												<div className="truncate font-mono text-xs text-t1">
+													{orgId}
+												</div>
+												<Button
+													variant="secondary"
+													size="sm"
+													onClick={() => removeOrg({ orgId })}
+												>
+													Remove
+												</Button>
+											</div>
+										))
+									)}
+								</div>
+							</div>
+
+							<div className="rounded-lg border border-border p-3 text-xs text-t3">
+								<div className="mb-2 flex items-center gap-2">
+									<Badge
+										variant="muted"
+										className={
+											config.configHealthy
+												? "border-emerald-200 bg-emerald-50 text-emerald-700"
+												: "border-amber-200 bg-amber-50 text-amber-700"
+										}
+									>
+										{config.configHealthy
+											? "Config healthy"
+											: "Config unavailable"}
+									</Badge>
+									{config.lastSuccessAt && (
+										<span>
+											Last refresh:{" "}
+											{new Date(config.lastSuccessAt).toLocaleString()}
+										</span>
+									)}
+								</div>
+								<div>
+									{config.configConfigured === false
+										? "S3 stripe sync config is not configured."
+										: config.error ||
+											"Config updates within 60 seconds of saving."}
+								</div>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-2">
+							<div className="text-xs font-medium uppercase tracking-wide text-t3">
+								Raw JSON
+							</div>
+							<div className="overflow-hidden rounded-md border border-border">
+								<Editor
+									height="420px"
+									language="json"
+									value={jsonText}
+									onChange={handleJsonChange}
+									options={{
+										minimap: { enabled: false },
+										scrollBeyondLastLine: false,
+										fontSize: 12,
+										tabSize: 2,
+										wordWrap: "on",
+										formatOnPaste: true,
+										formatOnType: true,
+									}}
+									theme="vs-dark"
+								/>
+							</div>
+							{jsonError && (
+								<div className="text-xs text-red-500">{jsonError}</div>
+							)}
+						</div>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button variant="secondary" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						onClick={handleSave}
+						isLoading={saving}
+						disabled={loading || !!jsonError}
+					>
+						Save
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Stripe Sync enablement by matching orgs by ID or slug, and adds admin APIs and UI to view and update the Stripe Sync edge config with runtime status.

- **New Features**
  - Added `GET /admin/stripe-sync-config` and `PUT /admin/stripe-sync-config` to read/write the full config with status fields (`configHealthy`, `configConfigured`, `lastSuccessAt`, `error`).
  - New Stripe Sync editor in Admin → Edge Config with a form and raw JSON editor to manage `enabledOrgIds` (IDs or slugs). Shows health and last refresh time.
  - Store updates: `getRuntimeStripeSyncStatus`, `getStripeSyncConfigFromSource`, and `updateFullStripeSyncConfig` for edge-config backed reads/writes.

- **Bug Fixes**
  - `stripeSyncMiddleware` now uses `isStripeSyncEnabled({ orgId, orgSlug })` to honor org slugs as well as IDs, ensuring production webhooks sync when either is configured.

<sup>Written for commit 4004d5adb09414f066c17232c14ed8c53bfe67d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a Stripe sync feature that mirrors Stripe webhook events into a secondary PostgreSQL database, with per-org enablement controls managed through an admin UI. It adds a lazy-initialized singleton `StripeSync` engine, a post-handler webhook middleware, an edge-config-backed store for the allow-list, and a Monaco-powered admin dialog for managing which orgs participate in the sync.

**Key changes:**
- **[Improvements]** New `@autumn/stripe-sync` package with lazy singleton engine, graceful shutdown, and fail-open event processing with multi-tenancy metadata stamping
- **[Improvements]** `stripeSyncMiddleware` fires post-handler stripe sync as fire-and-forget, gated by per-org allow-list in production
- **[API changes]** New `GET /admin/stripe-sync-config` and `PUT /admin/stripe-sync-config` endpoints backed by the edge-config store
- **[Improvements]** Admin `StripeSyncDialog` with dual-mode editing (form + raw JSON) and live health-status badge
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 clarifications/suggestions with no blocking correctness issues

The implementation is solid and well-structured: the sync engine is fail-open throughout, webhook processing is fire-and-forget, and the backend validates all config writes via Zod. The three comments raised (fail-once init, dummy webhook secret, non-production bypass) are all style or design clarifications with no present data-loss or correctness risk.

packages/stripe-sync/src/initStripeSync.ts — fail-once init semantics and dummy webhook secret worth a second look

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/stripe-sync/src/initStripeSync.ts | Lazy singleton engine with fail-once initialization; a transient startup DB failure permanently disables sync for the process lifetime, and the dummy webhook secret string is fragile |
| server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts | Post-handler fire-and-forget middleware; the isStripeSyncEnabled guard is intentionally skipped in non-production, which syncs all events unconditionally in dev/staging if a sync DB is configured |
| server/src/internal/misc/stripeSync/stripeSyncStore.ts | Edge-config store correctly polls every 60s; isStripeSyncEnabled accepts both org IDs and slugs against a field named enabledOrgIds, which is intentional but slightly misleading |
| server/src/internal/admin/adminRouter.ts | New GET/PUT routes for stripe-sync-config added cleanly alongside existing admin routes |
| vite/src/views/admin/components/StripeSyncDialog.tsx | Well-structured admin dialog with dual form/JSON editing and health-status badge; minor: re-parses jsonText on save instead of using the already-synced config state |
| server/src/internal/admin/handleGetAdminStripeSyncConfig.ts | Clean GET handler merging runtime status with persisted config |
| server/src/internal/admin/handleUpsertAdminStripeSyncConfig.ts | Clean upsert handler; validates body against StripeSyncConfigSchema before writing |
| vite/src/views/admin/components/EdgeConfigTab.tsx | New Stripe Sync entry added to edge config tab, consistent with existing panel items |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant WebhookHandler
    participant stripeSyncMiddleware
    participant isStripeSyncEnabled
    participant processStripeSyncEvent
    participant StripeSyncPG as StripeSync (PG)

    Stripe->>WebhookHandler: POST /webhook (event)
    WebhookHandler->>WebhookHandler: process event (next())
    WebhookHandler->>stripeSyncMiddleware: post-handler
    stripeSyncMiddleware->>stripeSyncMiddleware: check org and stripeEvent present
    alt NODE_ENV === production
        stripeSyncMiddleware->>isStripeSyncEnabled: isStripeSyncEnabled(orgId, orgSlug)
        isStripeSyncEnabled-->>stripeSyncMiddleware: true/false
    end
    stripeSyncMiddleware->>stripeSyncMiddleware: isSyncableEvent(eventType)?
    stripeSyncMiddleware->>processStripeSyncEvent: fire-and-forget
    processStripeSyncEvent->>StripeSyncPG: engine.processEvent(event)
    processStripeSyncEvent->>StripeSyncPG: UPDATE table SET stripe_account_id, org_id, env WHERE id=objectId
    StripeSyncPG-->>processStripeSyncEvent: ok
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/stripe-sync/src/initStripeSync.ts`, line 16-18 ([link](https://github.com/useautumn/autumn/blob/4004d5adb09414f066c17232c14ed8c53bfe67d6/packages/stripe-sync/src/initStripeSync.ts#L16-L18)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Transient startup failure permanently disables sync**

   `initAttempted` is set to `true` before the constructor is called, so if the PG pool constructor throws (e.g. due to a bad connection string or a transient network error at startup), every subsequent call to `getStripeSyncEngine()` will return `null` for the entire process lifetime — the only recovery path is calling `closeStripeSyncEngine()` or restarting the server. This is documented in the JSDoc, but silently failing forever after a transient error may be surprising in practice. Consider only locking `initAttempted` on a *successful* init, or resetting it after a configurable delay to allow recovery.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/stripe-sync/src/initStripeSync.ts
   Line: 16-18

   Comment:
   **Transient startup failure permanently disables sync**

   `initAttempted` is set to `true` before the constructor is called, so if the PG pool constructor throws (e.g. due to a bad connection string or a transient network error at startup), every subsequent call to `getStripeSyncEngine()` will return `null` for the entire process lifetime — the only recovery path is calling `closeStripeSyncEngine()` or restarting the server. This is documented in the JSDoc, but silently failing forever after a transient error may be surprising in practice. Consider only locking `initAttempted` on a *successful* init, or resetting it after a configurable delay to allow recovery.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `packages/stripe-sync/src/initStripeSync.ts`, line 37 ([link](https://github.com/useautumn/autumn/blob/4004d5adb09414f066c17232c14ed8c53bfe67d6/packages/stripe-sync/src/initStripeSync.ts#L37)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dummy webhook secret is fragile**

   The constructor receives a placeholder string because `StripeSync` requires the field, but the code only calls `engine.processEvent()` directly. If a future version of `@supabase/stripe-sync-engine` starts validating or using `stripeWebhookSecret` even inside `processEvent`, this will silently break. Consider reading this value from an env var (falling back to the placeholder) so it can be set properly for environments that do need it, and add a comment explaining why the placeholder is safe here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/stripe-sync/src/initStripeSync.ts
   Line: 37

   Comment:
   **Dummy webhook secret is fragile**

   The constructor receives a placeholder string because `StripeSync` requires the field, but the code only calls `engine.processEvent()` directly. If a future version of `@supabase/stripe-sync-engine` starts validating or using `stripeWebhookSecret` even inside `processEvent`, this will silently break. Consider reading this value from an env var (falling back to the placeholder) so it can be set properly for environments that do need it, and add a comment explaining why the placeholder is safe here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/stripe-sync/src/initStripeSync.ts
Line: 16-18

Comment:
**Transient startup failure permanently disables sync**

`initAttempted` is set to `true` before the constructor is called, so if the PG pool constructor throws (e.g. due to a bad connection string or a transient network error at startup), every subsequent call to `getStripeSyncEngine()` will return `null` for the entire process lifetime — the only recovery path is calling `closeStripeSyncEngine()` or restarting the server. This is documented in the JSDoc, but silently failing forever after a transient error may be surprising in practice. Consider only locking `initAttempted` on a *successful* init, or resetting it after a configurable delay to allow recovery.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/external/stripe/webhookMiddlewares/stripeSyncMiddleware.ts
Line: 23-27

Comment:
**Allow-list bypass in non-production**

The `isStripeSyncEnabled` check is only enforced when `NODE_ENV === "production"`, so any non-production environment with `STRIPE_SYNC_DATABASE_URL` configured will sync every event for every org unconditionally. If this is intentional (e.g. to make local testing easier without managing the allow-list), it's worth a short comment; if it was meant to apply in all environments, the outer `NODE_ENV` guard should be removed.

```suggestion
	if (!isStripeSyncEnabled({ orgId: org.id, orgSlug: org.slug })) return;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/stripe-sync/src/initStripeSync.ts
Line: 37

Comment:
**Dummy webhook secret is fragile**

The constructor receives a placeholder string because `StripeSync` requires the field, but the code only calls `engine.processEvent()` directly. If a future version of `@supabase/stripe-sync-engine` starts validating or using `stripeWebhookSecret` even inside `processEvent`, this will silently break. Consider reading this value from an env var (falling back to the placeholder) so it can be set properly for environments that do need it, and add a comment explaining why the placeholder is safe here.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stripe sync"](https://github.com/useautumn/autumn/commit/4004d5adb09414f066c17232c14ed8c53bfe67d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27992234)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->