### PR TITLE
(don't merge yet): feat: add autumn slack app under apps/autumn

### DIFF
--- a/apps/autumn/.env.example
+++ b/apps/autumn/.env.example
@@ -1,0 +1,22 @@
+# Redis (required - used by Chat SDK state + workspace store)
+REDIS_URL=redis://localhost:6379
+
+# Slack App (create at api.slack.com/apps)
+SLACK_CLIENT_ID=
+SLACK_CLIENT_SECRET=
+SLACK_SIGNING_SECRET=
+
+# Encryption key for storing tenant API keys (generate with: openssl rand -hex 32)
+ENCRYPTION_KEY=
+
+# AI Agent
+ANTHROPIC_API_KEY=
+
+# Autumn OAuth
+AUTUMN_BACKEND_URL=https://api.useautumn.com
+AUTUMN_OAUTH_CLIENT_ID=
+AUTUMN_OAUTH_CLIENT_SECRET=
+
+# Server
+PORT=3000
+BASE_URL=http://localhost:3000

--- a/apps/autumn/.gitignore
+++ b/apps/autumn/.gitignore
@@ -1,0 +1,30 @@
+# Environment
+.env
+.env.local
+.env.test
+!.env.example
+
+# Node
+node_modules/
+dist/
+*.tsbuildinfo
+
+# Docker
+docker/data/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude Code
+.claude/
+
+# Logs
+*.log

--- a/apps/autumn/CLAUDE.md
+++ b/apps/autumn/CLAUDE.md
@@ -1,0 +1,105 @@
+# Autumn Slack Bot
+
+Autumn's Slack bot where users interact with `@Autumn` via natural language for all billing operations. No billing slash commands, just an AI agent with confirmation buttons for mutations.
+
+This app lives at `apps/autumn` inside the main Autumn monorepo.
+
+## Tech Stack
+
+- Runtime: Bun
+- Server: Hono
+- Bot Framework: Chat SDK (`chat`, `@chat-adapter/slack`)
+- State: Redis (via `@chat-adapter/state-redis` + `ioredis`)
+- Billing API: `autumn-js@beta` (Autumn v2 SDK)
+- AI Agent: Anthropic Claude (via `@anthropic-ai/sdk`)
+- Webhook Verification: Svix
+
+## Architecture
+
+```
+src/
+├── index.ts           Hono server entry point
+├── bot.ts             Chat SDK instance, event handlers, App Home
+├── config.ts          Env validation
+├── routes/
+│   ├── webhooks.ts    Chat SDK webhook handler (/webhooks/slack)
+│   ├── autumn.ts      Autumn webhooks + Svix verification + alert routing
+│   ├── install.ts     Slack OAuth + welcome DM (/install/slack)
+│   └── connect.ts     Autumn OAuth (/connect)
+├── commands/
+│   ├── router.ts      /connect + /disconnect only
+│   ├── connect.ts     /connect (Autumn OAuth onboarding)
+│   └── disconnect.ts  /disconnect
+├── agent/
+│   ├── handler.ts     @Autumn mention -> Claude agent loop + confirm cards
+│   ├── tools.ts       Tool definitions (defineTool helper, read/mutating split)
+│   ├── executor.ts    Tool execution (read + computed)
+│   ├── confirm.ts     Confirmation execution (action registry + successCard)
+│   └── shared.ts      parseApiError, str, num utilities
+├── cards/
+│   └── alert.ts       Webhook alert cards
+├── services/
+│   ├── autumn.ts      Per-tenant Autumn SDK factory
+│   ├── workspace.ts   Redis workspace store (encrypted)
+│   ├── encryption.ts  AES-256-GCM
+│   └── renewals.ts    Upcoming renewal computation
+├── lib/
+│   ├── slack.ts       Workspace ID extraction + error helpers
+│   └── redis.ts       Redis singleton
+└── utils/
+    └── formatters.ts  formatNumber, parseDuration
+```
+
+## Agent-First
+
+All billing operations go through `@Autumn` mentions with 26 tools (16 read/computed, 10 mutating) where mutations trigger Confirm/Cancel buttons automatically and ambiguous customer names are disambiguated before acting.
+
+## Multi-Tenant
+
+Each Slack workspace stores encrypted credentials in Redis that get decrypted per-event to create a per-tenant Autumn SDK instance, with channel-based access control.
+
+## Onboarding
+
+1. Install via Slack OAuth -> welcome DM with Connect button
+2. `/connect` triggers Autumn OAuth (PKCE)
+3. Prod API key is provisioned automatically
+4. App Home shows connection status
+
+## Auth
+
+Users connect via `/connect` which triggers Autumn's OAuth flow. No API keys are pasted in chat.
+
+## Workspace Config
+
+```typescript
+type WorkspaceConfig = {
+  workspaceId: string;
+  apiKey: string | null;
+  orgSlug: string;
+  orgName: string;
+  commandChannels: string[];
+  alertChannel: string | null;
+  slackBotToken: string | null;
+  webhookSecret: string | null;
+  installedAt: number;
+  installedBotUserId: string | null;
+  connectedByUserId: string | null;
+};
+```
+
+## Commands
+
+- `bun setup` -- Generate `.env` for the Slack app
+- `docker compose -f docker-compose.dev.yml up -d` -- Start Redis from repo root (Windows)
+- `docker compose -f docker-compose.unix.yml up -d` -- Start Redis from repo root (macOS/Linux)
+- `bun dev` -- Start dev server with hot reload
+- `bun start` -- Start production server
+- `bun run check` -- Lint and format check
+- `bun run typecheck` -- TypeScript type checking
+
+## Style
+
+- Biome for formatting (tabs, double quotes, semicolons)
+- Chat SDK function-call API for cards (no JSX)
+- `.ts` extensions only
+- No doc comments, no decorative comment separators

--- a/apps/autumn/README.md
+++ b/apps/autumn/README.md
@@ -1,0 +1,87 @@
+# Autumn Slack Bot
+
+Mention `@Autumn` in any Slack channel to manage customers, subscriptions, usage, and billing through natural language with confirmation buttons for anything that mutates data.
+
+Originally written by [Kyle Graham Matzen](https://github.com/kylegrahammatzen) and now maintained by Autumn.
+
+## Getting Started
+
+### Prerequisites
+
+- Bun 1.3+
+- Redis
+- A Slack workspace where you can install apps
+- An [Autumn](https://useautumn.com) account
+
+### Setup
+
+```bash
+git clone https://github.com/useautumn/autumn.git
+cd autumn
+bun install
+cd apps/autumn
+bun setup
+docker compose -f ../../docker-compose.dev.yml up -d    # Windows
+# or
+docker compose -f ../../docker-compose.unix.yml up -d   # macOS/Linux
+```
+
+`bun setup` generates an encryption key and creates your `.env` file. Fill in your Slack and Autumn credentials, then run `bun dev` and expose it with a tunnel like `ngrok http 3000` so Slack can reach your local server.
+
+## Usage
+
+After installing, Autumn sends a welcome DM with a link to connect your Autumn account via OAuth. Once connected you can mention `@Autumn` anywhere to interact with billing in natural language.
+
+```
+@Autumn what plan is acme on?
+@Autumn show me usage for customer acme
+@Autumn grant acme 5000 messages
+@Autumn attach the Pro plan to acme at $29.99/mo
+@Autumn who's renewing in the next 7 days?
+```
+
+The only slash commands are `/connect` to link your Autumn account and `/disconnect` to remove it, since everything else goes through `@Autumn`.
+
+## Webhook Alerts
+
+Autumn receives billing events via Svix and posts alert cards to a configured Slack channel covering subscription changes, plan upgrades and downgrades, cancellations, usage thresholds, payment issues, and renewals.
+
+## Auth
+
+Teams connect through `/connect` which kicks off Autumn's OAuth flow with PKCE. The prod API key is provisioned automatically and stored AES-256-GCM encrypted in Redis, so no credentials are ever pasted in chat.
+
+## Architecture
+
+```
+src/
+├── index.ts           Hono server entry point
+├── bot.ts             Chat SDK instance and event handlers
+├── config.ts          Env validation
+├── routes/
+│   ├── webhooks.ts    Chat SDK webhook handler (/webhooks/slack)
+│   ├── autumn.ts      Autumn webhook receiver and alert routing
+│   ├── install.ts     Slack OAuth install flow
+│   └── connect.ts     Autumn OAuth connect flow
+├── commands/
+│   ├── router.ts      /connect and /disconnect parser
+│   ├── connect.ts     Connect workspace to Autumn
+│   └── disconnect.ts  Disconnect workspace from Autumn
+├── agent/
+│   ├── handler.ts     Mention and message handlers with Claude agent loop
+│   ├── tools.ts       Tool definitions for Claude
+│   ├── executor.ts    Tool execution
+│   └── confirm.ts     Confirmation flow for mutating actions
+├── cards/
+│   └── alert.ts       Webhook alert cards
+├── services/
+│   ├── autumn.ts      Per-tenant Autumn SDK factory
+│   ├── workspace.ts   Redis workspace credential store
+│   └── encryption.ts  AES-256-GCM encryption for API keys
+└── lib/
+    ├── redis.ts       Redis client
+    └── slack.ts       Slack utilities
+```
+
+## License
+
+Licensed under the MIT License. See [LICENSE](../../LICENSE).

--- a/apps/autumn/biome.json
+++ b/apps/autumn/biome.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"noNonNullAssertion": "off"
+			}
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"lineWidth": 100
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always"
+		}
+	}
+}

--- a/apps/autumn/manifest.yaml
+++ b/apps/autumn/manifest.yaml
@@ -1,0 +1,85 @@
+display_information:
+  name: Autumn
+  description: AI billing ops assistant powered by Autumn
+  long_description: >-
+    Autumn is an AI billing ops assistant that lives in your Slack
+    workspace, letting your team manage customers, subscriptions,
+    usage, and billing through natural language by mentioning
+    @Autumn in any channel.
+
+    Any action that changes data requires confirmation before
+    executing so your team stays in control, and real time alerts
+    via webhooks for subscription changes, usage thresholds, and payment events.
+  background_color: "#9149fd"
+
+features:
+  assistant_view:
+    assistant_description: Manage customers, subscriptions, usage, and billing through natural language.
+    suggested_prompts:
+      - title: Customer lookup
+        message: What plan is customer acme on?
+      - title: Usage check
+        message: Show me usage for customer acme
+      - title: Attach a plan
+        message: Attach the Pro plan to customer acme
+  app_home:
+    home_tab_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
+  bot_user:
+    display_name: Autumn
+    always_online: true
+  slash_commands:
+    - command: /connect
+      url: https://YOUR_DOMAIN/webhooks/slack
+      description: Connect your Autumn billing account
+      usage_hint: Autumn
+      should_escape: false
+    - command: /disconnect
+      url: https://YOUR_DOMAIN/webhooks/slack
+      description: Disconnect Autumn from this workspace
+      usage_hint: Autumn
+      should_escape: false
+
+oauth_config:
+  redirect_urls:
+    - https://YOUR_DOMAIN/slack/callback
+  scopes:
+    bot:
+      # Messaging
+      - chat:write
+      - commands
+      # Assistant
+      - assistant:write
+      # Channel access
+      - app_mentions:read
+      - channels:history
+      - channels:read
+      - groups:history
+      - groups:read
+      # DMs
+      - im:history
+      - im:read
+      - im:write
+      - mpim:history
+      - mpim:read
+      # Users
+      - users:read
+
+settings:
+  event_subscriptions:
+    request_url: https://YOUR_DOMAIN/webhooks/slack
+    bot_events:
+      - app_home_opened
+      - assistant_thread_started
+      - assistant_thread_context_changed
+      - message.channels
+      - message.groups
+      - message.im
+      - message.mpim
+  interactivity:
+    is_enabled: true
+    request_url: https://YOUR_DOMAIN/webhooks/slack
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/apps/autumn/package.json
+++ b/apps/autumn/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "autumn-slack",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"setup": "bun run scripts/setup.ts",
+		"dev": "bun run --watch src/index.ts",
+		"start": "bun run src/index.ts",
+		"check": "biome check .",
+		"check:fix": "biome check --write .",
+		"ts": "bunx tsgo --build --noEmit"
+	},
+	"dependencies": {
+		"@anthropic-ai/sdk": "^0.71.1",
+		"@chat-adapter/slack": "^4.14.0",
+		"@chat-adapter/state-redis": "^4.14.0",
+		"arctic": "^3.7.0",
+		"autumn-js": "workspace:*",
+		"chat": "^4.14.0",
+		"hono": "4.12.7",
+		"ioredis": "^5.5.0",
+		"svix": "^1.45.1",
+		"zod": "^3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.7",
+		"@types/bun": "^1.3.3",
+		"@typescript/native-preview": "catalog:",
+		"typescript": "~5.9.3"
+	}
+}

--- a/apps/autumn/scripts/setup.ts
+++ b/apps/autumn/scripts/setup.ts
@@ -1,0 +1,69 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dirname, "..");
+const repoRoot = join(root, "..", "..");
+
+function log(msg: string) {
+	console.log(`  ${msg}`);
+}
+
+function header(msg: string) {
+	console.log(`\n${msg}`);
+}
+
+function checkPrerequisites() {
+	header("Checking prerequisites...");
+
+	if (!existsSync(join(repoRoot, "node_modules")) && !existsSync(join(root, "node_modules"))) {
+		console.error("node_modules not found. Run `bun install` from the repo root first.");
+		process.exit(1);
+	}
+	log("Dependencies installed");
+}
+
+function createEnvFile() {
+	header("Setting up environment...");
+
+	const envPath = join(root, ".env");
+	const examplePath = join(root, ".env.example");
+
+	if (existsSync(envPath)) {
+		log(".env already exists, skipping");
+		return;
+	}
+
+	if (!existsSync(examplePath)) {
+		console.error(".env.example not found");
+		process.exit(1);
+	}
+
+	let content = readFileSync(examplePath, "utf-8");
+
+	const encryptionKey = randomBytes(32).toString("hex");
+	content = content.replace("ENCRYPTION_KEY=", `ENCRYPTION_KEY=${encryptionKey}`);
+
+	writeFileSync(envPath, content);
+	log("Created .env with generated ENCRYPTION_KEY");
+	log("Edit .env to add your Slack and Autumn credentials");
+}
+
+function printNextSteps() {
+	header("Setup complete!\n");
+	console.log("Next steps:\n");
+	console.log("  1. Add your Slack, Autumn OAuth, and Anthropic credentials to .env\n");
+	console.log("  2. Start Redis from the repo root:");
+	console.log("     docker compose -f docker-compose.dev.yml up -d    # Windows");
+	console.log("     docker compose -f docker-compose.unix.yml up -d   # macOS/Linux\n");
+	console.log("  3. Start the app:");
+	console.log("     bun dev\n");
+	console.log("  4. Expose with a tunnel:");
+	console.log("     ngrok http 3000\n");
+	console.log("  5. Update Slack Event Subscriptions URL to:");
+	console.log("     https://<tunnel>/webhooks/slack\n");
+}
+
+checkPrerequisites();
+createEnvFile();
+printNextSteps();

--- a/apps/autumn/src/agent/confirm.ts
+++ b/apps/autumn/src/agent/confirm.ts
@@ -314,7 +314,8 @@ const actions: Record<string, ActionHandler> = {
 				customerId: str(d.customer_id),
 				planId: str(d.plan_id),
 			};
-			if (d.customize) params.customize = d.customize;
+			const customize = mapCustomize(d.customize);
+			if (customize) params.customize = customize;
 			if (d.success_url) params.successUrl = d.success_url;
 			return autumn.billing.attach(params as Parameters<typeof autumn.billing.attach>[0]);
 		},

