### PR TITLE
feat: 🎸 limit entities from sharing customer level balances

### DIFF
--- a/server/src/_luaScriptsV2/customers/updateCustomerData.lua
+++ b/server/src/_luaScriptsV2/customers/updateCustomerData.lua
@@ -19,7 +19,8 @@
         auto_topups?: array | null,
         spend_limits?: array | null,
         usage_alerts?: array | null,
-        overage_allowed?: array | null
+        overage_allowed?: array | null,
+        config?: object | null
       }
     }
 
@@ -129,6 +130,15 @@ if updates.overage_allowed ~= nil then
     redis.call('JSON.SET', cache_key, '$.overage_allowed', cjson.encode(updates.overage_allowed))
   end
   table.insert(updated_fields, 'overage_allowed')
+end
+
+if updates.config ~= nil then
+  if is_nil(updates.config) then
+    redis.call('JSON.SET', cache_key, '$.config', 'null')
+  else
+    redis.call('JSON.SET', cache_key, '$.config', cjson.encode(updates.config))
+  end
+  table.insert(updated_fields, 'config')
 end
 
 return cjson.encode({ success = true, updated_fields = updated_fields })

--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -26,6 +26,7 @@ import {
 	type CreateScheduleParamsV0Input,
 	type CreateScheduleResponse,
 	type CustomerBillingControlsParams,
+	type CustomerData,
 	CustomerExpand,
 	type DeleteBalanceParamsV0,
 	EntityExpand,
@@ -524,6 +525,7 @@ export class AutumnInt {
 				send_email_receipts?: boolean;
 				metadata?: Record<string, unknown>;
 				billing_controls?: CustomerBillingControlsParams;
+				config?: CustomerData["config"];
 			},
 		) => {
 			const data = await this.patch(`/customers/${customerId}`, updates);
@@ -540,6 +542,7 @@ export class AutumnInt {
 				send_email_receipts?: boolean;
 				metadata?: Record<string, unknown>;
 				billing_controls?: CustomerBillingControlsParams;
+				config?: CustomerData["config"];
 			},
 		) => {
 			const data = await this.post(`/customers.update`, {

--- a/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
@@ -8,6 +8,7 @@ import {
 	getMaxOverage,
 	getRelevantFeatures,
 	isAllocatedCustomerEntitlement,
+	isEntityCusEnt,
 	isFreeCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
@@ -53,7 +54,7 @@ export const prepareFeatureDeduction = ({
 			});
 
 	// Get customer entitlements for these features (includes both product and loose entitlements)
-	const cusEnts = fullCustomerToCustomerEntitlements({
+	let cusEnts = fullCustomerToCustomerEntitlements({
 		fullCustomer,
 		featureIds: relevantFeatures.map((f) => f.id),
 		reverseOrder: org.config?.reverse_deduction_order,
@@ -61,6 +62,10 @@ export const prepareFeatureDeduction = ({
 		inStatuses: orgToInStatuses({ org }),
 		customerEntitlementFilters,
 	});
+
+	if (fullCustomer.entity?.id && fullCustomer.config?.block_shared_pool) {
+		cusEnts = cusEnts.filter((ce) => isEntityCusEnt({ cusEnt: ce }));
+	}
 
 	// Check if ANY relevant feature is unlimited
 	const unlimitedFeatureIds: string[] = [];

--- a/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
@@ -8,7 +8,6 @@ import {
 	getMaxOverage,
 	getRelevantFeatures,
 	isAllocatedCustomerEntitlement,
-	isEntityCusEnt,
 	isFreeCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
@@ -54,7 +53,7 @@ export const prepareFeatureDeduction = ({
 			});
 
 	// Get customer entitlements for these features (includes both product and loose entitlements)
-	let cusEnts = fullCustomerToCustomerEntitlements({
+	const cusEnts = fullCustomerToCustomerEntitlements({
 		fullCustomer,
 		featureIds: relevantFeatures.map((f) => f.id),
 		reverseOrder: org.config?.reverse_deduction_order,
@@ -62,10 +61,6 @@ export const prepareFeatureDeduction = ({
 		inStatuses: orgToInStatuses({ org }),
 		customerEntitlementFilters,
 	});
-
-	if (fullCustomer.entity?.id && fullCustomer.config?.disable_pooled_balance) {
-		cusEnts = cusEnts.filter((ce) => isEntityCusEnt({ cusEnt: ce }));
-	}
 
 	// Check if ANY relevant feature is unlimited
 	const unlimitedFeatureIds: string[] = [];

--- a/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
@@ -63,7 +63,7 @@ export const prepareFeatureDeduction = ({
 		customerEntitlementFilters,
 	});
 
-	if (fullCustomer.entity?.id && fullCustomer.config?.block_shared_pool) {
+	if (fullCustomer.entity?.id && fullCustomer.config?.disable_pooled_balance) {
 		cusEnts = cusEnts.filter((ce) => isEntityCusEnt({ cusEnt: ce }));
 	}
 

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -152,8 +152,8 @@ export const updateCustomer = async ({
 		? {
 				config: {
 					...(originalCustomer.config ?? {}),
-					...(config.block_shared_pool !== undefined && {
-						block_shared_pool: config.block_shared_pool,
+					...(config.disable_pooled_balance !== undefined && {
+						disable_pooled_balance: config.disable_pooled_balance,
 					}),
 				},
 			}

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -36,6 +36,7 @@ export const updateCustomer = async ({
 		customer_id: customerId,
 		new_customer_id: newCustomerId,
 		billing_controls,
+		config,
 		...newCusData
 	} = params;
 
@@ -146,11 +147,24 @@ export const updateCustomer = async ({
 			billingControlUpdates.overage_allowed = billing_controls.overage_allowed;
 	}
 
+	// Merge config partially so omitted keys don't clobber existing ones
+	const configUpdate = config
+		? {
+				config: {
+					...(originalCustomer.config ?? {}),
+					...(config.block_shared_pool !== undefined && {
+						block_shared_pool: config.block_shared_pool,
+					}),
+				},
+			}
+		: {};
+
 	const updateData: Partial<Customer> = {
 		...newCusData,
 		id: newCustomerId,
 		metadata: mergedMetadata,
 		...billingControlUpdates,
+		...configUpdate,
 	};
 
 	if (newStripeId) {

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.ts
@@ -86,7 +86,7 @@ export const getApiCustomerBase = async ({
 			overage_allowed: fullCus.overage_allowed ?? undefined,
 		},
 		config: {
-			block_shared_pool: fullCus.config?.block_shared_pool,
+			disable_pooled_balance: fullCus.config?.disable_pooled_balance,
 		},
 
 		invoices:

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.ts
@@ -85,6 +85,9 @@ export const getApiCustomerBase = async ({
 			usage_alerts: fullCus.usage_alerts ?? undefined,
 			overage_allowed: fullCus.overage_allowed ?? undefined,
 		},
+		config: {
+			block_shared_pool: fullCus.config?.block_shared_pool,
+		},
 
 		invoices:
 			fullCus.invoices && ctx.expand.includes(CustomerExpand.Invoices)

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/updateCachedCustomerData.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/updateCachedCustomerData.ts
@@ -24,6 +24,7 @@ type CustomerDataUpdates = Pick<
 	| "spend_limits"
 	| "usage_alerts"
 	| "overage_allowed"
+	| "config"
 >;
 
 /**

--- a/server/src/internal/customers/cusUtils/initCustomer.ts
+++ b/server/src/internal/customers/cusUtils/initCustomer.ts
@@ -38,6 +38,7 @@ const initCustomer = ({
 		spend_limits: customerData?.billing_controls?.spend_limits,
 		usage_alerts: customerData?.billing_controls?.usage_alerts,
 		overage_allowed: customerData?.billing_controls?.overage_allowed,
+		config: customerData?.config,
 	};
 };
 

--- a/server/src/utils/scriptUtils/testUtils/initCustomerV3.ts
+++ b/server/src/utils/scriptUtils/testUtils/initCustomerV3.ts
@@ -1,6 +1,5 @@
-import { ApiVersion } from "@autumn/shared";
+import { ApiVersion, type CustomerData } from "@autumn/shared";
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
-import type { CustomerData } from "autumn-js";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { attachPaymentMethod } from "../initCustomer.js";
@@ -75,6 +74,7 @@ export const initCustomerV3 = async ({
 		fingerprint: customerData?.fingerprint,
 		stripe_id: stripeCus.id,
 		send_email_receipts: sendEmailReceipts,
+		config: customerData?.config,
 		internalOptions: {
 			disable_defaults: !withDefault,
 			// Only pass default_group when defaults are enabled

--- a/server/tests/balances/track/entity-balances/track-entity-balances7.test.ts
+++ b/server/tests/balances/track/entity-balances/track-entity-balances7.test.ts
@@ -1,0 +1,217 @@
+import { expect, test } from "bun:test";
+import { ErrCode } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { setCustomerOverageAllowed } from "../../../integration/balances/utils/overage-allowed-utils/customerOverageAllowedUtils.js";
+
+/**
+ * track-entity-balances7: block_shared_pool
+ *
+ * When customer.config.block_shared_pool is true and a deduction is scoped
+ * to an entity, the entity must NOT fall back into the shared customer pool.
+ *
+ * Three deterministic branches:
+ *   1. reject          — entity overflow throws InsufficientBalance; nothing deducted
+ *   2. cap (no overage) — entity balance caps at 0; customer pool untouched
+ *   3. cap + overage   — entity balance goes to -100; customer pool untouched
+ *
+ * Shared product: customer pool = 5000, per-entity pool = 500.
+ */
+
+/**
+ * Fresh product fixture per test. `initProductsV0` mutates the product's `id`
+ * in-place to add a prefix (see tests/utils/testProductUtils/testProductUtils.ts:21),
+ * so sharing a module-level product across `test.concurrent` branches produces
+ * a race where each test over-prefixes the others and attach lookups miss.
+ */
+const makeFreeProd = () =>
+	products.base({
+		id: "block-shared-pool",
+		items: [
+			items.monthlyMessages({ includedUsage: 5000 }),
+			items.monthlyMessages({
+				includedUsage: 500,
+				entityFeatureId: TestFeature.Users,
+			}),
+		],
+	});
+
+// ──────────────────────────────────────────────────────────────────────
+// Branch 1: reject
+// ──────────────────────────────────────────────────────────────────────
+test.concurrent(`${chalk.yellowBright("track-entity-balances7-reject: entity overflow throws InsufficientBalance; nothing deducted")}`, async () => {
+	const customerId = "track-entity-balances7-reject";
+	const entityId = "ent-1";
+	const freeProd = makeFreeProd();
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.deleteCustomer({ customerId }),
+			s.customer({
+				testClock: false,
+				data: { config: { block_shared_pool: true } },
+			}),
+			s.products({ list: [freeProd] }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+		],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	// Pre-track: check() and entities.get() both report entity-only balance
+	const preCheck = await autumnV1.check({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(preCheck.balance).toBe(500);
+
+	const preEntity = await autumnV1.entities.get(customerId, entityId);
+	expect(preEntity.features[TestFeature.Messages].balance).toBe(500);
+
+	// Track 600 with reject → must throw
+	await expectAutumnError({
+		errCode: ErrCode.InsufficientBalance,
+		func: async () => {
+			await autumnV1.track({
+				customer_id: customerId,
+				entity_id: entityId,
+				feature_id: TestFeature.Messages,
+				value: 600,
+				overage_behavior: "reject",
+				skip_event: true,
+			});
+		},
+	});
+
+	// Post-track: both pools unchanged
+	const postEntity = await autumnV1.entities.get(customerId, entityId);
+	expect(postEntity.features[TestFeature.Messages].balance).toBe(500);
+
+	// Aggregated customer view unchanged: 5000 (customer) + 500 (entity) = 5500
+	const postCustomer = await autumnV1.customers.get(customerId);
+	expect(postCustomer.features[TestFeature.Messages].balance).toBe(5500);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Branch 2: cap (default, no overage_allowed)
+// ──────────────────────────────────────────────────────────────────────
+test.concurrent(`${chalk.yellowBright("track-entity-balances7-cap: entity caps at 0; customer pool untouched")}`, async () => {
+	const customerId = "track-entity-balances7-cap";
+	const entityId = "ent-1";
+	const freeProd = makeFreeProd();
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.deleteCustomer({ customerId }),
+			s.customer({
+				testClock: false,
+				data: { config: { block_shared_pool: true } },
+			}),
+			s.products({ list: [freeProd] }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+		],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	// Pre-track sanity
+	const preEntity = await autumnV1.entities.get(customerId, entityId);
+	expect(preEntity.features[TestFeature.Messages].balance).toBe(500);
+
+	const preCheck = await autumnV1.check({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(preCheck.balance).toBe(500);
+
+	// Track 600 under cap (default). Entity pool exhausted, overflow discarded.
+	await autumnV1.track({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+		value: 600,
+		skip_event: true,
+	});
+
+	// Entity caps at 0 (usage_allowed defaults to false for free products).
+	const postEntity = await autumnV1.entities.get(customerId, entityId);
+	expect(postEntity.features[TestFeature.Messages].balance).toBe(0);
+
+	const postCheck = await autumnV1.check({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(postCheck.balance).toBe(0);
+
+	// Customer pool untouched. Aggregated view = 5000 + 0 = 5000.
+	const postCustomer = await autumnV1.customers.get(customerId);
+	expect(postCustomer.features[TestFeature.Messages].balance).toBe(5000);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Branch 3: cap + overage_allowed
+// ──────────────────────────────────────────────────────────────────────
+test.concurrent(`${chalk.yellowBright("track-entity-balances7-overage: entity goes to -100 under overage_allowed; customer pool untouched")}`, async () => {
+	const customerId = "track-entity-balances7-overage";
+	const entityId = "ent-1";
+	const freeProd = makeFreeProd();
+
+	const { autumnV1, autumnV2_1 } = await initScenario({
+		customerId,
+		setup: [
+			s.deleteCustomer({ customerId }),
+			s.customer({
+				testClock: false,
+				data: { config: { block_shared_pool: true } },
+			}),
+			s.products({ list: [freeProd] }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+		],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	// Enable overage_allowed on the customer so the entity balance can
+	// go negative under cap.
+	await setCustomerOverageAllowed({
+		autumn: autumnV2_1 as any,
+		customerId,
+		featureId: TestFeature.Messages,
+		enabled: true,
+	});
+
+	// Pre-track sanity
+	const preEntity = await autumnV1.entities.get(customerId, entityId);
+	expect(preEntity.features[TestFeature.Messages].balance).toBe(500);
+
+	// Track 600 under cap with overage_allowed enabled.
+	await autumnV1.track({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+		value: 600,
+		skip_event: true,
+	});
+
+	// Entity can go negative because overage_allowed forces usage_allowed=true.
+	// Customer pool is blocked by the flag, so overflow lands on entity only.
+	const postEntity = await autumnV1.entities.get(customerId, entityId);
+	expect(postEntity.features[TestFeature.Messages].balance).toBe(-100);
+
+	const postCheck = await autumnV1.check({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(postCheck.balance).toBe(-100);
+
+	// Customer pool untouched. Aggregated view = 5000 + (-100) = 4900.
+	const postCustomer = await autumnV1.customers.get(customerId);
+	expect(postCustomer.features[TestFeature.Messages].balance).toBe(4900);
+});

--- a/server/tests/balances/track/entity-balances/track-entity-balances7.test.ts
+++ b/server/tests/balances/track/entity-balances/track-entity-balances7.test.ts
@@ -9,9 +9,9 @@ import chalk from "chalk";
 import { setCustomerOverageAllowed } from "../../../integration/balances/utils/overage-allowed-utils/customerOverageAllowedUtils.js";
 
 /**
- * track-entity-balances7: block_shared_pool
+ * track-entity-balances7: disable_pooled_balance
  *
- * When customer.config.block_shared_pool is true and a deduction is scoped
+ * When customer.config.disable_pooled_balance is true and a deduction is scoped
  * to an entity, the entity must NOT fall back into the shared customer pool.
  *
  * Three deterministic branches:
@@ -54,7 +54,7 @@ test.concurrent(`${chalk.yellowBright("track-entity-balances7-reject: entity ove
 			s.deleteCustomer({ customerId }),
 			s.customer({
 				testClock: false,
-				data: { config: { block_shared_pool: true } },
+				data: { config: { disable_pooled_balance: true } },
 			}),
 			s.products({ list: [freeProd] }),
 			s.entities({ count: 1, featureId: TestFeature.Users }),
@@ -111,7 +111,7 @@ test.concurrent(`${chalk.yellowBright("track-entity-balances7-cap: entity caps a
 			s.deleteCustomer({ customerId }),
 			s.customer({
 				testClock: false,
-				data: { config: { block_shared_pool: true } },
+				data: { config: { disable_pooled_balance: true } },
 			}),
 			s.products({ list: [freeProd] }),
 			s.entities({ count: 1, featureId: TestFeature.Users }),
@@ -169,7 +169,7 @@ test.concurrent(`${chalk.yellowBright("track-entity-balances7-overage: entity go
 			s.deleteCustomer({ customerId }),
 			s.customer({
 				testClock: false,
-				data: { config: { block_shared_pool: true } },
+				data: { config: { disable_pooled_balance: true } },
 			}),
 			s.products({ list: [freeProd] }),
 			s.entities({ count: 1, featureId: TestFeature.Users }),

--- a/server/tests/balances/track/entity-balances/track-entity-balances7.test.ts
+++ b/server/tests/balances/track/entity-balances/track-entity-balances7.test.ts
@@ -14,12 +14,15 @@ import { setCustomerOverageAllowed } from "../../../integration/balances/utils/o
  * When customer.config.disable_pooled_balance is true and a deduction is scoped
  * to an entity, the entity must NOT fall back into the shared customer pool.
  *
- * Three deterministic branches:
- *   1. reject          — entity overflow throws InsufficientBalance; nothing deducted
+ * Four deterministic branches:
+ *   1. reject           — entity overflow throws InsufficientBalance; nothing deducted
  *   2. cap (no overage) — entity balance caps at 0; customer pool untouched
- *   3. cap + overage   — entity balance goes to -100; customer pool untouched
+ *   3. cap + overage    — entity balance goes to -100; customer pool untouched
+ *   4. entity-attached product — entity has its own plan via `attach(customer_id, entity_id)`;
+ *                                shared customer pool still blocked
  *
  * Shared product: customer pool = 5000, per-entity pool = 500.
+ * Entity-attached product: 500 messages granted directly to the entity.
  */
 
 /**
@@ -38,6 +41,28 @@ const makeFreeProd = () =>
 				entityFeatureId: TestFeature.Users,
 			}),
 		],
+	});
+
+/**
+ * Entity-level free plan. No `entityFeatureId` on the item — instead the plan
+ * is attached directly to an entity via `attach({ customer_id, entity_id })`,
+ * which scopes its balance to that entity through `customer_product.internal_entity_id`.
+ */
+const makeEntityLevelProd = () =>
+	products.base({
+		id: "entity-level",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+
+/**
+ * Customer-level shared pool product. No per-entity slice — a single 5000-message
+ * pool that any entity would normally fall back into if disable_pooled_balance
+ * weren't set.
+ */
+const makeCustomerPooledProd = () =>
+	products.base({
+		id: "customer-pooled",
+		items: [items.monthlyMessages({ includedUsage: 5000 })],
 	});
 
 // ──────────────────────────────────────────────────────────────────────
@@ -214,4 +239,86 @@ test.concurrent(`${chalk.yellowBright("track-entity-balances7-overage: entity go
 	// Customer pool untouched. Aggregated view = 5000 + (-100) = 4900.
 	const postCustomer = await autumnV1.customers.get(customerId);
 	expect(postCustomer.features[TestFeature.Messages].balance).toBe(4900);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Branch 4: entity-attached product (Plan A attached directly to an entity)
+// Confirms the filter works for the *other* way an entity can have a balance:
+// not `X per Entity` (entityFeatureId), but a whole plan attached via
+// attach({ customer_id, entity_id }).
+// ──────────────────────────────────────────────────────────────────────
+test.concurrent(`${chalk.yellowBright("track-entity-balances7-entity-attached: entity-attached plan works with disable_pooled_balance")}`, async () => {
+	const customerId = "track-entity-balances7-entity-attached";
+	const entityId = "ent-1";
+	const pooledProd = makeCustomerPooledProd();
+	const entityProd = makeEntityLevelProd();
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.deleteCustomer({ customerId }),
+			s.customer({
+				testClock: false,
+				data: { config: { disable_pooled_balance: true } },
+			}),
+			s.products({ list: [pooledProd, entityProd] }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+		],
+		actions: [],
+	});
+
+	// Attach the pooled product at the customer level. This creates the shared
+	// 5000-message pool that should be blocked from the entity's view.
+	await autumnV1.attach({
+		customer_id: customerId,
+		product_id: pooledProd.id,
+	});
+
+	// Attach the entity-level plan directly to the entity. Grants the entity
+	// its own 500-message balance via customer_product.internal_entity_id.
+	await autumnV1.attach({
+		customer_id: customerId,
+		entity_id: entityId,
+		product_id: entityProd.id,
+	});
+
+	// Verify both attaches landed: customer aggregate view shows 5000 + 500 = 5500.
+	const customerAfterAttach = await autumnV1.customers.get(customerId);
+	expect(customerAfterAttach.features[TestFeature.Messages].balance).toBe(5500);
+
+	// Entity view must show ONLY the entity-attached plan's 500, NOT the 5500
+	// aggregate — the shared pool is blocked by disable_pooled_balance.
+	const preEntity = await autumnV1.entities.get(customerId, entityId);
+	expect(preEntity.features[TestFeature.Messages].balance).toBe(500);
+
+	const preCheck = await autumnV1.check({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(preCheck.balance).toBe(500);
+
+	// Track 300 on the entity. Should deduct from the entity's 500 only.
+	await autumnV1.track({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+		value: 300,
+		skip_event: true,
+	});
+
+	// Entity balance = 500 - 300 = 200.
+	const postEntity = await autumnV1.entities.get(customerId, entityId);
+	expect(postEntity.features[TestFeature.Messages].balance).toBe(200);
+
+	const postCheck = await autumnV1.check({
+		customer_id: customerId,
+		entity_id: entityId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(postCheck.balance).toBe(200);
+
+	// Customer pool untouched: aggregated view = 5000 (pooled) + 200 (entity) = 5200.
+	const postCustomer = await autumnV1.customers.get(customerId);
+	expect(postCustomer.features[TestFeature.Messages].balance).toBe(5200);
 });

--- a/server/tests/integration/crud/customers/customer-config.test.ts
+++ b/server/tests/integration/crud/customers/customer-config.test.ts
@@ -5,256 +5,232 @@ import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService.js";
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// CUSTOMER CONFIG — block_shared_pool
+// CUSTOMER CONFIG — disable_pooled_balance
 // Mirrors the billing_controls test style: cached API read, uncached API read,
 // and a direct DB read to prove the field round-trips through every layer.
 // ═══════════════════════════════════════════════════════════════════════════════
 
-test.concurrent(
-	`${chalk.yellowBright("customer config: create customer without config leaves block_shared_pool undefined")}`,
-	async () => {
-		const customerId = "customer-config-default";
-		const { autumnV2_1, ctx } = await initScenario({
-			setup: [s.deleteCustomer({ customerId })],
-			actions: [],
-		});
+test.concurrent(`${chalk.yellowBright("customer config: create customer without config leaves disable_pooled_balance undefined")}`, async () => {
+	const customerId = "customer-config-default";
+	const { autumnV2_1, ctx } = await initScenario({
+		setup: [s.deleteCustomer({ customerId })],
+		actions: [],
+	});
 
-		await autumnV2_1.customers.create({
-			id: customerId,
-			name: "Config Default",
-			email: `${customerId}@example.com`,
-		});
+	await autumnV2_1.customers.create({
+		id: customerId,
+		name: "Config Default",
+		email: `${customerId}@example.com`,
+	});
 
-		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(cached.config).toBeDefined();
-		expect(cached.config?.block_shared_pool).toBeUndefined();
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.config).toBeDefined();
+	expect(cached.config?.disable_pooled_balance).toBeUndefined();
 
-		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
-			skip_cache: "true",
-		});
-		expect(uncached.config?.block_shared_pool).toBeUndefined();
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.config?.disable_pooled_balance).toBeUndefined();
 
-		const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
-		// DB row should be null/undefined when no config was provided.
-		expect(fromDb.config?.block_shared_pool).toBeUndefined();
-	},
-);
+	const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	// DB row should be null/undefined when no config was provided.
+	expect(fromDb.config?.disable_pooled_balance).toBeUndefined();
+});
 
-test.concurrent(
-	`${chalk.yellowBright("customer config: create customer with block_shared_pool=true")}`,
-	async () => {
-		const customerId = "customer-config-create-true";
-		const { autumnV2_1, ctx } = await initScenario({
-			setup: [s.deleteCustomer({ customerId })],
-			actions: [],
-		});
+test.concurrent(`${chalk.yellowBright("customer config: create customer with disable_pooled_balance=true")}`, async () => {
+	const customerId = "customer-config-create-true";
+	const { autumnV2_1, ctx } = await initScenario({
+		setup: [s.deleteCustomer({ customerId })],
+		actions: [],
+	});
 
-		await autumnV2_1.customers.create({
-			id: customerId,
-			name: "Config Create True",
-			email: `${customerId}@example.com`,
-			config: { block_shared_pool: true },
-		});
+	await autumnV2_1.customers.create({
+		id: customerId,
+		name: "Config Create True",
+		email: `${customerId}@example.com`,
+		config: { disable_pooled_balance: true },
+	});
 
-		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(cached.config?.block_shared_pool).toBe(true);
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.config?.disable_pooled_balance).toBe(true);
 
-		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
-			skip_cache: "true",
-		});
-		expect(uncached.config?.block_shared_pool).toBe(true);
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.config?.disable_pooled_balance).toBe(true);
 
-		const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
-		expect(fromDb.config?.block_shared_pool).toBe(true);
-	},
-);
+	const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	expect(fromDb.config?.disable_pooled_balance).toBe(true);
+});
 
-test.concurrent(
-	`${chalk.yellowBright("customer config: create customer with block_shared_pool=false")}`,
-	async () => {
-		const customerId = "customer-config-create-false";
-		const { autumnV2_1, ctx } = await initScenario({
-			setup: [s.deleteCustomer({ customerId })],
-			actions: [],
-		});
+test.concurrent(`${chalk.yellowBright("customer config: create customer with disable_pooled_balance=false")}`, async () => {
+	const customerId = "customer-config-create-false";
+	const { autumnV2_1, ctx } = await initScenario({
+		setup: [s.deleteCustomer({ customerId })],
+		actions: [],
+	});
 
-		await autumnV2_1.customers.create({
-			id: customerId,
-			name: "Config Create False",
-			email: `${customerId}@example.com`,
-			config: { block_shared_pool: false },
-		});
+	await autumnV2_1.customers.create({
+		id: customerId,
+		name: "Config Create False",
+		email: `${customerId}@example.com`,
+		config: { disable_pooled_balance: false },
+	});
 
-		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(cached.config?.block_shared_pool).toBe(false);
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.config?.disable_pooled_balance).toBe(false);
 
-		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
-			skip_cache: "true",
-		});
-		expect(uncached.config?.block_shared_pool).toBe(false);
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.config?.disable_pooled_balance).toBe(false);
 
-		const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
-		expect(fromDb.config?.block_shared_pool).toBe(false);
-	},
-);
+	const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	expect(fromDb.config?.disable_pooled_balance).toBe(false);
+});
 
-test.concurrent(
-	`${chalk.yellowBright("customer config: update block_shared_pool from unset to true")}`,
-	async () => {
-		const customerId = "customer-config-update-true";
-		const { autumnV2_1, ctx } = await initScenario({
-			customerId,
-			setup: [s.customer({})],
-			actions: [],
-		});
+test.concurrent(`${chalk.yellowBright("customer config: update disable_pooled_balance from unset to true")}`, async () => {
+	const customerId = "customer-config-update-true";
+	const { autumnV2_1, ctx } = await initScenario({
+		customerId,
+		setup: [s.customer({})],
+		actions: [],
+	});
 
-		const before = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(before.config?.block_shared_pool).toBeUndefined();
+	const before = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(before.config?.disable_pooled_balance).toBeUndefined();
 
-		await autumnV2_1.customers.update(customerId, {
-			config: { block_shared_pool: true },
-		});
+	await autumnV2_1.customers.update(customerId, {
+		config: { disable_pooled_balance: true },
+	});
 
-		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(cached.config?.block_shared_pool).toBe(true);
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.config?.disable_pooled_balance).toBe(true);
 
-		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
-			skip_cache: "true",
-		});
-		expect(uncached.config?.block_shared_pool).toBe(true);
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.config?.disable_pooled_balance).toBe(true);
 
-		const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
-		expect(fromDb.config?.block_shared_pool).toBe(true);
-	},
-);
+	const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	expect(fromDb.config?.disable_pooled_balance).toBe(true);
+});
 
-test.concurrent(
-	`${chalk.yellowBright("customer config: update block_shared_pool from true to false")}`,
-	async () => {
-		const customerId = "customer-config-update-false";
-		const { autumnV2_1 } = await initScenario({
-			setup: [s.deleteCustomer({ customerId })],
-			actions: [],
-		});
+test.concurrent(`${chalk.yellowBright("customer config: update disable_pooled_balance from true to false")}`, async () => {
+	const customerId = "customer-config-update-false";
+	const { autumnV2_1 } = await initScenario({
+		setup: [s.deleteCustomer({ customerId })],
+		actions: [],
+	});
 
-		await autumnV2_1.customers.create({
-			id: customerId,
-			name: "Config Flip Off",
-			email: `${customerId}@example.com`,
-			config: { block_shared_pool: true },
-		});
+	await autumnV2_1.customers.create({
+		id: customerId,
+		name: "Config Flip Off",
+		email: `${customerId}@example.com`,
+		config: { disable_pooled_balance: true },
+	});
 
-		const before = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(before.config?.block_shared_pool).toBe(true);
+	const before = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(before.config?.disable_pooled_balance).toBe(true);
 
-		await autumnV2_1.customers.update(customerId, {
-			config: { block_shared_pool: false },
-		});
+	await autumnV2_1.customers.update(customerId, {
+		config: { disable_pooled_balance: false },
+	});
 
-		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(cached.config?.block_shared_pool).toBe(false);
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.config?.disable_pooled_balance).toBe(false);
 
-		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
-			skip_cache: "true",
-		});
-		expect(uncached.config?.block_shared_pool).toBe(false);
-	},
-);
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.config?.disable_pooled_balance).toBe(false);
+});
 
-test.concurrent(
-	`${chalk.yellowBright("customer config: partial update leaves other fields untouched")}`,
-	async () => {
-		// Regression guard: mirrors the billing_controls pattern — updating config
-		// shouldn't clobber name/email/send_email_receipts.
-		const customerId = "customer-config-partial";
-		const { autumnV2_1 } = await initScenario({
-			setup: [s.deleteCustomer({ customerId })],
-			actions: [],
-		});
+test.concurrent(`${chalk.yellowBright("customer config: partial update leaves other fields untouched")}`, async () => {
+	// Regression guard: mirrors the billing_controls pattern — updating config
+	// shouldn't clobber name/email/send_email_receipts.
+	const customerId = "customer-config-partial";
+	const { autumnV2_1 } = await initScenario({
+		setup: [s.deleteCustomer({ customerId })],
+		actions: [],
+	});
 
-		await autumnV2_1.customers.create({
-			id: customerId,
-			name: "Original Name",
-			email: `${customerId}@example.com`,
-			send_email_receipts: true,
-		});
+	await autumnV2_1.customers.create({
+		id: customerId,
+		name: "Original Name",
+		email: `${customerId}@example.com`,
+		send_email_receipts: true,
+	});
 
-		await autumnV2_1.customers.update(customerId, {
-			config: { block_shared_pool: true },
-		});
+	await autumnV2_1.customers.update(customerId, {
+		config: { disable_pooled_balance: true },
+	});
 
-		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(cached.name).toBe("Original Name");
-		expect(cached.email).toBe(`${customerId}@example.com`);
-		expect(cached.send_email_receipts).toBe(true);
-		expect(cached.config?.block_shared_pool).toBe(true);
-	},
-);
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.name).toBe("Original Name");
+	expect(cached.email).toBe(`${customerId}@example.com`);
+	expect(cached.send_email_receipts).toBe(true);
+	expect(cached.config?.disable_pooled_balance).toBe(true);
+});
 
-test.concurrent(
-	`${chalk.yellowBright("customer config: omitting config in update does not reset it")}`,
-	async () => {
-		const customerId = "customer-config-omit";
-		const { autumnV2_1 } = await initScenario({
-			setup: [s.deleteCustomer({ customerId })],
-			actions: [],
-		});
+test.concurrent(`${chalk.yellowBright("customer config: omitting config in update does not reset it")}`, async () => {
+	const customerId = "customer-config-omit";
+	const { autumnV2_1 } = await initScenario({
+		setup: [s.deleteCustomer({ customerId })],
+		actions: [],
+	});
 
-		await autumnV2_1.customers.create({
-			id: customerId,
-			name: "Config Persist",
-			email: `${customerId}@example.com`,
-			config: { block_shared_pool: true },
-		});
+	await autumnV2_1.customers.create({
+		id: customerId,
+		name: "Config Persist",
+		email: `${customerId}@example.com`,
+		config: { disable_pooled_balance: true },
+	});
 
-		// Update something unrelated — config should survive.
-		await autumnV2_1.customers.update(customerId, {
-			name: "Config Persist Renamed",
-		});
+	// Update something unrelated — config should survive.
+	await autumnV2_1.customers.update(customerId, {
+		name: "Config Persist Renamed",
+	});
 
-		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(cached.name).toBe("Config Persist Renamed");
-		expect(cached.config?.block_shared_pool).toBe(true);
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.name).toBe("Config Persist Renamed");
+	expect(cached.config?.disable_pooled_balance).toBe(true);
 
-		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
-			skip_cache: "true",
-		});
-		expect(uncached.config?.block_shared_pool).toBe(true);
-	},
-);
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.config?.disable_pooled_balance).toBe(true);
+});
 
-test.concurrent(
-	`${chalk.yellowBright("customer config: updating billing_controls alongside config does not clobber either")}`,
-	async () => {
-		// Cross-field regression: config and billing_controls are both partial
-		// updates on the same row — updating one must not reset the other.
-		const customerId = "customer-config-mixed";
-		const { autumnV2_1 } = await initScenario({
-			setup: [s.deleteCustomer({ customerId })],
-			actions: [],
-		});
+test.concurrent(`${chalk.yellowBright("customer config: updating billing_controls alongside config does not clobber either")}`, async () => {
+	// Cross-field regression: config and billing_controls are both partial
+	// updates on the same row — updating one must not reset the other.
+	const customerId = "customer-config-mixed";
+	const { autumnV2_1 } = await initScenario({
+		setup: [s.deleteCustomer({ customerId })],
+		actions: [],
+	});
 
-		await autumnV2_1.customers.create({
-			id: customerId,
-			name: "Mixed",
-			email: `${customerId}@example.com`,
-			config: { block_shared_pool: true },
-		});
+	await autumnV2_1.customers.create({
+		id: customerId,
+		name: "Mixed",
+		email: `${customerId}@example.com`,
+		config: { disable_pooled_balance: true },
+	});
 
-		await autumnV2_1.customers.update(customerId, {
-			billing_controls: {
-				spend_limits: [],
-			},
-		});
+	await autumnV2_1.customers.update(customerId, {
+		billing_controls: {
+			spend_limits: [],
+		},
+	});
 
-		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(cached.config?.block_shared_pool).toBe(true);
-		expect(cached.billing_controls?.spend_limits).toEqual([]);
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.config?.disable_pooled_balance).toBe(true);
+	expect(cached.billing_controls?.spend_limits).toEqual([]);
 
-		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
-			skip_cache: "true",
-		});
-		expect(uncached.config?.block_shared_pool).toBe(true);
-		expect(uncached.billing_controls?.spend_limits).toEqual([]);
-	},
-);
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.config?.disable_pooled_balance).toBe(true);
+	expect(uncached.billing_controls?.spend_limits).toEqual([]);
+});

--- a/server/tests/integration/crud/customers/customer-config.test.ts
+++ b/server/tests/integration/crud/customers/customer-config.test.ts
@@ -1,0 +1,260 @@
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CUSTOMER CONFIG — block_shared_pool
+// Mirrors the billing_controls test style: cached API read, uncached API read,
+// and a direct DB read to prove the field round-trips through every layer.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("customer config: create customer without config leaves block_shared_pool undefined")}`,
+	async () => {
+		const customerId = "customer-config-default";
+		const { autumnV2_1, ctx } = await initScenario({
+			setup: [s.deleteCustomer({ customerId })],
+			actions: [],
+		});
+
+		await autumnV2_1.customers.create({
+			id: customerId,
+			name: "Config Default",
+			email: `${customerId}@example.com`,
+		});
+
+		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.config).toBeDefined();
+		expect(cached.config?.block_shared_pool).toBeUndefined();
+
+		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(uncached.config?.block_shared_pool).toBeUndefined();
+
+		const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
+		// DB row should be null/undefined when no config was provided.
+		expect(fromDb.config?.block_shared_pool).toBeUndefined();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer config: create customer with block_shared_pool=true")}`,
+	async () => {
+		const customerId = "customer-config-create-true";
+		const { autumnV2_1, ctx } = await initScenario({
+			setup: [s.deleteCustomer({ customerId })],
+			actions: [],
+		});
+
+		await autumnV2_1.customers.create({
+			id: customerId,
+			name: "Config Create True",
+			email: `${customerId}@example.com`,
+			config: { block_shared_pool: true },
+		});
+
+		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.config?.block_shared_pool).toBe(true);
+
+		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(uncached.config?.block_shared_pool).toBe(true);
+
+		const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
+		expect(fromDb.config?.block_shared_pool).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer config: create customer with block_shared_pool=false")}`,
+	async () => {
+		const customerId = "customer-config-create-false";
+		const { autumnV2_1, ctx } = await initScenario({
+			setup: [s.deleteCustomer({ customerId })],
+			actions: [],
+		});
+
+		await autumnV2_1.customers.create({
+			id: customerId,
+			name: "Config Create False",
+			email: `${customerId}@example.com`,
+			config: { block_shared_pool: false },
+		});
+
+		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.config?.block_shared_pool).toBe(false);
+
+		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(uncached.config?.block_shared_pool).toBe(false);
+
+		const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
+		expect(fromDb.config?.block_shared_pool).toBe(false);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer config: update block_shared_pool from unset to true")}`,
+	async () => {
+		const customerId = "customer-config-update-true";
+		const { autumnV2_1, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		const before = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(before.config?.block_shared_pool).toBeUndefined();
+
+		await autumnV2_1.customers.update(customerId, {
+			config: { block_shared_pool: true },
+		});
+
+		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.config?.block_shared_pool).toBe(true);
+
+		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(uncached.config?.block_shared_pool).toBe(true);
+
+		const fromDb = await CusService.getFull({ ctx, idOrInternalId: customerId });
+		expect(fromDb.config?.block_shared_pool).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer config: update block_shared_pool from true to false")}`,
+	async () => {
+		const customerId = "customer-config-update-false";
+		const { autumnV2_1 } = await initScenario({
+			setup: [s.deleteCustomer({ customerId })],
+			actions: [],
+		});
+
+		await autumnV2_1.customers.create({
+			id: customerId,
+			name: "Config Flip Off",
+			email: `${customerId}@example.com`,
+			config: { block_shared_pool: true },
+		});
+
+		const before = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(before.config?.block_shared_pool).toBe(true);
+
+		await autumnV2_1.customers.update(customerId, {
+			config: { block_shared_pool: false },
+		});
+
+		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.config?.block_shared_pool).toBe(false);
+
+		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(uncached.config?.block_shared_pool).toBe(false);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer config: partial update leaves other fields untouched")}`,
+	async () => {
+		// Regression guard: mirrors the billing_controls pattern — updating config
+		// shouldn't clobber name/email/send_email_receipts.
+		const customerId = "customer-config-partial";
+		const { autumnV2_1 } = await initScenario({
+			setup: [s.deleteCustomer({ customerId })],
+			actions: [],
+		});
+
+		await autumnV2_1.customers.create({
+			id: customerId,
+			name: "Original Name",
+			email: `${customerId}@example.com`,
+			send_email_receipts: true,
+		});
+
+		await autumnV2_1.customers.update(customerId, {
+			config: { block_shared_pool: true },
+		});
+
+		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.name).toBe("Original Name");
+		expect(cached.email).toBe(`${customerId}@example.com`);
+		expect(cached.send_email_receipts).toBe(true);
+		expect(cached.config?.block_shared_pool).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer config: omitting config in update does not reset it")}`,
+	async () => {
+		const customerId = "customer-config-omit";
+		const { autumnV2_1 } = await initScenario({
+			setup: [s.deleteCustomer({ customerId })],
+			actions: [],
+		});
+
+		await autumnV2_1.customers.create({
+			id: customerId,
+			name: "Config Persist",
+			email: `${customerId}@example.com`,
+			config: { block_shared_pool: true },
+		});
+
+		// Update something unrelated — config should survive.
+		await autumnV2_1.customers.update(customerId, {
+			name: "Config Persist Renamed",
+		});
+
+		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.name).toBe("Config Persist Renamed");
+		expect(cached.config?.block_shared_pool).toBe(true);
+
+		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(uncached.config?.block_shared_pool).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer config: updating billing_controls alongside config does not clobber either")}`,
+	async () => {
+		// Cross-field regression: config and billing_controls are both partial
+		// updates on the same row — updating one must not reset the other.
+		const customerId = "customer-config-mixed";
+		const { autumnV2_1 } = await initScenario({
+			setup: [s.deleteCustomer({ customerId })],
+			actions: [],
+		});
+
+		await autumnV2_1.customers.create({
+			id: customerId,
+			name: "Mixed",
+			email: `${customerId}@example.com`,
+			config: { block_shared_pool: true },
+		});
+
+		await autumnV2_1.customers.update(customerId, {
+			billing_controls: {
+				spend_limits: [],
+			},
+		});
+
+		const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.config?.block_shared_pool).toBe(true);
+		expect(cached.billing_controls?.spend_limits).toEqual([]);
+
+		const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(uncached.config?.block_shared_pool).toBe(true);
+		expect(uncached.billing_controls?.spend_limits).toEqual([]);
+	},
+);

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -9,7 +9,7 @@ import {
 	type RewardRedemption,
 } from "@autumn/shared";
 import { resetAndGetCusEnt } from "@tests/balances/track/rollovers/rolloverTestUtils.js";
-import type { CustomerData } from "autumn-js";
+import type { CustomerData } from "@autumn/shared";
 import { addHours, addMonths } from "date-fns";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { removeAllPaymentMethods } from "@/external/stripe/customers/paymentMethods/operations/removeAllPaymentMethods.js";

--- a/shared/api/common/customerData.ts
+++ b/shared/api/common/customerData.ts
@@ -58,7 +58,7 @@ export const CustomerDataSchema = z
 			.object({
 				disable_pooled_balance: z.boolean().optional().meta({
 					description:
-						"Whether to block this customer from the shared feature pool.",
+						"Whether to disable the shared customer-level pool for entities.",
 				}),
 			})
 			.optional()

--- a/shared/api/common/customerData.ts
+++ b/shared/api/common/customerData.ts
@@ -54,6 +54,18 @@ export const CustomerDataSchema = z
 			description: "Billing controls for the customer (auto top-ups, etc.)",
 		}),
 
+		config: z
+			.object({
+				block_shared_pool: z.boolean().optional().meta({
+					description:
+						"Whether to block this customer from the shared feature pool.",
+				}),
+			})
+			.optional()
+			.meta({
+				description: "Miscellaneous configurations for the customer.",
+			}),
+
 		internal_options: CreateCustomerInternalOptionsSchema.optional().meta({
 			internal: true,
 		}),

--- a/shared/api/common/customerData.ts
+++ b/shared/api/common/customerData.ts
@@ -56,7 +56,7 @@ export const CustomerDataSchema = z
 
 		config: z
 			.object({
-				block_shared_pool: z.boolean().optional().meta({
+				disable_pooled_balance: z.boolean().optional().meta({
 					description:
 						"Whether to block this customer from the shared feature pool.",
 				}),

--- a/shared/api/customers/apiCustomerV5.ts
+++ b/shared/api/customers/apiCustomerV5.ts
@@ -76,7 +76,7 @@ export const API_CUSTOMER_V5_EXAMPLE = {
 		},
 	},
 	config: {
-		block_shared_pool: false,
+		disable_pooled_balance: false,
 	},
 };
 
@@ -99,12 +99,9 @@ export const BaseApiCustomerV5Schema = BaseApiCustomerSchema.extend({
 	}),
 	config: z
 		.object({
-			block_shared_pool: z
-				.boolean()
-				.optional()
-				.meta({
-					description: "Whether to block the shared pool for the customer.",
-				}),
+			disable_pooled_balance: z.boolean().optional().meta({
+				description: "Whether to block the shared pool for the customer.",
+			}),
 		})
 		.optional()
 		.meta({

--- a/shared/api/customers/apiCustomerV5.ts
+++ b/shared/api/customers/apiCustomerV5.ts
@@ -75,6 +75,9 @@ export const API_CUSTOMER_V5_EXAMPLE = {
 			feature_id: "advanced_workflows",
 		},
 	},
+	config: {
+		block_shared_pool: false,
+	},
 };
 
 // V5 base customer - uses V1 subscriptions (single array with status field) and V1 balances
@@ -94,6 +97,19 @@ export const BaseApiCustomerV5Schema = BaseApiCustomerSchema.extend({
 		description:
 			"Boolean feature flags keyed by feature ID, showing enabled access for on/off features.",
 	}),
+	config: z
+		.object({
+			block_shared_pool: z
+				.boolean()
+				.optional()
+				.meta({
+					description: "Whether to block the shared pool for the customer.",
+				}),
+		})
+		.optional()
+		.meta({
+			description: "Configuration for the customer.",
+		}),
 }).meta({
 	examples: [API_CUSTOMER_V5_EXAMPLE],
 });

--- a/shared/api/customers/apiCustomerV5.ts
+++ b/shared/api/customers/apiCustomerV5.ts
@@ -100,7 +100,8 @@ export const BaseApiCustomerV5Schema = BaseApiCustomerSchema.extend({
 	config: z
 		.object({
 			disable_pooled_balance: z.boolean().optional().meta({
-				description: "Whether to block the shared pool for the customer.",
+				description:
+					"Whether to let entities fall back into the shared customer-level pool.",
 			}),
 		})
 		.optional()

--- a/shared/api/customers/cusFeatures/utils/getApiBalances.ts
+++ b/shared/api/customers/cusFeatures/utils/getApiBalances.ts
@@ -29,11 +29,11 @@ export const getApiBalances = async ({
 		entity: fullCus.entity,
 	});
 
-	// When block_shared_pool is enabled and we're scoped to an entity, drop
+	// When disable_pooled_balance is enabled and we're scoped to an entity, drop
 	// customer-level (shared pool) cusEnts so the returned balances reflect
 	// only the entity's own pool. Matches the filter in prepareFeatureDeduction
 	// so the deduction path and reporting stay consistent.
-	if (fullCus.entity?.id && fullCus.config?.block_shared_pool) {
+	if (fullCus.entity?.id && fullCus.config?.disable_pooled_balance) {
 		allCusEnts = allCusEnts.filter((ce) => isEntityCusEnt({ cusEnt: ce }));
 	}
 

--- a/shared/api/customers/cusFeatures/utils/getApiBalances.ts
+++ b/shared/api/customers/cusFeatures/utils/getApiBalances.ts
@@ -5,6 +5,7 @@ import {
 	type FullCusEntWithFullCusProduct,
 	type FullCustomer,
 	fullCustomerToCustomerEntitlements,
+	isEntityCusEnt,
 	orgToInStatuses,
 	type SharedContext,
 	scopeExpandForCtx,
@@ -22,11 +23,19 @@ export const getApiBalances = async ({
 	balances: Record<string, ApiBalanceV1>;
 	flags: Record<string, ApiFlagV0>;
 }> => {
-	const allCusEnts = fullCustomerToCustomerEntitlements({
+	let allCusEnts = fullCustomerToCustomerEntitlements({
 		fullCustomer: fullCus,
 		inStatuses: orgToInStatuses({ org: ctx.org }),
 		entity: fullCus.entity,
 	});
+
+	// When block_shared_pool is enabled and we're scoped to an entity, drop
+	// customer-level (shared pool) cusEnts so the returned balances reflect
+	// only the entity's own pool. Matches the filter in prepareFeatureDeduction
+	// so the deduction path and reporting stay consistent.
+	if (fullCus.entity?.id && fullCus.config?.block_shared_pool) {
+		allCusEnts = allCusEnts.filter((ce) => isEntityCusEnt({ cusEnt: ce }));
+	}
 
 	const featureToCusEnt: Record<string, FullCusEntWithFullCusProduct[]> = {};
 	for (const cusEnt of allCusEnts) {

--- a/shared/models/cusModels/cusModels.ts
+++ b/shared/models/cusModels/cusModels.ts
@@ -29,7 +29,7 @@ export const CustomerSchema = z.object({
 	overage_allowed: z.array(DbOverageAllowedSchema).nullish(),
 	config: z
 		.object({
-			block_shared_pool: z.boolean().optional(),
+			disable_pooled_balance: z.boolean().optional(),
 		})
 		.nullish(),
 });

--- a/shared/models/cusModels/cusModels.ts
+++ b/shared/models/cusModels/cusModels.ts
@@ -27,6 +27,11 @@ export const CustomerSchema = z.object({
 	spend_limits: z.array(DbSpendLimitSchema).nullish(),
 	usage_alerts: z.array(DbUsageAlertSchema).nullish(),
 	overage_allowed: z.array(DbOverageAllowedSchema).nullish(),
+	config: z
+		.object({
+			block_shared_pool: z.boolean().optional(),
+		})
+		.nullish(),
 });
 
 export type Customer = z.infer<typeof CustomerSchema>;

--- a/shared/models/cusModels/cusTable.ts
+++ b/shared/models/cusModels/cusTable.ts
@@ -21,7 +21,7 @@ import type {
 } from "./billingControls/customerBillingControls.js";
 
 export type CustomerConfig = {
-	block_shared_pool?: boolean;
+	disable_pooled_balance?: boolean;
 };
 
 export type CustomerProcessor = {

--- a/shared/models/cusModels/cusTable.ts
+++ b/shared/models/cusModels/cusTable.ts
@@ -20,6 +20,10 @@ import type {
 	DbUsageAlert,
 } from "./billingControls/customerBillingControls.js";
 
+export type CustomerConfig = {
+	block_shared_pool?: boolean;
+};
+
 export type CustomerProcessor = {
 	type: "stripe";
 	id: string;
@@ -46,6 +50,7 @@ export const customers = pgTable(
 		spend_limits: jsonb().$type<DbSpendLimit[]>(),
 		usage_alerts: jsonb().$type<DbUsageAlert[]>(),
 		overage_allowed: jsonb().$type<DbOverageAllowed[]>(),
+		config: jsonb().$type<CustomerConfig>().default({}),
 	},
 	(table) => [
 		unique("cus_id_constraint").on(table.org_id, table.id, table.env),

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToCustomerEntitlements.ts
@@ -1,3 +1,4 @@
+import { isEntityCusEnt } from "@utils/cusEntUtils/cusEntUtils.js";
 import type { Entity } from "../../../models/cusModels/entityModels/entityModels.js";
 import type { FullCustomer } from "../../../models/cusModels/fullCusModel.js";
 import type { CustomerEntitlementFilters } from "../../../models/cusProductModels/cusEntModels/cusEntModels.js";
@@ -104,6 +105,14 @@ export const fullCustomerToCustomerEntitlements = ({
 				(cusEnt.external_id ?? cusEnt.id) ===
 				customerEntitlementFilters.balanceId,
 		);
+	}
+
+	// When disable_pooled_balance is enabled and we're scoped to an entity, drop
+	// customer-level (shared pool) cusEnts so the returned balances reflect
+	// only the entity's own pool. Matches the filter in prepareFeatureDeduction
+	// so the deduction path and reporting stay consistent.
+	if (fullCustomer.entity?.id && fullCustomer.config?.disable_pooled_balance) {
+		cusEnts = cusEnts.filter((ce) => isEntityCusEnt({ cusEnt: ce }));
 	}
 
 	return cusEnts as FullCusEntWithFullCusProduct[];

--- a/shared/utils/productDisplayUtils.ts
+++ b/shared/utils/productDisplayUtils.ts
@@ -112,10 +112,12 @@ export const formatTiers = ({
 export const getFeatureItemDisplay = ({
 	item,
 	feature,
+	entityFeature,
 	fullDisplay = false,
 }: {
 	item: ProductItem;
 	feature?: Feature;
+	entityFeature?: Feature;
 	fullDisplay?: boolean;
 }): DisplayResult => {
 	if (!feature) {
@@ -130,17 +132,34 @@ export const getFeatureItemDisplay = ({
 
 	const primaryText = getIncludedUsageText(item, feature);
 
-	// Determine secondary text (interval display)
+	// Determine secondary text: per-entity scope + interval.
+	// e.g. "per user per month" when entity_feature_id is set, otherwise "per month".
 	let secondaryText: string | undefined;
 	if (fullDisplay) {
+		const parts: string[] = [];
+
+		if (item.entity_feature_id && entityFeature) {
+			const entityName = getFeatureName({
+				feature: entityFeature,
+				units: 1,
+			});
+			if (entityName) {
+				parts.push(`per ${entityName}`);
+			}
+		}
+
 		const intervalDisplay = getIntervalDisplay(item);
 		if (intervalDisplay) {
-			secondaryText = intervalDisplay;
+			parts.push(intervalDisplay);
 		} else if (
 			isSingleUseFeature(feature) &&
 			item.included_usage !== Infinite
 		) {
-			secondaryText = "one-off";
+			parts.push("one-off");
+		}
+
+		if (parts.length > 0) {
+			secondaryText = parts.join(" ");
 		}
 	}
 
@@ -294,11 +313,16 @@ export const getProductItemDisplay = ({
 	amountFormatOptions?: Intl.NumberFormatOptions;
 }): DisplayResult => {
 	const findFeature = () => features.find((f) => f.id === item.feature_id);
+	const findEntityFeature = () =>
+		item.entity_feature_id
+			? features.find((f) => f.id === item.entity_feature_id)
+			: undefined;
 
 	if (isFeatureItem(item)) {
 		return getFeatureItemDisplay({
 			item,
 			feature: findFeature(),
+			entityFeature: findEntityFeature(),
 			fullDisplay,
 		});
 	}


### PR DESCRIPTION
- **feat: 🎸 schema changes for block_shared_pool**
- **feat: 🎸 update customer additions**
- **feat: 🎸 filter out cus level balances**
- **test: 💍 for block_shared_pool**
- **feat: 🎸 rename block_shared_pool to disable_pooled_balance**
- **feat: 🎸 change descriptions**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a customer setting `config.disable_pooled_balance` that stops entities from falling back to the shared customer balance. Deduction and balance reporting now use entity-only balances when this flag is on.

- **New Features**
  - Added `config.disable_pooled_balance` on customers (DB + API). Create/update supports partial merge; omitting `config` keeps existing values. `autumnCli` accepts `config` in create/update.
  - Deduction: when scoped to an entity and the flag is true, only entity entitlements are used (no shared-pool fallback).
  - Balances and entitlement listing mirror this filter so APIs match deduction (`getApiBalances` and `fullCustomerToCustomerEntitlements`).
  - Cache/data flow updated to persist and expose `config` (Lua cache update, cached customer updates, base customer API, init paths).
  - Tests cover CRUD round-trips and entity-only behavior: reject, cap, overage, plus an entity-attached plan case.
  - Misc: renamed from `block_shared_pool` to `disable_pooled_balance`; improved product display to show per-entity scope (e.g., “per user per month”).

<sup>Written for commit cec6c971db5a64312ba4f5c4165537429dc24eca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `customer.config.disable_pooled_balance`, a flag that prevents entities from drawing on the shared customer-level balance pool during both deduction (`prepareFeatureDeduction`) and reporting (`getApiBalances`). The change is propagated end-to-end: schema, Drizzle table definition, Lua cache script, API surface, update path with partial-merge semantics, and comprehensive tests.

- **[Improvements, API changes]** New `config.disable_pooled_balance` field added to `CustomerSchema`, `CustomerDataSchema`, and `BaseApiCustomerV5Schema`; both PATCH and POST update methods accept the field with safe partial-merge logic.
- **[Bug fixes]** `CustomerData` import corrected from `autumn-js` → `@autumn/shared` in two test/util files.
- **[Improvements]** The `config` column is added to `cusTable.ts` (Drizzle ORM schema), but **no companion migration file** was committed to `shared/drizzle/`; the column won't exist in production until one is generated and applied.
</details>

<h3>Confidence Score: 4/5</h3>

Not safe to merge until a database migration for the `config` column is committed; all other changes are well-implemented.

A P1 finding (missing Drizzle migration) means the `config` column won't exist in production, causing runtime errors on any customer read/write that references it after deploy.

`shared/models/cusModels/cusTable.ts` — the `config jsonb` column addition requires a generated migration in `shared/drizzle/`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/models/cusModels/cusTable.ts | Adds `config jsonb` column to the `customers` Drizzle schema; no companion migration file was generated/committed — P1 issue. |
| shared/api/customers/apiCustomerV5.ts | Exposes `config` on `BaseApiCustomerV5Schema`; `disable_pooled_balance` description is semantically inverted (P2). |
| server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts | Filters out customer-level entitlements when `entity.id` is set and `disable_pooled_balance` is true; logic is clean and targeted. |
| shared/api/customers/cusFeatures/utils/getApiBalances.ts | Mirrors the deduction filter in the balance-reporting path so API responses stay consistent with what would actually be deducted. |
| server/src/internal/customers/actions/update/updateCustomer.ts | Implements partial config merge correctly so omitting `config` on update does not clobber existing keys. |
| server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.ts | Always includes `config` object in API response; value is `{}` when unset, consistent with new test expectations. |
| server/src/_luaScriptsV2/customers/updateCustomerData.lua | Adds `config` to the Lua cache-update script with proper nil-check and JSON encoding, consistent with other field patterns. |
| server/tests/balances/track/entity-balances/track-entity-balances7.test.ts | New test covers all three deduction branches (reject, cap, cap+overage) with `disable_pooled_balance`; well-structured and isolated. |
| server/tests/integration/crud/customers/customer-config.test.ts | Comprehensive CRUD coverage for `config`: create, update, partial update, omit, and cross-field regression tests. |
| server/src/external/autumn/autumnCli.ts | Adds `config` to the `patch` and `post` update method parameter types; correctly typed against `CustomerData["config"]`. |
| server/src/utils/scriptUtils/testUtils/initCustomerV3.ts | Threads `config` from `customerData` into the customer init payload; also fixes import from `@autumn/shared` instead of `autumn-js`. |
| server/tests/utils/testInitUtils/initScenario.ts | Fixes `CustomerData` import from `autumn-js` to `@autumn/shared` for consistency. |
| shared/models/cusModels/cusModels.ts | Adds `.nullish()` `config` field to `CustomerSchema` matching the new table column; consistent with Zod usage elsewhere. |
| shared/api/common/customerData.ts | Adds `config` with `disable_pooled_balance` to `CustomerDataSchema`; description is accurate here. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Track / Check request\nscoped to entity_id] --> B{entity.id set AND\ndisable_pooled_balance=true?}
    B -- No --> C[allCusEnts = entity-level\n+ customer-level entitlements]
    B -- Yes --> D[allCusEnts filtered\nto entity-level only\nisEntityCusEnt]
    C --> E[prepareFeatureDeduction\ngetApiBalances]
    D --> E
    E --> F{Deduction path}
    F -- reject --> G[InsufficientBalance if\nentity pool exhausted]
    F -- cap --> H[Entity balance caps at 0\nCustomer pool untouched]
    F -- cap + overage_allowed --> I[Entity balance goes negative\nCustomer pool untouched]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: shared/models/cusModels/cusTable.ts
Line: 50-51

Comment:
**Missing database migration for `config` column**

The `config jsonb` column is added to the Drizzle schema (`cusTable.ts`) but no corresponding migration file exists in `shared/drizzle/`. The only file there (`0010_steady_ares.sql`) pre-dates this PR and covers a different table. Without a generated migration the production `customers` table won't have the column, causing immediate runtime errors on any read or write that touches `config`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: shared/api/customers/apiCustomerV5.ts
Line: 103-105

Comment:
**Inverted description for `disable_pooled_balance`**

The description says *"Whether to let entities fall back into the shared customer-level pool"* — but that describes the behaviour when the flag is **false** (the default). When `true` the pool is **disabled**, so the description is semantically inverted. Compare with the matching schema in `customerData.ts` which correctly reads: *"Whether to disable the shared customer-level pool for entities."*

```suggestion
					description:
						"Whether to disable the shared customer-level pool for entities.",
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 change descriptions"](https://github.com/useautumn/autumn/commit/aaf37734d23ad6b8b7377db706370d8a3159b91e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28985333)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->