### PR TITLE
Fix: skip arrear line items when carry_over_usages is enabled

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
@@ -55,6 +55,8 @@ export const computeAttachPlan = ({
 		params,
 	});
 
+	const includeArrearLineItems = !params.carry_over_usages?.enabled;
+
 	const { allLineItems: lineItems, updateCustomerEntitlements } =
 		planTiming === "immediate"
 			? buildAutumnLineItems({
@@ -62,7 +64,7 @@ export const computeAttachPlan = ({
 					newCustomerProducts: [newCustomerProduct],
 					deletedCustomerProduct: currentCustomerProduct,
 					billingContext: attachBillingContext,
-					includeArrearLineItems: true,
+					includeArrearLineItems,
 				})
 			: { allLineItems: [], updateCustomerEntitlements: [] };
 


### PR DESCRIPTION
## Summary
- When `carry_over_usages` is enabled in attach, arrear line items for the old product's consumable overages were still being computed and charged, even though that same usage was carried over to the new product — resulting in double billing.
- Skips arrear line item generation when `carry_over_usages.enabled` is true. Non-consumable features (seats, fixed prices) are unaffected as they flow through the separate refund/charge line item paths.

## Test plan
- [ ] Verify attach with `carry_over_usages: { enabled: true }` no longer generates arrear charges for the old product
- [ ] Verify preview attach also reflects the corrected line items
- [ ] Verify attach without `carry_over_usages` still bills arrears as before
- [ ] Verify seats and fixed-price features are unaffected during upgrades

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip arrear line items during attach when `carry_over_usages.enabled` is true to prevent double billing on upgrades. Seats and fixed-price features are unaffected.

- **Bug Fixes**
  - Compute `includeArrearLineItems` as `!params.carry_over_usages?.enabled` and pass it to `buildAutumnLineItems` for immediate attaches.

<sup>Written for commit 2dc490ad6532d0c41b42be9cd343bdb31159e884. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a double-billing bug where enabling `carry_over_usages` during a product attach would both carry the old product's consumable usage to the new product **and** charge it as an arrear line item.

**Bug fixes**
- Skips arrear line item generation for the old (deleted) product's consumable overages when `carry_over_usages.enabled` is `true`, preventing double charging during immediate plan switches.

The fix introduces one edge case: when `carry_over_usages.feature_ids` is supplied (partial carry-over), ALL arrear line items are skipped — not just those for the carried-over features — so any non-carried features' overages are silently dropped rather than billed.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge only if `carry_over_usages.feature_ids` (partial carry-over) is not currently used in production; the fix correctly handles the all-features case but silently drops arrears for non-carried features in the partial case.

There is one P1 finding: when `feature_ids` is a non-empty subset, arrear line items are skipped for features whose usages were NOT carried over, resulting in those overages being forgiven rather than billed. If partial carry-over is not yet exposed or used, the risk is low, but the API type fully supports it and no guard prevents it from being called today.

server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts — the `includeArrearLineItems` flag should be feature-scoped when `carry_over_usages.feature_ids` is set.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts | Adds `includeArrearLineItems = !params.carry_over_usages?.enabled` to prevent double billing; correctly handles the all-features-carried-over case but silently drops arrears for features not listed in `feature_ids` when a partial carry-over is requested. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["computeAttachPlan called\n(carry_over_usages.enabled = true)"] --> B{feature_ids provided?}
    B -- "No (carry all)" --> C["includeArrearLineItems = false\n✅ Correct — all consumable usages\ncarried over, none double-billed"]
    B -- "Yes (partial)" --> D["includeArrearLineItems = false\n⚠️ Bug — arrears skipped for ALL features,\nnot just the carried-over ones"]
    D --> E["Non-carried features' overages\nsilently dropped — never billed"]
    C --> F["buildAutumnLineItems\narrearLineItems = []"]
    F --> G["cusProductToExistingBalanceCarryOvers\nsets usage on new product"]
    G --> H["New product billed\nfor carried-over usage ✅"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
Line: 58

Comment:
**Partial carry-over skips arrears for non-carried features**

When `carry_over_usages.feature_ids` is set to a subset of consumable features, this line skips **all** arrear line items — not just those for features whose usages are being carried over. Any feature NOT in `feature_ids` has its overage silently dropped: it won't appear in the new product (it wasn't carried over) and it won't be charged as an arrear (this flag is off). The customer is effectively given a free pass on that usage.

For example, with `carry_over_usages: { enabled: true, feature_ids: ["api-calls"] }` and usage on both `api-calls` and `storage`, `storage` arrears are never billed.

A safer approach is to pass feature-level context down to `customerProductToArrearLineItems` via its existing `cusEntFilter` option and only skip arrear generation for the features that are actually being carried over:

```typescript
const carriedOverFeatureIds = params.carry_over_usages?.enabled
  ? params.carry_over_usages.feature_ids ?? "all"
  : null;

// Then inside buildAutumnLineItems / customerProductToArrearLineItems:
//   if carriedOverFeatureIds === "all" → skip all arrear line items
//   if Array → skip only those feature IDs, bill the rest as arrears
//   if null → include all arrear line items (existing behaviour)
```

This fix is safe only for the default case where `feature_ids` is undefined (carry all consumable features).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Skip arrear line items when carry\_over\_u..."](https://github.com/useautumn/autumn/commit/2dc490ad6532d0c41b42be9cd343bdb31159e884) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28643351)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->