--- a/apps/autumn/src/agent/confirm.ts
+++ b/apps/autumn/src/agent/confirm.ts
@@ -1,0 +1,526 @@
+import type { Autumn } from "autumn-js";
+import type { ActionEvent } from "chat";
+import { Actions, Card, Field, Fields, LinkButton, CardText as Text } from "chat";
+import { runAgentWithContext } from "@/agent/handler";
+import {
+	mapBasePrice,
+	mapCustomize,
+	mapFreeTrial,
+	mapPlanItems,
+	num,
+	parseApiError,
+	str,
+} from "@/agent/shared";
+import { getWorkspaceIdFromRaw } from "@/lib/slack";
+import { createAutumnClient } from "@/services/autumn";
+import { getWorkspace } from "@/services/workspace";
+import { formatNumber } from "@/utils/formatters";
+
+const AUTUMN_APP_URL = "https://app.useautumn.com";
+
+type ActionData = Record<string, unknown>;
+
+type CardConfig = {
+	title: string;
+	fields?: [string, string][];
+	text?: string;
+	links?: Parameters<typeof LinkButton>[0][];
+};
+
+type ActionHandler = {
+	required: string[];
+	describe: (d: ActionData) => string;
+	execute: (autumn: Autumn, d: ActionData) => Promise<unknown>;
+	card: (d: ActionData, result: unknown) => CardConfig | null;
+	fallback?: string;
+};
+
+function customerUrl(id: string): string {
+	return `${AUTUMN_APP_URL}/customers/${encodeURIComponent(id)}`;
+}
+
+function successCard(config: CardConfig) {
+	const children = [];
+	if (config.text) {
+		children.push(Text(config.text));
+	}
+	if (config.fields?.length) {
+		children.push(Fields(config.fields.map(([label, value]) => Field({ label, value }))));
+	}
+	if (config.links?.length) {
+		children.push(Actions(config.links.map((l) => LinkButton(l))));
+	}
+	return Card({ title: config.title, children });
+}
+
+const actions: Record<string, ActionHandler> = {
+	create_customer: {
+		required: ["email"],
+		describe: (d) => `create customer *${d.email || d.name}*`,
+		execute: (autumn, d) => {
+			const params: Record<string, unknown> = {
+				email: str(d.email),
+			};
+			if (d.id) params.customerId = str(d.id);
+			if (d.name) params.name = str(d.name);
+			return autumn.customers.getOrCreate(
+				params as Parameters<typeof autumn.customers.getOrCreate>[0],
+			);
+		},
+		card: (d, result) => {
+			const res = result as Record<string, unknown> | undefined;
+			const customerId = str(d.id || res?.id);
+			const fields: [string, string][] = [];
+			if (d.name) fields.push(["Name", str(d.name)]);
+			fields.push(["Email", `\`${str(d.email)}\``]);
+			if (customerId) fields.push(["ID", `\`${customerId}\``]);
+			const links = customerId
+				? [{ label: "View Customer", url: customerUrl(customerId) }]
+				: [{ label: "View All Customers", url: `${AUTUMN_APP_URL}/customers` }];
+			return {
+				title: "Customer Created",
+				fields,
+				text: customerId
+					? undefined
+					: "The customer will appear in your dashboard once they interact with your product.",
+				links,
+			};
+		},
+	},
+	create_balance: {
+		required: ["customer_id", "feature_id"],
+		describe: (d) => `create balance for *${d.customer_id}*`,
+		execute: (autumn, d) =>
+			autumn.balances.create({
+				customerId: str(d.customer_id),
+				featureId: str(d.feature_id),
+				included: num(d.amount),
+			}),
+		card: (d) => ({
+			title: "Balance Created",
+			fields: [
+				["Customer", str(d.customer_id)],
+				["Feature", str(d.feature_id)],
+				["Amount", `+${formatNumber(num(d.amount))}`],
+			],
+			links: [{ label: "View Customer", url: customerUrl(str(d.customer_id)) }],
+		}),
+	},
+	set_balance: {
+		required: ["customer_id", "feature_id"],
+		describe: (d) => `set balance for *${d.customer_id}*`,
+		execute: (autumn, d) =>
+			autumn.balances.update({
+				customerId: str(d.customer_id),
+				featureId: str(d.feature_id),
+				remaining: num(d.balance),
+			}),
+		card: (d) => ({
+			title: "Balance Updated",
+			fields: [
+				["Customer", str(d.customer_id)],
+				["Feature", str(d.feature_id)],
+				["New Balance", formatNumber(num(d.balance))],
+			],
+			links: [{ label: "View Customer", url: customerUrl(str(d.customer_id)) }],
+		}),
+	},
+	track_usage: {
+		required: ["customer_id", "feature_id"],
+		describe: (d) => `track usage for *${d.customer_id}*`,
+		execute: (autumn, d) =>
+			autumn.track({
+				customerId: str(d.customer_id),
+				featureId: str(d.feature_id),
+				value: num(d.value, 1),
+			}),
+		card: (d) => {
+			const value = num(d.value, 1);
+			return {
+				title: "Usage Tracked",
+				fields: [
+					["Customer", str(d.customer_id)],
+					["Feature", str(d.feature_id)],
+					["Value", `${value >= 0 ? "+" : ""}${formatNumber(value)}`],
+				],
+				links: [{ label: "View Customer", url: customerUrl(str(d.customer_id)) }],
+			};
+		},
+	},
+	attach_plan: {
+		required: ["customer_id", "plan_id"],
+		describe: (d) => `attach *${d.plan_id}* to *${d.customer_id}*`,
+		execute: (autumn, d) => {
+			const params: Record<string, unknown> = {
+				customerId: str(d.customer_id),
+				planId: str(d.plan_id),
+			};
+			const customize = mapCustomize(d.customize);
+			if (customize) params.customize = customize;
+			if (d.success_url) params.successUrl = d.success_url;
+			if (d.invoice_mode && typeof d.invoice_mode === "object") {
+				const im = d.invoice_mode as Record<string, unknown>;
+				params.invoiceMode = {
+					enabled: im.enabled ?? true,
+					enablePlanImmediately: im.enable_plan_immediately,
+					finalize: im.finalize,
+				};
+			}
+			return autumn.billing.attach(params as Parameters<typeof autumn.billing.attach>[0]);
+		},
+		card: (d, result) => {
+			const res = result as {
+				paymentUrl?: string | null;
+				invoice?: { hostedInvoiceUrl?: string; status?: string; id?: string } | null;
+				requiredAction?: { reason?: string } | null;
+			};
+			const fields: [string, string][] = [
+				["Customer", str(d.customer_id)],
+				["Plan", str(d.plan_id)],
+			];
+			const links: Parameters<typeof LinkButton>[0][] = [];
+
+			if (res.paymentUrl) {
+				links.push({ label: "Checkout URL", url: res.paymentUrl, style: "primary" as const });
+				links.push({ label: "View Customer", url: customerUrl(str(d.customer_id)) });
+				return {
+					title: "Checkout Link Generated",
+					fields,
+					text: "Share this link with the customer to complete payment.",
+					links,
+				};
+			}
+
+			if (res.invoice) {
+				const status = res.invoice.status === "draft" ? "Draft" : res.invoice.status || "Created";
+				fields.push(["Invoice", `${status}${res.invoice.id ? ` (\`${res.invoice.id}\`)` : ""}`]);
+				if (res.invoice.hostedInvoiceUrl) {
+					links.push({
+						label: "View Invoice in Stripe",
+						url: res.invoice.hostedInvoiceUrl,
+						style: "primary" as const,
+					});
+				}
+				links.push({ label: "View Customer", url: customerUrl(str(d.customer_id)) });
+				return {
+					title: "Draft Invoice Created",
+					fields,
+					text: "Review and send the invoice from your Stripe dashboard.",
+					links,
+				};
+			}
+
+			links.push({ label: "View Customer", url: customerUrl(str(d.customer_id)) });
+			return { title: "Plan Attached", fields, links };
+		},
+	},
+	create_plan: {
+		required: ["plan_id", "name"],
+		describe: (d) => `create plan *${d.plan_id}*`,
+		execute: (autumn, d) => {
+			const params: Record<string, unknown> = {
+				planId: str(d.plan_id),
+				name: str(d.name),
+			};
+			if (d.group) params.group = str(d.group);
+			if (d.description) params.description = str(d.description);
+			if (d.add_on != null) params.addOn = !!d.add_on;
+			if (d.auto_enable != null) params.autoEnable = !!d.auto_enable;
+			const price = mapBasePrice(d.price);
+			if (price) params.price = price;
+			const items = mapPlanItems(d.items);
+			if (items) params.items = items;
+			const trial = mapFreeTrial(d.free_trial);
+			if (trial) params.freeTrial = trial;
+			return autumn.plans.create(params as Parameters<typeof autumn.plans.create>[0]);
+		},
+		card: (d) => {
+			const fields: [string, string][] = [
+				["Plan ID", `\`${str(d.plan_id)}\``],
+				["Name", str(d.name)],
+			];
+			if (d.group) fields.push(["Group", str(d.group)]);
+			if (d.add_on) fields.push(["Add-on", "Yes"]);
+			const items = d.items as unknown[] | undefined;
+			if (items?.length) fields.push(["Features", `${items.length} item(s)`]);
+			return {
+				title: "Plan Created",
+				fields,
+				links: [{ label: "View in Autumn", url: `${AUTUMN_APP_URL}/products/${str(d.plan_id)}` }],
+			};
+		},
+	},
+	update_plan: {
+		required: ["plan_id"],
+		describe: (d) => `update plan *${d.plan_id}*`,
+		execute: (autumn, d) => {
+			const params: Record<string, unknown> = {
+				planId: str(d.plan_id),
+			};
+			if (d.name) params.name = str(d.name);
+			if (d.description != null) params.description = str(d.description);
+			if (d.group) params.group = str(d.group);
+			if (d.add_on != null) params.addOn = !!d.add_on;
+			if (d.auto_enable != null) params.autoEnable = !!d.auto_enable;
+			if (d.archived != null) params.archived = !!d.archived;
+			const price = mapBasePrice(d.price);
+			if (price !== undefined) params.price = price;
+			const items = mapPlanItems(d.items);
+			if (items) params.items = items;
+			const trial = mapFreeTrial(d.free_trial);
+			if (trial !== undefined) params.freeTrial = trial;
+			return autumn.plans.update(params as Parameters<typeof autumn.plans.update>[0]);
+		},
+		card: (d) => {
+			const fields: [string, string][] = [["Plan ID", `\`${str(d.plan_id)}\``]];
+			if (d.name) fields.push(["Name", str(d.name)]);
+			if (d.archived) fields.push(["Status", "Archived"]);
+			return {
+				title: "Plan Updated",
+				text: "A new version was created. Existing customers keep their current version.",
+				fields,
+				links: [{ label: "View in Autumn", url: `${AUTUMN_APP_URL}/products/${str(d.plan_id)}` }],
+			};
+		},
+	},
+	update_subscription: {
+		required: ["customer_id", "plan_id"],
+		describe: (d) => `update *${d.plan_id}* for *${d.customer_id}*`,
+		execute: (autumn, d) => {
+			const params: Record<string, unknown> = {
+				customerId: str(d.customer_id),
+				planId: str(d.plan_id),
+			};
+			if (d.cancel_action) params.cancelAction = d.cancel_action;
+			if (d.feature_quantities) params.featureQuantities = d.feature_quantities;
+			const customize = mapCustomize(d.customize);
+			if (customize) params.customize = customize;
+			return autumn.billing.update(params as Parameters<typeof autumn.billing.update>[0]);
+		},
+		card: (d) => ({
+			title: "Subscription Updated",
+			fields: [
+				["Customer", str(d.customer_id)],
+				["Plan", str(d.plan_id)],
+			],
+			links: [{ label: "View Customer", url: customerUrl(str(d.customer_id)) }],
+		}),
+	},
+	generate_checkout_url: {
+		required: ["customer_id", "plan_id"],
+		describe: (d) => `generate checkout for *${d.customer_id}*`,
+		execute: (autumn, d) => {
+			const params: Record<string, unknown> = {
+				customerId: str(d.customer_id),
+				planId: str(d.plan_id),
+			};
+			if (d.customize) params.customize = d.customize;
+			if (d.success_url) params.successUrl = d.success_url;
+			return autumn.billing.attach(params as Parameters<typeof autumn.billing.attach>[0]);
+		},
+		card: (d, result) => {
+			const paymentUrl = (result as { paymentUrl?: string | null }).paymentUrl;
+			if (paymentUrl) {
+				return {
+					title: "Checkout URL",
+					fields: [
+						["Customer", str(d.customer_id)],
+						["Plan", str(d.plan_id)],
+					],
+					links: [
+						{ label: "Open Checkout", url: paymentUrl, style: "primary" as const },
+						{ label: "View Customer", url: customerUrl(str(d.customer_id)) },
+					],
+				};
+			}
+			return {
+				title: "Plan Attached",
+				text: `Attached *${str(d.plan_id)}* to *${str(d.customer_id)}* (no payment required).`,
+				links: [{ label: "View Customer", url: customerUrl(str(d.customer_id)) }],
+			};
+		},
+	},
+	setup_payment: {
+		required: ["customer_id"],
+		describe: (d) => `set up payment for *${d.customer_id}*`,
+		execute: (autumn, d) => autumn.billing.setupPayment({ customerId: str(d.customer_id) }),
+		card: (d, result) => {
+			const paymentUrl = (result as { url?: string }).url;
+			if (!paymentUrl) return null;
+			return {
+				title: "Payment Setup",
+				fields: [["Customer", str(d.customer_id)]],
+				links: [
+					{ label: "Setup Payment", url: paymentUrl, style: "primary" as const },
+					{ label: "View Customer", url: customerUrl(str(d.customer_id)) },
+				],
+			};
+		},
+		fallback: "Payment setup completed but no URL was returned.",
+	},
+	update_customer: {
+		required: ["customer_id"],
+		describe: (d) => `update customer *${d.customer_id}*`,
+		execute: (autumn, d) => {
+			const params: Record<string, unknown> = { customerId: str(d.customer_id) };
+			if (d.name) params.name = d.name;
+			if (d.email) params.email = d.email;
+			return autumn.customers.update(params as Parameters<typeof autumn.customers.update>[0]);
+		},
+		card: (d) => {
+			const fields: [string, string][] = [["Customer", str(d.customer_id)]];
+			if (d.name) fields.push(["Name", str(d.name)]);
+			if (d.email) fields.push(["Email", `\`${str(d.email)}\``]);
+			return {
+				title: "Customer Updated",
+				fields,
+				links: [{ label: "View in Autumn", url: customerUrl(str(d.customer_id)) }],
+			};
+		},
+	},
+	create_referral_code: {
+		required: ["customer_id", "program_id"],
+		describe: (d) => `create referral code for *${d.customer_id}*`,
+		execute: (autumn, d) =>
+			autumn.referrals.createCode({
+				customerId: str(d.customer_id),
+				programId: str(d.program_id),
+			}),
+		card: (d, result) => ({
+			title: "Referral Code Created",
+			fields: [
+				["Code", (result as { code?: string }).code || "unknown"],
+				["Customer", str(d.customer_id)],
+				["Program", str(d.program_id)],
+			],
+			links: [{ label: "View Customer", url: customerUrl(str(d.customer_id)) }],
+		}),
+	},
+	redeem_referral_code: {
+		required: ["code", "customer_id"],
+		describe: (d) => `redeem referral code for *${d.customer_id}*`,
+		execute: (autumn, d) =>
+			autumn.referrals.redeemCode({
+				code: str(d.code),
+				customerId: str(d.customer_id),
+			}),
+		card: (d) => ({
+			title: "Referral Code Redeemed",
+			fields: [
+				["Code", str(d.code)],
+				["Customer", str(d.customer_id)],
+			],
+			links: [{ label: "View Customer", url: customerUrl(str(d.customer_id)) }],
+		}),
+	},
+};
+
+export async function handleConfirmAction(event: ActionEvent): Promise<void> {
+	if (!event.value) {
+		await event.thread.post("No action data found.");
+		return;
+	}
+
+	const edit = (text: string) =>
+		event.adapter.editMessage(event.threadId, event.messageId, { markdown: text });
+
+	let actionData: ActionData & { action: string };
+	try {
+		actionData = JSON.parse(event.value);
+	} catch {
+		await edit("Invalid action data.");
+		return;
+	}
+
+	const workspaceId = getWorkspaceIdFromRaw(event.raw);
+	if (!workspaceId) {
+		await edit("Could not resolve workspace for this action.");
+		return;
+	}
+
+	const workspace = await getWorkspace(workspaceId);
+	if (!workspace) {
+		await edit("Workspace not connected.");
+		return;
+	}
+
+	const autumn = createAutumnClient(workspace);
+	const confirmedBy = event.user.fullName || event.user.userId;
+	const handler = actions[actionData.action];
+
+	if (!handler) {
+		await edit(`Unknown action: ${actionData.action}`);
+		return;
+	}
+
+	const missing = handler.required.find((k) => {
+		const v = actionData[k];
+		return v == null || v === "";
+	});
+	if (missing) {
+		await edit(`Invalid ${actionData.action} payload.`);
+		return;
+	}
+
+	const desc = handler.describe(actionData);
+
+	try {
+		console.log(
+			`confirm ${actionData.action} org=${workspace.orgSlug} user=${confirmedBy} ${desc}`,
+		);
+
+		await event.adapter.editMessage(event.threadId, event.messageId, {
+			markdown: `_Working on it..._`,
+		});
+
+		const result = await handler.execute(autumn, actionData);
+		const keys = result && typeof result === "object" ? Object.keys(result).join(",") : "";
+		console.log(
+			`confirm ${actionData.action} ok org=${workspace.orgSlug}${keys ? ` keys=${keys}` : ""}`,
+		);
+		const cardConfig = handler.card(actionData, result);
+		if (cardConfig) {
+			await event.adapter.editMessage(event.threadId, event.messageId, successCard(cardConfig));
+		} else if (handler.fallback) {
+			await event.adapter.editMessage(event.threadId, event.messageId, {
+				markdown: handler.fallback,
+			});
+		}
+	} catch (err) {
+		const reason = parseApiError(err);
+		console.error(
+			`confirm ${actionData.action} err="${reason}" org=${workspace.orgSlug} thread=${event.threadId}`,
+		);
+		const plain = `I tried to ${desc} but it failed: ${reason}`;
+		await event.adapter.editMessage(event.threadId, event.messageId, {
+			markdown: plain.replace(/\*/g, "`"),
+		});
+		const depth = Number(actionData._recoveryDepth) || 0;
+		await runAgentWithContext(
+			event.thread,
+			event.raw,
+			`The confirmed action failed: could not ${desc}. Error: ${reason}. Look up the correct IDs and try again.`,
+			depth + 1,
+		);
+	}
+}
+
+export async function handleCancelAction(event: ActionEvent): Promise<void> {
+	const name = event.user.fullName || event.user.userId;
+
+	let desc = "";
+	try {
+		const data = event.value ? JSON.parse(event.value) : null;
+		if (data?.action) {
+			const handler = actions[data.action];
+			if (handler) desc = handler.describe(data).replace(/\*/g, "");
+		}
+	} catch {}
+
+	const plain = desc
+		? `I canceled the action to ${desc} as requested by ${name}.`
+		: `Canceled by ${name}.`;
+	await event.adapter.editMessage(event.threadId, event.messageId, {
+		markdown: plain.replace(/\*/g, "`"),
+	});
+}

--- a/apps/autumn/src/agent/executor.ts
+++ b/apps/autumn/src/agent/executor.ts
@@ -1,0 +1,68 @@
+import type { Autumn, CustomerExpand, Range } from "autumn-js";
+import { mapCustomize, num, parseApiError, str } from "@/agent/shared";
+import { getSkillContent } from "@/agent/skills";
+
+type ToolResult = { success: true; data: unknown } | { success: false; error: string };
+type ToolParams = Record<string, unknown>;
+
+const toolHandlers: Record<string, (autumn: Autumn, p: ToolParams) => Promise<unknown>> = {
+	get_skill: (_autumn, p) => Promise.resolve(getSkillContent((p.skill_ids as string[]) || [])),
+	get_customer: (autumn, p) =>
+		autumn.customers.getOrCreate({
+			customerId: str(p.customer_id),
+			expand: p.expand as CustomerExpand[] | undefined,
+		}),
+	list_customers: (autumn, p) =>
+		autumn.customers.list({ limit: num(p.limit, 50), offset: num(p.offset, 0) }),
+	check_feature_access: (autumn, p) =>
+		autumn.check({ customerId: str(p.customer_id), featureId: str(p.feature_id) }),
+	get_usage_aggregate: (autumn, p) => {
+		const raw = str(p.feature_id);
+		const featureId = raw.includes(",") ? raw.split(",").map((s) => s.trim()) : raw;
+		return autumn.events.aggregate({
+			customerId: str(p.customer_id),
+			featureId,
+			range: str(p.range, "30d") as Range,
+		});
+	},
+	list_events: (autumn, p) =>
+		autumn.events.list({
+			customerId: str(p.customer_id),
+			featureId: str(p.feature_id),
+			limit: num(p.limit, 20),
+		}),
+	list_plans: (autumn) => autumn.plans.list(),
+	get_plan: (autumn, p) => autumn.plans.get({ planId: str(p.plan_id) }),
+	list_features: (autumn) => autumn.features.list(),
+	get_feature: (autumn, p) => autumn.features.get({ featureId: str(p.feature_id) }),
+	get_entity: (autumn, p) =>
+		autumn.entities.get({ customerId: str(p.customer_id), entityId: str(p.entity_id) }),
+	get_billing_portal_url: (autumn, p) =>
+		autumn.billing.openCustomerPortal({ customerId: str(p.customer_id) }),
+	preview_attach: (autumn, p) => {
+		const params: Record<string, unknown> = {
+			customerId: str(p.customer_id),
+			planId: str(p.plan_id),
+		};
+		const customize = mapCustomize(p.customize);
+		if (customize) params.customize = customize;
+		return autumn.billing.previewAttach(
+			params as Parameters<typeof autumn.billing.previewAttach>[0],
+		);
+	},
+};
+
+export async function executeTool(
+	name: string,
+	params: ToolParams,
+	autumn: Autumn,
+): Promise<ToolResult> {
+	const handler = toolHandlers[name];
+	if (!handler) return { success: false, error: `Unknown tool: ${name}` };
+	try {
+		const data = await handler(autumn, params);
+		return { success: true, data };
+	} catch (err) {
+		return { success: false, error: parseApiError(err) };
+	}
+}

--- a/apps/autumn/src/agent/handler.ts
+++ b/apps/autumn/src/agent/handler.ts
@@ -269,11 +269,16 @@ async function runAgentLoopInner(
 			);
 
 			let mutatingBlock: Anthropic.ToolUseBlock | null = null;
+			const skippedMutatingIds = new Set<string>();
 			const readBlocks: Anthropic.ToolUseBlock[] = [];
 
 			for (const toolUse of toolUseBlocks) {
 				if (MUTATING_TOOLS.has(toolUse.name)) {
-					mutatingBlock = toolUse;
+					if (!mutatingBlock) {
+						mutatingBlock = toolUse;
+					} else {
+						skippedMutatingIds.add(toolUse.id);
+					}
 				} else {
 					readBlocks.push(toolUse);
 				}
@@ -288,31 +293,29 @@ async function runAgentLoopInner(
 			}
 
 			const readResultsById = new Map(
-				(
-					await Promise.all(
-						readBlocks.map(async (toolUse) => {
-							const params = toolUse.input as Record<string, unknown>;
-							const paramStr = Object.entries(params)
-								.map(([k, v]) => `${k}=${v}`)
-								.join(" ");
-							const toolStart = Date.now();
-							const result = await executeTool(toolUse.name, params, autumn);
-							const toolMs = Date.now() - toolStart;
-							if (result.success) {
-								console.log(`tool rid=${rid} ${toolUse.name} ok ms=${toolMs} ${paramStr}`);
-							} else {
-								console.warn(
-									`tool rid=${rid} ${toolUse.name} err="${result.error}" ms=${toolMs} ${paramStr}`,
-								);
-							}
-							const toolResult = {
-								type: "tool_result" as const,
-								tool_use_id: toolUse.id,
-								content: JSON.stringify(result),
-							};
-							return [toolUse.id, toolResult] as const;
-						}),
-					)
+				await Promise.all(
+					readBlocks.map(async (toolUse) => {
+						const params = toolUse.input as Record<string, unknown>;
+						const paramStr = Object.entries(params)
+							.map(([k, v]) => `${k}=${v}`)
+							.join(" ");
+						const toolStart = Date.now();
+						const result = await executeTool(toolUse.name, params, autumn);
+						const toolMs = Date.now() - toolStart;
+						if (result.success) {
+							console.log(`tool rid=${rid} ${toolUse.name} ok ms=${toolMs} ${paramStr}`);
+						} else {
+							console.warn(
+								`tool rid=${rid} ${toolUse.name} err="${result.error}" ms=${toolMs} ${paramStr}`,
+							);
+						}
+						const toolResult = {
+							type: "tool_result" as const,
+							tool_use_id: toolUse.id,
+							content: JSON.stringify(result),
+						};
+						return [toolUse.id, toolResult] as const;
+					}),
 				),
 			);
 
@@ -341,6 +344,25 @@ async function runAgentLoopInner(
 					});
 					continue;
 				}
+
+				if (skippedMutatingIds.has(toolUse.id)) {
+					console.warn(
+						`mutation rid=${rid} skipped_extra tool=${toolUse.name} reason=multiple_mutations_in_single_turn`,
+					);
+					toolResults.push({
+						type: "tool_result",
+						tool_use_id: toolUse.id,
+						content: JSON.stringify({
+							status: "mutation_deferred",
+							message:
+								"Only one mutating action can be confirmed at a time. Continue with the first mutation and call additional mutating tools after confirmation.",
+							tool_name: toolUse.name,
+							params: toolUse.input,
+						}),
+					});
+					continue;
+				}
+
 				const readResult = readResultsById.get(toolUse.id);
 				if (readResult) toolResults.push(readResult);
 			}

