### PR TITLE
chore: add ready endpoint

### DIFF
--- a/server/src/honoUtils/handleReadyCheck.ts
+++ b/server/src/honoUtils/handleReadyCheck.ts
@@ -1,9 +1,13 @@
+import { timingSafeEqual } from "node:crypto";
+import type { Context } from "hono";
 import { clientCritical } from "../db/initDrizzle.js";
 import { getDbHealth, PgHealth } from "../db/pgHealthMonitor.js";
 import { redis } from "../external/redis/initRedis.js";
+import type { HonoEnv } from "./HonoEnv.js";
 
 const POSTGRES_TIMEOUT_MS = 1_000;
 const REDIS_TIMEOUT_MS = 500;
+const READY_CHECK_TOKEN = process.env.READY_CHECK_TOKEN?.trim();
 
 const withTimeout = async <T>({
 	timeoutMs,
@@ -93,22 +97,40 @@ const runRedisCheck = async () => {
 	}
 };
 
-export const handleReadyCheck = async () => {
+const hasReadyCheckAccess = (c: Context<HonoEnv>) => {
+	const providedToken = c.req.header("x-ready-check-token");
+
+	if (!READY_CHECK_TOKEN || !providedToken) return false;
+
+	const expected = Buffer.from(READY_CHECK_TOKEN);
+	const provided = Buffer.from(providedToken);
+
+	return (
+		expected.length === provided.length && timingSafeEqual(expected, provided)
+	);
+};
+
+export const handleReadyCheck = async (c: Context<HonoEnv>) => {
 	const [postgresResult, redisResult] = await Promise.all([
 		runPostgresCheck(),
 		runRedisCheck(),
 	]);
 
-	const ok = postgres.ok && redis.ok;
+	const ok = postgresResult.ok && redisResult.ok;
+	const status = ok ? 200 : 503;
 
-	return Response.json(
+	if (!hasReadyCheckAccess(c)) {
+		return c.json({ ok }, status);
+	}
+
+	return c.json(
 		{
 			ok,
 			checks: {
-				postgres,
-				redis,
+				postgres: postgresResult,
+				redis: redisResult,
 			},
 		},
-		{ status: ok ? 200 : 503 },
+		status,
 	);
 };

--- a/server/src/honoUtils/handleReadyCheck.ts
+++ b/server/src/honoUtils/handleReadyCheck.ts
@@ -1,0 +1,114 @@
+import { clientCritical } from "../db/initDrizzle.js";
+import { getDbHealth, PgHealth } from "../db/pgHealthMonitor.js";
+import { redis } from "../external/redis/initRedis.js";
+
+const POSTGRES_TIMEOUT_MS = 1_000;
+const REDIS_TIMEOUT_MS = 500;
+
+const withTimeout = async <T>({
+	timeoutMs,
+	fn,
+}: {
+	timeoutMs: number;
+	fn: () => Promise<T>;
+}): Promise<T> => {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	try {
+		return await Promise.race([
+			fn(),
+			new Promise<never>((_, reject) => {
+				timeoutId = setTimeout(
+					() => reject(new Error(`timed out after ${timeoutMs}ms`)),
+					timeoutMs,
+				);
+			}),
+		]);
+	} finally {
+		clearTimeout(timeoutId);
+	}
+};
+
+const runPostgresCheck = async () => {
+	const startedAt = Date.now();
+
+	try {
+		const health = getDbHealth();
+		await withTimeout({
+			timeoutMs: POSTGRES_TIMEOUT_MS,
+			fn: async () => {
+				await clientCritical`SELECT 1`;
+			},
+		});
+
+		return {
+			ok: health === PgHealth.Healthy,
+			latencyMs: Date.now() - startedAt,
+			monitorHealth: health,
+			timeoutMs: POSTGRES_TIMEOUT_MS,
+			error:
+				health === PgHealth.Healthy
+					? undefined
+					: "postgres health monitor is degraded",
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			latencyMs: Date.now() - startedAt,
+			monitorHealth: getDbHealth(),
+			timeoutMs: POSTGRES_TIMEOUT_MS,
+			error: error instanceof Error ? error.message : "unknown postgres error",
+		};
+	}
+};
+
+const runRedisCheck = async () => {
+	const startedAt = Date.now();
+
+	try {
+		const result = await withTimeout({
+			timeoutMs: REDIS_TIMEOUT_MS,
+			fn: () => redis.ping(),
+		});
+		const status = redis.status;
+
+		return {
+			ok: status === "ready" && result === "PONG",
+			latencyMs: Date.now() - startedAt,
+			status,
+			timeoutMs: REDIS_TIMEOUT_MS,
+			error:
+				status === "ready" && result === "PONG"
+					? undefined
+					: `unexpected redis state: status=${status}, ping=${result}`,
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			latencyMs: Date.now() - startedAt,
+			status: redis.status,
+			timeoutMs: REDIS_TIMEOUT_MS,
+			error: error instanceof Error ? error.message : "unknown redis error",
+		};
+	}
+};
+
+export const handleReadyCheck = async () => {
+	const [postgres, redis] = await Promise.all([
+		runPostgresCheck(),
+		runRedisCheck(),
+	]);
+
+	const ok = postgres.ok && redis.ok;
+
+	return Response.json(
+		{
+			ok,
+			checks: {
+				postgres,
+				redis,
+			},
+		},
+		{ status: ok ? 200 : 503 },
+	);
+};

--- a/server/src/honoUtils/handleReadyCheck.ts
+++ b/server/src/honoUtils/handleReadyCheck.ts
@@ -12,9 +12,11 @@ const READY_CHECK_TOKEN = process.env.READY_CHECK_TOKEN?.trim();
 const withTimeout = async <T>({
 	timeoutMs,
 	fn,
+	onTimeout,
 }: {
 	timeoutMs: number;
 	fn: () => Promise<T>;
+	onTimeout?: () => void;
 }): Promise<T> => {
 	let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
@@ -22,10 +24,11 @@ const withTimeout = async <T>({
 		return await Promise.race([
 			fn(),
 			new Promise<never>((_, reject) => {
-				timeoutId = setTimeout(
-					() => reject(new Error(`timed out after ${timeoutMs}ms`)),
-					timeoutMs,
-				);
+				timeoutId = setTimeout(() => {
+					onTimeout?.();
+					reject(new Error(`timed out after ${timeoutMs}ms`));
+				}, timeoutMs);
+				timeoutId.unref?.();
 			}),
 		]);
 	} finally {
@@ -38,11 +41,11 @@ const runPostgresCheck = async () => {
 
 	try {
 		const health = getDbHealth();
+		const query = clientCritical`SELECT 1`;
 		await withTimeout({
 			timeoutMs: POSTGRES_TIMEOUT_MS,
-			fn: async () => {
-				await clientCritical`SELECT 1`;
-			},
+			fn: () => query,
+			onTimeout: () => query.cancel(),
 		});
 
 		return {

--- a/server/src/honoUtils/handleReadyCheck.ts
+++ b/server/src/honoUtils/handleReadyCheck.ts
@@ -94,7 +94,7 @@ const runRedisCheck = async () => {
 };
 
 export const handleReadyCheck = async () => {
-	const [postgres, redis] = await Promise.all([
+	const [postgresResult, redisResult] = await Promise.all([
 		runPostgresCheck(),
 		runRedisCheck(),
 	]);

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -45,6 +45,8 @@ const ALLOWED_HEADERS = [
 	"If-None-Match",
 	"If-Modified-Since",
 	"If-Unmodified-Since",
+	"x-ready-check-token",
+	"X-Ready-Check-Token",
 	"idempotency-key",
 	"Idempotency-Key",
 	"User-Agent", // Required for better-auth v1.4.0+ compatibility with Safari/Zen browser

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -17,6 +17,7 @@ import { replicaDbMiddleware } from "./honoMiddlewares/replicaDbMiddleware.js";
 import { traceEnrichMiddleware } from "./honoMiddlewares/traceMiddleware.js";
 import type { HonoEnv } from "./honoUtils/HonoEnv.js";
 import { handleHealthCheck } from "./honoUtils/handleHealthCheck.js";
+import { handleReadyCheck } from "./honoUtils/handleReadyCheck.js";
 import { cliRouter } from "./internal/dev/cli/cliRouter.js";
 import { handleOAuthCallback } from "./internal/orgs/handlers/stripeHandlers/handleOAuthCallback.js";
 import { apiRouter } from "./routers/apiRouter.js";
@@ -81,6 +82,7 @@ export const createHonoApp = () => {
 	// Health check endpoint for AWS/ECS load balancer
 
 	app.get("/stripe/oauth_callback", handleOAuthCallback);
+	app.get("/ready", handleReadyCheck);
 
 	// Step 1: OTel HTTP span + base middleware + span enrichment
 	app.use(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a /ready endpoint that probes Postgres and Redis in parallel with strict timeouts and returns 200/503. Detailed results are only returned when a valid x-ready-check-token is provided.

- **New Features**
  - Registers GET /ready via handleReadyCheck before auth/OTel middleware.
  - Postgres: SELECT 1 (1s) and Redis: PING (500ms); both include latencyMs, timeoutMs, and error details; Postgres also includes monitorHealth, Redis includes status.
  - Timeout safety: timers are unref’d and cleared in finally to avoid hangs.
  - Security: returns only { ok } by default; exposes { ok, checks: { postgres, redis } } only when x-ready-check-token matches READY_CHECK_TOKEN (constant-time compare); adds x-ready-check-token/X-Ready-Check-Token to allowed headers.

<sup>Written for commit 64e32fdfd2a20a0005520d3cc3dcf2ca6c904269. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a `GET /ready` readiness endpoint that checks Postgres (1 s timeout via `clientCritical SELECT 1`) and Redis (500 ms timeout via `ping`) in parallel, returning `200` when both pass and `503` otherwise with per-check latency and error details.

**Key changes:**
- **Improvements**: New `handleReadyCheck` with structured `withTimeout` helper, parallel dependency probes, and detailed JSON diagnostics per check.
- **API changes**: `GET /ready` registered before auth/OTel middleware (correct for load-balancer readiness probes), consistent with existing `GET /` health-check placement.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only finding is a minor variable-shadowing style issue that carries no runtime risk.

All remaining findings are P2 style suggestions. The core implementation (parallel probes, timeout cleanup in finally blocks, correct 200/503 status codes, pre-middleware route placement) is solid.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoUtils/handleReadyCheck.ts | New readiness probe that checks Postgres (`clientCritical SELECT 1`, 1 s timeout) and Redis (`ping`, 500 ms timeout) in parallel; returns 200/503 — solid implementation with one minor variable-shadowing style issue. |
| server/src/initHono.ts | Registers `GET /ready` before auth/OTel middleware (correct placement for a readiness probe), mirroring the existing health-check pattern. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant LB as Load Balancer
    participant App as Hono /ready
    participant PG as Postgres (clientCritical)
    participant RD as Redis

    LB->>App: GET /ready
    App->>PG: SELECT 1 (timeout 1000ms)
    App->>RD: PING (timeout 500ms)
    PG-->>App: result + PgHealth state
    RD-->>App: PONG + status
    App-->>LB: 200 { ok: true } or 503 { ok: false, checks: {...} }
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/honoUtils/handleReadyCheck.ts
Line: 97

Comment:
**Variable shadows module-level `redis` import**

The destructured `redis` variable shadows the top-level `import { redis }` from `initRedis.js`. While it doesn't cause a functional bug here (the import is only used inside `runRedisCheck`, not in `handleReadyCheck`), it's confusing and can trip up future readers or refactors. Prefer a more specific name.

```suggestion
	const [postgresResult, redisResult] = await Promise.all([
```

Then update the response body accordingly:

```ts
checks: {
  postgres: postgresResult,
  redis: redisResult,
},
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add ready endpoint"](https://github.com/useautumn/autumn/commit/547c8aebf87cdaa8f2efe9300514ae27af7315c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28763766)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->