### PR TITLE
fix: 🐛 send cus.prods.updated during revcat events

### DIFF
--- a/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
@@ -137,6 +137,7 @@ export const handleRenewal = async ({
 			},
 			product,
 		),
+		sendWebhook: true,
 	});
 
 	logger.info(

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
@@ -9,6 +9,7 @@ import {
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
+import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
 import { createFullCusProduct } from "@/internal/customers/add-product/createFullCusProduct";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { getExistingCusProducts } from "@/internal/customers/cusProducts/cusProductUtils/getExistingCusProducts";
@@ -41,11 +42,23 @@ export const handleRenewal = async ({
 
 	const now = Date.now();
 
-	// If same product exists and is active, this is just a renewal - nothing to do
+	// If same product exists and is active, this is just a renewal - send webhook only
 	if (curSameProduct && ACTIVE_STATUSES.includes(curSameProduct.status)) {
 		logger.info(
-			`Renewal for existing active product ${product.id}, no action needed`,
+			`Renewal for existing active product ${product.id}, sending webhook`,
 		);
+
+		// Send webhook for simple renewal (no state change)
+		await addProductsUpdatedWebhookTask({
+			ctx,
+			internalCustomerId: curSameProduct.internal_customer_id,
+			org,
+			env,
+			customerId: customer.id || "",
+			scenario: AttachScenario.Renew,
+			cusProduct: curSameProduct,
+		});
+
 		return { success: true };
 	} else if (
 		curSameProduct &&
@@ -61,6 +74,18 @@ export const handleRenewal = async ({
 				status: CusProductStatus.Active,
 			},
 		});
+
+		// Send webhook for past_due → active recovery
+		await addProductsUpdatedWebhookTask({
+			ctx,
+			internalCustomerId: curSameProduct.internal_customer_id,
+			org,
+			env,
+			customerId: customer.id || "",
+			scenario: AttachScenario.Renew,
+			cusProduct: curSameProduct,
+		});
+
 		logger.info(`Marked past due product as active: ${curSameProduct.id}`);
 		return { success: true };
 	}
@@ -94,6 +119,17 @@ export const handleRenewal = async ({
 			},
 		});
 
+		// Send webhook for the expired product
+		await addProductsUpdatedWebhookTask({
+			ctx,
+			internalCustomerId: curMainProduct.internal_customer_id,
+			org,
+			env,
+			customerId: customer.id || "",
+			scenario: AttachScenario.Expired,
+			cusProduct: curMainProduct,
+		});
+
 		logger.info(`Expired old cus_product: ${curMainProduct.id}`);
 	} else if (curSameProduct) {
 		// Reactivate the same product if it was expired/cancelled
@@ -106,6 +142,17 @@ export const handleRenewal = async ({
 				ended_at: null,
 				canceled: false,
 			},
+		});
+
+		// Send webhook for reactivation
+		await addProductsUpdatedWebhookTask({
+			ctx,
+			internalCustomerId: curSameProduct.internal_customer_id,
+			org,
+			env,
+			customerId: customer.id || "",
+			scenario: AttachScenario.Renew,
+			cusProduct: curSameProduct,
 		});
 
 		logger.info(`Reactivated cus_product: ${curSameProduct.id}`);

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatBillingIssue.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatBillingIssue.ts
@@ -5,8 +5,8 @@ import { CusProductStatus } from "@shared/models/cusProductModels/cusProductEnum
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import {
 	ACTIVE_STATUSES,
-	CusProductService,
 } from "@/internal/customers/cusProducts/CusProductService";
+import { customerProductActions } from "@/internal/customers/cusProducts/actions";
 import { getExistingCusProducts } from "@/internal/customers/cusProducts/cusProductUtils/getExistingCusProducts";
 import { resolveRevenuecatResources } from "../misc/resolveRevenuecatResources";
 
@@ -17,10 +17,10 @@ export const handleBillingIssue = async ({
 	event: WebhookBillingIssue;
 	ctx: RevenueCatWebhookContext;
 }) => {
-	const { db, logger } = ctx;
+	const { logger } = ctx;
 	const { product_id, app_user_id } = event;
 
-	const { product, cusProducts } = await resolveRevenuecatResources({
+	const { product, customer, cusProducts } = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id,
@@ -47,12 +47,10 @@ export const handleBillingIssue = async ({
 	}
 
 	if (ACTIVE_STATUSES.includes(curSameProduct.status)) {
-		await CusProductService.update({
+		await customerProductActions.markPastDue({
 			ctx,
-			cusProductId: curSameProduct.id,
-			updates: {
-				status: CusProductStatus.PastDue,
-			},
+			customerProduct: curSameProduct,
+			fullCustomer: customer,
 		});
 
 		return { success: true };

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatCancellation.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatCancellation.ts
@@ -2,7 +2,7 @@ import type { WebhookCancellation } from "@puzzmo/revenue-cat-webhook-types";
 import { ErrCode, RecaseError } from "@shared/index";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
-import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { customerProductActions } from "@/internal/customers/cusProducts/actions";
 import { getExistingCusProducts } from "@/internal/customers/cusProducts/cusProductUtils/getExistingCusProducts";
 
 export const handleCancellation = async ({
@@ -12,11 +12,11 @@ export const handleCancellation = async ({
 	event: WebhookCancellation;
 	ctx: RevenueCatWebhookContext;
 }) => {
-	const { db, logger } = ctx;
+	const { logger } = ctx;
 	const { product_id, original_app_user_id, app_user_id, expiration_at_ms } =
 		event;
 
-	const { product, cusProducts } = await resolveRevenuecatResources({
+	const { product, customer, cusProducts } = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id ?? original_app_user_id,
@@ -35,14 +35,11 @@ export const handleCancellation = async ({
 		});
 	}
 
-	await CusProductService.update({
+	await customerProductActions.cancel({
 		ctx,
-		cusProductId: curSameProduct.id,
-		updates: {
-			canceled_at: Date.now(),
-			canceled: true,
-			ended_at: expiration_at_ms,
-		},
+		customerProduct: curSameProduct,
+		fullCustomer: customer,
+		endedAt: expiration_at_ms,
 	});
 
 	logger.info(

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts
@@ -38,6 +38,10 @@ export const handleExpiration = async ({
 		ctx,
 		customerProduct: curSameProduct,
 		fullCustomer: customer,
+		updates: {
+			ended_at: event.expiration_at_ms,
+			canceled: !!curSameProduct.canceled_at,
+		},
 	});
 
 	logger.info(`Expired cus_product: ${curSameProduct.id}`);

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts
@@ -1,9 +1,8 @@
 import type { WebhookExpiration } from "@puzzmo/revenue-cat-webhook-types";
-import { CusProductStatus, ErrCode, RecaseError } from "@shared/index";
+import { ErrCode, RecaseError } from "@shared/index";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
-import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { getExistingCusProducts } from "@/internal/customers/cusProducts/cusProductUtils/getExistingCusProducts";
 
 export const handleExpiration = async ({
@@ -13,7 +12,7 @@ export const handleExpiration = async ({
 	event: WebhookExpiration;
 	ctx: RevenueCatWebhookContext;
 }) => {
-	const { db, logger } = ctx;
+	const { logger } = ctx;
 	const { product_id, original_app_user_id, app_user_id } = event;
 
 	const { product, customer, cusProducts } = await resolveRevenuecatResources({
@@ -35,36 +34,11 @@ export const handleExpiration = async ({
 		});
 	}
 
-	// Expire the cus_product
-	await CusProductService.update({
+	await customerProductActions.expireAndActivateDefault({
 		ctx,
-		cusProductId: curSameProduct.id,
-		updates: {
-			status: CusProductStatus.Expired,
-			ended_at: event.expiration_at_ms,
-			canceled: !!curSameProduct.canceled_at,
-		},
-	});
-
-	logger.info(`Expired cus_product: ${curSameProduct.id}`);
-
-	await customerProductActions.activateFreeSuccessor({
-		ctx,
-		fromCustomerProduct: curSameProduct,
+		customerProduct: curSameProduct,
 		fullCustomer: customer,
 	});
 
-	// Activate default product if this was a main product
-	// const isMain = !product.is_add_on;
-	// const isOneOffProduct = isOneOff(product.prices);
-
-	// if (isMain && !isOneOffProduct) {
-
-	// 	// await activateDefaultProduct({
-	// 	// 	ctx,
-	// 	// 	productGroup: product.group,
-	// 	// 	fullCus: customer,
-	// 	// 	curCusProduct: curSameProduct,
-	// 	// });
-	// }
+	logger.info(`Expired cus_product: ${curSameProduct.id}`);
 };

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatInitialPurchase.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatInitialPurchase.ts
@@ -109,6 +109,7 @@ export const handleInitialPurchase = async ({
 			},
 			product,
 		),
+		sendWebhook: true,
 	});
 
 	logger.info(

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts
@@ -63,6 +63,7 @@ export const handleNonRenewingPurchase = async ({
 			},
 			product,
 		),
+		sendWebhook: true,
 	});
 
 	logger.info(

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatUncancellation.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatUncancellation.ts
@@ -1,13 +1,8 @@
 import type { WebhookUnCancellation } from "@puzzmo/revenue-cat-webhook-types";
-import {
-	CusProductStatus,
-	ErrCode,
-	ProcessorType,
-	RecaseError,
-} from "@shared/index";
+import { ErrCode, ProcessorType, RecaseError } from "@shared/index";
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
-import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { customerProductActions } from "@/internal/customers/cusProducts/actions";
 
 export const handleUncancellation = async ({
 	event,
@@ -16,10 +11,10 @@ export const handleUncancellation = async ({
 	event: WebhookUnCancellation;
 	ctx: RevenueCatWebhookContext;
 }) => {
-	const { db } = ctx;
+	const { logger } = ctx;
 	const { product_id, original_app_user_id, app_user_id } = event;
 
-	const { product, cusProducts } = await resolveRevenuecatResources({
+	const { product, customer, cusProducts } = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id ?? original_app_user_id,
@@ -31,22 +26,19 @@ export const handleUncancellation = async ({
 			cp.processor?.type === ProcessorType.RevenueCat,
 	);
 
-	if (cusProduct) {
-		await CusProductService.update({
-			ctx,
-			cusProductId: cusProduct.id,
-			updates: {
-				canceled_at: null,
-				canceled: false,
-				ended_at: null,
-				status: CusProductStatus.Active,
-			},
-		});
-	} else {
+	if (!cusProduct) {
 		throw new RecaseError({
 			message: "Cus product not found",
 			code: ErrCode.CusProductNotFound,
 			statusCode: 404,
 		});
 	}
+
+	await customerProductActions.uncancel({
+		ctx,
+		customerProduct: cusProduct,
+		fullCustomer: customer,
+	});
+
+	logger.info(`Uncancelled cus_product ${cusProduct.id}`);
 };

--- a/server/src/internal/customers/cusProducts/actions/cancelCustomerProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/cancelCustomerProduct.ts
@@ -1,0 +1,70 @@
+import {
+	AttachScenario,
+	type FullCusProduct,
+	type FullCustomer,
+	type InsertCustomerProduct,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+
+/**
+ * Cancels a customer product (marks it as canceled with a future end date).
+ *
+ * This action:
+ * 1. Sets canceled=true, canceled_at, and ended_at on the customer product
+ * 2. Sends products_updated webhook with Cancel scenario
+ * 3. Updates the FullCustomer in memory
+ *
+ * Used by RevenueCat cancellation webhooks and any external cancellation flow.
+ */
+export const cancelCustomerProduct = async ({
+	ctx,
+	customerProduct,
+	fullCustomer,
+	endedAt,
+}: {
+	ctx: AutumnContext;
+	customerProduct: FullCusProduct;
+	fullCustomer: FullCustomer;
+	endedAt?: number | null;
+}): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
+	const { org, env } = ctx;
+
+	// 1. Cancel the product
+	const updates: Partial<InsertCustomerProduct> = {
+		canceled_at: Date.now(),
+		canceled: true,
+		ended_at: endedAt ?? undefined,
+	};
+
+	await CusProductService.update({
+		ctx,
+		cusProductId: customerProduct.id,
+		updates,
+	});
+
+	ctx.logger.debug(
+		`[cancelCustomerProduct]: canceling ${customerProduct.product.name}`,
+	);
+
+	// 2. Send webhook
+	await addProductsUpdatedWebhookTask({
+		ctx,
+		internalCustomerId: customerProduct.internal_customer_id,
+		org,
+		env,
+		customerId: fullCustomer.id || "",
+		scenario: AttachScenario.Cancel,
+		cusProduct: customerProduct,
+	});
+
+	// 3. Update full customer in memory
+	fullCustomer.customer_products = fullCustomer.customer_products.map((cp) =>
+		cp.id === customerProduct.id
+			? ({ ...cp, ...updates } as FullCusProduct)
+			: cp,
+	);
+
+	return { updates };
+};

--- a/server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts
+++ b/server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts
@@ -26,10 +26,12 @@ export const expireCustomerProductAndActivateDefault = async ({
 	ctx,
 	customerProduct,
 	fullCustomer,
+	updates: extraUpdates,
 }: {
 	ctx: AutumnContext;
 	customerProduct: FullCusProduct;
 	fullCustomer: FullCustomer;
+	updates?: Partial<InsertCustomerProduct>;
 }): Promise<{
 	updates: Partial<InsertCustomerProduct>;
 	activatedCustomerProduct?: FullCusProduct;
@@ -40,6 +42,7 @@ export const expireCustomerProductAndActivateDefault = async ({
 	// 1. Expire the product
 	const updates: Partial<InsertCustomerProduct> = {
 		status: CusProductStatus.Expired,
+		...extraUpdates,
 	};
 
 	await CusProductService.update({

--- a/server/src/internal/customers/cusProducts/actions/index.ts
+++ b/server/src/internal/customers/cusProducts/actions/index.ts
@@ -1,12 +1,15 @@
 import { getExpiredCustomerProductsCacheAndMerge } from "@/internal/customers/cusProducts/actions/expiredCache/getExpiredCustomerProductsCache";
 import { activateFreeSuccessorProduct } from "./activateFreeSuccessorProduct";
 import { activateScheduledCustomerProduct } from "./activateScheduled";
+import { cancelCustomerProduct } from "./cancelCustomerProduct";
 import { deleteScheduledCustomerProduct } from "./deleteScheduledCustomerProduct";
 import { expireCustomerProductAndActivateDefault } from "./expireAndActivateDefault";
 import {
 	getExpiredCustomerProductsCache,
 	setExpiredCustomerProductsCache,
 } from "./expiredCache";
+import { markCustomerProductPastDue } from "./markCustomerProductPastDue";
+import { uncancelCustomerProduct } from "./uncancelCustomerProduct";
 import { updateCustomerProductDbAndCache } from "./updateDbAndCache";
 
 export const customerProductActions = {
@@ -18,6 +21,15 @@ export const customerProductActions = {
 
 	/** Activates a scheduled customer product with new subscription/schedule IDs */
 	activateScheduled: activateScheduledCustomerProduct,
+
+	/** Cancels a customer product and sends a Cancel webhook */
+	cancel: cancelCustomerProduct,
+
+	/** Uncancels a customer product and sends a Renew webhook */
+	uncancel: uncancelCustomerProduct,
+
+	/** Marks a customer product as past due and sends a PastDue webhook */
+	markPastDue: markCustomerProductPastDue,
 
 	/** Deletes any scheduled main customer product in the same group */
 	deleteScheduled: deleteScheduledCustomerProduct,

--- a/server/src/internal/customers/cusProducts/actions/markCustomerProductPastDue.ts
+++ b/server/src/internal/customers/cusProducts/actions/markCustomerProductPastDue.ts
@@ -1,0 +1,67 @@
+import {
+	AttachScenario,
+	CusProductStatus,
+	type FullCusProduct,
+	type FullCustomer,
+	type InsertCustomerProduct,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+
+/**
+ * Marks a customer product as past due (billing issue).
+ *
+ * This action:
+ * 1. Sets status to PastDue on the customer product
+ * 2. Sends products_updated webhook with PastDue scenario
+ * 3. Updates the FullCustomer in memory
+ *
+ * Used by RevenueCat billing issue webhooks and any external billing issue flow.
+ */
+export const markCustomerProductPastDue = async ({
+	ctx,
+	customerProduct,
+	fullCustomer,
+}: {
+	ctx: AutumnContext;
+	customerProduct: FullCusProduct;
+	fullCustomer: FullCustomer;
+}): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
+	const { org, env } = ctx;
+
+	// 1. Mark as past due
+	const updates: Partial<InsertCustomerProduct> = {
+		status: CusProductStatus.PastDue,
+	};
+
+	await CusProductService.update({
+		ctx,
+		cusProductId: customerProduct.id,
+		updates,
+	});
+
+	ctx.logger.debug(
+		`[markCustomerProductPastDue]: marking ${customerProduct.product.name} as past due`,
+	);
+
+	// 2. Send webhook
+	await addProductsUpdatedWebhookTask({
+		ctx,
+		internalCustomerId: customerProduct.internal_customer_id,
+		org,
+		env,
+		customerId: fullCustomer.id || "",
+		scenario: AttachScenario.PastDue,
+		cusProduct: customerProduct,
+	});
+
+	// 3. Update full customer in memory
+	fullCustomer.customer_products = fullCustomer.customer_products.map((cp) =>
+		cp.id === customerProduct.id
+			? ({ ...cp, ...updates } as FullCusProduct)
+			: cp,
+	);
+
+	return { updates };
+};

--- a/server/src/internal/customers/cusProducts/actions/uncancelCustomerProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/uncancelCustomerProduct.ts
@@ -1,0 +1,70 @@
+import {
+	AttachScenario,
+	CusProductStatus,
+	type FullCusProduct,
+	type FullCustomer,
+	type InsertCustomerProduct,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+
+/**
+ * Uncancels a customer product (reverses a previous cancellation).
+ *
+ * This action:
+ * 1. Clears canceled/canceled_at/ended_at and sets status back to Active
+ * 2. Sends products_updated webhook with Renew scenario
+ * 3. Updates the FullCustomer in memory
+ *
+ * Used by RevenueCat uncancellation webhooks.
+ */
+export const uncancelCustomerProduct = async ({
+	ctx,
+	customerProduct,
+	fullCustomer,
+}: {
+	ctx: AutumnContext;
+	customerProduct: FullCusProduct;
+	fullCustomer: FullCustomer;
+}): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
+	const { org, env } = ctx;
+
+	// 1. Uncancel the product
+	const updates: Partial<InsertCustomerProduct> = {
+		canceled_at: null,
+		canceled: false,
+		ended_at: null,
+		status: CusProductStatus.Active,
+	};
+
+	await CusProductService.update({
+		ctx,
+		cusProductId: customerProduct.id,
+		updates,
+	});
+
+	ctx.logger.debug(
+		`[uncancelCustomerProduct]: uncanceling ${customerProduct.product.name}`,
+	);
+
+	// 2. Send webhook
+	await addProductsUpdatedWebhookTask({
+		ctx,
+		internalCustomerId: customerProduct.internal_customer_id,
+		org,
+		env,
+		customerId: fullCustomer.id || "",
+		scenario: AttachScenario.Renew,
+		cusProduct: customerProduct,
+	});
+
+	// 3. Update full customer in memory
+	fullCustomer.customer_products = fullCustomer.customer_products.map((cp) =>
+		cp.id === customerProduct.id
+			? ({ ...cp, ...updates } as FullCusProduct)
+			: cp,
+	);
+
+	return { updates };
+};

--- a/server/tests/integration/external-psps/revenuecat-webhooks.test.ts
+++ b/server/tests/integration/external-psps/revenuecat-webhooks.test.ts
@@ -1,0 +1,829 @@
+/**
+ * RevenueCat Webhook Integration Tests
+ *
+ * Tests that RevenueCat webhook events trigger the correct Autumn
+ * customer.products.updated webhooks via Svix Play.
+ *
+ * Each test sends a RevenueCat webhook event and verifies that the
+ * corresponding outgoing webhook contains the correct scenario:
+ * - Initial purchase → new
+ * - Renewal → renew
+ * - Upgrade (monthly → yearly) → upgrade
+ * - Downgrade (yearly → monthly) → downgrade
+ * - Cancellation → cancel
+ * - Uncancellation → renew
+ * - Billing issue → past_due
+ * - Expiration → expire
+ * - Non-renewing purchase → new
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import type { ApiCustomerV3, ApiProduct } from "@autumn/shared";
+import { AppEnv } from "@autumn/shared";
+import {
+	getPlayHistory,
+	getTestSvixAppId,
+	parseEventBody,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
+import { OrgService } from "@/internal/orgs/OrgService";
+import { encryptData } from "@/utils/encryptUtils";
+import { RevenueCatWebhookClient } from "./utils/revenue-cat-webhook-client";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type RevenueCatScenario =
+	| "new"
+	| "renew"
+	| "upgrade"
+	| "downgrade"
+	| "cancel"
+	| "uncancel"
+	| "past_due"
+	| "expired";
+
+type CustomerProductsUpdatedPayload = {
+	type: string;
+	data: {
+		scenario: RevenueCatScenario;
+		customer: ApiCustomerV3;
+		updated_product: ApiProduct;
+		entity?: any;
+	};
+};
+
+const RC_WEBHOOK_SECRET = "test_rc_webhook_secret_12345";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const setupRevenueCatOrg = async () => {
+	if (
+		ctx.org.processor_configs?.revenuecat?.sandbox_webhook_secret !==
+		RC_WEBHOOK_SECRET
+	) {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				processor_configs: {
+					...ctx.org.processor_configs,
+					revenuecat: {
+						api_key: encryptData("mock_rc_api_key_live"),
+						sandbox_api_key: encryptData("mock_rc_api_key_sandbox"),
+						project_id: "mock_project_live",
+						sandbox_project_id: "mock_project_sandbox",
+						webhook_secret: RC_WEBHOOK_SECRET,
+						sandbox_webhook_secret: RC_WEBHOOK_SECRET,
+					},
+				},
+			},
+		});
+	}
+};
+
+// ─── Svix Play Setup ─────────────────────────────────────────────────────────
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	await setupRevenueCatOrg();
+
+	const appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["customer.products.updated"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Initial Purchase → scenario: new
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: initial purchase → scenario: new")}`, async () => {
+	const customerId = "rc-webhook-initial-purchase";
+	const RC_PRO_MONTHLY_ID = "com.app.rcwh1_pro_monthly";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const proMonthly = products.pro({
+		id: "pro-monthly",
+		items: [messagesItem],
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [proMonthly] }),
+		],
+		actions: [],
+	});
+
+	await RCMappingService.upsert({
+		db: ctx.db,
+		data: {
+			org_id: ctx.org.id,
+			env: AppEnv.Sandbox,
+			autumn_product_id: proMonthly.id,
+			revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+		},
+	});
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	await rcClient.initialPurchase({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh1_tx_001",
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("new");
+	expect(data.updated_product.id).toBe(proMonthly.id);
+	expect(data.customer.id).toBe(customerId);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Renewal → scenario: renew
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: renewal → scenario: renew")}`, async () => {
+	const customerId = "rc-webhook-renewal";
+	const RC_PRO_MONTHLY_ID = "com.app.rcwh2_pro_monthly";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const proMonthly = products.pro({
+		id: "pro-monthly",
+		items: [messagesItem],
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [proMonthly] }),
+		],
+		actions: [],
+	});
+
+	await RCMappingService.upsert({
+		db: ctx.db,
+		data: {
+			org_id: ctx.org.id,
+			env: AppEnv.Sandbox,
+			autumn_product_id: proMonthly.id,
+			revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+		},
+	});
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	// First: initial purchase to create the subscription
+	await rcClient.initialPurchase({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh2_tx_001",
+	});
+
+	// Wait for the initial purchase webhook to arrive before triggering renewal
+	await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	// Then: renewal
+	await rcClient.renewal({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh2_tx_001",
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "renew",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("renew");
+	expect(data.updated_product.id).toBe(proMonthly.id);
+	expect(data.customer.id).toBe(customerId);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: Upgrade → scenario: upgrade
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: upgrade (monthly → yearly) → scenario: upgrade")}`, async () => {
+	const customerId = "rc-webhook-upgrade";
+	const RC_PRO_MONTHLY_ID = "com.app.rcwh3_pro_monthly";
+	const RC_PRO_YEARLY_ID = "com.app.rcwh3_pro_yearly";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const proMonthly = products.pro({
+		id: "pro-monthly",
+		items: [messagesItem],
+	});
+	const proYearly = products.proAnnual({
+		id: "pro-yearly",
+		items: [items.monthlyMessages({ includedUsage: 1000 })],
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [proMonthly, proYearly] }),
+		],
+		actions: [],
+	});
+
+	await Promise.all([
+		RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: proMonthly.id,
+				revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+			},
+		}),
+		RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: proYearly.id,
+				revenuecat_product_ids: [RC_PRO_YEARLY_ID],
+			},
+		}),
+	]);
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	// First: initial purchase on monthly
+	await rcClient.initialPurchase({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh3_tx_001",
+	});
+
+	await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	// Then: renewal to yearly (upgrade)
+	await rcClient.renewal({
+		productId: RC_PRO_YEARLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh3_tx_001",
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "upgrade",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("upgrade");
+	expect(data.updated_product.id).toBe(proYearly.id);
+	expect(data.customer.id).toBe(customerId);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 4: Downgrade → scenario: downgrade
+// Uses premium ($50/mo) → pro ($20/mo) so the price decrease is a genuine downgrade
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: downgrade (premium → pro) → scenario: downgrade")}`, async () => {
+	const customerId = "rc-webhook-downgrade";
+	const RC_PRO_ID = "com.app.rcwh4_pro";
+	const RC_PREMIUM_ID = "com.app.rcwh4_premium";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const pro = products.pro({
+		id: "pro",
+		items: [messagesItem],
+	});
+	const premium = products.premium({
+		id: "premium",
+		items: [messagesItem],
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [pro, premium] }),
+		],
+		actions: [],
+	});
+
+	await Promise.all([
+		RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: pro.id,
+				revenuecat_product_ids: [RC_PRO_ID],
+			},
+		}),
+		RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: premium.id,
+				revenuecat_product_ids: [RC_PREMIUM_ID],
+			},
+		}),
+	]);
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	// First: initial purchase on premium ($50/mo)
+	await rcClient.initialPurchase({
+		productId: RC_PREMIUM_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh4_tx_001",
+	});
+
+	await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	// Then: renewal to pro ($20/mo) — genuine downgrade
+	await rcClient.renewal({
+		productId: RC_PRO_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh4_tx_001",
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "downgrade",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("downgrade");
+	expect(data.updated_product.id).toBe(pro.id);
+	expect(data.customer.id).toBe(customerId);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 5: Cancellation → scenario: cancel
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: cancellation → scenario: cancel")}`, async () => {
+	const customerId = "rc-webhook-cancel";
+	const RC_PRO_MONTHLY_ID = "com.app.rcwh5_pro_monthly";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const proMonthly = products.pro({
+		id: "pro-monthly",
+		items: [messagesItem],
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [proMonthly] }),
+		],
+		actions: [],
+	});
+
+	await RCMappingService.upsert({
+		db: ctx.db,
+		data: {
+			org_id: ctx.org.id,
+			env: AppEnv.Sandbox,
+			autumn_product_id: proMonthly.id,
+			revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+		},
+	});
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	// First: initial purchase
+	await rcClient.initialPurchase({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh5_tx_001",
+	});
+
+	await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	// Then: cancellation
+	await rcClient.cancellation({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh5_tx_001",
+		expirationAtMs: Date.now() + 1000 * 60 * 60 * 24 * 30,
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "cancel",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("cancel");
+	expect(data.updated_product.id).toBe(proMonthly.id);
+	expect(data.customer.id).toBe(customerId);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 6: Uncancellation → scenario: renew
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: uncancellation → scenario: renew")}`, async () => {
+	const customerId = "rc-webhook-uncancel";
+	const RC_PRO_MONTHLY_ID = "com.app.rcwh6_pro_monthly";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const proMonthly = products.pro({
+		id: "pro-monthly",
+		items: [messagesItem],
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [proMonthly] }),
+		],
+		actions: [],
+	});
+
+	await RCMappingService.upsert({
+		db: ctx.db,
+		data: {
+			org_id: ctx.org.id,
+			env: AppEnv.Sandbox,
+			autumn_product_id: proMonthly.id,
+			revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+		},
+	});
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	// Step 1: initial purchase
+	await rcClient.initialPurchase({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh6_tx_001",
+	});
+
+	await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	// Step 2: cancellation
+	await rcClient.cancellation({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh6_tx_001",
+		expirationAtMs: Date.now() + 1000 * 60 * 60 * 24 * 30,
+	});
+
+	await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "cancel",
+		timeoutMs: 15000,
+	});
+
+	// Step 3: uncancellation
+	await rcClient.uncancellation({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "renew",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("renew");
+	expect(data.updated_product.id).toBe(proMonthly.id);
+	expect(data.customer.id).toBe(customerId);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 7: Billing Issue → scenario: past_due
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: billing issue → scenario: past_due")}`, async () => {
+	const customerId = "rc-webhook-billing-issue";
+	const RC_PRO_MONTHLY_ID = "com.app.rcwh7_pro_monthly";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const proMonthly = products.pro({
+		id: "pro-monthly",
+		items: [messagesItem],
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [proMonthly] }),
+		],
+		actions: [],
+	});
+
+	await RCMappingService.upsert({
+		db: ctx.db,
+		data: {
+			org_id: ctx.org.id,
+			env: AppEnv.Sandbox,
+			autumn_product_id: proMonthly.id,
+			revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+		},
+	});
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	// First: initial purchase
+	await rcClient.initialPurchase({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh7_tx_001",
+	});
+
+	await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	// Then: billing issue
+	await rcClient.billingIssue({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh7_tx_001",
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "past_due",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("past_due");
+	expect(data.updated_product.id).toBe(proMonthly.id);
+	expect(data.customer.id).toBe(customerId);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 8: Expiration → scenario: expire
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: expiration → scenario: expired")}`, async () => {
+	const customerId = "rc-webhook-expire";
+	const RC_PRO_MONTHLY_ID = "com.app.rcwh8_pro_monthly";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const proMonthly = products.pro({
+		id: "pro-monthly",
+		items: [messagesItem],
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [proMonthly] }),
+		],
+		actions: [],
+	});
+
+	await RCMappingService.upsert({
+		db: ctx.db,
+		data: {
+			org_id: ctx.org.id,
+			env: AppEnv.Sandbox,
+			autumn_product_id: proMonthly.id,
+			revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+		},
+	});
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	// First: initial purchase
+	await rcClient.initialPurchase({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh8_tx_001",
+	});
+
+	await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	// Then: expiration
+	await rcClient.expiration({
+		productId: RC_PRO_MONTHLY_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh8_tx_001",
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "expired",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("expired");
+	expect(data.updated_product.id).toBe(proMonthly.id);
+	expect(data.customer.id).toBe(customerId);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 9: Non-Renewing Purchase → scenario: new
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("rc-webhook: non-renewing purchase (add-on) → scenario: new")}`, async () => {
+	const customerId = "rc-webhook-non-renewing";
+	const RC_ADD_ON_ID = "com.app.rcwh9_add_on_pack";
+
+	const addOnPack = products.base({
+		id: "add-on",
+		items: [items.lifetimeMessages({ includedUsage: 100 })],
+		isAddOn: true,
+	});
+
+	await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false, skipWebhooks: true }),
+			s.products({ list: [addOnPack] }),
+		],
+		actions: [],
+	});
+
+	await RCMappingService.upsert({
+		db: ctx.db,
+		data: {
+			org_id: ctx.org.id,
+			env: AppEnv.Sandbox,
+			autumn_product_id: addOnPack.id,
+			revenuecat_product_ids: [RC_ADD_ON_ID],
+		},
+	});
+
+	const rcClient = new RevenueCatWebhookClient({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		webhookSecret: RC_WEBHOOK_SECRET,
+	});
+
+	await rcClient.nonRenewingPurchase({
+		productId: RC_ADD_ON_ID,
+		appUserId: customerId,
+		originalTransactionId: "rcwh9_addon_tx_001",
+	});
+
+	const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "customer.products.updated" &&
+			payload.data?.customer?.id === customerId &&
+			payload.data?.scenario === "new",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.scenario).toBe("new");
+	expect(data.updated_product.id).toBe(addOnPack.id);
+	expect(data.customer.id).toBe(customerId);
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always trigger the `cus.prods.updated` webhook for all RevenueCat events: initial purchase, renewal (incl. simple renewals and reactivations), upgrade/downgrade, cancel/uncancel, billing issue, expiration, and non‑renewing purchase. Introduced `customerProductActions` (`cancel`, `uncancel`, `markPastDue`), set `sendWebhook: true` on creates, fixed expiration to persist `ended_at`/`canceled`, and added integration tests for all 9 scenarios.

<sup>Written for commit 531aa584a2737114fa97a7ef064d1b9223fa50d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes missing `customer.products.updated` webhook emissions for RevenueCat lifecycle events by adding direct `addProductsUpdatedWebhookTask` calls across all early-return paths in the renewal handler, and by introducing three encapsulated action functions (`cancelCustomerProduct`, `uncancelCustomerProduct`, `markCustomerProductPastDue`) that bundle DB update + webhook dispatch. It also extends `expireAndActivateDefault` with an optional `updates` spread to restore the previously dropped `ended_at`/`canceled` persistence on expiration.

**Key changes:**
- [Bug fixes] Webhook now fires for all RevenueCat renewal paths (active, past_due→active, reactivation, upgrade/downgrade) and for cancel, uncancel, billing-issue, and expiration events
- [Improvements] New `cancel`, `uncancel`, and `markPastDue` action functions consolidate the update+webhook pattern into reusable units
- [Bug fixes] `expireAndActivateDefault` now accepts extra DB fields so `ended_at` and `canceled` are correctly persisted on expiration
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all webhook gaps are now covered, the previously flagged `ended_at` data-loss on expiration is fixed, and a comprehensive integration test suite is included.

Only one P2 finding remains (the `endedAt ?? undefined` null-coalescing in `cancelCustomerProduct` that silently drops an explicit null). No current caller passes null here, so there is no production impact today. All previously flagged P1 concerns (missing webhooks, dropped `ended_at`) are resolved in this PR.

server/src/internal/customers/cusProducts/actions/cancelCustomerProduct.ts — minor null-handling inconsistency on line 37.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts | Adds direct `addProductsUpdatedWebhookTask` calls for active-renewal, past_due→active, reactivation, and upgrade/downgrade paths; `createFullCusProduct` now passes `sendWebhook: true` for the full-create path. |
| server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts | Refactored to use `customerProductActions.expireAndActivateDefault`, now correctly passing `ended_at` and `canceled` via the new `updates` param — resolves the previously flagged data-loss concern. |
| server/src/internal/customers/cusProducts/actions/cancelCustomerProduct.ts | New action that cancels a customer product, fires a Cancel webhook, and updates the in-memory customer. Minor null-coalescing issue: `endedAt ?? undefined` silently drops an explicit `null`, preventing callers from clearing `ended_at`. |
| server/src/internal/customers/cusProducts/actions/uncancelCustomerProduct.ts | New action that restores a cancelled customer product to Active, fires a Renew webhook, and updates in-memory state. Logic and webhook task usage look correct. |
| server/src/internal/customers/cusProducts/actions/markCustomerProductPastDue.ts | New action that marks a customer product as PastDue, fires a PastDue webhook, and updates in-memory state. Consistent with the cancel/uncancel action pattern. |
| server/tests/integration/external-psps/revenuecat-webhooks.test.ts | New integration test covering all 9 RC webhook scenarios (initial purchase, renewal, upgrade, downgrade, cancel, uncancel, billing issue, expiration, non-renewing purchase) via Svix Play. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RC as RevenueCat
    participant AW as Autumn Webhook Handler
    participant DB as Database
    participant Q as Job Queue
    participant SV as Svix

    RC->>AW: RENEWAL / INITIAL_PURCHASE / NON_RENEWING_PURCHASE
    AW->>DB: resolve resources (product, customer, cusProducts)
    alt product already active (simple renewal)
        AW->>Q: addProductsUpdatedWebhookTask(scenario=renew)
    else product is past_due
        AW->>DB: update status to Active
        AW->>Q: addProductsUpdatedWebhookTask(scenario=renew)
    else upgrade / downgrade
        AW->>DB: expire old cusProduct
        AW->>Q: addProductsUpdatedWebhookTask(scenario=expired)
        AW->>DB: createFullCusProduct(sendWebhook=true)
        AW->>Q: addProductsUpdatedWebhookTask(scenario=upgrade|downgrade)
    else new product
        AW->>DB: createFullCusProduct(sendWebhook=true)
        AW->>Q: addProductsUpdatedWebhookTask(scenario=new)
    end
    Q->>DB: fetch fresh customer state
    Q->>SV: customer.products.updated event

    RC->>AW: CANCELLATION
    AW->>DB: cancel (canceled_at, ended_at, canceled=true)
    AW->>Q: addProductsUpdatedWebhookTask(scenario=cancel)

    RC->>AW: UNCANCELLATION
    AW->>DB: uncancel (cleared fields, status=Active)
    AW->>Q: addProductsUpdatedWebhookTask(scenario=renew)

    RC->>AW: BILLING_ISSUE
    AW->>DB: update status to PastDue
    AW->>Q: addProductsUpdatedWebhookTask(scenario=past_due)

    RC->>AW: EXPIRATION
    AW->>DB: update status=Expired, ended_at, canceled
    AW->>Q: addProductsUpdatedWebhookTask(scenario=expired)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts`, line 50-65 ([link](https://github.com/useautumn/autumn/blob/ae67497f02d31903438554f447bd72b5a73c39a1/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts#L50-L65)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Reactivation paths skip the `cus.prods.updated` webhook**

   Both early-return branches update the customer product's status to `Active` via `CusProductService.update` (which has no built-in webhook logic), but then return without dispatching a webhook. The `PAST_DUE → Active` path at line 57 and the `Expired/Cancelled → Active` path at line 100 are real state changes that consumers depend on — yet they are silently omitted from the fix this PR is landing. Only the `createFullCusProduct` code path (new product / upgrade / downgrade) will now emit `cus.prods.updated`, leaving renewal reactivations dark.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
   Line: 50-65

   Comment:
   **Reactivation paths skip the `cus.prods.updated` webhook**

   Both early-return branches update the customer product's status to `Active` via `CusProductService.update` (which has no built-in webhook logic), but then return without dispatching a webhook. The `PAST_DUE → Active` path at line 57 and the `Expired/Cancelled → Active` path at line 100 are real state changes that consumers depend on — yet they are silently omitted from the fix this PR is landing. Only the `createFullCusProduct` code path (new product / upgrade / downgrade) will now emit `cus.prods.updated`, leaving renewal reactivations dark.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/customers/cusProducts/actions/cancelCustomerProduct.ts
Line: 37-38

Comment:
**Null silently dropped for `ended_at`**

`endedAt ?? undefined` converts an explicit `null` to `undefined`. Drizzle ORM skips `undefined` fields in UPDATE statements, so when `endedAt` is `null` the `ended_at` column is never cleared — a caller that expects to explicitly reset the field would be silently ignored. The parameter type already admits `null`, so the implementation should honour it.

```suggestion
		ended_at: endedAt !== undefined ? endedAt : undefined,
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: 🐛 extra updates dropped"](https://github.com/useautumn/autumn/commit/531aa584a2737114fa97a7ef064d1b9223fa50d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28491374)</sub>

<!-- /greptile_comment -->