--- a/apps/autumn/src/agent/handler.ts
+++ b/apps/autumn/src/agent/handler.ts
@@ -1,0 +1,444 @@
+import Anthropic, { APIConnectionError, APIError, RateLimitError } from "@anthropic-ai/sdk";
+import type { Message, Thread } from "chat";
+import { Actions, Button, Card, LinkButton, CardText as Text } from "chat";
+import { executeTool } from "@/agent/executor";
+import { parseApiError } from "@/agent/shared";
+import { getTools, MUTATING_TOOLS } from "@/agent/tools";
+import { getEnv } from "@/config";
+import { getWorkspaceIdFromRaw } from "@/lib/slack";
+import { createAutumnClient } from "@/services/autumn";
+import type { WorkspaceConfig } from "@/services/workspace";
+import { getWorkspace } from "@/services/workspace";
+
+const MAX_TOOL_ITERATIONS = 8;
+const MAX_RECOVERY_DEPTH = 1;
+const MAX_HISTORY = 20;
+
+const MODEL = "claude-opus-4-6";
+
+// Tracks threads with an active agent loop so we can notify them on shutdown.
+// Without this, hot-reloads leave Slack showing "Typing..." with no response.
+const activeThreads = new Set<Thread<unknown>>();
+
+function handleShutdown() {
+	if (activeThreads.size === 0) return;
+	console.log(`shutdown: notifying ${activeThreads.size} active thread(s)`);
+	const posts = [...activeThreads].map((thread) =>
+		thread.post("Autumn restarted, please try again.").catch(() => {}),
+	);
+	activeThreads.clear();
+	// Wait for posts to reach Slack before exiting, with a 3s hard timeout
+	Promise.allSettled(posts).then(() => process.exit(0));
+	setTimeout(() => process.exit(1), 3000);
+}
+
+process.on("SIGTERM", handleShutdown);
+process.on("SIGINT", handleShutdown);
+
+function buildSystemPrompt(workspace: WorkspaceConfig): string {
+	return `You are Autumn, a billing ops assistant in Slack for Autumn (useautumn.com). You manage customers, subscriptions, usage, and billing through tools.
+
+Connected to: ${workspace.orgName} (${workspace.orgSlug})
+
+Rules:
+- For mutating tools, write a short summary of what you'll do. Confirm/Cancel buttons appear automatically — never ask the user to confirm in text.
+- For read tools, run them and present results directly.
+- If a tool errors, explain clearly and suggest next steps.
+- When the user asks to retry or try again, always re-call the relevant tools. Never rely on previous error messages in the conversation — the underlying issue may have been fixed.
+- When a user refers to a customer by name or email (not an exact ID), use list_customers first, then use the exact customer ID from the response. Never guess customer IDs.
+- When a user refers to a plan by name, use list_plans to find the correct plan ID first.
+- When multiple customers match a name, list them with IDs and ask which one.
+- If someone asks what you can do, give a brief 2-3 sentence overview, not a full list.
+
+Formatting:
+- This is Slack. Use *bold* for emphasis, backticks for IDs/values/emails, and • for bullet lists.
+- No emojis. Be concise. No filler like "Sure!", "Great question!", "I'd be happy to help!".
+- NEVER put app.useautumn.com URLs in your text. Slack mangles @ in URLs. Link buttons for View Customer, View Plan, etc. are added automatically below your response.
+- For other links, use standard markdown: [label](url).
+
+Skills — load guidance before responding:
+- Before responding to any non-trivial message, call get_skill to load relevant guidance. Skip ONLY for trivial one-liners.
+- Load "response_formatting" for any response that presents info, compares items, or walks through steps.
+- Load "custom_plans" when creating, updating, or customizing plans/pricing.
+- Load "billing_flows" when attaching plans, previewing costs, invoices, or checkout.
+- Load "customer_ops" for customer lookups, balance ops, billing portal, or "can't do X" scenarios.
+- You can load multiple skills in one call: get_skill(["customer_ops", "response_formatting"]).
+- Skills are cached in conversation history — only load each skill once per thread.`;
+}
+
+let _anthropic: Anthropic | null = null;
+
+function getAnthropic(): Anthropic {
+	if (!_anthropic) {
+		const apiKey = getEnv().ANTHROPIC_API_KEY;
+		if (!apiKey) throw new Error("ANTHROPIC_API_KEY not configured");
+		_anthropic = new Anthropic({ apiKey });
+	}
+	return _anthropic;
+}
+
+function resolveWorkspaceId(raw: unknown): string | null {
+	const workspaceId = getWorkspaceIdFromRaw(raw);
+	if (!workspaceId) {
+		const rawObj = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+		console.warn(
+			`workspace_resolve err=not_found keys=${Object.keys(rawObj).join(",") || "none"} team=${rawObj.team ?? "null"} team_id=${rawObj.team_id ?? "null"}`,
+		);
+	}
+	return workspaceId;
+}
+
+async function handleIncomingAgentMessage(
+	thread: Thread,
+	message: Message,
+	mode: "mention" | "subscribed",
+): Promise<void> {
+	if (thread.isDM) {
+		if (mode === "mention") {
+			await thread.post("DMs aren't supported yet, mention me in a channel instead.");
+		}
+		return;
+	}
+
+	const workspaceId = resolveWorkspaceId(message.raw);
+	const workspace = workspaceId ? await getWorkspace(workspaceId) : null;
+
+	if (mode === "mention") {
+		await thread.subscribe();
+	}
+
+	if (!workspace) {
+		if (mode === "mention") {
+			console.warn(`workspace_lookup err=not_found id=${workspaceId} channel=${thread.channelId}`);
+			await thread.post("Ask an admin to run `/connect` to set up Autumn for this workspace.");
+		} else {
+			await thread.post("Run `/connect` to set up Autumn first.");
+		}
+		return;
+	}
+
+	if (!workspace.apiKey) {
+		await thread.post(
+			mode === "mention"
+				? "This workspace isn't connected to Autumn yet, run `/connect` to get started."
+				: "Run `/connect` to set up Autumn first.",
+		);
+		return;
+	}
+
+	const channelBlocked =
+		workspace.commandChannels.length > 0 &&
+		thread.channelId &&
+		!workspace.commandChannels.includes(thread.channelId);
+
+	if (channelBlocked) {
+		if (mode === "mention") {
+			await thread.post(
+				"Autumn isn't enabled in this channel, ask an admin to add it in settings.",
+			);
+		}
+		return;
+	}
+
+	const text = message.text.length > 80 ? `${message.text.slice(0, 80)}...` : message.text;
+	const rid = message.id;
+	console.log(`agent rid=${rid} org=${workspace.orgSlug} msg="${text}"`);
+
+	const messages = await buildMessages(thread, message);
+	await runAgentLoopInner(thread, workspace, messages, 0, rid);
+}
+
+export async function handleAgentMention(thread: Thread, message: Message): Promise<void> {
+	await handleIncomingAgentMessage(thread, message, "mention");
+}
+
+export async function handleAgentMessage(thread: Thread, message: Message): Promise<void> {
+	await handleIncomingAgentMessage(thread, message, "subscribed");
+}
+
+async function buildMessages(thread: Thread, message: Message): Promise<Anthropic.MessageParam[]> {
+	await thread.refresh();
+
+	const history = thread.recentMessages
+		.filter((msg) => msg.text.trim().length > 0)
+		.sort((a, b) => a.metadata.dateSent.getTime() - b.metadata.dateSent.getTime())
+		.slice(-MAX_HISTORY)
+		.map((msg) => {
+			if (msg.author.isMe) {
+				return {
+					role: "assistant" as const,
+					content: `[Previous response — may be outdated, always re-check with tools]\n${msg.text}`,
+				};
+			}
+			return {
+				role: "user" as const,
+				content: msg.text,
+			};
+		});
+
+	if (history.length > 0) return history;
+	return [{ role: "user", content: message.text }];
+}
+
+type PendingMutation = {
+	toolName: string;
+	toolInput: Record<string, unknown>;
+};
+
+export async function runAgentWithContext(
+	thread: Thread<unknown>,
+	raw: unknown,
+	text: string,
+	recoveryDepth = 0,
+): Promise<void> {
+	if (recoveryDepth > MAX_RECOVERY_DEPTH) {
+		console.warn(`Recovery depth ${recoveryDepth} exceeded limit, stopping`);
+		await thread.post(
+			"Automatic recovery failed. Please try the operation again or adjust the parameters.",
+		);
+		return;
+	}
+
+	const workspaceId = resolveWorkspaceId(raw);
+	if (!workspaceId) return;
+
+	const workspace = await getWorkspace(workspaceId);
+	if (!workspace?.apiKey) return;
+
+	const rid = `recovery-${recoveryDepth}`;
+	console.log(`agent rid=${rid} org=${workspace.orgSlug} msg="${text.slice(0, 80)}"`);
+	await runAgentLoopInner(thread, workspace, [{ role: "user", content: text }], recoveryDepth, rid);
+}
+
+async function runAgentLoopInner(
+	thread: Thread<unknown>,
+	workspace: WorkspaceConfig,
+	messages: Anthropic.MessageParam[],
+	recoveryDepth = 0,
+	rid = "recovery",
+): Promise<void> {
+	activeThreads.add(thread);
+	try {
+		const autumn = createAutumnClient(workspace);
+		const anthropic = getAnthropic();
+
+		await thread.startTyping().catch(() => {});
+
+		let pendingMutation: PendingMutation | null = null;
+		let iterations = 0;
+		let lastCustomerId: string | null = null;
+		let lastPlanId: string | null = null;
+		const loadedSkills = new Set<string>();
+		const systemPrompt = buildSystemPrompt(workspace);
+
+		const logLLM = (r: Anthropic.Message, ms: number) => {
+			const tools = r.content
+				.filter((b) => b.type === "tool_use")
+				.map((b) => (b as Anthropic.ToolUseBlock).name);
+			console.log(
+				`llm rid=${rid} stop=${r.stop_reason} in=${r.usage.input_tokens} out=${r.usage.output_tokens} ms=${ms}${tools.length ? ` tools=${tools.join(",")}` : ""}`,
+			);
+		};
+
+		let response: Anthropic.Message;
+
+		while (true) {
+			const t0 = Date.now();
+			response = await anthropic.messages.create({
+				model: MODEL,
+				max_tokens: 4096,
+				system: systemPrompt,
+				tools: getTools(loadedSkills),
+				messages,
+			});
+			logLLM(response, Date.now() - t0);
+
+			if (response.stop_reason !== "tool_use") break;
+
+			iterations++;
+			if (iterations > MAX_TOOL_ITERATIONS) {
+				console.warn(`agent rid=${rid} err=tool_loop_exceeded iterations=${iterations}`);
+				await thread.post(
+					"This request required too many steps. Try breaking it into smaller questions.",
+				);
+				return;
+			}
+
+			const toolUseBlocks = response.content.filter(
+				(b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+			);
+
+			let mutatingBlock: Anthropic.ToolUseBlock | null = null;
+			const readBlocks: Anthropic.ToolUseBlock[] = [];
+
+			for (const toolUse of toolUseBlocks) {
+				if (MUTATING_TOOLS.has(toolUse.name)) {
+					mutatingBlock = toolUse;
+				} else {
+					readBlocks.push(toolUse);
+				}
+				const input = toolUse.input as Record<string, unknown>;
+				if (typeof input.customer_id === "string" && !toolUse.name.startsWith("list_"))
+					lastCustomerId = input.customer_id;
+				if (typeof input.plan_id === "string" && !toolUse.name.startsWith("list_"))
+					lastPlanId = input.plan_id;
+				if (toolUse.name === "get_skill") {
+					for (const id of (input.skill_ids as string[]) || []) loadedSkills.add(id);
+				}
+			}
+
+			const readResultsById = new Map(
+				(
+					await Promise.all(
+						readBlocks.map(async (toolUse) => {
+							const params = toolUse.input as Record<string, unknown>;
+							const paramStr = Object.entries(params)
+								.map(([k, v]) => `${k}=${v}`)
+								.join(" ");
+							const toolStart = Date.now();
+							const result = await executeTool(toolUse.name, params, autumn);
+							const toolMs = Date.now() - toolStart;
+							if (result.success) {
+								console.log(`tool rid=${rid} ${toolUse.name} ok ms=${toolMs} ${paramStr}`);
+							} else {
+								console.warn(
+									`tool rid=${rid} ${toolUse.name} err="${result.error}" ms=${toolMs} ${paramStr}`,
+								);
+							}
+							const toolResult = {
+								type: "tool_result" as const,
+								tool_use_id: toolUse.id,
+								content: JSON.stringify(result),
+							};
+							return [toolUse.id, toolResult] as const;
+						}),
+					)
+				),
+			);
+
+			const toolResults: Anthropic.ToolResultBlockParam[] = [];
+			for (const toolUse of toolUseBlocks) {
+				if (mutatingBlock && toolUse.id === mutatingBlock.id) {
+					const params = toolUse.input as Record<string, unknown>;
+					const paramStr = Object.entries(params)
+						.map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : v}`)
+						.join(" ");
+					console.log(`mutation rid=${rid} ${toolUse.name} ${paramStr}`);
+					pendingMutation = {
+						toolName: toolUse.name,
+						toolInput: toolUse.input as Record<string, unknown>,
+					};
+					toolResults.push({
+						type: "tool_result",
+						tool_use_id: toolUse.id,
+						content: JSON.stringify({
+							status: "confirmation_required",
+							message:
+								"This is a mutating action. Describe what you're about to do clearly and concisely. Confirm/Cancel buttons will appear automatically after your message.",
+							tool_name: toolUse.name,
+							params: toolUse.input,
+						}),
+					});
+					continue;
+				}
+				const readResult = readResultsById.get(toolUse.id);
+				if (readResult) toolResults.push(readResult);
+			}
+
+			messages.push({ role: "assistant", content: response.content });
+			messages.push({ role: "user", content: toolResults });
+		}
+
+		const textBlocks = response.content.filter((b): b is Anthropic.TextBlock => b.type === "text");
+		const responseText = textBlocks.map((b) => b.text).join("\n");
+
+		if (responseText && pendingMutation) {
+			const actionPayload = {
+				action: pendingMutation.toolName,
+				...pendingMutation.toolInput,
+				_recoveryDepth: recoveryDepth,
+			};
+			const actionValue = JSON.stringify(actionPayload);
+			const isAttachPlan = pendingMutation.toolName === "attach_plan";
+			const isPlanSwitch =
+				isAttachPlan && !!(pendingMutation.toolInput as Record<string, unknown>).is_plan_switch;
+			const buttons: ReturnType<typeof Button>[] = [
+				Button({
+					id: "confirm",
+					label: isAttachPlan ? (isPlanSwitch ? "Confirm Charge" : "Checkout Link") : "Confirm",
+					style: "primary",
+					value: actionValue,
+				}),
+			];
+
+			if (isAttachPlan) {
+				buttons.push(
+					Button({
+						id: "confirm_invoice",
+						label: "Draft Invoice",
+						value: JSON.stringify({
+							...actionPayload,
+							invoice_mode: { enabled: true, finalize: false },
+						}),
+					}),
+				);
+			}
+
+			buttons.push(
+				Button({
+					id: "cancel",
+					label: "Cancel",
+					style: "danger",
+					value: actionValue,
+				}),
+			);
+
+			await thread.post(
+				Card({
+					children: [Text(responseText), Actions(buttons)],
+				}),
+			);
+		} else if (responseText) {
+			const linkButtons: ReturnType<typeof LinkButton>[] = [];
+			if (lastCustomerId) {
+				linkButtons.push(
+					LinkButton({
+						label: "View All Customers",
+						url: "https://app.useautumn.com/customers",
+					}),
+				);
+			}
+			if (lastPlanId) {
+				linkButtons.push(
+					LinkButton({
+						label: "View Plan",
+						url: `https://app.useautumn.com/products/${encodeURIComponent(lastPlanId)}`,
+					}),
+				);
+			}
+
+			if (linkButtons.length > 0) {
+				await thread.post(Card({ children: [Text(responseText), Actions(linkButtons)] }));
+			} else {
+				await thread.post({ markdown: responseText });
+			}
+		} else {
+			console.warn(`agent rid=${rid} empty_response out=${response.usage.output_tokens}`);
+			await thread.post("Something went wrong, try rephrasing or starting a new thread.");
+		}
+	} catch (err) {
+		if (err instanceof RateLimitError) {
+			await thread.post("I'm being rate limited, try again in a moment.");
+		} else if (err instanceof APIConnectionError) {
+			await thread.post("I couldn't reach the AI service, try again in a moment.");
+		} else if (err instanceof APIError && err.status >= 500) {
+			await thread.post("The AI service is temporarily unavailable, try again later.");
+		} else {
+			const message = parseApiError(err);
+			console.error(`agent rid=${rid} err="${message}"`);
+			await thread.post("Something went wrong, try again later.");
+		}
+	} finally {
+		activeThreads.delete(thread);
+	}
+}

