### PR TITLE
Only pass prepaid options when user explicitly sets quantity

### DIFF
--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -99,7 +99,7 @@ export function generateItemChanges({
 	originalItems: ProductItem[] | undefined;
 	updatedItems: ProductItem[] | null;
 	features?: Feature[];
-	prepaidOptions?: Record<string, number>;
+	prepaidOptions?: Record<string, number | undefined>;
 }): ItemEdit[] {
 	if (!updatedItems || !originalItems) return [];
 

--- a/shared/utils/productV2Utils/compareProductUtils/generatePrepaidChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generatePrepaidChanges.ts
@@ -11,8 +11,8 @@ export function generatePrepaidChanges({
 	currency = "usd",
 }: {
 	prepaidItems: ProductItem[];
-	originalOptions: Record<string, number>;
-	updatedOptions: Record<string, number>;
+	originalOptions: Record<string, number | undefined>;
+	updatedOptions: Record<string, number | undefined>;
 	currency?: string;
 }): ItemEdit[] {
 	return prepaidItems

--- a/vite/src/components/forms/attach-product/attach-product-form-schema.ts
+++ b/vite/src/components/forms/attach-product/attach-product-form-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod/v4";
 
 export const AttachProductFormSchema = z.object({
 	productId: z.string(),
-	prepaidOptions: z.record(z.string(), z.number()),
+	prepaidOptions: z.record(z.string(), z.number().optional()),
 });
 
 export type AttachProductForm = z.infer<typeof AttachProductFormSchema>;

--- a/vite/src/components/forms/attach-product/use-attach-body-builder.ts
+++ b/vite/src/components/forms/attach-product/use-attach-body-builder.ts
@@ -14,7 +14,7 @@ interface AttachBodyBuilderParams {
 	productId?: string;
 	product?: ProductV2;
 	entityId?: string;
-	prepaidOptions?: Record<string, number>;
+	prepaidOptions?: Record<string, number | undefined>;
 	version?: number;
 	useInvoice?: boolean;
 	enableProductImmediately?: boolean;

--- a/vite/src/components/forms/attach-v2/attachFormSchema.ts
+++ b/vite/src/components/forms/attach-v2/attachFormSchema.ts
@@ -16,7 +16,7 @@ export interface FormCustomLineItem {
 
 export const AttachFormSchema = z.object({
 	productId: z.string(),
-	prepaidOptions: z.record(z.string(), z.number().nonnegative()),
+	prepaidOptions: z.record(z.string(), z.number().nonnegative().optional()),
 	items: z.custom<ProductItem[]>().nullable(),
 	version: z.number().positive().optional(),
 	trialLength: z.number().positive().nullable(),

--- a/vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx
@@ -19,12 +19,17 @@ export function AttachPlanSection({
 		productWithFormItems: product,
 		hasCustomizations,
 		initialPrepaidOptions,
+		previewPrepaidOptions,
 		handleEditPlan,
 		previewDiff,
 	} = useAttachFormContext();
 
 	const hideEditButton = readOnly || formValues.grantFree;
 	const { prepaidOptions } = formValues;
+
+	const effectiveInitialPrepaidOptions = readOnly
+		? previewPrepaidOptions
+		: initialPrepaidOptions;
 
 	const { org } = useOrg();
 	const currency = org?.default_currency ?? "USD";
@@ -45,7 +50,7 @@ export function AttachPlanSection({
 		originalItems: originalItemsForDiff,
 		features,
 		prepaidOptions,
-		initialPrepaidOptions,
+		initialPrepaidOptions: effectiveInitialPrepaidOptions,
 		form,
 		showDiff: shouldShowDiff,
 		currency,

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -15,7 +15,6 @@ import {
 	isFreeProductV2,
 	isOneOffProductV2,
 	productV2ToFrontendProduct,
-	UsageModel,
 } from "@autumn/shared";
 import { useStore } from "@tanstack/react-form";
 import {
@@ -65,6 +64,7 @@ interface AttachFormContextValue {
 	hasCustomizations: boolean;
 	numVersions: number;
 	initialPrepaidOptions: Record<string, number>;
+	previewPrepaidOptions: Record<string, number>;
 
 	isFreeToPaidTransition: boolean;
 
@@ -130,9 +130,6 @@ export function AttachFormProvider({
 	children,
 }: AttachFormProviderProps) {
 	const [showPlanEditor, setShowPlanEditor] = useState(false);
-	const [initialPrepaidOptions, setInitialPrepaidOptions] = useState<
-		Record<string, number>
-	>({});
 
 	const form = useAttachForm({ initialProductId });
 
@@ -281,14 +278,7 @@ export function AttachFormProvider({
 
 		// Initialize prepaid options for the selected product
 		if (product) {
-			const newInitialPrepaidOptions: Record<string, number> = {};
-			for (const item of product.items) {
-				if (item.usage_model === UsageModel.Prepaid && item.feature_id) {
-					newInitialPrepaidOptions[item.feature_id] = 0;
-				}
-			}
-			form.setFieldValue("prepaidOptions", newInitialPrepaidOptions);
-			setInitialPrepaidOptions(newInitialPrepaidOptions);
+			form.setFieldValue("prepaidOptions", {});
 
 			if (product.free_trial) {
 				form.setFieldValue("trialEnabled", true);
@@ -365,6 +355,21 @@ export function AttachFormProvider({
 
 	const previewQuery = useAttachPreview({ requestBody });
 
+	const previewPrepaidOptions = useMemo(() => {
+		const incoming = previewQuery.data?.incoming;
+		if (!incoming || incoming.length === 0) return {};
+
+		const options: Record<string, number> = {};
+		for (const change of incoming) {
+			for (const featureQuantity of change.feature_quantities) {
+				options[featureQuantity.feature_id] = featureQuantity.quantity;
+			}
+		}
+		return options;
+	}, [previewQuery.data?.incoming]);
+
+	const initialPrepaidOptions: Record<string, number> = {};
+
 	const previewDiff = usePreviewDiff({
 		previewQuery,
 		productId: productId ?? "",
@@ -420,25 +425,6 @@ export function AttachFormProvider({
 				},
 			});
 
-			const currentPrepaidOptions = form.store.state.values.prepaidOptions;
-			const updatedPrepaidOptions = { ...currentPrepaidOptions };
-			let hasNewPrepaidItems = false;
-
-			for (const item of draftProduct.items) {
-				if (
-					item.usage_model === "prepaid" &&
-					item.feature_id &&
-					updatedPrepaidOptions[item.feature_id] === undefined
-				) {
-					updatedPrepaidOptions[item.feature_id] = 0;
-					hasNewPrepaidItems = true;
-				}
-			}
-
-			if (hasNewPrepaidItems) {
-				form.setFieldValue("prepaidOptions", updatedPrepaidOptions);
-			}
-
 			setShowPlanEditor(false);
 			onPlanEditorClose?.();
 		},
@@ -462,6 +448,7 @@ export function AttachFormProvider({
 			hasCustomizations,
 			numVersions,
 			initialPrepaidOptions,
+			previewPrepaidOptions,
 			isFreeToPaidTransition,
 			previewQuery,
 			previewDiff,
@@ -484,7 +471,7 @@ export function AttachFormProvider({
 			productWithFormItems,
 			hasCustomizations,
 			numVersions,
-			initialPrepaidOptions,
+			previewPrepaidOptions,
 			isFreeToPaidTransition,
 			previewQuery,
 			previewDiff,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -22,7 +22,7 @@ export interface BuildAttachRequestBodyParams {
 	customerId: string | undefined;
 	entityId: string | undefined;
 	product: ProductV2 | undefined;
-	prepaidOptions: Record<string, number>;
+	prepaidOptions: Record<string, number | undefined>;
 	items: ProductItem[] | null;
 	version: number | undefined;
 	trialLength: number | null;

--- a/vite/src/components/forms/shared/PlanItemsSection.tsx
+++ b/vite/src/components/forms/shared/PlanItemsSection.tsx
@@ -38,8 +38,8 @@ export interface PlanItemsSectionProps {
 	originalItems: ProductItem[] | undefined;
 	features: Feature[];
 
-	prepaidOptions: Record<string, number>;
-	initialPrepaidOptions: Record<string, number>;
+	prepaidOptions: Record<string, number | undefined>;
+	initialPrepaidOptions: Record<string, number | undefined>;
 	existingOptions?: FeatureOptions[];
 
 	form: UseUpdateSubscriptionForm | UseAttachForm;

--- a/vite/src/components/forms/shared/plan-items/PlanItemRow.tsx
+++ b/vite/src/components/forms/shared/plan-items/PlanItemRow.tsx
@@ -14,8 +14,8 @@ export function getPlanItemPrepaidQuantity({
 	features,
 }: {
 	featureId: string;
-	prepaidOptions: Record<string, number>;
-	initialPrepaidOptions: Record<string, number>;
+	prepaidOptions: Record<string, number | undefined>;
+	initialPrepaidOptions: Record<string, number | undefined>;
 	existingOptions?: FeatureOptions[];
 	features: Feature[];
 }) {
@@ -82,8 +82,8 @@ export function PlanItemRow({
 	originalItemsMap: Map<string, ProductItem>;
 	originalItems: ProductItem[] | undefined;
 	features: Feature[];
-	prepaidOptions: Record<string, number>;
-	initialPrepaidOptions: Record<string, number>;
+	prepaidOptions: Record<string, number | undefined>;
+	initialPrepaidOptions: Record<string, number | undefined>;
 	existingOptions?: FeatureOptions[];
 	form: UseUpdateSubscriptionForm | UseAttachForm;
 	showDiff: boolean;

--- a/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
@@ -52,16 +52,18 @@ function usePrepaidDisplayState({
 	featureId: string | undefined;
 	isEditingQuantity: boolean;
 }) {
-	const inputQuantity = prepaidQuantity ?? 0;
+	const inputQuantity = prepaidQuantity ?? undefined;
 	const billingUnitStep = item.billing_units ?? 1;
 
 	const normalizedBillingUnits = billingUnitStep > 0 ? billingUnitStep : 1;
 	const roundedQuantity = roundUsageToNearestBillingUnit({
-		usage: inputQuantity,
+		usage: inputQuantity ?? 0,
 		billingUnits: normalizedBillingUnits,
 	});
 	const shouldShowRoundingHint =
-		normalizedBillingUnits > 1 && roundedQuantity !== inputQuantity;
+		inputQuantity !== undefined &&
+		normalizedBillingUnits > 1 &&
+		roundedQuantity !== inputQuantity;
 
 	const showDebouncedOffUnitRing = useDebounce({
 		value: shouldShowRoundingHint,
@@ -97,16 +99,18 @@ function PrepaidQuantityControl({
 	readOnly: boolean;
 	form: UseUpdateSubscriptionForm | UseAttachForm;
 	featureId: string;
-	inputQuantity: number;
+	inputQuantity: number | undefined;
 	step: number;
 	showRing: boolean;
 	isEditing: boolean;
 	onEditingChange: (editing: boolean) => void;
 }) {
+	const displayText = inputQuantity !== undefined ? `x${inputQuantity}` : "—";
+
 	if (readOnly) {
 		return (
 			<div className="flex items-center h-10 px-3 rounded-xl input-base w-fit shrink-0">
-				<span className="text-sm tabular-nums text-t3">x{inputQuantity}</span>
+				<span className="text-sm tabular-nums text-t3">{displayText}</span>
 			</div>
 		);
 	}
@@ -159,9 +163,11 @@ function PrepaidQuantityControl({
 						transition={FAST_TRANSITION}
 						className="flex items-center gap-2"
 					>
-						<span className="text-sm tabular-nums text-t3">
-							x{inputQuantity}
-						</span>
+						{inputQuantity !== undefined && (
+							<span className="text-sm tabular-nums text-t3">
+								{displayText}
+							</span>
+						)}
 						<IconButton
 							icon={<PencilSimpleIcon size={14} />}
 							variant="skeleton"

--- a/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
+++ b/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
@@ -64,7 +64,7 @@ interface UpdateSubscriptionFormContextValue {
 
 	// Derived values
 	originalItems: ProductItem[] | undefined;
-	initialPrepaidOptions: Record<string, number>;
+	initialPrepaidOptions: Record<string, number | undefined>;
 	changedPrepaidOptions: Record<string, number> | undefined;
 	productWithFormItems: FrontendProduct | undefined;
 	isVersionReady: boolean;
@@ -232,7 +232,10 @@ export function UpdateSubscriptionFormProvider({
 		for (const [featureId, quantity] of Object.entries(
 			normalizedPrepaidOptions,
 		)) {
-			if (quantity !== initialPrepaidOptions[featureId]) {
+			if (
+				quantity !== undefined &&
+				quantity !== initialPrepaidOptions[featureId]
+			) {
 				changed[featureId] = quantity;
 			}
 		}
@@ -338,25 +341,6 @@ export function UpdateSubscriptionFormProvider({
 					form.setFieldValue(field, value);
 				},
 			});
-
-			const currentPrepaidOptions = form.store.state.values.prepaidOptions;
-			const updatedPrepaidOptions = { ...currentPrepaidOptions };
-			let hasNewPrepaidItems = false;
-
-			for (const item of draftProduct.items) {
-				if (
-					item.usage_model === "prepaid" &&
-					item.feature_id &&
-					updatedPrepaidOptions[item.feature_id] === undefined
-				) {
-					updatedPrepaidOptions[item.feature_id] = 0;
-					hasNewPrepaidItems = true;
-				}
-			}
-
-			if (hasNewPrepaidItems) {
-				form.setFieldValue("prepaidOptions", updatedPrepaidOptions);
-			}
 
 			setShowPlanEditor(false);
 			onPlanEditorClose?.();

--- a/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
@@ -23,7 +23,7 @@ export function useHasSubscriptionChanges({
 	features,
 }: {
 	formValues: UpdateSubscriptionForm;
-	initialPrepaidOptions: Record<string, number>;
+	initialPrepaidOptions: Record<string, number | undefined>;
 	initialBillingBehavior: BillingBehavior | null;
 	prepaidItems: PrepaidItemWithFeature[];
 	customerProduct: FullCusProduct;

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
@@ -18,8 +18,8 @@ export function buildUpdateSubscriptionOptions({
 	initialBackendQuantities,
 }: {
 	prepaidItems: PrepaidItemInput[];
-	prepaidOptions: Record<string, number>;
-	initialPrepaidOptions: Record<string, number>;
+	prepaidOptions: Record<string, number | undefined>;
+	initialPrepaidOptions: Record<string, number | undefined>;
 	initialBackendQuantities: Record<string, number>;
 }): { feature_id: string; quantity: number }[] {
 	const getFeatureId = ({ item }: { item: PrepaidItemInput }) =>

--- a/vite/src/components/forms/update-subscription-v2/updateSubscriptionFormSchema.ts
+++ b/vite/src/components/forms/update-subscription-v2/updateSubscriptionFormSchema.ts
@@ -9,7 +9,7 @@ import { z } from "zod/v4";
 import { RefundBehaviorSchema } from "@/components/forms/update-subscription-v2/types/refundBehaviourSchema";
 
 export const UpdateSubscriptionFormSchema = z.object({
-	prepaidOptions: z.record(z.string(), z.number().nonnegative()),
+	prepaidOptions: z.record(z.string(), z.number().nonnegative().optional()),
 
 	trialLength: z.number().positive().nullable(),
 	trialDuration: z.enum(FreeTrialDuration),

--- a/vite/src/components/forms/update-subscription/use-update-subscription-body-builder.ts
+++ b/vite/src/components/forms/update-subscription/use-update-subscription-body-builder.ts
@@ -22,7 +22,7 @@ interface UpdateSubscriptionBodyBuilderParams {
 	productId?: string;
 	product?: ProductV2;
 	entityId?: string;
-	prepaidOptions?: Record<string, number>;
+	prepaidOptions?: Record<string, number | undefined>;
 	version?: number;
 	useInvoice?: boolean;
 	enableProductImmediately?: boolean;
@@ -118,12 +118,14 @@ export function useUpdateSubscriptionBodyBuilder(
 export function buildLegacyUpdateSubscriptionOptions({
 	prepaidOptions,
 }: {
-	prepaidOptions?: Record<string, number>;
+	prepaidOptions?: Record<string, number | undefined>;
 }): FeatureOptions[] {
 	if (!prepaidOptions) return [];
 
-	return Object.entries(prepaidOptions).map(([featureId, quantity]) => ({
-		feature_id: featureId,
-		quantity: quantity || 0,
-	}));
+	return Object.entries(prepaidOptions)
+		.filter((entry): entry is [string, number] => entry[1] !== undefined)
+		.map(([featureId, quantity]) => ({
+			feature_id: featureId,
+			quantity,
+		}));
 }

--- a/vite/src/utils/billing/prepaidQuantityUtils.ts
+++ b/vite/src/utils/billing/prepaidQuantityUtils.ts
@@ -53,7 +53,7 @@ export function convertPrepaidOptionsToFeatureOptions({
 	prepaidOptions,
 	product,
 }: {
-	prepaidOptions: Record<string, number>;
+	prepaidOptions: Record<string, number | undefined>;
 	product: ProductV2 | undefined;
 }): FeatureOptions[] | undefined {
 	if (!product || Object.keys(prepaidOptions).length === 0) {
@@ -63,9 +63,10 @@ export function convertPrepaidOptionsToFeatureOptions({
 	const options: FeatureOptions[] = [];
 
 	for (const [featureId, quantity] of Object.entries(prepaidOptions)) {
+		if (quantity === undefined) continue;
 		options.push({
 			feature_id: featureId,
-			quantity: quantity || 0,
+			quantity,
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Prepaid quantities are no longer eagerly initialized to 0; form values start as `undefined` and are only included in the API payload when the user explicitly sets them
- In the review stage, the backend-resolved quantities from the preview response are shown as fallback display values
- Updated types across attach and update-subscription flows to support `number | undefined` for prepaid options

## Test plan
- [ ] Attach a product with prepaid features — verify no `options` array is sent unless user edits quantities
- [ ] Explicitly set a prepaid quantity to 0 — verify `quantity: 0` is sent
- [ ] Switch from a plan with existing prepaid quantities — verify review stage shows carried-over quantities
- [ ] Update subscription prepaid quantities — verify change detection still works correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only include prepaid options when the user sets a quantity. Quantities start as undefined; the review step falls back to backend preview quantities, and explicit 0 is respected.

- **Bug Fixes**
  - Schemas and compare utils accept `number | undefined` for prepaid options.
  - Attach/update body builders and converters filter out `undefined`; no `options` payload unless edited; send `quantity: 0` when explicitly set.
  - Review/read-only UI shows preview-resolved quantities when unset; displays an em dash when not set; rounding hints only show after input; change detection/diffs ignore undefined values.

<sup>Written for commit 437229cd696585ff1c523ea0c2235b60b1efd0d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes prepaid quantity initialization so form values start as `undefined` instead of `0`, with `undefined` values filtered from API payloads. The review stage now surfaces backend-resolved quantities from the preview response as fallback display values.

**Key Changes:**
- [Improvements] `prepaidOptions` form fields start as `undefined`; only user-set values are included in API payloads — fixes the accidental zero-quantity sends
- [Bug fixes] `buildLegacyUpdateSubscriptionOptions` now filters out `undefined` entries instead of coercing them to `0` with `|| 0`, so an explicit `quantity: 0` is no longer indistinguishable from \"not set\"
- [Improvements] New `previewPrepaidOptions` context value computed from the preview response is used as the display fallback in the read-only (review) stage
- [API changes] Type broadened to `number | undefined` across attach and update-subscription form schemas, hooks, and shared utilities
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core logic is correct, all undefined filtering paths are handled, and the only finding is a benign missing useMemo dep that has no runtime impact.

All P0/P1 paths are clean: undefined values are filtered before API calls in every code path (convertPrepaidOptionsToFeatureOptions, buildLegacyUpdateSubscriptionOptions, buildUpdateSubscriptionOptions), and the || 0 bug is properly fixed. The single P2 finding (missing useMemo dep) is functionally harmless because the value is always {}.

vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx — missing useMemo dep for initialPrepaidOptions (P2 only)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx | Core context provider – removes initialPrepaidOptions state; introduces previewPrepaidOptions from preview response; `initialPrepaidOptions` is now a plain object literal missing from useMemo deps (benign but causes lint warnings) |
| vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx | Removes plan-editor save hook that eagerly initialised new prepaid features to 0; normalizedPrepaidOptions now handles min-quantity enforcement for newly added features |
| vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts | buildUpdateSubscriptionOptions correctly skips undefined quantities and only sends user-set values to the backend |
| vite/src/components/forms/update-subscription/use-update-subscription-body-builder.ts | buildLegacyUpdateSubscriptionOptions now filters undefined values instead of coercing with || 0 — correctly distinguishes "not set" from "explicitly zero" |
| vite/src/utils/billing/prepaidQuantityUtils.ts | convertPrepaidOptionsToFeatureOptions now skips undefined entries correctly; returns undefined when all quantities are undefined |
| vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx | Quantity display updated: undefined shows "—" in readonly, nothing + edit icon in editable mode; rounding hint guard added for undefined inputQuantity |
| shared/utils/productV2Utils/compareProductUtils/generatePrepaidChanges.ts | Type-only change: undefined values are handled via ?? 0 in the existing function body, so comparison semantics are preserved |
| vite/src/components/forms/attach-v2/components/AttachPlanSection.tsx | effectiveInitialPrepaidOptions correctly switches to previewPrepaidOptions in read-only (review) stage for backend-resolved quantity display |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
Line: 371

Comment:
**`initialPrepaidOptions` missing from `useMemo` deps**

`initialPrepaidOptions` is a plain object literal recreated on every render and included in the context value object, but it is absent from the `useMemo` dependency array (the diff swapped it for `previewPrepaidOptions`). Because the value is always `{}` this is functionally harmless, but it creates a stale-closure that will trigger an `exhaustive-deps` lint warning and could silently break if the constant is ever made non-empty.

Consider either memoising it (`const initialPrepaidOptions = useMemo(() => ({}), [])`) or, since it is always `{}`, inlining it directly in the context value object rather than assigning it to a named variable.

```suggestion
	const initialPrepaidOptions = useMemo(
		(): Record<string, number> => ({}),
		[],
	);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Only pass prepaid options when user expl..."](https://github.com/useautumn/autumn/commit/437229cd696585ff1c523ea0c2235b60b1efd0d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28205234)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->