### PR TITLE
Website and docs updates

### DIFF
--- a/apps/docs/mintlify/docs.json
+++ b/apps/docs/mintlify/docs.json
@@ -131,6 +131,7 @@
 						"pages": [
 							"documentation/webhooks",
 							"documentation/fail-open",
+							"documentation/rate-limits",
 							"documentation/external-providers/convex",
 							"documentation/external-providers/revenuecat",
 							"documentation/external-providers/vercel-marketplace"

--- a/apps/docs/mintlify/documentation/rate-limits.mdx
+++ b/apps/docs/mintlify/documentation/rate-limits.mdx
@@ -1,0 +1,42 @@
+---
+title: "Rate Limits"
+description: "Default API rate limits and how to request increases"
+---
+
+Autumn enforces rate limits to ensure reliable performance for all users. Limits are applied per **organization** or per **customer**, depending on the endpoint.
+
+## Default Limits
+
+| Endpoint Group | Limit | Window | Scope |
+|---|---|---|---|
+| **Check / Entitled / Get Customer** | 10,000 requests | 1 second | Per customer |
+| **Track / Usage / Balance updates** | 10,000 requests | 1 second | Per customer |
+| **Attach / Cancel / Billing operations** | 30 requests | 1 minute | Per customer |
+| **Events (list / aggregate / query)** | 5 requests | 1 second | Per customer |
+| **List Customers** | 5 requests | 1 second | Per organization |
+| **All other endpoints** | 25 requests | 1 second | Per organization |
+
+## Scopes
+
+- **Per customer** -- the limit applies independently to each customer you make requests for. For example, tracking usage for `customer_a` and `customer_b` each get their own 10,000 req/s allowance.
+- **Per organization** -- the limit is shared across all requests from your API key, regardless of which customer the request is for.
+
+## What happens when you hit a limit
+
+When a rate limit is exceeded, the API returns a `429 Too Many Requests` response. Your application should back off and retry after the rate limit window resets.
+
+## Preview endpoints are not rate limited
+
+Preview endpoints like `/v1/attach/preview`, `/v1/billing.preview_attach`, and `/v1/billing.preview_update` are **not** subject to rate limits. You can call these freely to display pricing previews to your users.
+
+## Requesting higher limits
+
+The default limits are designed to handle the vast majority of use cases. If your application requires higher throughput, we can increase rate limits for your organization on a case-by-case basis.
+
+Reach out to us on [Discord](https://discord.gg/STqxY92zuS) or email **support@useautumn.com** and include:
+
+- Your organization name
+- Which endpoint group needs a higher limit
+- The throughput you need
+
+We typically respond within a few hours.

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -1,7 +1,6 @@
 import ElasticRecoil from "@/components/elastic-footer";
 import HomeSections from "@/components/home-sections";
 import Navbar from "@/components/navbar";
-import Preloader from "@/components/preloader";
 import type { PageStyle } from "@/lib/types";
 
 export default function Home() {
@@ -12,7 +11,6 @@ export default function Home() {
 				{ "--page-pad": "max(2.5rem, calc((100vw - 1440px) / 2))" } as PageStyle
 			}
 		>
-			<Preloader />
 			<ElasticRecoil>
 				<div className="relative z-10 bg-[#000000] min-h-screen">
 					<div className="relative w-full px-4 md:px-(--page-pad) pt-5">

--- a/apps/website/components/autumn-config.tsx
+++ b/apps/website/components/autumn-config.tsx
@@ -45,7 +45,7 @@ const autumnTheme = {
 	"hljs-punctuation": { color: "#BFBFBF" },
 };
 
-const TOTAL_LINES = 16;
+const TOTAL_LINES = 19;
 const LINE_HEIGHT = 24;
 
 const codeContent = `// Your entire billing integration

--- a/apps/website/components/hero.tsx
+++ b/apps/website/components/hero.tsx
@@ -27,7 +27,6 @@ const getLoggedInHintCookie = () => {
 
 export default function Hero() {
 	const containerRef = useRef<HTMLDivElement | null>(null);
-	const heroTlRef = useRef<gsap.core.Timeline | null>(null);
 	const [displayedText, setDisplayedText] = useState("");
 	const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -68,20 +67,11 @@ export default function Hero() {
 			}, 150);
 		};
 
-		window.addEventListener("preloader:complete", startTypewriter, {
-			once: true,
-		});
+		startTypewriter();
 		return () => {
-			window.removeEventListener("preloader:complete", startTypewriter);
 			if (timeoutId) clearTimeout(timeoutId);
 			if (intervalId) clearInterval(intervalId);
 		};
-	}, []);
-
-	useEffect(() => {
-		const handler = () => heroTlRef.current?.play();
-		window.addEventListener("preloader:complete", handler, { once: true });
-		return () => window.removeEventListener("preloader:complete", handler);
 	}, []);
 
 	useGSAP(
@@ -106,11 +96,8 @@ export default function Hero() {
 			gsap.set(".hero-cta", { opacity: 0, scale: 0.95 });
 
 			const tl = gsap.timeline({
-				paused: true,
 				defaults: { overwrite: "auto" },
 			});
-			heroTlRef.current = tl;
-
 			tl.to(".hero-root", { opacity: 1, duration: 0.3, ease: "none" })
 
 				.to(".hero-bg", {
@@ -205,7 +192,6 @@ export default function Hero() {
 						<div className="relative z-10 translate-y-16 w-full flex justify-center">
 							<AutumnConfig
 								initialDelay={200}
-								awaitEvent="preloader:complete"
 							/>
 						</div>
 					</div>

--- a/apps/website/components/pricing.tsx
+++ b/apps/website/components/pricing.tsx
@@ -36,7 +36,7 @@ const plans = [
 		name: "ENTERPRISE",
 		price: "Custom",
 		description: "For compliance, scale, or custom requirements.",
-		features: ["Dedicated support", "Multi-region", "Compliance assistance"],
+		features: ["Dedicated support", "Forward deployed engineer", "Multi-region", "Compliance assistance"],
 		buttonText: "Book a call",
 		href: "https://cal.com/ayrod/a?user=ayrod",
 		isPro: false,


### PR DESCRIPTION
## Summary
- Remove preloader and start hero animation immediately, update pricing on website
- Add API rate limits page to docs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the homepage preloader so the hero animation starts immediately and updated Enterprise pricing features. Added an API Rate Limits docs page and linked it in the sidebar.

- **New Features**
  - Docs: Added a Rate Limits page with defaults, scopes, 429 behavior, and how to request higher limits; preview endpoints noted as unlimited; linked in `docs.json`.
  - Website: Hero animation now starts on load; removed the preloader and related event hooks; `AutumnConfig` no longer waits on an event.
  - Pricing: Enterprise plan now includes “Forward deployed engineer.”

<sup>Written for commit e8a6d290351004ec803c89395515c4f11722d0b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the website preloader so hero animations start immediately on page load, updates the Enterprise pricing tier, and adds a new API rate limits documentation page to the Mintlify docs.

**Key changes:**
- [Improvements] Remove `Preloader` component and all `preloader:complete` event listeners from `hero.tsx` and `page.tsx`; GSAP timeline now plays immediately on mount
- [Improvements] Add new `documentation/rate-limits.mdx` page covering per-customer and per-org limits, 429 handling, and how to request increases
- [Improvements] Add "Forward deployed engineer" to the Enterprise plan feature list in `pricing.tsx`
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are minor style cleanups with no functional impact.

No P0 or P1 issues found. The two P2 comments (dead awaitEvent prop and stale commented-out JSX) are cleanup suggestions that don't affect runtime behavior.

autumn-config.tsx has a now-unused awaitEvent prop and useEffect that can be cleaned up in a follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/docs/mintlify/docs.json | Adds rate-limits page to the "More" nav group — correct placement between fail-open and external-providers. |
| apps/docs/mintlify/documentation/rate-limits.mdx | New rate limits reference page with table, scope explanations, 429 handling guidance, and contact info — well structured. |
| apps/website/app/page.tsx | Removes Preloader import and component from the home page root — clean deletion. |
| apps/website/components/autumn-config.tsx | TOTAL_LINES bumped from 16→19; awaitEvent prop and its useEffect listener are now dead code after preloader removal. |
| apps/website/components/hero.tsx | Removes heroTlRef, preloader event listeners, and paused timeline — animation now starts immediately on mount; one stale commented-out line remains. |
| apps/website/components/pricing.tsx | Adds "Forward deployed engineer" to Enterprise plan feature list — straightforward copy update. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page Mount] --> B[Hero component mounts]
    B --> C[useGSAP runs immediately]
    C --> D[Set initial hidden states\nhero-root, hero-bg, hero-reveal, hero-cta]
    D --> E[GSAP timeline plays\nno paused:true]
    E --> F[Fade in hero-root]
    F --> G[Animate hero-bg\nblur + brightness flash]
    G --> H[Reveal hero-reveal elements\nstagger 0.1s]
    H --> I[Animate hero-cta buttons\nback.out ease]
    B --> J[Badge typewriter starts\nimmediately after 150ms delay]
    B --> K[AutumnConfig starts\nafter 200ms initialDelay]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/website/components/hero.tsx`, line 279 ([link](https://github.com/useautumn/autumn/blob/e8a6d290351004ec803c89395515c4f11722d0b2/apps/website/components/hero.tsx#L279)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead commented-out code**

   This commented-out `AutumnConfig` line still references the removed `preloader:complete` event and is no longer valid. Since the mobile view is now using a static image, the entire comment can be removed.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/website/components/hero.tsx
   Line: 279

   Comment:
   **Dead commented-out code**

   This commented-out `AutumnConfig` line still references the removed `preloader:complete` event and is no longer valid. Since the mobile view is now using a static image, the entire comment can be removed.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/website/components/autumn-config.tsx`, line 65-92 ([link](https://github.com/useautumn/autumn/blob/e8a6d290351004ec803c89395515c4f11722d0b2/apps/website/components/autumn-config.tsx#L65-L92)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Orphaned `awaitEvent` prop and listener logic**

   The `awaitEvent` parameter and its accompanying `useEffect` listener (lines 87–92) are no longer used anywhere in the codebase now that the preloader has been removed. Both usages in `hero.tsx` were deleted (`awaitEvent="preloader:complete"` on the desktop `AutumnConfig` and the commented-out mobile one). The dead prop and effect can be removed to simplify the component.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/website/components/autumn-config.tsx
   Line: 65-92

   Comment:
   **Orphaned `awaitEvent` prop and listener logic**

   The `awaitEvent` parameter and its accompanying `useEffect` listener (lines 87–92) are no longer used anywhere in the codebase now that the preloader has been removed. Both usages in `hero.tsx` were deleted (`awaitEvent="preloader:complete"` on the desktop `AutumnConfig` and the commented-out mobile one). The dead prop and effect can be removed to simplify the component.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/website/components/hero.tsx
Line: 279

Comment:
**Dead commented-out code**

This commented-out `AutumnConfig` line still references the removed `preloader:complete` event and is no longer valid. Since the mobile view is now using a static image, the entire comment can be removed.

```suggestion
							/>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/website/components/autumn-config.tsx
Line: 65-92

Comment:
**Orphaned `awaitEvent` prop and listener logic**

The `awaitEvent` parameter and its accompanying `useEffect` listener (lines 87–92) are no longer used anywhere in the codebase now that the preloader has been removed. Both usages in `hero.tsx` were deleted (`awaitEvent="preloader:complete"` on the desktop `AutumnConfig` and the commented-out mobile one). The dead prop and effect can be removed to simplify the component.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["website: remove preloader, start hero an..."](https://github.com/useautumn/autumn/commit/e8a6d290351004ec803c89395515c4f11722d0b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28782847)</sub>

<!-- /greptile_comment -->