### PR TITLE
chore: add preview create schedule endpoint

### DIFF
--- a/server/src/internal/billing/billingRouter.ts
+++ b/server/src/internal/billing/billingRouter.ts
@@ -9,6 +9,7 @@ import { handleLegacyApiCheckout } from "./checkout/handleLegacyApiCheckout.js";
 import { handleSetupPayment } from "./handlers/handleSetupPayment.js";
 import { handleAttachV2 } from "./v2/handlers/handleAttachV2.js";
 import { handleCreateSchedule } from "./v2/handlers/handleCreateSchedule.js";
+import { handlePreviewCreateSchedule } from "./v2/handlers/handlePreviewCreateSchedule.js";
 import { handleMultiAttach } from "./v2/handlers/handleMultiAttach.js";
 import { handlePreviewMultiAttach } from "./v2/handlers/handlePreviewMultiAttach.js";
 import { handlePreviewUpdateSubscription } from "./v2/handlers/handlePreviewUpdateSubscription.js";
@@ -35,6 +36,10 @@ billingRpcRouter.post(
 );
 billingRpcRouter.post("/billing.attach", ...handleAttachV2);
 billingRpcRouter.post("/billing.create_schedule", ...handleCreateSchedule);
+billingRpcRouter.post(
+	"/billing.preview_create_schedule",
+	...handlePreviewCreateSchedule,
+);
 billingRpcRouter.post("/billing.multi_attach", ...handleMultiAttach);
 billingRpcRouter.post(
 	"/billing.preview_multi_attach",

--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -1,0 +1,49 @@
+import { type CreateScheduleParamsV0, RecaseError } from "@autumn/shared";
+import type { BillingPreviewResponse } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
+import { billingPlanToPreviewResponse } from "@/internal/billing/v2/utils/billingPlanToPreviewResponse";
+import { computeCreateSchedulePlan } from "./compute/computeCreateSchedulePlan";
+import { normalizeCreateSchedulePhases } from "./errors/normalizeCreateSchedulePhases";
+import { setupCreateScheduleBillingContext } from "./setup/setupCreateScheduleBillingContext";
+
+/** Preview the immediate-phase billing cost for a create_schedule call. */
+export const previewCreateSchedule = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: CreateScheduleParamsV0;
+}): Promise<BillingPreviewResponse> => {
+	const currentEpochMs = Date.now();
+	const normalizedPhases = normalizeCreateSchedulePhases({
+		currentEpochMs,
+		phases: params.phases,
+	});
+	const [immediatePhase] = normalizedPhases;
+
+	const billingContext = await setupCreateScheduleBillingContext({
+		ctx,
+		params,
+		immediatePhase,
+	});
+
+	if (billingContext.checkoutMode) {
+		throw new RecaseError({
+			message: "Please attach a payment method before creating a schedule.",
+			statusCode: 400,
+		});
+	}
+
+	const autumnBillingPlan = computeCreateSchedulePlan({ ctx, billingContext });
+	const stripeBillingPlan = await evaluateStripeBillingPlan({
+		ctx,
+		billingContext,
+		autumnBillingPlan,
+		checkoutMode: billingContext.checkoutMode,
+	});
+
+	const billingPlan = { autumn: autumnBillingPlan, stripe: stripeBillingPlan };
+
+	return billingPlanToPreviewResponse({ ctx, billingContext, billingPlan });
+};

--- a/server/src/internal/billing/v2/actions/index.ts
+++ b/server/src/internal/billing/v2/actions/index.ts
@@ -1,5 +1,6 @@
 import { attach } from "@/internal/billing/v2/actions/attach/attach";
 import { createSchedule } from "@/internal/billing/v2/actions/createSchedule/createSchedule";
