### PR TITLE
feat: hydrate customer names for customer_id grouping

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -473,6 +473,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.18",
         "ag-charts-community": "^12.0.2",
+        "ag-charts-react": "^12.0.2",
         "ag-grid-community": "^34.0.2",
         "ag-grid-react": "^34.0.2",
         "ai": "^6.0.5",
@@ -2026,7 +2027,7 @@
 
     "@types/buffer-from": ["@types/buffer-from@1.1.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-2lq4YC9uLUMGHkl2IDtX4tCXSo2+hwMpOJcY1qiIk1kybc31rIlPyM1HCVJhkPFIo75a/pOVxqyvwuf5TpCG/w=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
@@ -6168,6 +6169,8 @@
 
     "@types/buffer-from/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
     "@types/cacheable-request/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/chai-http/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
@@ -7716,6 +7719,8 @@
 
     "@types/buffer-from/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "@types/cacheable-request/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@types/chai-http/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
@@ -8813,6 +8818,8 @@
     "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/server/src/internal/analytics/actions/getCustomerNames.ts
+++ b/server/src/internal/analytics/actions/getCustomerNames.ts
@@ -1,13 +1,10 @@
 import { getClickhouseClient } from "@/external/tinybird/initClickhouse.js";
+import { escapeChString } from "../clickhouseUtils.js";
 
 type CustomerNameRow = {
 	id: string;
 	name: string | null;
 };
-
-/** Escapes a string for safe use in a ClickHouse string literal (single-quoted). */
-const escapeChString = ({ value }: { value: string }): string =>
-	value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 
 /** Looks up customer names from the customers datasource by their IDs. Returns a map of id -> name (or id if name is null/empty). */
 export const getCustomerNames = async ({

--- a/server/src/internal/analytics/actions/getCustomerNames.ts
+++ b/server/src/internal/analytics/actions/getCustomerNames.ts
@@ -1,0 +1,62 @@
+import { getClickhouseClient } from "@/external/tinybird/initClickhouse.js";
+
+type CustomerNameRow = {
+	id: string;
+	name: string | null;
+};
+
+/** Escapes a string for safe use in a ClickHouse string literal (single-quoted). */
+const escapeChString = ({ value }: { value: string }): string =>
+	value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+
+/** Looks up customer names from the customers datasource by their IDs. Returns a map of id -> name (or id if name is null/empty). */
+export const getCustomerNames = async ({
+	customerIds,
+	orgId,
+	env,
+}: {
+	customerIds: string[];
+	orgId: string;
+	env: string;
+}): Promise<Record<string, string>> => {
+	if (customerIds.length === 0) return {};
+
+	const ch = getClickhouseClient();
+
+	const inList = customerIds
+		.map((id) => `'${escapeChString({ value: id })}'`)
+		.join(",");
+
+	const query = `
+		SELECT id, name
+		FROM customers FINAL
+		WHERE org_id = {org_id:String}
+			AND env = {env:String}
+			AND id IN (${inList})
+	`;
+
+	const result = await ch.query({
+		query,
+		query_params: {
+			org_id: orgId,
+			env,
+		},
+		format: "JSON",
+	});
+
+	const resultJson = (await result.json()) as { data: CustomerNameRow[] };
+
+	const nameMap: Record<string, string> = {};
+	for (const row of resultJson.data) {
+		if (!row.id) continue;
+		nameMap[row.id] = row.name || row.id;
+	}
+
+	for (const id of customerIds) {
+		if (!nameMap[id]) {
+			nameMap[id] = id;
+		}
+	}
+
+	return nameMap;
+};

--- a/server/src/internal/analytics/actions/getEntityNames.ts
+++ b/server/src/internal/analytics/actions/getEntityNames.ts
@@ -1,13 +1,10 @@
 import { getClickhouseClient } from "@/external/tinybird/initClickhouse.js";
+import { escapeChString } from "../clickhouseUtils.js";
 
 type EntityNameRow = {
 	id: string;
 	name: string;
 };
-
-/** Escapes a string for safe use in a ClickHouse string literal (single-quoted). */
-const escapeChString = ({ value }: { value: string }): string =>
-	value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 
 /** Looks up entity names from the entities datasource by their IDs. Returns a map of id -> name (or id if name is null/empty). */
 export const getEntityNames = async ({

--- a/server/src/internal/analytics/clickhouseUtils.ts
+++ b/server/src/internal/analytics/clickhouseUtils.ts
@@ -1,0 +1,6 @@
+/**
+ * Escapes a string for safe use in a ClickHouse string literal (single-quoted).
+ * Escapes backslashes and single quotes to prevent injection.
+ */
+export const escapeChString = ({ value }: { value: string }): string =>
+	value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -9,6 +9,7 @@ import { StatusCodes } from "http-status-codes";
 import { z } from "zod/v4";
 import { assertTinybirdAvailable } from "@/external/tinybird/tinybirdUtils.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { getCustomerNames } from "@/internal/analytics/actions/getCustomerNames.js";
 import { getEntityNames } from "@/internal/analytics/actions/getEntityNames.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { eventActions } from "../actions/eventActions.js";
@@ -122,6 +123,27 @@ export const handleInternalAggregateEvents = createRoute({
 			}
 		}
 
+		let customerNames: Record<string, string> | undefined;
+		if (group_by === "customer_id" && events?.data) {
+			const customerIds = [
+				...new Set(
+					events.data
+						.map((row: Record<string, unknown>) => row.customer_id as string)
+						.filter(
+							(id: string) => id && id !== "AUTUMN_RESERVED" && id !== "",
+						),
+				),
+			];
+
+			if (customerIds.length > 0) {
+				customerNames = await getCustomerNames({
+					customerIds,
+					orgId: org.id,
+					env,
+				});
+			}
+		}
+
 		return c.json({
 			customer,
 			events,
@@ -130,6 +152,7 @@ export const handleInternalAggregateEvents = createRoute({
 			bcExclusionFlag,
 			truncated,
 			entityNames,
+			customerNames,
 		});
-	},
-});
+		},
+	});

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -154,5 +154,5 @@ export const handleInternalAggregateEvents = createRoute({
 			entityNames,
 			customerNames,
 		});
-		},
-	});
+	},
+});

