### PR TITLE
chore: fix attach sheet issue

### DIFF
--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -11,7 +11,6 @@ import { SubscriptionCancelSheet } from "@/views/customers2/components/sheets/Su
 import { SubscriptionUncancelSheet } from "@/views/customers2/components/sheets/SubscriptionUncancelSheet";
 import { SubscriptionUpdateSheet2 } from "@/views/customers2/components/sheets/SubscriptionUpdateSheet2";
 import { AttachProductSheet } from "../components/sheets/AttachProductSheet";
-import { AttachProductSheetV2 } from "../components/sheets/AttachProductSheetV2";
 import { AttachProductSheetV3 } from "../components/sheets/AttachProductSheetV3";
 import { BalanceCreateSheet } from "../components/sheets/BalanceCreateSheet";
 import { BalanceDeleteSheet } from "../components/sheets/BalanceDeleteSheet";
@@ -32,6 +31,7 @@ import { SHEET_ANIMATION } from "./customerAnimations";
 export function CustomerSheets() {
 	const isMobile = useIsMobile();
 	const sheetType = useSheetStore((s) => s.type);
+	const sheetData = useSheetStore((s) => s.data);
 	const closeSheet = useSheetStore((s) => s.closeSheet);
 	const closeBalanceSheet = useCustomerBalanceSheetStore((s) => s.closeSheet);
 	useSheetEscapeHandler();


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the attach product sheet so it opens reliably and uses the correct V3 component.

- **Bug Fixes**
  - Read `data` from `useSheetStore` inside `CustomerSheets` to pass sheet payloads correctly.
  - Remove `AttachProductSheetV2` import to prevent conflicts; V3 is the active sheet.

<sup>Written for commit f37c2abd8dbba556b900e9cdafbeb5c52884f6ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

**[Bug fixes]** Fixes an issue where editing a product plan within a schedule (via `"attach-product-v2"` sheet type with `scheduleEditMode: true`) bypassed the `CreateScheduleFormProvider` context. The fix routes the `scheduleEditMode` variant of `"attach-product-v2"` through `<CreateScheduleSheet />`, which provides the form context required for schedule editing callbacks (`editingPlanValue`, `onScheduleEditCancel`, `onScheduleEditSave`) to work correctly.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted one-line conditional fix with no side effects on other sheet types.

The change is minimal and well-scoped: only the attach-product-v2 case is affected, and only when scheduleEditMode is explicitly set in sheet data. All other sheet routes are unchanged. The fix correctly threads the CreateScheduleFormProvider context through to AttachProductSheetV3 when editing schedule plans. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/customer/CustomerSheets.tsx | Routes the attach-product-v2 sheet to CreateScheduleSheet when scheduleEditMode is set in sheet data, ensuring the schedule form context is preserved during plan editing; otherwise falls through to AttachProductSheetV3 as before. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SchedulePlanRow
    participant CustomerSheets
    participant CreateScheduleSheet
    participant AttachProductSheetV3

    User->>SchedulePlanRow: Click edit plan in schedule
    SchedulePlanRow->>CustomerSheets: setSheet({ type: "attach-product-v2", data: { scheduleEditMode: true } })
    CustomerSheets->>CreateScheduleSheet: render (scheduleEditMode == true)
    CreateScheduleSheet->>AttachProductSheetV3: render with scheduleEditPlan + callbacks
    User->>AttachProductSheetV3: Save / Cancel
    AttachProductSheetV3->>CustomerSheets: setSheet({ type: "create-schedule" })
    CustomerSheets->>CreateScheduleSheet: render (reuses instance, form state preserved)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix attach sheet issue"](https://github.com/useautumn/autumn/commit/f37c2abd8dbba556b900e9cdafbeb5c52884f6ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28659767)</sub>

<!-- /greptile_comment -->