### PR TITLE
fix: sort customer products by relevant status before applying limit

### DIFF
--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -43,6 +43,7 @@ const customerProductFields = {
 	canceled_at: customerProducts.canceled_at,
 	status: customerProducts.status,
 	trial_ends_at: customerProducts.trial_ends_at,
+	created_at: customerProducts.created_at,
 };
 
 const productFields = {

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -1,6 +1,7 @@
 import {
 	type AppEnv,
 	CusProductStatus,
+	RELEVANT_STATUSES,
 	customerProducts,
 	customers,
 	products,
@@ -398,10 +399,9 @@ export class CusSearchService {
 		const cusProductLimit = getOrgCusProductLimit({ orgId, orgSlug });
 		const processedData = Array.from(customerMap.values());
 		for (const customer of processedData) {
-			customer.customer_products = customer.customer_products.slice(
-				0,
-				cusProductLimit,
-			);
+			customer.customer_products = sortRelevantFirst(
+				customer.customer_products,
+			).slice(0, cusProductLimit);
 		}
 
 		const totalCount = totalCountResult[0]?.totalCount || 0;
@@ -735,15 +735,41 @@ export class CusSearchService {
 		const cusProductLimit = getOrgCusProductLimit({ orgId, orgSlug });
 		const finalResults = Array.from(customerMap.values());
 		for (const customer of finalResults) {
-			customer.customer_products = customer.customer_products.slice(
-				0,
-				cusProductLimit,
-			);
+			customer.customer_products = sortRelevantFirst(
+				customer.customer_products,
+			).slice(0, cusProductLimit);
 		}
 
 		return { data: finalResults, count: totalCount };
 	}
 }
+
+const sortRelevantFirst = (
+	customerProducts: Array<{
+		status?: string;
+		created_at?: string | number;
+		product?: { is_add_on?: boolean; name?: string | null };
+	}>,
+) => {
+	return customerProducts.sort((a, b) => {
+		const isRelevant = (status?: string) =>
+			RELEVANT_STATUSES.includes(status as CusProductStatus) ||
+			status === CusProductStatus.Trialing;
+		const aRelevant = isRelevant(a.status) ? 0 : 1;
+		const bRelevant = isRelevant(b.status) ? 0 : 1;
+		if (aRelevant !== bRelevant) return aRelevant - bRelevant;
+
+		const aAddOn = a.product?.is_add_on ? 1 : 0;
+		const bAddOn = b.product?.is_add_on ? 1 : 0;
+		if (aAddOn !== bAddOn) return aAddOn - bAddOn;
+
+		const aName = (a.product?.name ?? "").toLowerCase();
+		const bName = (b.product?.name ?? "").toLowerCase();
+		if (aName !== bName) return aName.localeCompare(bName);
+
+		return Number(b.created_at ?? 0) - Number(a.created_at ?? 0);
+	});
+};
 // // Legacy support for product_id field (if still used)
 // let productIds: string[] = [];
 // if (filters.product_id) {

--- a/vite/src/components/forms/attach-v2/components/AttachFooter.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooter.tsx
@@ -11,7 +11,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/v2/tooltips/Tooltip";
-import { useOrg } from "@/hooks/common/useOrg";
 import { cn } from "@/lib/utils";
 import { useAttachFormContext } from "../context/AttachFormProvider";
 import { usePlanScheduleField } from "../hooks/usePlanScheduleField";
@@ -26,15 +25,11 @@ export function AttachFooter() {
 		formValues,
 	} = useAttachFormContext();
 
-	const { org } = useOrg();
-	const ownStripeAccount = org?.stripe_connection !== "default";
 	const { isEndOfCycleSelected } = usePlanScheduleField();
 
 	const invoiceDisabledReason = isEndOfCycleSelected
 		? "Invoices are not available for end of cycle changes as there is no immediate charge to invoice"
-		: !ownStripeAccount
-			? "Connect your own Stripe account to send invoices"
-			: null;
+		: null;
 
 	const hasProductSelected = !!formValues.productId;
 	const isLoading = previewQuery.isLoading;

--- a/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
@@ -5,7 +5,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/v2/tooltips/Tooltip";
-import { useOrg } from "@/hooks/common/useOrg";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { cn } from "@/lib/utils";
 import { useAttachFormContext } from "../context/AttachFormProvider";
@@ -44,8 +43,6 @@ export function AttachFooterV3() {
 	const { setSheet } = useSheetStore();
 	const itemId = useSheetStore((s) => s.itemId);
 
-	const { org } = useOrg();
-	const ownStripeAccount = org?.stripe_connection !== "default";
 	const { isEndOfCycleSelected } = usePlanScheduleField();
 
 	const previewData = previewQuery.data;
@@ -55,11 +52,9 @@ export function AttachFooterV3() {
 
 	const invoiceDisabledReason = isEndOfCycleSelected
 		? "Invoices are not available for end of cycle changes as there is no immediate charge to invoice"
-		: !ownStripeAccount
-			? "Connect your own Stripe account to send invoices"
-			: isZeroAmount
-				? "Cannot send an invoice for $0 amounts. Please confirm the change instead."
-				: null;
+		: isZeroAmount
+			? "Cannot send an invoice for $0 amounts. Please confirm the change instead."
+			: null;
 
 	return (
 		<SheetFooter className="flex flex-col grid-cols-1 mt-0">

--- a/vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx
+++ b/vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx
@@ -13,7 +13,6 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/v2/tooltips/Tooltip";
-import { useOrg } from "@/hooks/common/useOrg";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { cn } from "@/lib/utils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
@@ -156,17 +155,12 @@ export function CreateScheduleReviewContent() {
 	const { setSheet } = useSheetStore();
 	const hasSchedule = useHasSchedule();
 
-	const { org } = useOrg();
-	const ownStripeAccount = org?.stripe_connection !== "default";
-
 	const confirmLabel = getConfirmLabel({ preview });
 	const isZeroAmount = preview && preview.total <= 0;
 
-	const invoiceDisabledReason = !ownStripeAccount
-		? "Connect your own Stripe account to send invoices"
-		: isZeroAmount
-			? "Cannot send an invoice for $0 amounts. Please confirm the change instead."
-			: null;
+	const invoiceDisabledReason = isZeroAmount
+		? "Cannot send an invoice for $0 amounts. Please confirm the change instead."
+		: null;
 
 	const isDisabled = isPreviewLoading || !!error;
 


### PR DESCRIPTION
## Summary
- Customer list page could show no products for customers with many expired products because the `cusProductLimit` slice didn't prioritize active/trialing products. Now sorts by relevant status (active, past_due, scheduled, trialing) first, then by add-on, product name, and created_at before slicing.
- Removes `ownStripeAccount` invoice gating from attach and schedule footers.

## Test plan
- [ ] Verify a customer with 15+ expired products and an active subscription shows the active product on the customer list page
- [ ] Verify trialing products also appear on the customer list
- [ ] Confirm attach and schedule footers no longer gate invoice sending on own Stripe account

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts customer products by relevant status before applying `cusProductLimit` so active/trialing items show up on the customer list. Also removes own-Stripe-account invoice gating in attach and schedule flows.

- **Bug Fixes**
  - Sort customer products by status (active, past_due, scheduled, trialing) → add-on → product name → created_at, then apply the limit; includes `created_at` in fetched fields for the tiebreaker.
  - Remove `ownStripeAccount` invoice gating in attach and schedule footers; invoices are now only blocked for end-of-cycle or $0 amounts.

<sup>Written for commit 4a087206b677444ffa89abcd405409557251bac8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent data-loss bug on the customer list page where customers with many expired products could appear to have no active subscription, and removes the `ownStripeAccount` UI gate that unnecessarily blocked invoice sending for orgs on the default Stripe connection.

- **Bug fixes**: `sortRelevantFirst` sorts customer products by relevant status (active, past_due, scheduled, trialing) before the `cusProductLimit` slice, ensuring active/trialing products always appear.
- **Improvements**: `ownStripeAccount` check removed from `AttachFooter`, `AttachFooterV3`, and `CreateScheduleSheetContent` — invoice option is now available to all orgs.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the bug fix is correct and the only remaining findings are P2 style suggestions.

The sorting logic is correct and `created_at` is stored as a numeric timestamp so `Number()` conversion is safe. Both call sites are updated consistently. The UI invoice-gating removal is intentional per the PR description. No P0/P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/CusSearchService.ts | Adds `sortRelevantFirst` helper to ensure active/past_due/scheduled/trialing products appear before expired ones prior to the `cusProductLimit` slice — fixes the silent data loss on the customer list page for customers with many expired products. |
| vite/src/components/forms/attach-v2/components/AttachFooter.tsx | Removes `ownStripeAccount` guard on invoice disabled reason — invoices are now available regardless of whether the org uses a default or custom Stripe connection. |
| vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx | Same `ownStripeAccount` guard removed as in `AttachFooter.tsx`; the `isZeroAmount` guard is preserved correctly. |
| vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx | Removes `ownStripeAccount` invoice gating from schedule footer, consistent with the attach footer changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer map values] --> B[sortRelevantFirst]
    B --> C{status relevant?}
    C -->|Active / PastDue / Scheduled / Trialing| D[rank = 0]
    C -->|Expired / Cancelled / etc.| E[rank = 1]
    D --> F[Sort by is_add_on asc]
    E --> F
    F --> G[Sort by product name asc]
    G --> H[Sort by created_at desc]
    H --> I[.slice 0 .. cusProductLimit]
    I --> J[Customer list response]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/customers/CusSearchService.ts
Line: 755-757

Comment:
**`Trialing` duplicates existing constant semantics**

`RELEVANT_STATUSES` already exists to capture "display-relevant" statuses, but `Trialing` is checked separately rather than being included. This means the constant name is now slightly misleading — callers of `RELEVANT_STATUSES` elsewhere won't treat trialing as relevant, while this sort does. Consider either adding `CusProductStatus.Trialing` to `RELEVANT_STATUSES` (if it should be treated as relevant everywhere), or introducing a dedicated `SORT_RELEVANT_STATUSES` constant used only here to make the intent explicit and avoid divergence.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/customers/CusSearchService.ts
Line: 754-771

Comment:
**In-place mutation before slice**

`Array.prototype.sort` mutates `customerProducts` in place before the result is sliced and reassigned. While functionally correct here (the reference is immediately overwritten on both code paths), it's easy to miss and could cause subtle bugs if a caller expects the original array to be unmodified. Using `.toSorted()` (ES2023) or `[...customerProducts].sort(...)` makes the intent clearer.

```suggestion
	return [...customerProducts].sort((a, b) => {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: sort customer products by relevant ..."](https://github.com/useautumn/autumn/commit/697532671f966c096e58080740adac55c8abe817) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29008329)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->