### PR TITLE
fix: 🐛 a bug with isDefaultTrialFullProduct not passed correctly

### DIFF
--- a/server/src/internal/customers/actions/createWithDefaults/setup/setupDefaultProductsContext.ts
+++ b/server/src/internal/customers/actions/createWithDefaults/setup/setupDefaultProductsContext.ts
@@ -41,7 +41,7 @@ const getOverrideAutoEnableProduct = async ({
 
 	if (
 		!isFreeProduct({ prices: plan.prices }) &&
-		!isDefaultTrialFullProduct({ product: plan })
+		!isDefaultTrialFullProduct({ product: plan, skipDefault: true })
 	) {
 		throw new RecaseError({
 			message: `Auto-enable plan must be a free product, or have a free trial with 'card_required' as false`,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip Stripe `proration_behavior` for one‑off products during attach setup and fix auto‑enable validation for default‑trial full products by correctly passing `skipDefault` to `isDefaultTrialFullProduct`.

- **Bug Fixes**
  - Set `requestedProrationBehavior` to `undefined` for one‑off products to prevent unintended proration.
  - Pass `{ skipDefault: true }` to `isDefaultTrialFullProduct` during auto‑enable checks to correctly accept valid default‑trial full products and avoid attach failures.

<sup>Written for commit 62b9d900db94972decc1aeb3478e1c59f1933dc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `requestedProrationBehavior` was forwarded as-is for one-off (non-recurring) products, causing `finalizeLineItems` to return an empty array when `proration_behavior: "none"` was provided alongside a one-off product attach request. The fix wraps the value with an `isOneOffProduct` guard, setting it to `undefined` for one-off products so that proration logic is correctly skipped.

**Bug fixes**: `requestedProrationBehavior` is now set to `undefined` for one-off products, preventing `finalizeLineItems` from incorrectly short-circuiting to an empty result.
</details>


<h3>Confidence Score: 5/5</h3>

- Safe to merge — the core fix is correct and remaining findings are minor style/consistency suggestions.
- The single-line fix correctly prevents proration logic from applying to one-off products. Both remaining comments are P2 (inconsistent guard in `anchorResetRefund` and a mislabeled PR title); neither blocks correctness or introduces data risk.
- No files require special attention for merge readiness.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts | Guards `requestedProrationBehavior` for one-off products; `anchorResetRefund` (line 252–254) still receives `params.proration_behavior` directly without the same guard, which is an inconsistency worth reviewing. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[setupAttachBillingContext] --> B{isOneOffProduct?}
    B -- Yes --> C[requestedProrationBehavior = undefined]
    B -- No --> D[requestedProrationBehavior = params.proration_behavior]
    C --> E[AttachBillingContext returned]
    D --> E
    E --> F[finalizeLineItems]
    F --> G{requestedProrationBehavior === 'none' AND NOT anchorResetRefund.noPartialRefund?}
    G -- Yes --> H[return empty line items]
    G -- No --> I[continue normal line item computation]
    E --> J[setupAnchorResetRefund]
    J --> K{billingCycleAnchor === 'now' AND prorationBehavior === 'none'?}
    K -- Yes --> L[AnchorResetRefund set — even for one-off products]
    K -- No --> M[anchorResetRefund = undefined]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts`, line 252-256 ([link](https://github.com/useautumn/autumn/blob/62b9d900db94972decc1aeb3478e1c59f1933dc1/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts#L252-L256)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inconsistent one-off guard for `anchorResetRefund`**

   `requestedProrationBehavior` is now correctly set to `undefined` for one-off products, but `setupAnchorResetRefund` on this line still receives `params.proration_behavior` directly. If a caller passes both `billing_cycle_anchor: "now"` and `proration_behavior: "none"` with a one-off product, `anchorResetRefund` will be set to `{ noPartialRefund: true, ... }`, which propagates into `customerProductToLineItems` via `augmentBillingContextForAnchorResetRefund`. For consistency, this should apply the same guard:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
   Line: 252-256

   Comment:
   **Inconsistent one-off guard for `anchorResetRefund`**

   `requestedProrationBehavior` is now correctly set to `undefined` for one-off products, but `setupAnchorResetRefund` on this line still receives `params.proration_behavior` directly. If a caller passes both `billing_cycle_anchor: "now"` and `proration_behavior: "none"` with a one-off product, `anchorResetRefund` will be set to `{ noPartialRefund: true, ... }`, which propagates into `customerProductToLineItems` via `augmentBillingContextForAnchorResetRefund`. For consistency, this should apply the same guard:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts`, line 227-231 ([link](https://github.com/useautumn/autumn/blob/62b9d900db94972decc1aeb3478e1c59f1933dc1/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts#L227-L231)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **PR title doesn't match the change**

   The PR title references `isDefaultTrialFullProduct` but the actual fix is unrelated — it guards `requestedProrationBehavior` using `isOneOffProduct`. Worth updating the title for accurate git history and searchability.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
   Line: 227-231

   Comment:
   **PR title doesn't match the change**

   The PR title references `isDefaultTrialFullProduct` but the actual fix is unrelated — it guards `requestedProrationBehavior` using `isOneOffProduct`. Worth updating the title for accurate git history and searchability.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
Line: 252-256

Comment:
**Inconsistent one-off guard for `anchorResetRefund`**

`requestedProrationBehavior` is now correctly set to `undefined` for one-off products, but `setupAnchorResetRefund` on this line still receives `params.proration_behavior` directly. If a caller passes both `billing_cycle_anchor: "now"` and `proration_behavior: "none"` with a one-off product, `anchorResetRefund` will be set to `{ noPartialRefund: true, ... }`, which propagates into `customerProductToLineItems` via `augmentBillingContextForAnchorResetRefund`. For consistency, this should apply the same guard:

```suggestion
		anchorResetRefund: setupAnchorResetRefund({
			billingCycleAnchor: params.billing_cycle_anchor,
			prorationBehavior: isOneOffProduct({ prices: attachProduct.prices })
				? undefined
				: params.proration_behavior,
			outgoingCustomerProduct: currentCustomerProduct,
			carryOverBalances: params.carry_over_balances,
		}),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
Line: 227-231

Comment:
**PR title doesn't match the change**

The PR title references `isDefaultTrialFullProduct` but the actual fix is unrelated — it guards `requestedProrationBehavior` using `isOneOffProduct`. Worth updating the title for accurate git history and searchability.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 : a bug with isDefaultTrialFullP..."](https://github.com/useautumn/autumn/commit/62b9d900db94972decc1aeb3478e1c59f1933dc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28342992)</sub>

<!-- /greptile_comment -->