--- a/apps/autumn/src/agent/shared.ts
+++ b/apps/autumn/src/agent/shared.ts
@@ -1,0 +1,129 @@
+import { AutumnError } from "autumn-js";
+
+export function parseApiError(err: unknown): string {
+	if (err instanceof AutumnError) {
+		try {
+			const body = JSON.parse(err.body);
+			if (body.message) return body.message;
+		} catch {}
+	}
+	if (err instanceof Error) return err.message;
+	return String(err);
+}
+
+export function str(val: unknown, fallback = ""): string {
+	return typeof val === "string" ? val : fallback;
+}
+
+export function num(val: unknown, fallback = 0): number {
+	const n = Number(val);
+	return Number.isNaN(n) ? fallback : n;
+}
+
+type Raw = Record<string, unknown>;
+
+function mapReset(r: unknown): { interval: string; intervalCount?: number } | undefined {
+	if (!r || typeof r !== "object") return undefined;
+	const raw = r as Raw;
+	return {
+		interval: str(raw.interval),
+		...(raw.interval_count != null ? { intervalCount: num(raw.interval_count) } : {}),
+	};
+}
+
+function mapItemPrice(p: unknown): Record<string, unknown> | undefined {
+	if (!p || typeof p !== "object") return undefined;
+	const raw = p as Raw;
+	const out: Record<string, unknown> = {
+		interval: str(raw.interval),
+		billingMethod: str(raw.billing_method),
+	};
+	if (raw.amount != null) out.amount = num(raw.amount);
+	if (raw.tiers && Array.isArray(raw.tiers)) {
+		out.tiers = (raw.tiers as Raw[]).map((t) => ({
+			to: t.to === "inf" ? "inf" : num(t.to),
+			amount: num(t.amount),
+		}));
+	}
+	if (raw.interval_count != null) out.intervalCount = num(raw.interval_count);
+	if (raw.billing_units != null) out.billingUnits = num(raw.billing_units);
+	if (raw.max_purchase != null) out.maxPurchase = num(raw.max_purchase);
+	return out;
+}
+
+function mapProration(p: unknown): { onIncrease: string; onDecrease: string } | undefined {
+	if (!p || typeof p !== "object") return undefined;
+	const raw = p as Raw;
+	return {
+		onIncrease: str(raw.on_increase),
+		onDecrease: str(raw.on_decrease),
+	};
+}
+
+function mapRollover(r: unknown): Record<string, unknown> | undefined {
+	if (!r || typeof r !== "object") return undefined;
+	const raw = r as Raw;
+	const out: Record<string, unknown> = {
+		expiryDurationType: str(raw.expiry_duration_type),
+	};
+	if (raw.max != null) out.max = num(raw.max);
+	if (raw.expiry_duration_length != null)
+		out.expiryDurationLength = num(raw.expiry_duration_length);
+	return out;
+}
+
+export function mapPlanItems(items: unknown): Record<string, unknown>[] | undefined {
+	if (!items || !Array.isArray(items)) return undefined;
+	return (items as Raw[]).map((item) => {
+		const out: Record<string, unknown> = { featureId: str(item.feature_id) };
+		if (item.included != null) out.included = num(item.included);
+		if (item.unlimited != null) out.unlimited = !!item.unlimited;
+		const reset = mapReset(item.reset);
+		if (reset) out.reset = reset;
+		const price = mapItemPrice(item.price);
+		if (price) out.price = price;
+		const proration = mapProration(item.proration);
+		if (proration) out.proration = proration;
+		const rollover = mapRollover(item.rollover);
+		if (rollover) out.rollover = rollover;
+		return out;
+	});
+}
+
+export function mapBasePrice(
+	p: unknown,
+): { amount: number; interval: string; intervalCount?: number } | null | undefined {
+	if (p === null) return null;
+	if (!p || typeof p !== "object") return undefined;
+	const raw = p as Raw;
+	return {
+		amount: num(raw.amount),
+		interval: str(raw.interval),
+		...(raw.interval_count != null ? { intervalCount: num(raw.interval_count) } : {}),
+	};
+}
+
+export function mapFreeTrial(t: unknown): Record<string, unknown> | null | undefined {
+	if (t === null) return null;
+	if (!t || typeof t !== "object") return undefined;
+	const raw = t as Raw;
+	const out: Record<string, unknown> = {
+		durationLength: num(raw.duration_length),
+	};
+	if (raw.duration_type) out.durationType = str(raw.duration_type);
+	if (raw.card_required != null) out.cardRequired = !!raw.card_required;
+	return out;
+}
+
+export function mapCustomize(c: unknown): Record<string, unknown> | undefined {
+	if (!c || typeof c !== "object") return undefined;
+	const raw = c as Raw;
+	const out: Record<string, unknown> = {};
+	const price = mapBasePrice(raw.price);
+	if (price !== undefined) out.price = price;
+	const items = mapPlanItems(raw.items);
+	if (items) out.items = items;
+	const trial = mapFreeTrial(raw.free_trial);
+	if (trial !== undefined) out.freeTrial = trial;
+	return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/apps/autumn/src/agent/skills.ts
+++ b/apps/autumn/src/agent/skills.ts
@@ -1,0 +1,154 @@
+const bt = "\u0060";
+
+const skills: Record<string, { description: string; content: string }> = {
+	custom_plans: {
+		description:
+			"Load when creating, updating, or customizing plans. Contains feature types, item patterns, pricing models, and guidelines.",
+		content: `Creating and customizing plans:
+- When a user wants to create a new plan, call list_features first to see what features exist. If a feature doesn't exist yet, it will be auto-created when you reference it in the plan items — just include feature_type (single_use, continuous_use, or boolean) so the system knows what kind of feature to create.
+- Walk through the plan configuration step by step. Ask about: base price (flat fee), which features to include, usage limits, overage pricing, billing interval. Don't try to build everything in one shot — confirm each piece.
+- For custom pricing on an existing plan for a specific customer, use attach_plan or update_subscription with customize instead of creating a whole new plan. Explain this to the user if they're unsure which approach to take.
+- When updating a plan with update_plan, remind the user that existing customers keep their current version (grandfathered). The update only affects new customers.
+- For credit systems or advanced feature configuration that you can't model through the tools, direct the user to the Autumn dashboard.
+- Plan and feature IDs should be lowercase with hyphens (e.g. ${bt}pro-monthly${bt}, ${bt}api-calls${bt}).
+- Never set auto_enable=true for plans with prices. Only free plans can be auto-enabled.
+- For annual variants, create a separate plan with the annual interval. Name it like "Pro - Annual".
+
+Feature types:
+- single_use: consumable resources that reset periodically (API calls, tokens, messages, credits)
+- continuous_use: persistent allocated resources (seats, workspaces, projects, team members)
+- boolean: on/off access gates (advanced analytics, priority support, SSO)
+
+Plan item patterns — use these when building items for create_plan:
+1. Flat fee (base subscription price, no feature):
+   price: { amount: 49, interval: "month" } on the plan itself, no item needed.
+2. Free feature allocation (no charge):
+   { feature_id: "credits", included: 10000, reset: { interval: "month" } }
+3. Usage-based / pay-as-you-go (included free amount + overage):
+   { feature_id: "credits", included: 10000, reset: { interval: "month" }, price: { amount: 0.01, interval: "month", billing_method: "usage_based" } }
+4. Prepaid / per-seat (pay upfront per unit):
+   { feature_id: "seats", included: 5, price: { amount: 10, interval: "month", billing_method: "prepaid" } }
+5. Tiered pricing:
+   { feature_id: "api-calls", included: 1000, reset: { interval: "month" }, price: { tiers: [{ to: 5000, amount: 0.02 }, { to: "inf", amount: 0.01 }], interval: "month", billing_method: "usage_based" } }
+6. Boolean gate (on/off, included with plan):
+   { feature_id: "sso" } — no price, no included amount. Just grants access.
+
+Important rules for items:
+- Features define WHAT can be tracked. Items define HOW that feature is granted in a plan. Never create duplicate features for the same resource — e.g. "monthly-tokens" and "bonus-tokens" should be the same feature "tokens" referenced by different items.
+- A plan can combine a flat base price with multiple items for a hybrid model (e.g. $49/month base + usage-based API calls + 5 included seats).
+- If the user mentions more than 3 features, start with the 3 most important and ask if they want to add more.`,
+	},
+
+	billing_flows: {
+		description:
+			"Load when attaching plans, previewing costs, generating checkout URLs, or working with invoices.",
+		content: `Billing flow guidance:
+- ALWAYS call preview_attach before attach_plan so the user can see exactly what will be charged.
+- After showing the preview, present the cost and let the user choose. Confirm buttons are added automatically:
+  - For NEW customers (no active plan): "Checkout Link" (generates a Stripe payment URL to share) or "Draft Invoice"
+  - For PLAN SWITCHES (customer already has a plan, set is_plan_switch=true): "Confirm Charge" or "Draft Invoice"
+- The "Draft Invoice" button creates an invoice in Stripe with finalize=false so they can review it before sending.
+- invoice_mode options: enabled=true activates invoice billing, finalize=true sends immediately, enable_plan_immediately=true activates the plan before the invoice is paid.
+- Use customize on attach_plan or update_subscription to give a specific customer custom pricing, feature limits, or additional features without creating a separate plan.
+- When the user asks to add a feature to a customer's plan that isn't in the plan's defaults, call list_features first to confirm the feature exists in Autumn, then use customize to add it.
+- When attaching a plan where the customer already has an active plan in the same group, set is_plan_switch=true.
+- generate_checkout_url is for standalone checkout links without the full attach flow.
+- setup_payment generates a link for customers to add/update their payment method.
+
+When you can't perform an action directly (e.g. delete/void an invoice, refund a charge, modify Stripe settings), don't give vague instructions. Instead:
+1. Offer to generate a billing portal URL with get_billing_portal_url — the customer (or the user on their behalf) can manage invoices and payment methods there.
+2. Mention the customer's page in Autumn (link buttons are added automatically — don't put URLs in your text).
+3. If the user just finished a read operation, proactively offer the billing portal as a follow-up — don't wait for them to ask.
+
+After completing a billing action, suggest relevant next steps. For example: "Want me to check their updated subscription, generate a billing portal link, or do anything else?"`,
+	},
+
+	customer_ops: {
+		description:
+			"Load for customer lookups, balance operations, billing portal, or when the user asks to do something you can't do directly.",
+		content: `Customer operations guidance:
+- CRITICAL: After calling list_customers, use the "id" field from the response as the customer_id. The id might be an email, a slug, or a generated ID. Always use whatever the "id" field contains.
+- If a customer already exists in list_customers results, NEVER create a new one. Use their existing ID.
+- Customers with a null external ID are normal — they were created in Autumn but haven't logged into the product yet. Their email serves as their identifier. Never suggest recreating or deleting these customers.
+- When presenting monetary amounts, format cents as dollars (e.g. 500 cents = $5.00).
+- When showing a customer's current plan, include the status and renewal date if available.
+- After showing customer info, offer relevant next actions. For example: "Want me to check their usage, preview a plan change, or generate a billing portal link?"
+- Never say "contact Autumn support" — you are Autumn support. If you can't do something, say so directly.
+
+Balance operations:
+- create_balance ADDS to existing balance — use for granting bonus credits, promotional allowances, one-time grants.
+- set_balance REPLACES the current balance with an exact value — use when the user says "set balance to X" or "reset balance to X".
+- track_usage records a usage event — positive values consume balance, negative values credit back.
+
+When you can't perform an action directly (e.g. delete/void an invoice, refund a charge, modify Stripe settings):
+1. Offer to generate a billing portal URL with get_billing_portal_url.
+2. Mention the customer's page in Autumn (link buttons are added automatically).
+3. Proactively offer these after read operations — don't wait for the user to ask.`,
+	},
+
+	response_formatting: {
+		description:
+			"Load when presenting customer info, comparing plans, multi-step walkthroughs, or any structured response.",
+		content:
+			"Formatting — backtick wrapping (important, Slack mangles bare values):\n" +
+			`- Email addresses: always ${bt}user@example.com${bt}, never bare. Slack turns bare @ into broken mentions.\n` +
+			`- Customer IDs: ${bt}cus_abc123${bt}\n` +
+			`- Plan IDs: ${bt}plan_pro_monthly${bt}\n` +
+			`- Feature IDs: ${bt}api-calls${bt}\n` +
+			`- Invoice IDs: ${bt}inv_abc123${bt}\n` +
+			`- Monetary values: ${bt}$29.99${bt}\n` +
+			"- Any technical identifier or value the user might copy-paste should be in backticks.\n" +
+			"\n" +
+			"Formatting — user mentions:\n" +
+			'- When referring to the person who messaged you, use "you" — never try to @-mention them.\n' +
+			"- When the message references another Slack user (e.g. <@U12345>), preserve the mention as-is. Don't convert to a name or strip it.\n" +
+			"\n" +
+			"Formatting — tables and lists:\n" +
+			"- For comparing 2-3 items (plans, customers), use a bullet list with *bold* labels. Don't attempt ASCII tables — they render poorly in Slack.\n" +
+			`- Good: • *Pro* — ${bt}$49/mo${bt}, 10,000 API calls\n` +
+			"- Bad: | Plan | Price | Calls | (ASCII table)\n" +
+			"\n" +
+			"Formatting — multi-step walkthroughs:\n" +
+			"- Slack does NOT support nested lists. Never put bullets inside numbered items — they render as a jumbled mess.\n" +
+			"- For step-by-step flows (like plan creation), ask ONE question at a time. Don't dump all steps at once.\n" +
+			"- If you need to outline steps, use a flat numbered list with one sentence per step. No sub-bullets.\n" +
+			"- Bad (nested, runs together in Slack):\n" +
+			"  1. Plan basics\n" +
+			"  • What's the name?\n" +
+			"  • What's the ID?\n" +
+			"  2. Pricing\n" +
+			"  • Flat or usage?\n" +
+			"- Good (one question at a time):\n" +
+			`  First, what should we call this plan? Give me a name and a plan ID (lowercase with hyphens, e.g. ${bt}custom-pro${bt}).\n` +
+			"- Good (flat overview, no nesting):\n" +
+			"  Here's what I'll need:\n" +
+			"  1. Plan name and ID\n" +
+			"  2. Base price (flat fee, or usage-only)\n" +
+			"  3. Which features to include and their limits\n" +
+			"\n" +
+			"  Let's start with #1 — what should we call it?",
+	},
+};
+
+export const SKILL_IDS = Object.keys(skills);
+
+export function getSkillContent(ids: string[]): { skills: Record<string, string> } {
+	const result: Record<string, string> = {};
+	for (const id of ids) {
+		const skill = skills[id];
+		if (skill) {
+			result[id] = skill.content;
+		} else {
+			result[id] = `Unknown skill: ${id}. Available: ${SKILL_IDS.join(", ")}`;
+		}
+	}
+	return { skills: result };
+}
+
+export function getSkillDescriptions(): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const [id, skill] of Object.entries(skills)) {
+		result[id] = skill.description;
+	}
+	return result;
+}

