### PR TITLE
Fix RevenueCat customer filtering and badge

### DIFF
--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -71,7 +71,7 @@ export class CusBatchService {
 		const withEntities = expand.includes(CustomerExpand.Entities);
 		const withTrialsUsed = expand.includes(CustomerExpand.TrialsUsed);
 
-		const { limit, offset, plans, subscription_status, search } = query;
+		const { limit, offset, plans, subscription_status, search, processors } = query;
 
 		const cusProductLimit = getOrgCusProductLimit({
 			orgId: ctx.org.id,
@@ -91,6 +91,7 @@ export class CusBatchService {
 			offset,
 			search,
 			plans,
+			processors,
 			cusProductLimit,
 		});
 		const results = await ctx.db.execute(sqlQuery);

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -60,6 +60,33 @@ interface SearchFilters {
 }
 
 export class CusSearchService {
+	private static getProcessorFilterSql({
+		customerTableAlias = customers,
+	}: {
+		customerTableAlias?: typeof customers;
+	}) {
+		return ({ proc }: { proc: string }) => {
+			if (proc === "stripe") {
+				return sql`(${customerTableAlias.processor}->>'id' IS NOT NULL)`;
+			}
+
+			if (proc === "revenuecat") {
+				return sql`EXISTS (
+					SELECT 1
+					FROM customer_products cp_processor
+					WHERE cp_processor.internal_customer_id = ${customerTableAlias.internal_id}
+						AND cp_processor.processor->>'type' = 'revenuecat'
+				)`;
+			}
+
+			if (proc === "vercel") {
+				return sql`(${customerTableAlias.processors}->>'vercel' IS NOT NULL)`;
+			}
+
+			return undefined;
+		};
+	}
+
 	static async searchByProduct({
 		db,
 		orgId,
@@ -234,15 +261,9 @@ export class CusSearchService {
 			filters.processor?.length
 				? or(
 						...filters.processor
-							.map((proc) => {
-								if (proc === "stripe")
-									return sql`(${customers.processor}->>'id' IS NOT NULL)`;
-								if (proc === "revenuecat")
-									return sql`(${customers.processors}->>'revenuecat' IS NOT NULL)`;
-								if (proc === "vercel")
-									return sql`(${customers.processors}->>'vercel' IS NOT NULL)`;
-								return undefined;
-							})
+							.map((proc) =>
+								CusSearchService.getProcessorFilterSql({})({ proc }),
+							)
 							.filter((c): c is NonNullable<typeof c> => c !== undefined),
 					)
 				: undefined,
@@ -435,15 +456,9 @@ export class CusSearchService {
 			filters?.processor?.length
 				? or(
 						...filters.processor
-							.map((proc) => {
-								if (proc === "stripe")
-									return sql`(${customers.processor}->>'id' IS NOT NULL)`;
-								if (proc === "revenuecat")
-									return sql`(${customers.processors}->>'revenuecat' IS NOT NULL)`;
-								if (proc === "vercel")
-									return sql`(${customers.processors}->>'vercel' IS NOT NULL)`;
-								return undefined;
-							})
+							.map((proc) =>
+								CusSearchService.getProcessorFilterSql({})({ proc }),
+							)
 							.filter((c): c is NonNullable<typeof c> => c !== undefined),
 					)
 				: undefined,
@@ -610,15 +625,9 @@ export class CusSearchService {
 			filters?.processor?.length
 				? or(
 						...filters.processor
-							.map((proc) => {
-								if (proc === "stripe")
-									return sql`(${customers.processor}->>'id' IS NOT NULL)`;
-								if (proc === "revenuecat")
-									return sql`(${customers.processors}->>'revenuecat' IS NOT NULL)`;
-								if (proc === "vercel")
-									return sql`(${customers.processors}->>'vercel' IS NOT NULL)`;
-								return undefined;
-							})
+							.map((proc) =>
+								CusSearchService.getProcessorFilterSql({})({ proc }),
+							)
 							.filter((c): c is NonNullable<typeof c> => c !== undefined),
 					)
 				: undefined,

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -343,7 +343,12 @@ export class CusService {
 							if (proc === "stripe")
 								return sql`(${customers.processor}->>'id' IS NOT NULL)`;
 							if (proc === "revenuecat")
-								return sql`(${customers.processors}->>'revenuecat' IS NOT NULL)`;
+								return sql`EXISTS (
+									SELECT 1
+									FROM customer_products cp_processor
+									WHERE cp_processor.internal_customer_id = ${customers.internal_id}
+										AND cp_processor.processor->>'type' = 'revenuecat'
+								)`;
 							if (proc === "vercel")
 								return sql`(${customers.processors}->>'vercel' IS NOT NULL)`;
 							return undefined;

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -850,7 +850,12 @@ export const getCustomerListFilterSql = ({
 			.map((proc) => {
 				if (proc === "stripe") return sql`(c.processor->>'id' IS NOT NULL)`;
 				if (proc === "revenuecat")
-					return sql`(c.processors->>'revenuecat' IS NOT NULL)`;
+					return sql`EXISTS (
+						SELECT 1
+						FROM customer_products cp_processor
+						WHERE cp_processor.internal_customer_id = c.internal_id
+							AND cp_processor.processor->>'type' = 'revenuecat'
+					)`;
 				if (proc === "vercel")
 					return sql`(c.processors->>'vercel' IS NOT NULL)`;
 				return null;

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { AppEnv } from "@autumn/shared";
+import { AppEnv, ProcessorType } from "@autumn/shared";
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router";
+import { RevenueCatIcon } from "@/components/v2/icons/AutumnIcons";
 import {
 	Tooltip,
 	TooltipContent,
@@ -67,6 +68,10 @@ export default function CustomerView2() {
 			</ErrorScreen>
 		);
 	}
+
+	const isRevenueCatCustomer = customer.customer_products.some(
+		(cp) => cp.processor?.type === ProcessorType.RevenueCat,
+	);
 
 	return (
 		<CustomerContext.Provider
@@ -132,6 +137,20 @@ export default function CustomerView2() {
 														</TooltipTrigger>
 														<TooltipContent>
 															<span>Vercel Marketplace Customer</span>
+														</TooltipContent>
+													</Tooltip>
+												</TooltipProvider>
+											)}
+											{isRevenueCatCustomer && (
+												<TooltipProvider>
+													<Tooltip delayDuration={0}>
+														<TooltipTrigger>
+															<span className="text-[#ff5f45] dark:text-[#ff8b78]">
+																<RevenueCatIcon size={12} />
+															</span>
+														</TooltipTrigger>
+														<TooltipContent>
+															<span>RevenueCat Customer</span>
 														</TooltipContent>
 													</Tooltip>
 												</TooltipProvider>


### PR DESCRIPTION
## Summary
- fix RevenueCat customer filtering to detect customers via `customer_products.processor.type = revenuecat`
- pass processor filters through the v2 customer list query path
- add a RevenueCat badge to `CustomerView2`

## Verification
- bunx biome check server/src/internal/customers
- bunx biome check vite/src/views/customers2/customer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RevenueCat customer detection by checking `customer_products.processor.type = 'revenuecat'` and pipes processor filters through the v2 customer list. Adds a RevenueCat badge in the customer view.

- **Bug Fixes**
  - Detect RevenueCat via an EXISTS check on `customer_products` instead of `customers.processors`.
  - Pass `processors` filters through the v2 list/search path and centralize processor filter SQL.

- **New Features**
  - Show a RevenueCat badge in the customer header when applicable.

<sup>Written for commit ae91bc36081a9a117e9967735b7bb05a34f8ea17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes RevenueCat customer filtering by replacing the old `c.processors->>'revenuecat'` JSONB column check with a correct EXISTS subquery on `customer_products.processor->>'type'`, threads the `processors` param through the v2 customer list query path (`CusBatchService.getPage` → `getPaginatedFullCusQuery` → `getCustomerListFilterSql`), and adds a RevenueCat badge to `CustomerView2`.

- **Bug fixes**: `getCustomerListFilterSql` and `CusSearchService.getProcessorFilterSql` now correctly detect RevenueCat customers via `customer_products`
- **Bug fixes**: `processors` filter is now properly forwarded through the v2 paginated list path
- **Improvements**: RevenueCat badge added to `CustomerView2` alongside the existing Vercel badge
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the stale revenuecat filter in the searchByNone count query and removing the debug console.log.

One P1 finding: the count query in CusSearchService.searchByNone still uses the old incorrect revenuecat filter, causing wrong pagination counts for the 'no active products' + revenuecat filter combination. Additionally a leftover console.log was added in this PR.

server/src/internal/customers/CusSearchService.ts (count query in searchByNone), server/src/internal/customers/CusService.ts (debug log)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/CusSearchService.ts | Updated `getProcessorFilterSql` to use EXISTS subquery for RevenueCat detection; main query paths are correct, but `searchByNone` count query still uses the old stale `c.processors->>'revenuecat'` check. |
| server/src/internal/customers/CusBatchService.ts | Added `processors` to destructuring in `getPage()` and passes it through to `getPaginatedFullCusQuery` — looks correct. |
| server/src/internal/customers/getFullCusQuery.ts | Added `processors` param to `getPaginatedFullCusQuery`; `getCustomerListFilterSql` now correctly uses an EXISTS subquery on `customer_products` for RevenueCat detection. |
| server/src/internal/customers/CusService.ts | Only change is an added `console.log` debug statement on line 94 that should be removed before merging. |
| vite/src/views/customers2/customer/CustomerView2.tsx | Added RevenueCat badge using `customer_products` processor type check; consistent with the existing Vercel badge pattern. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["API: GET /customers?processors=revenuecat"] --> B[CusBatchService.getPage]
    B --> C["getPaginatedFullCusQuery\nNEW: passes processors param"]
    C --> D["getCustomerListFilterSql\nNEW: EXISTS on customer_products"]
    D --> E{proc === revenuecat?}
    E -->|NEW| F["EXISTS SELECT 1 FROM customer_products\nWHERE processor->>'type' = 'revenuecat'"]
    E -->|OLD - broken| G["c.processors->>'revenuecat' IS NOT NULL"]
    F --> H[Correct results]
    G --> I[Empty / wrong results]

    J[CusSearchService.searchByNone] --> K["Main query via getProcessorFilterSql\nNEW: correct EXISTS"]
    J --> L["Count query - STILL OLD logic\nc.processors->>'revenuecat'"]
    K --> M[Correct rows]
    L --> N[Wrong count / broken pagination]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/customers/CusSearchService.ts`, line 506-521 ([link](https://github.com/useautumn/autumn/blob/ae91bc36081a9a117e9967735b7bb05a34f8ea17/server/src/internal/customers/CusSearchService.ts#L506-L521)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale revenuecat filter in `searchByNone` count query**

   The count subquery in `searchByNone` still uses the old `c.processors->>'revenuecat' IS NOT NULL` logic instead of the EXISTS subquery introduced in `getProcessorFilterSql`. When a user filters by `revenuecat` on customers with no active products, the count returned will not match the actual results, breaking pagination.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/CusSearchService.ts
   Line: 506-521

   Comment:
   **Stale revenuecat filter in `searchByNone` count query**

   The count subquery in `searchByNone` still uses the old `c.processors->>'revenuecat' IS NOT NULL` logic instead of the EXISTS subquery introduced in `getProcessorFilterSql`. When a user filters by `revenuecat` on customers with no active products, the count returned will not match the actual results, breaking pagination.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/customers/CusService.ts`, line 94 ([link](https://github.com/useautumn/autumn/blob/ae91bc36081a9a117e9967735b7bb05a34f8ea17/server/src/internal/customers/CusService.ts#L94)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Debug `console.log` left in production**

   This statement was added as part of this PR and will produce noise in production logs for every `getFull` call.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/CusService.ts
   Line: 94

   Comment:
   **Debug `console.log` left in production**

   This statement was added as part of this PR and will produce noise in production logs for every `getFull` call.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/customers/CusSearchService.ts
Line: 506-521

Comment:
**Stale revenuecat filter in `searchByNone` count query**

The count subquery in `searchByNone` still uses the old `c.processors->>'revenuecat' IS NOT NULL` logic instead of the EXISTS subquery introduced in `getProcessorFilterSql`. When a user filters by `revenuecat` on customers with no active products, the count returned will not match the actual results, breaking pagination.

```suggestion
							filters?.processor?.length
								? or(
										...filters.processor
											.map((proc) =>
												CusSearchService.getProcessorFilterSql({})({ proc }),
											)
											.filter((c): c is NonNullable<typeof c> => c !== undefined),
									)
								: undefined,
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/customers/CusService.ts
Line: 94

Comment:
**Debug `console.log` left in production**

This statement was added as part of this PR and will produce noise in production logs for every `getFull` call.

```suggestion

```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add RevenueCat customer badge"](https://github.com/useautumn/autumn/commit/ae91bc36081a9a117e9967735b7bb05a34f8ea17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28105774)</sub>

<!-- /greptile_comment -->