### PR TITLE
fix: limit boolean cusEnts

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -50,13 +50,18 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		params,
 	});
 
-	const { customerProduct, fullProduct, customPrices, customEnts } =
-		await setupUpdateSubscriptionProductContext({
-			ctx,
-			fullCustomer,
-			params,
-			contextOverride,
-		});
+	const {
+		customerProduct,
+		fullProduct,
+		customPrices,
+		customEnts,
+		isUpdatingFreeCustomerProduct,
+	} = await setupUpdateSubscriptionProductContext({
+		ctx,
+		fullCustomer,
+		params,
+		contextOverride,
+	});
 
 	const featureQuantities = setupFeatureQuantitiesContext({
 		ctx,
@@ -77,7 +82,8 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		orgDisableStripeWrites({ ctx }) ||
 		params.no_billing_changes === true ||
 		params.processor_subscription_id !== undefined ||
-		billingRelatedFields.length === 0;
+		billingRelatedFields.length === 0 ||
+		isUpdatingFreeCustomerProduct;
 
 	const {
 		stripeSubscription,
@@ -93,6 +99,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		contextOverride,
 		skipBillingChanges,
 		product: fullProduct,
+		skipSubscriptionFetching: isUpdatingFreeCustomerProduct,
 	});
 
 	const currentEpochMs = testClockFrozenTime ?? Date.now();

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts
@@ -1,6 +1,8 @@
 import {
 	cusProductToProduct,
 	type FullCustomer,
+	isCustomerProductFree,
+	isFreeProduct,
 	notNullish,
 	type UpdateSubscriptionBillingContextOverride,
 	type UpdateSubscriptionV1Params,
@@ -23,7 +25,17 @@ export const setupUpdateSubscriptionProductContext = async ({
 }) => {
 	const { productContext } = contextOverride;
 
-	if (productContext) return productContext;
+	if (productContext) {
+		return {
+			customerProduct: productContext.customerProduct,
+			fullProduct: productContext.fullProduct,
+			customPrices: productContext.customPrices,
+			customEnts: productContext.customEnts,
+			isUpdatingFreeCustomerProduct:
+				isCustomerProductFree(productContext.customerProduct) ||
+				isFreeProduct({ prices: productContext.fullProduct.prices }),
+		};
+	}
 
 	const targetCustomerProduct = findTargetCustomerProduct({
 		params,
@@ -55,10 +67,15 @@ export const setupUpdateSubscriptionProductContext = async ({
 		customizePlan: params.customize,
 	});
 
+	const isUpdatingFreeCustomerProduct =
+		isCustomerProductFree(targetCustomerProduct) ||
+		isFreeProduct({ prices: customFullProduct.prices });
+
 	return {
 		customerProduct: targetCustomerProduct,
 		fullProduct: customFullProduct,
 		customPrices,
 		customEnts,
+		isUpdatingFreeCustomerProduct,
 	};
 };

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts
@@ -68,7 +68,7 @@ export const setupUpdateSubscriptionProductContext = async ({
 	});
 
 	const isUpdatingFreeCustomerProduct =
-		isCustomerProductFree(targetCustomerProduct) ||
+		isCustomerProductFree(targetCustomerProduct) &&
 		isFreeProduct({ prices: customFullProduct.prices });
 
 	return {

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/setCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/setCachedFullCustomer.ts
@@ -1,4 +1,4 @@
-import type { FullCustomer } from "@autumn/shared";
+import { type FullCustomer, isBooleanCusEnt } from "@autumn/shared";
 import { redis } from "@/external/redis/initRedis.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildPathIndex } from "@/internal/customers/cache/pathIndex/buildPathIndex.js";
@@ -10,6 +10,61 @@ import {
 } from "./fullCustomerCacheConfig.js";
 
 type SetCacheResult = "OK" | "STALE_WRITE" | "CACHE_EXISTS" | "FAILED";
+
+const BOOLEAN_ENTITLEMENT_LIMIT_ORG_ID = "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF";
+const MAX_BOOLEAN_CUSTOMER_ENTITLEMENTS_PER_PRODUCT = 3;
+
+const limitBooleanCustomerEntitlementsPerCustomerProduct = ({
+	fullCustomer,
+	orgId,
+}: {
+	fullCustomer: FullCustomer;
+	orgId: string;
+}): FullCustomer => {
+	if (orgId !== BOOLEAN_ENTITLEMENT_LIMIT_ORG_ID) return fullCustomer;
+
+	let hasChanges = false;
+	const customerProducts = fullCustomer.customer_products.map(
+		(customerProduct) => {
+			let booleanCustomerEntitlementCount = 0;
+			let customerProductHasChanges = false;
+
+			const customerEntitlements = customerProduct.customer_entitlements.filter(
+				(customerEntitlement) => {
+					const isBooleanCustomerEntitlement = isBooleanCusEnt({
+						cusEnt: customerEntitlement,
+					});
+
+					if (!isBooleanCustomerEntitlement) return true;
+
+					if (
+						booleanCustomerEntitlementCount >=
+						MAX_BOOLEAN_CUSTOMER_ENTITLEMENTS_PER_PRODUCT
+					) {
+						hasChanges = true;
+						customerProductHasChanges = true;
+						return false;
+					}
+
+					booleanCustomerEntitlementCount += 1;
+					return true;
+				},
+			);
+
+			if (!customerProductHasChanges) return customerProduct;
+			return {
+				...customerProduct,
+				customer_entitlements: customerEntitlements,
+			};
+		},
+	);
+
+	if (!hasChanges) return fullCustomer;
+	return {
+		...fullCustomer,
+		customer_products: customerProducts,
+	};
+};
 
 /**
  * Set FullCustomer in Redis cache
@@ -31,13 +86,20 @@ export const setCachedFullCustomer = async ({
 	overwrite?: boolean;
 }): Promise<SetCacheResult> => {
 	const { org, env, logger } = ctx;
+	const fullCustomerForCache =
+		limitBooleanCustomerEntitlementsPerCustomerProduct({
+			fullCustomer,
+			orgId: org.id,
+		});
 
 	const cacheKey = buildFullCustomerCacheKey({
 		orgId: org.id,
 		env,
 		customerId,
 	});
-	const pathIndexEntries = buildPathIndex({ fullCustomer });
+	const pathIndexEntries = buildPathIndex({
+		fullCustomer: fullCustomerForCache,
+	});
 	const pathIndexJson = JSON.stringify(pathIndexEntries);
 
 	const result = await tryRedisWrite(async () => {
@@ -48,7 +110,7 @@ export const setCachedFullCustomer = async ({
 			customerId,
 			String(fetchTimeMs),
 			String(FULL_CUSTOMER_CACHE_TTL_SECONDS),
-			JSON.stringify(fullCustomer),
+			JSON.stringify(fullCustomerForCache),
 			String(overwrite),
 			pathIndexJson,
 		);
@@ -67,7 +129,7 @@ export const setCachedFullCustomer = async ({
 		extras: {
 			setCache: {
 				result,
-				fullCustomer,
+				fullCustomer: fullCustomerForCache,
 			},
 		},
 	});

--- a/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionAdvancedSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionAdvancedSection.tsx
@@ -6,9 +6,8 @@ import { Switch } from "@/components/ui/switch";
 import { useUpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 
 export function UpdateSubscriptionAdvancedSection() {
-	const { form, formValues, formContext } =
-		useUpdateSubscriptionFormContext();
-	const { billingBehavior, resetBillingCycle } = formValues;
+	const { form, formValues, formContext } = useUpdateSubscriptionFormContext();
+	const { billingBehavior, resetBillingCycle, noBillingChanges } = formValues;
 	const { customerProduct } = formContext;
 
 	const hasActiveSubscription =
@@ -27,6 +26,18 @@ export function UpdateSubscriptionAdvancedSection() {
 						checked={isProrate}
 						onCheckedChange={(checked) =>
 							form.setFieldValue("billingBehavior", checked ? null : "none")
+						}
+					/>
+				}
+			/>
+			<ConfigRow
+				title="No Billing Changes"
+				description="Update subscription state without applying Stripe billing changes"
+				action={
+					<Switch
+						checked={noBillingChanges}
+						onCheckedChange={(checked) =>
+							form.setFieldValue("noBillingChanges", !!checked)
 						}
 					/>
 				}

--- a/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
+++ b/vite/src/components/forms/update-subscription-v2/context/UpdateSubscriptionFormProvider.tsx
@@ -272,11 +272,12 @@ export function UpdateSubscriptionFormProvider({
 	const hasPrepaidQuantityChanges = changedPrepaidOptions !== undefined;
 	const isVersionLoading = isVersionChanged && !isVersionReady;
 	const hasNoBillingChanges =
-		hasChanges &&
-		!hasBillingChanges &&
-		!hasPrepaidQuantityChanges &&
-		!isVersionLoading &&
-		!normalizedFormValues.resetBillingCycle;
+		normalizedFormValues.noBillingChanges ||
+		(hasChanges &&
+			!hasBillingChanges &&
+			!hasPrepaidQuantityChanges &&
+			!isVersionLoading &&
+			!normalizedFormValues.resetBillingCycle);
 
 	const { buildRequestBody } = useUpdateSubscriptionRequestBody({
 		updateSubscriptionFormContext: formContext,

--- a/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useHasSubscriptionChanges.ts
@@ -34,6 +34,7 @@ export function useHasSubscriptionChanges({
 	return useMemo(() => {
 		if (formValues.billingBehavior !== initialBillingBehavior) return true;
 		if (formValues.resetBillingCycle) return true;
+		if (formValues.noBillingChanges) return true;
 
 		const trialChanges = generateTrialChanges({
 			customerProduct,
@@ -81,6 +82,7 @@ export function useHasSubscriptionChanges({
 	}, [
 		formValues.billingBehavior,
 		formValues.resetBillingCycle,
+		formValues.noBillingChanges,
 		initialBillingBehavior,
 		formValues.removeTrial,
 		formValues.trialLength,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limits boolean customer entitlements per product for a specific org to keep cached customers small, and adds a “No Billing Changes” toggle. Billing now skips Stripe writes and subscription fetching for free customer products or when the toggle is on, with more accurate free-plan detection.

- **Bug Fixes**
  - Cap boolean customer entitlements to 3 per customer product in Redis cache for the targeted org to prevent cache bloat.

- **New Features**
  - Add “No Billing Changes” switch in Advanced; the form treats this as a change and sends `no_billing_changes` to the backend.
  - Skip Stripe billing and subscription fetching when updating a free customer product or when `no_billing_changes` is true; improves free-plan detection to avoid unnecessary calls.

<sup>Written for commit 5e0f9c55d9cde471886169345947bfc5bffea2c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