--- a/apps/autumn/src/agent/tools.ts
+++ b/apps/autumn/src/agent/tools.ts
@@ -1,0 +1,586 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { SKILL_IDS } from "@/agent/skills";
+
+const p = {
+	customer_id: {
+		type: "string",
+		description:
+			"The exact customer ID from a previous API response (e.g. from list_customers). Never guess — always look it up first.",
+	},
+	feature_id: {
+		type: "string",
+		description:
+			"The feature ID (e.g. 'api-calls', 'seats'). Use list_features if unsure of the exact ID.",
+	},
+	plan_id: {
+		type: "string",
+		description: "The plan ID (e.g. 'pro', 'starter'). Use list_plans if unsure of the exact ID.",
+	},
+};
+
+function defineTool(
+	name: string,
+	description: string,
+	properties: Record<string, unknown>,
+	required: string[] = [],
+): Anthropic.Tool {
+	return { name, description, input_schema: { type: "object" as const, properties, required } };
+}
+
+const intervalEnum = ["one_off", "week", "month", "quarter", "semi_annual", "year"];
+const resetIntervalEnum = [
+	"one_off",
+	"minute",
+	"hour",
+	"day",
+	"week",
+	"month",
+	"quarter",
+	"semi_annual",
+	"year",
+];
+
+const planItemSchema = {
+	type: "object",
+	description: "A feature configuration within a plan.",
+	properties: {
+		feature_id: {
+			type: "string",
+			description:
+				"The feature ID. If it doesn't exist yet, it will be auto-created (provide feature_type for metered features).",
+		},
+		feature_type: {
+			type: "string",
+			enum: ["single_use", "continuous_use", "boolean"],
+			description:
+				"Type for auto-creating the feature. single_use = consumable (API calls, credits), continuous_use = allocated (seats, projects), boolean = on/off gate. Only needed if the feature doesn't already exist.",
+		},
+		included: {
+			type: "number",
+			description:
+				"Free units included with the plan. Resets each interval for consumable features.",
+		},
+		unlimited: { type: "boolean", description: "If true, unlimited access to this feature." },
+		reset: {
+			type: "object",
+			description: "Reset config for consumable features. Omit for non-consumable (seats).",
+			properties: {
+				interval: {
+					type: "string",
+					enum: resetIntervalEnum,
+					description: "Reset interval (e.g. 'month').",
+				},
+				interval_count: {
+					type: "number",
+					description: "Number of intervals between resets. Default 1.",
+				},
+			},
+			required: ["interval"],
+		},
+		price: {
+			type: "object",
+			description: "Pricing for usage beyond included units. Omit for free features.",
+			properties: {
+				amount: {
+					type: "number",
+					description: "Price per billing_units. Use this OR tiers, not both.",
+				},
+				tiers: {
+					type: "array",
+					description:
+						"Tiered pricing. Each tier has 'to' (upper limit, or 'inf') and 'amount' (price per unit).",
+					items: {
+						type: "object",
+						properties: {
+							to: { description: "Upper limit of this tier (number or 'inf' for unlimited)." },
+							amount: { type: "number", description: "Price per unit in this tier." },
+						},
+						required: ["to", "amount"],
+					},
+				},
+				interval: {
+					type: "string",
+					enum: intervalEnum,
+					description: "Billing interval. Should match reset.interval for consumable features.",
+				},
+				billing_units: {
+					type: "number",
+					description:
+						"Units per price increment. E.g. billing_units=100 means pricing is per 100 units.",
+				},
+				billing_method: {
+					type: "string",
+					enum: ["prepaid", "usage_based"],
+					description:
+						"prepaid = upfront payment (seats), usage_based = pay-as-you-go (API calls).",
+				},
+				max_purchase: { type: "number", description: "Max purchasable units beyond included." },
+			},
+			required: ["interval", "billing_method"],
+		},
+		proration: {
+			type: "object",
+			description: "Mid-cycle billing behavior for prepaid features (seats). Usually not needed.",
+			properties: {
+				on_increase: {
+					type: "string",
+					enum: [
+						"bill_immediately",
+						"prorate_immediately",
+						"prorate_next_cycle",
+						"bill_next_cycle",
+					],
+				},
+				on_decrease: {
+					type: "string",
+					enum: ["prorate", "prorate_immediately", "prorate_next_cycle", "none", "no_prorations"],
+				},
+			},
+			required: ["on_increase", "on_decrease"],
+		},
+		rollover: {
+			type: "object",
+			description: "Carry over unused units to the next cycle.",
+			properties: {
+				max: { type: "number", description: "Max rollover units. Omit for unlimited." },
+				expiry_duration_type: { type: "string", enum: ["month", "forever"] },
+				expiry_duration_length: { type: "number", description: "Periods before rollover expires." },
+			},
+			required: ["expiry_duration_type"],
+		},
+	},
+	required: ["feature_id"],
+};
+
+const basePriceSchema = {
+	type: "object",
+	description: "Base recurring price for the plan (e.g. $49/month flat fee).",
+	properties: {
+		amount: { type: "number", description: "Price amount in dollars." },
+		interval: { type: "string", enum: intervalEnum, description: "Billing interval." },
+		interval_count: { type: "number", description: "Number of intervals per cycle. Default 1." },
+	},
+	required: ["amount", "interval"],
+};
+
+const freeTrialSchema = {
+	type: "object",
+	description: "Free trial configuration.",
+	properties: {
+		duration_length: { type: "number", description: "Length of the trial period." },
+		duration_type: {
+			type: "string",
+			enum: ["day", "month", "year"],
+			description: "Unit for the trial length. Default: day.",
+		},
+		card_required: {
+			type: "boolean",
+			description: "If true, payment method required to start trial.",
+		},
+	},
+	required: ["duration_length"],
+};
+
+const customizeSchema = {
+	type: "object",
+	description:
+		"Override the plan's defaults for this specific customer. Use to give a customer custom pricing, custom feature limits, or a custom trial without creating a separate plan.",
+	properties: {
+		price: {
+			...basePriceSchema,
+			description: "Override the base price. Pass null to remove the base price entirely.",
+		},
+		items: {
+			type: "array",
+			items: planItemSchema,
+			description:
+				"Override feature configurations. Replaces the plan's default items for this customer.",
+		},
+		free_trial: {
+			...freeTrialSchema,
+			description: "Override the trial. Pass null to remove the trial.",
+		},
+	},
+};
+
+const baseReadTools = [
+	defineTool(
+		"get_skill",
+		"Load contextual guidance and unlock additional tools before responding. Call this for any non-trivial response. Pass one or more skill IDs. Skills are cached in conversation history — only load each once per thread. Loading 'custom_plans' unlocks create_plan and update_plan. Loading 'billing_flows' unlocks attach_plan, preview_attach, and update_subscription.",
+		{
+			skill_ids: {
+				type: "array",
+				items: {
+					type: "string",
+					enum: SKILL_IDS,
+				},
+				description:
+					"custom_plans = creating/updating/customizing plans and pricing. billing_flows = attaching plans, previewing costs, invoices, checkout. customer_ops = customer lookups, balances, billing portal, unsupported actions. response_formatting = how to format responses in Slack (backticks, lists, walkthroughs).",
+			},
+		},
+		["skill_ids"],
+	),
+	defineTool(
+		"get_customer",
+		"Look up a single customer by their exact ID. Returns their current plan, subscription status, feature balances, and renewal info. Use expand to include invoices, entities, rewards, or payment method. This is the primary tool for answering questions about a specific customer.",
+		{
+			customer_id: p.customer_id,
+			expand: {
+				type: "array",
+				items: {
+					type: "string",
+					enum: ["invoices", "entities", "rewards", "payment_method"],
+				},
+				description:
+					"Additional data to include. Use 'invoices' when asked about billing history, 'payment_method' when asked about payment info, 'entities' for sub-resources like team members.",
+			},
+		},
+		["customer_id"],
+	),
+	defineTool(
+		"list_customers",
+		"List all customers with pagination. Use this when a user refers to a customer by name or email — search the results to find the matching customer ID. Also use when asked for an overview of all customers.",
+		{
+			limit: { type: "number", description: "Max results per page (default 50)" },
+			offset: { type: "number", description: "Pagination offset for fetching subsequent pages" },
+		},
+	),
+	defineTool(
+		"check_feature_access",
+		"Check whether a customer currently has access to a specific feature and how much balance remains. Use this to answer questions like 'can customer X use feature Y?' or 'how many API calls does this customer have left?'.",
+		{ customer_id: p.customer_id, feature_id: p.feature_id },
+		["customer_id", "feature_id"],
+	),
+	defineTool(
+		"get_usage_aggregate",
+		"Get total usage for a customer's feature(s) over a time range. Returns aggregated counts, not individual events. Use this for questions like 'how much has customer X used this month?' or 'what's their usage trend?'. For individual event details, use list_events instead.",
+		{
+			customer_id: p.customer_id,
+			feature_id: {
+				type: "string",
+				description: "Feature ID, or multiple comma-separated IDs (e.g. 'api-calls,storage')",
+			},
+			range: {
+				type: "string",
+				enum: ["24h", "7d", "30d", "90d", "last_cycle"],
+				description:
+					"Time range to aggregate over. Use 'last_cycle' for current billing period. Default: 30d.",
+			},
+		},
+		["customer_id", "feature_id"],
+	),
+	defineTool(
+		"list_events",
+		"List individual usage events for a customer's feature, ordered by most recent. Use this when the user wants to see specific events, audit a usage log, or debug a particular usage record. For totals, use get_usage_aggregate instead.",
+		{
+			customer_id: p.customer_id,
+			feature_id: p.feature_id,
+			limit: { type: "number", description: "Max events to return (default 20)" },
+		},
+		["customer_id", "feature_id"],
+	),
+	defineTool(
+		"list_plans",
+		"List all plans configured in Autumn with their features, pricing, and billing intervals. Use this when the user refers to a plan by name (to find the correct plan ID), when comparing plans, or when asked 'what plans are available?'.",
+		{},
+	),
+	defineTool(
+		"get_plan",
+		"Get full details of a specific plan including all features, pricing tiers, and configuration. Use when the user asks about a particular plan's details after you already know the plan ID.",
+		{ plan_id: p.plan_id },
+		["plan_id"],
+	),
+	defineTool(
+		"list_features",
+		"List all features defined in Autumn. Use this when the user asks about available features, or when you need to find the correct feature ID for a name the user mentioned.",
+		{},
+	),
+	defineTool(
+		"get_feature",
+		"Get details of a specific feature including its type, metering config, and which plans include it.",
+		{ feature_id: p.feature_id },
+		["feature_id"],
+	),
+	defineTool(
+		"get_entity",
+		"Get an entity (sub-resource like a team member or project) and its individual feature balances. Entities belong to a customer and can have their own usage limits.",
+		{
+			customer_id: p.customer_id,
+			entity_id: { type: "string", description: "The entity ID (e.g. team member ID, project ID)" },
+		},
+		["customer_id", "entity_id"],
+	),
+	defineTool(
+		"get_billing_portal_url",
+		"Generate a Stripe billing portal URL where the customer can manage their payment methods, view/pay invoices, and update billing info. Use this when the user needs to share a self-service link, or when they want to do something you can't do directly (like void an invoice, add a payment method, or issue a refund).",
+		{ customer_id: p.customer_id },
+		["customer_id"],
+	),
+];
+
+const billingFlowReadTools = [
+	defineTool(
+		"preview_attach",
+		"Preview cost of attaching a plan to a customer. Always call before attach_plan. Supports customize for custom pricing.",
+		{
+			customer_id: p.customer_id,
+			plan_id: p.plan_id,
+			customize: customizeSchema,
+		},
+		["customer_id", "plan_id"],
+	),
+];
+
+const billingFlowMutatingTools = [
+	defineTool(
+		"attach_plan",
+		"Subscribe a customer to a plan. Always preview_attach first. Set is_plan_switch=true if upgrading/downgrading. Use customize for custom pricing. See billing_flows skill for details.",
+		{
+			customer_id: p.customer_id,
+			plan_id: p.plan_id,
+			is_plan_switch: {
+				type: "boolean",
+				description:
+					"Set to true if the customer already has an active plan (upgrade/downgrade). Determines whether checkout link or direct charge is offered.",
+			},
+			customize: customizeSchema,
+			success_url: {
+				type: "string",
+				description: "URL to redirect to after the customer completes Stripe checkout",
+			},
+			invoice_mode: {
+				type: "object",
+				description:
+					"Create an invoice instead of charging the card on file. The 'Draft Invoice' button sets this automatically — do not set it yourself unless the user specifically asks for invoice billing.",
+				properties: {
+					enabled: { type: "boolean", description: "Enable invoice mode" },
+					enable_plan_immediately: {
+						type: "boolean",
+						description: "If true, activates the plan before the invoice is paid",
+					},
+					finalize: {
+						type: "boolean",
+						description:
+							"If true, finalizes and sends the invoice immediately. If false (default for Draft Invoice button), keeps it as a draft for manual review in Stripe.",
+					},
+				},
+				required: ["enabled"],
+			},
+		},
+		["customer_id", "plan_id"],
+	),
+	defineTool(
+		"update_subscription",
+		"Modify a subscription: change quantities, customize feature limits, or cancel/uncancel. See billing_flows skill for details.",
+		{
+			customer_id: p.customer_id,
+			plan_id: p.plan_id,
+			feature_quantities: {
+				type: "array",
+				items: {
+					type: "object",
+					properties: {
+						feature_id: { type: "string" },
+						quantity: { type: "number" },
+					},
+					required: ["feature_id", "quantity"],
+				},
+				description:
+					"New quantities for seat-based or quantity-based features (e.g. change seats from 5 to 10)",
+			},
+			cancel_action: {
+				type: "string",
+				enum: ["cancel_immediately", "cancel_end_of_cycle", "uncancel"],
+				description:
+					"cancel_end_of_cycle = cancel at period end (recommended default), cancel_immediately = revoke access now, uncancel = reverse a pending cancellation",
+			},
+			customize: customizeSchema,
+		},
+		["customer_id", "plan_id"],
+	),
+];
+
+const customPlanTools = [
+	defineTool(
+		"create_plan",
+		"Create a new plan. Call list_features first. Features auto-create if feature_type is set. See custom_plans skill for patterns.",
+		{
+			plan_id: {
+				type: "string",
+				description:
+					"Unique plan ID, lowercase with hyphens (e.g. 'pro-monthly', 'enterprise-annual').",
+			},
+			name: { type: "string", description: "Display name (e.g. 'Pro Plan', 'Enterprise Annual')." },
+			group: {
+				type: "string",
+				description:
+					"Plans in the same group are mutually exclusive (attaching one replaces the other). E.g. 'main' for base plans.",
+			},
+			description: { type: "string", description: "Optional plan description." },
+			add_on: {
+				type: "boolean",
+				description:
+					"If true, this plan can be purchased alongside other plans (e.g. credit packs, premium features). Default false.",
+			},
+			auto_enable: {
+				type: "boolean",
+				description:
+					"If true, auto-attached when a customer is created. Use only for free tiers. Default false.",
+			},
+			price: basePriceSchema,
+			items: {
+				type: "array",
+				items: planItemSchema,
+				description:
+					"Feature configurations. Each item defines what the customer gets and how overage is priced.",
+			},
+			free_trial: freeTrialSchema,
+		},
+		["plan_id", "name"],
+	),
+	defineTool(
+		"update_plan",
+		"Update a plan. Creates a new version (existing customers are grandfathered). Call get_plan first. See custom_plans skill for details.",
+		{
+			plan_id: p.plan_id,
+			name: { type: "string", description: "New display name." },
+			description: { type: "string", description: "New description." },
+			group: { type: "string", description: "New group." },
+			add_on: { type: "boolean", description: "Whether this is an add-on plan." },
+			auto_enable: { type: "boolean", description: "Whether to auto-attach on customer creation." },
+			archived: {
+				type: "boolean",
+				description: "Set true to archive the plan (cannot be attached to new customers).",
+			},
+			price: {
+				...basePriceSchema,
+				description: "New base price. Pass null to remove the base price.",
+			},
+			items: {
+				type: "array",
+				items: planItemSchema,
+				description: "New feature configurations. Replaces all existing items.",
+			},
+			free_trial: {
+				...freeTrialSchema,
+				description: "New trial config. Pass null to remove the trial.",
+			},
+		},
+		["plan_id"],
+	),
+];
+
+const baseMutatingTools = [
+	defineTool(
+		"create_customer",
+		"Create a new customer in Autumn. Use when the user explicitly asks to create/add a customer. Email is required; name is optional but recommended.",
+		{
+			name: { type: "string", description: "Customer display name" },
+			email: {
+				type: "string",
+				description: "Customer email address (required)",
+			},
+			id: {
+				type: "string",
+				description:
+					"Custom customer ID. Only set this if the user explicitly provides an ID. Otherwise omit and the system will assign one.",
+			},
+		},
+		["email"],
+	),
+	defineTool(
+		"create_balance",
+		"Grant additional balance to a customer's feature. This ADDS to any existing balance — it does not replace it. Use for giving bonus credits, promotional allowances, or one-time grants. To set an exact balance, use set_balance instead.",
+		{
+			customer_id: p.customer_id,
+			feature_id: p.feature_id,
+			amount: { type: "number", description: "Amount to add to the balance" },
+			unlimited: {
+				type: "boolean",
+				description: "If true, grants unlimited access to this feature (ignores amount)",
+			},
+		},
+		["customer_id", "feature_id"],
+	),
+	defineTool(
+		"set_balance",
+		"Set a customer's feature balance to an exact value, replacing whatever it was before. Use when the user says 'set balance to X' or 'reset balance to X'. To add credits on top of existing balance, use create_balance instead.",
+		{
+			customer_id: p.customer_id,
+			feature_id: p.feature_id,
+			balance: {
+				type: "number",
+				description: "The exact balance value to set (replaces current balance)",
+			},
+		},
+		["customer_id", "feature_id", "balance"],
+	),
+	defineTool(
+		"track_usage",
+		"Record a usage event for a customer's feature. Positive values consume balance (e.g. customer used 5 API calls), negative values credit back (e.g. undo a charge, grant a refund of usage). Each call creates one event record.",
+		{
+			customer_id: p.customer_id,
+			feature_id: p.feature_id,
+			value: {
+				type: "number",
+				description:
+					"Positive = consume balance, negative = credit back. E.g. 5 to deduct 5 units, -3 to refund 3 units.",
+			},
+		},
+		["customer_id", "feature_id", "value"],
+	),
+	defineTool(
+		"generate_checkout_url",
+		"Generate a standalone Stripe checkout URL for a customer and plan. Use this when you only need a checkout link without the full attach_plan flow (e.g. the user just wants a link to share). The customer does not need a payment method on file — they enter it during checkout.",
+		{ customer_id: p.customer_id, plan_id: p.plan_id },
+		["customer_id", "plan_id"],
+	),
+	defineTool(
+		"setup_payment",
+		"Generate a Stripe payment method setup link. The customer visits this URL to add or update their card/payment method. Use when a customer needs to add payment info before being charged, or when they want to update an expired card.",
+		{ customer_id: p.customer_id },
+		["customer_id"],
+	),
+	defineTool(
+		"update_customer",
+		"Update a customer's name or email address. At least one field must be provided. Use when the user asks to rename a customer, fix a typo in their email, or update contact info.",
+		{
+			customer_id: p.customer_id,
+			name: { type: "string", description: "New display name" },
+			email: { type: "string", description: "New email address" },
+		},
+		["customer_id"],
+	),
+	defineTool(
+		"create_referral_code",
+		"Create a referral code that this customer can share with others. The code is tied to a specific referral program. When someone redeems it, both parties get the rewards defined in the program.",
+		{
+			customer_id: p.customer_id,
+			program_id: {
+				type: "string",
+				description: "The referral program ID that defines the rewards",
+			},
+		},
+		["customer_id", "program_id"],
+	),
+	defineTool(
+		"redeem_referral_code",
+		"Apply a referral code for a customer, giving them (and the referrer) the rewards defined in the referral program.",
+		{
+			code: { type: "string", description: "The referral code to redeem" },
+			customer_id: p.customer_id,
+		},
+		["code", "customer_id"],
+	),
+];
+
+const allMutating = [...baseMutatingTools, ...billingFlowMutatingTools, ...customPlanTools];
+
+export const MUTATING_TOOLS = new Set(allMutating.map((t) => t.name));
+
+export function getTools(skills: Set<string>): Anthropic.Tool[] {
+	const tools: Anthropic.Tool[] = [...baseReadTools, ...baseMutatingTools];
+	if (skills.has("billing_flows")) tools.push(...billingFlowReadTools, ...billingFlowMutatingTools);
+	if (skills.has("custom_plans")) tools.push(...customPlanTools);
+	return tools;
+}

--- a/apps/autumn/src/bot.ts
+++ b/apps/autumn/src/bot.ts
@@ -1,0 +1,136 @@
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { createRedisState } from "@chat-adapter/state-redis";
+import { Chat } from "chat";
+import { handleCancelAction, handleConfirmAction } from "@/agent/confirm";
+import { handleAgentMention, handleAgentMessage } from "@/agent/handler";
+import { handleSlashCommandByName } from "@/commands/router";
+import { getEnv } from "@/config";
+import { getWorkspace } from "@/services/workspace";
+
+const env = getEnv();
+
+export const slackAdapter = createSlackAdapter({
+	clientId: env.SLACK_CLIENT_ID,
+	clientSecret: env.SLACK_CLIENT_SECRET,
+});
+
+// Patch missing Slack envelope fields onto inner events for App Home + Slack Connect.
+const adapter = slackAdapter as unknown as Record<string, unknown>;
+
+const origProcess = adapter.processEventPayload as (
+	payload: Record<string, unknown>,
+	options?: unknown,
+) => void;
+
+adapter.processEventPayload = function (payload: Record<string, unknown>, options?: unknown) {
+	if (payload.type === "event_callback" && payload.event) {
+		const event = payload.event as Record<string, unknown>;
+		if (event.type === "app_home_opened" && !event.team_id && payload.team_id) {
+			event.team_id = payload.team_id;
+		}
+		if (!event.authorizations && payload.authorizations) {
+			event.authorizations = payload.authorizations;
+		}
+	}
+	return origProcess.call(this, payload, options);
+};
+
+const origHandleHome = adapter.handleAppHomeOpened as (
+	event: Record<string, unknown>,
+	options?: unknown,
+) => void;
+
+let appHomeTeamId: string | null = null;
+
+adapter.handleAppHomeOpened = function (event: Record<string, unknown>, options?: unknown) {
+	appHomeTeamId = (event.team_id as string) || null;
+	return origHandleHome.call(this, event, options);
+};
+
+export const bot = new Chat({
+	userName: "autumn",
+	logger: "warn",
+	adapters: { slack: slackAdapter },
+	state: createRedisState(),
+});
+
+bot.onSlashCommand(async (event) => {
+	await handleSlashCommandByName(event);
+});
+
+bot.onNewMention(async (thread, message) => {
+	await handleAgentMention(thread, message);
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+	await handleAgentMessage(thread, message);
+});
+
+bot.onAction(["confirm", "confirm_invoice"], async (event) => {
+	await handleConfirmAction(event);
+});
+
+bot.onAction("cancel", async (event) => {
+	await handleCancelAction(event);
+});
+
+bot.onAssistantThreadStarted(async (event) => {
+	try {
+		await slackAdapter.setSuggestedPrompts(event.channelId, event.threadTs, [
+			{ title: "Customer lookup", message: "What plan is customer acme on?" },
+			{ title: "Usage check", message: "Show me usage for customer acme" },
+			{ title: "Attach a plan", message: "Attach the Pro plan to customer acme" },
+		]);
+	} catch (err) {
+		console.error("assistant_thread_started error:", err);
+	}
+});
+
+bot.onAppHomeOpened(async (event) => {
+	try {
+		const workspaceId = appHomeTeamId;
+		appHomeTeamId = null;
+		const workspace = workspaceId ? await getWorkspace(workspaceId) : null;
+		const slack = bot.getAdapter("slack");
+
+		const blocks: Record<string, unknown>[] = [];
+
+		if (workspace?.orgName) {
+			blocks.push(
+				{ type: "header", text: { type: "plain_text", text: "Autumn" } },
+				{
+					type: "section",
+					text: {
+						type: "mrkdwn",
+						text: `*Connected to:* ${workspace.orgName}`,
+					},
+				},
+				{ type: "divider" },
+			);
+		} else {
+			blocks.push(
+				{ type: "header", text: { type: "plain_text", text: "Autumn" } },
+				{
+					type: "section",
+					text: {
+						type: "mrkdwn",
+						text: "Not connected yet. Run `/connect` in any channel to get started.",
+					},
+				},
+				{ type: "divider" },
+			);
+		}
+
+		blocks.push({
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: '*Getting Started*\nMention `@Autumn` in any channel to ask about customers, subscriptions, usage, and billing.\n\nExamples:\n- "What plan is acme on?"\n- "Grant acme 5000 messages"\n- "Show upcoming renewals"',
+			},
+		});
+
+		await slack.publishHomeView(event.userId, { type: "home", blocks });
+	} catch (err) {
+		console.error("app_home_opened error:", err);
+	}
+});

--- a/apps/autumn/src/bot.ts
+++ b/apps/autumn/src/bot.ts
@@ -5,6 +5,7 @@ import { handleCancelAction, handleConfirmAction } from "@/agent/confirm";
 import { handleAgentMention, handleAgentMessage } from "@/agent/handler";
 import { handleSlashCommandByName } from "@/commands/router";
 import { getEnv } from "@/config";
+import { getWorkspaceIdFromRaw } from "@/lib/slack";
 import { getWorkspace } from "@/services/workspace";
 
 const env = getEnv();
@@ -33,18 +34,6 @@ adapter.processEventPayload = function (payload: Record<string, unknown>, option
 		}
 	}
 	return origProcess.call(this, payload, options);
