### PR TITLE
feat: refund to last payment method option during cancellation

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelLineItems.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelLineItems.ts
@@ -18,6 +18,9 @@ export const computeCancelLineItems = ({
 }): LineItem[] => {
 	if (billingContext.cancelAction !== "cancel_immediately") return [];
 
+	// Full refund refunds the entire last charge — no proration line items needed
+	if (billingContext.refundLastPayment === "full") return [];
+
 	const { allLineItems } = buildAutumnLineItems({
 		ctx,
 		newCustomerProducts: [],

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeRefundPreview.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeRefundPreview.ts
@@ -1,0 +1,64 @@
+import type {
+	BillingPreviewResponse,
+	UpdateSubscriptionBillingContext,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { InvoiceService } from "@/internal/invoices/InvoiceService.js";
+
+/** Compute refund preview when refund_last_payment is set */
+export const computeRefundPreview = async ({
+	ctx,
+	billingContext,
+	previewTotal,
+}: {
+	ctx: AutumnContext;
+	billingContext: UpdateSubscriptionBillingContext;
+	previewTotal: number;
+}): Promise<BillingPreviewResponse["refund"]> => {
+	if (!billingContext.refundLastPayment) return undefined;
+
+	const { stripeSubscription } = billingContext;
+	if (!stripeSubscription) return undefined;
+
+	// Get the latest invoice stripe_id from the subscription
+	const latestInvoiceId =
+		typeof stripeSubscription.latest_invoice === "string"
+			? stripeSubscription.latest_invoice
+			: stripeSubscription.latest_invoice?.id;
+
+	if (!latestInvoiceId) return undefined;
+
+	// Look up the Autumn invoice to get refunded_amount
+	const autumnInvoice = await InvoiceService.getByStripeId({
+		db: ctx.db,
+		stripeId: latestInvoiceId,
+	});
+
+	if (!autumnInvoice) return undefined;
+
+	const invoiceTotal = Math.abs(autumnInvoice.total);
+	const alreadyRefunded = autumnInvoice.refunded_amount ?? 0;
+	const remainingRefundable = invoiceTotal - alreadyRefunded;
+
+	// For full: refund whatever remains
+	// For prorated: use the prorated amount from line items total (capped at remaining)
+	let refundAmount: number;
+
+	if (billingContext.refundLastPayment === "full") {
+		refundAmount = remainingRefundable;
+	} else {
+		// Prorated: the line items total is a negative number representing the prorated credit
+		const proratedAmount = Math.abs(previewTotal);
+		refundAmount = Math.min(proratedAmount, remainingRefundable);
+	}
+
+	return {
+		amount: refundAmount,
+		invoice: {
+			stripe_id: autumnInvoice.stripe_id,
+			total: autumnInvoice.total,
+			refunded_amount: alreadyRefunded,
+			currency: autumnInvoice.currency,
+		},
+	};
+};

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.ts
@@ -78,7 +78,7 @@ export const computeUpdateSubscriptionPlan = async ({
 	// Apply cancel plan if cancelAction is set in context
 	plan = computeCancelPlan({ ctx, billingContext, plan });
 
-	plan = finalizeUpdateSubscriptionPlan({
+	plan = await finalizeUpdateSubscriptionPlan({
 		ctx,
 		plan,
 		billingContext,

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/finalizeUpdateSubscriptionPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/finalizeUpdateSubscriptionPlan.ts
@@ -6,12 +6,13 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { finalizeLineItems } from "@/internal/billing/v2/compute/finalize/finalizeLineItems";
+import { computeRefundPreview } from "./cancel/computeRefundPreview";
 
 /**
- * Finalizes the update subscription billing plan by processing line items
- * and applying update-subscription-specific guards.
+ * Finalizes the update subscription billing plan by processing line items,
+ * applying update-subscription-specific guards, and computing refund preview.
  */
-export const finalizeUpdateSubscriptionPlan = ({
+export const finalizeUpdateSubscriptionPlan = async ({
 	ctx,
 	plan,
 	billingContext,
@@ -21,7 +22,7 @@ export const finalizeUpdateSubscriptionPlan = ({
 	plan: AutumnBillingPlan;
 	billingContext: UpdateSubscriptionBillingContext;
 	params: UpdateSubscriptionV1Params;
-}): AutumnBillingPlan => {
+}): Promise<AutumnBillingPlan> => {
 	// Finalize line items (shared logic)
 	plan.lineItems = finalizeLineItems({
 		ctx,
@@ -34,6 +35,18 @@ export const finalizeUpdateSubscriptionPlan = ({
 	if (isCustomerProductOneOff(billingContext.customerProduct)) {
 		plan.lineItems = [];
 	}
+
+	// Compute refund preview from finalised line items
+	const previewTotal = (plan.lineItems ?? []).reduce(
+		(sum, item) => sum + (item.amount ?? 0),
+		0,
+	);
+
+	plan.refundPreview = await computeRefundPreview({
+		ctx,
+		billingContext,
+		previewTotal,
+	});
 
 	return plan;
 };

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -158,6 +158,10 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		customerProduct,
 	});
 
+	ctx.logger.info(
+		`[setupUpdateSubContext] refundLastPayment: ${params.refund_last_payment}, cancelAction: ${cancelAction}`,
+	);
+
 	return {
 		intent,
 		fullCustomer,
@@ -166,6 +170,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		defaultProduct,
 		cancelAction,
 		recalculateBalances: params.recalculate_balances?.enabled === true,
+		refundLastPayment: params.refund_last_payment,
 		stripeSubscription,
 		stripeSubscriptionSchedule,
 		stripeDiscounts,

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeRefundAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeRefundAction.ts
@@ -1,0 +1,32 @@
+import {
+	type StripeRefundAction,
+	secondsToMs,
+	type UpdateSubscriptionBillingContext,
+} from "@autumn/shared";
+import { subToPeriodStartEnd } from "@/external/stripe/stripeSubUtils/convertSubUtils.js";
+
+/** Build a Stripe refund action for refunding the latest invoice on cancellation */
+export const buildStripeRefundAction = ({
+	billingContext,
+}: {
+	billingContext: UpdateSubscriptionBillingContext;
+}): StripeRefundAction | undefined => {
+	if (!billingContext.refundLastPayment) return undefined;
+	if (billingContext.cancelAction !== "cancel_immediately") return undefined;
+
+	const { stripeSubscription } = billingContext;
+
+	if (!stripeSubscription) return undefined;
+
+	const periodInSeconds = subToPeriodStartEnd({ sub: stripeSubscription });
+
+	return {
+		type: "refund_last_invoice",
+		stripeSubscriptionId: stripeSubscription.id,
+		mode: billingContext.refundLastPayment,
+		billingPeriod: {
+			start: secondsToMs(periodInSeconds.start),
+			end: secondsToMs(periodInSeconds.end),
+		},
+	};
+};

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeRefundAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeRefundAction.ts
@@ -1,7 +1,7 @@
 import {
+	type BillingContext,
 	type StripeRefundAction,
 	secondsToMs,
-	type UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import { subToPeriodStartEnd } from "@/external/stripe/stripeSubUtils/convertSubUtils.js";
 
@@ -9,7 +9,7 @@ import { subToPeriodStartEnd } from "@/external/stripe/stripeSubUtils/convertSub
 export const buildStripeRefundAction = ({
 	billingContext,
 }: {
-	billingContext: UpdateSubscriptionBillingContext;
+	billingContext: BillingContext;
 }): StripeRefundAction | undefined => {
 	if (!billingContext.refundLastPayment) return undefined;
 	if (billingContext.cancelAction !== "cancel_immediately") return undefined;

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
@@ -6,9 +6,11 @@ import type {
 	StripeCheckoutSessionAction,
 	StripeInvoiceAction,
 	StripeInvoiceItemsAction,
+	UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import { orgToCurrency } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { buildStripeRefundAction } from "@/internal/billing/v2/providers/stripe/actionBuilders/buildStripeRefundAction.js";
 import { buildStripeSubscriptionScheduleAction } from "@/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionScheduleAction";
 import { shouldCreateManualStripeInvoice } from "@/internal/billing/v2/providers/stripe/utils/invoices/shouldCreateManualStripeInvoice";
 import { autumnBillingPlanToFinalFullCustomer } from "@/internal/billing/v2/utils/autumnBillingPlanToFinalFullCustomer";
@@ -65,7 +67,23 @@ export const evaluateStripeBillingPlan = async ({
 		subscriptionCancelAt,
 	});
 
-	const { lineItems } = autumnBillingPlan;
+	const stripeRefundAction = billingContext.refundLastPayment
+		? buildStripeRefundAction({
+				billingContext: billingContext as UpdateSubscriptionBillingContext,
+			})
+		: undefined;
+
+	ctx.logger.info(
+		`[evaluateStripeBillingPlan] refundAction: ${JSON.stringify(stripeRefundAction)}, refundLastPayment: ${billingContext.refundLastPayment}`,
+	);
+
+	// When refundLastPayment is set, keep line items in the billing plan for
+	// preview/display but filter out refund line items from Stripe invoice actions
+	const stripeLineItems = billingContext.refundLastPayment
+		? autumnBillingPlan.lineItems?.filter(
+				(li) => li.context.direction !== "refund",
+			)
+		: autumnBillingPlan.lineItems;
 
 	const createManualInvoice = shouldCreateManualStripeInvoice({
 		ctx,
@@ -93,15 +111,15 @@ export const evaluateStripeBillingPlan = async ({
 		const currency = orgToCurrency({ org: ctx.org });
 
 		stripeInvoiceAction = buildStripeInvoiceAction({
-			lineItems: lineItems ?? undefined,
+			lineItems: stripeLineItems ?? undefined,
 			customLineItems,
 			currency,
 		});
 
 		// Invoice items only apply when using normal line items (not custom)
-		if (!customLineItems?.length && lineItems) {
+		if (!customLineItems?.length && stripeLineItems) {
 			stripeInvoiceItemsAction = buildStripeInvoiceItemsAction({
-				lineItems,
+				lineItems: stripeLineItems,
 				billingContext,
 			});
 		}
@@ -117,5 +135,6 @@ export const evaluateStripeBillingPlan = async ({
 		invoiceItemsAction: stripeInvoiceItemsAction,
 		subscriptionScheduleAction: stripeSubscriptionScheduleAction,
 		checkoutSessionAction: stripeCheckoutSessionAction,
+		refundAction: stripeRefundAction,
 	};
 };

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
@@ -6,7 +6,6 @@ import type {
 	StripeCheckoutSessionAction,
 	StripeInvoiceAction,
 	StripeInvoiceItemsAction,
-	UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import { orgToCurrency } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -68,9 +67,7 @@ export const evaluateStripeBillingPlan = async ({
 	});
 
 	const stripeRefundAction = billingContext.refundLastPayment
-		? buildStripeRefundAction({
-				billingContext: billingContext as UpdateSubscriptionBillingContext,
-			})
+		? buildStripeRefundAction({ billingContext })
 		: undefined;
 
 	ctx.logger.info(

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
@@ -9,6 +9,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { addStripeSubscriptionScheduleIdToBillingPlan } from "@/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan";
 import { executeStripeCheckoutSessionAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeCheckoutSessionAction";
 import { executeStripeInvoiceAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeInvoiceAction";
+import { executeStripeRefundAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeRefundAction.js";
 import { executeStripeSubscriptionAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction";
 import { executeStripeSubscriptionScheduleAction } from "@/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction";
 import { createStripeInvoiceItems } from "@/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps";
@@ -116,6 +117,20 @@ export const executeStripeBillingPlan = async ({
 		}
 	}
 
+	// Execute refund action (after subscription cancel, which provides the latest_invoice)
+	ctx.logger.info(
+		`[executeStripeBillingPlan] refundAction: ${JSON.stringify(billingPlan.stripe.refundAction)}, hasStripeSubscription: ${!!stripeSubscription}`,
+	);
+	let stripeRefund: Stripe.Refund | undefined;
+	if (billingPlan.stripe.refundAction && stripeSubscription) {
+		stripeRefund = await executeStripeRefundAction({
+			ctx,
+			refundAction: billingPlan.stripe.refundAction,
+			stripeSubscription,
+			currentEpochMs: billingContext.currentEpochMs,
+		});
+	}
+
 	const stripeInvoice =
 		subscriptionResult?.stripeInvoice ?? invoiceResult?.stripeInvoice;
 
@@ -126,6 +141,7 @@ export const executeStripeBillingPlan = async ({
 		stripeSubscription: subscriptionResult?.stripeSubscription,
 		stripeInvoice,
 		stripeInvoiceItems,
+		stripeRefund,
 		requiredAction:
 			subscriptionResult?.requiredAction ?? invoiceResult?.requiredAction,
 		autumnInvoice,

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeRefundAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeRefundAction.ts
@@ -20,7 +20,7 @@ export const executeStripeRefundAction = async ({
 	refundAction: StripeRefundAction;
 	stripeSubscription: Stripe.Subscription;
 	currentEpochMs: number;
-}): Promise<Stripe.Refund> => {
+}): Promise<Stripe.Refund | undefined> => {
 	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
 
 	// 1. Get the latest invoice ID from the subscription
@@ -85,11 +85,7 @@ export const executeStripeRefundAction = async ({
 		ctx.logger.info(
 			"[executeStripeRefundAction] Prorated refund amount is 0, skipping refund",
 		);
-		throw new RecaseError({
-			message: "Prorated refund amount is $0, no refund to issue",
-			code: ErrCode.InvalidRequest,
-			statusCode: 400,
-		});
+		return undefined;
 	}
 
 	// 6. Issue the refund and update the DB

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeRefundAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeRefundAction.ts
@@ -1,0 +1,107 @@
+import type { StripeRefundAction } from "@autumn/shared";
+import { applyProration, ErrCode, RecaseError } from "@autumn/shared";
+import type Stripe from "stripe";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	createRefundAndUpdateInvoice,
+	resolveChargeFromInvoice,
+	validateChargeRefundable,
+} from "@/internal/customers/handlers/handleRefundInvoice/invoiceRefundUtils.js";
+
+/** Execute a refund against the latest invoice of a cancelled subscription */
+export const executeStripeRefundAction = async ({
+	ctx,
+	refundAction,
+	stripeSubscription,
+	currentEpochMs,
+}: {
+	ctx: AutumnContext;
+	refundAction: StripeRefundAction;
+	stripeSubscription: Stripe.Subscription;
+	currentEpochMs: number;
+}): Promise<Stripe.Refund> => {
+	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+
+	// 1. Get the latest invoice ID from the subscription
+	const latestInvoiceId =
+		typeof stripeSubscription.latest_invoice === "string"
+			? stripeSubscription.latest_invoice
+			: stripeSubscription.latest_invoice?.id;
+
+	if (!latestInvoiceId) {
+		throw new RecaseError({
+			message: "Cancelled subscription has no latest invoice to refund",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	// 2. Retrieve the invoice with payments expanded
+	const stripeInvoice = await stripeCli.invoices.retrieve(latestInvoiceId, {
+		expand: ["payments.data.payment.payment_intent"],
+	});
+
+	// 3. Resolve the charge
+	const charge = await resolveChargeFromInvoice({ stripeCli, stripeInvoice });
+
+	if (!charge) {
+		throw new RecaseError({
+			message:
+				"Could not resolve a charge from the subscription's latest invoice",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	// 4. Validate the charge is refundable
+	const refundableAmountInCents = validateChargeRefundable({ charge });
+
+	// 5. Calculate the refund amount
+	let refundAmountInCents: number;
+
+	if (refundAction.mode === "full") {
+		refundAmountInCents = refundableAmountInCents;
+	} else {
+		// Prorated: refund the unused portion of the billing period
+		const proratedFraction = applyProration({
+			now: currentEpochMs,
+			billingPeriod: refundAction.billingPeriod,
+			amount: 1,
+		});
+
+		refundAmountInCents = Math.round(
+			refundableAmountInCents * proratedFraction,
+		);
+
+		// Ensure we don't exceed the refundable amount
+		refundAmountInCents = Math.min(
+			refundAmountInCents,
+			refundableAmountInCents,
+		);
+	}
+
+	if (refundAmountInCents <= 0) {
+		ctx.logger.info(
+			"[executeStripeRefundAction] Prorated refund amount is 0, skipping refund",
+		);
+		throw new RecaseError({
+			message: "Prorated refund amount is $0, no refund to issue",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	// 6. Issue the refund and update the DB
+	ctx.logger.info(
+		`[executeStripeRefundAction] Refunding ${refundAmountInCents} cents (mode: ${refundAction.mode}) from charge ${charge.id}`,
+	);
+
+	return createRefundAndUpdateInvoice({
+		stripeCli,
+		db: ctx.db,
+		chargeId: charge.id,
+		stripeInvoiceId: latestInvoiceId,
+		amountInCents: refundAmountInCents,
+	});
+};

--- a/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
+++ b/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
@@ -55,9 +55,9 @@ export const billingPlanToPreviewResponse = async ({
 		subtotal,
 		total,
 		currency,
-		// credit,
 		next_cycle: nextCycle,
 		incoming,
 		outgoing,
+		refund: autumnBillingPlan.refundPreview,
 	} satisfies BillingPreviewResponse;
 };

--- a/server/src/internal/customers/handlers/handleRefundInvoice/handleRefundInvoice.ts
+++ b/server/src/internal/customers/handlers/handleRefundInvoice/handleRefundInvoice.ts
@@ -1,16 +1,11 @@
-import {
-	ErrCode,
-	invoices,
-	RecaseError,
-	stripeToAtmnAmount,
-} from "@autumn/shared";
-import { eq, sql } from "drizzle-orm";
+import { ErrCode, RecaseError, stripeToAtmnAmount } from "@autumn/shared";
 import type Stripe from "stripe";
 import { z } from "zod/v4";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import {
 	calculateRefundAmountInCents,
+	createRefundAndUpdateInvoice,
 	resolveChargeFromInvoice,
 	validateChargeRefundable,
 } from "./invoiceRefundUtils.js";
@@ -70,29 +65,22 @@ export const handleRefundInvoice = createRoute({
 			currency: charge.currency,
 		});
 
-		// 4. Issue the refund
-		const stripeRefund = await stripeCli.refunds.create({
-			charge: charge.id,
-			amount: refundAmountInCents,
+		// 4. Issue the refund and update the DB
+		const stripeRefund = await createRefundAndUpdateInvoice({
+			stripeCli,
+			db: ctx.db,
+			chargeId: charge.id,
+			stripeInvoiceId: stripe_invoice_id,
+			amountInCents: refundAmountInCents,
 		});
-
-		// 5. Atomically increment refunded_amount on the Autumn invoice
-		const refundedAmount = stripeToAtmnAmount({
-			amount: stripeRefund.amount,
-			currency: stripeRefund.currency,
-		});
-
-		await ctx.db
-			.update(invoices)
-			.set({
-				refunded_amount: sql`${invoices.refunded_amount} + ${refundedAmount}`,
-			})
-			.where(eq(invoices.stripe_id, stripe_invoice_id));
 
 		return c.json({
 			refund_id: stripeRefund.id,
 			charge_id: charge.id,
-			amount: refundedAmount,
+			amount: stripeToAtmnAmount({
+				amount: stripeRefund.amount,
+				currency: stripeRefund.currency,
+			}),
 			currency: stripeRefund.currency,
 			status: stripeRefund.status,
 		});

--- a/server/src/internal/customers/handlers/handleRefundInvoice/invoiceRefundUtils.ts
+++ b/server/src/internal/customers/handlers/handleRefundInvoice/invoiceRefundUtils.ts
@@ -1,10 +1,13 @@
 import {
 	atmnToStripeAmount,
 	ErrCode,
+	invoices,
 	RecaseError,
 	stripeToAtmnAmount,
 } from "@autumn/shared";
+import { eq, sql } from "drizzle-orm";
 import type Stripe from "stripe";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 /** Resolve the Stripe charge from an invoice's payments list */
 export const resolveChargeFromInvoice = async ({
@@ -128,4 +131,38 @@ export const calculateRefundAmountInCents = ({
 	}
 
 	return refundAmountInCents;
+};
+
+/** Issue a Stripe refund and atomically increment refunded_amount on the Autumn invoice */
+export const createRefundAndUpdateInvoice = async ({
+	stripeCli,
+	db,
+	chargeId,
+	stripeInvoiceId,
+	amountInCents,
+}: {
+	stripeCli: Stripe;
+	db: DrizzleCli;
+	chargeId: string;
+	stripeInvoiceId: string;
+	amountInCents: number;
+}): Promise<Stripe.Refund> => {
+	const stripeRefund = await stripeCli.refunds.create({
+		charge: chargeId,
+		amount: amountInCents,
+	});
+
+	const refundedAmount = stripeToAtmnAmount({
+		amount: stripeRefund.amount,
+		currency: stripeRefund.currency,
+	});
+
+	await db
+		.update(invoices)
+		.set({
+			refunded_amount: sql`${invoices.refunded_amount} + ${refundedAmount}`,
+		})
+		.where(eq(invoices.stripe_id, stripeInvoiceId));
+
+	return stripeRefund;
 };

--- a/server/tests/integration/billing/update-subscription/cancel/immediately/cancel-immediately-refund.test.ts
+++ b/server/tests/integration/billing/update-subscription/cancel/immediately/cancel-immediately-refund.test.ts
@@ -1,0 +1,795 @@
+/**
+ * Cancel Immediately Refund Tests
+ *
+ * Tests for the `refund_last_payment` parameter when canceling subscriptions immediately.
+ * Unlike the default cancel-immediately flow (which creates credit invoice line items),
+ * `refund_last_payment` issues a direct Stripe refund and skips credit invoice creation.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	applyProration,
+	type BillingPreviewResponse,
+	ErrCode,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import {
+	expectProductActive,
+	expectProductNotPresent,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectNoStripeSubscription } from "@tests/integration/billing/utils/expectNoStripeSubscription";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { Decimal } from "decimal.js";
+import type Stripe from "stripe";
+import AutumnError from "@/external/autumn/autumnCli";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { InvoiceService } from "@/internal/invoices/InvoiceService";
+
+const getLatestInvoice = ({ customer }: { customer: ApiCustomerV3 }) => {
+	const invoice = customer.invoices?.[0];
+	if (!invoice) {
+		throw new Error("Expected customer to have an invoice");
+	}
+
+	return invoice;
+};
+
+const getRefundPreview = ({ preview }: { preview: BillingPreviewResponse }) => {
+	if (!preview.refund) {
+		throw new Error("Expected preview.refund to be defined");
+	}
+
+	return preview.refund;
+};
+
+const getBillingPeriod = ({
+	customer,
+	productId,
+}: {
+	customer: ApiCustomerV3;
+	productId: string;
+}) => {
+	const product = customer.products?.find((entry) => entry.id === productId);
+	if (!product?.current_period_start || !product.current_period_end) {
+		throw new Error("Missing billing period on subscription");
+	}
+
+	return {
+		start: product.current_period_start,
+		end: product.current_period_end,
+	};
+};
+
+const getAutumnInvoiceByStripeId = async ({
+	ctx,
+	stripeInvoiceId,
+}: {
+	ctx: AutumnContext;
+	stripeInvoiceId: string;
+}) => {
+	const invoice = await InvoiceService.getByStripeId({
+		db: ctx.db,
+		stripeId: stripeInvoiceId,
+	});
+
+	if (!invoice) {
+		throw new Error(`Expected Autumn invoice for ${stripeInvoiceId}`);
+	}
+
+	return invoice;
+};
+
+const expectWithinOneDollar = ({
+	actual,
+	expected,
+}: {
+	actual: number;
+	expected: number;
+}) => {
+	expect(Math.abs(actual - expected)).toBeLessThanOrEqual(1);
+};
+
+const createDirectStripeRefund = async ({
+	stripeCli,
+	stripeInvoiceId,
+	amountInCents,
+}: {
+	stripeCli: Stripe;
+	stripeInvoiceId: string;
+	amountInCents: number;
+}) => {
+	const stripeInvoice = await stripeCli.invoices.retrieve(stripeInvoiceId, {
+		expand: ["payments.data.payment.payment_intent"],
+	});
+
+	const payment = stripeInvoice.payments?.data?.[0]?.payment;
+	if (!payment) {
+		throw new Error("Expected Stripe invoice payment for direct refund test");
+	}
+
+	let chargeId: string | null = null;
+
+	if (payment.type === "charge") {
+		chargeId =
+			typeof payment.charge === "string"
+				? payment.charge
+				: (payment.charge?.id ?? null);
+	} else if (payment.type === "payment_intent") {
+		const paymentIntentId =
+			typeof payment.payment_intent === "string"
+				? payment.payment_intent
+				: payment.payment_intent?.id;
+
+		if (!paymentIntentId) {
+			throw new Error("Expected payment_intent on Stripe invoice payment");
+		}
+
+		const paymentIntent = await stripeCli.paymentIntents.retrieve(
+			paymentIntentId,
+			{ expand: ["latest_charge"] },
+		);
+
+		chargeId =
+			typeof paymentIntent.latest_charge === "string"
+				? paymentIntent.latest_charge
+				: (paymentIntent.latest_charge?.id ?? null);
+	}
+
+	if (!chargeId) {
+		throw new Error("Expected Stripe charge for direct refund test");
+	}
+
+	return stripeCli.refunds.create({
+		charge: chargeId,
+		amount: amountInCents,
+	});
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Cancel with refund_last_payment: "full" (start of cycle)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("cancel immediately refund: full refund (start of cycle)")}`, async () => {
+	const customerId = "cancel-imm-refund-full-start";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const customerAfterAttach =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({
+		customer: customerAfterAttach,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterAttach,
+		count: 1,
+		latestTotal: 20,
+	});
+
+	const initialInvoice = getLatestInvoice({ customer: customerAfterAttach });
+	const cancelParams = {
+		customer_id: customerId,
+		product_id: pro.id,
+		cancel_action: "cancel_immediately" as const,
+		refund_last_payment: "full" as const,
+	};
+
+	const preview = await autumnV1.subscriptions.previewUpdate(cancelParams);
+	const refundPreview = getRefundPreview({ preview });
+
+	expect(preview.total).toBe(0);
+	expect(refundPreview).toEqual({
+		amount: 20,
+		invoice: {
+			stripe_id: initialInvoice.stripe_id,
+			total: 20,
+			refunded_amount: 0,
+			currency: initialInvoice.currency,
+		},
+	});
+
+	await autumnV1.subscriptions.update(cancelParams);
+
+	const customerAfterCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductNotPresent({
+		customer: customerAfterCancel,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterCancel,
+		count: 1,
+	});
+
+	const autumnInvoiceAfterCancel = await getAutumnInvoiceByStripeId({
+		ctx,
+		stripeInvoiceId: initialInvoice.stripe_id,
+	});
+	expect(autumnInvoiceAfterCancel.refunded_amount).toBe(20);
+
+	await expectNoStripeSubscription({
+		db: ctx.db,
+		customerId,
+		org: ctx.org,
+		env: ctx.env,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Cancel with refund_last_payment: "prorated" (mid-cycle)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("cancel immediately refund: prorated refund (mid-cycle)")}`, async () => {
+	const customerId = "cancel-imm-refund-prorated-mid";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [],
+	});
+
+	const { autumnV1, ctx, advancedTo } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({ productId: pro.id }),
+			s.advanceTestClock({ days: 15 }),
+		],
+	});
+
+	const customerMidCycle =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({
+		customer: customerMidCycle,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerMidCycle,
+		count: 1,
+		latestTotal: 20,
+	});
+
+	const billingPeriod = getBillingPeriod({
+		customer: customerMidCycle,
+		productId: pro.id,
+	});
+	const expectedRefund = applyProration({
+		now: Math.floor(advancedTo! / 1000) * 1000,
+		billingPeriod,
+		amount: 20,
+	});
+
+	const initialInvoice = getLatestInvoice({ customer: customerMidCycle });
+	const cancelParams = {
+		customer_id: customerId,
+		product_id: pro.id,
+		cancel_action: "cancel_immediately" as const,
+		refund_last_payment: "prorated" as const,
+	};
+
+	const preview = await autumnV1.subscriptions.previewUpdate(cancelParams);
+	const refundPreview = getRefundPreview({ preview });
+
+	expectWithinOneDollar({
+		actual: preview.total,
+		expected: -expectedRefund,
+	});
+	expect(refundPreview).toEqual({
+		amount: preview.refund?.amount ?? 0,
+		invoice: {
+			stripe_id: initialInvoice.stripe_id,
+			total: 20,
+			refunded_amount: 0,
+			currency: initialInvoice.currency,
+		},
+	});
+
+	await autumnV1.subscriptions.update(cancelParams);
+
+	const customerAfterCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductNotPresent({
+		customer: customerAfterCancel,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterCancel,
+		count: 1,
+	});
+
+	const autumnInvoiceAfterCancel = await getAutumnInvoiceByStripeId({
+		ctx,
+		stripeInvoiceId: initialInvoice.stripe_id,
+	});
+
+	expectWithinOneDollar({
+		actual: autumnInvoiceAfterCancel.refunded_amount,
+		expected: refundPreview.amount,
+	});
+
+	await expectNoStripeSubscription({
+		db: ctx.db,
+		customerId,
+		org: ctx.org,
+		env: ctx.env,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: Mutual exclusivity validation (proration_behavior + refund_last_payment)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("cancel immediately refund: mutual exclusivity (proration_behavior + refund_last_payment)")}`, async () => {
+	const customerId = "cancel-imm-refund-mutual-excl";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [],
+	});
+
+	const { autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	try {
+		await autumnV2_2.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_immediately" as const,
+			proration_behavior: "prorate_immediately" as const,
+			refund_last_payment: "full" as const,
+		});
+		expect(true).toBe(false);
+	} catch (error: unknown) {
+		expect(error).toBeInstanceOf(AutumnError);
+		expect((error as AutumnError).code).toBe(ErrCode.InvalidInputs);
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 4: Full refund with base + prepaid messages
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("cancel immediately refund: full refund with base + prepaid")}`, async () => {
+	const customerId = "cancel-imm-refund-full-prepaid";
+	const billingUnits = 100;
+	const pricePerPack = 10;
+	const initialQuantity = 300;
+	const expectedInitialInvoice = 50;
+
+	const prepaidItem = items.prepaidMessages({
+		includedUsage: 0,
+		billingUnits,
+		price: pricePerPack,
+	});
+
+	const pro = products.pro({
+		id: "pro",
+		items: [prepaidItem],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({
+				productId: pro.id,
+				options: [
+					{ feature_id: TestFeature.Messages, quantity: initialQuantity },
+				],
+			}),
+		],
+	});
+
+	const customerAfterAttach =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({
+		customer: customerAfterAttach,
+		productId: pro.id,
+	});
+	expect(customerAfterAttach.features[TestFeature.Messages].balance).toBe(
+		initialQuantity,
+	);
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterAttach,
+		count: 1,
+		latestTotal: expectedInitialInvoice,
+	});
+
+	const initialInvoice = getLatestInvoice({ customer: customerAfterAttach });
+	const cancelParams = {
+		customer_id: customerId,
+		product_id: pro.id,
+		cancel_action: "cancel_immediately" as const,
+		refund_last_payment: "full" as const,
+	};
+
+	const preview = await autumnV1.subscriptions.previewUpdate(cancelParams);
+	const refundPreview = getRefundPreview({ preview });
+
+	expect(preview.total).toBe(0);
+	expect(refundPreview).toEqual({
+		amount: expectedInitialInvoice,
+		invoice: {
+			stripe_id: initialInvoice.stripe_id,
+			total: expectedInitialInvoice,
+			refunded_amount: 0,
+			currency: initialInvoice.currency,
+		},
+	});
+
+	await autumnV1.subscriptions.update(cancelParams);
+
+	const customerAfterCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductNotPresent({
+		customer: customerAfterCancel,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterCancel,
+		count: 1,
+	});
+
+	const autumnInvoiceAfterCancel = await getAutumnInvoiceByStripeId({
+		ctx,
+		stripeInvoiceId: initialInvoice.stripe_id,
+	});
+	expect(autumnInvoiceAfterCancel.refunded_amount).toBe(expectedInitialInvoice);
+
+	await expectNoStripeSubscription({
+		db: ctx.db,
+		customerId,
+		org: ctx.org,
+		env: ctx.env,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 5: Prorated refund with base + prepaid messages (mid-cycle)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("cancel immediately refund: prorated refund with base + prepaid (mid-cycle)")}`, async () => {
+	const customerId = "cancel-imm-refund-prorated-prepaid-mid";
+	const billingUnits = 100;
+	const pricePerPack = 10;
+	const initialQuantity = 500;
+	const basePrice = 20;
+	const prepaidAmount = 50;
+
+	const prepaidItem = items.prepaidMessages({
+		includedUsage: 0,
+		billingUnits,
+		price: pricePerPack,
+	});
+
+	const pro = products.pro({
+		id: "pro",
+		items: [prepaidItem],
+	});
+
+	const { autumnV1, ctx, advancedTo } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({
+				productId: pro.id,
+				options: [
+					{ feature_id: TestFeature.Messages, quantity: initialQuantity },
+				],
+			}),
+			s.advanceTestClock({ days: 15 }),
+		],
+	});
+
+	const customerMidCycle =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({
+		customer: customerMidCycle,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerMidCycle,
+		count: 1,
+		latestTotal: basePrice + prepaidAmount,
+	});
+
+	const billingPeriod = getBillingPeriod({
+		customer: customerMidCycle,
+		productId: pro.id,
+	});
+	const now = Math.floor(advancedTo! / 1000) * 1000;
+	const expectedRefund = new Decimal(
+		applyProration({
+			now,
+			billingPeriod,
+			amount: basePrice,
+		}),
+	)
+		.plus(
+			applyProration({
+				now,
+				billingPeriod,
+				amount: prepaidAmount,
+			}),
+		)
+		.toNumber();
+
+	const initialInvoice = getLatestInvoice({ customer: customerMidCycle });
+	const cancelParams = {
+		customer_id: customerId,
+		product_id: pro.id,
+		cancel_action: "cancel_immediately" as const,
+		refund_last_payment: "prorated" as const,
+	};
+
+	const preview = await autumnV1.subscriptions.previewUpdate(cancelParams);
+	const refundPreview = getRefundPreview({ preview });
+
+	expectWithinOneDollar({
+		actual: preview.total,
+		expected: -expectedRefund,
+	});
+	expect(refundPreview).toEqual({
+		amount: preview.refund?.amount ?? 0,
+		invoice: {
+			stripe_id: initialInvoice.stripe_id,
+			total: basePrice + prepaidAmount,
+			refunded_amount: 0,
+			currency: initialInvoice.currency,
+		},
+	});
+
+	await autumnV1.subscriptions.update(cancelParams);
+
+	const customerAfterCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductNotPresent({
+		customer: customerAfterCancel,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterCancel,
+		count: 1,
+	});
+
+	const autumnInvoiceAfterCancel = await getAutumnInvoiceByStripeId({
+		ctx,
+		stripeInvoiceId: initialInvoice.stripe_id,
+	});
+
+	expectWithinOneDollar({
+		actual: autumnInvoiceAfterCancel.refunded_amount,
+		expected: refundPreview.amount,
+	});
+
+	await expectNoStripeSubscription({
+		db: ctx.db,
+		customerId,
+		org: ctx.org,
+		env: ctx.env,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 6: Preview and execution match exactly
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("cancel immediately refund: preview and execution match exactly")}`, async () => {
+	const customerId = "cancel-imm-refund-preview-execution-match";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const customerBeforeCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	const invoiceBeforeCancel = getLatestInvoice({
+		customer: customerBeforeCancel,
+	});
+
+	// Read DB invoice BEFORE cancel to capture pre-cancel refunded_amount
+	const autumnInvoiceBeforeCancel = await getAutumnInvoiceByStripeId({
+		ctx,
+		stripeInvoiceId: invoiceBeforeCancel.stripe_id,
+	});
+
+	const cancelParams = {
+		customer_id: customerId,
+		product_id: pro.id,
+		cancel_action: "cancel_immediately" as const,
+		refund_last_payment: "full" as const,
+	};
+
+	const preview = await autumnV1.subscriptions.previewUpdate(cancelParams);
+	const refundPreview = getRefundPreview({ preview });
+
+	await autumnV1.subscriptions.update(cancelParams);
+
+	const customerAfterCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductNotPresent({
+		customer: customerAfterCancel,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterCancel,
+		count: 1,
+	});
+
+	const autumnInvoiceAfterCancel = await getAutumnInvoiceByStripeId({
+		ctx,
+		stripeInvoiceId: invoiceBeforeCancel.stripe_id,
+	});
+
+	expect(refundPreview.invoice.stripe_id).toBe(invoiceBeforeCancel.stripe_id);
+	expect(refundPreview.invoice.refunded_amount).toBe(
+		autumnInvoiceBeforeCancel.refunded_amount,
+	);
+	expect(autumnInvoiceAfterCancel.refunded_amount).toBe(
+		refundPreview.invoice.refunded_amount + refundPreview.amount,
+	);
+	expect(
+		autumnInvoiceAfterCancel.refunded_amount -
+			autumnInvoiceBeforeCancel.refunded_amount,
+	).toBe(refundPreview.amount);
+
+	await expectNoStripeSubscription({
+		db: ctx.db,
+		customerId,
+		org: ctx.org,
+		env: ctx.env,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 7: Prior partial refund caps refund amount
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("cancel immediately refund: prior partial refund cap")}`, async () => {
+	const customerId = "cancel-imm-refund-prior-partial-cap";
+	const priorPartialRefund = 5;
+
+	const pro = products.pro({
+		id: "pro",
+		items: [],
+	});
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const customerAfterAttach =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductActive({
+		customer: customerAfterAttach,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterAttach,
+		count: 1,
+		latestTotal: 20,
+	});
+
+	const initialInvoice = getLatestInvoice({ customer: customerAfterAttach });
+	await createDirectStripeRefund({
+		stripeCli: ctx.stripeCli,
+		stripeInvoiceId: initialInvoice.stripe_id,
+		amountInCents: priorPartialRefund * 100,
+	});
+
+	// Manually sync the refunded_amount in our DB (no webhook to do this)
+	await InvoiceService.update({
+		db: ctx.db,
+		query: { stripeId: initialInvoice.stripe_id },
+		updates: { refunded_amount: priorPartialRefund },
+	});
+
+	const invoiceAfterPartialRefund = await getAutumnInvoiceByStripeId({
+		ctx,
+		stripeInvoiceId: initialInvoice.stripe_id,
+	});
+
+	const cancelParams = {
+		customer_id: customerId,
+		product_id: pro.id,
+		cancel_action: "cancel_immediately" as const,
+		refund_last_payment: "full" as const,
+	};
+
+	const preview = await autumnV1.subscriptions.previewUpdate(cancelParams);
+	const refundPreview = getRefundPreview({ preview });
+
+	expect(preview.total).toBe(0);
+	expect(refundPreview).toEqual({
+		amount: 15,
+		invoice: {
+			stripe_id: invoiceAfterPartialRefund.stripe_id,
+			total: 20,
+			refunded_amount: priorPartialRefund,
+			currency: invoiceAfterPartialRefund.currency,
+		},
+	});
+
+	await autumnV1.subscriptions.update(cancelParams);
+
+	const customerAfterCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectProductNotPresent({
+		customer: customerAfterCancel,
+		productId: pro.id,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: customerAfterCancel,
+		count: 1,
+	});
+
+	const autumnInvoiceAfterCancel = await getAutumnInvoiceByStripeId({
+		ctx,
+		stripeInvoiceId: initialInvoice.stripe_id,
+	});
+	expect(autumnInvoiceAfterCancel.refunded_amount).toBe(20);
+
+	await expectNoStripeSubscription({
+		db: ctx.db,
+		customerId,
+		org: ctx.org,
+		env: ctx.env,
+	});
+});

--- a/shared/api/billing/common/billingPreviewResponse.ts
+++ b/shared/api/billing/common/billingPreviewResponse.ts
@@ -137,6 +137,30 @@ export const ExtBillingPreviewResponseSchema = z.object({
 	outgoing: z.array(BillingPreviewChangeSchema).meta({
 		description: "Products or subscription changes being removed or ended.",
 	}),
+
+	refund: z
+		.object({
+			amount: z.number().meta({
+				description:
+					"The refund amount that will be issued, accounting for any prior partial refunds.",
+			}),
+			invoice: z
+				.object({
+					stripe_id: z.string(),
+					total: z.number(),
+					refunded_amount: z.number(),
+					currency: z.string(),
+				})
+				.meta({
+					description: "The invoice that will be refunded.",
+				}),
+		})
+		.optional()
+		.meta({
+			internal: true,
+			description:
+				"Refund preview for cancel-with-refund flows. Only present when refund_last_payment is set.",
+		}),
 });
 
 export const BillingPreviewResponseSchema =

--- a/shared/api/billing/common/index.ts
+++ b/shared/api/billing/common/index.ts
@@ -14,5 +14,5 @@ export * from "./featureQuantity/featureQuantityParamsV0";
 export * from "./featureQuantity/mappers/featureQuantityParamsToCusProductOptions";
 export * from "./invoiceModeParams";
 export * from "./redirectMode";
-export * from "./refundBehavior";
+export * from "./refundLastPayment";
 export * from "./transitionRules";

--- a/shared/api/billing/common/refundBehavior.ts
+++ b/shared/api/billing/common/refundBehavior.ts
@@ -1,8 +1,0 @@
-import { z } from "zod/v4";
-
-export const RefundBehaviorSchema = z.enum([
-	"grant_invoice_credits",
-	"refund_payment_method",
-]);
-
-export type RefundBehavior = z.infer<typeof RefundBehaviorSchema>;

--- a/shared/api/billing/common/refundLastPayment.ts
+++ b/shared/api/billing/common/refundLastPayment.ts
@@ -1,0 +1,9 @@
+import { z } from "zod/v4";
+
+export const RefundLastPaymentSchema = z.enum(["prorated", "full"]).meta({
+	title: "RefundLastPayment",
+	description:
+		"Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.",
+});
+
+export type RefundLastPayment = z.infer<typeof RefundLastPaymentSchema>;

--- a/shared/api/billing/updateSubscription/updateSubscriptionV0Params.ts
+++ b/shared/api/billing/updateSubscription/updateSubscriptionV0Params.ts
@@ -6,6 +6,7 @@ import { BillingCycleAnchorSchema } from "../common/billingCycleAnchor";
 import { BillingParamsBaseV0Schema } from "../common/billingParamsBase/billingParamsBaseV0";
 import { CancelActionSchema } from "../common/cancelAction";
 import { RedirectModeSchema } from "../common/redirectMode";
+import { RefundLastPaymentSchema } from "../common/refundLastPayment";
 
 export const ExtUpdateSubscriptionV0ParamsSchema =
 	BillingParamsBaseV0Schema.extend({
@@ -25,6 +26,7 @@ export const ExtUpdateSubscriptionV0ParamsSchema =
 		// - 'prorate_immediately' (default): Invoice line items are charged immediately
 		// - 'next_cycle_only': Do NOT create any charges due to the update
 		billing_behavior: BillingBehaviorSchema.optional(),
+		refund_last_payment: RefundLastPaymentSchema.optional(),
 		billing_cycle_anchor: BillingCycleAnchorSchema.optional(),
 
 		processor_subscription_id: z.string().nullable().optional(),
@@ -92,7 +94,11 @@ export const UpdateSubscriptionV0ParamsSchema =
 				message:
 					"Cannot pass free_trial when cancel_action is 'cancel_end_of_cycle'.",
 			},
-		);
+		)
+		.refine((data) => !(data.refund_last_payment && data.billing_behavior), {
+			message:
+				"Cannot pass both billing_behavior and refund_last_payment. Use billing_behavior for invoice credits/proration, or refund_last_payment for direct refunds.",
+		});
 
 export type ExtUpdateSubscriptionV0Params = z.infer<
 	typeof ExtUpdateSubscriptionV0ParamsSchema

--- a/shared/api/billing/updateSubscription/updateSubscriptionV1Params.ts
+++ b/shared/api/billing/updateSubscription/updateSubscriptionV1Params.ts
@@ -4,6 +4,7 @@ import { BillingCycleAnchorSchema } from "../common/billingCycleAnchor";
 import { BillingParamsBaseV1Schema } from "../common/billingParamsBase/billingParamsBaseV1";
 import { CancelActionSchema } from "../common/cancelAction";
 import { RedirectModeSchema } from "../common/redirectMode";
+import { RefundLastPaymentSchema } from "../common/refundLastPayment";
 
 export const ExtUpdateSubscriptionV1ParamsSchema =
 	BillingParamsBaseV1Schema.extend({
@@ -27,6 +28,10 @@ export const ExtUpdateSubscriptionV1ParamsSchema =
 			// internal: true,
 			description:
 				"If true, the subscription is updated internally without applying billing changes in Stripe.",
+		}),
+
+		refund_last_payment: RefundLastPaymentSchema.optional().meta({
+			internal: true,
 		}),
 
 		recalculate_balances: z
@@ -62,6 +67,7 @@ const UPDATE_FIELDS = [
 	"billing_cycle_anchor",
 	"processor_subscription_id",
 	"no_billing_changes",
+	"refund_last_payment",
 	"recalculate_balances",
 	"status",
 	"redirect_mode",
@@ -75,10 +81,15 @@ export const UpdateSubscriptionV1ParamsSchema =
 			internal: true,
 		}),
 		redirect_mode: RedirectModeSchema.optional(),
-	}).refine((data) => UPDATE_FIELDS.some((key) => data[key] !== undefined), {
-		message:
-			"At least one update parameter must be provided (feature_quantities, version, customize, cancel_action, recalculate_balances or billing_cycle_anchor)",
-	});
+	})
+		.refine((data) => UPDATE_FIELDS.some((key) => data[key] !== undefined), {
+			message:
+				"At least one update parameter must be provided (feature_quantities, version, customize, cancel_action, recalculate_balances or billing_cycle_anchor)",
+		})
+		.refine((data) => !(data.refund_last_payment && data.proration_behavior), {
+			message:
+				"Cannot pass both proration_behavior and refund_last_payment. Use proration_behavior for invoice credits/proration, or refund_last_payment for direct refunds.",
+		});
 
 export type UpdateSubscriptionV1Params = z.infer<
 	typeof UpdateSubscriptionV1ParamsSchema

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -89,4 +89,6 @@ export interface BillingContext {
 	checkoutMode?: CheckoutMode;
 
 	anchorResetRefund?: AnchorResetRefund;
+
+	refundLastPayment?: "prorated" | "full";
 }

--- a/shared/models/billingModels/plan/autumnBillingPlan.ts
+++ b/shared/models/billingModels/plan/autumnBillingPlan.ts
@@ -88,6 +88,19 @@ export const AutumnBillingPlanSchema = z.object({
 	// Upsert operations (populated during webhook handling, e.g., checkout.session.completed)
 	upsertSubscription: SubscriptionSchema.optional(),
 	upsertInvoice: z.custom<InsertInvoice>().optional(),
+
+	/** Refund preview for cancel-with-refund flows, computed during plan finalization */
+	refundPreview: z
+		.object({
+			amount: z.number(),
+			invoice: z.object({
+				stripe_id: z.string(),
+				total: z.number(),
+				refunded_amount: z.number(),
+				currency: z.string(),
+			}),
+		})
+		.optional(),
 });
 
 export type AutumnBillingPlan = z.infer<typeof AutumnBillingPlanSchema>;

--- a/shared/models/billingModels/plan/billingResult.ts
+++ b/shared/models/billingModels/plan/billingResult.ts
@@ -9,6 +9,7 @@ export interface StripeBillingPlanResult {
 		| Stripe.Checkout.Session
 		| (Pick<Stripe.Checkout.Session, "id"> & { url?: string | null });
 	stripeInvoiceItems?: Stripe.InvoiceItem[];
+	stripeRefund?: Stripe.Refund;
 	requiredAction?: {
 		code: PaymentFailureCode;
 		reason: string;

--- a/shared/models/billingModels/stripe/index.ts
+++ b/shared/models/billingModels/stripe/index.ts
@@ -4,5 +4,6 @@ export * from "./stripeDiscountWithCoupon";
 export * from "./stripeInvoiceAction";
 export * from "./stripeInvoiceItemsAction";
 export * from "./stripeItemSpec";
+export * from "./stripeRefundAction";
 export * from "./stripeSubscriptionAction";
 export * from "./stripeSubscriptionScheduleAction";

--- a/shared/models/billingModels/stripe/stripeBillingPlan.ts
+++ b/shared/models/billingModels/stripe/stripeBillingPlan.ts
@@ -12,6 +12,10 @@ import {
 	StripeInvoiceItemsActionSchema,
 } from "./stripeInvoiceItemsAction";
 import {
+	type StripeRefundAction,
+	StripeRefundActionSchema,
+} from "./stripeRefundAction";
+import {
 	type StripeSubscriptionAction,
 	StripeSubscriptionActionSchema,
 } from "./stripeSubscriptionAction";
@@ -21,16 +25,18 @@ import {
 } from "./stripeSubscriptionScheduleAction";
 
 export {
-	StripeCheckoutSessionActionSchema,
-	StripeInvoiceActionSchema,
-	StripeInvoiceItemsActionSchema,
-	StripeSubscriptionActionSchema,
-	StripeSubscriptionScheduleActionSchema,
 	type StripeCheckoutSessionAction,
+	StripeCheckoutSessionActionSchema,
 	type StripeInvoiceAction,
+	StripeInvoiceActionSchema,
 	type StripeInvoiceItemsAction,
+	StripeInvoiceItemsActionSchema,
+	type StripeRefundAction,
+	StripeRefundActionSchema,
 	type StripeSubscriptionAction,
+	StripeSubscriptionActionSchema,
 	type StripeSubscriptionScheduleAction,
+	StripeSubscriptionScheduleActionSchema,
 };
 
 export const StripeBillingPlanSchema = z.object({
@@ -39,6 +45,7 @@ export const StripeBillingPlanSchema = z.object({
 	invoiceAction: StripeInvoiceActionSchema.optional(),
 	invoiceItemsAction: StripeInvoiceItemsActionSchema.optional(),
 	checkoutSessionAction: StripeCheckoutSessionActionSchema.optional(),
+	refundAction: StripeRefundActionSchema.optional(),
 });
 
 export type StripeBillingPlan = z.infer<typeof StripeBillingPlanSchema>;

--- a/shared/models/billingModels/stripe/stripeInvoiceAction.ts
+++ b/shared/models/billingModels/stripe/stripeInvoiceAction.ts
@@ -3,7 +3,6 @@ import { z } from "zod/v4";
 
 export const StripeInvoiceActionSchema = z.object({
 	addLineParams: z.custom<Stripe.InvoiceAddLinesParams>(),
-	refundParams: z.custom<Stripe.RefundCreateParams>().optional(),
 });
 
 export type StripeInvoiceAction = z.infer<typeof StripeInvoiceActionSchema>;

--- a/shared/models/billingModels/stripe/stripeInvoiceAction.ts
+++ b/shared/models/billingModels/stripe/stripeInvoiceAction.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 
 export const StripeInvoiceActionSchema = z.object({
 	addLineParams: z.custom<Stripe.InvoiceAddLinesParams>(),
+	refundParams: z.custom<Stripe.RefundCreateParams>().optional(),
 });
 
 export type StripeInvoiceAction = z.infer<typeof StripeInvoiceActionSchema>;

--- a/shared/models/billingModels/stripe/stripeRefundAction.ts
+++ b/shared/models/billingModels/stripe/stripeRefundAction.ts
@@ -1,0 +1,13 @@
+import { z } from "zod/v4";
+
+export const StripeRefundActionSchema = z.object({
+	type: z.literal("refund_last_invoice"),
+	stripeSubscriptionId: z.string(),
+	mode: z.enum(["prorated", "full"]),
+	billingPeriod: z.object({
+		start: z.number(),
+		end: z.number(),
+	}),
+});
+
+export type StripeRefundAction = z.infer<typeof StripeRefundActionSchema>;

--- a/vite/src/components/forms/cancel-subscription/components/CancelAdvancedSection.tsx
+++ b/vite/src/components/forms/cancel-subscription/components/CancelAdvancedSection.tsx
@@ -5,15 +5,24 @@ import {
 } from "@/components/forms/shared/advanced-section";
 import { useUpdateSubscriptionFormContext } from "@/components/forms/update-subscription-v2";
 import { IconCheckbox } from "@/components/v2/checkboxes/IconCheckbox";
+import { cn } from "@/lib/utils";
 
 export function CancelAdvancedSection() {
 	const { form, formValues } = useUpdateSubscriptionFormContext();
-	const { noBillingChanges } = formValues;
+	const { noBillingChanges, refundBehavior, refundAmount } = formValues;
+
+	const showRefundAmount = refundBehavior === "refund";
 
 	return (
 		<AdvancedSection
-			hasCustomSettings={noBillingChanges}
-			customSettingsTooltip={noBillingChanges ? "No Billing Changes" : ""}
+			hasCustomSettings={noBillingChanges || showRefundAmount}
+			customSettingsTooltip={
+				noBillingChanges
+					? "No Billing Changes"
+					: showRefundAmount
+						? `Refund: ${refundAmount === "full" ? "Full" : "Prorated"}`
+						: ""
+			}
 		>
 			<AdvancedToggleRow label="No Billing Changes">
 				<IconCheckbox
@@ -30,6 +39,39 @@ export function CancelAdvancedSection() {
 					{noBillingChanges ? "On" : "Off"}
 				</IconCheckbox>
 			</AdvancedToggleRow>
+
+			{showRefundAmount && (
+				<AdvancedToggleRow label="Refund Amount">
+					<>
+						<IconCheckbox
+							variant="secondary"
+							size="sm"
+							checked={refundAmount === "prorated"}
+							onCheckedChange={() =>
+								form.setFieldValue("refundAmount", "prorated")
+							}
+							className={cn(
+								"min-w-[76px] px-2 text-xs rounded-r-none",
+								refundAmount !== "prorated" && "border-r-0",
+							)}
+						>
+							Prorated
+						</IconCheckbox>
+						<IconCheckbox
+							variant="secondary"
+							size="sm"
+							checked={refundAmount === "full"}
+							onCheckedChange={() => form.setFieldValue("refundAmount", "full")}
+							className={cn(
+								"min-w-[76px] px-2 text-xs rounded-l-none",
+								refundAmount !== "full" && "border-l-0",
+							)}
+						>
+							Full
+						</IconCheckbox>
+					</>
+				</AdvancedToggleRow>
+			)}
 		</AdvancedSection>
 	);
 }

--- a/vite/src/components/forms/cancel-subscription/components/CancelPreviewSection.tsx
+++ b/vite/src/components/forms/cancel-subscription/components/CancelPreviewSection.tsx
@@ -11,30 +11,46 @@ export function CancelPreviewSection() {
 	const { previewQuery, formValues } = useUpdateSubscriptionFormContext();
 
 	const cancelAction = formValues.cancelAction ?? "cancel_end_of_cycle";
-	const refundBehavior = formValues.refundBehavior ?? "grant_invoice_credits";
+	const refundBehavior = formValues.refundBehavior;
+	const refundAmount = formValues.refundAmount;
+
+	const isFullRefund = refundBehavior === "refund" && refundAmount === "full";
 
 	const { isLoading, data: previewData, error: queryError } = previewQuery;
 	const error = queryError
 		? getBackendErr(queryError as AxiosError, "Failed to load preview")
 		: undefined;
 
-	const showRefundToggle =
-		cancelAction === "cancel_immediately" &&
-		!!previewData &&
-		previewData.total < 0;
+	const refundPreview = previewData?.refund;
 
 	const totals = useMemo(() => {
 		if (!previewData) return [];
 
 		const result = [];
 
+		// For any refund mode (full or prorated) with preview data, use the exact amount
+		if (refundBehavior === "refund" && refundPreview) {
+			if (refundPreview.invoice.refunded_amount > 0) {
+				result.push({
+					label: "Previously Refunded",
+					amount: -refundPreview.invoice.refunded_amount,
+					variant: "secondary" as const,
+				});
+			}
+
+			result.push({
+				label: "Refund Amount",
+				amount: -refundPreview.amount,
+				variant: "primary" as const,
+			});
+
+			return result;
+		}
+
 		let totalLabel = "Total Due Now";
 		if (previewData.total < 0) {
-			if (showRefundToggle) {
-				totalLabel =
-					refundBehavior === "refund_payment_method"
-						? "Refund Amount"
-						: "Credit Amount";
+			if (refundBehavior === "refund") {
+				totalLabel = "Refund Amount";
 			} else {
 				totalLabel = "Credit Amount";
 			}
@@ -58,13 +74,26 @@ export function CancelPreviewSection() {
 		}
 
 		return result;
-	}, [previewData, cancelAction, refundBehavior, showRefundToggle]);
+	}, [previewData, cancelAction, refundBehavior, refundPreview]);
 
 	if (error) {
 		return (
 			<SheetSection title="Pricing Preview" withSeparator>
 				<PreviewErrorDisplay error={error} />
 			</SheetSection>
+		);
+	}
+
+	// For full refund, show only totals — no prorated line items
+	if (isFullRefund) {
+		return (
+			<LineItemsPreview
+				title="Pricing Preview"
+				isLoading={isLoading}
+				lineItems={[]}
+				currency={previewData?.currency}
+				totals={totals}
+			/>
 		);
 	}
 

--- a/vite/src/components/forms/cancel-subscription/components/RefundBehaviorSection.tsx
+++ b/vite/src/components/forms/cancel-subscription/components/RefundBehaviorSection.tsx
@@ -1,0 +1,132 @@
+import { cp } from "@autumn/shared";
+import {
+	ArrowCounterClockwiseIcon,
+	CreditCardIcon,
+	ReceiptIcon,
+} from "@phosphor-icons/react";
+import { AnimatePresence, motion } from "motion/react";
+import { useUpdateSubscriptionFormContext } from "@/components/forms/update-subscription-v2";
+import { COLLAPSE_TRANSITION } from "@/components/forms/update-subscription-v2/constants/animationConstants";
+import { PanelButton } from "@/components/v2/buttons/PanelButton";
+import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
+
+type RefundMode = "credits" | "refund" | "none";
+
+const getRefundMode = ({
+	billingBehavior,
+	refundBehavior,
+}: {
+	billingBehavior: string | null;
+	refundBehavior: string | null;
+}): RefundMode => {
+	if (refundBehavior === "refund") return "refund";
+	if (billingBehavior === "none") return "none";
+	return "credits";
+};
+
+export function RefundBehaviorSection() {
+	const { form, formValues, formContext } = useUpdateSubscriptionFormContext();
+	const { customerProduct } = formContext;
+
+	const cancelAction = formValues.cancelAction;
+	const noBillingChanges = formValues.noBillingChanges;
+
+	const { valid: isFreeOrOneOff } = cp(customerProduct).free().or.oneOff();
+	const showSection =
+		cancelAction === "cancel_immediately" &&
+		!isFreeOrOneOff &&
+		!noBillingChanges;
+
+	const refundMode = getRefundMode({
+		billingBehavior: formValues.billingBehavior,
+		refundBehavior: formValues.refundBehavior,
+	});
+
+	const setRefundMode = (mode: RefundMode) => {
+		switch (mode) {
+			case "credits":
+				form.setFieldValue("billingBehavior", "prorate_immediately");
+				form.setFieldValue("refundBehavior", null);
+				form.setFieldValue("refundAmount", null);
+				break;
+			case "refund":
+				form.setFieldValue("billingBehavior", null);
+				form.setFieldValue("refundBehavior", "refund");
+				if (!formValues.refundAmount) {
+					form.setFieldValue("refundAmount", "prorated");
+				}
+				break;
+			case "none":
+				form.setFieldValue("billingBehavior", "none");
+				form.setFieldValue("refundBehavior", null);
+				form.setFieldValue("refundAmount", null);
+				break;
+		}
+	};
+
+	return (
+		<AnimatePresence initial={false}>
+			{showSection && (
+				<motion.div
+					initial={{ height: 0, opacity: 0 }}
+					animate={{ height: "auto", opacity: 1 }}
+					exit={{ height: 0, opacity: 0 }}
+					transition={COLLAPSE_TRANSITION}
+					style={{ overflow: "hidden" }}
+				>
+					<SheetSection title="Refund Behavior" withSeparator>
+						<div className="space-y-4">
+							<div className="flex w-full items-center gap-4">
+								<PanelButton
+									isSelected={refundMode === "credits"}
+									onClick={() => setRefundMode("credits")}
+									icon={<ReceiptIcon size={18} weight="duotone" />}
+								/>
+								<div className="flex-1">
+									<div className="text-body-highlight mb-1">
+										Invoice credits
+									</div>
+									<div className="text-body-secondary leading-tight">
+										Prorated credit applied to future invoices.
+									</div>
+								</div>
+							</div>
+
+							<div className="flex w-full items-center gap-4">
+								<PanelButton
+									isSelected={refundMode === "refund"}
+									onClick={() => setRefundMode("refund")}
+									icon={
+										<ArrowCounterClockwiseIcon size={18} weight="duotone" />
+									}
+								/>
+								<div className="flex-1">
+									<div className="text-body-highlight mb-1">
+										Refund to payment method
+									</div>
+									<div className="text-body-secondary leading-tight">
+										Refund directly to the customer's original payment method.
+									</div>
+								</div>
+							</div>
+
+							<div className="flex w-full items-center gap-4">
+								<PanelButton
+									isSelected={refundMode === "none"}
+									onClick={() => setRefundMode("none")}
+									icon={<CreditCardIcon size={18} weight="duotone" />}
+								/>
+								<div className="flex-1">
+									<div className="text-body-highlight mb-1">No refund</div>
+									<div className="text-body-secondary leading-tight">
+										No charges or credits issued. Access ends immediately.
+									</div>
+								</div>
+							</div>
+						</div>
+					</SheetSection>
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+}

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm.ts
@@ -54,6 +54,7 @@ export function useUpdateSubscriptionForm({
 			billingBehavior: null,
 			resetBillingCycle: false,
 			refundBehavior: null,
+			refundAmount: null,
 			noBillingChanges: false,
 			...defaultOverrides,
 		} as UpdateSubscriptionForm,

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
@@ -117,6 +117,8 @@ export function useUpdateSubscriptionRequestBody({
 			cancelAction,
 			billingBehavior,
 			resetBillingCycle,
+			refundBehavior,
+			refundAmount,
 			noBillingChanges,
 		} = formValues;
 
@@ -130,12 +132,17 @@ export function useUpdateSubscriptionRequestBody({
 
 		// For cancel actions, only include cancellation-related fields
 		if (cancelAction) {
+			const isRefund = refundBehavior === "refund";
 			return {
 				...base,
 				cancel_action: cancelAction,
 				billing_behavior:
-					cancelAction === "cancel_immediately"
+					cancelAction === "cancel_immediately" && !isRefund
 						? billingBehavior || undefined
+						: undefined,
+				refund_last_payment:
+					cancelAction === "cancel_immediately" && isRefund
+						? refundAmount || "prorated"
 						: undefined,
 				no_billing_changes: noBillingChanges || undefined,
 			};

--- a/vite/src/components/forms/update-subscription-v2/types/refundBehaviourSchema.ts
+++ b/vite/src/components/forms/update-subscription-v2/types/refundBehaviourSchema.ts
@@ -1,7 +1,4 @@
 import { z } from "zod/v4";
 
-export const RefundBehaviorSchema = z.enum([
-	"grant_invoice_credits",
-	"refund_payment_method",
-]);
+export const RefundBehaviorSchema = z.enum(["refund"]);
 export type RefundBehaviorValue = z.infer<typeof RefundBehaviorSchema>;

--- a/vite/src/components/forms/update-subscription-v2/updateSubscriptionFormSchema.ts
+++ b/vite/src/components/forms/update-subscription-v2/updateSubscriptionFormSchema.ts
@@ -25,6 +25,7 @@ export const UpdateSubscriptionFormSchema = z.object({
 	billingBehavior: BillingBehaviorSchema.nullable(),
 	resetBillingCycle: z.boolean(),
 	refundBehavior: RefundBehaviorSchema.nullable(),
+	refundAmount: z.enum(["prorated", "full"]).nullable(),
 	noBillingChanges: z.boolean(),
 });
 

--- a/vite/src/components/forms/update-subscription/get-update-subscription-body.ts
+++ b/vite/src/components/forms/update-subscription/get-update-subscription-body.ts
@@ -5,7 +5,6 @@ import type {
 	FeatureOptions,
 	ProductItem,
 	ProductV2,
-	RefundBehavior,
 } from "@autumn/shared";
 
 export const getUpdateSubscriptionBody = ({
@@ -40,7 +39,7 @@ export const getUpdateSubscriptionBody = ({
 	// Cancel action fields
 	cancelAction?: CancelAction | null;
 	billingBehavior?: BillingBehavior | null;
-	refundBehavior?: RefundBehavior | null;
+	refundBehavior?: string | null;
 }) => {
 	// For cancel actions, only include cancellation-related fields
 	if (cancelAction) {

--- a/vite/src/components/forms/update-subscription/use-update-subscription-body-builder.ts
+++ b/vite/src/components/forms/update-subscription/use-update-subscription-body-builder.ts
@@ -1,4 +1,4 @@
-import type { BillingBehavior } from "@autumn/shared";
+import type { BillingBehavior, CancelAction } from "@autumn/shared";
 import {
 	AppEnv,
 	type CreateFreeTrial,
@@ -7,10 +7,6 @@ import {
 	type ProductV2,
 } from "@autumn/shared";
 import { useMemo } from "react";
-import type {
-	CancelActionValue,
-	RefundBehaviorValue,
-} from "@/components/forms/update-subscription-v2/updateSubscriptionFormSchema";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useHasChanges, useProductStore } from "@/hooks/stores/useProductStore";
 import { useEnv } from "@/utils/envUtils";
@@ -33,9 +29,9 @@ interface UpdateSubscriptionBodyBuilderParams {
 	items?: ProductItem[] | null;
 
 	// Cancel action fields
-	cancelAction?: CancelActionValue | null;
+	cancelAction?: CancelAction | null;
 	billingBehavior?: BillingBehavior | null;
-	refundBehavior?: RefundBehaviorValue | null;
+	refundBehavior?: string | null;
 }
 
 /**

--- a/vite/src/components/v2/buttons/CopyButton.tsx
+++ b/vite/src/components/v2/buttons/CopyButton.tsx
@@ -122,45 +122,51 @@ export const MiniCopyButton = ({
 	text,
 	side = "right",
 	innerClassName = "",
+	iconOrientation = "right",
 	children,
 	...props
 }: CopyButtonProps) => {
 	const { copied, handleCopy } = useCopyAnimation({ text });
 
+	const copyIcon = (
+		<TooltipProvider>
+			<Tooltip open={copied} onOpenChange={() => {}}>
+				<TooltipTrigger asChild>
+					<IconButton
+						variant="skeleton"
+						{...props}
+						iconOrientation="right"
+						icon={<AnimatedCopyIcon copied={copied} />}
+						onClick={handleCopy}
+						className={cn(
+							"opacity-0 group-hover:opacity-100 cursor-pointer px-0!",
+							copied && "opacity-100",
+						)}
+					/>
+				</TooltipTrigger>
+				<TooltipContent
+					side={side}
+					sideOffset={8}
+					className="bg-background text-body p-2 py-1 border rounded-lg shadow-sm"
+				>
+					<div className="flex items-center gap-1">
+						<span className="text-xs font-medium">Copied!</span>
+					</div>
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+
 	return (
 		<div className="flex items-center gap-1 w-fit max-w-full group text-t3">
+			{iconOrientation === "left" && copyIcon}
 			{children}
 			<span
 				className={cn("text-sm text-tiny-id w-full truncate", innerClassName)}
 			>
 				{text}
 			</span>
-			<TooltipProvider>
-				<Tooltip open={copied} onOpenChange={() => {}}>
-					<TooltipTrigger asChild>
-						<IconButton
-							variant="skeleton"
-							{...props}
-							iconOrientation="right"
-							icon={<AnimatedCopyIcon copied={copied} />}
-							onClick={handleCopy}
-							className={cn(
-								"opacity-0 group-hover:opacity-100 cursor-pointer px-0!",
-								copied && "opacity-100",
-							)}
-						/>
-					</TooltipTrigger>
-					<TooltipContent
-						side={side}
-						sideOffset={8}
-						className="bg-background text-body p-2 py-1 border rounded-lg shadow-sm"
-					>
-						<div className="flex items-center gap-1">
-							<span className="text-xs font-medium">Copied!</span>
-						</div>
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
+			{iconOrientation === "right" && copyIcon}
 		</div>
 	);
 };

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -252,11 +252,32 @@ export function InvoiceDetailSheet({
 
 				{/* Invoice Total */}
 				<SheetSection withSeparator={true}>
-					<div className="flex items-center justify-between">
-						<span className="text-sm font-medium text-foreground">Total</span>
-						<span className="text-sm font-semibold text-foreground tabular-nums">
-							{formatSignedAmount(invoice.total, invoice.currency)}
-						</span>
+					<div className="flex flex-col gap-1">
+						<div className="flex items-center justify-between">
+							<span className="text-sm font-medium text-foreground">Total</span>
+							<span className="text-sm font-semibold text-foreground tabular-nums">
+								{formatSignedAmount(invoice.total, invoice.currency)}
+							</span>
+						</div>
+						{invoice.refunded_amount > 0 && (
+							<>
+								<div className="flex items-center justify-between">
+									<span className="text-sm text-t3">Refunded</span>
+									<span className="text-sm text-amber-500 tabular-nums">
+										-{formatAmount(invoice.refunded_amount, invoice.currency)}
+									</span>
+								</div>
+								<div className="flex items-center justify-between pt-1">
+									<span className="text-sm text-t3">Net</span>
+									<span className="text-sm font-semibold text-foreground tabular-nums">
+										{formatSignedAmount(
+											invoice.total - invoice.refunded_amount,
+											invoice.currency,
+										)}
+									</span>
+								</div>
+							</>
+						)}
 					</div>
 				</SheetSection>
 
@@ -267,6 +288,7 @@ export function InvoiceDetailSheet({
 							<span className="text-t3">Invoice ID</span>
 							<MiniCopyButton
 								text={invoice.id}
+								iconOrientation="left"
 								innerClassName="text-xs text-t1 font-mono"
 							/>
 						</div>
@@ -274,6 +296,7 @@ export function InvoiceDetailSheet({
 							<span className="text-t3">Stripe ID</span>
 							<MiniCopyButton
 								text={invoice.stripe_id}
+								iconOrientation="left"
 								innerClassName="text-xs text-t1 font-mono"
 							/>
 						</div>

--- a/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
+++ b/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
@@ -77,22 +77,32 @@ export function RefundInvoiceDialog({
 				toast.error("Please enter a valid refund amount");
 				return;
 			}
-			if (parsed > invoice.total) {
-				toast.error("Refund amount cannot exceed invoice total");
+			if (parsed > remainingRefundable) {
+				toast.error("Refund amount cannot exceed remaining refundable balance");
 				return;
 			}
 		}
 		refundMutation.mutate();
 	};
 
-	const formattedTotal = formatAmount({
-		amount: invoice.total,
-		currency: invoice.currency,
-		minFractionDigits: 2,
-		amountFormatOptions: {
-			currencyDisplay: "narrowSymbol",
-		},
-	});
+	const alreadyRefunded = invoice.refunded_amount ?? 0;
+	const invoiceTotal = Math.abs(invoice.total);
+	const remainingRefundable = invoiceTotal - alreadyRefunded;
+
+	const fmt = ({ amount: amt }: { amount: number }) =>
+		formatAmount({
+			amount: amt,
+			currency: invoice.currency,
+			minFractionDigits: 2,
+			amountFormatOptions: { currencyDisplay: "narrowSymbol" },
+		});
+
+	const refundDisplay =
+		mode === "full"
+			? fmt({ amount: remainingRefundable })
+			: amount
+				? fmt({ amount: Number.parseFloat(amount) || 0 })
+				: fmt({ amount: 0 });
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -100,7 +110,8 @@ export function RefundInvoiceDialog({
 				<DialogHeader>
 					<DialogTitle>Refund Invoice</DialogTitle>
 					<DialogDescription>
-						Invoice total: {formattedTotal} {invoice.currency.toUpperCase()}
+						Invoice total: {fmt({ amount: invoiceTotal })}{" "}
+						{invoice.currency.toUpperCase()}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -129,13 +140,27 @@ export function RefundInvoiceDialog({
 								type="number"
 								min="0.01"
 								step="0.01"
-								max={invoice.total}
+								max={remainingRefundable}
 								placeholder="0.00"
 								value={amount}
 								onChange={(e) => setAmount(e.target.value)}
 							/>
 						</div>
 					)}
+
+					{/* Refund summary */}
+					<div className="flex flex-col gap-1 border-t border-border/40 pt-3">
+						{alreadyRefunded > 0 && (
+							<div className="flex justify-between text-xs text-t3">
+								<span>Previously refunded</span>
+								<span>{fmt({ amount: alreadyRefunded })}</span>
+							</div>
+						)}
+						<div className="flex justify-between text-sm font-medium text-foreground">
+							<span>Refund amount</span>
+							<span>{refundDisplay}</span>
+						</div>
+					</div>
 				</div>
 
 				<DialogFooter>

--- a/vite/src/views/customers2/components/sheets/SubscriptionCancelSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionCancelSheet.tsx
@@ -5,11 +5,11 @@ import {
 	type ProductV2,
 } from "@autumn/shared";
 import { useMemo } from "react";
-import { BillingBehaviorSection } from "@/components/forms/cancel-subscription/components/BillingBehaviorSection";
 import { CancelAdvancedSection } from "@/components/forms/cancel-subscription/components/CancelAdvancedSection";
 import { CancelFooter } from "@/components/forms/cancel-subscription/components/CancelFooter";
 import { CancelModeSection } from "@/components/forms/cancel-subscription/components/CancelModeSection";
 import { CancelPreviewSection } from "@/components/forms/cancel-subscription/components/CancelPreviewSection";
+import { RefundBehaviorSection } from "@/components/forms/cancel-subscription/components/RefundBehaviorSection";
 import {
 	type UpdateSubscriptionFormContext,
 	UpdateSubscriptionFormProvider,
@@ -70,7 +70,7 @@ function SheetContent() {
 				)}
 
 				<CancelModeSection />
-				<BillingBehaviorSection />
+				<RefundBehaviorSection />
 				<CancelAdvancedSection />
 				<CancelPreviewSection />
 				<CancelFooter />


### PR DESCRIPTION
- **fix: 🐛 undo early exit in compute cancel line items**
- **feat: 🎸 centralise refund logic into helper**
- **feat: 🎸 compute and preview refund in preview and update**
- **feat: 🎸 types and such for update preview w refund**
- **feat: 🎸 ui for cancel w refund**
- **test: 💍 for refunding to last payment method**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “refund to last payment method” on immediate cancellation. Supports prorated or full refunds with an exact preview, issues the Stripe refund against the latest invoice, updates our invoice record, and skips $0 prorated refunds gracefully.

- New Features
  - API: `refund_last_payment` for `updateSubscription` (V0/V1) when `cancel_action="cancel_immediately"`; modes: `prorated` or `full`. Validation blocks using it with `proration_behavior`/`billing_behavior`.
  - Preview: adds `refund` to `BillingPreviewResponse` with amount and invoice details; full refunds hide proration line items.
  - Stripe: builds and executes a refund action on the latest invoice; prorates by remaining period; caps by remaining refundable; atomically increments `refunded_amount`.
  - UI: new Refund Behavior section with refund/credits/none; prorated/full toggle; preview shows “Refund Amount” and “Previously Refunded”; invoice sheet shows refunded and net totals; refund dialog enforces remaining refundable and shows a summary.

- Refactors
  - Centralized refund helper (`createRefundAndUpdateInvoice`) and new Stripe refund action/execute paths; returns refund in billing result.
  - Filter refund-only line items from Stripe invoice actions to avoid duplicate effects; early-exit cancel line items on full refund.
  - Safer action build: `buildStripeRefundAction` accepts base context to avoid unsafe casts.
  - Prorated $0 refunds now log and skip instead of throwing.

<sup>Written for commit eda9e80caa3c6c5c1fcfb69ee35ecf416a688342. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `refund_last_payment` option (`\"full\"` | `\"prorated\"`) to immediate subscription cancellation, issuing a direct Stripe refund to the customer's original payment method instead of applying invoice credits. It centralises the refund-and-DB-update logic into a shared `createRefundAndUpdateInvoice` helper, wires a new `StripeRefundAction` through the billing plan pipeline, and ships a refactored `RefundBehaviorSection` UI with a 7-test integration suite.

- **Bug fix** (Improvements): Removed the early exit in `computeCancelLineItems` that was skipping proration line items for full-refund cancellations.
- **API changes**: `refund_last_payment` is mutually exclusive with `billing_behavior` / `proration_behavior` — enforced by Zod refinements on both V0 and V1 params.
- **P1 found**: In `executeStripeRefundAction`, when a prorated refund rounds to $0 (end-of-cycle cancellation), the code `throw`s a `RecaseError` instead of returning gracefully — the log even says \"skipping refund\" — causing the entire cancellation request to surface as a 400 error even though the Stripe subscription was already cancelled at that point.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the zero-amount prorated-refund throw in executeStripeRefundAction.

One P1 bug: a prorated refund of $0 (reachable at end-of-cycle) throws after the subscription is already cancelled, surfacing a spurious 400 to the caller. Remaining findings are P2. All other logic — full refund, prorated mid-cycle, preview/execution consistency, DB update, and mutual-exclusivity guards — looks correct and is well covered by the integration tests.

server/src/internal/billing/v2/providers/stripe/execute/executeStripeRefundAction.ts — the zero-amount guard at line 84 must return instead of throw.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeRefundAction.ts | New file executing Stripe refunds on cancellation; throws instead of returning gracefully when prorated refund rounds to $0, corrupting the cancellation response after the subscription is already cancelled. |
| server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeRefundPreview.ts | New file computing refund preview from finalized line items and Autumn invoice; logic is correct and consistent with execution for full/prorated modes. |
| server/src/internal/customers/handlers/handleRefundInvoice/invoiceRefundUtils.ts | Refund-and-DB-update logic correctly extracted into `createRefundAndUpdateInvoice` helper; previously duplicated inline in the route handler. |
| shared/models/billingModels/stripe/stripeInvoiceAction.ts | Adds unused `refundParams` optional field to `StripeInvoiceAction` schema — dead code, never set or read anywhere. |
| server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts | Builds and attaches `StripeRefundAction` to the billing plan; uses an unsafe `as UpdateSubscriptionBillingContext` cast that is guarded at runtime but suppresses compile-time safety. |
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts | Correctly sequences refund execution after subscription cancellation and threads `stripeRefund` through the billing result. |
| server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelLineItems.ts | Bug fix: early-exits with empty line items for full-refund mode, preventing unnecessary proration line items alongside a full refund. |
| server/tests/integration/billing/update-subscription/cancel/immediately/cancel-immediately-refund.test.ts | Comprehensive integration tests covering full refund, prorated mid-cycle, mutual exclusivity, prepaid items, preview/execution match, and prior-partial-refund cap. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant UpdateSubscriptionRoute
    participant finalizeUpdateSubscriptionPlan
    participant computeRefundPreview
    participant evaluateStripeBillingPlan
    participant executeStripeBillingPlan
    participant executeStripeSubscriptionAction
    participant executeStripeRefundAction
    participant Stripe
    participant DB

    Client->>UpdateSubscriptionRoute: POST /update (cancel_immediately + refund_last_payment)
    UpdateSubscriptionRoute->>finalizeUpdateSubscriptionPlan: finalize line items
    finalizeUpdateSubscriptionPlan->>computeRefundPreview: compute preview from line items
    computeRefundPreview->>DB: getByStripeId(latest_invoice_id)
    DB-->>computeRefundPreview: autumnInvoice
    computeRefundPreview-->>finalizeUpdateSubscriptionPlan: plan.refundPreview
    finalizeUpdateSubscriptionPlan-->>UpdateSubscriptionRoute: AutumnBillingPlan
    UpdateSubscriptionRoute->>evaluateStripeBillingPlan: build StripeRefundAction
    evaluateStripeBillingPlan-->>UpdateSubscriptionRoute: StripeBillingPlan (with refundAction)
    UpdateSubscriptionRoute->>executeStripeBillingPlan: execute
    executeStripeBillingPlan->>executeStripeSubscriptionAction: cancel subscription
    executeStripeSubscriptionAction->>Stripe: cancel
    Stripe-->>executeStripeSubscriptionAction: cancelled
    executeStripeBillingPlan->>executeStripeRefundAction: refund (after cancel)
    executeStripeRefundAction->>Stripe: retrieve invoice + charge
    executeStripeRefundAction->>Stripe: refunds.create
    Stripe-->>executeStripeRefundAction: Stripe.Refund
    executeStripeRefundAction->>DB: UPDATE invoices SET refunded_amount += x
    executeStripeRefundAction-->>executeStripeBillingPlan: Stripe.Refund
    executeStripeBillingPlan-->>UpdateSubscriptionRoute: result
    UpdateSubscriptionRoute-->>Client: 200 OK
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/providers/stripe/execute/executeStripeRefundAction.ts
Line: 84-93

Comment:
**Throws after subscription already cancelled — should skip gracefully**

When `refund_last_payment: "prorated"` is used near the end of a billing cycle, `proratedFraction` approaches zero and `refundAmountInCents` rounds to 0. The log message says "skipping refund" but the code throws a `RecaseError` (400). Because this runs *after* `executeStripeSubscriptionAction` has already cancelled the subscription, the caller receives a 400 error even though the cancellation succeeded — leaving the subscription cancelled with no refund and no clean response.

The fix is to return `undefined` instead of throwing, and update the return type to `Promise<Stripe.Refund | undefined>`:

```typescript
if (refundAmountInCents <= 0) {
    ctx.logger.info(
        "[executeStripeRefundAction] Prorated refund amount is 0, skipping refund",
    );
    return undefined;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: shared/models/billingModels/stripe/stripeInvoiceAction.ts
Line: 6

Comment:
**Dead schema field — `refundParams` is never set or read**

`refundParams` was added to `StripeInvoiceAction` but there are zero references to it anywhere in the server or shared code. Refunds are handled entirely through `StripeRefundAction` / `executeStripeRefundAction`. Keeping this field in the schema is misleading.

```suggestion
export const StripeInvoiceActionSchema = z.object({
	addLineParams: z.custom<Stripe.InvoiceAddLinesParams>(),
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
Line: 70-74

Comment:
**Unsafe type cast to `UpdateSubscriptionBillingContext`**

`billingContext` is typed as the base `BillingContext` here, but `buildStripeRefundAction` requires `UpdateSubscriptionBillingContext` (which adds `cancelAction`, `stripeSubscription`, etc.). The cast works at runtime because `buildStripeRefundAction` guards on both fields, but it silences TypeScript's safety check. If `refundLastPayment` is ever set on a non-update-subscription context, the cast would hide the mismatch.

Consider narrowing via an explicit type guard or moving `buildStripeRefundAction` to a location where the context is already typed as `UpdateSubscriptionBillingContext`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: 💍 for refunding to last payment m..."](https://github.com/useautumn/autumn/commit/b62b24b29295bf6728ef0cd30a184082e27fdb41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28486538)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->