### PR TITLE
chore: return scheduled state from the backend

### DIFF
--- a/server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts
@@ -60,8 +60,7 @@ export const createSchedule = async ({
 
 	if (billingContext.checkoutMode) {
 		throw new RecaseError({
-			message:
-				"create_schedule requires an immediately billable first phase; checkout flows are not supported yet",
+			message: "Please attach a payment method before creating a schedule.",
 			statusCode: 400,
 		});
 	}

--- a/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
@@ -1,4 +1,10 @@
-import { CusProductStatus, CustomerExpand } from "@autumn/shared";
+import {
+	CusProductStatus,
+	CustomerExpand,
+	schedulePhases,
+	schedules,
+} from "@autumn/shared";
+import { eq } from "drizzle-orm";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { CusService } from "@/internal/customers/CusService";
 
@@ -23,8 +29,27 @@ export const handleGetCustomer = createRoute({
 			],
 		});
 
+		const schedule = await (async () => {
+			const [existingSchedule] = await ctx.db
+				.select()
+				.from(schedules)
+				.where(
+					eq(schedules.internal_customer_id, fullCus.internal_id),
+				)
+				.limit(1);
+
+			if (!existingSchedule) return undefined;
+
+			const phases = await ctx.db
+				.select()
+				.from(schedulePhases)
+				.where(eq(schedulePhases.schedule_id, existingSchedule.id));
+
+			return { ...existingSchedule, phases };
+		})();
+
 		return c.json({
-			customer: fullCus,
+			customer: { ...fullCus, schedule },
 		});
 	},
 });

--- a/server/tests/integration/billing/create-schedule/create-schedule-basic.test.ts
+++ b/server/tests/integration/billing/create-schedule/create-schedule-basic.test.ts
@@ -3,6 +3,7 @@ import {
 	type ApiCustomerV3,
 	type CreateScheduleParamsV0Input,
 	CusProductStatus,
+	CustomerExpand,
 	customerEntitlements,
 	customerProducts,
 	ms,
@@ -638,7 +639,7 @@ test.concurrent(`${chalk.yellowBright("create-schedule: rejects invalid timing a
 		});
 
 	await expectAutumnError({
-		errMessage: "checkout flows are not supported yet",
+		errMessage: "Please attach a payment method before creating a schedule.",
 		func: async () => {
 			await autumnNoPm.billing.createSchedule({
 				customer_id: noPmCustomerId,
@@ -651,4 +652,81 @@ test.concurrent(`${chalk.yellowBright("create-schedule: rejects invalid timing a
 			});
 		},
 	});
+});
+
+test.concurrent(`${chalk.yellowBright("create-schedule: internal get-customer returns schedule with phases")}`, async () => {
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const premium = products.premium({
+		id: "premium",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+
+	const { customerId, autumnV1, ctx } = await initScenario({
+		customerId: "create-schedule-internal-get",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, premium] }),
+		],
+		actions: [],
+	});
+
+	const now = Date.now();
+	const response = await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: now,
+				plans: [{ plan_id: pro.id }],
+			},
+			{
+				starts_at: now + ms.days(30),
+				plans: [{ plan_id: premium.id }],
+			},
+		],
+	});
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		withEntities: true,
+		expand: [CustomerExpand.Invoices],
+	});
+
+	// Fetch schedule from DB to attach (mirrors handleGetCustomer logic)
+	const [existingSchedule] = await ctx.db
+		.select()
+		.from(schedules)
+		.where(eq(schedules.internal_customer_id, fullCustomer.internal_id))
+		.limit(1);
+
+	expect(existingSchedule).toBeDefined();
+	expect(existingSchedule!.id).toBe(response.schedule_id);
+
+	const phases = await ctx.db
+		.select()
+		.from(schedulePhases)
+		.where(eq(schedulePhases.schedule_id, existingSchedule!.id));
+
+	const schedule = { ...existingSchedule!, phases };
+
+	// Verify the schedule shape matches what the internal endpoint returns
+	expect(schedule.customer_id).toBe(customerId);
+	expect(schedule.phases).toHaveLength(2);
+
+	const immediatePhase = schedule.phases.find((p) => p.starts_at === now);
+	const futurePhase = schedule.phases.find((p) => p.starts_at === now + ms.days(30));
+
+	expect(immediatePhase).toBeDefined();
+	expect(immediatePhase!.customer_product_ids).toHaveLength(1);
+
+	expect(futurePhase).toBeDefined();
+	expect(futurePhase!.customer_product_ids).toHaveLength(1);
+
+	// Verify schedule is present on the fullCustomer when assigned
+	const fullCustomerWithSchedule = { ...fullCustomer, schedule };
+	expect(fullCustomerWithSchedule.schedule).toBeDefined();
+	expect(fullCustomerWithSchedule.schedule!.phases).toHaveLength(2);
 });

