### PR TITLE
chore: remove header on /ready

### DIFF
--- a/server/src/honoUtils/handleReadyCheck.ts
+++ b/server/src/honoUtils/handleReadyCheck.ts
@@ -1,4 +1,3 @@
-import { timingSafeEqual } from "node:crypto";
 import type { Context } from "hono";
 import { clientCritical } from "../db/initDrizzle.js";
 import { getDbHealth, PgHealth } from "../db/pgHealthMonitor.js";
@@ -7,8 +6,6 @@ import type { HonoEnv } from "./HonoEnv.js";
 
 const POSTGRES_TIMEOUT_MS = 1_000;
 const REDIS_TIMEOUT_MS = 500;
-const READY_CHECK_TOKEN = process.env.READY_CHECK_TOKEN?.trim();
-
 const withTimeout = async <T>({
 	timeoutMs,
 	fn,
@@ -100,19 +97,6 @@ const runRedisCheck = async () => {
 	}
 };
 
-const hasReadyCheckAccess = (c: Context<HonoEnv>) => {
-	const providedToken = c.req.header("x-ready-check-token");
-
-	if (!READY_CHECK_TOKEN || !providedToken) return false;
-
-	const expected = Buffer.from(READY_CHECK_TOKEN);
-	const provided = Buffer.from(providedToken);
-
-	return (
-		expected.length === provided.length && timingSafeEqual(expected, provided)
-	);
-};
-
 export const handleReadyCheck = async (c: Context<HonoEnv>) => {
 	const [postgresResult, redisResult] = await Promise.all([
 		runPostgresCheck(),
@@ -121,10 +105,6 @@ export const handleReadyCheck = async (c: Context<HonoEnv>) => {
 
 	const ok = postgresResult.ok && redisResult.ok;
 	const status = ok ? 200 : 503;
-
-	if (!hasReadyCheckAccess(c)) {
-		return c.json({ ok }, status);
-	}
 
 	return c.json(
 		{

--- a/server/src/honoUtils/handleReadyCheck.ts
+++ b/server/src/honoUtils/handleReadyCheck.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { Context } from "hono";
 import { clientCritical } from "../db/initDrizzle.js";
 import { getDbHealth, PgHealth } from "../db/pgHealthMonitor.js";
@@ -6,6 +7,7 @@ import type { HonoEnv } from "./HonoEnv.js";
 
 const POSTGRES_TIMEOUT_MS = 1_000;
 const REDIS_TIMEOUT_MS = 500;
+const READY_CHECK_TOKEN = process.env.READY_CHECK_TOKEN?.trim();
 const withTimeout = async <T>({
 	timeoutMs,
 	fn,
@@ -98,6 +100,20 @@ const runRedisCheck = async () => {
 };
 
 export const handleReadyCheck = async (c: Context<HonoEnv>) => {
+	const providedToken = c.req.param("token");
+
+	if (!READY_CHECK_TOKEN || !providedToken) return c.notFound();
+
+	const expected = Buffer.from(READY_CHECK_TOKEN);
+	const provided = Buffer.from(providedToken);
+
+	if (
+		expected.length !== provided.length ||
+		!timingSafeEqual(expected, provided)
+	) {
+		return c.notFound();
+	}
+
 	const [postgresResult, redisResult] = await Promise.all([
 		runPostgresCheck(),
 		runRedisCheck(),

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -45,8 +45,6 @@ const ALLOWED_HEADERS = [
 	"If-None-Match",
 	"If-Modified-Since",
 	"If-Unmodified-Since",
-	"x-ready-check-token",
-	"X-Ready-Check-Token",
 	"idempotency-key",
 	"Idempotency-Key",
 	"User-Agent", // Required for better-auth v1.4.0+ compatibility with Safari/Zen browser

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -82,7 +82,7 @@ export const createHonoApp = () => {
 	// Health check endpoint for AWS/ECS load balancer
 
 	app.get("/stripe/oauth_callback", handleOAuthCallback);
-	app.get("/ready", handleReadyCheck);
+	app.get("/ready/:token", handleReadyCheck);
 
 	// Step 1: OTel HTTP span + base middleware + span enrichment
 	app.use(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `/ready` to use a URL token instead of the `x-ready-check-token` header. New route is `/ready/:token`; it returns full health details with 200 on OK, 503 on failure, and 404 when the token is missing or invalid. CORS header entries for the old header were removed.

- **Migration**
  - Keep the `READY_CHECK_TOKEN` env/secret.
  - Update probes/monitors to GET `/ready/{READY_CHECK_TOKEN}` and stop sending `X-Ready-Check-Token`/`x-ready-check-token`.

<sup>Written for commit a1660855b03f8cedb71ba7129632fd349976d7b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the `x-ready-check-token` header-based access control from the `/ready` health-check endpoint, so it now always returns the full diagnostic payload (postgres latency, Redis status, error messages) to any caller rather than gating that detail behind a shared secret.

**Key changes:**
- **Improvements**: Simplifies the `/ready` handler by removing the `hasReadyCheckAccess` guard, `READY_CHECK_TOKEN` env var, and `timingSafeEqual` import.
- **Improvements**: Cleans up `ALLOWED_HEADERS` in CORS config by removing the now-unused `x-ready-check-token` entries.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; the only finding is a P2 question about intentional information disclosure that the author likely already considered.

Both changed files are clean, the removal is consistent (import, constant, function, CORS header all cleaned up together), and the sole concern — publicly exposing detailed health diagnostics — is a deliberate design decision by the PR author rather than a bug. P2 findings don't reduce the score below 5.

No files require special attention beyond confirming the intentional exposure of detailed diagnostics in handleReadyCheck.ts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoUtils/handleReadyCheck.ts | Removes token-gated access to detailed health diagnostics; the full checks payload (latency, errors, Redis state) is now returned to all unauthenticated callers. |
| server/src/initHono.ts | Removes x-ready-check-token / X-Ready-Check-Token from the CORS allowed-headers list — correct cleanup now that the header is no longer used. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Any Caller
    participant Server as /ready endpoint
    participant PG as Postgres
    participant Redis as Redis

    Note over Caller,Server: Before this PR
    Caller->>Server: GET /ready (no token)
    Server-->>Caller: { ok } only
    Caller->>Server: GET /ready + x-ready-check-token
    Server->>PG: SELECT 1 (timeout 1s)
    Server->>Redis: PING (timeout 500ms)
    Server-->>Caller: { ok, checks: { postgres, redis } }

    Note over Caller,Server: After this PR
    Caller->>Server: GET /ready (no auth required)
    Server->>PG: SELECT 1 (timeout 1s)
    Server->>Redis: PING (timeout 500ms)
    Server-->>Caller: { ok, checks: { postgres, redis } }
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/honoUtils/handleReadyCheck.ts`, line 109-118 ([link](https://github.com/useautumn/autumn/blob/ddb1342d6481ff855e6e121bdc9a4dd427365c10/server/src/honoUtils/handleReadyCheck.ts#L109-L118)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Detailed health data now publicly exposed**

   Previously, the detailed `checks` payload (postgres latency, Redis status, error message strings) was gated behind the `x-ready-check-token` header. Unauthenticated callers only received `{ ok }`. After this change, any internet-accessible caller receives the full internal diagnostic data: exact query latency, `PgHealth` enum values, and infrastructure error messages. For a load balancer health check the 200/503 status code is sufficient — the detailed response was only ever useful to authorized monitoring tools. Worth confirming this exposure is intentional and that there are no concerns with error messages (e.g. `"unexpected redis state: status=..., ping=..."`) leaking internal topology to external clients.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/honoUtils/handleReadyCheck.ts
   Line: 109-118

   Comment:
   **Detailed health data now publicly exposed**

   Previously, the detailed `checks` payload (postgres latency, Redis status, error message strings) was gated behind the `x-ready-check-token` header. Unauthenticated callers only received `{ ok }`. After this change, any internet-accessible caller receives the full internal diagnostic data: exact query latency, `PgHealth` enum values, and infrastructure error messages. For a load balancer health check the 200/503 status code is sufficient — the detailed response was only ever useful to authorized monitoring tools. Worth confirming this exposure is intentional and that there are no concerns with error messages (e.g. `"unexpected redis state: status=..., ping=..."`) leaking internal topology to external clients.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/honoUtils/handleReadyCheck.ts
Line: 109-118

Comment:
**Detailed health data now publicly exposed**

Previously, the detailed `checks` payload (postgres latency, Redis status, error message strings) was gated behind the `x-ready-check-token` header. Unauthenticated callers only received `{ ok }`. After this change, any internet-accessible caller receives the full internal diagnostic data: exact query latency, `PgHealth` enum values, and infrastructure error messages. For a load balancer health check the 200/503 status code is sufficient — the detailed response was only ever useful to authorized monitoring tools. Worth confirming this exposure is intentional and that there are no concerns with error messages (e.g. `"unexpected redis state: status=..., ping=..."`) leaking internal topology to external clients.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove header on /ready"](https://github.com/useautumn/autumn/commit/ddb1342d6481ff855e6e121bdc9a4dd427365c10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28777969)</sub>

<!-- /greptile_comment -->