### PR TITLE
Fix invoice refund status when credits applied

### DIFF
--- a/server/src/internal/invoices/InvoiceService.ts
+++ b/server/src/internal/invoices/InvoiceService.ts
@@ -216,6 +216,11 @@ export class InvoiceService {
 			currency: stripeInvoice.currency,
 		});
 
+		const atmnAmountPaid = stripeToAtmnAmount({
+			amount: stripeInvoice.amount_paid,
+			currency: stripeInvoice.currency,
+		});
+
 		const invoice: Invoice = {
 			id: generateId("inv"),
 			internal_customer_id: internalCustomerId,
@@ -229,6 +234,7 @@ export class InvoiceService {
 
 			// Stripe stuff
 			total: atmnTotal,
+			amount_paid: atmnAmountPaid,
 			refunded_amount: 0,
 			currency: stripeInvoice.currency,
 			discounts: getInvoiceDiscounts({
@@ -323,6 +329,7 @@ export class InvoiceService {
 					hosted_invoice_url: invoice.hosted_invoice_url,
 					discounts: invoice.discounts,
 					total: invoice.total,
+					amount_paid: invoice.amount_paid,
 					product_ids: invoice.product_ids?.length
 						? sql`CASE
 							WHEN ${invoices.product_ids} IS NULL OR cardinality(${invoices.product_ids}) = 0

--- a/server/src/internal/invoices/actions/updateFromStripe.ts
+++ b/server/src/internal/invoices/actions/updateFromStripe.ts
@@ -29,6 +29,10 @@ export const updateInvoiceFromStripe = async ({
 				amount: stripeInvoice.total,
 				currency: stripeInvoice.currency,
 			}),
+			amount_paid: stripeToAtmnAmount({
+				amount: stripeInvoice.amount_paid,
+				currency: stripeInvoice.currency,
+			}),
 		},
 	});
 

--- a/server/src/internal/invoices/utils/initInvoiceFromStripe.ts
+++ b/server/src/internal/invoices/utils/initInvoiceFromStripe.ts
@@ -50,6 +50,11 @@ export const initInvoiceFromStripe = async ({
 		currency: stripeInvoice.currency,
 	});
 
+	const atmnAmountPaid = stripeToAtmnAmount({
+		amount: stripeInvoice.amount_paid,
+		currency: stripeInvoice.currency,
+	});
+
 	return {
 		id: generateId("inv"),
 		internal_customer_id: internalCustomerId,
@@ -61,6 +66,7 @@ export const initInvoiceFromStripe = async ({
 		status: stripeInvoice.status as string | undefined,
 		internal_entity_id: internalEntityId || null,
 		total: atmnTotal,
+		amount_paid: atmnAmountPaid,
 		currency: stripeInvoice.currency,
 		discounts: getInvoiceDiscounts({ expandedInvoice: stripeInvoice }),
 		items: autumnInvoiceItems,

--- a/shared/models/cusModels/invoiceModels/invoiceModels.ts
+++ b/shared/models/cusModels/invoiceModels/invoiceModels.ts
@@ -39,6 +39,7 @@ export const InvoiceSchema = z.object({
 
 	// Total amount of the invoice
 	total: z.number(),
+	amount_paid: z.number().nullish(),
 	refunded_amount: z.number().default(0),
 	currency: z.string(),
 	receipt_url: z.string().nullish(),

--- a/shared/models/cusModels/invoiceModels/invoiceTable.ts
+++ b/shared/models/cusModels/invoiceModels/invoiceTable.ts
@@ -28,6 +28,7 @@ export const invoices = pgTable(
 		status: text("status").notNull().default("draft"),
 		hosted_invoice_url: text("hosted_invoice_url"),
 		total: numeric({ mode: "number" }).notNull().default(0),
+		amount_paid: numeric({ mode: "number" }),
 		refunded_amount: numeric({ mode: "number" }).notNull().default(0),
 		currency: text("currency").notNull().default("usd"),
 		discounts: jsonb("discounts").$type<InvoiceDiscount>().array().default([]),

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -8,8 +8,11 @@ import {
 import {
 	ArrowCounterClockwiseIcon,
 	ArrowSquareOutIcon,
+	CalendarBlankIcon,
+	CreditCardIcon,
 	EyeIcon,
 	EyeSlashIcon,
+	HashIcon,
 } from "@phosphor-icons/react";
 import { format } from "date-fns";
 import { useMemo, useState } from "react";
@@ -17,6 +20,7 @@ import { AdminHover } from "@/components/general/AdminHover";
 import { Badge } from "@/components/v2/badges/Badge";
 import { Button } from "@/components/v2/buttons/Button";
 import { MiniCopyButton } from "@/components/v2/buttons/CopyButton";
+import { InfoRow } from "@/components/v2/InfoRow";
 import { SheetHeader, SheetSection } from "@/components/v2/sheets/InlineSheet";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
@@ -189,7 +193,7 @@ export function InvoiceDetailSheet({
 	};
 
 	return (
-		<div className="flex flex-col h-full">
+		<div className="flex flex-col h-full overflow-y-auto">
 			<SheetHeader
 				title={
 					<div className="flex items-center gap-2">
@@ -204,91 +208,94 @@ export function InvoiceDetailSheet({
 				description={`${formatDate(invoice.created_at)} • ${formatSignedAmount(invoice.total, invoice.currency)}`}
 			/>
 
-			<div className="flex-1 overflow-y-auto min-h-0">
-				{/* Product groups with line items */}
-				{productGroups.map((productGroup) => (
-					<SheetSection
-						key={productGroup.productId ?? "unknown"}
-						withSeparator={true}
-					>
-						{/* Product header with description toggle */}
-						<div className="flex items-center justify-between mb-2">
-							<span className="text-xs font-medium text-t3 truncate">
-								{productGroup.productName}
-							</span>
-							<button
-								type="button"
-								onClick={() => setShowDescriptions((prev) => !prev)}
-								className="text-t4 hover:text-t2 transition-colors p-0.5 rounded"
-								title={
-									showDescriptions
-										? "Show computed display"
-										: "Show descriptions"
-								}
-							>
-								{showDescriptions ? (
-									<EyeSlashIcon size={14} />
-								) : (
-									<EyeIcon size={14} />
-								)}
-							</button>
-						</div>
-
-						{/* Line item groups within this product */}
-						<div className="flex flex-col gap-2">
-							{productGroup.lineItemGroups.map((group) => (
-								<LineItemGroupRow
-									key={group.groupKey}
-									group={group}
-									formatAmount={formatAmount}
-									formatPeriod={formatPeriod}
-									currency={invoice.currency}
-									showDescriptions={showDescriptions}
-								/>
-							))}
-						</div>
-					</SheetSection>
-				))}
-
-				{/* Invoice Total */}
-				<SheetSection withSeparator={true}>
-					<div className="flex items-center justify-between">
-						<span className="text-sm font-medium text-foreground">Total</span>
-						<span className="text-sm font-semibold text-foreground tabular-nums">
-							{formatSignedAmount(invoice.total, invoice.currency)}
+			{productGroups.map((productGroup) => (
+				<SheetSection
+					key={productGroup.productId ?? "unknown"}
+					withSeparator={true}
+				>
+					<div className="flex items-center justify-between mb-2">
+						<span className="text-xs font-medium text-t3 truncate">
+							{productGroup.productName}
 						</span>
+						<button
+							type="button"
+							onClick={() => setShowDescriptions((prev) => !prev)}
+							className="text-t4 hover:text-t2 transition-colors p-0.5 rounded"
+							title={
+								showDescriptions ? "Show computed display" : "Show descriptions"
+							}
+						>
+							{showDescriptions ? (
+								<EyeSlashIcon size={14} />
+							) : (
+								<EyeIcon size={14} />
+							)}
+						</button>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						{productGroup.lineItemGroups.map((group) => (
+							<LineItemGroupRow
+								key={group.groupKey}
+								group={group}
+								formatAmount={formatAmount}
+								formatPeriod={formatPeriod}
+								currency={invoice.currency}
+								showDescriptions={showDescriptions}
+							/>
+						))}
 					</div>
 				</SheetSection>
+			))}
 
-				{/* Invoice Details - Compact */}
-				<SheetSection withSeparator={false}>
-					<div className="space-y-2">
-						<div className="flex items-center justify-between text-xs">
-							<span className="text-t3">Invoice ID</span>
+			<SheetSection withSeparator={true}>
+				<div className="flex items-center justify-between">
+					<span className="text-sm font-medium text-foreground">Total</span>
+					<span className="text-sm font-semibold text-foreground tabular-nums">
+						{formatSignedAmount(invoice.total, invoice.currency)}
+					</span>
+				</div>
+			</SheetSection>
+
+			<SheetSection withSeparator={false}>
+				<div className="space-y-3">
+					<InfoRow
+						icon={<HashIcon size={16} weight="duotone" />}
+						label="Invoice ID"
+						value={
 							<MiniCopyButton
 								text={invoice.id}
-								innerClassName="text-xs text-t1 font-mono"
+								innerClassName="text-sm text-t1 font-mono"
 							/>
-						</div>
-						<div className="flex items-center justify-between text-xs">
-							<span className="text-t3">Stripe ID</span>
+						}
+					/>
+					<InfoRow
+						icon={<CreditCardIcon size={16} weight="duotone" />}
+						label="Stripe ID"
+						value={
 							<MiniCopyButton
 								text={invoice.stripe_id}
-								innerClassName="text-xs text-t1 font-mono"
+								innerClassName="text-sm text-t1 font-mono"
 							/>
-						</div>
-						<div className="flex items-center justify-between text-xs">
-							<span className="text-t3">Created</span>
-							<span className="text-t1">
-								{format(new Date(invoice.created_at), "MMM d, yyyy HH:mm")}
-							</span>
-						</div>
-					</div>
-				</SheetSection>
-			</div>
+						}
+					/>
+					<InfoRow
+						icon={<CalendarBlankIcon size={16} weight="duotone" />}
+						label="Created"
+						value={
+							<MiniCopyButton
+								text={format(
+									new Date(invoice.created_at),
+									"MMM d, yyyy HH:mm",
+								)}
+								innerClassName="text-sm text-t1"
+							/>
+						}
+					/>
+				</div>
+			</SheetSection>
 
-			{/* Footer */}
-			<div className="p-4 flex gap-2 border-t border-border/40">
+			<div className="sticky bottom-0 p-4 flex gap-2 bg-card">
 				<Button
 					variant="secondary"
 					className="flex-1"

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -70,7 +70,6 @@ export function InvoiceDetailSheet() {
 	const [refundDialogOpen, setRefundDialogOpen] = useState(false);
 	const { customer } = useCusQuery();
 
-	console.log("Invoice data:", { total: invoice?.total, amount_paid: invoice?.amount_paid, refunded_amount: invoice?.refunded_amount, status: invoice?.status });
 
 	const productGroups = useMemo(() => {
 		// Step 1: bucket line items by product_id

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -10,8 +10,6 @@ import {
 	ArrowSquareOutIcon,
 	CalendarBlankIcon,
 	CreditCardIcon,
-	EyeIcon,
-	EyeSlashIcon,
 	HashIcon,
 } from "@phosphor-icons/react";
 import { format } from "date-fns";
@@ -25,17 +23,13 @@ import { SheetHeader, SheetSection } from "@/components/v2/sheets/InlineSheet";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { cn } from "@/lib/utils";
 import { useEnv } from "@/utils/envUtils";
 import { getStripeInvoiceLink } from "@/utils/linkUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { CustomerInvoiceStatus } from "../table/customer-invoices/CustomerInvoiceStatus";
 import { RefundInvoiceDialog } from "./RefundInvoiceDialog";
-
-interface InvoiceDetailSheetProps {
-	invoice: Invoice;
-	lineItems: InvoiceLineItem[];
-}
 
 type LineItemGroup = {
 	groupKey: string;
@@ -64,29 +58,20 @@ const resolveFeatureName = ({
 	return feature?.name ?? featureId;
 };
 
-export function InvoiceDetailSheet({
-	invoice,
-	lineItems,
-}: InvoiceDetailSheetProps) {
+export function InvoiceDetailSheet() {
+	const sheetData = useSheetStore((s) => s.data);
+	const invoice = sheetData?.invoice as Invoice | undefined;
+	const lineItems = (sheetData?.lineItems as InvoiceLineItem[]) ?? [];
+
 	const { stripeAccount } = useOrgStripeQuery();
 	const { features } = useFeaturesQuery();
 	const { products } = useProductsQuery();
 	const env = useEnv();
-	const [showDescriptions, setShowDescriptions] = useState(false);
 	const [refundDialogOpen, setRefundDialogOpen] = useState(false);
 	const { customer } = useCusQuery();
-	const isStripeCustomer = customer?.processor?.type === ProcessorType.Stripe;
-	const isFullyRefunded =
-		invoice.refunded_amount > 0 &&
-		invoice.refunded_amount >= Math.abs(invoice.total);
-	const canRefund =
-		isStripeCustomer &&
-		invoice.status === InvoiceStatus.Paid &&
-		!isFullyRefunded;
 
-	// Group line items: first by product_id, then within each product by
-	// stripe_subscription_item_id (for tiered) or individually.
-	// Sort: base price first, then alphabetically by label within each product.
+	console.log("Invoice data:", { total: invoice?.total, amount_paid: invoice?.amount_paid, refunded_amount: invoice?.refunded_amount, status: invoice?.status });
+
 	const productGroups = useMemo(() => {
 		// Step 1: bucket line items by product_id
 		const byProduct = new Map<string, InvoiceLineItem[]>();
@@ -150,6 +135,17 @@ export function InvoiceDetailSheet({
 		return result;
 	}, [lineItems, features, products]);
 
+	if (!invoice) return null;
+
+	const isStripeCustomer = customer?.processor?.type === ProcessorType.Stripe;
+	const refundableAmount = Math.abs(invoice.amount_paid ?? invoice.total);
+	const isFullyRefunded =
+		invoice.refunded_amount > 0 && invoice.refunded_amount >= refundableAmount;
+	const canRefund =
+		isStripeCustomer &&
+		invoice.status === InvoiceStatus.Paid &&
+		!isFullyRefunded;
+
 	const formatAmount = (amount: number, currency: string) => {
 		const absAmount = Math.abs(amount);
 		return new Intl.NumberFormat("en-US", {
@@ -200,6 +196,7 @@ export function InvoiceDetailSheet({
 						<span>Invoice</span>
 						<CustomerInvoiceStatus
 							status={invoice.status ?? "paid"}
+							amountPaid={invoice.amount_paid}
 							total={invoice.total}
 							refundedAmount={invoice.refunded_amount}
 						/>
@@ -213,24 +210,10 @@ export function InvoiceDetailSheet({
 					key={productGroup.productId ?? "unknown"}
 					withSeparator={true}
 				>
-					<div className="flex items-center justify-between mb-2">
+					<div className="mb-2">
 						<span className="text-xs font-medium text-t3 truncate">
 							{productGroup.productName}
 						</span>
-						<button
-							type="button"
-							onClick={() => setShowDescriptions((prev) => !prev)}
-							className="text-t4 hover:text-t2 transition-colors p-0.5 rounded"
-							title={
-								showDescriptions ? "Show computed display" : "Show descriptions"
-							}
-						>
-							{showDescriptions ? (
-								<EyeSlashIcon size={14} />
-							) : (
-								<EyeIcon size={14} />
-							)}
-						</button>
 					</div>
 
 					<div className="flex flex-col gap-2">
@@ -241,7 +224,6 @@ export function InvoiceDetailSheet({
 								formatAmount={formatAmount}
 								formatPeriod={formatPeriod}
 								currency={invoice.currency}
-								showDescriptions={showDescriptions}
 							/>
 						))}
 					</div>
@@ -249,11 +231,21 @@ export function InvoiceDetailSheet({
 			))}
 
 			<SheetSection withSeparator={true}>
-				<div className="flex items-center justify-between">
-					<span className="text-sm font-medium text-foreground">Total</span>
-					<span className="text-sm font-semibold text-foreground tabular-nums">
-						{formatSignedAmount(invoice.total, invoice.currency)}
-					</span>
+				<div className="flex flex-col gap-1.5">
+					<div className="flex items-center justify-between">
+						<span className="text-sm font-medium text-foreground">Total</span>
+						<span className="text-sm font-semibold text-foreground tabular-nums">
+							{formatSignedAmount(invoice.total, invoice.currency)}
+						</span>
+					</div>
+					{invoice.amount_paid != null && invoice.amount_paid !== invoice.total && (
+						<div className="flex items-center justify-between">
+							<span className="text-sm text-t2">Amount Paid</span>
+							<span className="text-sm tabular-nums text-t2">
+								{formatSignedAmount(invoice.amount_paid, invoice.currency)}
+							</span>
+						</div>
+					)}
 				</div>
 			</SheetSection>
 
@@ -284,10 +276,7 @@ export function InvoiceDetailSheet({
 						label="Created"
 						value={
 							<MiniCopyButton
-								text={format(
-									new Date(invoice.created_at),
-									"MMM d, yyyy HH:mm",
-								)}
+								text={format(new Date(invoice.created_at), "MMM d, yyyy HH:mm")}
 								innerClassName="text-sm text-t1"
 							/>
 						}
@@ -331,13 +320,11 @@ function LineItemGroupRow({
 	formatAmount,
 	formatPeriod,
 	currency,
-	showDescriptions,
 }: {
 	group: LineItemGroup;
 	formatAmount: (amount: number, currency: string) => string;
 	formatPeriod: (startMs: number | null, endMs: number | null) => string | null;
 	currency: string;
-	showDescriptions: boolean;
 }) {
 	const isSingleItem = group.items.length === 1;
 	const firstItem = group.items[0];
@@ -373,20 +360,19 @@ function LineItemGroupRow({
 				{/* Group header with label and total */}
 				<div className="flex items-start justify-between gap-2">
 					<div className="flex flex-col min-w-0 flex-1 gap-0.5">
-						{showDescriptions ? (
+						<div className="flex items-center gap-1.5">
+							<span className="text-sm text-t1">{group.label}</span>
+							{totalQuantity > 0 && (
+								<Badge
+									variant="muted"
+									className="text-[10px] px-1.5 py-0 text-t3"
+								>
+									Qty: {totalQuantity}
+								</Badge>
+							)}
+						</div>
+						{firstItem.description && (
 							<span className="text-xs text-t3">{firstItem.description}</span>
-						) : (
-							<div className="flex items-center gap-1.5">
-								<span className="text-sm text-t1">{group.label}</span>
-								{totalQuantity > 0 && (
-									<Badge
-										variant="muted"
-										className="text-[10px] px-1.5 py-0 text-t3"
-									>
-										Qty: {totalQuantity}
-									</Badge>
-								)}
-							</div>
 						)}
 						{period && <span className="text-xs text-t4">{period}</span>}
 					</div>
@@ -395,7 +381,6 @@ function LineItemGroupRow({
 					</span>
 				</div>
 
-				{/* Tier breakdown - each row has own hover */}
 				<div className="mt-1 ml-3 flex flex-col gap-0.5">
 					{group.items.map((item) => (
 						<TierRow
@@ -404,7 +389,6 @@ function LineItemGroupRow({
 							hoverTexts={getLineItemHoverTexts(item)}
 							formatAmount={formatAmount}
 							currency={currency}
-							showDescriptions={showDescriptions}
 						/>
 					))}
 				</div>
@@ -421,26 +405,25 @@ function LineItemGroupRow({
 			<div className="flex flex-col py-1">
 				<div className="flex items-start justify-between gap-2">
 					<div className="flex flex-col min-w-0 flex-1 gap-0.5">
-						{showDescriptions ? (
+						<div className="flex items-center gap-1.5">
+							<span className="text-sm text-t1">{group.label}</span>
+							{(!group.isBasePrice && firstItem.total_quantity) ||
+							(group.isBasePrice &&
+								firstItem.stripe_quantity &&
+								firstItem.stripe_quantity > 1) ? (
+								<Badge
+									variant="muted"
+									className="text-[10px] px-1.5 py-0 text-t3"
+								>
+									Qty:{" "}
+									{group.isBasePrice
+										? firstItem.stripe_quantity
+										: firstItem.total_quantity}
+								</Badge>
+							) : null}
+						</div>
+						{firstItem.description && (
 							<span className="text-xs text-t3">{firstItem.description}</span>
-						) : (
-							<div className="flex items-center gap-1.5">
-								<span className="text-sm text-t1">{group.label}</span>
-								{(!group.isBasePrice && firstItem.total_quantity) ||
-								(group.isBasePrice &&
-									firstItem.stripe_quantity &&
-									firstItem.stripe_quantity > 1) ? (
-									<Badge
-										variant="muted"
-										className="text-[10px] px-1.5 py-0 text-t3"
-									>
-										Qty:{" "}
-										{group.isBasePrice
-											? firstItem.stripe_quantity
-											: firstItem.total_quantity}
-									</Badge>
-								) : null}
-							</div>
 						)}
 						{period && <span className="text-xs text-t4">{period}</span>}
 					</div>
@@ -490,23 +473,18 @@ function TierRow({
 	hoverTexts,
 	formatAmount,
 	currency,
-	showDescriptions,
 }: {
 	item: InvoiceLineItem;
 	hoverTexts: { key: string; value: string }[];
 	formatAmount: (amount: number, currency: string) => string;
 	currency: string;
-	showDescriptions: boolean;
 }) {
 	const isRefund = item.direction === "refund";
-	const quantityLabel = item.total_quantity ? `${item.total_quantity}` : "";
 
 	return (
 		<AdminHover asChild texts={hoverTexts}>
 			<div className="flex items-center justify-between text-xs text-t3">
-				<span>
-					{showDescriptions ? item.description : `${quantityLabel} units`}
-				</span>
+				<span>{item.description}</span>
 				<span
 					className={cn(
 						"tabular-nums",

--- a/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
+++ b/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
@@ -70,6 +70,8 @@ export function RefundInvoiceDialog({
 		},
 	});
 
+	const refundableAmount = invoice.amount_paid ?? invoice.total;
+
 	const handleSubmit = () => {
 		if (mode === "partial") {
 			const parsed = Number.parseFloat(amount);
@@ -77,8 +79,8 @@ export function RefundInvoiceDialog({
 				toast.error("Please enter a valid refund amount");
 				return;
 			}
-			if (parsed > invoice.total) {
-				toast.error("Refund amount cannot exceed invoice total");
+			if (parsed > refundableAmount) {
+				toast.error("Refund amount cannot exceed the amount paid");
 				return;
 			}
 		}
@@ -86,7 +88,7 @@ export function RefundInvoiceDialog({
 	};
 
 	const formattedTotal = formatAmount({
-		amount: invoice.total,
+		amount: refundableAmount,
 		currency: invoice.currency,
 		minFractionDigits: 2,
 		amountFormatOptions: {
@@ -100,7 +102,7 @@ export function RefundInvoiceDialog({
 				<DialogHeader>
 					<DialogTitle>Refund Invoice</DialogTitle>
 					<DialogDescription>
-						Invoice total: {formattedTotal} {invoice.currency.toUpperCase()}
+						Amount paid: {formattedTotal} {invoice.currency.toUpperCase()}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -129,7 +131,7 @@ export function RefundInvoiceDialog({
 								type="number"
 								min="0.01"
 								step="0.01"
-								max={invoice.total}
+								max={refundableAmount}
 								placeholder="0.00"
 								value={amount}
 								onChange={(e) => setAmount(e.target.value)}

--- a/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoiceStatus.tsx
+++ b/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoiceStatus.tsx
@@ -24,14 +24,17 @@ const statusConfig = {
 };
 
 const getRefundStatus = ({
+	amountPaid,
 	total,
 	refundedAmount,
 }: {
+	amountPaid: number;
 	total: number;
 	refundedAmount: number;
 }): { color: string; label: string } | null => {
 	if (refundedAmount <= 0) return null;
-	if (refundedAmount >= Math.abs(total)) {
+	const refundableAmount = Math.abs(amountPaid ?? total);
+	if (refundedAmount >= refundableAmount) {
 		return {
 			color: "bg-amber-500 dark:bg-amber-600",
 			label: "Fully Refunded",
@@ -45,10 +48,12 @@ const getRefundStatus = ({
 
 export function CustomerInvoiceStatus({
 	status,
+	amountPaid,
 	total,
 	refundedAmount,
 }: {
 	status: InvoiceStatus | null | undefined;
+	amountPaid?: number | null;
 	total?: number;
 	refundedAmount?: number;
 }) {
@@ -59,7 +64,11 @@ export function CustomerInvoiceStatus({
 		status === InvoiceStatus.Paid &&
 		total !== undefined &&
 		refundedAmount !== undefined
-			? getRefundStatus({ total, refundedAmount })
+			? getRefundStatus({
+					amountPaid: amountPaid ?? total,
+					total,
+					refundedAmount,
+				})
 			: null;
 
 	const config = refundStatus ?? statusConfig[status];

--- a/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesColumns.tsx
@@ -32,10 +32,11 @@ export const CustomerInvoicesColumns = [
 		accessorKey: "total",
 		cell: ({ row }: { row: Row<CustomerInvoice> }) => {
 			const invoice = row.original;
+			const displayTotal = invoice.amount_paid ?? invoice.total;
 			const discountAmount = getTotalDiscountAmount(invoice);
 			return (
 				<div>
-					{invoice.total.toFixed(2)} {invoice.currency.toUpperCase()}
+					{displayTotal.toFixed(2)} {invoice.currency.toUpperCase()}
 					{discountAmount > 0 && (
 						<span className="text-t3"> (-{discountAmount.toFixed(2)})</span>
 					)}
@@ -51,6 +52,7 @@ export const CustomerInvoicesColumns = [
 			return (
 				<CustomerInvoiceStatus
 					status={invoice.status}
+					amountPaid={invoice.amount_paid}
 					total={invoice.total}
 					refundedAmount={invoice.refunded_amount}
 				/>

--- a/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
@@ -36,7 +36,7 @@ export function CustomerInvoicesTable() {
 	);
 
 	const { lineItemsByInvoiceId } = useInvoiceLineItemsQuery({
-		customerId: customer?.internal_id || customer?.id,
+		customerId: customer?.id || customer?.internal_id,
 		invoiceIds,
 		enabled: invoiceIds.length > 0,
 	});

--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -1,4 +1,3 @@
-import type { Invoice, InvoiceLineItem } from "@autumn/shared";
 import { AnimatePresence, motion } from "motion/react";
 import { SheetContainer } from "@/components/v2/sheets/InlineSheet";
 import { SheetCloseButton } from "@/components/v2/sheets/SheetCloseButton";
@@ -32,7 +31,6 @@ import { SHEET_ANIMATION } from "./customerAnimations";
 export function CustomerSheets() {
 	const isMobile = useIsMobile();
 	const sheetType = useSheetStore((s) => s.type);
-	const sheetData = useSheetStore((s) => s.data);
 	const closeSheet = useSheetStore((s) => s.closeSheet);
 	const closeBalanceSheet = useCustomerBalanceSheetStore((s) => s.closeSheet);
 	useSheetEscapeHandler();
@@ -64,12 +62,8 @@ export function CustomerSheets() {
 				return <BalanceDeleteSheet />;
 			case "balance-create":
 				return <BalanceCreateSheet />;
-			case "invoice-detail": {
-				const invoice = sheetData?.invoice as Invoice | undefined;
-				const lineItems = (sheetData?.lineItems as InvoiceLineItem[]) ?? [];
-				if (!invoice) return null;
-				return <InvoiceDetailSheet invoice={invoice} lineItems={lineItems} />;
-			}
+			case "invoice-detail":
+				return <InvoiceDetailSheet />;
 			case "sync-stripe":
 				return <SyncStripeSheet />;
 			case "billing-auto-topup-add":


### PR DESCRIPTION
## Summary
- Stores Stripe's `amount_paid` alongside `total` on invoice records to account for customer credit balance
- Fixes refund status showing "Partially Refunded" when an invoice with credits is fully refunded, since the charged amount is less than the invoice total
- Dashboard invoice table and detail sheet now display `amount_paid` (falling back to `total` for older invoices), and the detail sheet shows both Total and Amount Paid separately when they differ

## SQL to run
```sql
ALTER TABLE invoices ADD COLUMN amount_paid numeric;
```

## Test plan
- [ ] Verify invoices without credits still display correctly (amount_paid = total, single "Total" row)
- [ ] Verify invoices with credits show both Total and Amount Paid in the detail sheet
- [ ] Verify full refund on a credit-applied invoice shows "Fully Refunded" instead of "Partially Refunded"
- [ ] Verify partial refund dialog caps at amount_paid, not total

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores Stripe `amount_paid` on invoices and uses it for refund logic and UI. Fixes fully refunded invoices with credits showing as partial, and updates the detail sheet and refund dialog to use the charged amount.

- **Bug Fixes**
  - Save `amount_paid` with each invoice and use it for refund status and refund dialog limits.
  - Dashboard table and invoice detail display `Amount Paid` (fallback to `total` for older invoices) and show both Total and Amount Paid when they differ.
  - Invoice detail sheet now reads from the sheet store; invoices table prefers customer `id` over `internal_id` for line-item queries.

- **Migration**
  - Run: `ALTER TABLE invoices ADD COLUMN amount_paid numeric;`

<sup>Written for commit ffe58a6f8529f4e39c6aa4e1ff090d7bd207f885. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where invoices with customer credits applied were showing "Partially Refunded" after a full refund, because the refund status was compared against the invoice `total` instead of the actual `amount_paid`. Stripe's `amount_paid` is now stored on the invoice record and used throughout the dashboard for refund status, display totals, and the refund dialog cap.

**Key changes:**
- [Bug fixes] Store `stripeInvoice.amount_paid` on new and updated invoice records; nullable column supports older rows via fallback to `total`.
- [Bug fixes] `CustomerInvoiceStatus`, `InvoiceDetailSheet`, and `RefundInvoiceDialog` all now use `amount_paid ?? total` so fully-refunded credit invoices display correctly and the partial-refund cap is accurate.
- [Improvements] `InvoiceDetailSheet` refactored to pull data from the sheet store instead of receiving props; customer ID priority in `CustomerInvoicesTable` corrected to prefer the external ID (`id`) that the API ownership check actually compares against.

⚠️ A `console.log` statement that emits financial invoice fields was left in `InvoiceDetailSheet.tsx` (line 73) — this should be removed before merging.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after removing the leftover console.log at InvoiceDetailSheet.tsx line 73.

All remaining findings are P1 (debug log) and P2 (dead null-coalescing). The core logic — storing amount_paid, using it for refund status, and capping the refund dialog — is correct and consistent across all three server paths and all frontend consumers. The one blocking issue is the console.log that emits financial data on every render.

vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx — remove console.log at line 73

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/invoices/InvoiceService.ts | Correctly persists `amount_paid` (converted from Stripe's minor-units integer) alongside `total` on both insert and upsert paths. |
| server/src/internal/invoices/actions/updateFromStripe.ts | Adds `amount_paid` to the Stripe update path, consistent with the create path. |
| server/src/internal/invoices/utils/initInvoiceFromStripe.ts | Adds `amount_paid` to the invoice initialisation helper, mirroring other server-side changes. |
| shared/models/cusModels/invoiceModels/invoiceModels.ts | Adds `amount_paid` as `z.number().nullish()` — correct nullability for older rows that predate the migration. |
| shared/models/cusModels/invoiceModels/invoiceTable.ts | Adds nullable `amount_paid numeric` column to the Drizzle table definition, matching the SQL migration. |
| vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx | Refactors sheet to pull data from store instead of props and uses `amount_paid` for refund status; a debug `console.log` leaking financial fields was left in at line 73. |
| vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx | Correctly caps partial-refund input and validation at `amount_paid` (falling back to `total`), fixing the dialog's max-refund limit. |
| vite/src/views/customers2/components/table/customer-invoices/CustomerInvoiceStatus.tsx | Core refund-status fix is correct; contains a minor dead null-coalescing (`amountPaid ?? total`) inside `getRefundStatus` where `amountPaid` is already typed as `number`. |
| vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesColumns.tsx | Displays `amount_paid ?? total` in the table column and passes `amountPaid` to the status component — correct fallback for legacy rows. |
| vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx | Flips customer ID priority from `internal_id || id` to `id || internal_id`, aligning with the API's ownership check that compares against the external customer ID. |
| vite/src/views/customers2/customer/CustomerSheets.tsx | Removes explicit prop-passing to `InvoiceDetailSheet`; the component now self-selects data from the sheet store. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Server
    participant DB
    participant Dashboard

    Stripe->>Server: Invoice webhook (amount_paid, total)
    Server->>Server: stripeToAtmnAmount(amount_paid)
    Server->>DB: INSERT/UPDATE invoice { total, amount_paid }

    Dashboard->>Server: GET customer invoices
    Server->>Dashboard: { total, amount_paid, refunded_amount }

    Dashboard->>Dashboard: displayTotal = amount_paid ?? total
    Dashboard->>Dashboard: refundableAmount = amount_paid ?? total
    Dashboard->>Dashboard: isFullyRefunded = refunded_amount >= refundableAmount
    Dashboard->>Dashboard: Render status badge (Fully/Partially Refunded / Paid)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
Line: 73

Comment:
**Debug `console.log` left in production code**

This log statement was left in from development and will emit financial data (total, amount_paid, refunded_amount, status) to the browser console on every render of the invoice detail sheet.

```suggestion
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers2/components/table/customer-invoices/CustomerInvoiceStatus.tsx
Line: 36

Comment:
**Unreachable null-coalescing inside `getRefundStatus`**

`amountPaid` is typed as `number` (non-nullable) in this function's signature, so `amountPaid ?? total` can never fall through to `total`. The null-check is already done at the call site. The dead coalescing is harmless but misleading.

```suggestion
	const refundableAmount = Math.abs(amountPaid);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Store invoice amount\_paid to fix refund ..."](https://github.com/useautumn/autumn/commit/4256a3d86045f82461bc4542cab5e0e27608f137) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28634488)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->