### PR TITLE
feat/rollover on create balance

### DIFF
--- a/server/src/internal/balances/createBalance/validateCreateBalance.ts
+++ b/server/src/internal/balances/createBalance/validateCreateBalance.ts
@@ -1,16 +1,19 @@
 import {
 	type CreateBalanceParamsV0,
+	type EntInterval,
 	ErrCode,
 	type Feature,
 	FeatureType,
 	type FullCustomer,
 	isContUseFeature,
 	RecaseError,
+	ResetInterval,
 	ValidateCreateBalanceParamsSchema,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
 import { getApiCustomerBase } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase";
+import { getNextResetAt } from "@/utils/timeUtils";
 
 export const validateCreateBalanceParams = async ({
 	ctx,
@@ -55,6 +58,25 @@ export const validateCreateBalanceParams = async ({
 		throw new RecaseError({
 			message: `Rollover cannot be provided for one-time balances`,
 		});
+	}
+
+	if (
+		params.rollover &&
+		params.expires_at &&
+		params.reset?.interval &&
+		params.reset.interval !== ResetInterval.OneOff
+	) {
+		const nextResetAt = getNextResetAt({
+			curReset: null,
+			interval: params.reset.interval as unknown as EntInterval,
+			intervalCount: params.reset.interval_count,
+		});
+
+		if (nextResetAt > params.expires_at) {
+			throw new RecaseError({
+				message: `expires_at (${new Date(params.expires_at).toISOString()}) occurs before the next rollover event (${new Date(nextResetAt).toISOString()})`,
+			});
+		}
 	}
 
 	if (params.balance_id) {

--- a/server/src/internal/balances/createBalance/validateCreateBalance.ts
+++ b/server/src/internal/balances/createBalance/validateCreateBalance.ts
@@ -4,6 +4,7 @@ import {
 	type Feature,
 	FeatureType,
 	type FullCustomer,
+	isContUseFeature,
 	RecaseError,
 	ValidateCreateBalanceParamsSchema,
 } from "@autumn/shared";
@@ -38,6 +39,21 @@ export const validateCreateBalanceParams = async ({
 	if (entity && feature.id === entity.feature_id) {
 		throw new RecaseError({
 			message: `Cannot give an entity a balance of its own feature type`,
+		});
+	}
+
+	if (
+		isContUseFeature({ feature }) &&
+		Object.keys(params.rollover || {}).length > 0
+	) {
+		throw new RecaseError({
+			message: `Rollover is not supported for continuous use features`,
+		});
+	}
+
+	if (Object.keys(params.reset || {}).length <= 0 && params.rollover) {
+		throw new RecaseError({
+			message: `Rollover cannot be provided for one-time balances`,
 		});
 	}
 

--- a/server/tests/integration/balances/create/create-balance-with-rollover.test.ts
+++ b/server/tests/integration/balances/create/create-balance-with-rollover.test.ts
@@ -52,7 +52,7 @@ test.concurrent(`${chalk.yellowBright("balance-rollover-create-1: loose balance 
 		value: usage,
 	});
 
-	await timeout(2000);
+	await timeout(3000);
 
 	// Trigger a reset (lazy)
 	await expireCusEntForReset({
@@ -130,6 +130,43 @@ test.concurrent(`${chalk.yellowBright("balance-rollover-create-3: rollover on on
 				feature_id: TestFeature.Messages,
 				included_grant: 100,
 				// no reset → one-time balance
+				rollover: {
+					max: 50,
+					length: 1,
+					duration: RolloverExpiryDurationType.Month,
+				},
+			});
+		},
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BALANCE-ROLLOVER-CREATE-4: Rejection — expires_at before next rollover
+//
+// A rollover event fires at the next reset. If expires_at occurs before
+// that next reset, the rollover would never take effect. The API should
+// reject the request.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("balance-rollover-create-4: expires_at before next rollover is rejected")}`, async () => {
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "balance-rollover-create-4",
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	// expires_at is 1 day from now, but reset is monthly → next rollover
+	// would be ~1 month from now, well after expiry.
+	const expiresAt = Date.now() + 1000 * 60 * 60 * 24;
+
+	await expectAutumnError({
+		func: async () => {
+			await autumnV2_2.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				included_grant: 100,
+				reset: { interval: ResetInterval.Month },
+				expires_at: expiresAt,
 				rollover: {
 					max: 50,
 					length: 1,

--- a/server/tests/integration/balances/create/create-balance-with-rollover.test.ts
+++ b/server/tests/integration/balances/create/create-balance-with-rollover.test.ts
@@ -1,0 +1,141 @@
+import { test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	ResetInterval,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expireCusEntForReset } from "@tests/utils/cusProductUtils/resetTestUtils.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════
+// BALANCE-ROLLOVER-CREATE-1: Happy path — rollover applied on reset
+//
+// Create a loose messages balance with a monthly reset + rollover config.
+// Track partial usage, trigger a lazy reset, and verify:
+//   - fresh grant is re-added
+//   - unused balance rolls over as a rollover entry (capped by max)
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("balance-rollover-create-1: loose balance rollover applied on reset")}`, async () => {
+	const includedGrant = 400;
+	const rolloverMax = 500;
+	const usage = 250;
+
+	const { customerId, autumnV2_2, ctx } = await initScenario({
+		customerId: "balance-rollover-create-1",
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	// Create loose balance with rollover
+	await autumnV2_2.balances.create({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		included_grant: includedGrant,
+		reset: { interval: ResetInterval.Month },
+		rollover: {
+			max: rolloverMax,
+			length: 1,
+			duration: RolloverExpiryDurationType.Month,
+		},
+	});
+
+	// Track partial usage
+	await autumnV2_2.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: usage,
+	});
+
+	await timeout(2000);
+
+	// Trigger a reset (lazy)
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+
+	const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+
+	// Unused (400 - 250) = 150 rolls over; capped by max=500 → 150
+	const expectedRollover = Math.min(includedGrant - usage, rolloverMax);
+	const expectedRemaining = includedGrant + expectedRollover;
+
+	expectBalanceCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		remaining: expectedRemaining,
+		usage: 0,
+		rollovers: [{ balance: expectedRollover }],
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BALANCE-ROLLOVER-CREATE-2: Rejection — rollover on continuous-use feature
+//
+// Rollover is not meaningful for continuous-use features. The API should
+// reject the request.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("balance-rollover-create-2: rollover on continuous-use feature is rejected")}`, async () => {
+	const { customerId, autumnV2 } = await initScenario({
+		customerId: "balance-rollover-create-2",
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	await expectAutumnError({
+		func: async () => {
+			await autumnV2.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Users, // continuous-use
+				included_grant: 5,
+				reset: { interval: ResetInterval.Month },
+				rollover: {
+					max: 10,
+					length: 1,
+					duration: RolloverExpiryDurationType.Month,
+				},
+			});
+		},
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BALANCE-ROLLOVER-CREATE-3: Rejection — rollover on one-time balance
+//
+// A balance without a reset interval is one-time / never resets, so
+// rollover makes no sense. The API should reject the request.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("balance-rollover-create-3: rollover on one-time balance is rejected")}`, async () => {
+	const { customerId, autumnV2 } = await initScenario({
+		customerId: "balance-rollover-create-3",
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	await expectAutumnError({
+		func: async () => {
+			await autumnV2.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				included_grant: 100,
+				// no reset → one-time balance
+				rollover: {
+					max: 50,
+					length: 1,
+					duration: RolloverExpiryDurationType.Month,
+				},
+			});
+		},
+	});
+});

--- a/shared/api/balances/create/createBalanceParams.ts
+++ b/shared/api/balances/create/createBalanceParams.ts
@@ -1,4 +1,9 @@
-import { FeatureSchema, FeatureType, ResetInterval } from "@autumn/shared";
+import {
+	FeatureSchema,
+	FeatureType,
+	ResetInterval,
+	RolloverConfigSchema,
+} from "@autumn/shared";
 import { z } from "zod/v4";
 import { BalanceParamsBaseSchema } from "../common/balanceParamsBase";
 
@@ -28,6 +33,11 @@ export const ExtCreateBalanceParamsSchema = BalanceParamsBaseSchema.extend({
 			description:
 				"Reset configuration for the balance. If not provided, the balance is a one-time grant that never resets.",
 		}),
+
+	rollover: RolloverConfigSchema.optional().meta({
+		description: "Rollover configuration for the balance.",
+	}),
+
 	expires_at: z.number().optional().meta({
 		description:
 			"Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset.",

--- a/shared/api/balances/create/mappers/createBalanceParamsV0ToPlanItemV0.ts
+++ b/shared/api/balances/create/mappers/createBalanceParamsV0ToPlanItemV0.ts
@@ -30,5 +30,13 @@ export const createBalanceParamsV0ToPlanItemV0 = ({
 				}
 			: null,
 		price: null,
+		rollover: params.rollover
+			? {
+					max: params.rollover.max ?? null,
+					max_percentage: params.rollover.max_percentage ?? null,
+					expiry_duration_type: params.rollover.duration,
+					expiry_duration_length: params.rollover.length,
+				}
+			: undefined,
 	};
 };

--- a/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
@@ -1,4 +1,10 @@
-import { type Feature, FeatureType, ResetInterval } from "@autumn/shared";
+import {
+	type Feature,
+	FeatureType,
+	isContUseFeature,
+	ResetInterval,
+	type RolloverConfig,
+} from "@autumn/shared";
 import { CalendarXIcon, InfinityIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -26,6 +32,7 @@ import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { RolloverConfigForm } from "@/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm";
 import { useCustomerContext } from "../../customer/CustomerContext";
 
 const RESET_INTERVAL_LABELS: Record<string, string> = {
@@ -54,6 +61,11 @@ export function BalanceCreateSheet() {
 	const [resetInterval, setResetInterval] = useState<string>("");
 	const [oneOff, setOneOff] = useState(false);
 	const [expiresAt, setExpiresAt] = useState<number | null>(null);
+	const [rollover, setRollover] = useState<RolloverConfig | null>(null);
+
+	// Rollover requires a recurring reset interval. If the interval goes away
+	// (or the user picks one-off/unlimited), clear rollover to keep state valid.
+	const hasRecurringReset = Boolean(resetInterval) && !oneOff && !unlimited;
 
 	const nonArchivedFeatures = features.filter((f: Feature) => !f.archived);
 	const selectedFeature = nonArchivedFeatures.find(
@@ -62,6 +74,36 @@ export function BalanceCreateSheet() {
 	const isMetered =
 		selectedFeature?.type === FeatureType.Metered ||
 		selectedFeature?.type === FeatureType.CreditSystem;
+
+	// Continuous-use features (non-consumable) don't support rollover — the
+	// server rejects it in validateCreateBalanceParams, so we gate the UI too.
+	const isContUse = selectedFeature
+		? isContUseFeature({ feature: selectedFeature })
+		: false;
+	const canEnableRollover = isMetered && !isContUse && hasRecurringReset;
+
+	/**
+	 * Authoritative feature-select handler.
+	 *
+	 * Rollover is only valid for metered/credit-system features that are
+	 * consumable (non-continuous). When the user swaps features, clear any
+	 * existing rollover state synchronously here — no useEffect needed.
+	 */
+	const handleSelectFeature = (nextFeatureId: string) => {
+		setFeatureId(nextFeatureId);
+		const nextFeature = nonArchivedFeatures.find(
+			(f: Feature) => f.id === nextFeatureId,
+		);
+		const nextIsMetered =
+			nextFeature?.type === FeatureType.Metered ||
+			nextFeature?.type === FeatureType.CreditSystem;
+		const nextIsContUse = nextFeature
+			? isContUseFeature({ feature: nextFeature })
+			: false;
+		if (!nextIsMetered || nextIsContUse) {
+			setRollover(null);
+		}
+	};
 
 	const handleCreate = async () => {
 		const customerId = customer?.id || customer?.internal_id;
@@ -95,6 +137,10 @@ export function BalanceCreateSheet() {
 			params.reset = { interval: resetInterval };
 		}
 
+		if (rollover && canEnableRollover) {
+			params.rollover = rollover;
+		}
+
 		if (expiresAt) {
 			params.expires_at = expiresAt;
 		}
@@ -125,7 +171,7 @@ export function BalanceCreateSheet() {
 					<FeatureSearchDropdown
 						features={nonArchivedFeatures}
 						value={featureId || null}
-						onSelect={setFeatureId}
+						onSelect={handleSelectFeature}
 					/>
 				</SheetSection>
 
@@ -164,6 +210,7 @@ export function BalanceCreateSheet() {
 													setIncludedGrant("");
 													setResetInterval("");
 													setOneOff(false);
+													setRollover(null);
 												}
 											}}
 											className="py-1 w-26 text-t4 gap-2"
@@ -204,7 +251,10 @@ export function BalanceCreateSheet() {
 											checked={oneOff}
 											onCheckedChange={(checked) => {
 												setOneOff(checked);
-												if (checked) setResetInterval("");
+												if (checked) {
+													setResetInterval("");
+													setRollover(null);
+												}
 											}}
 											className="py-1 w-26 text-t4 gap-2 justify-start"
 										>
@@ -224,6 +274,14 @@ export function BalanceCreateSheet() {
 										use24Hour
 									/>
 								</div>
+							)}
+
+							{isMetered && !unlimited && !isContUse && (
+								<RolloverConfigForm
+									value={rollover}
+									onChange={setRollover}
+									disabled={!canEnableRollover}
+								/>
 							)}
 						</div>
 					</SheetSection>

--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfig.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfig.tsx
@@ -1,20 +1,9 @@
-import {
-	type RolloverConfig as RolloverConfigType,
-	RolloverExpiryDurationType,
-} from "@autumn/shared";
-import { AreaCheckbox } from "@/components/v2/checkboxes/AreaCheckbox";
-import { FormLabel } from "@/components/v2/form/FormLabel";
-import { Input } from "@/components/v2/inputs/Input";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/v2/selects/Select";
+import type { RolloverConfig as RolloverConfigType } from "@autumn/shared";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
-
-type MaxMode = "absolute" | "percentage" | "unlimited";
+import {
+	DEFAULT_ROLLOVER_CONFIG,
+	RolloverConfigForm,
+} from "./RolloverConfigForm";
 
 /** Visibility is controlled by parent AdvancedSettings */
 export function RolloverConfig() {
@@ -22,208 +11,36 @@ export function RolloverConfig() {
 
 	if (!item) return null;
 
-	const defaultRollover: RolloverConfigType = {
-		duration: RolloverExpiryDurationType.Month,
-		length: 1 as number,
-		max: null,
-		max_percentage: null,
+	const rollover = (item.config?.rollover as RolloverConfigType) ?? null;
+
+	const handleChange = (next: RolloverConfigType | null) => {
+		const newConfig = { ...(item.config || {}) };
+		if (next === null) {
+			delete newConfig.rollover;
+			setItem({ ...item, config: newConfig });
+		} else {
+			newConfig.rollover = next;
+			setItem({ ...item, config: newConfig });
+		}
 	};
 
-	const setRolloverConfigKey = (
-		key: keyof RolloverConfigType,
-		value: null | number | RolloverExpiryDurationType,
-	) => {
+	const handleEnable = () => {
 		setItem({
 			...item,
+			reset_usage_when_enabled: true,
 			config: {
 				...(item.config || {}),
-				rollover: {
-					...(item.config?.rollover || defaultRollover),
-					[key]: value,
-				},
+				rollover: { ...DEFAULT_ROLLOVER_CONFIG },
 			},
 		});
 	};
 
-	const setRolloverConfig = (rollover: RolloverConfigType | null) => {
-		const newConfig = { ...(item.config || {}) };
-		if (rollover === null) {
-			delete newConfig.rollover;
-		} else {
-			newConfig.rollover = rollover;
-		}
-		setItem({
-			...item,
-			config: newConfig,
-		});
-	};
-
-	const rollover = item.config?.rollover as RolloverConfigType;
-	const hasRollover = item.config?.rollover != null;
-
-	const maxMode: MaxMode =
-		rollover?.max_percentage != null
-			? "percentage"
-			: rollover?.max === null
-				? "unlimited"
-				: "absolute";
-
-	const handleMaxModeChange = (mode: MaxMode) => {
-		const current = item.config?.rollover || defaultRollover;
-		if (mode === "unlimited") {
-			setRolloverConfig({
-				...current,
-				max: null,
-				max_percentage: null,
-			});
-		} else if (mode === "absolute") {
-			setRolloverConfig({
-				...current,
-				max: 0,
-				max_percentage: null,
-			});
-		} else {
-			setRolloverConfig({
-				...current,
-				max: null,
-				max_percentage: 50,
-			});
-		}
-	};
-
 	return (
-		<AreaCheckbox
-			title="Rollovers"
-			tooltip="Rollovers carry unused credits to the next billing cycle. Set a maximum rollover amount and specify how many cycles before resetting."
-			checked={hasRollover}
+		<RolloverConfigForm
+			value={rollover}
+			onChange={handleChange}
+			onEnable={handleEnable}
 			disabled={!item.interval}
-			onCheckedChange={(checked) => {
-				if (checked) {
-					setItem({
-						...item,
-						reset_usage_when_enabled: true,
-						config: {
-							...(item.config || {}),
-							rollover: defaultRollover,
-						},
-					});
-				} else {
-					setRolloverConfig(null);
-				}
-			}}
-		>
-			<div className="space-y-4 w-xs max-w-full">
-				<div className="space-y-2 w-full">
-					<FormLabel>Maximum rollover</FormLabel>
-					<div className="flex items-center gap-2">
-						<Select
-							value={maxMode}
-							onValueChange={(value) =>
-								handleMaxModeChange(value as MaxMode)
-							}
-						>
-							<SelectTrigger
-								className="w-32"
-								onClick={(e) => e.stopPropagation()}
-							>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="unlimited">Unlimited</SelectItem>
-								<SelectItem value="absolute">Absolute</SelectItem>
-								<SelectItem value="percentage">Percentage</SelectItem>
-							</SelectContent>
-						</Select>
-
-						{maxMode === "absolute" && (
-							<Input
-								type="number"
-								value={
-									rollover?.max === 0 ? "" : (rollover?.max ?? "")
-								}
-								className="flex-1"
-								placeholder="e.g. 100 credits"
-								onChange={(e) => {
-									const value = e.target.value;
-									const numValue =
-										value === "" ? 0 : parseInt(value) || 0;
-									setRolloverConfigKey("max", numValue);
-								}}
-								onClick={(e) => e.stopPropagation()}
-							/>
-						)}
-
-						{maxMode === "percentage" && (
-							<div className="flex items-center gap-1 flex-1">
-								<Input
-									type="number"
-									value={
-										rollover?.max_percentage === 0
-											? ""
-											: (rollover?.max_percentage ?? "")
-									}
-									className="flex-1"
-									placeholder="e.g. 50"
-									onChange={(e) => {
-										const value = e.target.value;
-										const numValue =
-											value === "" ? 0 : parseInt(value) || 0;
-										setRolloverConfigKey(
-											"max_percentage",
-											Math.min(100, Math.max(0, numValue)),
-										);
-									}}
-									onClick={(e) => e.stopPropagation()}
-								/>
-								<span className="text-t3 text-sm">%</span>
-							</div>
-						)}
-					</div>
-				</div>
-
-				<div className="space-y-2">
-					<FormLabel>Rollover duration</FormLabel>
-					<div className="flex items-center gap-2">
-						{rollover?.duration === RolloverExpiryDurationType.Month && (
-							<Input
-								type="number"
-								value={rollover?.length === 0 ? "" : rollover?.length || ""}
-								onChange={(e) => {
-									const value = e.target.value;
-									const numValue = value === "" ? 0 : parseInt(value) || 0;
-									setRolloverConfigKey("length", numValue);
-								}}
-								className="w-16"
-								placeholder="e.g. 1 month"
-								onClick={(e) => e.stopPropagation()}
-							/>
-						)}
-						<Select
-							value={rollover?.duration}
-							onValueChange={(value) => {
-								setRolloverConfigKey(
-									"duration",
-									value as RolloverExpiryDurationType,
-								);
-							}}
-						>
-							<SelectTrigger
-								className="flex-1"
-								onClick={(e) => e.stopPropagation()}
-							>
-								<SelectValue placeholder="Select duration" />
-							</SelectTrigger>
-							<SelectContent>
-								{Object.values(RolloverExpiryDurationType).map((duration) => (
-									<SelectItem key={duration} value={duration}>
-										{duration}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</div>
-				</div>
-			</div>
-		</AreaCheckbox>
+		/>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx
@@ -131,19 +131,18 @@ export function RolloverConfigForm({
 							<div className="flex items-center gap-1 flex-1">
 								<Input
 									type="number"
-									value={
-										rollover?.max_percentage === 0
-											? ""
-											: (rollover?.max_percentage ?? "")
-									}
+									value={rollover?.max_percentage ?? ""}
 									className="flex-1"
 									placeholder="e.g. 50"
 									onChange={(e) => {
 										const v = e.target.value;
-										const numValue = v === "" ? 0 : parseInt(v) || 0;
+										// Empty input → fall back to the minimum valid percentage (1).
+										// max_percentage must be > 0 and <= 100 per backend validation,
+										// so coercing empty to 0 would produce an unsaveable config.
+										const parsed = v === "" ? 1 : parseInt(v) || 1;
 										setRolloverConfigKey(
 											"max_percentage",
-											Math.min(100, Math.max(0, numValue)),
+											Math.min(100, Math.max(1, parsed)),
 										);
 									}}
 									onClick={(e) => e.stopPropagation()}

--- a/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx
@@ -1,0 +1,202 @@
+import {
+	type RolloverConfig as RolloverConfigType,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { AreaCheckbox } from "@/components/v2/checkboxes/AreaCheckbox";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+
+type MaxMode = "absolute" | "percentage" | "unlimited";
+
+export const DEFAULT_ROLLOVER_CONFIG: RolloverConfigType = {
+	duration: RolloverExpiryDurationType.Month,
+	length: 1,
+	max: null,
+	max_percentage: null,
+};
+
+type RolloverConfigFormProps = {
+	value: RolloverConfigType | null | undefined;
+	onChange: (value: RolloverConfigType | null) => void;
+	/** Disables the enable/disable checkbox (e.g., when no reset interval is set). */
+	disabled?: boolean;
+	tooltip?: string;
+	title?: string;
+	/** Called when the user toggles the rollover on. Defaults to { ...DEFAULT_ROLLOVER_CONFIG }. */
+	onEnable?: () => void;
+};
+
+/**
+ * Fully controlled rollover config UI. The same visual component used inside the plan
+ * editor's advanced settings and the balance-create sheet.
+ */
+export function RolloverConfigForm({
+	value,
+	onChange,
+	disabled,
+	tooltip = "Rollovers carry unused credits to the next billing cycle. Set a maximum rollover amount and specify how many cycles before resetting.",
+	title = "Rollovers",
+	onEnable,
+}: RolloverConfigFormProps) {
+	const rollover = value ?? null;
+	const hasRollover = rollover != null;
+
+	const setRolloverConfigKey = (
+		key: keyof RolloverConfigType,
+		next: null | number | RolloverExpiryDurationType,
+	) => {
+		onChange({
+			...(rollover ?? DEFAULT_ROLLOVER_CONFIG),
+			[key]: next,
+		});
+	};
+
+	const maxMode: MaxMode =
+		rollover?.max_percentage != null
+			? "percentage"
+			: rollover?.max === null
+				? "unlimited"
+				: "absolute";
+
+	const handleMaxModeChange = (mode: MaxMode) => {
+		const current = rollover ?? DEFAULT_ROLLOVER_CONFIG;
+		if (mode === "unlimited") {
+			onChange({ ...current, max: null, max_percentage: null });
+		} else if (mode === "absolute") {
+			onChange({ ...current, max: 0, max_percentage: null });
+		} else {
+			onChange({ ...current, max: null, max_percentage: 50 });
+		}
+	};
+
+	return (
+		<AreaCheckbox
+			title={title}
+			tooltip={tooltip}
+			checked={hasRollover}
+			disabled={disabled}
+			onCheckedChange={(checked) => {
+				if (checked) {
+					if (onEnable) onEnable();
+					else onChange({ ...DEFAULT_ROLLOVER_CONFIG });
+				} else {
+					onChange(null);
+				}
+			}}
+		>
+			<div className="space-y-4 w-xs max-w-full">
+				<div className="space-y-2 w-full">
+					<FormLabel>Maximum rollover</FormLabel>
+					<div className="flex items-center gap-2">
+						<Select
+							value={maxMode}
+							onValueChange={(v) => handleMaxModeChange(v as MaxMode)}
+						>
+							<SelectTrigger
+								className="w-32"
+								onClick={(e) => e.stopPropagation()}
+							>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="unlimited">Unlimited</SelectItem>
+								<SelectItem value="absolute">Absolute</SelectItem>
+								<SelectItem value="percentage">Percentage</SelectItem>
+							</SelectContent>
+						</Select>
+
+						{maxMode === "absolute" && (
+							<Input
+								type="number"
+								value={rollover?.max === 0 ? "" : (rollover?.max ?? "")}
+								className="flex-1"
+								placeholder="e.g. 100 credits"
+								onChange={(e) => {
+									const v = e.target.value;
+									const numValue = v === "" ? 0 : parseInt(v) || 0;
+									setRolloverConfigKey("max", numValue);
+								}}
+								onClick={(e) => e.stopPropagation()}
+							/>
+						)}
+
+						{maxMode === "percentage" && (
+							<div className="flex items-center gap-1 flex-1">
+								<Input
+									type="number"
+									value={
+										rollover?.max_percentage === 0
+											? ""
+											: (rollover?.max_percentage ?? "")
+									}
+									className="flex-1"
+									placeholder="e.g. 50"
+									onChange={(e) => {
+										const v = e.target.value;
+										const numValue = v === "" ? 0 : parseInt(v) || 0;
+										setRolloverConfigKey(
+											"max_percentage",
+											Math.min(100, Math.max(0, numValue)),
+										);
+									}}
+									onClick={(e) => e.stopPropagation()}
+								/>
+								<span className="text-t3 text-sm">%</span>
+							</div>
+						)}
+					</div>
+				</div>
+
+				<div className="space-y-2">
+					<FormLabel>Rollover duration</FormLabel>
+					<div className="flex items-center gap-2">
+						{rollover?.duration === RolloverExpiryDurationType.Month && (
+							<Input
+								type="number"
+								value={rollover?.length === 0 ? "" : rollover?.length || ""}
+								onChange={(e) => {
+									const v = e.target.value;
+									const numValue = v === "" ? 0 : parseInt(v) || 0;
+									setRolloverConfigKey("length", numValue);
+								}}
+								className="w-16"
+								placeholder="e.g. 1 month"
+								onClick={(e) => e.stopPropagation()}
+							/>
+						)}
+						<Select
+							value={rollover?.duration}
+							onValueChange={(v) => {
+								setRolloverConfigKey(
+									"duration",
+									v as RolloverExpiryDurationType,
+								);
+							}}
+						>
+							<SelectTrigger
+								className="flex-1"
+								onClick={(e) => e.stopPropagation()}
+							>
+								<SelectValue placeholder="Select duration" />
+							</SelectTrigger>
+							<SelectContent>
+								{Object.values(RolloverExpiryDurationType).map((duration) => (
+									<SelectItem key={duration} value={duration}>
+										{duration}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				</div>
+			</div>
+		</AreaCheckbox>
+	);
+}


### PR DESCRIPTION
- **feat: 🎸 rollovers on create balance**
- **fix: 🐛 address PR comments**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add rollover support to balance creation, with server-side validation and a shared UI to configure it. This lets unused credits carry over on reset for eligible features.

- **New Features**
  - API: `balances.create` accepts `rollover` (absolute or percentage max, expiry duration/length) via `@autumn/shared`.
  - Validation blocks rollovers for continuous-use features, one-time balances, or when `expires_at` is before the next reset.
  - UI: Balance Create sheet shows a gated rollover form only for metered/credit features with recurring resets.
  - Tests: Added integration tests for happy path and all rejection cases.

- **Refactors**
  - Introduced reusable `RolloverConfigForm` and used it in plan advanced settings and balance creation, removing duplicated logic.
  - Mapper now forwards `rollover` fields to plan items during create.

<sup>Written for commit 39760837fcd9b965086593cdf7c5d8d7de48a268. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds rollover support to the `balances.create` API endpoint — users can now specify a `rollover` config (max amount, percentage-based cap, or unlimited) alongside a recurring reset interval when creating a loose balance. The change includes server-side validation guards, a shared `RolloverConfigForm` UI component reused across the plan editor and the balance-create sheet, field mapping from the external API shape to the internal `ApiPlanItemV0`, and integration tests covering the happy path and all rejection scenarios.

**Key changes:**
- [Improvements] [API changes] `rollover` field added to `CreateBalanceParamsV0` and mapped to `ApiPlanItemV0` via `createBalanceParamsV0ToPlanItemV0`
- [Improvements] Three new validation guards in `validateCreateBalance`: rejects rollover on continuous-use features, on one-time balances, and when `expires_at` precedes the first reset event
- [Bug fixes] `RolloverConfigForm` extracted as a shared component and `BalanceCreateSheet` correctly gates rollover inclusion behind `canEnableRollover`
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/quality suggestions with no correctness or data-integrity risk on the primary path.

All three inline comments are P2: a double-cast type smell, a minor inconsistency in the presence check, and a UI edge case for length=0 when switching duration types. None of these affect the correctness of the core rollover-on-reset behaviour, which is well covered by the new integration tests.

validateCreateBalance.ts (type cast), RolloverConfigForm.tsx (length=0 edge case)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/createBalance/validateCreateBalance.ts | Adds three new rollover validation guards: rejects rollover on continuous-use features, rejects rollover without a reset, and validates expires_at is not before the next reset. Contains a `as unknown as EntInterval` cast and a minor inconsistency in the rollover presence check. |
| shared/api/balances/create/mappers/createBalanceParamsV0ToPlanItemV0.ts | Maps external `duration`/`length` rollover fields to internal `expiry_duration_type`/`expiry_duration_length` in ApiPlanItemV0. Field names align correctly with the target schema. |
| vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx | Integrates RolloverConfigForm into the balance-create sheet; correctly gates rollover inclusion in the API call behind canEnableRollover and clears rollover state on incompatible option changes. |
| vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx | New shared rollover config UI component extracted for reuse. The `length` input is hidden for Forever duration but its value (which can be 0) persists silently in state. |
| server/tests/integration/balances/create/create-balance-with-rollover.test.ts | New integration tests covering rollover happy path, rejection for continuous-use/one-time/expires_at-before-reset scenarios, and percentage-based max rollover. Comprehensive coverage of the new validation paths. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as /v1/balances.create
    participant Validate as validateCreateBalanceParams
    participant Mapper as createBalanceParamsV0ToPlanItemV0
    participant DB

    Client->>API: POST {feature_id, reset, rollover, expires_at}
    API->>Validate: validateCreateBalanceParams(params, feature)
    Note over Validate: 1. Reject if cont-use feature + rollover
    Note over Validate: 2. Reject if no reset + rollover
    Note over Validate: 3. Reject if expires_at < nextResetAt
    Validate-->>API: OK / RecaseError
    API->>Mapper: createBalanceParamsV0ToPlanItemV0(params)
    Note over Mapper: duration → expiry_duration_type, length → expiry_duration_length
    Mapper-->>API: ApiPlanItemV0 (with rollover)
    API->>DB: persist CusEntitlement with rollover config
    DB-->>API: saved
    API-->>Client: 200 OK
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/balances/createBalance/validateCreateBalance.ts
Line: 71

Comment:
**`as unknown as EntInterval` double-cast suggests type misalignment**

`params.reset.interval` is typed as `ResetInterval`, but `getNextResetAt` expects `EntInterval`. Using `as unknown as EntInterval` to bridge the two suggests these enums carry overlapping but structurally distinct values. If the enum values diverge over time (e.g., a new `ResetInterval` is added but not mirrored in `EntInterval`), `getNextResetAt` would silently receive an unrecognised interval and potentially return a wrong timestamp, making the `expires_at` guard incorrect.

Consider aligning the two types (or providing an explicit mapping function) so the compiler enforces correctness rather than suppressing the error.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/balances/createBalance/validateCreateBalance.ts
Line: 48-55

Comment:
**Inconsistent rollover presence check**

The continuous-use guard uses `Object.keys(params.rollover || {}).length > 0` while the one-time balance guard immediately below simply checks `params.rollover` (truthy). Since Zod has already validated the schema before this point, a valid `params.rollover` will always be `undefined` or a well-formed object — the `Object.keys` path is functionally equivalent to a truthy check but adds unnecessary complexity. Aligning the two checks improves readability.

```suggestion
	if (isContUseFeature({ feature }) && params.rollover) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm.tsx
Line: 159-172

Comment:
**`length` input hidden for non-Month durations but still sent as-is**

The length number input is only rendered when `duration === RolloverExpiryDurationType.Month`. When the user picks `Forever`, the input disappears and the existing `length` value (which can be `0` if the field was cleared) is silently preserved in state and forwarded to the API. The backend's `RolloverConfigSchema` accepts any `z.number()` for `length`, including `0`.

A `length: 0` with `duration: "month"` would mean "rollover expires after 0 months" — which is effectively immediate expiry. If the backend doesn't guard against this, clearing the field then switching duration types produces a subtly broken config. Consider resetting `length` to `1` when switching to `Forever`, or adding a `z.number().min(1)` constraint in the schema.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 address PR comments"](https://github.com/useautumn/autumn/commit/39760837fcd9b965086593cdf7c5d8d7de48a268) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29106471)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->