### PR TITLE
feat: 🎸 max entities edge config

### DIFF
--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -34,7 +34,10 @@ import { executeWithHealthTracking } from "@/db/pgHealthMonitor.js";
 import type { RepoContext } from "@/db/repoContext.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { withSpan } from "../analytics/tracer/spanUtils.js";
-import { getOrgCusProductLimit } from "../misc/edgeConfig/orgLimitsStore.js";
+import {
+	getOrgCusProductLimit,
+	getOrgEntitiesLimit,
+} from "../misc/edgeConfig/orgLimitsStore.js";
 import { resetCustomerEntitlements } from "./actions/resetCustomerEntitlements/resetCustomerEntitlements.js";
 import {
 	ACTIVE_STATUSES,
@@ -90,6 +93,10 @@ export class CusService {
 					orgId,
 					orgSlug: org.slug,
 				});
+				const entitiesLimit = getOrgEntitiesLimit({
+					orgId,
+					orgSlug: org.slug,
+				});
 
 				const query = getFullCusQuery({
 					idOrInternalId,
@@ -103,6 +110,7 @@ export class CusService {
 					withEvents,
 					entityId,
 					cusProductLimit,
+					entitiesLimit,
 				});
 
 				if (explain) {

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -98,7 +98,13 @@ const buildOptimizedCusProductsCTE = ({
   `;
 };
 
-const buildEntitiesCTE = (withEntities: boolean) => {
+const buildEntitiesCTE = ({
+	withEntities,
+	entitiesLimit,
+}: {
+	withEntities: boolean;
+	entitiesLimit: number;
+}) => {
 	if (!withEntities) {
 		return sql``;
 	}
@@ -114,7 +120,7 @@ const buildEntitiesCTE = (withEntities: boolean) => {
         SELECT * FROM entities e
         WHERE e.internal_customer_id = (SELECT internal_id FROM customer_record)
         ORDER BY e.internal_id DESC
-        LIMIT 300
+        LIMIT ${entitiesLimit}
       ) e
     )
   `;
@@ -284,6 +290,7 @@ export const getFullCusQuery = ({
 	withEvents,
 	entityId,
 	cusProductLimit,
+	entitiesLimit = 300,
 }: {
 	idOrInternalId: string;
 	orgId: string;
@@ -296,6 +303,7 @@ export const getFullCusQuery = ({
 	withEvents: boolean;
 	entityId?: string;
 	cusProductLimit: number;
+	entitiesLimit?: number;
 }) => {
 	const sqlChunks: SQL[] = [];
 
@@ -316,7 +324,7 @@ export const getFullCusQuery = ({
 	// Step 2: Get entities
 	if (withEntities) {
 		sqlChunks.push(sql`, `);
-		sqlChunks.push(buildEntitiesCTE(withEntities));
+		sqlChunks.push(buildEntitiesCTE({ withEntities, entitiesLimit }));
 	}
 
 	// Step 3: Get entity

--- a/server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts
@@ -6,6 +6,7 @@ export const OrgLimitsConfigSchema = z.object({
 			z.string(),
 			z.object({
 				maxCusProducts: z.number().min(1).optional(),
+				maxEntities: z.number().min(1).optional(),
 			}),
 		)
 		.default({}),

--- a/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
@@ -53,16 +53,22 @@ export const getOrgLimitsConfigFromSource = async () => {
 export const updateOrgLimitsInSource = async ({
 	orgId,
 	maxCusProducts,
+	maxEntities,
 }: {
 	orgId: string;
 	maxCusProducts?: number;
+	maxEntities?: number;
 }) => {
 	const config = await store.readFromSource();
 
-	if (maxCusProducts === undefined) {
+	if (maxCusProducts === undefined && maxEntities === undefined) {
 		delete config.orgs[orgId];
 	} else {
-		config.orgs[orgId] = { maxCusProducts };
+		config.orgs[orgId] = {
+			...config.orgs[orgId],
+			...(maxCusProducts !== undefined ? { maxCusProducts } : {}),
+			...(maxEntities !== undefined ? { maxEntities } : {}),
+		};
 	}
 
 	await store.writeToSource({ config });

--- a/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
+++ b/server/src/internal/misc/edgeConfig/orgLimitsStore.ts
@@ -7,6 +7,7 @@ import {
 } from "./orgLimitsSchemas.js";
 
 export const DEFAULT_CUS_PRODUCT_LIMIT = 15;
+export const DEFAULT_ENTITIES_LIMIT = 300;
 
 const store = createEdgeConfigStore<OrgLimitsConfig>({
 	s3Key: ADMIN_ORG_LIMITS_CONFIG_KEY,
@@ -28,9 +29,21 @@ export const getOrgCusProductLimit = ({
 }): number => {
 	const orgs = store.get().orgs;
 	const orgConfig =
-		(orgId ? orgs[orgId] : undefined) ??
-		(orgSlug ? orgs[orgSlug] : undefined);
+		(orgId ? orgs[orgId] : undefined) ?? (orgSlug ? orgs[orgSlug] : undefined);
 	return orgConfig?.maxCusProducts ?? DEFAULT_CUS_PRODUCT_LIMIT;
+};
+
+export const getOrgEntitiesLimit = ({
+	orgId,
+	orgSlug,
+}: {
+	orgId?: string;
+	orgSlug?: string;
+}): number => {
+	const orgs = store.get().orgs;
+	const orgConfig =
+		(orgId ? orgs[orgId] : undefined) ?? (orgSlug ? orgs[orgSlug] : undefined);
+	return orgConfig?.maxEntities ?? DEFAULT_ENTITIES_LIMIT;
 };
 
 export const getOrgLimitsConfigFromSource = async () => {
@@ -62,4 +75,16 @@ export const updateFullOrgLimitsConfig = async ({
 	config: OrgLimitsConfig;
 }) => {
 	await store.writeToSource({ config });
+};
+
+/**
+ * Test-only helper: override the in-memory org limits config without touching S3.
+ * Use inside tests to simulate admin-configured org limits deterministically.
+ */
+export const _setOrgLimitsConfigForTesting = ({
+	config,
+}: {
+	config: OrgLimitsConfig;
+}) => {
+	store._setRuntimeConfigForTesting(config);
 };

--- a/server/tests/integration/crud/entities/get-entities-max-entities-limit.test.ts
+++ b/server/tests/integration/crud/entities/get-entities-max-entities-limit.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService.js";
+import type { OrgLimitsConfig } from "@/internal/misc/edgeConfig/orgLimitsSchemas.js";
+import {
+	_setOrgLimitsConfigForTesting,
+	DEFAULT_ENTITIES_LIMIT,
+	getOrgEntitiesLimit,
+} from "@/internal/misc/edgeConfig/orgLimitsStore.js";
+
+/**
+ * These tests mutate the in-memory org limits store (a module-level singleton)
+ * so they must run serially, not concurrently, to avoid leaking state into
+ * unrelated tests.
+ *
+ * They call CusService.getFull directly (in-process) rather than going through
+ * the HTTP server, because the running server has its own copy of the
+ * orgLimitsStore that only refreshes from S3 every 30s. Calling in-process
+ * exercises the same SQL path (getFullCusQuery -> buildEntitiesCTE) while
+ * picking up the in-memory override immediately.
+ */
+
+const resetOrgLimits = () => {
+	_setOrgLimitsConfigForTesting({ config: { orgs: {} } });
+};
+
+afterAll(() => {
+	resetOrgLimits();
+});
+
+test(`${chalk.yellowBright("maxEntities: caps entities returned by CusService.getFull to configured limit")}`, async () => {
+	const customerId = "max-entities-cap";
+	const entityCount = 5;
+	const maxEntities = 3;
+
+	const { ctx, entities } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({}),
+			s.entities({ count: entityCount, featureId: TestFeature.Users }),
+		],
+		actions: [],
+	});
+
+	expect(entities.length).toBe(entityCount);
+
+	try {
+		const config: OrgLimitsConfig = {
+			orgs: { [ctx.org.id]: { maxEntities } },
+		};
+		_setOrgLimitsConfigForTesting({ config });
+
+		// Verify the accessor resolves to the override
+		expect(getOrgEntitiesLimit({ orgId: ctx.org.id })).toBe(maxEntities);
+
+		const fullCus = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+
+		expect(fullCus.entities).toBeDefined();
+		expect(fullCus.entities.length).toBe(maxEntities);
+	} finally {
+		resetOrgLimits();
+	}
+});
+
+test(`${chalk.yellowBright("maxEntities: returns all entities when override is absent (falls back to default)")}`, async () => {
+	const customerId = "max-entities-default";
+	const entityCount = 4;
+
+	const { ctx, entities } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({}),
+			s.entities({ count: entityCount, featureId: TestFeature.Users }),
+		],
+		actions: [],
+	});
+
+	expect(entities.length).toBe(entityCount);
+
+	resetOrgLimits();
+
+	// No override for this org -> default (300) applies
+	expect(getOrgEntitiesLimit({ orgId: ctx.org.id })).toBe(
+		DEFAULT_ENTITIES_LIMIT,
+	);
+
+	const fullCus = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		withEntities: true,
+	});
+
+	expect(fullCus.entities).toBeDefined();
+	expect(fullCus.entities.length).toBe(entityCount);
+});
+
+test(`${chalk.yellowBright("maxEntities: raising the limit exposes previously-hidden entities")}`, async () => {
+	const customerId = "max-entities-raise";
+	const entityCount = 4;
+
+	const { ctx, entities } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({}),
+			s.entities({ count: entityCount, featureId: TestFeature.Users }),
+		],
+		actions: [],
+	});
+
+	expect(entities.length).toBe(entityCount);
+
+	try {
+		// Start with a tight cap
+		_setOrgLimitsConfigForTesting({
+			config: { orgs: { [ctx.org.id]: { maxEntities: 2 } } },
+		});
+
+		const capped = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		expect(capped.entities.length).toBe(2);
+
+		// Raise the cap above the entity count
+		_setOrgLimitsConfigForTesting({
+			config: { orgs: { [ctx.org.id]: { maxEntities: 50 } } },
+		});
+
+		const uncapped = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		expect(uncapped.entities.length).toBe(entityCount);
+	} finally {
+		resetOrgLimits();
+	}
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an org-level `maxEntities` edge config to cap how many entities `CusService.getFull` returns. Default is 300 to control payload size. Also fixes config updates so existing limits aren’t wiped.

- **New Features**
  - Added `maxEntities` to `OrgLimitsConfig` and `orgLimitsStore` with default `300`.
  - Introduced `getOrgEntitiesLimit`; `CusService.getFull` passes this to `getFullCusQuery`, and `buildEntitiesCTE` applies it in SQL.
  - Added test-only `_setOrgLimitsConfigForTesting` and integration tests covering cap, default fallback, and raising the limit.

- **Bug Fixes**
  - `updateOrgLimitsInSource` now merges updates instead of overwriting, preserving existing `maxEntities` and `maxCusProducts`.

<sup>Written for commit 2f588fdbd4b817149ed70bf8be7f0064622f7605. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing per-org edge-config system to support a configurable `maxEntities` limit (alongside the existing `maxCusProducts` limit), wiring it through `CusService.getFull` → `getFullCusQuery` → `buildEntitiesCTE` with a default of 300. Three integration tests cover cap, default fallback, and raising the limit.

- **Bug**: `updateOrgLimitsInSource` replaces the entire org config object with `{ maxCusProducts }`, so calling it will permanently destroy any previously-stored `maxEntities` value. The fix is to spread the existing config before applying changes. [Improvements]
- **Bug**: `getPaginatedFullCusQuery` (used by `CusBatchService.getPage` and `getByInternalIds`) still has a hardcoded `LIMIT 300` for entities and never reads `getOrgEntitiesLimit`, so the configurable limit has no effect on the list-customers API path. [Improvements]
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with caution — two P1 gaps mean the feature is incomplete and `updateOrgLimitsInSource` can silently destroy `maxEntities` config.

Two P1 issues remain: `updateOrgLimitsInSource` overwrites per-org config destroying any `maxEntities` value when updating `maxCusProducts`, and `getPaginatedFullCusQuery` ignores the new per-org limit entirely. The single-customer path is correctly wired, schema and store lookups are sound, and tests are good — but the gaps reduce confidence below a clean 5.

`server/src/internal/misc/edgeConfig/orgLimitsStore.ts` (updateOrgLimitsInSource data-loss bug) and `server/src/internal/customers/getFullCusQuery.ts` (hardcoded LIMIT 300 in paginated path)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/misc/edgeConfig/orgLimitsSchemas.ts | Adds `maxEntities` optional field to `OrgLimitsConfigSchema`; schema change is correct and consistent with the existing `maxCusProducts` field. |
| server/src/internal/misc/edgeConfig/orgLimitsStore.ts | Adds `DEFAULT_ENTITIES_LIMIT` and `getOrgEntitiesLimit`; however `updateOrgLimitsInSource` overwrites the full org config with only `maxCusProducts`, silently deleting any existing `maxEntities` value. |
| server/src/internal/customers/CusService.ts | Correctly reads the per-org entities limit and passes it to `getFullCusQuery`; the single-customer path is now fully wired up. |
| server/src/internal/customers/getFullCusQuery.ts | `buildEntitiesCTE` and `getFullCusQuery` correctly receive and apply `entitiesLimit`, but `getPaginatedFullCusQuery` still has a hardcoded `LIMIT 300` for entities and accepts no `entitiesLimit` parameter, so the per-org limit is not applied to the list-customers path. |
| server/tests/integration/crud/entities/get-entities-max-entities-limit.test.ts | Good integration tests covering cap, default fallback, and raising the limit; only exercises the `CusService.getFull` path (single customer), which is consistent with the current implementation scope. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request: getFull / getPage] --> B{Single or Paginated?}
    B -- Single --> C[CusService.getFull]
    B -- Paginated --> D[CusBatchService.getPage / getByInternalIds]

    C --> E[getOrgEntitiesLimit ✅]
    E --> F[getFullCusQuery]
    F --> G[buildEntitiesCTE\nLIMIT entitiesLimit ✅]

    D --> H[getOrgCusProductLimit only]
    H --> I[getPaginatedFullCusQuery]
    I --> J[Inline entities CTE\nLIMIT 300 hardcoded ⚠️]

    K[(orgLimitsStore\nmaxEntities config)] --> E
    K --> L[updateOrgLimitsInSource]
    L --> M[Overwrites entire org config\nloses maxEntities ⚠️]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/misc/edgeConfig/orgLimitsStore.ts`, line 53-70 ([link](https://github.com/useautumn/autumn/blob/50aa88b91f519b4758e5816ea094cfd55c89c24a/server/src/internal/misc/edgeConfig/orgLimitsStore.ts#L53-L70)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`updateOrgLimitsInSource` silently destroys `maxEntities` config**

   When `maxCusProducts` is provided, line 65 replaces the entire org config object with `{ maxCusProducts }`, discarding any existing `maxEntities` value. Even the delete path (`maxCusProducts === undefined`) wipes the full org entry, so calling this function with only a `maxCusProducts` change will permanently erase any per-org `maxEntities` that was previously set.

   The fix is to merge with the current config rather than replace:

   ```typescript
   export const updateOrgLimitsInSource = async ({
   	orgId,
   	maxCusProducts,
   	maxEntities,
   }: {
   	orgId: string;
   	maxCusProducts?: number;
   	maxEntities?: number;
   }) => {
   	const config = await store.readFromSource();

   	if (maxCusProducts === undefined && maxEntities === undefined) {
   		delete config.orgs[orgId];
   	} else {
   		config.orgs[orgId] = {
   			...config.orgs[orgId],
   			...(maxCusProducts !== undefined ? { maxCusProducts } : {}),
   			...(maxEntities !== undefined ? { maxEntities } : {}),
   		};
   	}

   	await store.writeToSource({ config });
   	return config.orgs[orgId];
   };
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/misc/edgeConfig/orgLimitsStore.ts
   Line: 53-70

   Comment:
   **`updateOrgLimitsInSource` silently destroys `maxEntities` config**

   When `maxCusProducts` is provided, line 65 replaces the entire org config object with `{ maxCusProducts }`, discarding any existing `maxEntities` value. Even the delete path (`maxCusProducts === undefined`) wipes the full org entry, so calling this function with only a `maxCusProducts` change will permanently erase any per-org `maxEntities` that was previously set.

   The fix is to merge with the current config rather than replace:

   ```typescript
   export const updateOrgLimitsInSource = async ({
   	orgId,
   	maxCusProducts,
   	maxEntities,
   }: {
   	orgId: string;
   	maxCusProducts?: number;
   	maxEntities?: number;
   }) => {
   	const config = await store.readFromSource();

   	if (maxCusProducts === undefined && maxEntities === undefined) {
   		delete config.orgs[orgId];
   	} else {
   		config.orgs[orgId] = {
   			...config.orgs[orgId],
   			...(maxCusProducts !== undefined ? { maxCusProducts } : {}),
   			...(maxEntities !== undefined ? { maxEntities } : {}),
   		};
   	}

   	await store.writeToSource({ config });
   	return config.orgs[orgId];
   };
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/customers/getFullCusQuery.ts`, line 700-706 ([link](https://github.com/useautumn/autumn/blob/50aa88b91f519b4758e5816ea094cfd55c89c24a/server/src/internal/customers/getFullCusQuery.ts#L700-L706)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`getPaginatedFullCusQuery` ignores per-org `maxEntities` limit**

   The paginated query path (used by `CusBatchService.getPage` and `CusBatchService.getByInternalIds`) still has a hardcoded `LIMIT 300` for entities and neither accepts nor reads `getOrgEntitiesLimit`. The configurable limit therefore only applies when fetching a single customer via `CusService.getFull`, leaving the list-customers API unaffected.

   `getPaginatedFullCusQuery` needs an `entitiesLimit` parameter (analogous to `cusProductLimit`), and `CusBatchService` needs to call `getOrgEntitiesLimit` and pass it through — the same pattern already used for `cusProductLimit`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/getFullCusQuery.ts
   Line: 700-706

   Comment:
   **`getPaginatedFullCusQuery` ignores per-org `maxEntities` limit**

   The paginated query path (used by `CusBatchService.getPage` and `CusBatchService.getByInternalIds`) still has a hardcoded `LIMIT 300` for entities and neither accepts nor reads `getOrgEntitiesLimit`. The configurable limit therefore only applies when fetching a single customer via `CusService.getFull`, leaving the list-customers API unaffected.

   `getPaginatedFullCusQuery` needs an `entitiesLimit` parameter (analogous to `cusProductLimit`), and `CusBatchService` needs to call `getOrgEntitiesLimit` and pass it through — the same pattern already used for `cusProductLimit`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/misc/edgeConfig/orgLimitsStore.ts
Line: 53-70

Comment:
**`updateOrgLimitsInSource` silently destroys `maxEntities` config**

When `maxCusProducts` is provided, line 65 replaces the entire org config object with `{ maxCusProducts }`, discarding any existing `maxEntities` value. Even the delete path (`maxCusProducts === undefined`) wipes the full org entry, so calling this function with only a `maxCusProducts` change will permanently erase any per-org `maxEntities` that was previously set.

The fix is to merge with the current config rather than replace:

```typescript
export const updateOrgLimitsInSource = async ({
	orgId,
	maxCusProducts,
	maxEntities,
}: {
	orgId: string;
	maxCusProducts?: number;
	maxEntities?: number;
}) => {
	const config = await store.readFromSource();

	if (maxCusProducts === undefined && maxEntities === undefined) {
		delete config.orgs[orgId];
	} else {
		config.orgs[orgId] = {
			...config.orgs[orgId],
			...(maxCusProducts !== undefined ? { maxCusProducts } : {}),
			...(maxEntities !== undefined ? { maxEntities } : {}),
		};
	}

	await store.writeToSource({ config });
	return config.orgs[orgId];
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/customers/getFullCusQuery.ts
Line: 700-706

Comment:
**`getPaginatedFullCusQuery` ignores per-org `maxEntities` limit**

The paginated query path (used by `CusBatchService.getPage` and `CusBatchService.getByInternalIds`) still has a hardcoded `LIMIT 300` for entities and neither accepts nor reads `getOrgEntitiesLimit`. The configurable limit therefore only applies when fetching a single customer via `CusService.getFull`, leaving the list-customers API unaffected.

`getPaginatedFullCusQuery` needs an `entitiesLimit` parameter (analogous to `cusProductLimit`), and `CusBatchService` needs to call `getOrgEntitiesLimit` and pass it through — the same pattern already used for `cusProductLimit`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 max entities edge config"](https://github.com/useautumn/autumn/commit/50aa88b91f519b4758e5816ea094cfd55c89c24a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28758318)</sub>

<!-- /greptile_comment -->