### PR TITLE
Replace info box with toggle for granted balance in balance edit sheet

### DIFF
--- a/server/src/internal/balances/handlers/handleUpdateBalance.ts
+++ b/server/src/internal/balances/handlers/handleUpdateBalance.ts
@@ -1,12 +1,8 @@
 import {
-	ErrCode,
 	findFeatureById,
 	notNullish,
-	nullish,
-	RecaseError,
 	UpdateBalanceParamsV0Schema,
 } from "@autumn/shared";
-import { StatusCodes } from "http-status-codes";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { runUpdateBalanceV2 } from "@/internal/balances/updateBalance/runUpdateBalanceV2";
 import { runUpdateUsage } from "@/internal/balances/updateBalance/runUpdateUsage";
@@ -32,15 +28,6 @@ export const handleUpdateBalance = createRoute({
 
 		const targetBalance = params.remaining ?? params.current_balance;
 
-		if (notNullish(params.included_grant) && nullish(targetBalance)) {
-			throw new RecaseError({
-				message:
-					"'remaining' is required when updating granted balance",
-				code: ErrCode.InvalidRequest,
-				statusCode: StatusCodes.BAD_REQUEST,
-			});
-		}
-
 		let fullCustomer = await getOrSetCachedFullCustomer({
 			ctx,
 			customerId: params.customer_id,
@@ -59,7 +46,6 @@ export const handleUpdateBalance = createRoute({
 		}
 
 		if (notNullish(params.included_grant)) {
-
 			ctx.logger.info(
 				`updating granted balance for feature ${params.feature_id} to ${params.included_grant}`,
 			);

--- a/server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts
+++ b/server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts
@@ -83,14 +83,7 @@ test.concurrent(`${chalk.yellowBright("update-prepaid-granted1: granted_balance 
 	});
 
 	// ── Simulate BalanceEditSheet "set" mode submission ──
-	// Form defaults mirror the API state:
-	//   defaultGPB       = granted + purchased = 300
-	//   defaultBalance   = current_balance     = 270
-	//   prepaidAllowance = purchased_balance    = 200
-	//
 	// User increases GPB from 300 → 320 (wants +20 on granted)
-	const defaultGPB = bal.granted_balance + bal.purchased_balance; // 300
-	const defaultBalance = bal.current_balance; // 270
 	const prepaidAllowance = bal.purchased_balance; // 200
 	const newGPB = 320;
 

--- a/server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts
+++ b/server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts
@@ -96,8 +96,6 @@ test.concurrent(`${chalk.yellowBright("update-prepaid-granted1: granted_balance 
 
 	const grantedBalanceInput = computeGrantedBalanceInput({
 		newGPB,
-		defaultGPB,
-		defaultBalance,
 		prepaidAllowance,
 	});
 

--- a/shared/utils/cusEntUtils/balanceUtils/computeGrantedBalanceInput.ts
+++ b/shared/utils/cusEntUtils/balanceUtils/computeGrantedBalanceInput.ts
@@ -11,8 +11,6 @@ export function computeGrantedBalanceInput({
 	prepaidAllowance,
 }: {
 	newGPB: number;
-	defaultGPB: number;
-	defaultBalance: number;
 	prepaidAllowance: number;
 }): number {
 	return newGPB - prepaidAllowance;

--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -13,7 +13,9 @@ import { ClockCountdownIcon } from "@phosphor-icons/react";
 import { useStore } from "@tanstack/react-form";
 import { useState } from "react";
 import { toast } from "sonner";
+import { ConfigRow } from "@/components/forms/shared/ConfigRow";
 import { DateInputUnix } from "@/components/general/DateInputUnix";
+import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/v2/buttons/Button";
 import { CopyButton } from "@/components/v2/buttons/CopyButton";
 import { GroupedTabButton } from "@/components/v2/buttons/GroupedTabButton";
@@ -26,7 +28,6 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { formatUnixToDateTime } from "@/utils/formatUtils/formatDateUtils";
 import { getBackendErr, notNullish } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
 import { useCustomerContext } from "../../customer/CustomerContext";
 import { BalanceEditPreviews } from "./BalanceEditPreviews";
 import { GrantedBalancePopover } from "./GrantedBalancePopover";
@@ -463,6 +464,11 @@ function SetBalanceFields({
 /* ─── Add Balance Mode ─── */
 
 function AddBalanceFields({ form }: { form: BalanceEditFormInstance }) {
+	const updateGrantedBalance = useStore(
+		form.store,
+		(s) => s.values.updateGrantedBalance,
+	);
+
 	return (
 		<div className="flex flex-col gap-3">
 			<form.Field name="addValue">
@@ -482,9 +488,18 @@ function AddBalanceFields({ form }: { form: BalanceEditFormInstance }) {
 					/>
 				)}
 			</form.Field>
-			<InfoBox variant="note">
-				Current and total granted balance will both be updated.
-			</InfoBox>
+			<ConfigRow
+				title="Also Update Granted Balance"
+				description="Increase the total granted balance by the same amount"
+				action={
+					<Switch
+						checked={updateGrantedBalance}
+						onCheckedChange={(checked) =>
+							form.setFieldValue("updateGrantedBalance", !!checked)
+						}
+					/>
+				}
+			/>
 		</div>
 	);
 }
@@ -551,9 +566,6 @@ function SubmitButton({
 				if (values.mode === "set") {
 					const grantedBalanceInput = computeGrantedBalanceInput({
 						newGPB: values.grantedAndPurchasedBalance ?? 0,
-						defaultGPB:
-							form.options.defaultValues?.grantedAndPurchasedBalance ?? 0,
-						defaultBalance: form.options.defaultValues?.balance ?? 0,
 						prepaidAllowance: form.prepaidAllowance,
 					});
 
@@ -566,18 +578,29 @@ function SubmitButton({
 							feature_id: featureId,
 							current_balance: targetBalance,
 							included_grant: grantedBalanceInput ?? undefined,
-							granted_balance: grantedBalanceInput ?? undefined,
 							customer_entitlement_id: selectedCusEnt.id,
 							entity_id: entityId ?? undefined,
 							next_reset_at: values.nextResetAt ?? undefined,
 						}),
 					);
 				} else {
+					const addAmount = parseFloat(String(values.addValue));
+					const defaultGPB =
+						form.options.defaultValues?.grantedAndPurchasedBalance ?? 0;
+					const newGPB = defaultGPB + addAmount;
+					const grantedBalanceInput = values.updateGrantedBalance
+						? computeGrantedBalanceInput({
+								newGPB,
+								prepaidAllowance: form.prepaidAllowance,
+							})
+						: undefined;
+
 					promises.push(
 						axiosInstance.post("/v1/balances/update", {
 							customer_id: customer.id || customer.internal_id,
 							feature_id: featureId,
-							add_to_balance: parseFloat(String(values.addValue)),
+							add_to_balance: addAmount,
+							included_grant: grantedBalanceInput,
 							customer_entitlement_id: selectedCusEnt.id,
 							entity_id: entityId ?? undefined,
 						}),

--- a/vite/src/views/customers2/components/sheets/balanceEditFormSchema.ts
+++ b/vite/src/views/customers2/components/sheets/balanceEditFormSchema.ts
@@ -7,6 +7,7 @@ export const BalanceEditFormSchema = z
 		grantedAndPurchasedBalance: z.number().nullable(),
 		nextResetAt: z.number().nullable(),
 		addValue: z.number().nullable(),
+		updateGrantedBalance: z.boolean(),
 	})
 	.check((ctx) => {
 		const { mode, balance, addValue } = ctx.value;

--- a/vite/src/views/customers2/components/sheets/useBalanceEditForm.ts
+++ b/vite/src/views/customers2/components/sheets/useBalanceEditForm.ts
@@ -50,6 +50,7 @@ export function useBalanceEditForm({
 			grantedAndPurchasedBalance: grantedAndPurchasedBalance ?? null,
 			nextResetAt: selectedCusEnt.next_reset_at ?? null,
 			addValue: null,
+			updateGrantedBalance: true,
 		} as BalanceEditForm,
 		validators: {
 			onChange: BalanceEditFormSchema,


### PR DESCRIPTION
## Summary
- Replace the static "Current and total granted balance will both be updated" info box in the Add to Balance mode with a `ConfigRow` + `Switch` toggle ("Also Update Granted Balance") so users can control whether adding to balance also bumps the granted balance
- Remove the overly restrictive `included_grant` validation in `handleUpdateBalance` that blocked sending `included_grant` without `remaining`
- Clean up dead `defaultGPB` / `defaultBalance` params from `computeGrantedBalanceInput`

## Test plan
- [ ] Open customer page → edit balance sheet → switch to "Add to Balance" tab
- [ ] Verify the toggle appears instead of the old info box
- [ ] Add to balance with toggle ON → confirm both current and granted balance are updated
- [ ] Add to balance with toggle OFF → confirm only current balance is updated
- [ ] "Set Balance" mode still works as before

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the static notice in Add Balance with an “Also Update Granted Balance” toggle so users can choose whether adding funds also increases the granted balance. Relaxed server validation to accept `included_grant` without `remaining` and simplified granted balance input logic.

- **New Features**
  - Added `ConfigRow` + `Switch` in Add Balance; on by default.
  - When on, the UI computes and sends `included_grant`; when off, only current balance is updated.

- **Bug Fixes**
  - Removed the check in `handleUpdateBalance` that required `remaining` when sending `included_grant`.
  - Dropped unused `defaultGPB` and `defaultBalance` params from `computeGrantedBalanceInput` and removed unused test variables.

<sup>Written for commit 40707dd6e70597877f91642795a7981ae9f22965. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces a static info box in the "Add to Balance" sheet with a `ConfigRow` + `Switch` toggle ("Also Update Granted Balance"), giving users control over whether adding to balance also bumps the granted balance. It also cleans up two unused params from `computeGrantedBalanceInput` and removes an overly restrictive server-side validation that blocked sending `included_grant` without `remaining`.

**Key changes:**
- **Improvements**: `AddBalanceFields` now renders a user-controlled toggle instead of a hard-coded note; defaults to `true` to preserve existing behaviour.
- **Bug fixes**: Removes the server validation that incorrectly rejected `included_grant` when no `remaining`/`current_balance` was provided — blocking the new "add + update granted" path.
- **Improvements**: Dead `defaultGPB`/`defaultBalance` params removed from `computeGrantedBalanceInput`; duplicate `granted_balance` field removed from the "set" mode API payload.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/cleanup suggestions that do not affect runtime behaviour.

Logic is sound: the granted-balance computation for 'add' mode correctly derives the absolute target (currentGranted + addAmount) via the shared util. The server-side guard removal is justified now that `included_grant` can accompany `add_to_balance`. Default toggle value preserves prior behaviour. Only open items are a deprecated component import and two unused test variables.

Minor attention to `update-balance-prepaid-granted.test.ts` (unused `defaultGPB`/`defaultBalance` variables) and `BalanceEditSheet.tsx` (deprecated `ui/switch` import).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx | Replaces static InfoBox with ConfigRow+Switch toggle; computes grantedBalanceInput in "add" mode; removes duplicate `granted_balance` field from "set" mode payload. Minor: imports from deprecated `@/components/ui/switch`. |
| server/src/internal/balances/handlers/handleUpdateBalance.ts | Removes overly restrictive validation that required `remaining`/`current_balance` alongside `included_grant`; also removes an extra blank line. Clean and correct. |
| shared/utils/cusEntUtils/balanceUtils/computeGrantedBalanceInput.ts | Removes dead `defaultGPB`/`defaultBalance` params that were never used in the computation. Correct cleanup; JSDoc is now slightly stale. |
| server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts | Test updated to remove unused params from `computeGrantedBalanceInput`, but `defaultGPB` and `defaultBalance` local variables are still defined and now unused — will trigger lint warnings. |
| vite/src/views/customers2/components/sheets/balanceEditFormSchema.ts | Adds `updateGrantedBalance: z.boolean()` to the form schema. Straightforward addition. |
| vite/src/views/customers2/components/sheets/useBalanceEditForm.ts | Adds `updateGrantedBalance: true` as default form value, preserving prior default behaviour (both balances updated). |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant BalanceEditSheet
    participant API as /v1/balances/update
    participant Handler as handleUpdateBalance
    participant UpdateBalance as runUpdateBalanceV2
    participant UpdateGranted as updateGrantedBalance

    User->>BalanceEditSheet: Switch to "Add to Balance" tab
    User->>BalanceEditSheet: Enter addValue
    User->>BalanceEditSheet: Toggle "Also Update Granted Balance" (default: ON)
    User->>BalanceEditSheet: Click Update

    alt updateGrantedBalance = true
        BalanceEditSheet->>BalanceEditSheet: computeGrantedBalanceInput(newGPB, prepaidAllowance)
        BalanceEditSheet->>API: POST { add_to_balance, included_grant }
    else updateGrantedBalance = false
        BalanceEditSheet->>API: POST { add_to_balance }
    end

    API->>Handler: validate params
    Handler->>UpdateBalance: runUpdateBalanceV2 (add_to_balance)
    opt included_grant present
        Handler->>UpdateGranted: updateGrantedBalance(targetGrantedBalance)
    end
    Handler-->>API: { success: true }
    API-->>BalanceEditSheet: 200 OK
    BalanceEditSheet-->>User: toast("Updated successfully")
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts`, line 92-93 ([link](https://github.com/useautumn/autumn/blob/1d9a1b96dd67156145105aac44e6c4753f74382c/server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts#L92-L93)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unused variables left after removing params**

   `defaultGPB` and `defaultBalance` are now defined but never used — they were only there to pass into `computeGrantedBalanceInput`, which no longer accepts those params. Biome/TypeScript will flag these as `no-unused-vars`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts
   Line: 92-93

   Comment:
   **Unused variables left after removing params**

   `defaultGPB` and `defaultBalance` are now defined but never used — they were only there to pass into `computeGrantedBalanceInput`, which no longer accepts those params. Biome/TypeScript will flag these as `no-unused-vars`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `shared/utils/cusEntUtils/balanceUtils/computeGrantedBalanceInput.ts`, line 1-8 ([link](https://github.com/useautumn/autumn/blob/1d9a1b96dd67156145105aac44e6c4753f74382c/shared/utils/cusEntUtils/balanceUtils/computeGrantedBalanceInput.ts#L1-L8)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale JSDoc after dual-mode usage**

   The comment still says "when the BalanceEditSheet 'set' mode submits" but this function is now also called in "add" mode from `BalanceEditSheet`. Worth updating so the doc reflects the actual usage.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: shared/utils/cusEntUtils/balanceUtils/computeGrantedBalanceInput.ts
   Line: 1-8

   Comment:
   **Stale JSDoc after dual-mode usage**

   The comment still says "when the BalanceEditSheet 'set' mode submits" but this function is now also called in "add" mode from `BalanceEditSheet`. Worth updating so the doc reflects the actual usage.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/tests/integration/balances/update/balance/update-balance-prepaid-granted.test.ts
Line: 92-93

Comment:
**Unused variables left after removing params**

`defaultGPB` and `defaultBalance` are now defined but never used — they were only there to pass into `computeGrantedBalanceInput`, which no longer accepts those params. Biome/TypeScript will flag these as `no-unused-vars`.

```suggestion
	const prepaidAllowance = bal.purchased_balance; // 200
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
Line: 15

Comment:
**Deprecated component import**

`Switch` is imported from the deprecated `@/components/ui/switch`. Per project guidelines, new UI code should use components from `@/components/v2/`. Check if a v2 `Switch` exists; if not, consider whether `ConfigRow` has a built-in toggle option, or note this for a follow-up migration.

```suggestion
import { Switch } from "@/components/v2/Switch";
```

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: shared/utils/cusEntUtils/balanceUtils/computeGrantedBalanceInput.ts
Line: 1-8

Comment:
**Stale JSDoc after dual-mode usage**

The comment still says "when the BalanceEditSheet 'set' mode submits" but this function is now also called in "add" mode from `BalanceEditSheet`. Worth updating so the doc reflects the actual usage.

```suggestion
/**
 * Computes the absolute granted_balance value to send to the balance update API.
 * Used in both "set" mode and "add" mode of the BalanceEditSheet.
 *
 * Derives the granted_balance by subtracting the prepaid allowance
 * from the user's desired total GPB (grantedAndPurchasedBalance).
 */
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Replace info box with toggle for granted..."](https://github.com/useautumn/autumn/commit/1d9a1b96dd67156145105aac44e6c4753f74382c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28773454)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->