### PR TITLE
chore: correct webhook logic

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5600,6 +5600,8 @@
 
     "@autumn/server/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@autumn/server/@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260413.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260413.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260413.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-twzr3V4QLEbXaESuI2DqdzutOVFGpkY3VZDR9sF8YlLsAXkwyQvZo58cKM77mZcsHoCR4lCYcdTatWTTa/+8tw=="],
+
     "@autumn/server/autumn-js": ["autumn-js@0.1.85", "", { "dependencies": { "query-string": "^9.2.2", "rou3": "^0.6.1", "swr": "^2.3.3", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": "^1.3.17", "better-call": "^1.0.12", "convex": "^1.25.4" }, "optionalPeers": ["better-auth", "better-call", "convex"] }, "sha512-PDud/t8z5bDJcD7ptyHzTaoJ0A8zkxvQ4TYcJ48RtgKDdOkVY36D1T6udVLwLDnWw4J5KXwJgEuGxHdd+cuABw=="],
 
     "@autumn/server/ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
@@ -6393,6 +6395,8 @@
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "@useautumn/sdk/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@useautumn/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@vercel/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -7229,6 +7233,20 @@
     "@asyncapi/parser/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "@autumn/server/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260413.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CDgxIPvAWRCfOiQKvSk4wUkAoRW4Cy6vfAUBPNHSeLalIt43ToF0LOAsa5uLyRGsftjfMYY0A4qFOmgDvBhgzQ=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260413.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-oiMmUtNMaqBh+eUogX53ichcEf7d+7upC0qa7xS9zWl85XEPKlrZCZpZ79yixw1PkdpjqJJigI11bmCi/JVv+g=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260413.1", "", { "os": "linux", "cpu": "arm" }, "sha512-0lSXBzBVsxIGrFv/PxoswzMptsnU6BgSk7GMAUt/o1dVw36R2XrSs538vwKnujaJwt4iIdMS0uGdpUC5s9jkzQ=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260413.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-hPKanfs9c+7953gIYw13CNxN0HqFAOfJjnWk4SHqSBe3Pj9pxoeJvvRWlofp5C833eOZK6gZB7ll0/uNb0djtA=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260413.1", "", { "os": "linux", "cpu": "x64" }, "sha512-8Cr477HRmHZ5YyLfikNvw7qp3/WmnRjzIzJhUDrAx5173OBe8BdyV9jPemFHKDPqwI1AUMTijvptOFoQE7429w=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260413.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-ulJD9ZbIQyTBIDx8zzAzQLtbvQDGHSWrNRgkgBU5Os2NTYADQRco4pU747R9wZPMLopy3IeNck6m8vwPoYMk1g=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260413.1", "", { "os": "win32", "cpu": "x64" }, "sha512-x7DsSXnLQBf5XBBR8luHf1Nc/T1eByUmrOSEThW6825UB7lHoPlqKdhIoUNnTnS4nXQMxLwcusD4P1EP23GPJw=="],
 
     "@autumn/server/autumn-js/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/expireEndedCustomerProducts.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/expireEndedCustomerProducts.ts
@@ -1,4 +1,8 @@
-import { type FullCusProduct, hasCustomerProductEnded } from "@autumn/shared";
+import {
+	customerProductHasActiveStatus,
+	type FullCusProduct,
+	hasCustomerProductEnded,
+} from "@autumn/shared";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
 import { expireAndActivateWithTracking } from "../../../common";
@@ -22,7 +26,12 @@ export const expireEndedCustomerProducts = async ({
 	const expiredCustomerProducts: FullCusProduct[] = [];
 
 	for (const customerProduct of customerProducts) {
-		if (!hasCustomerProductEnded(customerProduct, { nowMs })) continue;
+		const shouldExpire =
+			hasCustomerProductEnded(customerProduct, { nowMs }) ||
+			(customerProductHasActiveStatus(customerProduct) &&
+				customerProduct.ended_at != null &&
+				nowMs >= customerProduct.ended_at);
+		if (!shouldExpire) continue;
 
 		logger.info(
 			`Expiring product: ${customerProduct.product.name}${customerProduct.entity_id ? `@${customerProduct.entity_id}` : ""}`,

--- a/server/src/internal/billing/v2/actions/createSchedule/compute/computeCreateSchedulePlan.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/compute/computeCreateSchedulePlan.ts
@@ -1,19 +1,208 @@
 import type {
+	AttachBillingContext,
 	AutumnBillingPlan,
+	CreateScheduleParamsV0,
+	FullCusProduct,
 	MultiAttachBillingContext,
 } from "@autumn/shared";
+import {
+	CusProductStatus,
+	customerProductHasActiveStatus,
+	isCustomerProductOneOff,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { computeImmediateMultiProductPlan } from "../../common/immediateMultiProduct/computeImmediateMultiProductPlan";
+import { computeAttachNewCustomerProduct } from "@/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct";
+import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
+import { finalizeLineItems } from "@/internal/billing/v2/compute/finalize/finalizeLineItems";
+import { applyCustomerProductUpdate } from "@/internal/billing/v2/utils/billingPlan/customerProductMutations";
 
-/** Compute the immediate phase billing plan. */
+export type CreateSchedulePlanResult = {
+	autumnBillingPlan: AutumnBillingPlan;
+	immediatePhaseCustomerProducts: FullCusProduct[];
+};
+
+const getExpireCustomerProductUpdate = ({
+	customerProduct,
+	currentEpochMs,
+}: {
+	customerProduct: FullCusProduct;
+	currentEpochMs: number;
+}) => ({
+	customerProduct,
+	updates: {
+		status: CusProductStatus.Expired,
+		ended_at: currentEpochMs,
+		canceled: true,
+		canceled_at: currentEpochMs,
+		scheduled_ids: [],
+	},
+});
+
+const planReusesCurrentCustomerProduct = ({
+	plan,
+}: {
+	plan: CreateScheduleParamsV0["phases"][number]["plans"][number];
+}) =>
+	plan.customize === undefined &&
+	(plan.feature_quantities === undefined ||
+		plan.feature_quantities.length === 0);
+
+/** Compute the exact immediate phase for create_schedule. */
 export const computeCreateSchedulePlan = ({
 	ctx,
 	billingContext,
+	immediatePhase,
+	nextPhaseStartsAt,
 }: {
 	ctx: AutumnContext;
 	billingContext: MultiAttachBillingContext;
-}): AutumnBillingPlan =>
-	computeImmediateMultiProductPlan({
+	immediatePhase: CreateScheduleParamsV0["phases"][number];
+	nextPhaseStartsAt?: number;
+}): CreateSchedulePlanResult => {
+	const currentRecurringCustomerProducts =
+		billingContext.fullCustomer.customer_products.filter(
+			(customerProduct) =>
+				customerProductHasActiveStatus(customerProduct) &&
+				!isCustomerProductOneOff(customerProduct),
+		);
+	const scheduledRecurringCustomerProducts =
+		billingContext.fullCustomer.customer_products.filter(
+			(customerProduct) =>
+				customerProduct.status === CusProductStatus.Scheduled &&
+				!isCustomerProductOneOff(customerProduct),
+		);
+
+	const handledCurrentProductIds = new Set<string>();
+	const insertCustomerProducts: FullCusProduct[] = [];
+	const updateCustomerProducts: NonNullable<
+		AutumnBillingPlan["updateCustomerProducts"]
+	> = [];
+	const expiredCustomerProducts: FullCusProduct[] = [];
+	const immediatePhaseCustomerProducts: FullCusProduct[] = [];
+
+	for (const [
+		index,
+		productContext,
+	] of billingContext.productContexts.entries()) {
+		const plan = immediatePhase.plans[index];
+		if (!plan) continue;
+
+		const sameProductCurrent = currentRecurringCustomerProducts.find(
+			(customerProduct) =>
+				customerProduct.product.id === productContext.fullProduct.id &&
+				!handledCurrentProductIds.has(customerProduct.id),
+		);
+
+		if (sameProductCurrent && planReusesCurrentCustomerProduct({ plan })) {
+			const updates = {
+				ended_at: nextPhaseStartsAt ?? null,
+				canceled: false,
+				canceled_at: null,
+				scheduled_ids: [],
+			};
+
+			handledCurrentProductIds.add(sameProductCurrent.id);
+			updateCustomerProducts.push({
+				customerProduct: sameProductCurrent,
+				updates,
+			});
+			immediatePhaseCustomerProducts.push(
+				applyCustomerProductUpdate({
+					customerProduct: sameProductCurrent,
+					updates,
+				}),
+			);
+			continue;
+		}
+
+		const customerProductToReplace =
+			sameProductCurrent ?? productContext.currentCustomerProduct;
+
+		if (
+			customerProductToReplace &&
+			!handledCurrentProductIds.has(customerProductToReplace.id)
+		) {
+			handledCurrentProductIds.add(customerProductToReplace.id);
+			updateCustomerProducts.push(
+				getExpireCustomerProductUpdate({
+					customerProduct: customerProductToReplace,
+					currentEpochMs: billingContext.currentEpochMs,
+				}),
+			);
+			expiredCustomerProducts.push(customerProductToReplace);
+		}
+
+		const attachBillingContext: AttachBillingContext = {
+			...billingContext,
+			attachProduct: productContext.fullProduct,
+			fullProducts: [productContext.fullProduct],
+			featureQuantities: productContext.featureQuantities,
+			customPrices: productContext.customPrices,
+			customEnts: productContext.customEnts,
+			currentCustomerProduct: customerProductToReplace,
+			scheduledCustomerProduct: productContext.scheduledCustomerProduct,
+			planTiming: "immediate",
+			externalId: productContext.externalId,
+		};
+		const newCustomerProduct = computeAttachNewCustomerProduct({
+			ctx,
+			attachBillingContext,
+		});
+
+		newCustomerProduct.ended_at = nextPhaseStartsAt ?? null;
+		newCustomerProduct.scheduled_ids = [];
+
+		insertCustomerProducts.push(newCustomerProduct);
+		immediatePhaseCustomerProducts.push(newCustomerProduct);
+	}
+
+	for (const customerProduct of currentRecurringCustomerProducts) {
+		if (handledCurrentProductIds.has(customerProduct.id)) continue;
+
+		handledCurrentProductIds.add(customerProduct.id);
+		updateCustomerProducts.push(
+			getExpireCustomerProductUpdate({
+				customerProduct,
+				currentEpochMs: billingContext.currentEpochMs,
+			}),
+		);
+		expiredCustomerProducts.push(customerProduct);
+	}
+
+	const { allLineItems, updateCustomerEntitlements } = buildAutumnLineItems({
 		ctx,
+		newCustomerProducts: insertCustomerProducts,
+		deletedCustomerProducts: expiredCustomerProducts,
 		billingContext,
+		includeArrearLineItems: expiredCustomerProducts.length > 0,
 	});
+
+	const autumnBillingPlan: AutumnBillingPlan = {
+		customerId:
+			billingContext.fullCustomer.id ?? billingContext.fullCustomer.internal_id,
+		insertCustomerProducts,
+		updateCustomerProducts:
+			updateCustomerProducts.length > 0 ? updateCustomerProducts : undefined,
+		deleteCustomerProducts:
+			scheduledRecurringCustomerProducts.length > 0
+				? scheduledRecurringCustomerProducts
+				: undefined,
+		customPrices: billingContext.customPrices,
+		customEntitlements: billingContext.customEnts,
+		customFreeTrial: billingContext.trialContext?.customFreeTrial,
+		lineItems: allLineItems,
+		updateCustomerEntitlements,
+	};
+
+	autumnBillingPlan.lineItems = finalizeLineItems({
+		ctx,
+		lineItems: autumnBillingPlan.lineItems ?? [],
+		billingContext,
+		autumnBillingPlan,
+	});
+
+	return {
+		autumnBillingPlan,
+		immediatePhaseCustomerProducts,
+	};
+};

--- a/server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/createSchedule.ts
@@ -43,21 +43,18 @@ export const createSchedule = async ({
 		});
 	}
 
-	const immediateAutumnBillingPlan = computeCreateSchedulePlan({
-		ctx,
-		billingContext,
-	});
-	const immediatePhaseCustomerProductIds =
-		immediateAutumnBillingPlan.insertCustomerProducts.map(
-			(customerProduct) => customerProduct.id,
-		);
-	const stripeBillingPlan = await evaluateStripeBillingPlan({
-		ctx,
-		billingContext,
+	const {
 		autumnBillingPlan: immediateAutumnBillingPlan,
-		checkoutMode: billingContext.checkoutMode,
+		immediatePhaseCustomerProducts,
+	} = computeCreateSchedulePlan({
+		ctx,
+		billingContext,
+		immediatePhase,
+		nextPhaseStartsAt: futurePhases[0]?.starts_at,
 	});
-
+	const immediatePhaseCustomerProductIds = immediatePhaseCustomerProducts.map(
+		(customerProduct) => customerProduct.id,
+	);
 	const futureScheduledPhases = await materializeScheduledPhases({
 		ctx,
 		currentEpochMs,
@@ -67,6 +64,12 @@ export const createSchedule = async ({
 	const autumnExecutionPlan = buildCreateScheduleExecutionPlan({
 		immediateAutumnBillingPlan,
 		futureScheduledPhases,
+	});
+	const stripeBillingPlan = await evaluateStripeBillingPlan({
+		ctx,
+		billingContext,
+		autumnBillingPlan: autumnExecutionPlan,
+		checkoutMode: billingContext.checkoutMode,
 	});
 
 	const billingPlan = {

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans.ts
@@ -1,0 +1,39 @@
+import { type FullProduct, isOneOffProduct, RecaseError } from "@autumn/shared";
+
+/** Reject conflicting main recurring plans within a single create_schedule phase. */
+export const validateCreateSchedulePhasePlans = ({
+	fullProducts,
+}: {
+	fullProducts: FullProduct[];
+}) => {
+	const groupedProducts = new Map<string, FullProduct[]>();
+
+	for (const fullProduct of fullProducts) {
+		if (
+			fullProduct.is_add_on ||
+			isOneOffProduct({ prices: fullProduct.prices })
+		) {
+			continue;
+		}
+
+		const group = fullProduct.group ?? "";
+		const productsInGroup = groupedProducts.get(group) ?? [];
+		productsInGroup.push(fullProduct);
+		groupedProducts.set(group, productsInGroup);
+	}
+
+	const conflictingProducts = [...groupedProducts.values()].flatMap(
+		(products) => (products.length > 1 ? products : []),
+	);
+
+	if (conflictingProducts.length <= 1) return;
+
+	const planIds = conflictingProducts
+		.map((product) => `"${product.id}"`)
+		.join(", ");
+
+	throw new RecaseError({
+		message: `Create schedule supports at most one plan per group in each phase, but plans ${planIds} conflict with another requested plan in their group.`,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans.ts
@@ -26,7 +26,7 @@ export const validateCreateSchedulePhasePlans = ({
 		(products) => (products.length > 1 ? products : []),
 	);
 
-	if (conflictingProducts.length <= 1) return;
+	if (conflictingProducts.length === 0) return;
 
 	const planIds = conflictingProducts
 		.map((product) => `"${product.id}"`)

--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -1,5 +1,5 @@
-import { type CreateScheduleParamsV0, RecaseError } from "@autumn/shared";
 import type { BillingPreviewResponse } from "@autumn/shared";
+import { type CreateScheduleParamsV0, RecaseError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { billingPlanToPreviewResponse } from "@/internal/billing/v2/utils/billingPlanToPreviewResponse";
@@ -35,7 +35,11 @@ export const previewCreateSchedule = async ({
 		});
 	}
 
-	const autumnBillingPlan = computeCreateSchedulePlan({ ctx, billingContext });
+	const { autumnBillingPlan } = computeCreateSchedulePlan({
+		ctx,
+		billingContext,
+		immediatePhase,
+	});
 	const stripeBillingPlan = await evaluateStripeBillingPlan({
 		ctx,
 		billingContext,

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -5,7 +5,7 @@ import type {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupImmediateMultiProductBillingContext } from "../../common/immediateMultiProduct/setupImmediateMultiProductBillingContext";
-import { validateImmediateMultiProductTransitions } from "../../common/immediateMultiProduct/validateImmediateMultiProductTransitions";
+import { validateCreateSchedulePhasePlans } from "../errors/validateCreateSchedulePhasePlans";
 
 /** Build billing context for the immediate phase. */
 export const setupCreateScheduleBillingContext = async ({
@@ -34,8 +34,8 @@ export const setupCreateScheduleBillingContext = async ({
 		params: immediateParams,
 	});
 
-	validateImmediateMultiProductTransitions({
-		productContexts: billingContext.productContexts,
+	validateCreateSchedulePhasePlans({
+		fullProducts: billingContext.fullProducts,
 	});
 
 	return billingContext;

--- a/server/src/internal/billing/v2/actions/createSchedule/utils/materializeScheduledPhases.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/utils/materializeScheduledPhases.ts
@@ -9,6 +9,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupFeatureQuantitiesContext } from "@/internal/billing/v2/setup/setupFeatureQuantitiesContext";
 import { initFullCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct";
 import { setupAttachProductContext } from "../../attach/setup/setupAttachProductContext";
+import { validateCreateSchedulePhasePlans } from "../errors/validateCreateSchedulePhasePlans";
 
 export type MaterializedScheduledPhase = {
 	starts_at: number;
@@ -34,7 +35,8 @@ export const materializeScheduledPhases = async ({
 	phases: CreateScheduleParamsV0["phases"];
 }): Promise<MaterializedScheduledPhase[]> => {
 	return await Promise.all(
-		phases.map(async (phase) => {
+		phases.map(async (phase, index) => {
+			const nextPhaseStartsAt = phases[index + 1]?.starts_at;
 			const materializedProducts = await Promise.all(
 				phase.plans.map(async (plan) => {
 					const {
@@ -62,6 +64,7 @@ export const materializeScheduledPhases = async ({
 					});
 
 					return {
+						fullProduct,
 						customerProduct: initFullCustomerProduct({
 							ctx,
 							initContext: {
@@ -76,6 +79,7 @@ export const materializeScheduledPhases = async ({
 							},
 							initOptions: {
 								startsAt: phase.starts_at,
+								endedAt: nextPhaseStartsAt,
 								status: CusProductStatus.Scheduled,
 							},
 						}),
@@ -84,6 +88,11 @@ export const materializeScheduledPhases = async ({
 					};
 				}),
 			);
+			validateCreateSchedulePhasePlans({
+				fullProducts: materializedProducts.map(
+					({ fullProduct }) => fullProduct,
+				),
+			});
 
 			return {
 				starts_at: phase.starts_at,

--- a/server/src/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems.ts
+++ b/server/src/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems.ts
@@ -1,4 +1,9 @@
-import type { BillingContext, FullCusProduct } from "@autumn/shared";
+import type {
+	BillingContext,
+	FullCusProduct,
+	LineItem,
+	UpdateCustomerEntitlement,
+} from "@autumn/shared";
 import { customerProductToArrearLineItems } from "@/internal/billing/v2/utils/lineItems/customerProductToArrearLineItems";
 import type { AutumnContext } from "../../../../../honoUtils/HonoEnv";
 import { customerProductToLineItems } from "../../utils/lineItems/customerProductToLineItems";
@@ -8,43 +13,56 @@ export const buildAutumnLineItems = ({
 	ctx,
 	newCustomerProducts,
 	deletedCustomerProduct,
+	deletedCustomerProducts,
 	billingContext,
 	includeArrearLineItems = false,
 }: {
 	ctx: AutumnContext;
 	newCustomerProducts: FullCusProduct[];
 	deletedCustomerProduct?: FullCusProduct;
+	deletedCustomerProducts?: FullCusProduct[];
 	billingContext: BillingContext;
 	includeArrearLineItems?: boolean;
 }) => {
 	const { logger } = ctx;
+	const customerProductsToDelete = [
+		...(deletedCustomerProduct ? [deletedCustomerProduct] : []),
+		...(deletedCustomerProducts ?? []),
+	];
 
 	// For now, update subscription doesn't charge for existing usage.
-	let { lineItems: arrearLineItems, updateCustomerEntitlements } =
-		deletedCustomerProduct && includeArrearLineItems
-			? customerProductToArrearLineItems({
-					ctx,
-					customerProduct: deletedCustomerProduct,
-					billingContext,
-					options: {
-						includePeriodDescription: true,
-						updateNextResetAt: true,
-					},
-				})
-			: { lineItems: [], updateCustomerEntitlements: [] };
+	let arrearLineItems: LineItem[] = [];
+	const updateCustomerEntitlements: UpdateCustomerEntitlement[] = [];
+	if (includeArrearLineItems) {
+		for (const customerProduct of customerProductsToDelete) {
+			const arrearResult = customerProductToArrearLineItems({
+				ctx,
+				customerProduct,
+				billingContext,
+				options: {
+					includePeriodDescription: true,
+					updateNextResetAt: true,
+				},
+			});
+			arrearLineItems.push(...arrearResult.lineItems);
+			updateCustomerEntitlements.push(
+				...arrearResult.updateCustomerEntitlements,
+			);
+		}
+	}
 
 	arrearLineItems = arrearLineItems.filter((lineItem) => lineItem.amount !== 0);
 
 	// Get line items for ongoing cus product
-	const deletedLineItems = deletedCustomerProduct
-		? customerProductToLineItems({
-				ctx,
-				customerProduct: deletedCustomerProduct,
-				billingContext,
-				direction: "refund",
-				priceFilters: { excludeOneOffPrices: true },
-			})
-		: [];
+	const deletedLineItems = customerProductsToDelete.flatMap((customerProduct) =>
+		customerProductToLineItems({
+			ctx,
+			customerProduct,
+			billingContext,
+			direction: "refund",
+			priceFilters: { excludeOneOffPrices: true },
+		}),
+	);
 
 	const newLineItems = newCustomerProducts.flatMap((newCustomerProduct) =>
 		customerProductToLineItems({

--- a/server/src/internal/billing/v2/compute/computeAutumnUtils/buildSharedSubscriptionTrialLineItems.ts
+++ b/server/src/internal/billing/v2/compute/computeAutumnUtils/buildSharedSubscriptionTrialLineItems.ts
@@ -9,7 +9,10 @@ import chalk from "chalk";
 import type { Logger } from "@/external/logtail/logtailUtils";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { getTrialStateTransition } from "@/internal/billing/v2/utils/billingContext/getTrialStateTransition";
-import { billingPlanToUpdatedCustomerProduct } from "@/internal/billing/v2/utils/billingPlan/billingPlanToUpdatedCustomerProduct";
+import {
+	getDeleteCustomerProducts,
+	getUpdateCustomerProducts,
+} from "@/internal/billing/v2/utils/billingPlan/customerProductMutations";
 import { customerProductToLineItems } from "@/internal/billing/v2/utils/lineItems/customerProductToLineItems";
 
 const formatLineItem = (item: LineItem) => ({
@@ -74,14 +77,14 @@ const getSiblingCustomerProducts = ({
 	autumnBillingPlan: AutumnBillingPlan;
 	stripeSubscriptionId: string;
 }): FullCusProduct[] => {
-	const updatedCustomerProduct = billingPlanToUpdatedCustomerProduct({
-		autumnBillingPlan,
-	});
-
 	const handledIds = new Set([
 		...autumnBillingPlan.insertCustomerProducts.map((cp) => cp.id),
-		updatedCustomerProduct?.id,
-		autumnBillingPlan.deleteCustomerProduct?.id,
+		...getUpdateCustomerProducts({ autumnBillingPlan }).map(
+			(updateCustomerProduct) => updateCustomerProduct.customerProduct.id,
+		),
+		...getDeleteCustomerProducts({ autumnBillingPlan }).map(
+			(customerProduct) => customerProduct.id,
+		),
 	]);
 
 	return customerProducts.filter((customerProduct) => {

--- a/server/src/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan.ts
@@ -3,6 +3,7 @@ import type {
 	AutumnBillingPlan,
 	StripeBillingPlan,
 } from "@autumn/shared";
+import { getUpdateCustomerProducts } from "@/internal/billing/v2/utils/billingPlan/customerProductMutations";
 
 export const addStripeSubscriptionScheduleIdToBillingPlan = ({
 	autumnBillingPlan,
@@ -21,9 +22,7 @@ export const addStripeSubscriptionScheduleIdToBillingPlan = ({
 		customerProduct.scheduled_ids = [stripeSubscriptionScheduleId];
 	}
 
-	// Add to update customer product
-	if (autumnBillingPlan.updateCustomerProduct) {
-		const { updates } = autumnBillingPlan.updateCustomerProduct;
+	for (const { updates } of getUpdateCustomerProducts({ autumnBillingPlan })) {
 		const isExpiring = updates.status === CusProductStatus.Expired;
 
 		if (!isExpiring) {

--- a/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
@@ -2,6 +2,10 @@ import type { AutumnBillingPlan, Invoice } from "@autumn/shared";
 import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { insertNewCusProducts } from "@/internal/billing/v2/execute/executeAutumnActions/insertNewCusProducts";
+import {
+	getDeleteCustomerProducts,
+	getUpdateCustomerProducts,
+} from "@/internal/billing/v2/utils/billingPlan/customerProductMutations";
 import { updateCustomerEntitlements } from "@/internal/billing/v2/execute/executeAutumnActions/updateCustomerEntitlements";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
@@ -29,13 +33,13 @@ export const executeAutumnBillingPlan = async ({
 	const { db } = ctx;
 	const {
 		insertCustomerProducts,
-		updateCustomerProduct,
-		deleteCustomerProduct,
 		customPrices,
 		customEntitlements,
 		customFreeTrial,
 		insertCustomerEntitlements,
 	} = autumnBillingPlan;
+	const updateCustomerProducts = getUpdateCustomerProducts({ autumnBillingPlan });
+	const deleteCustomerProducts = getDeleteCustomerProducts({ autumnBillingPlan });
 
 	if (customEntitlements) {
 		await EntitlementService.insert({
@@ -75,9 +79,7 @@ export const executeAutumnBillingPlan = async ({
 	});
 
 	// 3. Update customer product (DB + cache)
-	if (updateCustomerProduct) {
-		const { customerProduct, updates } = updateCustomerProduct;
-
+	for (const { customerProduct, updates } of updateCustomerProducts) {
 		await customerProductActions.updateDbAndCache({
 			ctx,
 			customerId: autumnBillingPlan.customerId,
@@ -87,7 +89,7 @@ export const executeAutumnBillingPlan = async ({
 	}
 
 	// 4. Delete scheduled customer product (e.g., when updating while canceling)
-	if (deleteCustomerProduct) {
+	for (const deleteCustomerProduct of deleteCustomerProducts) {
 		ctx.logger.debug(
 			`[executeAutumnBillingPlan] deleting scheduled customer product: ${deleteCustomerProduct.product.id}`,
 		);

--- a/server/src/internal/billing/v2/utils/autumnBillingPlanToFinalFullCustomer.ts
+++ b/server/src/internal/billing/v2/utils/autumnBillingPlanToFinalFullCustomer.ts
@@ -1,5 +1,9 @@
 import type { AutumnBillingPlan, BillingContext } from "@autumn/shared";
-import { billingPlanToUpdatedCustomerProduct } from "@/internal/billing/v2/utils/billingPlan/billingPlanToUpdatedCustomerProduct";
+import {
+	applyCustomerProductUpdate,
+	getDeleteCustomerProducts,
+	getUpdateCustomerProducts,
+} from "@/internal/billing/v2/utils/billingPlan/customerProductMutations";
 
 export const autumnBillingPlanToFinalFullCustomer = ({
 	billingContext,
@@ -9,10 +13,11 @@ export const autumnBillingPlanToFinalFullCustomer = ({
 	autumnBillingPlan: AutumnBillingPlan;
 }) => {
 	const {
-		deleteCustomerProduct,
 		insertCustomerProducts,
 		updateCustomerEntitlements,
 	} = autumnBillingPlan;
+	const deleteCustomerProducts = getDeleteCustomerProducts({ autumnBillingPlan });
+	const updateCustomerProducts = getUpdateCustomerProducts({ autumnBillingPlan });
 
 	const finalFullCustomer = structuredClone(billingContext.fullCustomer);
 
@@ -22,21 +27,29 @@ export const autumnBillingPlanToFinalFullCustomer = ({
 		...insertCustomerProducts,
 	];
 
-	// 2. Replace updated customer product if applicable
-	const updatedCustomerProduct = billingPlanToUpdatedCustomerProduct({
-		autumnBillingPlan,
-	});
-
 	let customerProducts = combinedCustomerProducts.map((customerProduct) =>
-		customerProduct.id === updatedCustomerProduct?.id
-			? updatedCustomerProduct
+		updateCustomerProducts.find(
+			(updateCustomerProduct) =>
+				updateCustomerProduct.customerProduct.id === customerProduct.id,
+		)
+			? applyCustomerProductUpdate({
+					customerProduct,
+					updates:
+						updateCustomerProducts.find(
+							(updateCustomerProduct) =>
+								updateCustomerProduct.customerProduct.id === customerProduct.id,
+						)!.updates,
+				})
 			: customerProduct,
 	);
 
 	// 3. Remove deleted customer product if applicable
-	if (deleteCustomerProduct) {
+	if (deleteCustomerProducts.length > 0) {
+		const deletedIds = new Set(
+			deleteCustomerProducts.map((customerProduct) => customerProduct.id),
+		);
 		customerProducts = customerProducts.filter(
-			(customerProduct) => customerProduct.id !== deleteCustomerProduct.id,
+			(customerProduct) => !deletedIds.has(customerProduct.id),
 		);
 	}
 

--- a/server/src/internal/billing/v2/utils/billingPlan/customerProductMutations.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/customerProductMutations.ts
@@ -1,0 +1,47 @@
+import type { AutumnBillingPlan, FullCusProduct } from "@autumn/shared";
+import { CusProductStatus } from "@autumn/shared";
+
+export const getUpdateCustomerProducts = ({
+	autumnBillingPlan,
+}: {
+	autumnBillingPlan: AutumnBillingPlan;
+}) => [
+	...(autumnBillingPlan.updateCustomerProduct
+		? [autumnBillingPlan.updateCustomerProduct]
+		: []),
+	...(autumnBillingPlan.updateCustomerProducts ?? []),
+];
+
+export const getDeleteCustomerProducts = ({
+	autumnBillingPlan,
+}: {
+	autumnBillingPlan: AutumnBillingPlan;
+}) => [
+	...(autumnBillingPlan.deleteCustomerProduct
+		? [autumnBillingPlan.deleteCustomerProduct]
+		: []),
+	...(autumnBillingPlan.deleteCustomerProducts ?? []),
+];
+
+export const applyCustomerProductUpdate = ({
+	customerProduct,
+	updates,
+}: {
+	customerProduct: FullCusProduct;
+	updates: NonNullable<
+		ReturnType<typeof getUpdateCustomerProducts>[number]
+	>["updates"];
+}): FullCusProduct => ({
+	...customerProduct,
+	...updates,
+	canceled: updates.canceled ?? customerProduct.canceled,
+});
+
+export const getExpiredUpdatedCustomerProducts = ({
+	autumnBillingPlan,
+}: {
+	autumnBillingPlan: AutumnBillingPlan;
+}) =>
+	getUpdateCustomerProducts({ autumnBillingPlan })
+		.filter((update) => update.updates.status === CusProductStatus.Expired)
+		.map((update) => update.customerProduct);

--- a/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
+++ b/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
@@ -19,6 +19,10 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { CreateCustomerContext } from "@/internal/customers/actions/createWithDefaults/createCustomerContext";
+import {
+	getExpiredUpdatedCustomerProducts,
+	getUpdateCustomerProducts,
+} from "@/internal/billing/v2/utils/billingPlan/customerProductMutations";
 import { workflows } from "@/queue/workflows.js";
 
 // ============================================================================
@@ -113,21 +117,6 @@ const getInsertScenario = ({
  * Get the expired product from the billing plan's updateCustomerProduct.
  * Returns the customer product if it's being set to "expired" status.
  */
-const getExpiredProduct = ({
-	updateCustomerProduct,
-}: {
-	updateCustomerProduct: AutumnBillingPlan["updateCustomerProduct"];
-}): FullCusProduct | undefined => {
-	if (!updateCustomerProduct) return undefined;
-
-	// Check if the update is setting the status to "expired"
-	if (updateCustomerProduct.updates.status === CusProductStatus.Expired) {
-		return updateCustomerProduct.customerProduct;
-	}
-
-	return undefined;
-};
-
 // ============================================================================
 // MAIN FUNCTION
 // ============================================================================
@@ -145,13 +134,12 @@ export const billingPlanToSendProductsUpdated = async ({
 
 	const { fullCustomer } = billingContext;
 	const customerId = fullCustomer.id ?? fullCustomer.internal_id;
-	const { insertCustomerProducts, updateCustomerProduct } = autumnBillingPlan;
-
-	// Get the expired product from updateCustomerProduct (if status is being set to "expired")
-	const expiredProduct = getExpiredProduct({ updateCustomerProduct });
+	const { insertCustomerProducts } = autumnBillingPlan;
+	const updateCustomerProducts = getUpdateCustomerProducts({ autumnBillingPlan });
+	const [expiredProduct] = getExpiredUpdatedCustomerProducts({ autumnBillingPlan });
 
 	// A. Handle cancel/uncancel webhook for updateCustomerProduct
-	if (updateCustomerProduct) {
+	for (const updateCustomerProduct of updateCustomerProducts) {
 		const scenario = getUpdateScenario({
 			updates: updateCustomerProduct.updates,
 			insertCustomerProducts,

--- a/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
+++ b/server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
@@ -136,7 +136,7 @@ export const billingPlanToSendProductsUpdated = async ({
 	const customerId = fullCustomer.id ?? fullCustomer.internal_id;
 	const { insertCustomerProducts } = autumnBillingPlan;
 	const updateCustomerProducts = getUpdateCustomerProducts({ autumnBillingPlan });
-	const [expiredProduct] = getExpiredUpdatedCustomerProducts({ autumnBillingPlan });
+	const expiredProducts = getExpiredUpdatedCustomerProducts({ autumnBillingPlan });
 
 	// A. Handle cancel/uncancel webhook for updateCustomerProduct
 	for (const updateCustomerProduct of updateCustomerProducts) {
@@ -167,8 +167,12 @@ export const billingPlanToSendProductsUpdated = async ({
 	}
 
 	// B. Queue webhooks for inserted products (excluding scheduled ones)
-	for (const cusProduct of insertCustomerProducts) {
-		if (isCustomerProductScheduled(cusProduct)) continue;
+	const activeInsertCustomerProducts = insertCustomerProducts.filter(
+		(cusProduct) => !isCustomerProductScheduled(cusProduct),
+	);
+
+	for (const [index, cusProduct] of activeInsertCustomerProducts.entries()) {
+		const expiredProduct = expiredProducts[index];
 
 		const scenario = getInsertScenario({
 			insertedProduct: cusProduct,

--- a/server/tests/integration/billing/create-schedule/create-schedule-basic.test.ts
+++ b/server/tests/integration/billing/create-schedule/create-schedule-basic.test.ts
@@ -15,12 +15,35 @@ import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
 import { items } from "@tests/utils/fixtures/items";
 import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
 import { products } from "@tests/utils/fixtures/products";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { and, eq, inArray } from "drizzle-orm";
 import { CusService } from "@/internal/customers/CusService";
 import { hydrateCustomerWithSchedules } from "@/internal/customers/cusUtils/getFullCustomerSchedule";
 import { attachPaymentMethod } from "@/utils/scriptUtils/initCustomer";
+
+const getCustomerProductRows = async ({
+	ctx,
+	customerId,
+	productIds,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	customerId: string;
+	productIds: string[];
+}) =>
+	await ctx.db
+		.select({
+			productId: customerProducts.product_id,
+			status: customerProducts.status,
+		})
+		.from(customerProducts)
+		.where(
+			and(
+				eq(customerProducts.customer_id, customerId),
+				inArray(customerProducts.product_id, productIds),
+			),
+		);
 
 test.concurrent(`${chalk.yellowBright("create-schedule: bills the first phase immediately and stores later phases as scheduled")}`, async () => {
 	const pro = products.pro({
@@ -497,6 +520,614 @@ test.concurrent(`${chalk.yellowBright("create-schedule: persists the new schedul
 	expect(phasesAfterDeferredAttempt).toHaveLength(1);
 	expect(phasesAfterDeferredAttempt[0]!.customer_product_ids).toEqual(
 		deferredResponse.phases[0]!.customer_product_ids,
+	);
+});
+
+test.concurrent(`${chalk.yellowBright("create-schedule: allows multiple group replacements when they only conflict with current plans")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const usersItem = items.monthlyUsers({ includedUsage: 5 });
+
+	const existingA = products.base({
+		id: "create-schedule-existing-a",
+		items: [messagesItem, items.monthlyPrice({ price: 5 })],
+	});
+	const existingB = products.base({
+		id: "create-schedule-existing-b",
+		items: [usersItem, items.monthlyPrice({ price: 5 })],
+		group: "group-b",
+	});
+	const replacementA = products.pro({
+		id: "create-schedule-replacement-a",
+		items: [messagesItem],
+	});
+	const replacementB = products.base({
+		id: "create-schedule-replacement-b",
+		items: [usersItem, items.monthlyPrice({ price: 20 })],
+		group: "group-b",
+	});
+
+	const { customerId, autumnV1 } = await initScenario({
+		customerId: "create-schedule-multi-replace",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({
+				list: [existingA, existingB, replacementA, replacementB],
+			}),
+		],
+		actions: [
+			s.billing.attach({ productId: existingA.id }),
+			s.billing.attach({ productId: existingB.id }),
+		],
+	});
+
+	const response = await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: Date.now(),
+				plans: [{ plan_id: replacementA.id }, { plan_id: replacementB.id }],
+			},
+		],
+	});
+
+	expect(response.customer_id).toBe(customerId);
+	expect(response.phases).toHaveLength(1);
+	expect(response.phases[0]!.customer_product_ids).toHaveLength(2);
+});
+
+test.concurrent(`${chalk.yellowBright("create-schedule: later-phase-only plans stay scheduled and never hit immediate billing")}`, async () => {
+	const nowBase = products.pro({
+		id: "create-schedule-now-base",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const nowAddon = products.recurringAddOn({
+		id: "create-schedule-now-addon",
+		items: [items.monthlyWords({ includedUsage: 50 })],
+	});
+	const futureGroupB = products.base({
+		id: "create-schedule-future-group-b",
+		items: [items.monthlyUsers({ includedUsage: 5 }), items.monthlyPrice()],
+		group: "group-b",
+	});
+	const futureGroupC = products.base({
+		id: "create-schedule-future-group-c",
+		items: [
+			items.monthlyMessages({ includedUsage: 250 }),
+			items.monthlyPrice(),
+		],
+		group: "group-c",
+	});
+
+	const { customerId, autumnV1, ctx } = await initScenario({
+		customerId: "create-schedule-future-only-not-now",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({
+				list: [nowBase, nowAddon, futureGroupB, futureGroupC],
+			}),
+		],
+		actions: [],
+	});
+
+	const now = Date.now();
+	await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: now,
+				plans: [{ plan_id: nowBase.id }, { plan_id: nowAddon.id }],
+			},
+			{
+				starts_at: now + ms.days(15),
+				plans: [{ plan_id: futureGroupB.id }],
+			},
+			{
+				starts_at: now + ms.days(30),
+				plans: [{ plan_id: futureGroupC.id }],
+			},
+		],
+	});
+
+	const productRows = await getCustomerProductRows({
+		ctx,
+		customerId,
+		productIds: [nowBase.id, nowAddon.id, futureGroupB.id, futureGroupC.id],
+	});
+	const activeRows = productRows
+		.filter((productRow) => productRow.status === CusProductStatus.Active)
+		.sort((a, b) => a.productId!.localeCompare(b.productId!));
+	const scheduledRows = productRows
+		.filter((productRow) => productRow.status === CusProductStatus.Scheduled)
+		.sort((a, b) => a.productId!.localeCompare(b.productId!));
+
+	expect(activeRows).toEqual(
+		[
+			{ productId: nowBase.id, status: CusProductStatus.Active },
+			{ productId: nowAddon.id, status: CusProductStatus.Active },
+		].sort((a, b) => a.productId.localeCompare(b.productId)),
+	);
+	expect(scheduledRows).toEqual(
+		[
+			{ productId: futureGroupB.id, status: CusProductStatus.Scheduled },
+			{ productId: futureGroupC.id, status: CusProductStatus.Scheduled },
+		].sort((a, b) => a.productId.localeCompare(b.productId)),
+	);
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectCustomerInvoiceCorrect({
+		customer,
+		count: 1,
+		latestInvoiceProductIds: [nowBase.id, nowAddon.id],
+	});
+	expect(customer.invoices?.[0]?.product_ids).not.toContain(futureGroupB.id);
+	expect(customer.invoices?.[0]?.product_ids).not.toContain(futureGroupC.id);
+});
+
+test.concurrent(`${chalk.yellowBright("create-schedule: future replacements for an active group stay scheduled until their phase")}`, async () => {
+	const currentGroupB = products.base({
+		id: "create-schedule-current-group-b",
+		items: [
+			items.monthlyUsers({ includedUsage: 5 }),
+			items.monthlyPrice({ price: 5 }),
+		],
+		group: "group-b",
+	});
+	const nowBase = products.pro({
+		id: "create-schedule-active-now-base",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const futureReplacementB = products.base({
+		id: "create-schedule-future-replacement-b",
+		items: [
+			items.monthlyMessages({ includedUsage: 200 }),
+			items.monthlyPrice({ price: 15 }),
+		],
+		group: "group-b",
+	});
+
+	const { customerId, autumnV1, ctx } = await initScenario({
+		customerId: "create-schedule-future-replacement-stays-scheduled",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({
+				list: [currentGroupB, nowBase, futureReplacementB],
+			}),
+		],
+		actions: [s.billing.attach({ productId: currentGroupB.id })],
+	});
+
+	const now = Date.now();
+	await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: now,
+				plans: [{ plan_id: nowBase.id }],
+			},
+			{
+				starts_at: now + ms.days(30),
+				plans: [{ plan_id: futureReplacementB.id }],
+			},
+		],
+	});
+
+	const productRows = await getCustomerProductRows({
+		ctx,
+		customerId,
+		productIds: [nowBase.id, futureReplacementB.id],
+	});
+
+	expect(
+		productRows.filter(
+			(productRow) => productRow.productId === futureReplacementB.id,
+		),
+	).toEqual([
+		{
+			productId: futureReplacementB.id,
+			status: CusProductStatus.Scheduled,
+		},
+	]);
+	expect(
+		productRows.filter(
+			(productRow) =>
+				productRow.productId === futureReplacementB.id &&
+				productRow.status === CusProductStatus.Active,
+		),
+	).toHaveLength(0);
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectCustomerInvoiceCorrect({
+		customer,
+		count: 2,
+		latestInvoiceProductIds: [nowBase.id],
+	});
+	expect(customer.invoices?.[0]?.product_ids).not.toContain(
+		futureReplacementB.id,
+	);
+});
+
+test.concurrent(`${chalk.yellowBright("create-schedule: now phase stays the exact active set across groups and future phases")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const usersItem = items.monthlyUsers({ includedUsage: 5 });
+	const wordsItem = items.monthlyWords({ includedUsage: 25 });
+
+	const currentA = products.base({
+		id: "create-schedule-exact-current-a",
+		items: [messagesItem, items.monthlyPrice({ price: 5 })],
+	});
+	const keepNowB = products.base({
+		id: "create-schedule-exact-keep-b",
+		items: [usersItem, items.monthlyPrice({ price: 5 })],
+		group: "group-b",
+	});
+	const currentAddon = products.recurringAddOn({
+		id: "create-schedule-exact-current-addon",
+		items: [wordsItem],
+	});
+	const nowReplacementA = products.pro({
+		id: "create-schedule-exact-now-a",
+		items: [messagesItem],
+	});
+	const futureReplacementB = products.base({
+		id: "create-schedule-exact-future-b",
+		items: [usersItem, items.monthlyPrice({ price: 15 })],
+		group: "group-b",
+	});
+	const futureAddon = products.recurringAddOn({
+		id: "create-schedule-exact-future-addon",
+		items: [wordsItem],
+	});
+
+	const { customerId, autumnV1, ctx } = await initScenario({
+		customerId: "create-schedule-exact-now-set",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({
+				list: [
+					currentA,
+					keepNowB,
+					currentAddon,
+					nowReplacementA,
+					futureReplacementB,
+					futureAddon,
+				],
+			}),
+		],
+		actions: [
+			s.billing.attach({ productId: currentA.id }),
+			s.billing.attach({ productId: keepNowB.id }),
+			s.billing.attach({ productId: currentAddon.id }),
+		],
+	});
+
+	const now = Date.now();
+	await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: now,
+				plans: [{ plan_id: nowReplacementA.id }, { plan_id: keepNowB.id }],
+			},
+			{
+				starts_at: now + ms.days(15),
+				plans: [
+					{ plan_id: futureReplacementB.id },
+					{ plan_id: futureAddon.id },
+				],
+			},
+			{
+				starts_at: now + ms.days(30),
+				plans: [{ plan_id: currentA.id }],
+			},
+		],
+	});
+
+	const productRows = await getCustomerProductRows({
+		ctx,
+		customerId,
+		productIds: [
+			currentA.id,
+			keepNowB.id,
+			currentAddon.id,
+			nowReplacementA.id,
+			futureReplacementB.id,
+			futureAddon.id,
+		],
+	});
+	const activeRows = productRows
+		.filter((productRow) => productRow.status === CusProductStatus.Active)
+		.sort((a, b) => a.productId!.localeCompare(b.productId!));
+	const scheduledRows = productRows
+		.filter((productRow) => productRow.status === CusProductStatus.Scheduled)
+		.sort((a, b) => a.productId!.localeCompare(b.productId!));
+
+	expect(activeRows).toEqual(
+		[
+			{ productId: keepNowB.id, status: CusProductStatus.Active },
+			{ productId: nowReplacementA.id, status: CusProductStatus.Active },
+		].sort((a, b) => a.productId.localeCompare(b.productId)),
+	);
+	expect(scheduledRows).toEqual(
+		[
+			{ productId: currentA.id, status: CusProductStatus.Scheduled },
+			{ productId: futureAddon.id, status: CusProductStatus.Scheduled },
+			{
+				productId: futureReplacementB.id,
+				status: CusProductStatus.Scheduled,
+			},
+		].sort((a, b) => a.productId.localeCompare(b.productId)),
+	);
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	expect(customer.invoices?.[0]?.product_ids).not.toContain(
+		futureReplacementB.id,
+	);
+	expect(customer.invoices?.[0]?.product_ids).not.toContain(futureAddon.id);
+});
+
+test.concurrent(`${chalk.yellowBright("create-schedule: plans omitted from the next phase end at the phase boundary")}`, async () => {
+	const nowBase = products.pro({
+		id: "create-schedule-phase-end-now-base",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const nowAddon = products.recurringAddOn({
+		id: "create-schedule-phase-end-now-addon",
+		items: [items.monthlyWords({ includedUsage: 25 })],
+	});
+	const nextBase = products.premium({
+		id: "create-schedule-phase-end-next-base",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+	const nextAddon = products.recurringAddOn({
+		id: "create-schedule-phase-end-next-addon",
+		items: [items.monthlyWords({ includedUsage: 75 })],
+	});
+
+	const { customerId, autumnV1, ctx, testClockId, advancedTo } =
+		await initScenario({
+			customerId: "create-schedule-phase-end-boundary",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [nowBase, nowAddon, nextBase, nextAddon] }),
+			],
+			actions: [],
+		});
+
+	const now = advancedTo;
+	await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: now,
+				plans: [{ plan_id: nowBase.id }, { plan_id: nowAddon.id }],
+			},
+			{
+				starts_at: now + ms.days(15),
+				plans: [{ plan_id: nextBase.id }, { plan_id: nextAddon.id }],
+			},
+		],
+	});
+
+	await advanceTestClock({
+		stripeCli: ctx.stripeCli,
+		testClockId: testClockId!,
+		advanceTo: now + ms.days(16),
+		waitForSeconds: 30,
+	});
+
+	const productRows = await getCustomerProductRows({
+		ctx,
+		customerId,
+		productIds: [nowBase.id, nowAddon.id, nextBase.id, nextAddon.id],
+	});
+
+	expect(
+		productRows
+			.filter((productRow) => productRow.status === CusProductStatus.Active)
+			.sort((a, b) => a.productId!.localeCompare(b.productId!)),
+	).toEqual(
+		[
+			{ productId: nextAddon.id, status: CusProductStatus.Active },
+			{ productId: nextBase.id, status: CusProductStatus.Active },
+		].sort((a, b) => a.productId.localeCompare(b.productId)),
+	);
+	expect(
+		productRows.filter(
+			(productRow) => productRow.status === CusProductStatus.Scheduled,
+		),
+	).toHaveLength(0);
+	expect(
+		productRows
+			.filter((productRow) => productRow.status === CusProductStatus.Expired)
+			.sort((a, b) => a.productId!.localeCompare(b.productId!)),
+	).toEqual(
+		[
+			{ productId: nowAddon.id, status: CusProductStatus.Expired },
+			{ productId: nowBase.id, status: CusProductStatus.Expired },
+		].sort((a, b) => a.productId.localeCompare(b.productId)),
+	);
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	expect(customer.products?.map((product) => product.id).sort()).toEqual(
+		[nextAddon.id, nextBase.id].sort(),
+	);
+});
+
+test.concurrent(`${chalk.yellowBright("create-schedule: replacing a schedule removes old phases and leaves the correct replacement state in db")}`, async () => {
+	const currentA = products.base({
+		id: "create-schedule-replace-state-current-a",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const currentB = products.base({
+		id: "create-schedule-replace-state-current-b",
+		items: [items.monthlyUsers({ includedUsage: 5 })],
+		group: "group-b",
+	});
+	const currentAddon = products.recurringAddOn({
+		id: "create-schedule-replace-state-current-addon",
+		items: [items.monthlyWords({ includedUsage: 25 })],
+	});
+	const firstFutureA = products.pro({
+		id: "create-schedule-replace-state-first-future-a",
+		items: [items.monthlyMessages({ includedUsage: 300 })],
+	});
+	const firstFutureAddon = products.recurringAddOn({
+		id: "create-schedule-replace-state-first-future-addon",
+		items: [items.monthlyWords({ includedUsage: 75 })],
+	});
+	const secondNowA = products.premium({
+		id: "create-schedule-replace-state-second-now-a",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+	const secondFutureA = products.pro({
+		id: "create-schedule-replace-state-second-future-a",
+		items: [items.monthlyMessages({ includedUsage: 300 })],
+	});
+	const secondFutureB = products.pro({
+		id: "create-schedule-replace-state-second-future-b",
+		items: [items.monthlyUsers({ includedUsage: 10 })],
+		group: "group-b",
+	});
+
+	const { customerId, autumnV1, ctx, advancedTo } = await initScenario({
+		customerId: "create-schedule-replace-state",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({
+				list: [
+					currentA,
+					currentB,
+					currentAddon,
+					firstFutureA,
+					firstFutureAddon,
+					secondNowA,
+					secondFutureA,
+					secondFutureB,
+				],
+			}),
+		],
+		actions: [
+			s.billing.attach({ productId: currentA.id }),
+			s.billing.attach({ productId: currentB.id }),
+			s.billing.attach({ productId: currentAddon.id }),
+		],
+	});
+
+	const now = advancedTo;
+	const firstResponse = await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: now,
+				plans: [
+					{ plan_id: currentA.id },
+					{ plan_id: currentB.id },
+					{ plan_id: currentAddon.id },
+				],
+			},
+			{
+				starts_at: now + ms.days(15),
+				plans: [{ plan_id: firstFutureA.id }, { plan_id: firstFutureAddon.id }],
+			},
+		],
+	});
+
+	const replacementNow = Date.now();
+	const secondResponse = await autumnV1.billing.createSchedule({
+		customer_id: customerId,
+		phases: [
+			{
+				starts_at: replacementNow,
+				plans: [{ plan_id: secondNowA.id }, { plan_id: currentAddon.id }],
+			},
+			{
+				starts_at: replacementNow + ms.days(15),
+				plans: [{ plan_id: secondFutureA.id }, { plan_id: secondFutureB.id }],
+			},
+		],
+	});
+
+	const dbSchedules = await ctx.db
+		.select()
+		.from(schedules)
+		.where(eq(schedules.customer_id, customerId));
+	expect(dbSchedules).toHaveLength(1);
+	expect(dbSchedules[0]!.id).toBe(secondResponse.schedule_id);
+
+	const firstSchedule = await ctx.db
+		.select()
+		.from(schedules)
+		.where(eq(schedules.id, firstResponse.schedule_id));
+	expect(firstSchedule).toHaveLength(0);
+
+	const secondSchedulePhases = await ctx.db
+		.select()
+		.from(schedulePhases)
+		.where(eq(schedulePhases.schedule_id, secondResponse.schedule_id));
+	expect(secondSchedulePhases).toHaveLength(2);
+
+	const firstSchedulePhases = await ctx.db
+		.select()
+		.from(schedulePhases)
+		.where(eq(schedulePhases.schedule_id, firstResponse.schedule_id));
+	expect(firstSchedulePhases).toHaveLength(0);
+
+	const productRowsAfterReplace = await getCustomerProductRows({
+		ctx,
+		customerId,
+		productIds: [
+			currentA.id,
+			currentB.id,
+			currentAddon.id,
+			firstFutureA.id,
+			firstFutureAddon.id,
+			secondNowA.id,
+			secondFutureA.id,
+			secondFutureB.id,
+		],
+	});
+
+	expect(
+		productRowsAfterReplace
+			.filter((productRow) => productRow.status === CusProductStatus.Active)
+			.sort((a, b) => a.productId!.localeCompare(b.productId!)),
+	).toEqual(
+		[
+			{ productId: currentAddon.id, status: CusProductStatus.Active },
+			{ productId: secondNowA.id, status: CusProductStatus.Active },
+		].sort((a, b) => a.productId.localeCompare(b.productId)),
+	);
+	expect(
+		productRowsAfterReplace
+			.filter((productRow) => productRow.status === CusProductStatus.Scheduled)
+			.sort((a, b) => a.productId!.localeCompare(b.productId!)),
+	).toEqual(
+		[
+			{ productId: secondFutureA.id, status: CusProductStatus.Scheduled },
+			{ productId: secondFutureB.id, status: CusProductStatus.Scheduled },
+		].sort((a, b) => a.productId.localeCompare(b.productId)),
+	);
+	expect(
+		productRowsAfterReplace.filter(
+			(productRow) =>
+				productRow.productId === firstFutureA.id ||
+				productRow.productId === firstFutureAddon.id,
+		),
+	).toHaveLength(0);
+
+	const customerAfterReplace =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	expect(
+		customerAfterReplace.products
+			?.map((product) => ({ id: product.id, status: product.status }))
+			.sort((a, b) => a.id.localeCompare(b.id)),
+	).toEqual(
+		[
+			{ id: currentAddon.id, status: "active" as const },
+			{ id: secondFutureA.id, status: "scheduled" as const },
+			{ id: secondFutureB.id, status: "scheduled" as const },
+			{ id: secondNowA.id, status: "active" as const },
+		].sort((a, b) => a.id.localeCompare(b.id)),
 	);
 });
 

--- a/server/tests/unit/billing/create-schedule/compute-create-schedule-plan.spec.ts
+++ b/server/tests/unit/billing/create-schedule/compute-create-schedule-plan.spec.ts
@@ -21,9 +21,14 @@ const createBillingContext = ({
 		(productContext) => productContext.fullProduct,
 	);
 	const currentCustomerProducts = productContexts.flatMap((productContext) =>
-		productContext.currentCustomerProduct
-			? [productContext.currentCustomerProduct]
-			: [],
+		[
+			...(productContext.currentCustomerProduct
+				? [productContext.currentCustomerProduct]
+				: []),
+			...(productContext.scheduledCustomerProduct
+				? [productContext.scheduledCustomerProduct]
+				: []),
+		],
 	);
 
 	return {
@@ -76,19 +81,25 @@ describe(chalk.yellowBright("computeCreateSchedulePlan"), () => {
 		const result = computeCreateSchedulePlan({
 			ctx,
 			billingContext,
+			immediatePhase: {
+				starts_at: Date.now(),
+				plans: [{ plan_id: baseProduct.id }, { plan_id: addonProduct.id }],
+			},
 		});
 
-		expect(result.insertCustomerProducts).toHaveLength(2);
+		expect(result.autumnBillingPlan.insertCustomerProducts).toHaveLength(2);
 		expect(
-			result.insertCustomerProducts.map((product) => product.product_id),
+			result.autumnBillingPlan.insertCustomerProducts.map(
+				(product) => product.product_id,
+			),
 		).toEqual(["base", "addon"]);
 		expect(
-			result.insertCustomerProducts.every(
+			result.autumnBillingPlan.insertCustomerProducts.every(
 				(product) => product.status === CusProductStatus.Active,
 			),
 		).toBe(true);
-		expect(result.updateCustomerProduct).toBeUndefined();
-		expect(result.deleteCustomerProduct).toBeUndefined();
+		expect(result.autumnBillingPlan.updateCustomerProduct).toBeUndefined();
+		expect(result.autumnBillingPlan.deleteCustomerProduct).toBeUndefined();
 	});
 
 	test("expires the current product and removes a scheduled replacement during a transition", () => {
@@ -141,18 +152,32 @@ describe(chalk.yellowBright("computeCreateSchedulePlan"), () => {
 		const result = computeCreateSchedulePlan({
 			ctx,
 			billingContext,
+			immediatePhase: {
+				starts_at: currentEpochMs,
+				plans: [{ plan_id: newProduct.id }],
+			},
 		});
 
-		expect(result.insertCustomerProducts).toHaveLength(1);
-		expect(result.insertCustomerProducts[0]!.product_id).toBe("pro");
-		expect(result.deleteCustomerProduct?.id).toBe("cus_prod_scheduled");
-		expect(result.updateCustomerProduct?.customerProduct.id).toBe(
-			"cus_prod_current",
+		expect(result.autumnBillingPlan.insertCustomerProducts).toHaveLength(1);
+		expect(result.autumnBillingPlan.insertCustomerProducts[0]!.product_id).toBe(
+			"pro",
 		);
-		expect(result.updateCustomerProduct?.updates.status).toBe(
-			CusProductStatus.Expired,
+		expect(result.autumnBillingPlan.deleteCustomerProducts).toHaveLength(1);
+		expect(result.autumnBillingPlan.deleteCustomerProducts?.[0]?.id).toBe(
+			"cus_prod_scheduled",
 		);
-		expect(result.updateCustomerProduct?.updates.ended_at).toBe(currentEpochMs);
-		expect(result.updateCustomerProduct?.updates.canceled).toBe(true);
+		expect(result.autumnBillingPlan.updateCustomerProducts).toHaveLength(1);
+		expect(
+			result.autumnBillingPlan.updateCustomerProducts?.[0]?.customerProduct.id,
+		).toBe("cus_prod_current");
+		expect(
+			result.autumnBillingPlan.updateCustomerProducts?.[0]?.updates.status,
+		).toBe(CusProductStatus.Expired);
+		expect(
+			result.autumnBillingPlan.updateCustomerProducts?.[0]?.updates.ended_at,
+		).toBe(currentEpochMs);
+		expect(
+			result.autumnBillingPlan.updateCustomerProducts?.[0]?.updates.canceled,
+		).toBe(true);
 	});
 });

--- a/server/tests/unit/billing/create-schedule/validate-create-schedule-phase-plans.spec.ts
+++ b/server/tests/unit/billing/create-schedule/validate-create-schedule-phase-plans.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { prices } from "@tests/utils/fixtures/db/prices";
+import { products } from "@tests/utils/fixtures/db/products";
+import chalk from "chalk";
+import { validateCreateSchedulePhasePlans } from "@/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans";
+
+describe(chalk.yellowBright("validateCreateSchedulePhasePlans"), () => {
+	test("allows plans in different groups even when each would replace a current plan", () => {
+		const productA = products.createFull({
+			id: "replacement-a",
+			prices: [prices.createFixed({ id: "price_replacement_a" })],
+		});
+		const productB = {
+			...products.createFull({
+				id: "replacement-b",
+				prices: [prices.createFixed({ id: "price_replacement_b" })],
+			}),
+			group: "group-b",
+		};
+
+		expect(() =>
+			validateCreateSchedulePhasePlans({
+				fullProducts: [productA, productB],
+			}),
+		).not.toThrow();
+	});
+
+	test("rejects multiple main recurring plans in the same group", () => {
+		const productA = products.createFull({
+			id: "replacement-a",
+			prices: [prices.createFixed({ id: "price_same_group_a" })],
+		});
+		const productB = products.createFull({
+			id: "replacement-b",
+			prices: [prices.createFixed({ id: "price_same_group_b" })],
+		});
+
+		expect(() =>
+			validateCreateSchedulePhasePlans({
+				fullProducts: [productA, productB],
+			}),
+		).toThrow("at most one plan per group");
+	});
+});

--- a/server/tests/unit/billing/update-subscription/billing-plan-send-products-updated.spec.ts
+++ b/server/tests/unit/billing/update-subscription/billing-plan-send-products-updated.spec.ts
@@ -16,12 +16,17 @@ afterEach(() => {
 
 const runPlan = async ({
 	updateCustomerProduct,
+	updateCustomerProducts = [],
 	insertCustomerProducts = [],
 }: {
 	updateCustomerProduct?: {
 		customerProduct: ReturnType<typeof customerProducts.create>;
 		updates: Record<string, unknown>;
 	};
+	updateCustomerProducts?: {
+		customerProduct: ReturnType<typeof customerProducts.create>;
+		updates: Record<string, unknown>;
+	}[];
 	insertCustomerProducts?: ReturnType<typeof customerProducts.create>[];
 }) => {
 	const calls: SendProductsUpdatedPayload[] = [];
@@ -38,6 +43,7 @@ const runPlan = async ({
 			customPrices: [],
 			customEntitlements: [],
 			updateCustomerProduct,
+			updateCustomerProducts,
 		},
 		billingContext: contexts.createBilling({}),
 	});
@@ -133,5 +139,90 @@ describe(chalk.yellowBright("billingPlanToSendProductsUpdated"), () => {
 		});
 
 		expect(calls).toHaveLength(0);
+	});
+
+	test("matches each inserted product to its own expired counterpart", async () => {
+		const calls = await runPlan({
+			updateCustomerProducts: [
+				{
+					customerProduct: customerProducts.create({
+						id: "cus_prod_expired_1",
+						productId: "prod_old_1",
+						customerPrices: [
+							prices.createCustomer({
+								customerProductId: "cus_prod_expired_1",
+								price: {
+									...prices.createFixed({ id: "price_old_1" }),
+									config: {
+										...prices.createFixed({ id: "price_old_1" }).config,
+										amount: 100,
+									},
+								},
+							}),
+						],
+					}),
+					updates: { status: CusProductStatus.Expired },
+				},
+				{
+					customerProduct: customerProducts.create({
+						id: "cus_prod_expired_2",
+						productId: "prod_old_2",
+						customerPrices: [
+							prices.createCustomer({
+								customerProductId: "cus_prod_expired_2",
+								price: {
+									...prices.createFixed({ id: "price_old_2" }),
+									config: {
+										...prices.createFixed({ id: "price_old_2" }).config,
+										amount: 300,
+									},
+								},
+							}),
+						],
+					}),
+					updates: { status: CusProductStatus.Expired },
+				},
+			],
+			insertCustomerProducts: [
+				customerProducts.create({
+					id: "cus_prod_new_1",
+					productId: "prod_new_1",
+					customerPrices: [
+						prices.createCustomer({
+							customerProductId: "cus_prod_new_1",
+							price: {
+								...prices.createFixed({ id: "price_new_1" }),
+								config: {
+									...prices.createFixed({ id: "price_new_1" }).config,
+									amount: 200,
+								},
+							},
+						}),
+					],
+				}),
+				customerProducts.create({
+					id: "cus_prod_new_2",
+					productId: "prod_new_2",
+					customerPrices: [
+						prices.createCustomer({
+							customerProductId: "cus_prod_new_2",
+							price: {
+								...prices.createFixed({ id: "price_new_2" }),
+								config: {
+									...prices.createFixed({ id: "price_new_2" }).config,
+									amount: 100,
+								},
+							},
+						}),
+					],
+				}),
+			],
+		});
+
+		expect(calls).toHaveLength(2);
+		expect(calls[0]?.customerProductId).toBe("cus_prod_new_1");
+		expect(calls[0]?.scenario).toBe(AttachScenario.Upgrade);
+		expect(calls[1]?.customerProductId).toBe("cus_prod_new_2");
+		expect(calls[1]?.scenario).toBe(AttachScenario.New);
 	});
 });

--- a/shared/models/billingModels/plan/autumnBillingPlan.ts
+++ b/shared/models/billingModels/plan/autumnBillingPlan.ts
@@ -39,28 +39,27 @@ export const UpdateCustomerEntitlementSchema = z.object({
 	insertReplaceables: z.array(z.custom<InsertReplaceable>()).optional(),
 });
 
+export const CustomerProductUpdateSchema = z.object({
+	customerProduct: FullCusProductSchema,
+	updates: z.object({
+		options: z.array(FeatureOptionsSchema).optional(),
+		status: z.enum(CusProductStatus).optional(),
+		billing_cycle_anchor_resets_at: z.number().nullish(),
+		// Cancel fields (nullish to support uncancel - setting to null)
+		canceled: z.boolean().nullish(),
+		canceled_at: z.number().nullish(),
+		ended_at: z.number().nullish(),
+		scheduled_ids: z.array(z.string()).optional(),
+		subscription_ids: z.array(z.string()).optional(),
+	}),
+});
+
 export const AutumnBillingPlanSchema = z.object({
 	customerId: z.string(),
 	insertCustomerProducts: z.array(FullCusProductSchema),
 
-	updateCustomerProduct: z
-		.object({
-			customerProduct: FullCusProductSchema,
-			updates: z.object({
-				options: z.array(FeatureOptionsSchema).optional(),
-				status: z.enum(CusProductStatus).optional(),
-				billing_cycle_anchor_resets_at: z.number().nullish(),
-				// Cancel fields (nullish to support uncancel - setting to null)
-				canceled: z.boolean().nullish(),
-				canceled_at: z.number().nullish(),
-				ended_at: z.number().nullish(),
-
-				scheduled_ids: z.array(z.string()).optional(),
-
-				subscription_ids: z.array(z.string()).optional(),
-			}),
-		})
-		.optional(),
+	updateCustomerProduct: CustomerProductUpdateSchema.optional(),
+	updateCustomerProducts: z.array(CustomerProductUpdateSchema).optional(),
 
 	updateByStripeScheduleId: z
 		.object({
@@ -70,6 +69,7 @@ export const AutumnBillingPlanSchema = z.object({
 		.optional(),
 
 	deleteCustomerProduct: FullCusProductSchema.optional(), // Scheduled product to delete (e.g., when updating while canceling)
+	deleteCustomerProducts: z.array(FullCusProductSchema).optional(),
 
 	customPrices: z.array(PriceSchema).optional(), // Custom prices to insert
 	customEntitlements: z.array(EntitlementSchema).optional(), // Custom entitlements to insert


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes a phase‑aware `create_schedule`: the immediate phase exactly matches the requested active set, future phases are saved with start/end boundaries, and replacing a schedule removes old phases. Also fixes Stripe expiry handling and tightens product‑updated webhook scenarios.

- **New Features**
  - Immediate phase: reuse unchanged plans (extend to next phase), replace changed ones (expire current now), expire other active recurring plans, and delete previously scheduled replacements; line items include arrears/refunds across multiple expirations.
  - Future phases: stored as `Scheduled` with `starts_at` and `ended_at` (next phase start); per‑phase validator enforces at most one main recurring plan per group.
  - Schema/helpers: `AutumnBillingPlan` adds `updateCustomerProducts`/`deleteCustomerProducts`; new helpers (`applyCustomerProductUpdate`, `getExpiredUpdatedCustomerProducts`) used across compute/execute/finalization; Stripe schedule IDs attach to all non‑expiring updated products.

- **Bug Fixes**
  - Stripe webhook expires active products once `ended_at` passes.
  - Webhook scenarios: iterate all `updateCustomerProducts`, skip scheduled inserts, and pair each insert with its own expired counterpart for correct "upgrade vs new" labels; sibling line items exclude all updated/deleted products; arrears computed for all expired products.

<sup>Written for commit cc519a66ad4b13775690448edaf0ca45c576280e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two things: the Stripe webhook handler now correctly expires **active** products whose `ended_at` has passed (previously `hasCustomerProductEnded` only matched products in a `Canceling` state), and the `create_schedule` action is rebuilt to be phase-aware — reusing unchanged products, expiring replaced ones, materialising future phases as `Scheduled` rows, and validating per-phase plan conflicts.

- **Bug fixes**: `expireEndedCustomerProducts` now correctly handles active products with a past `ended_at` by adding a second OR-branch alongside `hasCustomerProductEnded`.
- **Improvements**: `AutumnBillingPlan` gains `updateCustomerProducts` / `deleteCustomerProducts` array fields; all consumers updated via helper functions (`getUpdateCustomerProducts`, `getDeleteCustomerProducts`), enabling multi-product replacement in a single billing plan.
- **Improvements**: `computeCreateSchedulePlan` is a new phase-aware compute function covering reuse, expiry, insertion, and line-item finalization for the immediate phase.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style/clarity issues that don't affect billing correctness.

The main bug fix (expiring active products with past ended_at in the webhook handler) is correct and well-scoped. The new computeCreateSchedulePlan, materializeScheduledPhases, and multi-product helper functions are logically sound and covered by unit tests. The two P2 findings are a misleading guard condition and a single-expiry-product limitation for webhook scenario labels — neither affects data integrity or billing outcomes.

validateCreateSchedulePhasePlans.ts (misleading guard) and billingPlanToSendProductsUpdated.ts (first-expired-product shortcut for webhook scenarios).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/expireEndedCustomerProducts.ts | Bug fix: adds OR-branch to expire active products (not just canceling ones) when ended_at has passed. |
| server/src/internal/billing/v2/actions/createSchedule/compute/computeCreateSchedulePlan.ts | New phase-aware compute function; correctly reuses, expires, or replaces current products and finalizes line items. |
| server/src/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans.ts | Conflict validation is logically correct but the conflictingProducts.length <= 1 guard is misleading (can never be 1 due to flatMap semantics). |
| server/src/internal/billing/v2/actions/createSchedule/utils/materializeScheduledPhases.ts | Correctly materialises future scheduled phases with proper ended_at boundaries and per-phase conflict validation. |
| shared/models/billingModels/plan/autumnBillingPlan.ts | Adds updateCustomerProducts and deleteCustomerProducts array fields to the billing plan schema alongside legacy singular fields. |
| server/src/internal/billing/v2/utils/billingPlan/customerProductMutations.ts | New helpers correctly merge singular and plural fields; getExpiredUpdatedCustomerProducts is clean. |
| server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts | Updated to iterate all updateCustomerProducts, but getInsertScenario still uses only the first expired product for all inserts. |
| server/src/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan.ts | Now correctly attaches the Stripe schedule ID to all non-expiring updated products via the new plural helper. |
| server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts | Migrated to helper functions; handles both singular and plural update/delete fields transparently. |
| server/src/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems.ts | Now accepts both deletedCustomerProduct (singular) and deletedCustomerProducts (plural) and merges them for arrear/refund calculation. |
| server/src/internal/billing/v2/compute/computeAutumnUtils/buildSharedSubscriptionTrialLineItems.ts | getSiblingCustomerProducts now uses the plural helpers, correctly excluding all updated/deleted products from sibling line items. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createSchedule called] --> B[normalizeCreateSchedulePhases\nsort & validate phase order]
    B --> C[immediatePhase + futurePhases]
    C --> D[setupCreateScheduleBillingContext\nbuild MultiAttachBillingContext]
    D --> E[validateCreateSchedulePhasePlans\nimmediate phase: max 1 plan per group]
    E --> F[computeCreateSchedulePlan]

    F --> F1{same product\nand no customization?}
    F1 -- yes: reuse --> F2[updateCustomerProducts:\nset ended_at = nextPhaseStart]
    F1 -- no: replace --> F3[updateCustomerProducts:\nexpire old product]
    F3 --> F4[insertCustomerProducts:\nnew product for immediate phase]

    F2 --> G[products not in new schedule\nexpired via updateCustomerProducts]
    F4 --> G
    G --> H[buildAutumnLineItems\narrear + refund + new charges]
    H --> I[finalizeLineItems]

    I --> J[materializeScheduledPhases\nfor each future phase]
    J --> J1[validateCreateSchedulePhasePlans\nper phase]
    J1 --> J2[initFullCustomerProduct\nstatus=Scheduled, ended_at=nextPhase]

    J2 --> K[buildCreateScheduleExecutionPlan\nmerge immediate + scheduled inserts]
    K --> L[evaluateStripeBillingPlan]
    L --> M[executeBillingPlan]
    M --> N[addStripeScheduleId to all\nnon-expiring updateCustomerProducts]
    N --> O[persistCreateSchedule\nstore phases & schedule_id]
    O --> P[Return CreateScheduleResponse]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/actions/createSchedule/errors/validateCreateSchedulePhasePlans.ts
Line: 29

Comment:
**Unreachable guard branch**

`conflictingProducts` is built via `flatMap((products) => products.length > 1 ? products : [])`, so every group that contributes elements adds at least 2. The length is therefore always **0 or ≥ 2** — it can never be 1. The `<= 1` guard is effectively `=== 0`, which happens to produce the correct result, but the `length === 1` branch can never fire. If the intent is "no conflicts → return", spell it out explicitly:

```suggestion
	if (conflictingProducts.length === 0) return;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated.ts
Line: 139

Comment:
**First expired product used for all insert scenarios**

`[expiredProduct]` destructures only the first element of `getExpiredUpdatedCustomerProducts`. In a `create_schedule` call that replaces two products (e.g. starter → pro **and** addon → new-addon), both inserted products are then compared against the same first expired product when `getInsertScenario` is called. The second inserted product's "upgrade vs new" webhook scenario is determined by the wrong counterpart, which can produce incorrect outbound webhook labels downstream.

Consider matching each inserted product to its own expired counterpart (e.g. by `product_id`) before falling back to the first expired product.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: correct webhook logic"](https://github.com/useautumn/autumn/commit/ee7814407a16f40246eef92c80972afc7cdeb9bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28499794)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->