--- a/vite/package.json
+++ b/vite/package.json
@@ -50,6 +50,7 @@
 		"@tanstack/react-table": "^8.21.3",
 		"@tanstack/react-virtual": "^3.13.18",
 		"ag-charts-community": "^12.0.2",
+		"ag-charts-react": "^12.0.2",
 		"ag-grid-community": "^34.0.2",
 		"ag-grid-react": "^34.0.2",
 		"ai": "^6.0.5",

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -136,18 +136,18 @@ export const AnalyticsView = () => {
 			groupBy,
 		});
 
-			// Generate chart config with different colors per group
-			const config = generateChartConfig({
-				events: transformed,
-				features,
-				groupBy,
-				originalColors: colors,
-				entityNames,
-				customerNames,
-			});
+		// Generate chart config with different colors per group
+		const config = generateChartConfig({
+			events: transformed,
+			features,
+			groupBy,
+			originalColors: colors,
+			entityNames,
+			customerNames,
+		});
 
-			return { chartData: transformed, chartConfig: config };
-		}, [events, features, groupBy, groupFilter, entityNames, customerNames]);
+		return { chartData: transformed, chartConfig: config };
+	}, [events, features, groupBy, groupFilter, entityNames, customerNames]);
 
 	useEffect(() => {
 		if (
@@ -213,13 +213,13 @@ export const AnalyticsView = () => {
 				totalRows,
 				setTotalRows,
 				propertyKeys,
-					groupFilter,
-					setGroupFilter,
-					availableGroupValues,
-					entityNames,
-					customerNames,
-				}}
-			>
+				groupFilter,
+				setGroupFilter,
+				availableGroupValues,
+				entityNames,
+				customerNames,
+			}}
+		>
 			<div className="flex flex-col gap-4 h-full relative w-full text-sm pb-8 max-w-5xl mx-auto px-4 sm:px-10 pt-4 sm:pt-8">
 				<OnboardingGuide />
 				{showRevenueMetrics && <RevenueMetricsSection />}

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -53,6 +53,7 @@ export const AnalyticsView = () => {
 		groupBy,
 		truncated,
 		entityNames,
+		customerNames,
 	} = useAnalyticsData({ hasCleared });
 
 	// Show toast when data is truncated due to too many unique group values
