### PR TITLE
chore: s3 configs reads from env

### DIFF
--- a/scripts/setup/setupS3Admin.ts
+++ b/scripts/setup/setupS3Admin.ts
@@ -10,24 +10,12 @@ import {
 	S3Client,
 } from "@aws-sdk/client-s3";
 import {
-	ADMIN_REQUEST_BLOCK_CONFIG_KEY as REQUEST_BLOCK_CONFIG_KEY,
 	getAdminS3Config,
+	ADMIN_REQUEST_BLOCK_CONFIG_KEY as REQUEST_BLOCK_CONFIG_KEY,
 } from "@server/external/aws/s3/adminS3Config.js";
+
 const DEFAULT_REQUEST_BLOCK_CONFIG = {
 	orgs: {},
-};
-
-const getTargetFromArgs = () => {
-	const hasDevFlag = process.argv.includes("--dev");
-	const hasProdFlag = process.argv.includes("--prod");
-
-	if (hasDevFlag && hasProdFlag) {
-		throw new Error("Use either --dev or --prod, not both");
-	}
-
-	if (hasDevFlag) return "dev" as const;
-	if (hasProdFlag) return "prod" as const;
-	return undefined;
 };
 
 const createS3Client = ({ region }: { region: string }) => {
@@ -178,12 +166,11 @@ const ensureRequestBlockConfigExists = async ({
 };
 
 const main = async () => {
-	const target = getTargetFromArgs();
-	const { bucket, region } = getAdminS3Config({ target });
+	const { bucket, region } = getAdminS3Config();
 	const s3Client = createS3Client({ region });
 
 	console.log(
-		`Initializing S3 admin config for ${target || process.env.NODE_ENV || "default"} -> s3://${bucket}/${REQUEST_BLOCK_CONFIG_KEY}`,
+		`Initializing S3 admin config for ${process.env.NODE_ENV || "default"} -> s3://${bucket}/${REQUEST_BLOCK_CONFIG_KEY}`,
 	);
 
 	await ensureBucketExists({

--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -4,29 +4,12 @@ export const ADMIN_CUSTOMER_BLOCK_CONFIG_KEY =
 	"admin/customer-block-config.json";
 export const ADMIN_ORG_LIMITS_CONFIG_KEY = "admin/org-limits-config.json";
 
-type AdminS3Target = "dev" | "prod";
+const bucket = process.env.S3_BUCKET || "autumn-prod-server";
+const region = process.env.AWS_REGION || "us-east-2";
 
-const isDevTarget = ({ target }: { target?: AdminS3Target }) => {
-	if (target) return target === "dev";
-	return (
-		process.env.NODE_ENV === "dev" || process.env.NODE_ENV === "development"
-	);
-};
-
-export const getAdminS3Config = ({
-	target,
-}: {
-	target?: AdminS3Target;
-} = {}) => {
-	if (isDevTarget({ target })) {
-		return {
-			bucket: "autumn-dev-server",
-			region: "eu-west-2",
-		};
-	}
-
+export const getAdminS3Config = () => {
 	return {
-		bucket: "autumn-prod-server",
-		region: "us-east-2",
+		bucket,
+		region,
 	};
 };

--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -5,7 +5,7 @@ export const ADMIN_CUSTOMER_BLOCK_CONFIG_KEY =
 export const ADMIN_ORG_LIMITS_CONFIG_KEY = "admin/org-limits-config.json";
 
 const bucket = process.env.S3_BUCKET || "autumn-prod-server";
-const region = process.env.AWS_REGION || "us-east-2";
+const region = process.env.S3_REGION || "us-east-2";
 
 export const getAdminS3Config = () => {
 	return {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admin S3 config now reads `S3_BUCKET` and `S3_REGION` from env, defaulting to `autumn-prod-server` in `us-east-2`. Removed dev/prod target logic and the `--dev/--prod` setup flags; `getAdminS3Config()` no longer takes args.

- **Migration**
  - Set `S3_BUCKET` and `S3_REGION` in your environment (dev must set these to avoid defaulting to prod).
  - Remove target args: update `getAdminS3Config()` calls and run `scripts/setup/setupS3Admin.ts` without `--dev/--prod`.

<sup>Written for commit 6e7fb68780e9ae3f8615a9b2b65f5e0ec1ddf863. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the hardcoded dev/prod S3 bucket branching logic with environment variable reads (`S3_BUCKET`, `AWS_REGION`), simplifying `getAdminS3Config` and removing the optional `target` parameter that was never used at call sites.

- **[Improvements]** S3 bucket and region are now fully configurable via env vars, making deployment configuration more explicit and flexible.
- **[Bug fixes / Risk]** The old code automatically routed dev environments (`NODE_ENV=dev/development`) to `autumn-dev-server`; the new default of `autumn-prod-server` means any environment without `S3_BUCKET` set will silently target production S3.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge only if all environments (dev, CI, staging) already have S3_BUCKET set; otherwise the production bucket fallback is a real risk.

One P1 finding: the removal of the automatic dev-environment routing means unset S3_BUCKET silently falls through to autumn-prod-server, which could cause unintended reads/writes against production S3 in local or CI environments.

server/src/external/aws/s3/adminS3Config.ts — verify S3_BUCKET is documented and set in all non-production environments before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/aws/s3/adminS3Config.ts | Replaces hardcoded dev/prod branching with env-var-driven S3 config; removes the automatic dev-bucket safety net, defaulting all environments to autumn-prod-server when S3_BUCKET is unset. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Module Import] --> B{S3_BUCKET set?}
    B -- Yes --> C[bucket = S3_BUCKET]
    B -- No --> D[bucket = 'autumn-prod-server' ⚠️]
    A --> E{AWS_REGION set?}
    E -- Yes --> F[region = AWS_REGION]
    E -- No --> G[region = 'us-east-2']
    C & D --> H[getAdminS3Config]
    F & G --> H
    H --> I[edgeConfigStore → S3 read/write]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/external/aws/s3/adminS3Config.ts
Line: 7-8

Comment:
**Silent prod-bucket fallback when `S3_BUCKET` is unset**

The new default of `autumn-prod-server` means any environment (local dev, CI, staging) that doesn't explicitly set `S3_BUCKET` will silently target the production bucket. The old code used `NODE_ENV` to detect dev and routed to `autumn-dev-server`, providing an automatic safety net. With this change removed, a developer who forgets to set `S3_BUCKET` will read/write directly against production S3.

Consider keeping a dev-safe default (e.g. `autumn-dev-server` when `NODE_ENV !== "production"`) or throwing an explicit error when the var is absent, so mis-configuration is loud rather than silent.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/external/aws/s3/adminS3Config.ts
Line: 7-8

Comment:
**Env vars captured at module load, not at call time**

`bucket` and `region` are evaluated once when the module is first imported. The previous implementation read `process.env` inside the function body on every call, so it picked up changes to `process.env` at runtime (useful in tests that mutate env vars per-test). Any test that does `process.env.S3_BUCKET = "test-bucket"` after importing this module will silently get the original value instead.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: s3 configs reads from env"](https://github.com/useautumn/autumn/commit/263fa81311998757884371ae85d075e1685d2332) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28784771)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->