### PR TITLE
Update hooks configuration

### DIFF
--- a/.capy/settings.json
+++ b/.capy/settings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://capy.ai/settings.schema.json",
+  "hooks": {
+    "setup": [
+      {
+        "command": "bun agent:bootstrap"
+      }
+    ],
+    "terminals": [
+      {
+        "name": "dev",
+        "command": "bun dev:agent",
+        "readonly": true
+      }
+    ],
+    "context": {
+      "maxOutputLength": 2000
+    }
+  }
+}


### PR DESCRIPTION
<!-- capy:config-files -->

Updated via Capy instructions editor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.capy/settings.json` to configure Capy hooks: run `bun agent:bootstrap` during setup, provide a read-only `dev` terminal running `bun dev:agent`, and cap context output at 2000.

<sup>Written for commit 0fd26d0975c0364ee61c55605e746974a73c724c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `.capy/settings.json` configuration file for the Capy AI coding assistant, defining setup hooks and a readonly dev terminal. The config references two bun scripts (`agent:bootstrap` and `dev:agent`) that do not exist in any `package.json` across the monorepo, meaning the setup and terminal hooks will fail when Capy attempts to execute them.

- **Improvements**: Adds Capy agent tooling configuration with setup hooks and terminal definitions.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge only after adding the missing bun scripts; as-is, all Capy hooks will fail.

The config references two scripts that don't exist anywhere in the monorepo, making both the setup hook and dev terminal non-functional. This is a P1 correctness issue that should be resolved before merging — either by adding the scripts to a package.json or updating the commands to match existing scripts.

.capy/settings.json — references non-existent bun scripts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .capy/settings.json | New Capy AI tool config referencing bun scripts (`agent:bootstrap`, `dev:agent`) that don't exist in any package.json — hooks will fail at runtime. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Capy Agent Starts] --> B[Run setup hook]
    B --> C["bun agent:bootstrap"]
    C --> D{Script exists?}
    D -- No --> E["❌ bun: script not found\nagent:bootstrap"]
    D -- Yes --> F[Bootstrap complete]
    F --> G[Open terminal]
    G --> H["bun dev:agent (readonly)"]
    H --> I{Script exists?}
    I -- No --> J["❌ bun: script not found\ndev:agent"]
    I -- Yes --> K[Dev terminal running]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .capy/settings.json
Line: 6-12

Comment:
**Referenced scripts don't exist in the workspace**

Neither `agent:bootstrap` nor `dev:agent` are defined in any `package.json` in this monorepo. Running `bun agent:bootstrap` or `bun dev:agent` will produce `bun: script not found` errors when Capy triggers these hooks. The scripts need to be added to the root or a workspace `package.json` before this config is usable.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update hooks configuration"](https://github.com/useautumn/autumn/commit/0fd26d0975c0364ee61c55605e746974a73c724c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28806296)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->