-};
-
-const origHandleHome = adapter.handleAppHomeOpened as (
-	event: Record<string, unknown>,
-	options?: unknown,
-) => void;
-
-let appHomeTeamId: string | null = null;
-
-adapter.handleAppHomeOpened = function (event: Record<string, unknown>, options?: unknown) {
-	appHomeTeamId = (event.team_id as string) || null;
-	return origHandleHome.call(this, event, options);
 };
 
 export const bot = new Chat({
@@ -88,8 +77,9 @@ bot.onAssistantThreadStarted(async (event) => {
 
 bot.onAppHomeOpened(async (event) => {
 	try {
-		const workspaceId = appHomeTeamId;
-		appHomeTeamId = null;
+		const eventRaw =
+			((event as unknown as Record<string, unknown>).raw as unknown) ?? (event as unknown);
+		const workspaceId = getWorkspaceIdFromRaw(eventRaw);
 		const workspace = workspaceId ? await getWorkspace(workspaceId) : null;
 		const slack = bot.getAdapter("slack");
 

--- a/apps/autumn/src/cards/alert.ts
+++ b/apps/autumn/src/cards/alert.ts
@@ -1,0 +1,95 @@
+import { Card, CardText as Text } from "chat";
+
+type BaseAlertProps = {
+	customerId: string;
+	customerName?: string;
+};
+
+type PlanAlertProps = BaseAlertProps & {
+	planName: string;
+};
+
+type PlanChangedProps = BaseAlertProps & {
+	fromPlan: string;
+	toPlan: string;
+	direction: "upgrade" | "downgrade" | "change";
+};
+
+type CanceledProps = PlanAlertProps & {
+	cancelsAt?: number;
+};
+
+type UsageAlertProps = BaseAlertProps & {
+	featureId: string;
+	thresholdType: string;
+};
+
+function displayName(props: BaseAlertProps): string {
+	return props.customerName || props.customerId;
+}
+
+export function NewSubscriptionCard({ planName, ...props }: PlanAlertProps) {
+	return Card({
+		title: "🆕 New Subscription",
+		children: [Text(`*${displayName(props)}* subscribed to *${planName}*.`)],
+	});
+}
+
+export function PlanChangedCard({ fromPlan, toPlan, direction, ...props }: PlanChangedProps) {
+	const emoji = direction === "upgrade" ? "⬆️" : direction === "downgrade" ? "⬇️" : "🔄";
+	const label = direction.charAt(0).toUpperCase() + direction.slice(1);
+
+	return Card({
+		title: `${emoji} Plan ${label}`,
+		children: [Text(`*${displayName(props)}* ${direction}d from *${fromPlan}* to *${toPlan}*.`)],
+	});
+}
+
+export function SubscriptionCanceledCard({ planName, cancelsAt, ...props }: CanceledProps) {
+	const endsText = cancelsAt
+		? ` Access ends ${new Date(cancelsAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}.`
+		: "";
+
+	return Card({
+		title: "❌ Subscription Canceled",
+		children: [Text(`*${displayName(props)}* canceled *${planName}*.${endsText}`)],
+	});
+}
+
+export function SubscriptionRenewedCard({ planName, ...props }: PlanAlertProps) {
+	return Card({
+		title: "🔁 Subscription Renewed",
+		children: [Text(`*${displayName(props)}* renewed *${planName}*.`)],
+	});
+}
+
+export function TrialConvertedCard({ planName, ...props }: PlanAlertProps) {
+	return Card({
+		title: "🎉 Trial Converted",
+		children: [Text(`*${displayName(props)}* converted to *${planName}*.`)],
+	});
+}
+
+export function ExpiredCard({ planName, ...props }: PlanAlertProps) {
+	return Card({
+		title: "⏰ Subscription Expired",
+		children: [Text(`*${displayName(props)}*'s *${planName}* subscription has expired.`)],
+	});
+}
+
+export function PastDueCard({ planName, ...props }: PlanAlertProps) {
+	return Card({
+		title: "⚠️ Payment Past Due",
+		children: [Text(`*${displayName(props)}*'s payment for *${planName}* is past due.`)],
+	});
+}
+
+export function UsageAlertCard({ featureId, thresholdType, ...props }: UsageAlertProps) {
+	const label =
+		thresholdType === "limit_reached" ? "hit the limit for" : "approaching the limit for";
+
+	return Card({
+		title: thresholdType === "limit_reached" ? "🚨 Limit Reached" : "📊 Usage Alert",
+		children: [Text(`*${displayName(props)}* is ${label} *${featureId}*.`)],
+	});
+}

--- a/apps/autumn/src/commands/connect.ts
+++ b/apps/autumn/src/commands/connect.ts
@@ -1,0 +1,45 @@
+import type { SlashCommandEvent } from "chat";
+import { Actions, Card, LinkButton, CardText as Text } from "chat";
+import { getEnv } from "@/config";
+import { getWorkspace } from "@/services/workspace";
+
+export async function handleConnectCommand(
+	event: SlashCommandEvent,
+	workspaceId: string,
+): Promise<void> {
+	const existing = await getWorkspace(workspaceId);
+	if (existing?.apiKey) {
+		const canManageConnection = existing.connectedByUserId === event.user.userId;
+
+		if (!canManageConnection) {
+			await event.channel.postEphemeral(
+				event.user,
+				"Autumn is already connected. Only the admin who set it up can reconnect, ask them to run `/disconnect` first.",
+				{ fallbackToDM: true },
+			);
+			return;
+		}
+
+		await event.channel.postEphemeral(
+			event.user,
+			"Autumn is already connected. Run `/disconnect` first if you want to reconnect.",
+			{ fallbackToDM: true },
+		);
+		return;
+	}
+
+	const env = getEnv();
+	const connectUrl = `${env.BASE_URL}/connect?workspace_id=${workspaceId}&user_id=${event.user.userId}`;
+
+	await event.channel.post(
+		Card({
+			title: "",
+			children: [
+				Text("*Autumn Commands*"),
+				Text("To connect to Autumn, click the button below and complete the browser flow."),
+				Text("When you're done, return to Slack and mention @Autumn to get started."),
+				Actions([LinkButton({ label: "Connect Autumn", url: connectUrl, style: "primary" })]),
+			],
+		}),
+	);
+}

--- a/apps/autumn/src/commands/disconnect.ts
+++ b/apps/autumn/src/commands/disconnect.ts
@@ -1,0 +1,30 @@
+import type { SlashCommandEvent } from "chat";
+import { deleteWorkspace, getWorkspace } from "@/services/workspace";
+
+export async function handleDisconnectCommand(
+	event: SlashCommandEvent,
+	workspaceId: string,
+): Promise<void> {
+	const workspace = await getWorkspace(workspaceId);
+
+	if (!workspace) {
+		await event.channel.postEphemeral(
+			event.user,
+			"Autumn is not configured for this workspace yet, so there is nothing to disconnect.",
+			{ fallbackToDM: true },
+		);
+		return;
+	}
+
+	if (workspace.connectedByUserId !== event.user.userId) {
+		await event.channel.postEphemeral(
+			event.user,
+			"Only the admin who connected Autumn can disconnect it. Ask them to run `/disconnect`.",
+			{ fallbackToDM: true },
+		);
+		return;
+	}
+
+	await deleteWorkspace(workspaceId);
+	await event.channel.post("Autumn has been disconnected from this workspace.");
+}

--- a/apps/autumn/src/commands/router.ts
+++ b/apps/autumn/src/commands/router.ts
@@ -1,0 +1,62 @@
+import type { SlashCommandEvent } from "chat";
+import { handleConnectCommand } from "@/commands/connect";
+import { handleDisconnectCommand } from "@/commands/disconnect";
+import { getWorkspaceId, isRedisUnavailable, isSlackNotInChannel } from "@/lib/slack";
+
+export async function handleSlashCommandByName(event: SlashCommandEvent): Promise<void> {
+	const command = (event.command || "").toLowerCase();
+
+	try {
+		const workspaceId = getWorkspaceId(event);
+
+		console.log(
+			`command ${command} org=${workspaceId ?? "unknown"} user=${event.user.userId} channel=${event.channel.id}`,
+		);
+
+		if (!workspaceId) {
+			console.warn(
+				`command ${command} err=no_workspace raw_keys=${event.raw ? Object.keys(event.raw as Record<string, unknown>).join(",") : "none"}`,
+			);
+			await event.channel.postEphemeral(
+				event.user,
+				"Could not identify this workspace. Try reinstalling Autumn.",
+				{ fallbackToDM: true },
+			);
+			return;
+		}
+
+		switch (command) {
+			case "/connect":
+				return await handleConnectCommand(event, workspaceId);
+			case "/disconnect":
+				return await handleDisconnectCommand(event, workspaceId);
+			default:
+				await event.channel.postEphemeral(event.user, "Mention @Autumn to interact with billing.", {
+					fallbackToDM: true,
+				});
+		}
+	} catch (err) {
+		if (isRedisUnavailable(err)) {
+			await event.channel.postEphemeral(
+				event.user,
+				"Autumn is temporarily unavailable because Redis is offline. Try again in a minute.",
+				{ fallbackToDM: true },
+			);
+			return;
+		}
+		if (isSlackNotInChannel(err)) {
+			await event.channel.postEphemeral(
+				event.user,
+				"Invite Autumn to this channel first, then try again.",
+				{ fallbackToDM: true },
+			);
+			return;
+		}
+		console.error("Command error:", err);
+		await event.channel.postEphemeral(
+			event.user,
+			"Something went wrong running this command. Check the logs.",
+			{ fallbackToDM: true },
+		);
+	}
+}

--- a/apps/autumn/src/config.ts
+++ b/apps/autumn/src/config.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+const emptyStringToUndefined = (value: unknown) =>
+	typeof value === "string" && value.trim() === "" ? undefined : value;
+
+const envSchema = z.object({
+	REDIS_URL: z.string().default("redis://localhost:6379"),
+	SLACK_CLIENT_ID: z.string().optional(),
+	SLACK_CLIENT_SECRET: z.string().optional(),
+	SLACK_SIGNING_SECRET: z.string().optional(),
+	ENCRYPTION_KEY: z.string().min(1, "ENCRYPTION_KEY is required for storing tenant credentials"),
+	ANTHROPIC_API_KEY: z.string().optional(),
+	AUTUMN_BACKEND_URL: z.preprocess(
+		emptyStringToUndefined,
+		z.string().default("https://api.useautumn.com"),
+	),
+	AUTUMN_OAUTH_CLIENT_ID: z.string().min(1, "AUTUMN_OAUTH_CLIENT_ID is required"),
+	AUTUMN_OAUTH_CLIENT_SECRET: z.string().min(1, "AUTUMN_OAUTH_CLIENT_SECRET is required"),
+	PORT: z.coerce.number().default(3000),
+	BASE_URL: z.string().default("http://localhost:3000"),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+let _env: Env | null = null;
+
+export function getEnv(): Env {
+	if (!_env) {
+		const result = envSchema.safeParse(process.env);
+		if (!result.success) {
+			console.error("Invalid environment variables:");
+			for (const issue of result.error.issues) {
+				console.error(`  ${issue.path.join(".")}: ${issue.message}`);
+			}
+			process.exit(1);
+		}
+		_env = result.data;
+	}
+	return _env;
+}

--- a/apps/autumn/src/index.ts
+++ b/apps/autumn/src/index.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import { logger } from "hono/logger";
+import { bot } from "@/bot";
+import { getEnv } from "@/config";
+import { flushStaleLocks } from "@/lib/redis";
+import { autumnWebhookRoutes } from "@/routes/autumn";
+import { connectRoutes } from "@/routes/connect";
+import { installRoutes } from "@/routes/install";
+import { webhookRoutes } from "@/routes/webhooks";
+import { listWorkspaces } from "@/services/workspace";
+
+const app = new Hono();
+
+app.use("*", logger());
+
+app.get("/", (c) => c.json({ name: "autumn", status: "ok" }));
+app.get("/health", (c) => c.json({ status: "ok" }));
+app.get("/favicon.ico", (c) => c.body(null, 204));
+
+app.route("/webhooks", webhookRoutes);
+app.route("/autumn/webhooks", autumnWebhookRoutes);
+app.route("/", installRoutes);
+app.route("/connect", connectRoutes);
+
+const env = getEnv();
+
+bot
+	.initialize()
+	.then(() => flushStaleLocks())
+	.then((flushed) => {
+		if (flushed > 0) console.log(`startup flushed=${flushed} stale locks`);
+		return listWorkspaces();
+	})
+	.then((ids) =>
+		console.log(
+			`Autumn Slack bot running on port ${env.PORT} (${ids.length} workspace${ids.length === 1 ? "" : "s"})`,
+		),
+	)
+	.catch(() => console.log(`Autumn Slack bot running on port ${env.PORT} (no Redis)`));
+
+export default {
+	port: env.PORT,
+	fetch: app.fetch,
+};

--- a/apps/autumn/src/index.ts
+++ b/apps/autumn/src/index.ts
@@ -3,6 +3,7 @@ import { logger } from "hono/logger";
 import { bot } from "@/bot";
 import { getEnv } from "@/config";
 import { flushStaleLocks } from "@/lib/redis";
+import { isRedisUnavailable } from "@/lib/slack";
 import { autumnWebhookRoutes } from "@/routes/autumn";
 import { connectRoutes } from "@/routes/connect";
 import { installRoutes } from "@/routes/install";
@@ -36,7 +37,14 @@ bot
 			`Autumn Slack bot running on port ${env.PORT} (${ids.length} workspace${ids.length === 1 ? "" : "s"})`,
 		),
 	)
-	.catch(() => console.log(`Autumn Slack bot running on port ${env.PORT} (no Redis)`));
+	.catch((err) => {
+		if (isRedisUnavailable(err)) {
+			console.error(`Autumn Slack bot failed to start on port ${env.PORT} (Redis unavailable)`);
+			return;
+		}
+
+		console.error(`Autumn Slack bot failed to start on port ${env.PORT}:`, err);
+	});
 
 export default {
 	port: env.PORT,

--- a/apps/autumn/src/lib/redis.ts
+++ b/apps/autumn/src/lib/redis.ts
@@ -12,8 +12,17 @@ export function getRedis(): Redis {
 
 export async function flushStaleLocks(): Promise<number> {
 	const redis = getRedis();
-	const keys = await redis.keys("chat-sdk:lock:*");
-	if (keys.length === 0) return 0;
-	await redis.del(...keys);
-	return keys.length;
+	const pattern = "chat-sdk:lock:*";
+	let cursor = "0";
+	let deleted = 0;
+
+	do {
+		const [next, keys] = await redis.scan(cursor, "MATCH", pattern, "COUNT", 100);
+		cursor = next;
+		if (keys.length === 0) continue;
+		await redis.del(...keys);
+		deleted += keys.length;
+	} while (cursor !== "0");
+
+	return deleted;
 }

--- a/apps/autumn/src/lib/redis.ts
+++ b/apps/autumn/src/lib/redis.ts
@@ -1,0 +1,19 @@
+import Redis from "ioredis";
+import { getEnv } from "@/config";
+
+let _redis: Redis | null = null;
+
+export function getRedis(): Redis {
+	if (!_redis) {
+		_redis = new Redis(getEnv().REDIS_URL);
+	}
+	return _redis;
+}
+
+export async function flushStaleLocks(): Promise<number> {
+	const redis = getRedis();
+	const keys = await redis.keys("chat-sdk:lock:*");
+	if (keys.length === 0) return 0;
+	await redis.del(...keys);
+	return keys.length;
+}

--- a/apps/autumn/src/lib/slack.ts
+++ b/apps/autumn/src/lib/slack.ts
@@ -1,0 +1,54 @@
+import type { SlashCommandEvent } from "chat";
+
+export function getWorkspaceId(event: SlashCommandEvent): string | null {
+	return getWorkspaceIdFromRaw(event.raw);
+}
+
+export function getWorkspaceIdFromRaw(raw: unknown): string | null {
+	if (!raw || typeof raw !== "object") return null;
+	const obj = raw as Record<string, unknown>;
+
+	// In Slack Connect channels, team/team_id is the sender's workspace, but
+	// authorizations[0].team_id is the workspace where the bot is installed.
+	// Check authorizations first so we always resolve to the installing workspace.
+	if (Array.isArray(obj.authorizations) && obj.authorizations.length > 0) {
+		const auth = obj.authorizations[0] as Record<string, unknown>;
+		if (typeof auth.team_id === "string") return auth.team_id;
+	}
+
+	if (typeof obj.team_id === "string") return obj.team_id;
+
+	if (typeof obj.team === "string") return obj.team;
+	if (obj.team && typeof obj.team === "object") {
+		const team = obj.team as Record<string, unknown>;
+		if (typeof team.id === "string") return team.id;
+	}
+
+	if (typeof obj.teamId === "string") return obj.teamId;
+
+	return null;
+}
+
+type AppError = {
+	code?: string;
+	message?: string;
+	data?: { error?: string };
+};
+
+function coerceError(err: unknown): AppError {
+	if (!err || typeof err !== "object") return {};
+	return err as AppError;
+}
+
+export function isRedisUnavailable(err: unknown): boolean {
+	const e = coerceError(err);
+	return (
+		e.code === "ECONNREFUSED" ||
+		(typeof e.message === "string" && e.message.includes("ECONNREFUSED"))
+	);
+}
+
+export function isSlackNotInChannel(err: unknown): boolean {
+	const e = coerceError(err);
+	return e.code === "slack_webapi_platform_error" && e.data?.error === "not_in_channel";
+}

--- a/apps/autumn/src/routes/autumn.ts
+++ b/apps/autumn/src/routes/autumn.ts
@@ -1,0 +1,190 @@
+import { Hono } from "hono";
+import { Webhook } from "svix";
+import { bot } from "@/bot";
+import {
+	ExpiredCard,
+	NewSubscriptionCard,
+	PastDueCard,
+	PlanChangedCard,
+	SubscriptionCanceledCard,
+	SubscriptionRenewedCard,
+	TrialConvertedCard,
+	UsageAlertCard,
+} from "@/cards/alert";
+import type { WorkspaceConfig } from "@/services/workspace";
+import { getWorkspace, listWorkspaces } from "@/services/workspace";
+
+export const autumnWebhookRoutes = new Hono();
+
+type AutumnWebhookEvent = {
+	type: string;
+	data: Record<string, unknown>;
+	org_id?: string;
+};
+
+autumnWebhookRoutes.post("/", async (c) => {
+	const svixId = c.req.header("svix-id");
+	const svixTimestamp = c.req.header("svix-timestamp");
+	const svixSignature = c.req.header("svix-signature");
+
+	if (!svixId || !svixTimestamp || !svixSignature) {
+		return c.text("Missing Svix headers", 400);
+	}
+
+	const body = await c.req.text();
+	let payload: AutumnWebhookEvent;
+
+	try {
+		payload = JSON.parse(body);
+	} catch {
+		return c.text("Invalid JSON", 400);
+	}
+
+	const workspaces = await loadWorkspaces();
+	const workspace = payload.org_id
+		? workspaces.find((ws) => ws.orgSlug === payload.org_id) || null
+		: null;
+	const secret = payload.org_id
+		? workspace?.webhookSecret || null
+		: workspaces.find((ws) => ws.webhookSecret)?.webhookSecret || null;
+
+	if (secret) {
+		try {
+			const wh = new Webhook(secret);
+			wh.verify(body, {
+				"svix-id": svixId,
+				"svix-timestamp": svixTimestamp,
+				"svix-signature": svixSignature,
+			});
+		} catch (err) {
+			console.error("Webhook verification failed:", err);
+			return c.text("Webhook verification failed", 400);
+		}
+	}
+
+	try {
+		console.log(`Webhook: ${payload.type}${payload.org_id ? ` (${payload.org_id})` : ""}`);
+		await routeAutumnEvent(payload, workspace);
+		return c.text("OK", 200);
+	} catch (err) {
+		console.error("Failed to process Autumn webhook:", err);
+		return c.text("Webhook processing failed", 400);
+	}
+});
+
+async function loadWorkspaces(): Promise<WorkspaceConfig[]> {
+	const workspaceIds = await listWorkspaces();
+	const workspaces = await Promise.all(workspaceIds.map((id) => getWorkspace(id)));
+	return workspaces.filter((ws): ws is WorkspaceConfig => ws !== null);
+}
+
+async function routeAutumnEvent(
+	event: AutumnWebhookEvent,
+	workspace: WorkspaceConfig | null,
+): Promise<void> {
+	if (!workspace) {
+		console.warn(`No workspace found for Autumn event: ${event.type}`);
+		return;
+	}
+
+	if (!workspace.alertChannel) {
+		console.warn(`No alert channel configured for workspace: ${workspace.workspaceId}`);
+		return;
+	}
+
+	const card = buildAlertCard(event);
+	if (!card) {
+		console.log(`No alert card for event type: ${event.type}`);
+		return;
+	}
+
+	try {
+		const channelId = workspace.alertChannel.startsWith("slack:")
+			? workspace.alertChannel
+			: `slack:${workspace.alertChannel}`;
+		await bot.channel(channelId).post(card);
+	} catch (err) {
+		console.error(`Failed to post alert to channel ${workspace.alertChannel}:`, err);
+	}
+}
+
+function nested<T>(obj: Record<string, unknown>, key: string): T | undefined {
+	return (obj[key] as T) ?? undefined;
+}
+
+function buildAlertCard(event: AutumnWebhookEvent) {
+	const d = event.data;
+	const customer = nested<{ id?: string; name?: string }>(d, "customer");
+	const customerId = customer?.id || String(d.customer_id || "unknown");
+	const customerName = customer?.name;
+
+	switch (event.type) {
+		case "customer.products.updated": {
+			const scenario = String(d.scenario || "");
+			const updatedProduct = nested<{ name?: string; id?: string }>(d, "updated_product");
+			const previousProduct = nested<{ name?: string; id?: string }>(d, "previous_product");
+			const planName = updatedProduct?.name || updatedProduct?.id || "unknown";
+
+			switch (scenario) {
+				case "cancel":
+					return SubscriptionCanceledCard({
+						customerId,
+						customerName,
+						planName,
+						cancelsAt: d.cancels_at ? new Date(String(d.cancels_at)).getTime() : undefined,
+					});
+
+				case "upgrade":
+				case "downgrade":
+					return PlanChangedCard({
+						customerId,
+						customerName,
+						fromPlan: previousProduct?.name || previousProduct?.id || "unknown",
+						toPlan: planName,
+						direction: scenario,
+					});
+
+				case "new":
+					return NewSubscriptionCard({ customerId, customerName, planName });
+
+				case "expired":
+					return ExpiredCard({ customerId, customerName, planName });
+
+				case "past_due":
+					return PastDueCard({ customerId, customerName, planName });
+
+				case "renew":
+					return SubscriptionRenewedCard({ customerId, customerName, planName });
+
+				case "scheduled":
+					return PlanChangedCard({
+						customerId,
+						customerName,
+						fromPlan: previousProduct?.name || previousProduct?.id || "unknown",
+						toPlan: planName,
+						direction: "change",
+					});
+
+				default: {
+					if (d.was_trialing && d.status === "active") {
+						return TrialConvertedCard({ customerId, customerName, planName });
+					}
+					return null;
+				}
+			}
+		}
+
+		case "customer.threshold_reached": {
+			const feature = nested<{ id?: string }>(d, "feature");
+			return UsageAlertCard({
+				customerId,
+				customerName,
+				featureId: feature?.id || String(d.feature_id || "unknown"),
+				thresholdType: String(d.threshold_type || "percentage"),
+			});
+		}
+
+		default:
+			return null;
+	}
+}

--- a/apps/autumn/src/routes/autumn.ts
+++ b/apps/autumn/src/routes/autumn.ts
@@ -40,26 +40,34 @@ autumnWebhookRoutes.post("/", async (c) => {
 		return c.text("Invalid JSON", 400);
 	}
 
-	const workspaces = await loadWorkspaces();
-	const workspace = payload.org_id
-		? workspaces.find((ws) => ws.orgSlug === payload.org_id) || null
-		: null;
-	const secret = payload.org_id
-		? workspace?.webhookSecret || null
-		: workspaces.find((ws) => ws.webhookSecret)?.webhookSecret || null;
+	if (!payload.org_id) {
+		console.warn(`Webhook missing org_id for event type: ${payload.type}`);
+		return c.text("Missing org_id", 400);
+	}
 
-	if (secret) {
-		try {
-			const wh = new Webhook(secret);
-			wh.verify(body, {
-				"svix-id": svixId,
-				"svix-timestamp": svixTimestamp,
-				"svix-signature": svixSignature,
-			});
-		} catch (err) {
-			console.error("Webhook verification failed:", err);
-			return c.text("Webhook verification failed", 400);
-		}
+	const workspaces = await loadWorkspaces();
+	const workspace = workspaces.find((ws) => ws.orgSlug === payload.org_id) || null;
+
+	if (!workspace) {
+		console.warn(`No workspace for webhook org_id=${payload.org_id}`);
+		return c.text("OK", 200);
+	}
+
+	if (!workspace.webhookSecret) {
+		console.warn(`No webhook secret configured for org_id=${payload.org_id}`);
+		return c.text("OK", 200);
+	}
+
+	try {
+		const wh = new Webhook(workspace.webhookSecret);
+		wh.verify(body, {
+			"svix-id": svixId,
+			"svix-timestamp": svixTimestamp,
+			"svix-signature": svixSignature,
+		});
+	} catch (err) {
+		console.error("Webhook verification failed:", err);
+		return c.text("Webhook verification failed", 400);
 	}
 
 	try {

--- a/apps/autumn/src/routes/connect.ts
+++ b/apps/autumn/src/routes/connect.ts
@@ -1,6 +1,7 @@
 import * as arctic from "arctic";
 import type { Context } from "hono";
 import { Hono } from "hono";
+import { html } from "hono/html";
 import { getEnv } from "@/config";
 import { getRedis } from "@/lib/redis";
 import { getWorkspace, saveWorkspace } from "@/services/workspace";
@@ -32,7 +33,7 @@ function getClient(): arctic.OAuth2Client {
 }
 
 export function renderHtml(title: string, message: string): string {
-	return `
+	return html`
 <html>
 <head>
   <meta charset="utf-8">

--- a/apps/autumn/src/routes/connect.ts
+++ b/apps/autumn/src/routes/connect.ts
@@ -1,0 +1,194 @@
+import * as arctic from "arctic";
+import type { Context } from "hono";
+import { Hono } from "hono";
+import { getEnv } from "@/config";
+import { getRedis } from "@/lib/redis";
+import { getWorkspace, saveWorkspace } from "@/services/workspace";
+
+export const connectRoutes = new Hono();
+
+type StatePayload = {
+	workspaceId: string;
+	userId: string;
+	codeVerifier: string;
+};
+
+type ApiKeysResponse = {
+	prod_key?: string;
+	org_id?: string;
+	org_name?: string;
+	error?: string;
+};
+
+const STATE_PREFIX = "autumn:oauth:state:";
+
+function getClient(): arctic.OAuth2Client {
+	const env = getEnv();
+	return new arctic.OAuth2Client(
+		env.AUTUMN_OAUTH_CLIENT_ID,
+		env.AUTUMN_OAUTH_CLIENT_SECRET,
+		`${env.BASE_URL}/slack/callback`,
+	);
+}
+
+export function renderHtml(title: string, message: string): string {
+	return `
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+</head>
+<body style="font-family: system-ui; margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f7f7f5; color: #171717;">
+  <main style="max-width: 560px; padding: 24px; text-align: center; background: white; border: 1px solid #e7e5e4; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,.04);">
+    <h1 style="margin: 0 0 12px; font-size: 24px;">${title}</h1>
+    <p style="margin: 0; line-height: 1.5;">${message}</p>
+  </main>
+</body>
+</html>
+`;
+}
+
+connectRoutes.get("/", async (c) => {
+	const env = getEnv();
+	const workspaceId = c.req.query("workspace_id")?.trim();
+	const userId = c.req.query("user_id")?.trim();
+
+	if (!workspaceId || !userId) {
+		return c.html(
+			renderHtml(
+				"Missing Parameters",
+				"Expected workspace_id and user_id in the URL, run /connect from Slack again.",
+			),
+			400,
+		);
+	}
+
+	const client = getClient();
+	const state = arctic.generateState();
+	const codeVerifier = arctic.generateCodeVerifier();
+	const authorizeUrl = client.createAuthorizationURLWithPKCE(
+		`${env.AUTUMN_BACKEND_URL}/api/auth/oauth2/authorize`,
+		state,
+		arctic.CodeChallengeMethod.S256,
+		codeVerifier,
+		[],
+	);
+	authorizeUrl.searchParams.set("prompt", "consent");
+
+	const payload: StatePayload = { workspaceId, userId, codeVerifier };
+	await getRedis().setex(`${STATE_PREFIX}${state}`, 10 * 60, JSON.stringify(payload));
+
+	return c.redirect(authorizeUrl.toString());
+});
+
+export async function handleAutumnOAuthCallback(c: Context) {
+	const env = getEnv();
+	const code = c.req.query("code");
+	const state = c.req.query("state");
+	const oauthError = c.req.query("error");
+	const errorDesc = c.req.query("error_description");
+
+	if (oauthError) {
+		return c.html(renderHtml("Authorization Failed", errorDesc || oauthError), 400);
+	}
+
+	if (!code || !state) {
+		return c.html(
+			renderHtml("Invalid Callback", "Missing code or state, run /connect again."),
+			400,
+		);
+	}
+
+	const redis = getRedis();
+	const raw = await redis.get(`${STATE_PREFIX}${state}`);
+	await redis.del(`${STATE_PREFIX}${state}`);
+
+	if (!raw) {
+		return c.html(renderHtml("Session Expired", "This session expired, run /connect again."), 400);
+	}
+
+	let payload: StatePayload;
+	try {
+		payload = JSON.parse(raw) as StatePayload;
+	} catch {
+		return c.html(
+			renderHtml("Invalid Session", "Could not read the session, run /connect again."),
+			400,
+		);
+	}
+
+	try {
+		const client = getClient();
+		const tokens = await client.validateAuthorizationCode(
+			`${env.AUTUMN_BACKEND_URL}/api/auth/oauth2/token`,
+			code,
+			payload.codeVerifier,
+		);
+
+		const apiKeysRes = await fetch(`${env.AUTUMN_BACKEND_URL}/cli/api-keys`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${tokens.accessToken()}`,
+				"Content-Type": "application/json",
+			},
+		});
+
+		if (!apiKeysRes.ok) {
+			const err = (await apiKeysRes.json().catch(() => ({}))) as ApiKeysResponse;
+			return c.html(
+				renderHtml(
+					"Key Provisioning Failed",
+					err.error || "OAuth succeeded but key provisioning failed.",
+				),
+				400,
+			);
+		}
+
+		const apiKeys = (await apiKeysRes.json()) as ApiKeysResponse;
+
+		if (!apiKeys.prod_key || !apiKeys.org_id) {
+			return c.html(
+				renderHtml("Incomplete Response", "Autumn returned an incomplete key payload, try again."),
+				400,
+			);
+		}
+
+		const existing = await getWorkspace(payload.workspaceId);
+		const orgName = apiKeys.org_name || existing?.orgName || apiKeys.org_id;
+
+		await saveWorkspace({
+			workspaceId: payload.workspaceId,
+			apiKey: apiKeys.prod_key,
+			orgSlug: apiKeys.org_id,
+			orgName,
+			commandChannels: existing?.commandChannels || [],
+			alertChannel: existing?.alertChannel || null,
+			slackBotToken: existing?.slackBotToken || null,
+			webhookSecret: existing?.webhookSecret || null,
+			installedAt: existing?.installedAt || Date.now(),
+			installedBotUserId: existing?.installedBotUserId || null,
+			connectedByUserId: payload.userId,
+		});
+
+		console.log(`Workspace connected: ${orgName}`);
+
+		return c.html(
+			renderHtml(
+				"Autumn Connected",
+				"Autumn is now connected, return to Slack and mention @Autumn to get started.",
+			),
+			200,
+		);
+	} catch (err) {
+		if (err instanceof arctic.OAuth2RequestError) {
+			console.error(`Autumn OAuth failed: ${err.code}`);
+			return c.html(renderHtml("Authorization Failed", `OAuth error: ${err.code}`), 400);
+		}
+		console.error("Autumn OAuth failed:", err);
+		return c.html(
+			renderHtml("Connection Failed", "Something went wrong connecting to Autumn, try again."),
+			500,
+		);
+	}
+}

--- a/apps/autumn/src/routes/install.ts
+++ b/apps/autumn/src/routes/install.ts
@@ -1,0 +1,86 @@
+import { Hono } from "hono";
+import { slackAdapter } from "@/bot";
+import { getEnv } from "@/config";
+import { handleAutumnOAuthCallback, renderHtml } from "@/routes/connect";
+import { getWorkspace, saveWorkspace } from "@/services/workspace";
+
+export const installRoutes = new Hono();
+
+installRoutes.get("/slack", (c) => {
+	const env = getEnv();
+	const clientId = env.SLACK_CLIENT_ID;
+
+	if (!clientId) {
+		return c.text("SLACK_CLIENT_ID not configured", 500);
+	}
+
+	const scopes = [
+		// Messaging
+		"chat:write",
+		"commands",
+		// Assistant
+		"assistant:write",
+		// Channel access
+		"app_mentions:read",
+		"channels:history",
+		"channels:read",
+		"groups:history",
+		"groups:read",
+		// DMs
+		"im:history",
+		"im:read",
+		"im:write",
+		"mpim:history",
+		"mpim:read",
+		// Users
+		"users:read",
+	].join(",");
+
+	const url = `https://slack.com/oauth/v2/authorize?client_id=${clientId}&scope=${scopes}`;
+
+	return c.redirect(url);
+});
+
+installRoutes.get("/slack/callback", async (c) => {
+	if (c.req.query("state")) {
+		return handleAutumnOAuthCallback(c);
+	}
+
+	try {
+		const { teamId, installation } = await slackAdapter.handleOAuthCallback(c.req.raw);
+
+		const existing = await getWorkspace(teamId);
+		await saveWorkspace({
+			workspaceId: teamId,
+			apiKey: existing?.apiKey || null,
+			orgSlug: existing?.orgSlug || "",
+			orgName: existing?.orgName || installation.teamName || "",
+			commandChannels: existing?.commandChannels || [],
+			alertChannel: existing?.alertChannel || null,
+			slackBotToken: installation.botToken || null,
+			webhookSecret: existing?.webhookSecret || null,
+			installedAt: existing?.installedAt || Date.now(),
+			installedBotUserId: installation.botUserId || existing?.installedBotUserId || null,
+			connectedByUserId: existing?.connectedByUserId || null,
+		});
+
+		console.log(`Slack bot installed: ${installation.teamName} (${teamId})`);
+
+		return c.html(
+			renderHtml("Autumn installed!", "Head back to Slack and run /connect to finish setup."),
+		);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		const isInvalidCode = message.includes("invalid_code");
+		console.error(`Slack OAuth failed: ${isInvalidCode ? "invalid_code" : message}`);
+		return c.html(
+			renderHtml(
+				"Installation failed",
+				isInvalidCode
+					? "The authorization code expired or was already used, try installing again."
+					: "Something went wrong during installation, try again from /slack.",
+			),
+			400,
+		);
+	}
+});

--- a/apps/autumn/src/routes/webhooks.ts
+++ b/apps/autumn/src/routes/webhooks.ts
@@ -1,0 +1,76 @@
+import type { Context } from "hono";
+import { Hono } from "hono";
+import { bot } from "@/bot";
+import { getRedis } from "@/lib/redis";
+import { isRedisUnavailable } from "@/lib/slack";
+
+type Platform = keyof typeof bot.webhooks;
+
+export const webhookRoutes = new Hono();
+
+let redisHealthCache: { ok: boolean; expiresAt: number } | null = null;
+let lastRedisWarningAt = 0;
+
+async function isRedisAvailable(): Promise<boolean> {
+	const now = Date.now();
+	if (redisHealthCache && redisHealthCache.expiresAt > now) {
+		return redisHealthCache.ok;
+	}
+
+	let ok = false;
+	try {
+		ok = (await getRedis().ping()) === "PONG";
+	} catch {
+		ok = false;
+	}
+
+	redisHealthCache = {
+		ok,
+		expiresAt: now + (ok ? 5000 : 1500),
+	};
+
+	return ok;
+}
+
+function redisUnavailableResponse(c: Context) {
+	return c.json(
+		{
+			response_type: "ephemeral",
+			text: "Autumn is temporarily unavailable because Redis is offline, so please retry in a minute.",
+		},
+		200,
+	);
+}
+
+webhookRoutes.post("/:platform", async (c) => {
+	const platform = c.req.param("platform") as Platform;
+
+	if (!(await isRedisAvailable())) {
+		if (Date.now() - lastRedisWarningAt > 10_000) {
+			lastRedisWarningAt = Date.now();
+			console.warn("Redis is offline; returning graceful Slack response.");
+		}
+		return redisUnavailableResponse(c);
+	}
+
+	const handler = bot.webhooks[platform];
+	if (!handler) {
+		return c.text(`Unknown platform: ${platform}`, 404);
+	}
+
+	try {
+		return await handler(c.req.raw, {
+			waitUntil: (task) => {
+				task.catch(console.error);
+			},
+		});
+	} catch (err) {
+		console.error("Webhook handler error:", err);
+
+		if (isRedisUnavailable(err)) {
+			return redisUnavailableResponse(c);
+		}
+
+		return c.text("ok", 200);
+	}
+});

--- a/apps/autumn/src/services/autumn.ts
+++ b/apps/autumn/src/services/autumn.ts
@@ -1,0 +1,7 @@
+import { Autumn } from "autumn-js";
+import type { WorkspaceConfig } from "@/services/workspace";
+
+export function createAutumnClient(workspace: WorkspaceConfig): Autumn {
+	if (!workspace.apiKey) throw new Error("No API key configured");
+	return new Autumn({ secretKey: workspace.apiKey });
+}

--- a/apps/autumn/src/services/encryption.ts
+++ b/apps/autumn/src/services/encryption.ts
@@ -1,0 +1,78 @@
+const ALGORITHM = "AES-GCM";
+const IV_LENGTH = 12;
+const TAG_LENGTH = 128;
+const HEX_RE = /^[0-9a-f]+$/i;
+
+async function getKey(encryptionKey: string): Promise<CryptoKey> {
+	const keyBytes = hexToBytes(encryptionKey, "encryption key");
+	if (keyBytes.length !== 16 && keyBytes.length !== 24 && keyBytes.length !== 32) {
+		throw new Error("ENCRYPTION_KEY must be 32, 48, or 64 hex characters");
+	}
+
+	return crypto.subtle.importKey(
+		"raw",
+		keyBytes as BufferSource,
+		{ name: ALGORITHM },
+		false,
+		["encrypt", "decrypt"],
+	);
+}
+
+function hexToBytes(hex: string, label: string): Uint8Array {
+	const normalized = hex.trim();
+	if (normalized.length === 0 || normalized.length % 2 !== 0 || !HEX_RE.test(normalized)) {
+		throw new Error(`Invalid ${label} hex`);
+	}
+
+	const bytes = new Uint8Array(normalized.length / 2);
+	for (let i = 0; i < normalized.length; i += 2) {
+		bytes[i / 2] = Number.parseInt(normalized.substring(i, i + 2), 16);
+	}
+	return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+	return Array.from(bytes)
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+export async function encrypt(plaintext: string, encryptionKey: string): Promise<string> {
+	const key = await getKey(encryptionKey);
+	const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+	const encoded = new TextEncoder().encode(plaintext);
+
+	const ciphertext = await crypto.subtle.encrypt(
+		{ name: ALGORITHM, iv, tagLength: TAG_LENGTH },
+		key,
+		encoded,
+	);
+
+	const ivHex = bytesToHex(iv);
+	const ctHex = bytesToHex(new Uint8Array(ciphertext));
+	return `${ivHex}:${ctHex}`;
+}
+
+export async function decrypt(encrypted: string, encryptionKey: string): Promise<string> {
+	const key = await getKey(encryptionKey);
+	const parts = encrypted.split(":");
+	if (parts.length !== 2) {
+		throw new Error("Invalid encrypted payload format");
+	}
+
+	const [ivHex, ctHex] = parts;
+	const iv = hexToBytes(ivHex, "iv");
+	if (iv.length !== IV_LENGTH) {
+		throw new Error("Invalid iv length");
+	}
+
+	const ciphertext = hexToBytes(ctHex, "ciphertext");
+
+	const plaintext = await crypto.subtle.decrypt(
+		{ name: ALGORITHM, iv: iv as BufferSource, tagLength: TAG_LENGTH },
+		key,
+		ciphertext as BufferSource,
+	);
+
+	return new TextDecoder().decode(plaintext);
+}

--- a/apps/autumn/src/services/renewals.ts
+++ b/apps/autumn/src/services/renewals.ts
@@ -1,0 +1,46 @@
+import type { Autumn } from "autumn-js";
+import { parseDuration } from "@/utils/formatters";
+
+export type RenewalEntry = {
+	customerId: string;
+	customerName?: string;
+	planName: string;
+	planId: string;
+	renewsAt: number;
+};
+
+export async function findUpcomingRenewals(
+	autumn: Autumn,
+	period: string,
+): Promise<{ renewals: RenewalEntry[]; error?: string }> {
+	const durationMs = parseDuration(period);
+	if (!durationMs) return { renewals: [], error: `Invalid period: ${period}` };
+
+	const result = await autumn.customers.list({ limit: 100 });
+
+	const now = Date.now();
+	const cutoff = now + durationMs;
+	const renewals: RenewalEntry[] = [];
+
+	for (const customer of result.list) {
+		for (const sub of customer.subscriptions) {
+			const periodEnd = sub.currentPeriodEnd;
+			if (!periodEnd) continue;
+
+			const renewsAt = typeof periodEnd === "number" ? periodEnd : new Date(periodEnd).getTime();
+
+			if (renewsAt > now && renewsAt <= cutoff) {
+				renewals.push({
+					customerId: customer.id ?? "",
+					customerName: customer.name || undefined,
+					planName: sub.plan?.name || sub.planId || "Unknown",
+					planId: sub.planId || "",
+					renewsAt,
+				});
+			}
+		}
+	}
+
+	renewals.sort((a, b) => a.renewsAt - b.renewsAt);
+	return { renewals };
+}

--- a/apps/autumn/src/services/renewals.ts
+++ b/apps/autumn/src/services/renewals.ts
@@ -16,29 +16,36 @@ export async function findUpcomingRenewals(
 	const durationMs = parseDuration(period);
 	if (!durationMs) return { renewals: [], error: `Invalid period: ${period}` };
 
-	const result = await autumn.customers.list({ limit: 100 });
-
 	const now = Date.now();
 	const cutoff = now + durationMs;
 	const renewals: RenewalEntry[] = [];
+	const limit = 100;
+	let offset = 0;
 
-	for (const customer of result.list) {
-		for (const sub of customer.subscriptions) {
-			const periodEnd = sub.currentPeriodEnd;
-			if (!periodEnd) continue;
+	while (true) {
+		const result = await autumn.customers.list({ limit, offset });
 
-			const renewsAt = typeof periodEnd === "number" ? periodEnd : new Date(periodEnd).getTime();
+		for (const customer of result.list) {
+			for (const sub of customer.subscriptions) {
+				const periodEnd = sub.currentPeriodEnd;
+				if (!periodEnd) continue;
 
-			if (renewsAt > now && renewsAt <= cutoff) {
-				renewals.push({
-					customerId: customer.id ?? "",
-					customerName: customer.name || undefined,
-					planName: sub.plan?.name || sub.planId || "Unknown",
-					planId: sub.planId || "",
-					renewsAt,
-				});
+				const renewsAt = typeof periodEnd === "number" ? periodEnd : new Date(periodEnd).getTime();
+
+				if (renewsAt > now && renewsAt <= cutoff) {
+					renewals.push({
+						customerId: customer.id ?? "",
+						customerName: customer.name || undefined,
+						planName: sub.plan?.name || sub.planId || "Unknown",
+						planId: sub.planId || "",
+						renewsAt,
+					});
+				}
 			}
 		}
+
+		if (result.list.length < limit) break;
+		offset += result.list.length;
 	}
 
 	renewals.sort((a, b) => a.renewsAt - b.renewsAt);

--- a/apps/autumn/src/services/workspace.ts
+++ b/apps/autumn/src/services/workspace.ts
@@ -1,0 +1,84 @@
+import { getEnv } from "@/config";
+import { getRedis } from "@/lib/redis";
+import { decrypt, encrypt } from "@/services/encryption";
+
+export type WorkspaceConfig = {
+	workspaceId: string;
+	apiKey: string | null;
+	orgSlug: string;
+	orgName: string;
+	commandChannels: string[];
+	alertChannel: string | null;
+	slackBotToken: string | null;
+	webhookSecret: string | null;
+	installedAt: number;
+	installedBotUserId: string | null;
+	connectedByUserId: string | null;
+};
+
+const KEY_PREFIX = "autumn:workspace:";
+const ENCRYPTED_PATTERN = /^[0-9a-f]{24}:[0-9a-f]+$/;
+
+function isEncrypted(value: string): boolean {
+	return ENCRYPTED_PATTERN.test(value);
+}
+
+export async function getWorkspace(workspaceId: string): Promise<WorkspaceConfig | null> {
+	const redis = getRedis();
+	const data = await redis.get(`${KEY_PREFIX}${workspaceId}`);
+	if (!data) return null;
+
+	const workspace = JSON.parse(data) as WorkspaceConfig;
+	const encKey = getEnv().ENCRYPTION_KEY;
+
+	if (workspace.apiKey) {
+		workspace.apiKey = await decrypt(workspace.apiKey, encKey);
+	}
+	if (workspace.slackBotToken) {
+		workspace.slackBotToken = isEncrypted(workspace.slackBotToken)
+			? await decrypt(workspace.slackBotToken, encKey)
+			: workspace.slackBotToken;
+	}
+	if (workspace.webhookSecret) {
+		workspace.webhookSecret = await decrypt(workspace.webhookSecret, encKey);
+	}
+
+	return workspace;
+}
+
+export async function saveWorkspace(workspace: WorkspaceConfig): Promise<void> {
+	const redis = getRedis();
+	const encKey = getEnv().ENCRYPTION_KEY;
+
+	const toStore: WorkspaceConfig = {
+		...workspace,
+		apiKey: workspace.apiKey ? await encrypt(workspace.apiKey, encKey) : null,
+		slackBotToken: workspace.slackBotToken ? await encrypt(workspace.slackBotToken, encKey) : null,
+		webhookSecret: workspace.webhookSecret ? await encrypt(workspace.webhookSecret, encKey) : null,
+	};
+
+	await redis.set(`${KEY_PREFIX}${workspace.workspaceId}`, JSON.stringify(toStore));
+}
+
+export async function updateWorkspace(
+	workspaceId: string,
+	updates: Partial<Pick<WorkspaceConfig, "commandChannels" | "alertChannel">>,
+): Promise<void> {
+	const workspace = await getWorkspace(workspaceId);
+	if (!workspace) throw new Error(`Workspace ${workspaceId} not found`);
+
+	const updated = { ...workspace, ...updates };
+
+	await saveWorkspace(updated);
+}
+
+export async function deleteWorkspace(workspaceId: string): Promise<void> {
+	const redis = getRedis();
+	await redis.del(`${KEY_PREFIX}${workspaceId}`);
+}
+
+export async function listWorkspaces(): Promise<string[]> {
+	const redis = getRedis();
+	const keys = await redis.keys(`${KEY_PREFIX}*`);
+	return keys.map((k) => k.replace(KEY_PREFIX, ""));
+}

--- a/apps/autumn/src/services/workspace.ts
+++ b/apps/autumn/src/services/workspace.ts
@@ -32,7 +32,9 @@ export async function getWorkspace(workspaceId: string): Promise<WorkspaceConfig
 	const encKey = getEnv().ENCRYPTION_KEY;
 
 	if (workspace.apiKey) {
-		workspace.apiKey = await decrypt(workspace.apiKey, encKey);
+		workspace.apiKey = isEncrypted(workspace.apiKey)
+			? await decrypt(workspace.apiKey, encKey)
+			: workspace.apiKey;
 	}
 	if (workspace.slackBotToken) {
 		workspace.slackBotToken = isEncrypted(workspace.slackBotToken)
@@ -40,7 +42,9 @@ export async function getWorkspace(workspaceId: string): Promise<WorkspaceConfig
 			: workspace.slackBotToken;
 	}
 	if (workspace.webhookSecret) {
-		workspace.webhookSecret = await decrypt(workspace.webhookSecret, encKey);
+		workspace.webhookSecret = isEncrypted(workspace.webhookSecret)
+			? await decrypt(workspace.webhookSecret, encKey)
+			: workspace.webhookSecret;
 	}
 
 	return workspace;
@@ -79,6 +83,16 @@ export async function deleteWorkspace(workspaceId: string): Promise<void> {
 
 export async function listWorkspaces(): Promise<string[]> {
 	const redis = getRedis();
-	const keys = await redis.keys(`${KEY_PREFIX}*`);
-	return keys.map((k) => k.replace(KEY_PREFIX, ""));
+	const ids = new Set<string>();
+	let cursor = "0";
+
+	do {
+		const [next, keys] = await redis.scan(cursor, "MATCH", `${KEY_PREFIX}*`, "COUNT", 100);
+		cursor = next;
+		for (const key of keys) {
+			ids.add(key.replace(KEY_PREFIX, ""));
+		}
+	} while (cursor !== "0");
+
+	return [...ids];
 }

--- a/apps/autumn/src/utils/formatters.ts
+++ b/apps/autumn/src/utils/formatters.ts
@@ -1,0 +1,24 @@
+const NUMBER_FORMATTER = new Intl.NumberFormat("en-US");
+
+export function formatNumber(n: number): string {
+	return NUMBER_FORMATTER.format(n);
+}
+
+const DURATION_MS = {
+	h: 3_600_000,
+	d: 86_400_000,
+	w: 604_800_000,
+	m: 2_592_000_000,
+} as const;
+
+const DURATION_RE = /^(\d+)\s*([hdwm])$/i;
+
+export function parseDuration(input: string): number | null {
+	const match = DURATION_RE.exec(input.trim());
+	if (!match) return null;
+
+	const value = Number.parseInt(match[1], 10);
+	const unit = match[2].toLowerCase() as keyof typeof DURATION_MS;
+	const multiplier = DURATION_MS[unit];
+	return multiplier ? value * multiplier : null;
+}

--- a/apps/autumn/tsconfig.json
+++ b/apps/autumn/tsconfig.json
@@ -1,0 +1,24 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"skipLibCheck": true,
+		"strict": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "dist",
+		"rootDir": "src",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"]
+		},
+		"types": ["bun"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "autumn",
@@ -24,6 +25,28 @@
         "husky": "^9.1.7",
         "inquirer": "^12.10.0",
         "ts-to-zod": "^5.1.0",
+      },
+    },
+    "apps/autumn": {
+      "name": "autumn-slack",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.71.1",
+        "@chat-adapter/slack": "^4.14.0",
+        "@chat-adapter/state-redis": "^4.14.0",
+        "arctic": "^3.7.0",
+        "autumn-js": "workspace:*",
+        "chat": "^4.14.0",
+        "hono": "4.12.7",
+        "ioredis": "^5.5.0",
+        "svix": "^1.45.1",
+        "zod": "^3",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.7",
+        "@types/bun": "^1.3.3",
+        "@typescript/native-preview": "catalog:",
+        "typescript": "~5.9.3",
       },
     },
     "apps/checkout": {
@@ -900,6 +923,12 @@
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
+    "@chat-adapter/shared": ["@chat-adapter/shared@4.26.0", "", { "dependencies": { "chat": "4.26.0" } }, "sha512-YD0MGktFXrArUqTBsyPfL5vkdD1WBS58PAWO0oVrMQAMmPxpAXfWGjBtZCkf3y8R8Svb0uVuVXiMZSForaEnMQ=="],
+
+    "@chat-adapter/slack": ["@chat-adapter/slack@4.26.0", "", { "dependencies": { "@chat-adapter/shared": "4.26.0", "@slack/web-api": "^7.14.0", "chat": "4.26.0" } }, "sha512-NNN47rURI6qpJf4rRK8xyeumjPTAXr7YSU4/FnViU8cFV/vKYFR4xZTzlFMVWNrYi9SmSwasUjcBmQznigK54Q=="],
+
+    "@chat-adapter/state-redis": ["@chat-adapter/state-redis@4.26.0", "", { "dependencies": { "chat": "4.26.0", "redis": "^5.11.0" } }, "sha512-NSX2E6wkDlg0AMfKFx4LPoV6cBHolL08Ht3cT+S01jss24t9GzlDw/BUsrWOeoTElwEhxZcQw5bUkStUAA7JMg=="],
+
     "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@10.5.0", "", { "dependencies": { "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "lodash": "4.17.21" } }, "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw=="],
 
     "@chevrotain/gast": ["@chevrotain/gast@10.5.0", "", { "dependencies": { "@chevrotain/types": "10.5.0", "lodash": "4.17.21" } }, "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A=="],
@@ -1636,6 +1665,16 @@
 
     "@react-email/text": ["@react-email/text@0.1.5", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg=="],
 
+    "@redis/bloom": ["@redis/bloom@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA=="],
+
+    "@redis/client": ["@redis/client@5.12.1", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA=="],
+
+    "@redis/json": ["@redis/json@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg=="],
+
+    "@redis/search": ["@redis/search@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w=="],
+
+    "@redis/time-series": ["@redis/time-series@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ=="],
+
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
@@ -1775,6 +1814,12 @@
     "@sindresorhus/transliterate": ["@sindresorhus/transliterate@1.6.0", "", { "dependencies": { "escape-string-regexp": "^5.0.0" } }, "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ=="],
 
     "@sindresorhus/tsconfig": ["@sindresorhus/tsconfig@3.0.1", "", {}, "sha512-0/gtPNTY3++0J2BZM5nHHULg0BIMw886gqdn8vWN+Av6bgF5ZU2qIcHubAn+Z9KNvJhO8WFE+9kDOU3n6OcKtA=="],
+
+    "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
+
+    "@slack/types": ["@slack/types@2.20.1", "", {}, "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A=="],
+
+    "@slack/web-api": ["@slack/web-api@7.15.1", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.15.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@3.1.9", "", { "dependencies": { "@smithy/types": "^3.7.2", "tslib": "^2.6.2" } }, "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw=="],
 
@@ -2316,6 +2361,8 @@
 
     "@wooorm/starry-night": ["@wooorm/starry-night@3.9.0", "", { "dependencies": { "@types/hast": "^3.0.0", "import-meta-resolve": "^4.0.0", "vscode-oniguruma": "^2.0.0", "vscode-textmate": "^9.0.0" } }, "sha512-LXVGKfYhTuFhoRuPAHz2XolS/J45L4lI/lCSIBugDpklXYDUPrJyA8tk17u7G32fcFaGODJXH/YDwQDfUXdPRw=="],
 
+    "@workflow/serde": ["@workflow/serde@4.1.0-beta.2", "", {}, "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww=="],
+
     "@xtuc/ieee754": ["@xtuc/ieee754@1.2.0", "", {}, "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="],
 
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="],
@@ -2474,6 +2521,8 @@
 
     "autumn-js": ["autumn-js@workspace:packages/autumn-js"],
 
+    "autumn-slack": ["autumn-slack@workspace:apps/autumn"],
+
     "ava": ["ava@5.3.1", "", { "dependencies": { "acorn": "^8.8.2", "acorn-walk": "^8.2.0", "ansi-styles": "^6.2.1", "arrgv": "^1.0.2", "arrify": "^3.0.0", "callsites": "^4.0.0", "cbor": "^8.1.0", "chalk": "^5.2.0", "chokidar": "^3.5.3", "chunkd": "^2.0.1", "ci-info": "^3.8.0", "ci-parallel-vars": "^1.0.1", "clean-yaml-object": "^0.1.0", "cli-truncate": "^3.1.0", "code-excerpt": "^4.0.0", "common-path-prefix": "^3.0.0", "concordance": "^5.0.4", "currently-unhandled": "^0.4.1", "debug": "^4.3.4", "emittery": "^1.0.1", "figures": "^5.0.0", "globby": "^13.1.4", "ignore-by-default": "^2.1.0", "indent-string": "^5.0.0", "is-error": "^2.2.2", "is-plain-object": "^5.0.0", "is-promise": "^4.0.0", "matcher": "^5.0.0", "mem": "^9.0.2", "ms": "^2.1.3", "p-event": "^5.0.1", "p-map": "^5.5.0", "picomatch": "^2.3.1", "pkg-conf": "^4.0.0", "plur": "^5.1.0", "pretty-ms": "^8.0.0", "resolve-cwd": "^3.0.0", "stack-utils": "^2.0.6", "strip-ansi": "^7.0.1", "supertap": "^3.0.1", "temp-dir": "^3.0.0", "write-file-atomic": "^5.0.1", "yargs": "^17.7.2" }, "peerDependencies": { "@ava/typescript": "*" }, "optionalPeers": ["@ava/typescript"], "bin": { "ava": "entrypoints/cli.mjs" } }, "sha512-Scv9a4gMOXB6+ni4toLuhAm9KYWEjsgBglJl+kMGI5+IVDt120CCDZyB5HNU9DjmLI2t4I0GbnxGLmmRfGTJGg=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
@@ -2613,6 +2662,8 @@
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
     "charset": ["charset@1.0.1", "", {}, "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg=="],
+
+    "chat": ["chat@4.26.0", "", { "dependencies": { "@workflow/serde": "4.1.0-beta.2", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "remend": "^1.2.1", "unified": "^11.0.5" } }, "sha512-QToDnIEGpyb8yQA6YLMHOSRK30YVk4RtsyFyuWFYyB2c4jQlyIrSWtwVK7qyvmvqzQp9uDwCdJRAhS8GtCHAGQ=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
@@ -3630,6 +3681,8 @@
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
+
     "is-error": ["is-error@2.2.2", "", {}, "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
@@ -4612,6 +4665,8 @@
 
     "redent": ["redent@4.0.0", "", { "dependencies": { "indent-string": "^5.0.0", "strip-indent": "^4.0.0" } }, "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag=="],
 
+    "redis": ["redis@5.12.1", "", { "dependencies": { "@redis/bloom": "5.12.1", "@redis/client": "5.12.1", "@redis/json": "5.12.1", "@redis/search": "5.12.1", "@redis/time-series": "5.12.1" } }, "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g=="],
+
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
 
     "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
@@ -5444,13 +5499,7 @@
 
     "@asyncapi/parser/node-fetch": ["node-fetch@2.6.7", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ=="],
 
-    "@autumn/openapi/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
-
     "@autumn/openapi/dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
-
-    "@autumn/scripts/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
-
-    "@autumn/server/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@autumn/server/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
@@ -5461,8 +5510,6 @@
     "@autumn/server/ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
 
     "@autumn/shared/@date-fns/utc": ["@date-fns/utc@2.1.0", "", {}, "sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA=="],
-
-    "@autumn/shared/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@autumn/vite/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
@@ -6144,6 +6191,12 @@
 
     "@sentry/react/@sentry/core": ["@sentry/core@10.48.0", "", {}, "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g=="],
 
+    "@slack/logger/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@slack/web-api/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@slack/web-api/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
     "@smithy/abort-controller/@smithy/types": ["@smithy/types@3.7.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg=="],
 
     "@smithy/middleware-compression/fflate": ["fflate@0.8.1", "", {}, "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ=="],
@@ -6312,8 +6365,6 @@
 
     "atmn/@tanstack/react-query": ["@tanstack/react-query@5.97.0", "", { "dependencies": { "@tanstack/query-core": "5.97.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ=="],
 
-    "atmn/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
-
     "atmn/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "atmn/@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260410.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260410.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260410.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260410.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260410.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260410.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260410.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260410.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-K3TIwBw4XGQM33wW8KUqRU7r6ZY1IqB8chk1u1kT+CDj4iu+eQ6jCXgU7EDxmpJ++gbNcIf8iBYgWgYNssrhZQ=="],
@@ -6328,8 +6379,6 @@
 
     "atmn/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "atmn-tests/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
-
     "autumn-js/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "autumn-js/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
@@ -6337,6 +6386,8 @@
     "autumn-js/react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "autumn-js/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "autumn-slack/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
 
     "ava/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -6382,9 +6433,9 @@
 
     "camelcase-keys/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
-    "checkout/@tanstack/react-query": ["@tanstack/react-query@5.97.0", "", { "dependencies": { "@tanstack/query-core": "5.97.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ=="],
+    "chat/remend": ["remend@1.3.0", "", {}, "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="],
 
-    "checkout/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "checkout/@tanstack/react-query": ["@tanstack/react-query@5.97.0", "", { "dependencies": { "@tanstack/query-core": "5.97.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ=="],
 
     "checkout/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -7036,12 +7087,6 @@
 
     "@asyncapi/parser/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "@autumn/openapi/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
-    "@autumn/scripts/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
-    "@autumn/server/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
     "@autumn/server/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@autumn/server/@typescript/native-preview/@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260410.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bpLYm6woXd8BECzV9AQvPqISVeohpekK1qwpRopvNIxydhRQ4fEjZsS7EtDYpqHAW4/u1uEv07P9/iS6TAL1fQ=="],
@@ -7079,8 +7124,6 @@
     "@autumn/server/ink/type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
     "@autumn/server/ink/widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
-
-    "@autumn/shared/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@autumn/vite/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -7726,6 +7769,10 @@
 
     "@sentry/node/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
+    "@slack/logger/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@slack/web-api/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
     "@stoplight/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@stoplight/spectral-core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -7910,11 +7957,7 @@
 
     "artillery/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
-    "atmn-tests/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
     "atmn/@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.97.0", "", {}, "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg=="],
-
-    "atmn/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "atmn/@typescript/native-preview/@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260410.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bpLYm6woXd8BECzV9AQvPqISVeohpekK1qwpRopvNIxydhRQ4fEjZsS7EtDYpqHAW4/u1uEv07P9/iS6TAL1fQ=="],
 
@@ -7979,8 +8022,6 @@
     "c12/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "checkout/@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.97.0", "", {}, "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg=="],
-
-    "checkout/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "checkout/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -8458,15 +8499,9 @@
 
     "@artilleryio/int-core/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
-    "@autumn/openapi/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
-
-    "@autumn/scripts/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
-
     "@autumn/server/ink/@alcalzone/ansi-tokenize/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "@autumn/server/ink/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
-
-    "@autumn/shared/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
@@ -8958,10 +8993,6 @@
 
     "artillery/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "atmn-tests/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
-
-    "atmn/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
-
     "atmn/eslint-plugin-react-hooks/eslint/@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
 
     "atmn/eslint-plugin-react-hooks/eslint/@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
@@ -8993,8 +9024,6 @@
     "atmn/ink/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "ava/cli-truncate/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "checkout/@types/bun/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -9129,12 +9158,6 @@
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@artilleryio/int-core/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "@autumn/openapi/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "@autumn/scripts/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "@autumn/shared/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@aws-sdk/client-sso-oidc/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-http/@smithy/util-stream/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@4.1.3", "", { "dependencies": { "@smithy/protocol-http": "^4.1.8", "@smithy/querystring-builder": "^3.0.11", "@smithy/types": "^3.7.2", "@smithy/util-base64": "^3.0.0", "tslib": "^2.6.2" } }, "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA=="],
 
@@ -9282,10 +9305,6 @@
 
     "artillery/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
-    "atmn-tests/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "atmn/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
     "atmn/eslint-plugin-react-hooks/eslint/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "atmn/eslint-plugin-react-hooks/eslint/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -9299,8 +9318,6 @@
     "atmn/eslint-plugin-react-hooks/eslint/minimatch/brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
 
     "atmn/eslint-plugin-react-hooks/eslint/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "checkout/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "find-cache-dir/pkg-dir/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 			"shared",
 			"vite",
 			"scripts",
+			"apps/autumn",
 			"apps/checkout",
 			"apps/docs",
 			"apps/sdk-test",


### PR DESCRIPTION
## Summary
Adds the autumn slack app under apps/autumn and aligns setup docs and package wiring to monorepo conventions while removing app level Docker and duplicate license files

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Autumn Slack app under apps/autumn. Teams can manage billing in Slack with a tool-using agent, secure OAuth, Redis-backed state, and real-time alerts.

- **New Features**
  - Slack bot using `chat` and `@chat-adapter/slack` with App Home, mentions, and slash commands.
  - Agent with tools and guarded mutations (confirm/cancel cards), powered by `@anthropic-ai/sdk`.
  - Install + OAuth: Slack auth and Autumn OAuth (`/slack`, `/connect`, callback), with encrypted workspace storage in Redis.
  - Webhooks: Slack events (`/webhooks/slack`) and Autumn alerts (`/autumn/webhooks`) verified via `svix`, with alert cards.
  - Health: Redis availability checks and stale lock cleanup; workspace helpers and formatting utils.
  - Project setup: `apps/autumn` package, `.env.example`, `manifest.yaml`, setup script; aligned to monorepo (no per-app Docker or duplicate licenses).

- **Migration**
  - From repo root: `bun install`; then `cd apps/autumn && bun setup`.
  - Fill `.env`: `REDIS_URL`, Slack vars, `ENCRYPTION_KEY`, `AUTUMN_*`, `ANTHROPIC_API_KEY`.
  - Start services via repo Docker Compose; run `bun dev` in `apps/autumn`; expose port 3000.
  - Install Slack app with `manifest.yaml` or visit `/slack`; run `/connect` to link Autumn.
  - Configure webhooks: Slack → `/webhooks/slack`, Autumn → `/autumn/webhooks`.

<sup>Written for commit 62e2d66c2fa44b09d8f95d3c1640045fb4e50001. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

