### PR TITLE
fix: increase attach rate limit

### DIFF
--- a/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
@@ -158,7 +158,7 @@ export const RATE_LIMIT_CONFIGS: Record<RateLimitType, RateLimitConfig> = {
 	},
 	[RateLimitType.Attach]: {
 		name: "attach",
-		limit: 5,
+		limit: 30,
 		windowMs: 60000,
 		notInRedis: false,
 		scope: RateLimitScope.Customer,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increased the attach rate limit from 5 to 30 requests per minute to prevent unnecessary throttling during normal bursts. The window stays 60s and the limit remains customer-scoped.

<sup>Written for commit 3b8c52b42b4b549a6e34913aa09100bb1fcc2623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Increases the `Attach` rate limit from 5 to 30 requests per 60-second window (per customer). This is a straightforward config bump with no logic changes.

**[Bug fixes / Improvements]** — Raised `RateLimitType.Attach` limit 6× (5 → 30 per minute per customer) to reduce false-positive rate-limit rejections on attach-related endpoints (`/v1/attach`, `/v1/cancel`, billing endpoints, etc.).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — isolated config change with no logic or schema impact.

The change is a single integer update to a rate-limit config constant. No logic, schema, or API contract is modified. All findings are P2 or lower (none exist), so the score is 5.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/misc/rateLimiter/rateLimitConfigs.ts | Single-line bump of Attach rate limit from 5 to 30 per 60 s window; no other changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{getRateLimitType}
    B -->|matches /v1/attach, /v1/cancel,\n/v1/billing.* etc.| C[RateLimitType.Attach]
    B -->|other endpoints| D[RateLimitType.General / Check / Track / ...]
    C --> E{Redis counter\nscope: Customer}
    E -->|count <= 30 / 60 s| F[Request allowed]
    E -->|count > 30 / 60 s| G[429 Too Many Requests]
    D --> H[Other rate-limit handling]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: increase attach rate limit"](https://github.com/useautumn/autumn/commit/3b8c52b42b4b549a6e34913aa09100bb1fcc2623) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28248472)</sub>

<!-- /greptile_comment -->