### PR TITLE
fix: auto topup trigger

### DIFF
--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -528,6 +528,25 @@ export class AutumnInt {
 			return data;
 		},
 
+		/** Uses the RPC route POST /customers.update (handleUpdateCustomerV2) */
+		updateRpc: async (
+			customerId: string,
+			updates: {
+				new_customer_id?: string;
+				name?: string;
+				email?: string;
+				send_email_receipts?: boolean;
+				metadata?: Record<string, unknown>;
+				billing_controls?: CustomerBillingControlsParams;
+			},
+		) => {
+			const data = await this.post(`/customers.update`, {
+				customer_id: customerId,
+				...updates,
+			});
+			return data;
+		},
+
 		setBalance: async ({
 			customerId,
 			balances,

--- a/server/src/honoMiddlewares/analyticsMiddleware.ts
+++ b/server/src/honoMiddlewares/analyticsMiddleware.ts
@@ -33,7 +33,10 @@ const extractCustomerIdFromBody = ({
 	method: string;
 }): string | undefined => {
 	const isCreateCustomerPath =
-		(path.startsWith("/v1/customers") && method === "POST" && !path.includes("customers.get_or_create"));
+		path.startsWith("/v1/customers") &&
+		method === "POST" &&
+		!path.includes("customers.get_or_create") &&
+		!path.includes("customers.");
 	return (isCreateCustomerPath ? body?.id : body?.customer_id) as
 		| string
 		| undefined;

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -91,7 +91,6 @@ export class CusService {
 					orgSlug: org.slug,
 				});
 
-				console.log("Cus product limit:", cusProductLimit);
 				const query = getFullCusQuery({
 					idOrInternalId,
 					orgId,

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -16,6 +16,7 @@ import {
 	STRIPE_MAX_KEY_LENGTH,
 } from "@/external/stripe/customers/utils/autumnToStripeMetadata";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
 import { CusService } from "@/internal/customers/CusService";
 import { getOrSetCachedFullCustomer } from "../../cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer";
 import { updateCachedCustomerData } from "../../cusUtils/fullCustomerCacheUtils/updateCachedCustomerData";
@@ -181,6 +182,14 @@ export const updateCustomer = async ({
 		customerId: newCustomerId ?? customerId,
 		source: "updateCustomer",
 	});
+
+	triggerAutoTopUpsOnEnabled({
+		ctx,
+		oldCustomer: originalCustomer,
+		fullCustomer,
+	}).catch((err) =>
+		ctx.logger.error("triggerAutoTopUpsOnEnabled failed: ", { error: err }),
+	);
 
 	return {
 		oldCustomer: originalCustomer,

--- a/server/src/internal/customers/handlers/handleUpdateCustomer/handleUpdateCustomer.ts
+++ b/server/src/internal/customers/handlers/handleUpdateCustomer/handleUpdateCustomer.ts
@@ -5,7 +5,6 @@ import {
 	UpdateCustomerParamsV0Schema,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
-import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
 import { customerActions } from "@/internal/customers/actions";
 import { getApiCustomer } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomer";
 
@@ -30,15 +29,6 @@ export const handleUpdateCustomer = createRoute({
 				...params,
 			},
 		});
-
-		// Fire and forget without awaiting
-		triggerAutoTopUpsOnEnabled({
-			ctx,
-			oldCustomer,
-			fullCustomer: newFullCustomer,
-		}).catch((err) =>
-			ctx.logger.error("triggerAutoTopUpsOnEnabled failed: ", { error: err }),
-		);
 
 		const customerDetails = await getApiCustomer({
 			ctx,

--- a/server/src/internal/customers/handlers/handleUpdateCustomer/handleUpdateCustomerV2.ts
+++ b/server/src/internal/customers/handlers/handleUpdateCustomer/handleUpdateCustomerV2.ts
@@ -2,7 +2,6 @@ import { AffectedResource, UpdateCustomerParamsV1Schema } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { customerActions } from "@/internal/customers/actions/index.js";
 import { getApiCustomer } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomer.js";
-import { getOrSetCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.js";
 
 export const handleUpdateCustomerV2 = createRoute({
 	body: UpdateCustomerParamsV1Schema,
@@ -10,21 +9,14 @@ export const handleUpdateCustomerV2 = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const params = c.req.valid("json");
-		const { oldCustomer, newFullCustomer } = await customerActions.update({
+		const { newFullCustomer } = await customerActions.update({
 			ctx,
 			params,
 		});
 
-		ctx.skipCache = true;
-		const fullCustomer = await getOrSetCachedFullCustomer({
-			ctx,
-			customerId: newFullCustomer.id ?? oldCustomer.id ?? params.customer_id,
-			source: "handleUpdateCustomerV2",
-		});
-
 		const customerDetails = await getApiCustomer({
 			ctx,
-			fullCustomer,
+			fullCustomer: newFullCustomer,
 		});
 
 		return c.json(customerDetails);

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -264,6 +264,7 @@ export const processMessage = async ({
 	try {
 		await executeJob();
 	} catch (error) {
+		const errorLogger = workerCtx?.logger ?? workerLogger;
 		// Sync jobs: re-throw infrastructure errors so the message stays in SQS.
 		// Application errors (RecaseError, InternalError) are swallowed — they
 		// won't fix on retry. DB errors (connection, timeout) will.
@@ -272,7 +273,7 @@ export const processMessage = async ({
 			isRetryableDbError({ error })
 		) {
 			Sentry.captureException(error);
-			workerLogger.error(`[${job.name}] Retryable DB error, keeping in SQS`, {
+			errorLogger.error(`[${job.name}] Retryable DB error, keeping in SQS`, {
 				jobName: job.name,
 				error:
 					error instanceof Error
@@ -284,7 +285,7 @@ export const processMessage = async ({
 
 		Sentry.captureException(error);
 		if (error instanceof Error) {
-			workerLogger.error(`Failed to process SQS job: ${job.name}`, {
+			errorLogger.error(`Failed to process SQS job: ${job.name}`, {
 				jobName: job.name,
 				error: {
 					message: error.message,
@@ -295,13 +296,14 @@ export const processMessage = async ({
 	} finally {
 		if (workerCtx && Object.keys(workerCtx.extraLogs).length > 0) {
 			const maskedLogs = maskExtraLogs(workerCtx.extraLogs);
-			workerLogger.info(`[${job.name}] Finished`, {
+			const finalLogger = workerCtx.logger ?? workerLogger;
+			finalLogger.info(`[${job.name}] Finished`, {
 				extras: maskedLogs,
 				done: true,
 			});
 
 			if (process.env.NODE_ENV === "development") {
-				workerLogger.debug(
+				finalLogger.debug(
 					`FINISHED PROCESSING JOB ${job.name}, EXTRA LOGS: ${JSON.stringify(maskedLogs, null, 2)}`,
 				);
 			}

--- a/server/tests/integration/balances/auto-topup/auto-topup-on-enabled.test.ts
+++ b/server/tests/integration/balances/auto-topup/auto-topup-on-enabled.test.ts
@@ -535,3 +535,73 @@ test.concurrent(`${chalk.yellowBright("auto-topup on-enabled 6: multi-feature en
 	expect(messagesToppedUp || storageToppedUp).toBe(true);
 	expect(messagesToppedUp && storageToppedUp).toBe(false);
 });
+
+test.concurrent(`${chalk.yellowBright("auto-topup on-enabled 7: enabling via RPC customers.update endpoint triggers immediate top-up")}`, async () => {
+	const oneOffItem = items.oneOffMessages({
+		includedUsage: 0,
+		billingUnits: 100,
+		price: 10,
+	});
+	const prod = products.base({
+		id: "topup-on-enabled-7",
+		items: [oneOffItem],
+	});
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "auto-topup-on-enabled-7",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [prod] }),
+		],
+		actions: [
+			s.attach({
+				productId: prod.id,
+				options: [{ feature_id: TestFeature.Messages, quantity: 100 }],
+			}),
+		],
+	});
+
+	// Deplete balance to 15 (below future threshold of 20)
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 85,
+	});
+
+	await timeout(DB_SYNC_WAIT_MS);
+
+	const before = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expectBalanceCorrect({
+		customer: before,
+		featureId: TestFeature.Messages,
+		remaining: 15,
+	});
+
+	// Enable auto-topup via RPC route (POST /customers.update → handleUpdateCustomerV2)
+	await autumnV2_1.customers.updateRpc(customerId, {
+		billing_controls: makeAutoTopupConfig({
+			threshold: 20,
+			quantity: 100,
+			enabled: true,
+		}),
+	});
+
+	await timeout(AUTO_TOPUP_WAIT_MS);
+
+	// Balance should be: 15 + 100 = 115
+	const after = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expectBalanceCorrect({
+		customer: after,
+		featureId: TestFeature.Messages,
+		remaining: 115,
+	});
+
+	// 2 invoices: initial attach + auto top-up
+	await expectCustomerInvoiceCorrect({
+		customerId,
+		count: 2,
+		latestTotal: 10,
+		latestStatus: "paid",
+		latestInvoiceProductId: prod.id,
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes auto top-up so enabling it on a customer triggers an immediate top-up, including when updated via the RPC endpoint (`POST /customers.update`).

- **Bug Fixes**
  - Trigger moved to the `updateCustomer` action, ensuring both v1 and v2 update paths (including RPC `customers.update`) top up on enable.
  - Added client helper `customers.updateRpc(...)` and an integration test to verify immediate top-up via RPC.
  - Analytics middleware no longer treats `customers.*` RPC routes as creates and correctly reads `customer_id`.
  - Worker logs use the request-scoped logger when available for accurate job logging.

<sup>Written for commit fe8177d3302aa1bd6c29a60c2700991d3fe025fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where enabling auto top-up via the RPC endpoint (`POST /customers.update`) did not trigger an immediate top-up when the balance was already below the threshold. The fix moves `triggerAutoTopUpsOnEnabled` from the V1 PATCH handler into the shared `updateCustomer.ts` action, so both endpoints benefit. Two related improvements are also included: the analytics middleware is fixed to correctly extract `customer_id` (not `id`) from RPC-style request bodies, and `processMessage.ts` now uses the enriched worker-context logger for error reporting.

**Key Changes:**
- [Bug fixes] `triggerAutoTopUpsOnEnabled` moved to shared `updateCustomer.ts` so both PATCH and RPC (`customers.update`) handlers trigger auto top-up on enable
- [Bug fixes] Analytics middleware now correctly excludes `customers.*` RPC paths from \"create customer\" body parsing, fixing customer-ID tracking for those routes
- [Improvements] `processMessage.ts` uses enriched `workerCtx.logger` (with org/customer context) instead of the bare `workerLogger` when reporting job errors
- [Improvements] `autumnCli.ts` adds `updateRpc` test helper and 7 integration tests covering auto top-up on-enabled scenarios
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the bug fix is correct, both endpoints now share the trigger logic, and 7 integration tests validate the key scenarios.

All remaining findings are P2 (redundant condition clause, misleading test comment) with no impact on correctness or reliability.

No files require special attention beyond the minor style nit in `analyticsMiddleware.ts`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/actions/update/updateCustomer.ts | Core fix: `triggerAutoTopUpsOnEnabled` (fire-and-forget) and `skipCache`/`getOrSetCachedFullCustomer` moved here from the individual handlers, ensuring both V1 and V2 endpoints share the behaviour |
| server/src/internal/customers/handlers/handleUpdateCustomer/handleUpdateCustomerV2.ts | Simplified: redundant second `skipCache`/`getOrSetCachedFullCustomer` call removed since `updateCustomer.ts` now handles it; auto top-up trigger now fires via shared action |
| server/src/honoMiddlewares/analyticsMiddleware.ts | Fixed `isCreateCustomerPath` to exclude all `customers.*` RPC paths; `!path.includes("customers.get_or_create")` is now redundant since it's a subset of the new `!path.includes("customers.")` |
| server/src/queue/processMessage.ts | Minor improvement: error logging now uses `workerCtx?.logger ?? workerLogger` to include enriched org/customer context set during job processing |
| server/tests/integration/balances/auto-topup/auto-topup-on-enabled.test.ts | New integration tests covering 7 on-enabled auto top-up scenarios via both PATCH and RPC endpoints; tests are thorough but test 6 has a slightly misleading "non-deterministic" comment |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as PATCH or RPC Handler
    participant updateCustomer
    participant CusService
    participant Cache
    participant triggerAutoTopUps

    Client->>Handler: request with billing_controls
    Handler->>updateCustomer: ctx + params
    updateCustomer->>CusService: get originalCustomer
    updateCustomer->>CusService: update with new data
    updateCustomer->>Cache: updateCachedCustomerData
    updateCustomer->>Cache: getOrSetCachedFullCustomer skipCache=true
    Cache-->>updateCustomer: fullCustomer
    updateCustomer-->>triggerAutoTopUps: fire-and-forget oldCustomer + fullCustomer
    Note over triggerAutoTopUps: Finds first auto_topup transitioned to enabled, enqueues SQS job
    updateCustomer-->>Handler: oldCustomer + newFullCustomer
    Handler-->>Client: API response
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/tests/integration/balances/auto-topup/auto-topup-on-enabled.test.ts`, line 502-536 ([link](https://github.com/useautumn/autumn/blob/fe8177d3302aa1bd6c29a60c2700991d3fe025fb/server/tests/integration/balances/auto-topup/auto-topup-on-enabled.test.ts#L502-L536)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Misleading "non-deterministic" comment**

   The comment on line 526 says "non-deterministic which one" triggers, but `triggerAutoTopUpsOnEnabled` iterates `fullCustomer.auto_topups` in order and breaks after the first transitioning feature. Since PostgreSQL JSONB arrays preserve insertion order, Messages (sent first) will deterministically be the one that tops up. The assertion is still correct and will catch regressions, but the comment may confuse future readers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/tests/integration/balances/auto-topup/auto-topup-on-enabled.test.ts
   Line: 502-536

   Comment:
   **Misleading "non-deterministic" comment**

   The comment on line 526 says "non-deterministic which one" triggers, but `triggerAutoTopUpsOnEnabled` iterates `fullCustomer.auto_topups` in order and breaks after the first transitioning feature. Since PostgreSQL JSONB arrays preserve insertion order, Messages (sent first) will deterministically be the one that tops up. The assertion is still correct and will catch regressions, but the comment may confuse future readers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/honoMiddlewares/analyticsMiddleware.ts
Line: 35-39

Comment:
**Redundant `customers.get_or_create` exclusion**

Now that `!path.includes("customers.")` is in the condition, the preceding `!path.includes("customers.get_or_create")` check is a strict subset of it and can never trigger independently — every path containing `"customers.get_or_create"` already contains `"customers."`. It can be safely removed.

```suggestion
	const isCreateCustomerPath =
		path.startsWith("/v1/customers") &&
		method === "POST" &&
		!path.includes("customers.");
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/tests/integration/balances/auto-topup/auto-topup-on-enabled.test.ts
Line: 502-536

Comment:
**Misleading "non-deterministic" comment**

The comment on line 526 says "non-deterministic which one" triggers, but `triggerAutoTopUpsOnEnabled` iterates `fullCustomer.auto_topups` in order and breaks after the first transitioning feature. Since PostgreSQL JSONB arrays preserve insertion order, Messages (sent first) will deterministically be the one that tops up. The assertion is still correct and will catch regressions, but the comment may confuse future readers.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: auto top up trigger"](https://github.com/useautumn/autumn/commit/fe8177d3302aa1bd6c29a60c2700991d3fe025fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28127231)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->