### PR TITLE
feat: filter processor options by flags

### DIFF
--- a/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
@@ -7,6 +7,7 @@ import {
 	DropdownMenuSubTrigger,
 } from "@/components/v2/dropdowns/DropdownMenu";
 import { RevenueCatIcon } from "@/components/v2/icons/AutumnIcons";
+import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
 import { useCustomerFilters } from "../../hooks/useCustomerFilters";
 
 type Processor = "stripe" | "revenuecat" | "vercel";
@@ -31,7 +32,15 @@ const PROCESSORS: { value: Processor; label: string; icon: React.ReactNode }[] =
 	];
 
 export const ProcessorSubMenu = () => {
+	const flags = useAutumnFlags();
 	const { queryStates, setFilters } = useCustomerFilters();
+
+	const visibleProcessors = PROCESSORS.filter(({ value }) => {
+		if (value === "stripe") return true;
+		if (value === "revenuecat") return flags.revenuecat;
+		if (value === "vercel") return flags.vercel;
+		return false;
+	});
 
 	const selectedProcessors = queryStates.processor || [];
 	const hasSelections = selectedProcessors.length > 0;
@@ -56,7 +65,7 @@ export const ProcessorSubMenu = () => {
 				)}
 			</DropdownMenuSubTrigger>
 			<DropdownMenuSubContent>
-				{PROCESSORS.map(({ value, label, icon }) => {
+				{visibleProcessors.map(({ value, label, icon }) => {
 					const isActive = selectedProcessors.includes(value);
 					return (
 						<DropdownMenuItem


### PR DESCRIPTION
Hides RevenueCat and Vercel filter options on processor submenu based on feature flags, while keeping Stripe always visible.

- Imports `useAutumnFlags` hook
- Filters `PROCESSORS` array to conditionally show options
- Stripe always shows, RevenueCat and Vercel gated by flags

<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/pull/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/task/30fa62f5-5df3-4391-a84e-c6619061d3d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-14&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-14"><img alt="SCO-14 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-14"></picture></a>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated RevenueCat and Vercel options in the Processor filter using `useAutumnFlags`, so only enabled processors appear; Stripe is always visible. Satisfies SCO-14.

<sup>Written for commit 52e045d1fcfdde6941a63686b8c1a7f049bef383. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR gates the RevenueCat and Vercel processor filter options behind feature flags using `useAutumnFlags`, keeping Stripe always visible.

**Key changes:**
- **Improvements**: `visibleProcessors` derived array filters `PROCESSORS` by `flags.revenuecat` / `flags.vercel` before rendering checkboxes.

One P1 concern: if a processor is selected as a filter and its flag is later turned off, that value remains in `queryStates.processor` but the checkbox is no longer rendered — the filter stays silently active with no UI affordance to clear it, and the badge count becomes misleading.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the stuck-filter edge case when a flag is toggled off while a processor is selected.

One P1 finding: selected processors that become flag-hidden can't be cleared through the UI, leaving a phantom active filter. The rest of the change is straightforward and correct.

vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx — stale queryStates.processor values when flags are disabled

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx | Adds feature-flag gating to processor filter options using `useAutumnFlags`; stale selected processors can become stuck if a flag is toggled off while they are active. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProcessorSubMenu renders] --> B[useAutumnFlags returns flags]
    B --> C[Filter PROCESSORS array]
    C --> D{value === 'stripe'?}
    D -- Yes --> E[Always visible]
    D -- No --> F{value === 'revenuecat'?}
    F -- Yes --> G{flags.revenuecat?}
    G -- true --> E
    G -- false --> H[Hidden]
    F -- No --> I{value === 'vercel'?}
    I -- Yes --> J{flags.vercel?}
    J -- true --> E
    J -- false --> H
    I -- No --> H
    E --> K[Render checkbox in submenu]
    H --> L[Not rendered — but may still be in queryStates.processor]
    L --> M[⚠️ Badge count inflated, filter stuck active]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx`, line 38-55 ([link](https://github.com/useautumn/autumn/blob/52e045d1fcfdde6941a63686b8c1a7f049bef383/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx#L38-L55)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stuck filters when flag is disabled**

   If a user selects `revenuecat` or `vercel` as a processor filter, then the corresponding flag is turned off, that processor is removed from `visibleProcessors` but its value persists in `queryStates.processor`. The sub-trigger badge will show a non-zero count with no visible checkbox to deselect it — the filter is silently active with no way to clear it through this UI.

   Consider stripping flag-gated values from the active selection when they become invisible:

   ```typescript
   const visibleValues = new Set(visibleProcessors.map((p) => p.value));

   useEffect(() => {
     const stale = selectedProcessors.filter((p) => !visibleValues.has(p as Processor));
     if (stale.length > 0) {
       setFilters({ processor: selectedProcessors.filter((p) => visibleValues.has(p as Processor)) });
     }
   }, [flags.revenuecat, flags.vercel]);
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
   Line: 38-55

   Comment:
   **Stuck filters when flag is disabled**

   If a user selects `revenuecat` or `vercel` as a processor filter, then the corresponding flag is turned off, that processor is removed from `visibleProcessors` but its value persists in `queryStates.processor`. The sub-trigger badge will show a non-zero count with no visible checkbox to deselect it — the filter is silently active with no way to clear it through this UI.

   Consider stripping flag-gated values from the active selection when they become invisible:

   ```typescript
   const visibleValues = new Set(visibleProcessors.map((p) => p.value));

   useEffect(() => {
     const stale = selectedProcessors.filter((p) => !visibleValues.has(p as Processor));
     if (stale.length > 0) {
       setFilters({ processor: selectedProcessors.filter((p) => visibleValues.has(p as Processor)) });
     }
   }, [flags.revenuecat, flags.vercel]);
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx`, line 51 ([link](https://github.com/useautumn/autumn/blob/52e045d1fcfdde6941a63686b8c1a7f049bef383/vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx#L51)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Use `Processor` type instead of `string`**

   The `Processor` type is already defined in this file; using `string` here loses that type safety.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
   Line: 51

   Comment:
   **Use `Processor` type instead of `string`**

   The `Processor` type is already defined in this file; using `string` here loses that type safety.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
Line: 38-55

Comment:
**Stuck filters when flag is disabled**

If a user selects `revenuecat` or `vercel` as a processor filter, then the corresponding flag is turned off, that processor is removed from `visibleProcessors` but its value persists in `queryStates.processor`. The sub-trigger badge will show a non-zero count with no visible checkbox to deselect it — the filter is silently active with no way to clear it through this UI.

Consider stripping flag-gated values from the active selection when they become invisible:

```typescript
const visibleValues = new Set(visibleProcessors.map((p) => p.value));

useEffect(() => {
  const stale = selectedProcessors.filter((p) => !visibleValues.has(p as Processor));
  if (stale.length > 0) {
    setFilters({ processor: selectedProcessors.filter((p) => visibleValues.has(p as Processor)) });
  }
}, [flags.revenuecat, flags.vercel]);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers/components/filter-dropdown/ProcessorSubMenu.tsx
Line: 51

Comment:
**Use `Processor` type instead of `string`**

The `Processor` type is already defined in this file; using `string` here loses that type safety.

```suggestion
			? selectedProcessors.filter((p: Processor) => p !== processor)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Hide RevenueCat and Vercel processors ba..."](https://github.com/useautumn/autumn/commit/52e045d1fcfdde6941a63686b8c1a7f049bef383) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28002481)</sub>

<!-- /greptile_comment -->