@@ -135,17 +136,18 @@ export const AnalyticsView = () => {
 			groupBy,
 		});
 
-		// Generate chart config with different colors per group
-		const config = generateChartConfig({
-			events: transformed,
-			features,
-			groupBy,
-			originalColors: colors,
-			entityNames,
-		});
+			// Generate chart config with different colors per group
+			const config = generateChartConfig({
+				events: transformed,
+				features,
+				groupBy,
+				originalColors: colors,
+				entityNames,
+				customerNames,
+			});
 
-		return { chartData: transformed, chartConfig: config };
-	}, [events, features, groupBy, groupFilter, entityNames]);
+			return { chartData: transformed, chartConfig: config };
+		}, [events, features, groupBy, groupFilter, entityNames, customerNames]);
 
 	useEffect(() => {
 		if (
@@ -211,12 +213,13 @@ export const AnalyticsView = () => {
 				totalRows,
 				setTotalRows,
 				propertyKeys,
-				groupFilter,
-				setGroupFilter,
-				availableGroupValues,
-				entityNames,
-			}}
-		>
+					groupFilter,
+					setGroupFilter,
+					availableGroupValues,
+					entityNames,
+					customerNames,
+				}}
+			>
 			<div className="flex flex-col gap-4 h-full relative w-full text-sm pb-8 max-w-5xl mx-auto px-4 sm:px-10 pt-4 sm:pt-8">
 				<OnboardingGuide />
 				{showRevenueMetrics && <RevenueMetricsSection />}

