### PR TITLE
fix: cus product limit2

### DIFF
--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -90,6 +90,8 @@ export class CusService {
 					orgId,
 					orgSlug: org.slug,
 				});
+
+				console.log("Cus product limit:", cusProductLimit);
 				const query = getFullCusQuery({
 					idOrInternalId,
 					orgId,
@@ -149,7 +151,10 @@ export class CusService {
 						.slice(0, 5);
 				}
 
-				if (orgId === "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF") {
+				if (
+					orgId === "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF" &&
+					idOrInternalId === "698fb72e4c5fa12c1cd11ddc"
+				) {
 					fullCus.customer_products = (
 						fullCus.customer_products as FullCusProduct[]
 					)


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit customer product trimming to only customer 698fb72e4c5fa12c1cd11ddc in org GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF, instead of applying it to all customers in that org. Adds a debug log for the computed cusProductLimit.

<sup>Written for commit 8b3941ab71ca0ce7ab32574f0cc77bfdc60f2a74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires per-org `cusProductLimit` from the `orgLimitsStore` into `getFullCusQuery` so the DB-level `LIMIT` on `customer_products` is configurable per organization. It also adds two hard-coded org-ID blocks that apply an additional in-memory sort-and-slice (to 5 products) for specific high-volume customers as an emergency performance fix.

- **Bug fixes**: Per-org customer product limit is now correctly passed to the SQL query via `getOrgCusProductLimit`, replacing a likely hard-coded default.
- **Bug fixes / Improvements**: Emergency cap for two specific orgs applied in application code to prevent oversized payloads.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge after removing the console.log on the hot path; the hard-coded org blocks are an acceptable short-term workaround.

One P1 issue: a console.log fires on every CusService.getFull call, which is the primary customer-lookup hot path — this will spam production logs at scale and should be removed before merging. The hard-coded org ID blocks are P2 (maintainability) and can be addressed in a follow-up.

server/src/internal/customers/CusService.ts — console.log on line 94 and hard-coded org blocks on lines 146–165.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/CusService.ts | Adds per-org cusProductLimit to getFullCusQuery and two hard-coded org ID blocks for emergency per-customer limits; a stray console.log on the hot path will spam production logs. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CusService.getFull()"] --> B["getOrgCusProductLimit(orgId, orgSlug)"]
    B --> C{Org config found?}
    C -- Yes --> D["Use orgConfig.maxCusProducts"]
    C -- No --> E["DEFAULT_CUS_PRODUCT_LIMIT = 15"]
    D --> F["getFullCusQuery(..., cusProductLimit)"]
    E --> F
    F --> G["SQL LIMIT cusProductLimit on customer_products CTE"]
    G --> H["executeWithHealthTracking()"]
    H --> I{Hard-coded org check}
    I -- "org_2x5sJDcxhpVDjyUSqs4khaaNnxq" --> J["Sort by customer_prices.length DESC, slice(0,5)"]
    I -- "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF + specific cusId" --> K["Sort by customer_prices.length DESC, slice(0,5) + entities.slice(0,50)"]
    I -- Other orgs --> L["Return full result"]
    J --> M["resetCustomerEntitlements()"]
    K --> M
    L --> M
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/customers/CusService.ts`, line 146-165 ([link](https://github.com/useautumn/autumn/blob/8b3941ab71ca0ce7ab32574f0cc77bfdc60f2a74/server/src/internal/customers/CusService.ts#L146-L165)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hard-coded org IDs bypass the org limits store**

   These two blocks hard-code specific org IDs directly in the service, bypassing the `orgLimitsStore` that was built precisely for this purpose. Additionally, the post-query re-sort by `customer_prices.length` is opaque — if the desired limit is 5 products, setting `maxCusProducts: 5` in the store applies it at the DB level and avoids an extra in-memory sort+slice on every fetch.

   If the sort-by-price-count ordering is intentional (not just a debug artifact), that logic should be surfaced somewhere more visible rather than buried in an org-ID `if` block.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/CusService.ts
   Line: 146-165

   Comment:
   **Hard-coded org IDs bypass the org limits store**

   These two blocks hard-code specific org IDs directly in the service, bypassing the `orgLimitsStore` that was built precisely for this purpose. Additionally, the post-query re-sort by `customer_prices.length` is opaque — if the desired limit is 5 products, setting `maxCusProducts: 5` in the store applies it at the DB level and avoids an extra in-memory sort+slice on every fetch.

   If the sort-by-price-count ordering is intentional (not just a debug artifact), that logic should be surfaced somewhere more visible rather than buried in an org-ID `if` block.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/customers/CusService.ts
Line: 94

Comment:
**Debug `console.log` left in production path**

`getFull` is the hot path called for every customer lookup. This `console.log` will fire on each invocation, flooding production logs with noise and potentially creating performance/observability issues at scale.

```suggestion
				// console.log("Cus product limit:", cusProductLimit);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/customers/CusService.ts
Line: 146-165

Comment:
**Hard-coded org IDs bypass the org limits store**

These two blocks hard-code specific org IDs directly in the service, bypassing the `orgLimitsStore` that was built precisely for this purpose. Additionally, the post-query re-sort by `customer_prices.length` is opaque — if the desired limit is 5 products, setting `maxCusProducts: 5` in the store applies it at the DB level and avoids an extra in-memory sort+slice on every fetch.

If the sort-by-price-count ordering is intentional (not just a debug artifact), that logic should be surfaced somewhere more visible rather than buried in an org-ID `if` block.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: cus product limit 2"](https://github.com/useautumn/autumn/commit/8b3941ab71ca0ce7ab32574f0cc77bfdc60f2a74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28059590)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->