### PR TITLE
Decouple prorate toggle from reset billing cycle, add entity scope selector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "autumn",

--- a/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
@@ -108,6 +108,7 @@ export function AttachAdvancedSection() {
 	const {
 		discounts,
 		newBillingSubscription,
+		resetBillingCycle,
 		redirectMode,
 		noBillingChanges,
 		carryOverBalances,
@@ -443,14 +444,37 @@ export function AttachAdvancedSection() {
 						<Switch
 							checked={
 								showProrationBehavior &&
-								effectiveProrationBehavior === "prorate_immediately"
+								effectiveProrationBehavior === "prorate_immediately" &&
+								!resetBillingCycle
 							}
-							disabled={!showProrationBehavior || !isNoChargesAllowed}
+							disabled={
+								!showProrationBehavior ||
+								!isNoChargesAllowed ||
+								resetBillingCycle
+							}
 							onCheckedChange={(checked) =>
 								handleProrationBehaviorChange(
 									checked ? "prorate_immediately" : "none",
 								)
 							}
+						/>
+					}
+				/>
+			)}
+
+			{hasActiveSubscription && (
+				<ConfigRow
+					title="Reset Billing Cycle"
+					description="Restart the billing cycle from today"
+					action={
+						<Switch
+							checked={resetBillingCycle}
+							onCheckedChange={(checked) => {
+								form.setFieldValue("resetBillingCycle", !!checked);
+								if (checked) {
+									handleScheduleChange("immediate");
+								}
+							}}
 						/>
 					}
 				/>
@@ -465,11 +489,12 @@ export function AttachAdvancedSection() {
 					<IconCheckbox
 						variant="secondary"
 						size="sm"
-						checked={isImmediateSelected}
+						checked={isImmediateSelected || resetBillingCycle}
+						disabled={resetBillingCycle}
 						onCheckedChange={() => handleScheduleChange("immediate")}
 						className={cn(
 							"min-w-[76px] px-2 text-xs rounded-r-none",
-							!isImmediateSelected && "border-r-0",
+							!isImmediateSelected && !resetBillingCycle && "border-r-0",
 						)}
 					>
 						Immediately
@@ -480,8 +505,8 @@ export function AttachAdvancedSection() {
 								<IconCheckbox
 									variant="secondary"
 									size="sm"
-									checked={isEndOfCycleSelected}
-									disabled={!hasOutgoing}
+									checked={isEndOfCycleSelected && !resetBillingCycle}
+									disabled={!hasOutgoing || resetBillingCycle}
 									onCheckedChange={() => handleScheduleChange("end_of_cycle")}
 									className={cn(
 										"min-w-[76px] px-2 text-xs rounded-l-none",

--- a/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
@@ -435,7 +435,6 @@ export function AttachAdvancedSection() {
 				)}
 			</ConfigRow>
 
-			{/* Proration — disabled (not hidden) when schedule is end-of-cycle */}
 			{showProrationRow && (
 				<ConfigRow
 					title="Prorate Changes"
@@ -444,14 +443,9 @@ export function AttachAdvancedSection() {
 						<Switch
 							checked={
 								showProrationBehavior &&
-								effectiveProrationBehavior === "prorate_immediately" &&
-								!resetBillingCycle
+								effectiveProrationBehavior === "prorate_immediately"
 							}
-							disabled={
-								!showProrationBehavior ||
-								!isNoChargesAllowed ||
-								resetBillingCycle
-							}
+							disabled={!showProrationBehavior || !isNoChargesAllowed}
 							onCheckedChange={(checked) =>
 								handleProrationBehaviorChange(
 									checked ? "prorate_immediately" : "none",

--- a/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionAdvancedSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionAdvancedSection.tsx
@@ -6,10 +6,16 @@ import { Switch } from "@/components/ui/switch";
 import { useUpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 
 export function UpdateSubscriptionAdvancedSection() {
-	const { form, formValues } = useUpdateSubscriptionFormContext();
-	const { billingBehavior } = formValues;
+	const { form, formValues, formContext } =
+		useUpdateSubscriptionFormContext();
+	const { billingBehavior, resetBillingCycle } = formValues;
+	const { customerProduct } = formContext;
 
+	const hasActiveSubscription =
+		(customerProduct.subscription_ids?.length ?? 0) > 0;
 	const isProrate = billingBehavior !== "none";
+
+	if (!hasActiveSubscription) return null;
 
 	return (
 		<AdvancedSection>
@@ -18,9 +24,22 @@ export function UpdateSubscriptionAdvancedSection() {
 				description="Prorate price differences when changing plans mid-cycle"
 				action={
 					<Switch
-						checked={isProrate}
+						checked={isProrate && !resetBillingCycle}
+						disabled={resetBillingCycle}
 						onCheckedChange={(checked) =>
 							form.setFieldValue("billingBehavior", checked ? null : "none")
+						}
+					/>
+				}
+			/>
+			<ConfigRow
+				title="Reset Billing Cycle"
+				description="Restart the billing cycle from today"
+				action={
+					<Switch
+						checked={resetBillingCycle}
+						onCheckedChange={(checked) =>
+							form.setFieldValue("resetBillingCycle", !!checked)
 						}
 					/>
 				}

--- a/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionAdvancedSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionAdvancedSection.tsx
@@ -24,8 +24,7 @@ export function UpdateSubscriptionAdvancedSection() {
 				description="Prorate price differences when changing plans mid-cycle"
 				action={
 					<Switch
-						checked={isProrate && !resetBillingCycle}
-						disabled={resetBillingCycle}
+						checked={isProrate}
 						onCheckedChange={(checked) =>
 							form.setFieldValue("billingBehavior", checked ? null : "none")
 						}

--- a/vite/src/hooks/stores/useSubscriptionStore.ts
+++ b/vite/src/hooks/stores/useSubscriptionStore.ts
@@ -21,10 +21,6 @@ export const useEntity = () => {
 	const { customer } = useCusQuery();
 	const entities = (customer as FullCustomer)?.entities || [];
 
-	// #region agent log
-	fetch('http://127.0.0.1:7322/ingest/302190cd-01f7-494e-9c36-a1625f5cf969',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'0967f4'},body:JSON.stringify({sessionId:'0967f4',location:'useSubscriptionStore.ts:useEntity',message:'entities debug',data:{customerExists:!!customer,entitiesRaw:(customer as any)?.entities,entitiesIsArray:Array.isArray((customer as any)?.entities),entitiesLength:entities.length,entitiesNullCount:entities.filter((e:any) => e == null).length,firstFewEntities:entities.slice(0,3).map((e:any) => e == null ? 'NULL' : {id:e?.id,internal_id:e?.internal_id}),selectedEntityId},timestamp:Date.now()})}).catch(()=>{});
-	// #endregion
-
 	// Find the full entity object
 	const entity = entities.find(
 		(e: Entity) =>

--- a/vite/src/views/customers2/components/sheets/AttachProductSheetV3.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheetV3.tsx
@@ -1,7 +1,8 @@
 import type { Entity, FullCustomer } from "@autumn/shared";
-import { ArrowLeft } from "@phosphor-icons/react";
+import { ArrowLeft, PlusIcon } from "@phosphor-icons/react";
 import type { AxiosError } from "axios";
 import { format } from "date-fns";
+import { CheckIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
@@ -24,6 +25,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/v2/buttons/Button";
 import { InlinePlanEditor } from "@/components/v2/inline-custom-plan-editor/InlinePlanEditor";
 import { LineItemsPreview } from "@/components/v2/LineItemsPreview";
+import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
 import {
 	LayoutGroup,
 	SheetFooter,
@@ -38,6 +40,7 @@ import { getBackendErr } from "@/utils/genUtils";
 import { getStripeInvoiceLink } from "@/utils/linkUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerContext } from "@/views/customers2/customer/CustomerContext";
+import { CreateEntity } from "@/views/customers2/customer/components/CreateEntity";
 import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
 
 function ReviewPreviewSkeleton() {
@@ -217,13 +220,25 @@ function SheetContent() {
 	const { closeSheet } = useSheetStore();
 	const hasProductSelected = !!formValues.productId;
 
-	const { entityId } = useEntity();
+	const { entityId, setEntityId } = useEntity();
 	const { customer } = useCusQuery();
 	const fullCustomer = customer as FullCustomer | null;
 	const entities = fullCustomer?.entities || [];
 	const fullEntity = entities.find(
 		(e: Entity) => e.id === entityId || e.internal_id === entityId,
 	);
+
+	const [createEntityOpen, setCreateEntityOpen] = useState(false);
+
+	const CUSTOMER_LEVEL_VALUE = "";
+	type EntityOption = Entity | null;
+	const entityOptions: EntityOption[] = [null, ...entities];
+
+	const getEntityOptionValue = (option: EntityOption) =>
+		option === null ? CUSTOMER_LEVEL_VALUE : option.id || option.internal_id;
+
+	const getEntityOptionLabel = (option: EntityOption) =>
+		option === null ? "Customer-level" : option.name || option.id || "PENDING";
 
 	return (
 		<LayoutGroup>
@@ -238,6 +253,84 @@ function SheetContent() {
 						<SheetSection withSeparator={false} className="pb-0">
 							<div className="space-y-2">
 								<AttachProductSelection />
+
+								{entities.length > 0 && (
+									<div>
+										<div className="text-form-label block mb-1">
+											Select scope
+										</div>
+										<SearchableSelect<EntityOption>
+											value={entityId ?? CUSTOMER_LEVEL_VALUE}
+											onValueChange={(value) =>
+												setEntityId(
+													value === CUSTOMER_LEVEL_VALUE ? null : value,
+												)
+											}
+											options={entityOptions}
+											getOptionValue={getEntityOptionValue}
+											getOptionLabel={getEntityOptionLabel}
+											placeholder="Select entity"
+											searchable
+											searchPlaceholder="Search entities..."
+											emptyText="No entities found"
+											triggerClassName="w-full"
+											renderValue={(option) =>
+												option === null || option === undefined ? (
+													<span className="text-t2">Customer-level</span>
+												) : (
+													<span className="text-t2 truncate">
+														{option.name || option.id || "PENDING"}
+													</span>
+												)
+											}
+											renderOption={(option, isSelected) => {
+												if (option === null) {
+													return (
+														<>
+															<span className="text-sm">Customer-level</span>
+															{isSelected && (
+																<CheckIcon className="size-4 shrink-0" />
+															)}
+														</>
+													);
+												}
+												const entityLabel = option.id || "PENDING";
+												return (
+													<>
+														<div className="flex gap-2 items-center min-w-0 flex-1">
+															{option.name && (
+																<span className="text-sm shrink-0">
+																	{option.name}
+																</span>
+															)}
+															<span className="truncate text-t3 font-mono text-xs min-w-0">
+																{entityLabel}
+															</span>
+														</div>
+														{isSelected && (
+															<CheckIcon className="size-4 shrink-0" />
+														)}
+													</>
+												);
+											}}
+											footer={
+												<div className="border-t py-1.5 px-2">
+													<Button
+														variant="muted"
+														className="w-full"
+														onClick={() => setCreateEntityOpen(true)}
+													>
+														<PlusIcon
+															className="size-[14px] text-t2"
+															weight="regular"
+														/>
+														Create new entity
+													</Button>
+												</div>
+											}
+										/>
+									</div>
+								)}
 
 								{entityId ? (
 									<div className="pt-2">
@@ -333,6 +426,7 @@ function SheetContent() {
 					/>
 				)}
 			</div>
+			<CreateEntity open={createEntityOpen} setOpen={setCreateEntityOpen} />
 		</LayoutGroup>
 	);
 }

--- a/vite/src/views/customers2/components/table/customer-products/AttachProductSheetTrigger.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/AttachProductSheetTrigger.tsx
@@ -1,22 +1,14 @@
-import { getFeatureName } from "@autumn/shared";
 import { PlusIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/v2/buttons/Button";
-import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import {
 	useIsAttachingProduct,
 	useSheetStore,
 } from "@/hooks/stores/useSheetStore";
-import { useEntity } from "@/hooks/stores/useSubscriptionStore";
 import { cn } from "@/lib/utils";
 
 export function AttachProductSheetTrigger() {
-	const { setSheet, closeSheet } = useSheetStore();
+	const { setSheet } = useSheetStore();
 	const isAttachingProduct = useIsAttachingProduct();
-	const { entity } = useEntity();
-	const features = useFeaturesQuery();
-	const sheetType = useSheetStore((s) => s.type);
-
-	const feature = features.features.find((f) => f.id === entity?.feature_id);
 
 	const handleClick = () => {
 		setSheet({ type: "attach-product-v2" });
@@ -32,10 +24,7 @@ export function AttachProductSheetTrigger() {
 			onClick={handleClick}
 		>
 			<PlusIcon className="size-3.5" />
-			Attach Plan{" "}
-			{entity
-				? `to ${getFeatureName({ feature, plural: false, capitalize: false })}`
-				: ""}
+			Attach Plan
 		</Button>
 	);
 }


### PR DESCRIPTION
## Summary
- Removed coupling between "Prorate Changes" and "Reset Billing Cycle" toggles in the attach product sheet — they now operate independently
- Added entity scope selector to the attach product sheet, allowing users to choose between customer-level and specific entities
- Simplified `AttachProductSheetTrigger` by removing unused entity/feature logic

## Test plan
- [ ] Verify "Prorate Changes" toggle is no longer disabled when "Reset Billing Cycle" is on
- [ ] Verify entity scope selector appears when the customer has entities
- [ ] Verify attaching a plan at customer-level and entity-level both work correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples proration from end-of-cycle scheduling and adds an entity scope selector to the attach flow. Adds a Reset Billing Cycle control that forces immediate billing and disables proration for clearer, safer updates.

- **New Features**
  - Added Reset Billing Cycle toggle in attach and update sheets; when on, forces immediate schedule and disables proration and end-of-cycle.
  - Added entity scope selector with “Customer-level” or a specific entity, plus “Create new entity”.
  - Hide prorate/reset controls when no active Stripe subscription; hide advanced options for free plans.

- **Refactors**
  - Simplified `AttachProductSheetTrigger` copy and removed entity/feature coupling.
  - Removed debug fetch from `useSubscriptionStore`.

<sup>Written for commit f545f8ff0101bc8aa64826e8899c541cbb864740. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR decouples the "Prorate Changes" and "Reset Billing Cycle" toggles in the attach-product sheet (they previously shared a disabled-state dependency), and adds an entity-scope selector to the attach sheet so users can target a specific entity or the customer level. `AttachProductSheetTrigger` is also simplified by removing unused entity/feature props.

- **[Improvements]** `AttachAdvancedSection`: Prorate toggle no longer disabled when Reset Billing Cycle is on — the two controls are now independent.
- **[Improvements]** `AttachProductSheetV3` / `SheetContent`: Entity scope dropdown renders when the customer has entities, writing selection to a URL query param via the new `useEntity` hook.
- **[Improvements]** `AttachProductSheetTrigger`: Unused entity/feature logic removed, component simplified.
- **[API changes]** `useSubscriptionStore`: New `useEntity` hook introduced to sync selected entity between URL query params and component state.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/design suggestions with no functional breakage on the happy path.

The prorate decoupling is correct and the entity selector renders and wires up properly. The dual-state in `useEntity` and the two-instance render lag are design-level concerns; `AttachFormProvider` is fully reactive to `entityId` prop changes so no wrong data is submitted. All remaining comments are improvement suggestions, not blockers.

vite/src/hooks/stores/useSubscriptionStore.ts — dual-state design in `useEntity` is the most actionable improvement.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/hooks/stores/useSubscriptionStore.ts | Introduces `useEntity` hook with dual-state design: `selectedEntityId` local state shadows `entity_id` query state and is synced via `useEffect`, causing a 1-render lag on mount and unnecessary complexity. |
| vite/src/views/customers2/components/sheets/AttachProductSheetV3.tsx | Adds entity scope selector and wires `entityId` from `useEntity` into `AttachFormProvider`; has two separate `useEntity()` call sites (parent + child) where the parent's value lags by one render cycle after the child calls `setEntityId`. |
| vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx | Prorate toggle decoupled from Reset Billing Cycle — `disabled` condition no longer includes `resetBillingCycle`. Logic looks correct. |
| vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionAdvancedSection.tsx | Prorate toggle still has `disabled={resetBillingCycle}` coupling — unchanged relative to the attach form change; likely intentional, but worth confirming. |
| vite/src/views/customers2/components/table/customer-products/AttachProductSheetTrigger.tsx | Simplified correctly — unused entity/feature props removed; only opens the sheet now. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Attach Product Sheet] --> B{URL has entity_id?}
    B -- Yes --> C[useEntity: selectedEntityId = null on mount]
    B -- No --> D[useEntity: selectedEntityId = null]
    C --> E[useEffect fires → selectedEntityId = URL entity_id]
    E --> F[AttachFormProvider re-renders with correct entityId]
    D --> G[AttachFormProvider renders with entityId = undefined]
    F --> H[Select Stage]
    G --> H
    H --> I{Customer has entities?}
    I -- Yes --> J[Show scope selector dropdown]
    I -- No --> K[Skip selector]
    J --> L[User picks entity or Customer-level]
    L --> M[setEntityId called in SheetContent]
    M --> N[selectedEntityId updated in SheetContent instance]
    M --> O[entity_id URL query param updated via nuqs]
    O --> P[AttachProductSheetV3 useEntity re-renders — 1 render lag]
    P --> Q[AttachFormProvider receives new entityId prop]
    H --> R[User selects product → Preview Changes]
    R --> S[Review Stage]
    Q --> S
    S --> T[AttachAdvancedSection: Prorate & Reset Billing independent]
    S --> U[Preview API called with entityId + requestBody]
    U --> V{Confirm attach}
    V -- Invoice --> W[Open Stripe invoice]
    V -- Checkout --> X[Copy checkout URL]
    V -- Direct --> Y[Success → closeSheet]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/hooks/stores/useSubscriptionStore.ts`, line 14-45 ([link](https://github.com/useautumn/autumn/blob/4169e69e9d05e5807574864763cb09ea3f850086/vite/src/hooks/stores/useSubscriptionStore.ts#L14-L45)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unnecessary dual-state in `useEntity`**

   `selectedEntityId` is a local copy of `entity_id` (from nuqs) kept in sync via `useEffect`. This means the hook always returns `null` for `entityId` on the first render — even when the URL already has `entity_id` set — because `useState(null)` initialises before the effect runs. Every call site (including the `AttachFormProvider` parent) sees a stale `undefined` entity on mount.

   Since `entity_id` from `useQueryStates` is already synchronously available from the URL, you can use it directly and drop the shadow state entirely:

   ```ts
   export const useEntity = () => {
     const [{ entity_id }, setQueryStates] = useQueryStates({
       entity_id: parseAsString,
     });

     const { customer } = useCusQuery();
     const entities = (customer as FullCustomer)?.entities || [];

     const entity = entities.find(
       (e: Entity) =>
         e != null &&
         (e.id === entity_id || e.internal_id === entity_id),
     );

     const setEntityId = (entityId: string | null) => {
       setQueryStates({ entity_id: entityId });
     };

     return { entityId: entity_id, entity, setEntityId };
   };
   ```

   This also removes the `useEffect` whose dependency on `selectedEntityId` causes it to re-run once per sync cycle.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/hooks/stores/useSubscriptionStore.ts
   Line: 14-45

   Comment:
   **Unnecessary dual-state in `useEntity`**

   `selectedEntityId` is a local copy of `entity_id` (from nuqs) kept in sync via `useEffect`. This means the hook always returns `null` for `entityId` on the first render — even when the URL already has `entity_id` set — because `useState(null)` initialises before the effect runs. Every call site (including the `AttachFormProvider` parent) sees a stale `undefined` entity on mount.

   Since `entity_id` from `useQueryStates` is already synchronously available from the URL, you can use it directly and drop the shadow state entirely:

   ```ts
   export const useEntity = () => {
     const [{ entity_id }, setQueryStates] = useQueryStates({
       entity_id: parseAsString,
     });

     const { customer } = useCusQuery();
     const entities = (customer as FullCustomer)?.entities || [];

     const entity = entities.find(
       (e: Entity) =>
         e != null &&
         (e.id === entity_id || e.internal_id === entity_id),
     );

     const setEntityId = (entityId: string | null) => {
       setQueryStates({ entity_id: entityId });
     };

     return { entityId: entity_id, entity, setEntityId };
   };
   ```

   This also removes the `useEffect` whose dependency on `selectedEntityId` causes it to re-run once per sync cycle.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/hooks/stores/useSubscriptionStore.ts
Line: 14-45

Comment:
**Unnecessary dual-state in `useEntity`**

`selectedEntityId` is a local copy of `entity_id` (from nuqs) kept in sync via `useEffect`. This means the hook always returns `null` for `entityId` on the first render — even when the URL already has `entity_id` set — because `useState(null)` initialises before the effect runs. Every call site (including the `AttachFormProvider` parent) sees a stale `undefined` entity on mount.

Since `entity_id` from `useQueryStates` is already synchronously available from the URL, you can use it directly and drop the shadow state entirely:

```ts
export const useEntity = () => {
  const [{ entity_id }, setQueryStates] = useQueryStates({
    entity_id: parseAsString,
  });

  const { customer } = useCusQuery();
  const entities = (customer as FullCustomer)?.entities || [];

  const entity = entities.find(
    (e: Entity) =>
      e != null &&
      (e.id === entity_id || e.internal_id === entity_id),
  );

  const setEntityId = (entityId: string | null) => {
    setQueryStates({ entity_id: entityId });
  };

  return { entityId: entity_id, entity, setEntityId };
};
```

This also removes the `useEffect` whose dependency on `selectedEntityId` causes it to re-run once per sync cycle.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/AttachProductSheetV3.tsx
Line: 223-229

Comment:
**Two `useEntity()` instances create a render-lag for `AttachFormProvider`**

`AttachProductSheetV3` calls `useEntity()` to read `entityId` and passes it to `AttachFormProvider`, while `SheetContent` (a child of that provider) also calls `useEntity()` to call `setEntityId`. Because the parent's `selectedEntityId` is synchronised from the URL via `useEffect`, `AttachFormProvider` only receives the updated `entityId` one render cycle after the child's `setEntityId` fires.

`AttachFormProvider` is reactive (it re-evaluates `isFreeToPaidTransition` and the preview request body whenever `entityId` changes), so this does not cause incorrect data to be submitted. However, the lag does trigger an extra preview-API round trip with the previous entity. Consider reading `entityId` from a single shared source (e.g. lifting `useEntity` one level and passing `setEntityId` down via props or context) to keep the value consistent across both call sites without extra render cycles.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/AttachProductSheetV3.tsx
Line: 233

Comment:
**Entity selection persists in the URL across sheet sessions**

`entity_id` is written to the query string via nuqs but is never cleared when the sheet is dismissed. If a user selects an entity, closes the sheet, then re-opens it, the previously chosen entity will be pre-selected because the URL still carries `?entity_id=…`. Whether this is intentional (restore last selection) or surprising (expect a fresh sheet) should be confirmed; if not intentional, clearing the param on close (e.g. in `onSuccess` / sheet-close callback) would prevent the stale carry-over.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionAdvancedSection.tsx
Line: 26-29

Comment:
**Prorate still coupled to Reset Billing Cycle in the update-subscription form**

The attach-product sheet was decoupled by this PR, but `UpdateSubscriptionAdvancedSection` still disables the prorate toggle (`disabled={resetBillingCycle}`) when Reset Billing Cycle is on. If parity with the attach sheet is the goal, this needs the same treatment. If the coupling is intentional here (different semantics for update-subscription), a short comment explaining the distinction would prevent confusion.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Decouple prorate toggle from reset billi..."](https://github.com/useautumn/autumn/commit/4169e69e9d05e5807574864763cb09ea3f850086) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28000679)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->