### PR TITLE
feat: 🎸 rollovers on create balance

### DIFF
--- a/server/src/internal/balances/createBalance/validateCreateBalance.ts
+++ b/server/src/internal/balances/createBalance/validateCreateBalance.ts
@@ -4,6 +4,7 @@ import {
 	type Feature,
 	FeatureType,
 	type FullCustomer,
+	isContUseFeature,
 	RecaseError,
 	ValidateCreateBalanceParamsSchema,
 } from "@autumn/shared";
@@ -38,6 +39,21 @@ export const validateCreateBalanceParams = async ({
 	if (entity && feature.id === entity.feature_id) {
 		throw new RecaseError({
 			message: `Cannot give an entity a balance of its own feature type`,
+		});
+	}
+
+	if (
+		isContUseFeature({ feature }) &&
+		Object.keys(params.rollover || {}).length > 0
+	) {
+		throw new RecaseError({
+			message: `Rollover is not supported for continuous use features`,
+		});
+	}
+
+	if (Object.keys(params.reset || {}).length <= 0 && params.rollover) {
+		throw new RecaseError({
+			message: `Rollover cannot be provided for one-time balances`,
 		});
 	}
 

--- a/server/tests/integration/balances/create/create-balance-with-rollover.test.ts
+++ b/server/tests/integration/balances/create/create-balance-with-rollover.test.ts
@@ -1,0 +1,141 @@
+import { test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	ResetInterval,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expireCusEntForReset } from "@tests/utils/cusProductUtils/resetTestUtils.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════
+// BALANCE-ROLLOVER-CREATE-1: Happy path — rollover applied on reset
+//
+// Create a loose messages balance with a monthly reset + rollover config.
+// Track partial usage, trigger a lazy reset, and verify:
+//   - fresh grant is re-added
+//   - unused balance rolls over as a rollover entry (capped by max)
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("balance-rollover-create-1: loose balance rollover applied on reset")}`, async () => {
+	const includedGrant = 400;
+	const rolloverMax = 500;
+	const usage = 250;
+
+	const { customerId, autumnV2_2, ctx } = await initScenario({
+		customerId: "balance-rollover-create-1",
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	// Create loose balance with rollover
+	await autumnV2_2.balances.create({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		included_grant: includedGrant,
+		reset: { interval: ResetInterval.Month },
+		rollover: {
+			max: rolloverMax,
+			length: 1,
+			duration: RolloverExpiryDurationType.Month,
+		},
+	});
+
+	// Track partial usage
+	await autumnV2_2.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: usage,
+	});
+
+	await timeout(2000);
+
+	// Trigger a reset (lazy)
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+
+	const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+
+	// Unused (400 - 250) = 150 rolls over; capped by max=500 → 150
+	const expectedRollover = Math.min(includedGrant - usage, rolloverMax);
+	const expectedRemaining = includedGrant + expectedRollover;
+
+	expectBalanceCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		remaining: expectedRemaining,
+		usage: 0,
+		rollovers: [{ balance: expectedRollover }],
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BALANCE-ROLLOVER-CREATE-2: Rejection — rollover on continuous-use feature
+//
+// Rollover is not meaningful for continuous-use features. The API should
+// reject the request.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("balance-rollover-create-2: rollover on continuous-use feature is rejected")}`, async () => {
+	const { customerId, autumnV2 } = await initScenario({
+		customerId: "balance-rollover-create-2",
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	await expectAutumnError({
+		func: async () => {
+			await autumnV2.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Users, // continuous-use
+				included_grant: 5,
+				reset: { interval: ResetInterval.Month },
+				rollover: {
+					max: 10,
+					length: 1,
+					duration: RolloverExpiryDurationType.Month,
+				},
+			});
+		},
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BALANCE-ROLLOVER-CREATE-3: Rejection — rollover on one-time balance
+//
+// A balance without a reset interval is one-time / never resets, so
+// rollover makes no sense. The API should reject the request.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("balance-rollover-create-3: rollover on one-time balance is rejected")}`, async () => {
+	const { customerId, autumnV2 } = await initScenario({
+		customerId: "balance-rollover-create-3",
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	await expectAutumnError({
+		func: async () => {
+			await autumnV2.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				included_grant: 100,
+				// no reset → one-time balance
+				rollover: {
+					max: 50,
+					length: 1,
+					duration: RolloverExpiryDurationType.Month,
+				},
+			});
+		},
+	});
+});

--- a/shared/api/balances/create/createBalanceParams.ts
+++ b/shared/api/balances/create/createBalanceParams.ts
@@ -1,4 +1,9 @@
-import { FeatureSchema, FeatureType, ResetInterval } from "@autumn/shared";
+import {
+	FeatureSchema,
+	FeatureType,
+	ResetInterval,
+	RolloverConfigSchema,
+} from "@autumn/shared";
 import { z } from "zod/v4";
 import { BalanceParamsBaseSchema } from "../common/balanceParamsBase";
 
@@ -28,6 +33,11 @@ export const ExtCreateBalanceParamsSchema = BalanceParamsBaseSchema.extend({
 			description:
 				"Reset configuration for the balance. If not provided, the balance is a one-time grant that never resets.",
 		}),
+
+	rollover: RolloverConfigSchema.optional().meta({
+		description: "Rollover configuration for the balance.",
+	}),
+
 	expires_at: z.number().optional().meta({
 		description:
 			"Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset.",

--- a/shared/api/balances/create/mappers/createBalanceParamsV0ToPlanItemV0.ts
+++ b/shared/api/balances/create/mappers/createBalanceParamsV0ToPlanItemV0.ts
@@ -30,5 +30,13 @@ export const createBalanceParamsV0ToPlanItemV0 = ({
 				}
 			: null,
 		price: null,
+		rollover: params.rollover
+			? {
+					max: params.rollover.max ?? null,
+					max_percentage: params.rollover.max_percentage ?? null,
+					expiry_duration_type: params.rollover.duration,
+					expiry_duration_length: params.rollover.length,
+				}
+			: undefined,
 	};
 };

--- a/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
@@ -1,4 +1,10 @@
-import { type Feature, FeatureType, ResetInterval } from "@autumn/shared";
+import {
+	type Feature,
+	FeatureType,
+	isContUseFeature,
+	ResetInterval,
+	type RolloverConfig,
+} from "@autumn/shared";
 import { CalendarXIcon, InfinityIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -26,6 +32,7 @@ import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { RolloverConfigForm } from "@/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm";
 import { useCustomerContext } from "../../customer/CustomerContext";
 
 const RESET_INTERVAL_LABELS: Record<string, string> = {
@@ -54,6 +61,11 @@ export function BalanceCreateSheet() {
 	const [resetInterval, setResetInterval] = useState<string>("");
 	const [oneOff, setOneOff] = useState(false);
 	const [expiresAt, setExpiresAt] = useState<number | null>(null);
+	const [rollover, setRollover] = useState<RolloverConfig | null>(null);
+
+	// Rollover requires a recurring reset interval. If the interval goes away
+	// (or the user picks one-off/unlimited), clear rollover to keep state valid.
+	const hasRecurringReset = Boolean(resetInterval) && !oneOff && !unlimited;
 
 	const nonArchivedFeatures = features.filter((f: Feature) => !f.archived);
 	const selectedFeature = nonArchivedFeatures.find(
@@ -62,6 +74,36 @@ export function BalanceCreateSheet() {
 	const isMetered =
 		selectedFeature?.type === FeatureType.Metered ||
 		selectedFeature?.type === FeatureType.CreditSystem;
+
+	// Continuous-use features (non-consumable) don't support rollover — the
+	// server rejects it in validateCreateBalanceParams, so we gate the UI too.
+	const isContUse = selectedFeature
+		? isContUseFeature({ feature: selectedFeature })
+		: false;
+	const canEnableRollover = isMetered && !isContUse && hasRecurringReset;
+
+	/**
+	 * Authoritative feature-select handler.
+	 *
+	 * Rollover is only valid for metered/credit-system features that are
+	 * consumable (non-continuous). When the user swaps features, clear any
+	 * existing rollover state synchronously here — no useEffect needed.
+	 */
+	const handleSelectFeature = (nextFeatureId: string) => {
+		setFeatureId(nextFeatureId);
+		const nextFeature = nonArchivedFeatures.find(
+			(f: Feature) => f.id === nextFeatureId,
+		);
+		const nextIsMetered =
+			nextFeature?.type === FeatureType.Metered ||
+			nextFeature?.type === FeatureType.CreditSystem;
+		const nextIsContUse = nextFeature
+			? isContUseFeature({ feature: nextFeature })
+			: false;
+		if (!nextIsMetered || nextIsContUse) {
+			setRollover(null);
+		}
+	};
 
 	const handleCreate = async () => {
 		const customerId = customer?.id || customer?.internal_id;
@@ -95,6 +137,10 @@ export function BalanceCreateSheet() {
 			params.reset = { interval: resetInterval };
 		}
 
+		if (rollover && canEnableRollover) {
+			params.rollover = rollover;
+		}
+
 		if (expiresAt) {
 			params.expires_at = expiresAt;
 		}
@@ -125,7 +171,7 @@ export function BalanceCreateSheet() {
 					<FeatureSearchDropdown
 						features={nonArchivedFeatures}
 						value={featureId || null}
-						onSelect={setFeatureId}
+						onSelect={handleSelectFeature}
 					/>
 				</SheetSection>
 
@@ -164,6 +210,7 @@ export function BalanceCreateSheet() {
 													setIncludedGrant("");
 													setResetInterval("");
 													setOneOff(false);
+													setRollover(null);
 												}
 											}}
 											className="py-1 w-26 text-t4 gap-2"
@@ -204,7 +251,10 @@ export function BalanceCreateSheet() {
 											checked={oneOff}
 											onCheckedChange={(checked) => {
 												setOneOff(checked);
-												if (checked) setResetInterval("");
+												if (checked) {
+													setResetInterval("");
+													setRollover(null);
+												}
 											}}
 											className="py-1 w-26 text-t4 gap-2 justify-start"
 										>
@@ -224,6 +274,14 @@ export function BalanceCreateSheet() {
 										use24Hour
 									/>
 								</div>
+							)}
+
+							{isMetered && !unlimited && !isContUse && (
+								<RolloverConfigForm
+									value={rollover}
+									onChange={setRollover}
+									disabled={!canEnableRollover}
+								/>
 							)}
 						</div>
 					</SheetSection>

--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfig.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfig.tsx
@@ -1,20 +1,9 @@
-import {
-	type RolloverConfig as RolloverConfigType,
-	RolloverExpiryDurationType,
-} from "@autumn/shared";
-import { AreaCheckbox } from "@/components/v2/checkboxes/AreaCheckbox";
-import { FormLabel } from "@/components/v2/form/FormLabel";
-import { Input } from "@/components/v2/inputs/Input";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/v2/selects/Select";
+import type { RolloverConfig as RolloverConfigType } from "@autumn/shared";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
-
-type MaxMode = "absolute" | "percentage" | "unlimited";
+import {
+	DEFAULT_ROLLOVER_CONFIG,
+	RolloverConfigForm,
+} from "./RolloverConfigForm";
 
 /** Visibility is controlled by parent AdvancedSettings */
 export function RolloverConfig() {
@@ -22,208 +11,36 @@ export function RolloverConfig() {
 
 	if (!item) return null;
 
-	const defaultRollover: RolloverConfigType = {
-		duration: RolloverExpiryDurationType.Month,
-		length: 1 as number,
-		max: null,
-		max_percentage: null,
+	const rollover = (item.config?.rollover as RolloverConfigType) ?? null;
+
+	const handleChange = (next: RolloverConfigType | null) => {
+		const newConfig = { ...(item.config || {}) };
+		if (next === null) {
+			delete newConfig.rollover;
+			setItem({ ...item, config: newConfig });
+		} else {
+			newConfig.rollover = next;
+			setItem({ ...item, config: newConfig });
+		}
 	};
 
-	const setRolloverConfigKey = (
-		key: keyof RolloverConfigType,
-		value: null | number | RolloverExpiryDurationType,
-	) => {
+	const handleEnable = () => {
 		setItem({
 			...item,
+			reset_usage_when_enabled: true,
 			config: {
 				...(item.config || {}),
-				rollover: {
-					...(item.config?.rollover || defaultRollover),
-					[key]: value,
-				},
+				rollover: { ...DEFAULT_ROLLOVER_CONFIG },
 			},
 		});
 	};
 
-	const setRolloverConfig = (rollover: RolloverConfigType | null) => {
-		const newConfig = { ...(item.config || {}) };
-		if (rollover === null) {
-			delete newConfig.rollover;
-		} else {
-			newConfig.rollover = rollover;
-		}
-		setItem({
-			...item,
-			config: newConfig,
-		});
-	};
-
-	const rollover = item.config?.rollover as RolloverConfigType;
-	const hasRollover = item.config?.rollover != null;
-
-	const maxMode: MaxMode =
-		rollover?.max_percentage != null
-			? "percentage"
-			: rollover?.max === null
-				? "unlimited"
-				: "absolute";
-
-	const handleMaxModeChange = (mode: MaxMode) => {
-		const current = item.config?.rollover || defaultRollover;
-		if (mode === "unlimited") {
-			setRolloverConfig({
-				...current,
-				max: null,
-				max_percentage: null,
-			});
-		} else if (mode === "absolute") {
-			setRolloverConfig({
-				...current,
-				max: 0,
-				max_percentage: null,
-			});
-		} else {
-			setRolloverConfig({
-				...current,
-				max: null,
-				max_percentage: 50,
-			});
-		}
-	};
-
 	return (
-		<AreaCheckbox
-			title="Rollovers"
-			tooltip="Rollovers carry unused credits to the next billing cycle. Set a maximum rollover amount and specify how many cycles before resetting."
-			checked={hasRollover}
+		<RolloverConfigForm
+			value={rollover}
+			onChange={handleChange}
+			onEnable={handleEnable}
 			disabled={!item.interval}
-			onCheckedChange={(checked) => {
-				if (checked) {
-					setItem({
-						...item,
-						reset_usage_when_enabled: true,
-						config: {
-							...(item.config || {}),
-							rollover: defaultRollover,
-						},
-					});
-				} else {
-					setRolloverConfig(null);
-				}
-			}}
-		>
-			<div className="space-y-4 w-xs max-w-full">
-				<div className="space-y-2 w-full">
-					<FormLabel>Maximum rollover</FormLabel>
-					<div className="flex items-center gap-2">
-						<Select
-							value={maxMode}
-							onValueChange={(value) =>
-								handleMaxModeChange(value as MaxMode)
-							}
-						>
-							<SelectTrigger
-								className="w-32"
-								onClick={(e) => e.stopPropagation()}
-							>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="unlimited">Unlimited</SelectItem>
-								<SelectItem value="absolute">Absolute</SelectItem>
-								<SelectItem value="percentage">Percentage</SelectItem>
-							</SelectContent>
-						</Select>
-
-						{maxMode === "absolute" && (
-							<Input
-								type="number"
-								value={
-									rollover?.max === 0 ? "" : (rollover?.max ?? "")
-								}
-								className="flex-1"
-								placeholder="e.g. 100 credits"
-								onChange={(e) => {
-									const value = e.target.value;
-									const numValue =
-										value === "" ? 0 : parseInt(value) || 0;
-									setRolloverConfigKey("max", numValue);
-								}}
-								onClick={(e) => e.stopPropagation()}
-							/>
-						)}
-
-						{maxMode === "percentage" && (
-							<div className="flex items-center gap-1 flex-1">
-								<Input
-									type="number"
-									value={
-										rollover?.max_percentage === 0
-											? ""
-											: (rollover?.max_percentage ?? "")
-									}
-									className="flex-1"
-									placeholder="e.g. 50"
-									onChange={(e) => {
-										const value = e.target.value;
-										const numValue =
-											value === "" ? 0 : parseInt(value) || 0;
-										setRolloverConfigKey(
-											"max_percentage",
-											Math.min(100, Math.max(0, numValue)),
-										);
-									}}
-									onClick={(e) => e.stopPropagation()}
-								/>
-								<span className="text-t3 text-sm">%</span>
-							</div>
-						)}
-					</div>
-				</div>
-
-				<div className="space-y-2">
-					<FormLabel>Rollover duration</FormLabel>
-					<div className="flex items-center gap-2">
-						{rollover?.duration === RolloverExpiryDurationType.Month && (
-							<Input
-								type="number"
-								value={rollover?.length === 0 ? "" : rollover?.length || ""}
-								onChange={(e) => {
-									const value = e.target.value;
-									const numValue = value === "" ? 0 : parseInt(value) || 0;
-									setRolloverConfigKey("length", numValue);
-								}}
-								className="w-16"
-								placeholder="e.g. 1 month"
-								onClick={(e) => e.stopPropagation()}
-							/>
-						)}
-						<Select
-							value={rollover?.duration}
-							onValueChange={(value) => {
-								setRolloverConfigKey(
-									"duration",
-									value as RolloverExpiryDurationType,
-								);
-							}}
-						>
-							<SelectTrigger
-								className="flex-1"
-								onClick={(e) => e.stopPropagation()}
-							>
-								<SelectValue placeholder="Select duration" />
-							</SelectTrigger>
-							<SelectContent>
-								{Object.values(RolloverExpiryDurationType).map((duration) => (
-									<SelectItem key={duration} value={duration}>
-										{duration}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</div>
-				</div>
-			</div>
-		</AreaCheckbox>
+		/>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx
@@ -1,0 +1,202 @@
+import {
+	type RolloverConfig as RolloverConfigType,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { AreaCheckbox } from "@/components/v2/checkboxes/AreaCheckbox";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+
+type MaxMode = "absolute" | "percentage" | "unlimited";
+
+export const DEFAULT_ROLLOVER_CONFIG: RolloverConfigType = {
+	duration: RolloverExpiryDurationType.Month,
+	length: 1,
+	max: null,
+	max_percentage: null,
+};
+
+type RolloverConfigFormProps = {
+	value: RolloverConfigType | null | undefined;
+	onChange: (value: RolloverConfigType | null) => void;
+	/** Disables the enable/disable checkbox (e.g., when no reset interval is set). */
+	disabled?: boolean;
+	tooltip?: string;
+	title?: string;
+	/** Called when the user toggles the rollover on. Defaults to { ...DEFAULT_ROLLOVER_CONFIG }. */
+	onEnable?: () => void;
+};
+
+/**
+ * Fully controlled rollover config UI. The same visual component used inside the plan
+ * editor's advanced settings and the balance-create sheet.
+ */
+export function RolloverConfigForm({
+	value,
+	onChange,
+	disabled,
+	tooltip = "Rollovers carry unused credits to the next billing cycle. Set a maximum rollover amount and specify how many cycles before resetting.",
+	title = "Rollovers",
+	onEnable,
+}: RolloverConfigFormProps) {
+	const rollover = value ?? null;
+	const hasRollover = rollover != null;
+
+	const setRolloverConfigKey = (
+		key: keyof RolloverConfigType,
+		next: null | number | RolloverExpiryDurationType,
+	) => {
+		onChange({
+			...(rollover ?? DEFAULT_ROLLOVER_CONFIG),
+			[key]: next,
+		});
+	};
+
+	const maxMode: MaxMode =
+		rollover?.max_percentage != null
+			? "percentage"
+			: rollover?.max === null
+				? "unlimited"
+				: "absolute";
+
+	const handleMaxModeChange = (mode: MaxMode) => {
+		const current = rollover ?? DEFAULT_ROLLOVER_CONFIG;
+		if (mode === "unlimited") {
+			onChange({ ...current, max: null, max_percentage: null });
+		} else if (mode === "absolute") {
+			onChange({ ...current, max: 0, max_percentage: null });
+		} else {
+			onChange({ ...current, max: null, max_percentage: 50 });
+		}
+	};
+
+	return (
+		<AreaCheckbox
+			title={title}
+			tooltip={tooltip}
+			checked={hasRollover}
+			disabled={disabled}
+			onCheckedChange={(checked) => {
+				if (checked) {
+					if (onEnable) onEnable();
+					else onChange({ ...DEFAULT_ROLLOVER_CONFIG });
+				} else {
+					onChange(null);
+				}
+			}}
+		>
+			<div className="space-y-4 w-xs max-w-full">
+				<div className="space-y-2 w-full">
+					<FormLabel>Maximum rollover</FormLabel>
+					<div className="flex items-center gap-2">
+						<Select
+							value={maxMode}
+							onValueChange={(v) => handleMaxModeChange(v as MaxMode)}
+						>
+							<SelectTrigger
+								className="w-32"
+								onClick={(e) => e.stopPropagation()}
+							>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="unlimited">Unlimited</SelectItem>
+								<SelectItem value="absolute">Absolute</SelectItem>
+								<SelectItem value="percentage">Percentage</SelectItem>
+							</SelectContent>
+						</Select>
+
+						{maxMode === "absolute" && (
+							<Input
+								type="number"
+								value={rollover?.max === 0 ? "" : (rollover?.max ?? "")}
+								className="flex-1"
+								placeholder="e.g. 100 credits"
+								onChange={(e) => {
+									const v = e.target.value;
+									const numValue = v === "" ? 0 : parseInt(v) || 0;
+									setRolloverConfigKey("max", numValue);
+								}}
+								onClick={(e) => e.stopPropagation()}
+							/>
+						)}
+
+						{maxMode === "percentage" && (
+							<div className="flex items-center gap-1 flex-1">
+								<Input
+									type="number"
+									value={
+										rollover?.max_percentage === 0
+											? ""
+											: (rollover?.max_percentage ?? "")
+									}
+									className="flex-1"
+									placeholder="e.g. 50"
+									onChange={(e) => {
+										const v = e.target.value;
+										const numValue = v === "" ? 0 : parseInt(v) || 0;
+										setRolloverConfigKey(
+											"max_percentage",
+											Math.min(100, Math.max(0, numValue)),
+										);
+									}}
+									onClick={(e) => e.stopPropagation()}
+								/>
+								<span className="text-t3 text-sm">%</span>
+							</div>
+						)}
+					</div>
+				</div>
+
+				<div className="space-y-2">
+					<FormLabel>Rollover duration</FormLabel>
+					<div className="flex items-center gap-2">
+						{rollover?.duration === RolloverExpiryDurationType.Month && (
+							<Input
+								type="number"
+								value={rollover?.length === 0 ? "" : rollover?.length || ""}
+								onChange={(e) => {
+									const v = e.target.value;
+									const numValue = v === "" ? 0 : parseInt(v) || 0;
+									setRolloverConfigKey("length", numValue);
+								}}
+								className="w-16"
+								placeholder="e.g. 1 month"
+								onClick={(e) => e.stopPropagation()}
+							/>
+						)}
+						<Select
+							value={rollover?.duration}
+							onValueChange={(v) => {
+								setRolloverConfigKey(
+									"duration",
+									v as RolloverExpiryDurationType,
+								);
+							}}
+						>
+							<SelectTrigger
+								className="flex-1"
+								onClick={(e) => e.stopPropagation()}
+							>
+								<SelectValue placeholder="Select duration" />
+							</SelectTrigger>
+							<SelectContent>
+								{Object.values(RolloverExpiryDurationType).map((duration) => (
+									<SelectItem key={duration} value={duration}>
+										{duration}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				</div>
+			</div>
+		</AreaCheckbox>
+	);
+}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add rollover support to balance creation with clear server-side rules and a shared UI form. Rollover applies only to recurring metered/credit features; one-time and continuous-use balances are rejected.

- **New Features**
  - API: `rollover` added to create-balance params; validated to require a reset and disallow continuous-use features.
  - UI: Rollover options in Balance Create for metered/credit features with recurring resets; invalid selections auto-clear on feature/reset changes.
  - Mapper/Tests: Rollover mapped to plan items; integration tests cover happy path and rejection cases.

- **Refactors**
  - Extracted reusable `RolloverConfigForm` and simplified the plan editor’s `RolloverConfig` to a thin wrapper.

<sup>Written for commit 08aca230711e430997915ea9ff3a4bfc7d5fe366. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds rollover support to the balance-create API and the customer balance-create sheet UI. It extracts the existing `RolloverConfig` plan-editor component into a shared `RolloverConfigForm` that is reused in the new balance-create flow, and adds server-side validation to reject rollover for continuous-use features and one-time (no-reset) balances.

**Key changes:**
- [API changes] `rollover: RolloverConfigSchema.optional()` added to `ExtCreateBalanceParamsSchema` and mapped through `createBalanceParamsV0ToPlanItemV0`
- [Improvements] `RolloverConfig.tsx` refactored to delegate all rendering to the extracted `RolloverConfigForm`
- [Improvements] Three integration tests cover the happy path and both rejection cases
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no correctness or data-integrity concerns.

Server validation logic is correct and Zod guards run before the custom checks. The mapper correctly translates field names between schemas. UI state management properly clears rollover on all relevant state transitions (one-off, unlimited, feature change). Integration tests cover the happy path and both rejection cases.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/createBalance/validateCreateBalance.ts | Adds two validation guards (no rollover for continuous-use features, no rollover for one-time balances). Logic is correct; uses Object.keys(…).length idiom where plain truthiness checks suffice. |
| server/tests/integration/balances/create/create-balance-with-rollover.test.ts | New integration test covering the happy path (rollover applied on reset), rejection for continuous-use features, and rejection for one-time balances. Well structured with clear inline assertions. |
| shared/api/balances/create/createBalanceParams.ts | Adds rollover: RolloverConfigSchema.optional() to the balance create schema with a short description; straightforward API change. |
| shared/api/balances/create/mappers/createBalanceParamsV0ToPlanItemV0.ts | Maps the incoming rollover params (using duration/length field names) to the internal ApiPlanItemV0 shape (expiry_duration_type/expiry_duration_length). Field nullability is handled correctly with ?? null. |
| vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx | Adds rollover state and UI using the new RolloverConfigForm; correctly gates submission behind canEnableRollover and clears rollover on one-off/unlimited/feature-change paths. |
| vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfig.tsx | Refactored to delegate all rendering to the new RolloverConfigForm; now much thinner (~35 lines vs ~200), correctly preserves reset_usage_when_enabled: true via onEnable. |
| vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx | New shared controlled component extracted from RolloverConfig.tsx; exposes onEnable escape hatch for callers that need side-effects on first enable. Logic and props are clean. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as BalanceCreateSheet
    participant API as POST /v1/balances.create
    participant Validate as validateCreateBalanceParams
    participant Mapper as createBalanceParamsV0ToPlanItemV0

    UI->>UI: User selects feature + reset interval
    UI->>UI: Enable rollover via RolloverConfigForm
    UI->>API: POST { feature_id, included_grant, reset, rollover }
    API->>Validate: parse(params, feature)
    alt isContUseFeature && rollover
        Validate-->>API: RecaseError (not supported)
        API-->>UI: 400 error
    else !reset && rollover
        Validate-->>API: RecaseError (one-time balance)
        API-->>UI: 400 error
    else valid
        Validate-->>API: ok
        API->>Mapper: map params to ApiPlanItemV0
        Mapper-->>API: rollover with expiry_duration_type/length
        API-->>UI: 200 balance created
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/balances/createBalance/validateCreateBalance.ts
Line: 46-58

Comment:
**Overly complex truthiness checks**

`Object.keys(...).length > 0` and `Object.keys(...).length <= 0` are unnecessarily verbose here. Since `params.rollover` and `params.reset` are already validated by Zod before this point, simple truthiness checks are equivalent and much clearer.

```suggestion
	if (isContUseFeature({ feature }) && params.rollover) {
		throw new RecaseError({
			message: `Rollover is not supported for continuous use features`,
		});
	}

	if (!params.reset && params.rollover) {
		throw new RecaseError({
			message: `Rollover cannot be provided for one-time balances`,
		});
	}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 rollovers on create balance"](https://github.com/useautumn/autumn/commit/08aca230711e430997915ea9ff3a4bfc7d5fe366) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28795562)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->