--- a/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
@@ -30,8 +30,13 @@ export const SelectGroupByDropdown = ({
 	const navigate = useNavigate();
 	const location = useLocation();
 
-	const { groupFilter, setGroupFilter, availableGroupValues, entityNames } =
-		useAnalyticsContext();
+	const {
+		groupFilter,
+		setGroupFilter,
+		availableGroupValues,
+		entityNames,
+		customerNames,
+	} = useAnalyticsContext();
 
 	const currentGroupBy = searchParams.get("group_by") || "";
 	const customerId = searchParams.get("customer_id");
@@ -231,33 +236,37 @@ export const SelectGroupByDropdown = ({
 							<DropdownMenuLabel className="text-xs text-t4 font-normal">
 								Filter by value
 							</DropdownMenuLabel>
-							<DropdownMenuItem
-								onClick={() => setGroupFilter(null)}
-								className="flex items-center justify-between"
-							>
-								<span className="text-xs">All values</span>
-								{!groupFilter && <Check className="ml-2 h-3 w-3 text-t3" />}
-							</DropdownMenuItem>
-							{availableGroupValues.map((value: string) => {
-								const displayValue =
-									value === "AUTUMN_RESERVED"
-										? "Other values"
-										: (entityNames?.[value] ?? value);
-								return (
-									<DropdownMenuItem
-										key={value}
-										onClick={() => setGroupFilter(value)}
-										className="flex items-center justify-between"
-									>
-										<span className="text-xs font-mono truncate max-w-[150px]">
-											{displayValue}
-										</span>
-										{groupFilter === value && (
-											<Check className="ml-2 h-3 w-3 text-t3 shrink-0" />
-										)}
-									</DropdownMenuItem>
-								);
-							})}
+								<DropdownMenuItem
+									onClick={() => setGroupFilter(null)}
+									className="flex items-center justify-between"
+								>
+									<span className="text-xs">All values</span>
+									{!groupFilter && <Check className="ml-2 h-3 w-3 text-t3" />}
+								</DropdownMenuItem>
+								{availableGroupValues.map((value: string) => {
+									const displayValue =
+										value === "AUTUMN_RESERVED"
+											? "Other values"
+											: currentGroupBy === "entity_id"
+												? (entityNames?.[value] ?? value)
+												: currentGroupBy === "customer_id"
+													? (customerNames?.[value] ?? value)
+													: value;
+									return (
+										<DropdownMenuItem
+											key={value}
+											onClick={() => setGroupFilter(value)}
+											className="flex items-center justify-between"
+										>
+											<span className="text-xs font-mono truncate max-w-[150px]">
+												{displayValue}
+											</span>
+											{groupFilter === value && (
+												<Check className="ml-2 h-3 w-3 text-t3 shrink-0" />
+											)}
+										</DropdownMenuItem>
+									);
+								})}
 						</>
 					)}
 				</div>

--- a/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
@@ -236,37 +236,37 @@ export const SelectGroupByDropdown = ({
 							<DropdownMenuLabel className="text-xs text-t4 font-normal">
 								Filter by value
 							</DropdownMenuLabel>
-								<DropdownMenuItem
-									onClick={() => setGroupFilter(null)}
-									className="flex items-center justify-between"
-								>
-									<span className="text-xs">All values</span>
-									{!groupFilter && <Check className="ml-2 h-3 w-3 text-t3" />}
-								</DropdownMenuItem>
-								{availableGroupValues.map((value: string) => {
-									const displayValue =
-										value === "AUTUMN_RESERVED"
-											? "Other values"
-											: currentGroupBy === "entity_id"
-												? (entityNames?.[value] ?? value)
-												: currentGroupBy === "customer_id"
-													? (customerNames?.[value] ?? value)
-													: value;
-									return (
-										<DropdownMenuItem
-											key={value}
-											onClick={() => setGroupFilter(value)}
-											className="flex items-center justify-between"
-										>
-											<span className="text-xs font-mono truncate max-w-[150px]">
-												{displayValue}
-											</span>
-											{groupFilter === value && (
-												<Check className="ml-2 h-3 w-3 text-t3 shrink-0" />
-											)}
-										</DropdownMenuItem>
-									);
-								})}
+							<DropdownMenuItem
+								onClick={() => setGroupFilter(null)}
+								className="flex items-center justify-between"
+							>
+								<span className="text-xs">All values</span>
+								{!groupFilter && <Check className="ml-2 h-3 w-3 text-t3" />}
+							</DropdownMenuItem>
+							{availableGroupValues.map((value: string) => {
+								const displayValue =
+									value === "AUTUMN_RESERVED"
+										? "Other values"
+										: currentGroupBy === "entity_id"
+											? (entityNames?.[value] ?? value)
+											: currentGroupBy === "customer_id"
+												? (customerNames?.[value] ?? value)
+												: value;
+								return (
+									<DropdownMenuItem
+										key={value}
+										onClick={() => setGroupFilter(value)}
+										className="flex items-center justify-between"
+									>
+										<span className="text-xs font-mono truncate max-w-[150px]">
+											{displayValue}
+										</span>
+										{groupFilter === value && (
+											<Check className="ml-2 h-3 w-3 text-t3 shrink-0" />
+										)}
+									</DropdownMenuItem>
+								);
+							})}
 						</>
 					)}
 				</div>

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -99,8 +99,7 @@ export const useAnalyticsData = ({
 		groupBy,
 		truncated: data?.truncated ?? false,
 		entityNames: (data?.entityNames as Record<string, string>) ?? undefined,
-		customerNames:
-			(data?.customerNames as Record<string, string>) ?? undefined,
+		customerNames: (data?.customerNames as Record<string, string>) ?? undefined,
 	};
 };
 

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -99,6 +99,8 @@ export const useAnalyticsData = ({
 		groupBy,
 		truncated: data?.truncated ?? false,
 		entityNames: (data?.entityNames as Record<string, string>) ?? undefined,
+		customerNames:
+			(data?.customerNames as Record<string, string>) ?? undefined,
 	};
 };
 

--- a/vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts
+++ b/vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts
@@ -177,12 +177,14 @@ export function generateChartConfig({
 	groupBy,
 	originalColors,
 	entityNames,
+	customerNames,
 }: {
 	events: EventsData;
 	features: Feature[];
 	groupBy: string | null;
 	originalColors: string[];
 	entityNames?: Record<string, string>;
+	customerNames?: Record<string, string>;
 }): ChartSeriesConfig[] {
 	const colorsToUse = groupBy ? CHART_COLORS : originalColors;
 
@@ -214,15 +216,17 @@ export function generateChartConfig({
 		const featureKey = parts.slice(0, -1).join("__"); // Handle feature names with underscores
 		const groupValue = parts[parts.length - 1];
 
-		const featureName = getFeatureName({ key: featureKey, features });
-		let displayGroupValue: string;
-		if (groupValue === "AUTUMN_RESERVED") {
-			displayGroupValue = "Other values";
-		} else if (entityNames?.[groupValue]) {
-			displayGroupValue = entityNames[groupValue];
-		} else {
-			displayGroupValue = groupValue;
-		}
+			const featureName = getFeatureName({ key: featureKey, features });
+			let displayGroupValue: string;
+			if (groupValue === "AUTUMN_RESERVED") {
+				displayGroupValue = "Other values";
+			} else if (groupBy === "entity_id" && entityNames?.[groupValue]) {
+				displayGroupValue = entityNames[groupValue];
+			} else if (groupBy === "customer_id" && customerNames?.[groupValue]) {
+				displayGroupValue = customerNames[groupValue];
+			} else {
+				displayGroupValue = groupValue;
+			}
 
 		config.push({
 			xKey: "period",

--- a/vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts
+++ b/vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts
@@ -216,17 +216,17 @@ export function generateChartConfig({
 		const featureKey = parts.slice(0, -1).join("__"); // Handle feature names with underscores
 		const groupValue = parts[parts.length - 1];
 
-			const featureName = getFeatureName({ key: featureKey, features });
-			let displayGroupValue: string;
-			if (groupValue === "AUTUMN_RESERVED") {
-				displayGroupValue = "Other values";
-			} else if (groupBy === "entity_id" && entityNames?.[groupValue]) {
-				displayGroupValue = entityNames[groupValue];
-			} else if (groupBy === "customer_id" && customerNames?.[groupValue]) {
-				displayGroupValue = customerNames[groupValue];
-			} else {
-				displayGroupValue = groupValue;
-			}
+		const featureName = getFeatureName({ key: featureKey, features });
+		let displayGroupValue: string;
+		if (groupValue === "AUTUMN_RESERVED") {
+			displayGroupValue = "Other values";
+		} else if (groupBy === "entity_id" && entityNames?.[groupValue]) {
+			displayGroupValue = entityNames[groupValue];
+		} else if (groupBy === "customer_id" && customerNames?.[groupValue]) {
+			displayGroupValue = customerNames[groupValue];
+		} else {
+			displayGroupValue = groupValue;
+		}
 
 		config.push({
 			xKey: "period",

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -25,8 +25,13 @@ export default defineConfig({
 	],
 
 	resolve: {
+		dedupe: ["react", "react-dom"],
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
+
+			// Force all packages to use the same React version
+			react: path.resolve(__dirname, "./node_modules/react"),
+			"react-dom": path.resolve(__dirname, "./node_modules/react-dom"),
 
 			// Workspace packages
 			"autumn-js/react": path.resolve(


### PR DESCRIPTION
## Summary
Implements customer name hydration for internal analytics when grouping by `customer_id`, mirroring the existing `entity_id` pattern as closely as possible. Adds a parallel lookup path that queries `customers FINAL` and returns a `customerNames` map for the frontend to display in place of raw customer IDs.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Changes Made

### Backend
- Created `getCustomerNames` helper alongside `getEntityNames` that queries `customers FINAL` by external customer `id`, filtered by `org_id` and `env`
- Uses same ClickHouse literal escaping pattern (`'${escapeChString({ value })}'`) and empty-array fast return as entity implementation
- Falls back to raw `id` when name is null/empty or customer not found
- Added parallel hydration block in `handleInternalAggregateEvents` for `group_by === "customer_id"` that extracts unique IDs, filters out `AUTUMN_RESERVED` and empty strings, and populates `customerNames`
- Extended API response to include `customerNames` alongside existing `entityNames` field

### Frontend
- Updated `useAnalyticsData` to read and return `customerNames` from the response
- Extended `AnalyticsContext` and analytics view to pass `customerNames` through to chart configuration
- Modified `generateChartConfig` to accept `customerNames?: Record<string, string>` parameter
- Updated display label logic to prefer customer names when `groupBy === "customer_id"`, while preserving existing `entity_id` behavior and `AUTUMN_RESERVED` → "Other values" display
- Updated `SelectGroupByDropdown` filter section to mirror the same naming logic for customer groups

## Test plan
- [ ] Verify grouping by `entity_id` still works exactly as before
- [ ] Verify grouping by `customer_id` shows customer names in chart legend when available
- [ ] Verify customer name appears in "Filter by value" dropdown when grouping by `customer_id`
- [ ] Verify missing or unnamed customers fall back to raw ID display
- [ ] Verify `AUTUMN_RESERVED` still displays as "Other values"

<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/pull/1221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/task/30a0b467-522e-4728-87e7-33538dbe4003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=SCO-13&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=SCO-13"><img alt="SCO-13 · 5.4-Fast" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4-fast&task=SCO-13"></picture></a>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show customer names in analytics when grouping by `customer_id`, hydrating from ClickHouse and displaying them in charts and filters. Addresses SCO-13 and fixes AG Charts React rendering by deduping/aliasing `react`/`react-dom` and adding `ag-charts-react`.

- **New Features**
  - Backend: added `getCustomerNames` to query `customers FINAL` by org/env and IDs, exclude `AUTUMN_RESERVED`/empty IDs, fall back to ID, and return `customerNames` in the aggregate events response.
  - Frontend: threaded `customerNames` through `useAnalyticsData` → context → `generateChartConfig` and group-by dropdown; labels prefer names for `customer_id` while preserving `entity_id` and "Other values".

- **Bug Fixes**
  - Fixed hydration runtime error by passing `customerNames` into chart config and `SelectGroupByDropdown`.
  - Resolved AG Charts React issues by adding `ag-charts-react` and deduping/aliasing `react`/`react-dom` in `vite` config.
  - Extracted `escapeChString` to `clickhouseUtils` to remove duplication and keep escaping logic consistent.

<sup>Written for commit 1158c4fbe3aa8d8c0a3d956c6d9e1990e902b49f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds customer name hydration for analytics grouped by `customer_id`, mirroring the existing `entity_id` pattern. A new `getCustomerNames` ClickHouse helper is introduced server-side, and `customerNames` is threaded through the frontend hook → context → chart config and filter dropdown.

**Key changes:**
- [Improvements] `getCustomerNames` helper queries `customers FINAL` and returns an `id → name` map, with fallback to raw ID when name is absent — parallel to `getEntityNames`.
- [API changes] `handleInternalAggregateEvents` response extended with `customerNames` field when `group_by === \"customer_id\"`.
- [Improvements] Frontend display label logic in `generateChartConfig` and `SelectGroupByDropdown` updated to prefer customer names for `customer_id` grouping.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/formatting issues with no functional impact.

The feature logic is sound and mirrors the existing entity_id pattern correctly. All remaining comments are indentation inconsistencies and a minor code-duplication note, none of which affect runtime behaviour.

Indentation clean-up is spread across handleInternalAggregateEvents.ts, AnalyticsView.tsx, and SelectGroupByDropdown.tsx.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/getCustomerNames.ts | New helper that queries ClickHouse `customers FINAL` to resolve customer names; mirrors `getEntityNames` well but duplicates the private `escapeChString` utility. |
| server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts | Adds parallel `customerNames` hydration block and extends the JSON response; logic is correct but closing braces were accidentally over-indented. |
| vite/src/views/customers/customer/analytics/AnalyticsView.tsx | Threads `customerNames` from hook through context and into `generateChartConfig`; functional but introduces inconsistent indentation in `useMemo` and context value blocks. |
| vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx | Adds `customerNames` lookup to the filter-by-value dropdown with the same conditional display logic; indentation of the dropdown items block is off by one level. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | Straightforward: reads `customerNames` from the API response and returns it alongside the existing fields. |
| vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts | Extends `generateChartConfig` to accept `customerNames` and uses it for `customer_id` grouping; display logic is correct and mirrors the `entity_id` branch cleanly. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx`, line 239-275 ([link](https://github.com/useautumn/autumn/blob/0da90e5b5c33707d94763f8140d7b9f8144a8c06/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx#L239-L275)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Over-indented dropdown items**

   The `DropdownMenuItem` block and the `availableGroupValues.map(...)` call were each indented one additional level compared to the `DropdownMenuLabel` sibling element directly above them. They should sit at the same indent depth as the label.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
   Line: 239-275

   Comment:
   **Over-indented dropdown items**

   The `DropdownMenuItem` block and the `availableGroupValues.map(...)` call were each indented one additional level compared to the `DropdownMenuLabel` sibling element directly above them. They should sit at the same indent depth as the label.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/analytics/actions/getCustomerNames.ts
Line: 8-10

Comment:
**Duplicated `escapeChString` utility**

`escapeChString` is defined identically in both `getCustomerNames.ts` and `getEntityNames.ts`. It should be extracted to a shared analytics utility (e.g., `clickhouseUtils.ts`) and imported from there to avoid drift if the escaping logic ever needs to change.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
Line: 157-158

Comment:
**Incorrect closing-brace indentation**

The `},` / `});` that close the `handler` property and the `createRoute` call were shifted by one extra tab level. The original indentation was correct; the new version is over-indented.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers/customer/analytics/AnalyticsView.tsx
Line: 139-150

Comment:
**Extra indentation level in `useMemo` body**

The `generateChartConfig` call and its `return` statement were indented one extra level relative to the rest of the `useMemo` callback. This is inconsistent with the surrounding code and was likely an accidental paste-offset.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers/customer/analytics/AnalyticsView.tsx
Line: 216-221

Comment:
**Over-indented context value properties**

The `groupFilter`, `setGroupFilter`, `availableGroupValues`, `entityNames`, and `customerNames` props gained an extra indentation level relative to the rest of the `AnalyticsContext.Provider` value object.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
Line: 239-275

Comment:
**Over-indented dropdown items**

The `DropdownMenuItem` block and the `availableGroupValues.map(...)` call were each indented one additional level compared to the `DropdownMenuLabel` sibling element directly above them. They should sit at the same indent depth as the label.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Hydrate customer names when grouping ana..."](https://github.com/useautumn/autumn/commit/0da90e5b5c33707d94763f8140d7b9f8144a8c06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28105270)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->