+import { previewCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/previewCreateSchedule";
 import { legacyAttach } from "@/internal/billing/v2/actions/legacy/legacyAttach";
 import { renew } from "@/internal/billing/v2/actions/legacy/renew";
 import { updateQuantity } from "@/internal/billing/v2/actions/legacy/updateQuantity";
@@ -13,6 +14,7 @@ import { updateSubscription } from "@/internal/billing/v2/actions/updateSubscrip
 export const billingActions = {
 	attach: attach,
 	createSchedule: createSchedule,
+	previewCreateSchedule: previewCreateSchedule,
 	multiAttach: multiAttach,
 	setupPayment: setupPayment,
 	updateSubscription: updateSubscription,

--- a/server/src/internal/billing/v2/handlers/handlePreviewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/handlers/handlePreviewCreateSchedule.ts
@@ -1,5 +1,5 @@
 import { AffectedResource, CreateScheduleParamsV0Schema } from "@autumn/shared";
-import { previewCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/previewCreateSchedule";
+import { billingActions } from "@/internal/billing/v2/actions";
 import { createRoute } from "../../../../honoMiddlewares/routeHandler";
 
 export const handlePreviewCreateSchedule = createRoute({
@@ -9,7 +9,10 @@ export const handlePreviewCreateSchedule = createRoute({
 		const ctx = c.get("ctx");
 		const body = c.req.valid("json");
 
-		const preview = await previewCreateSchedule({ ctx, params: body });
+		const preview = await billingActions.previewCreateSchedule({
+			ctx,
+			params: body,
+		});
 
 		return c.json(preview, 200);
 	},

--- a/server/src/internal/billing/v2/handlers/handlePreviewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/handlers/handlePreviewCreateSchedule.ts
@@ -1,0 +1,16 @@
+import { AffectedResource, CreateScheduleParamsV0Schema } from "@autumn/shared";
+import { previewCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/previewCreateSchedule";
+import { createRoute } from "../../../../honoMiddlewares/routeHandler";
+
+export const handlePreviewCreateSchedule = createRoute({
+	body: CreateScheduleParamsV0Schema,
+	resource: AffectedResource.MultiAttach,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const body = c.req.valid("json");
+
+		const preview = await previewCreateSchedule({ ctx, params: body });
+
+		return c.json(preview, 200);
+	},
+});

--- a/server/src/internal/customers/cusUtils/getFullCustomerSchedule.ts
+++ b/server/src/internal/customers/cusUtils/getFullCustomerSchedule.ts
@@ -1,0 +1,65 @@
+import {
+	type FullCustomer,
+	type FullCustomerSchedule,
+	schedulePhases,
+	schedules,
+} from "@autumn/shared";
+import { asc, eq, inArray } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export const getAllCustomerSchedules = async ({
+	ctx,
+	internalCustomerId,
+}: {
+	ctx: AutumnContext;
+	internalCustomerId: string;
+}): Promise<FullCustomerSchedule[]> => {
+	const allSchedules = await ctx.db
+		.select()
+		.from(schedules)
+		.where(eq(schedules.internal_customer_id, internalCustomerId));
+
+	if (allSchedules.length === 0) return [];
+
+	const allPhases = await ctx.db
+		.select()
+		.from(schedulePhases)
+		.where(
+			inArray(
+				schedulePhases.schedule_id,
+				allSchedules.map((schedule) => schedule.id),
+			),
+		)
+		.orderBy(asc(schedulePhases.starts_at));
+
+	return allSchedules.map((schedule) => ({
+		...schedule,
+		phases: allPhases.filter((phase) => phase.schedule_id === schedule.id),
+	}));
+};
+
+/** Loads schedules and attaches them to the customer and its entities. */
+export const hydrateCustomerWithSchedules = async ({
+	ctx,
+	fullCustomer,
+}: {
+	ctx: AutumnContext;
+	fullCustomer: FullCustomer;
+}) => {
+	const allSchedules = await getAllCustomerSchedules({
+		ctx,
+		internalCustomerId: fullCustomer.internal_id,
+	});
+
+	return {
+		...fullCustomer,
+		schedule: allSchedules.find((schedule) => !schedule.internal_entity_id),
+		entities: fullCustomer.entities?.map((entity) => ({
+			...entity,
+			schedule:
+				allSchedules.find(
+					(schedule) => schedule.internal_entity_id === entity.internal_id,
+				) ?? undefined,
+		})),
+	};
+};

--- a/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
@@ -1,6 +1,7 @@
 import { CusProductStatus, CustomerExpand } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { CusService } from "@/internal/customers/CusService";
+import { hydrateCustomerWithSchedules } from "../cusUtils/getFullCustomerSchedule.js";
 
 /**
  * Internal route for get full customer object
@@ -22,9 +23,13 @@ export const handleGetCustomer = createRoute({
 				CusProductStatus.Expired,
 			],
 		});
+		const hydratedCustomer = await hydrateCustomerWithSchedules({
+			ctx,
+			fullCustomer: fullCus,
+		});
 
 		return c.json({
-			customer: fullCus,
+			customer: hydratedCustomer,
 		});
 	},
 });

--- a/server/tests/integration/billing/create-schedule/create-schedule-basic.test.ts
+++ b/server/tests/integration/billing/create-schedule/create-schedule-basic.test.ts
@@ -19,6 +19,7 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { and, eq, inArray } from "drizzle-orm";
 import { CusService } from "@/internal/customers/CusService";
+import { hydrateCustomerWithSchedules } from "@/internal/customers/cusUtils/getFullCustomerSchedule";
 import { attachPaymentMethod } from "@/utils/scriptUtils/initCustomer";
 
 test.concurrent(`${chalk.yellowBright("create-schedule: bills the first phase immediately and stores later phases as scheduled")}`, async () => {
@@ -647,4 +648,58 @@ test.concurrent(`${chalk.yellowBright("create-schedule: rejects invalid timing a
 			});
 		},
 	});
+});
+
+test.concurrent(`${chalk.yellowBright("create-schedule: hydrates schedules on the full customer")}`, async () => {
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const premium = products.premium({
+		id: "premium",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+
+	const { customerId, autumnV1, ctx } = await initScenario({
+		customerId: "create-schedule-hydrate-customer",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, premium] }),
+		],
+		actions: [],
+	});
+
+	const now = Date.now();
+	const response = await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: now,
+				plans: [{ plan_id: pro.id }],
+			},
+			{
+				starts_at: now + ms.days(30),
+				plans: [{ plan_id: premium.id }],
+			},
+		],
+	});
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		withEntities: true,
+		expand: [],
+	});
+	const hydratedCustomer = await hydrateCustomerWithSchedules({
+		ctx,
+		fullCustomer,
+	});
+
+	expect(hydratedCustomer.schedule?.id).toBe(response.schedule_id);
+	expect(hydratedCustomer.schedule?.customer_id).toBe(customerId);
+	expect(hydratedCustomer.schedule?.phases).toHaveLength(2);
+	expect(hydratedCustomer.schedule?.phases[0]?.starts_at).toBe(now);
+	expect(hydratedCustomer.schedule?.phases[1]?.starts_at).toBe(
+		now + ms.days(30),
+	);
 });

--- a/shared/models/cusModels/fullCusModel.ts
+++ b/shared/models/cusModels/fullCusModel.ts
@@ -7,6 +7,10 @@ import {
 	FullCusProductSchema,
 } from "../cusProductModels/cusProductModels.js";
 import type { Event } from "../eventModels/eventTable.js";
+import type {
+	Schedule,
+	SchedulePhase,
+} from "../scheduleModels/scheduleTable.js";
 import {
 	type Subscription,
 	SubscriptionSchema,
@@ -14,6 +18,26 @@ import {
 import { type Customer, CustomerSchema } from "./cusModels.js";
 import { type Entity, EntitySchema } from "./entityModels/entityModels.js";
 import { type Invoice, InvoiceSchema } from "./invoiceModels/invoiceModels.js";
+
+export const FullCustomerSchedulePhaseSchema = z.object({
+	id: z.string(),
+	schedule_id: z.string(),
+	starts_at: z.number(),
+	customer_product_ids: z.array(z.string()),
+	created_at: z.number(),
+});
+
+export const FullCustomerScheduleSchema = z.object({
+	id: z.string(),
+	org_id: z.string(),
+	env: z.string(),
+	internal_customer_id: z.string(),
+	customer_id: z.string(),
+	internal_entity_id: z.string().nullable(),
+	entity_id: z.string().nullable(),
+	created_at: z.number(),
+	phases: z.array(FullCustomerSchedulePhaseSchema),
+});
 
 export const FullCustomerSchema = CustomerSchema.extend({
 	customer_products: z.array(FullCusProductSchema),
@@ -31,7 +55,10 @@ export const FullCustomerSchema = CustomerSchema.extend({
 		)
 		.optional(),
 	invoices: z.array(InvoiceSchema).optional(),
+	schedule: FullCustomerScheduleSchema.optional(),
 });
+
+export type FullCustomerSchedule = Schedule & { phases: SchedulePhase[] };
 
 export type FullCustomer = Customer & {
 	customer_products: FullCusProduct[];
@@ -46,6 +73,7 @@ export type FullCustomer = Customer & {
 	subscriptions?: Subscription[];
 	events?: Event[];
 	extra_customer_entitlements: FullCustomerEntitlement[];
+	schedule?: FullCustomerSchedule;
 };
 
 export const CustomerWithProductsSchema = CustomerSchema.extend({


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only preview for `create_schedule` and restores schedule hydration on full customer responses. Estimate the immediate charge and fetch schedules with phases in one call.

- **New Features**
  - New POST RPC `/billing.preview_create_schedule` returning `BillingPreviewResponse`; validates with `CreateScheduleParamsV0Schema` from `@autumn/shared`; mirrors `createSchedule` immediate-phase calculation; routed via `billingActions`; returns 400 in checkout mode until a payment method is attached.
  - Internal get-customer now hydrates schedules with phases on `FullCustomer` and its entities (adds a `schedule` field); shared models updated to include `FullCustomerSchedule`.

<sup>Written for commit c84da41bb228a754cccffd3695b94f525caad774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a `POST /billing.preview_create_schedule` RPC endpoint that computes the immediate-phase billing cost for a `create_schedule` call without executing or persisting any changes. The implementation mirrors `createSchedule` — normalizing phases, building billing context, guarding against checkout mode, and evaluating the Stripe plan — but stops before `executeBillingPlan` and `persistCreateSchedule`.

**API changes**
- New `POST /billing.preview_create_schedule` route in the RPC router, validated with `CreateScheduleParamsV0Schema`, returning `BillingPreviewResponse`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the preview endpoint is read-only, mirrors the existing createSchedule pattern, and the only finding is a dead export.

All findings are P2. The implementation correctly avoids executing or persisting billing changes, the checkout-mode guard is in place, and the route wiring is consistent with existing RPC endpoints. The unused billingActions export is a minor cleanup item that does not affect correctness.

server/src/internal/billing/v2/actions/index.ts — dead previewCreateSchedule export

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/billingRouter.ts | Adds the new `/billing.preview_create_schedule` RPC route between `create_schedule` and `multi_attach` — consistent with existing route ordering. |
| server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts | New preview action: normalizes phases, builds billing context for the immediate phase only, guards against checkout mode, evaluates Stripe billing plan without executing/persisting — mirrors createSchedule minus side-effects. |
| server/src/internal/billing/v2/actions/index.ts | Exports previewCreateSchedule in billingActions, but the handler bypasses this export and imports the action directly — dead export. |
| server/src/internal/billing/v2/handlers/handlePreviewCreateSchedule.ts | Route handler validates body with CreateScheduleParamsV0Schema, calls previewCreateSchedule directly (bypassing billingActions), returns preview response — otherwise clean and correct. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant billingRpcRouter
    participant handlePreviewCreateSchedule
    participant previewCreateSchedule
    participant normalizeCreateSchedulePhases
    participant setupCreateScheduleBillingContext
    participant computeCreateSchedulePlan
    participant evaluateStripeBillingPlan
    participant billingPlanToPreviewResponse

    Client->>billingRpcRouter: POST /billing.preview_create_schedule
    billingRpcRouter->>handlePreviewCreateSchedule: route handler (CreateScheduleParamsV0Schema)
    handlePreviewCreateSchedule->>previewCreateSchedule: { ctx, params }
    previewCreateSchedule->>normalizeCreateSchedulePhases: normalize phases
    normalizeCreateSchedulePhases-->>previewCreateSchedule: [immediatePhase, ...]
    previewCreateSchedule->>setupCreateScheduleBillingContext: { ctx, params, immediatePhase }
    setupCreateScheduleBillingContext-->>previewCreateSchedule: billingContext
    alt checkoutMode === true
        previewCreateSchedule-->>Client: 400 RecaseError (payment method required)
    end
    previewCreateSchedule->>computeCreateSchedulePlan: { ctx, billingContext }
    computeCreateSchedulePlan-->>previewCreateSchedule: autumnBillingPlan
    previewCreateSchedule->>evaluateStripeBillingPlan: { ctx, billingContext, autumnBillingPlan }
    evaluateStripeBillingPlan-->>previewCreateSchedule: stripeBillingPlan
    previewCreateSchedule->>billingPlanToPreviewResponse: { ctx, billingContext, billingPlan }
    billingPlanToPreviewResponse-->>previewCreateSchedule: BillingPreviewResponse
    previewCreateSchedule-->>handlePreviewCreateSchedule: BillingPreviewResponse
    handlePreviewCreateSchedule-->>Client: 200 BillingPreviewResponse
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/actions/index.ts
Line: 17

Comment:
**Unused export in `billingActions`**

`billingActions.previewCreateSchedule` is exported here but never consumed — `handlePreviewCreateSchedule.ts` imports `previewCreateSchedule` directly from the action file rather than going through `billingActions`. Every other preview handler (`handlePreviewAttach`, `handlePreviewMultiAttach`) calls via `billingActions`, so this entry is dead code. Either wire the handler through `billingActions.previewCreateSchedule`, or remove it from this object to keep the barrel consistent.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add preview create schedule endpo..."](https://github.com/useautumn/autumn/commit/064a9f8375e53a73fcba11e52c21227d52951652) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28499790)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->