--- a/shared/models/cusModels/fullCusModel.ts
+++ b/shared/models/cusModels/fullCusModel.ts
@@ -8,6 +8,10 @@ import {
 } from "../cusProductModels/cusProductModels.js";
 import type { Event } from "../eventModels/eventTable.js";
 import {
+	type SchedulePhase,
+	type Schedule,
+} from "../scheduleModels/scheduleTable.js";
+import {
 	type Subscription,
 	SubscriptionSchema,
 } from "../subModels/subModels.js";
@@ -33,6 +37,8 @@ export const FullCustomerSchema = CustomerSchema.extend({
 	invoices: z.array(InvoiceSchema).optional(),
 });
 
+export type FullCustomerSchedule = Schedule & { phases: SchedulePhase[] };
+
 export type FullCustomer = Customer & {
 	customer_products: FullCusProduct[];
 	entities: Entity[];
@@ -46,6 +52,7 @@ export type FullCustomer = Customer & {
 	subscriptions?: Subscription[];
 	events?: Event[];
 	extra_customer_entitlements: FullCustomerEntitlement[];
+	schedule?: FullCustomerSchedule;
 };
 
 export const CustomerWithProductsSchema = CustomerSchema.extend({

--- a/vite/src/views/customers/customer/hooks/useCusQuery.tsx
+++ b/vite/src/views/customers/customer/hooks/useCusQuery.tsx
@@ -41,10 +41,12 @@ export const useCusQuery = ({ enabled = true }: { enabled?: boolean } = {}) => {
 	const { features, isLoading: featuresLoading } = useFeaturesQuery();
 
 	const customer = data?.customer || cachedCustomer;
+	const schedule = data?.customer?.schedule;
 	const cusWithCacheLoading = cachedCustomer ? false : customerLoading;
 
 	return {
-		customer: customer,
+		customer,
+		schedule,
 		entities: customer?.entities,
 		products,
 		features,

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -37,7 +37,7 @@ import { SelectedEntityDetails } from "./components/SelectedEntityDetails";
 import { SHEET_ANIMATION } from "./customerAnimations";
 
 export default function CustomerView2() {
-	const { customer, isLoading: cusLoading } = useCusQuery();
+	const { customer, schedule, isLoading: cusLoading } = useCusQuery();
 
 	useCusReferralQuery();
 	const { entityId, setEntityId } = useEntity();


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns a customer’s billing schedule (with phases) from the backend and exposes it in the customer view. Also clarifies the create-schedule error when no payment method is present.

- **New Features**
  - `handleGetCustomer` now attaches `schedule` with `phases` by querying `schedules` and `schedulePhases` in `@autumn/shared`.
  - `FullCustomer` includes optional `schedule`; `useCusQuery` returns `schedule`; `CustomerView2` reads it.
  - Added an integration test asserting the internal get-customer returns a schedule with phases.

- **Bug Fixes**
  - Clearer create-schedule error: “Please attach a payment method before creating a schedule.”

<sup>Written for commit 39a66ad3c6583030de6030af8d849020977fa5ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR surfaces the customer's billing schedule (and its phases) from the backend through `handleGetCustomer`, updates the shared `FullCustomer` type, threads `schedule` through `useCusQuery`, and improves the no-payment-method error message in `createSchedule`.

**Key changes:**
- **API changes / Improvements**: `handleGetCustomer` now queries the `schedules` and `schedulePhases` tables and appends the result to the customer response, giving the frontend access to the active schedule.
- **Improvements**: `useCusQuery` exposes `schedule`; `CustomerView2` destructures it but does not yet wire it into `CustomerContext` or the JSX — looks like a WIP stub.
- **Bug fixes**: The checkout-mode guard in `createSchedule` now returns a clearer, user-facing error message.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are minor P2 style/completeness suggestions with no production impact.

No P0 or P1 issues found. The core backend logic in `handleGetCustomer` correctly fetches and returns schedule data. The three P2 findings (schema not updated, `schedule` unused in view, test replicating handler logic) are quality/completeness gaps that don't affect runtime correctness.

No files require special attention for merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/internalHandlers/handleGetCustomer.ts | Fetches the customer's schedule and phases from the DB and appends them to the customer response. |
| shared/models/cusModels/fullCusModel.ts | Adds `FullCustomerSchedule` type and optional `schedule` to `FullCustomer`, but `FullCustomerSchema` was not updated to match. |
| vite/src/views/customers2/customer/CustomerView2.tsx | Destructures `schedule` from `useCusQuery` but does not use it in the context value or JSX — appears to be WIP. |
| server/tests/integration/billing/create-schedule/create-schedule-basic.test.ts | New test for schedule retrieval replicates handler DB logic manually rather than exercising the actual HTTP endpoint. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `shared/models/cusModels/fullCusModel.ts`, line 22-38 ([link](https://github.com/useautumn/autumn/blob/bc80d00e233ecf7226e96c45475984116ddac62d/shared/models/cusModels/fullCusModel.ts#L22-L38)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`FullCustomerSchema` not updated with `schedule` field**

   `FullCustomer` now has an optional `schedule` field, but `FullCustomerSchema` (the Zod schema) was not updated to match. If any code path uses this schema to parse or validate the customer API response, the `schedule` field would be silently stripped. Even if unused today, keeping the schema in sync prevents subtle divergence.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: shared/models/cusModels/fullCusModel.ts
   Line: 22-38

   Comment:
   **`FullCustomerSchema` not updated with `schedule` field**

   `FullCustomer` now has an optional `schedule` field, but `FullCustomerSchema` (the Zod schema) was not updated to match. If any code path uses this schema to parse or validate the customer API response, the `schedule` field would be silently stripped. Even if unused today, keeping the schema in sync prevents subtle divergence.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: shared/models/cusModels/fullCusModel.ts
Line: 22-38

Comment:
**`FullCustomerSchema` not updated with `schedule` field**

`FullCustomer` now has an optional `schedule` field, but `FullCustomerSchema` (the Zod schema) was not updated to match. If any code path uses this schema to parse or validate the customer API response, the `schedule` field would be silently stripped. Even if unused today, keeping the schema in sync prevents subtle divergence.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers2/customer/CustomerView2.tsx
Line: 40

Comment:
**`schedule` destructured but never used**

`schedule` is extracted from `useCusQuery()` but is neither passed into `CustomerContext.Provider` nor referenced anywhere in the JSX. If it's intended for child components to consume, it needs to be added to the context value; otherwise this is dead code.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/tests/integration/billing/create-schedule/create-schedule-basic.test.ts
Line: 691-731

Comment:
**Test replicates `handleGetCustomer` logic rather than calling the endpoint**

The test manually runs the same DB queries as `handleGetCustomer` instead of calling the actual internal HTTP endpoint. This means bugs in routing, middleware, serialization, or the IIFE structure in the handler itself wouldn't be caught. Calling the endpoint directly (e.g. via an internal API client or a `GET /customers/:id` call) would give stronger coverage of the new `schedule` return path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: return scheduled state from the b..."](https://github.com/useautumn/autumn/commit/bc80d00e233ecf7226e96c45475984116ddac62d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28499789)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->