### PR TITLE
chore: website copy updates, fix pricing nav, and lazy-load lottie animations

### DIFF
--- a/apps/website/components/animated-footer-image.tsx
+++ b/apps/website/components/animated-footer-image.tsx
@@ -10,14 +10,13 @@ const AnimatedFooterImage = forwardRef<HTMLDivElement>(
 				className="fixed bottom-0 left-0 w-full z-0 pointer-events-none overflow-hidden h-[420px] md:h-[580px]"
 			>
 				<div className="relative w-full h-full">
-					<Image
-						src="/images/footer/footer.webp"
-						alt="footer background"
-						fill
-						priority
-						sizes="100vw"
-						className="object-cover object-top"
-					/>
+				<Image
+					src="/images/footer/footer.webp"
+					alt="footer background"
+					fill
+					sizes="100vw"
+					className="object-cover object-top"
+				/>
 				</div>
 			</div>
 		);

--- a/apps/website/components/hero.tsx
+++ b/apps/website/components/hero.tsx
@@ -76,37 +76,18 @@ export default function Hero() {
 
 	useGSAP(
 		() => {
-			gsap.set(".hero-root", { opacity: 0 });
+			const tl = gsap.timeline({
+				defaults: { overwrite: "auto" },
+			});
 
-			gsap.set(".hero-bg", {
+			tl.from(".hero-bg", {
 				opacity: 0,
 				filter: "blur(6px) brightness(1)",
 				scale: 0.97,
 				transformOrigin: "center top",
-			});
-
-			gsap.set(".hero-reveal", {
-				opacity: 0,
-				y: 25,
-				filter: "blur(12px)",
-				scale: 0.96,
-				transformOrigin: "center bottom",
-			});
-
-			gsap.set(".hero-cta", { opacity: 0, scale: 0.95 });
-
-			const tl = gsap.timeline({
-				defaults: { overwrite: "auto" },
-			});
-			tl.to(".hero-root", { opacity: 1, duration: 0.3, ease: "none" })
-
-				.to(".hero-bg", {
-					opacity: 1,
-					filter: "blur(0px) brightness(1)",
-					scale: 1,
-					duration: 0.4,
-					ease: "power2.out",
-				})
+				duration: 0.4,
+				ease: "power2.out",
+			})
 
 				.to(".hero-bg", {
 					filter: "blur(0px) brightness(1.6)",
@@ -120,13 +101,14 @@ export default function Hero() {
 					ease: "power2.out",
 				})
 
-				.to(
+				.from(
 					".hero-reveal",
 					{
-						opacity: 1,
-						y: 0,
-						filter: "blur(0px)",
-						scale: 1,
+						opacity: 0,
+						y: 25,
+						filter: "blur(12px)",
+						scale: 0.96,
+						transformOrigin: "center bottom",
 						duration: 1.1,
 						stagger: 0.1,
 						ease: "power3.out",
@@ -134,11 +116,11 @@ export default function Hero() {
 					"-=0.2",
 				)
 
-				.to(
+				.from(
 					".hero-cta",
 					{
-						opacity: 1,
-						scale: 1,
+						opacity: 0,
+						scale: 0.95,
 						duration: 0.3,
 						stagger: 0.06,
 						ease: "back.out(1.5)",
@@ -151,7 +133,7 @@ export default function Hero() {
 
 	return (
 		<div ref={containerRef}>
-			<div className="relative hero-root opacity-0 flex flex-col items-stretch pb-0 md:pb-12 mb-0 bg-[#0F0F0F]">
+			<div className="relative hero-root flex flex-col items-stretch pb-0 md:pb-12 mb-0 bg-[#0F0F0F]">
 				<div className="flex justify-between">
 					<div className="flex flex-col gap-6 px-4 xl:px-22.75 py-8 bg-[#0F0F0F] mt-26">
 						<h4 className="hero-reveal relative uppercase font-mono tracking-[-2%] text-[12px] md:text-sm leading-sm text-white md:text-[#FFFFFF99] bg-[#2c2c2d] w-fit p-2 min-h-[30px] md:min-h-[36px] flex items-center">
@@ -165,14 +147,14 @@ export default function Hero() {
 						<div className="flex flex-col gap-6 w-full px-0 lg:px-0">
 							<h1 className="hero-reveal text-[44px] md:text-[56px] w-full max-w-sm sm:max-w-[480px] md:max-w-xl leading-[44px] tracking-[-5%] md:leading-14 font-sans">
 								<span className="text-[#FFFFFF99] font-normal">
-									The drop-in billing layer for
+									Drop-in credits and billing for
 								</span>{" "}
-								<span className="text-white block md:inline">AI startups</span>
+								<span className="text-white block md:inline">AI agents</span>
 							</h1>
 							<p className="hero-reveal tracking-[-2%] w-full max-w-xs sm:max-w-[480px] md:max-w-xl text-[#FFFFFF99] md:text-[16px] text-[14px] font-light leading-5 font-sans">
 								Stop rebuilding usage limits, credit ledgers and payment logic.{" "}
 								<span className="text-white font-light">
-									Autumn is your customer database
+									Autumn is the customer database
 								</span>{" "}
 								that scales from your first user to your largest contract.
 							</p>
@@ -239,7 +221,7 @@ export default function Hero() {
 								<div className="relative overflow-hidden flex items-center gap-1.5 md:gap-2.5 border-r border-[#292929] text-white cursor-pointer justify-between py-2 px-3 md:px-4 md:py-3.5 md:w-50 font-sans bg-[#0F0F0F] hover:bg-[#FFFFFF1F] transition-colors duration-300">
 									<CTALines />
 									<span className="relative z-10 tracking-[-2%] text-[12px] uppercase md:normal-case md:text-[16px] whitespace-nowrap">
-										Book a call
+										Get a demo
 									</span>
 									<span className="relative z-10 scale-100">
 										<IconCTADocs />

--- a/apps/website/components/home-sections.tsx
+++ b/apps/website/components/home-sections.tsx
@@ -1,26 +1,42 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useEffect } from "react";
 import Hero from "./hero";
 import SectionDivider from "./section-divider";
 
-const ProductionScale = dynamic(() => import("@/components/production-scale"), {
-	ssr: false,
-});
-const Problem = dynamic(() => import("@/components/problem"), { ssr: false });
-const Solution = dynamic(() => import("@/components/solution"), { ssr: false });
-const Features = dynamic(() => import("@/components/features"), { ssr: false });
-const PricingModels = dynamic(() => import("@/components/pricing-models"), {
-	ssr: false,
-});
-const Testimonials = dynamic(() => import("@/components/testimonials"), {
-	ssr: false,
-});
-const Pricing = dynamic(() => import("@/components/pricing"), { ssr: false });
-const FAQ = dynamic(() => import("@/components/faq"), { ssr: false });
-const Footer = dynamic(() => import("@/components/footer"), { ssr: false });
+const ProductionScale = dynamic(
+	() => import("@/components/production-scale"),
+);
+const Problem = dynamic(() => import("@/components/problem"));
+const Solution = dynamic(() => import("@/components/solution"));
+const Features = dynamic(() => import("@/components/features"));
+const PricingModels = dynamic(() => import("@/components/pricing-models"));
+const Testimonials = dynamic(() => import("@/components/testimonials"));
+const Pricing = dynamic(() => import("@/components/pricing"));
+const FAQ = dynamic(() => import("@/components/faq"));
+const Footer = dynamic(() => import("@/components/footer"));
+
+function scrollToHash() {
+	const hash = window.location.hash;
+	if (!hash) return;
+	const el = document.querySelector(hash);
+	if (!el) return;
+	const top = el.getBoundingClientRect().top + window.scrollY - 64;
+	window.scrollTo({ top, behavior: "smooth" });
+}
 
 export default function HomeSections() {
+	useEffect(() => {
+		if (!window.location.hash) return;
+		const timers = [
+			setTimeout(scrollToHash, 100),
+			setTimeout(scrollToHash, 500),
+			setTimeout(scrollToHash, 1200),
+		];
+		return () => timers.forEach(clearTimeout);
+	}, []);
+
 	return (
 		<>
 			<Hero />

--- a/apps/website/components/navbar.tsx
+++ b/apps/website/components/navbar.tsx
@@ -34,7 +34,7 @@ import { DashboardIconPixel } from "./dashboard-icon-pixel";
 const NAV_LINKS = [
 	{ label: "Docs", href: "https://docs.useautumn.com/welcome", Icon: IconDocs },
 	{ label: "Blog", href: "/blog", Icon: IconBlog },
-	{ label: "Pricing", href: "#pricing", Icon: IconPricing },
+	{ label: "Pricing", href: "/#pricing", Icon: IconPricing },
 	{
 		label: "Discord",
 		href: "https://discord.com/invite/STqxY92zuS",
@@ -110,13 +110,20 @@ NavIconPixel.displayName = "NavIconPixel";
 
 function NavLinkItem({ item }: { item: (typeof NAV_LINKS)[number] }) {
 	const iconRef = useRef<PixelHoverHandle | null>(null);
-	const isAnchor = item.href.startsWith("#");
+	const isAnchor =
+		item.href.startsWith("#") || item.href.startsWith("/#");
 
 	const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
 		if (!isAnchor) return;
-		e.preventDefault();
-		const target = document.querySelector(item.href);
-		if (target) target.scrollIntoView({ behavior: "smooth" });
+		const hash = item.href.startsWith("/#")
+			? item.href.slice(1)
+			: item.href;
+		const el = document.querySelector(hash);
+		if (el) {
+			e.preventDefault();
+			const top = el.getBoundingClientRect().top + window.scrollY - 64;
+			window.scrollTo({ top, behavior: "smooth" });
+		}
 	};
 
 	return (
@@ -335,7 +342,7 @@ export default function Navbar({
 							width={114}
 							height={28}
 							alt="Autumn"
-							loading="lazy"
+							priority
 							className="nav-logo ml-2 block w-[90px] sm:w-[110px] lg:w-[114px] h-auto"
 						/>
 					</Link>
@@ -400,24 +407,33 @@ export default function Navbar({
 				{/* Nav items */}
 				<div className="flex flex-col">
 					{NAV_LINKS.map((item) => {
-						const isAnchor = item.href.startsWith("#");
-						const isExternal = item.href.startsWith("http");
-						return (
-							<Link
-								key={item.label}
-								href={item.href}
-								target={isExternal ? "_blank" : undefined}
-								onClick={
-									isAnchor
-										? (e) => {
+					const isAnchor =
+						item.href.startsWith("#") || item.href.startsWith("/#");
+					const isExternal = item.href.startsWith("http");
+					return (
+						<Link
+							key={item.label}
+							href={item.href}
+							target={isExternal ? "_blank" : undefined}
+							onClick={
+								isAnchor
+									? (e) => {
+											const hash = item.href.startsWith("/#")
+												? item.href.slice(1)
+												: item.href;
+											const el = document.querySelector(hash);
+											setMenuOpen(false);
+											if (el) {
 												e.preventDefault();
-												setMenuOpen(false);
-												const target = document.querySelector(item.href);
-												if (target)
-													target.scrollIntoView({ behavior: "smooth" });
+												const top =
+													el.getBoundingClientRect().top +
+													window.scrollY -
+													64;
+												window.scrollTo({ top, behavior: "smooth" });
 											}
-										: undefined
-								}
+										}
+									: undefined
+							}
 								className="flex items-center gap-4 px-4 py-3.5 border-b border-[#292929] active:bg-[#141414ea] text-[#ffffff99] hover:text-white active:text-white transition-colors text-sm tracking-[-1%]"
 							>
 								<item.Icon className="h-3.5 w-3.5 shrink-0" />

--- a/apps/website/components/pricing.tsx
+++ b/apps/website/components/pricing.tsx
@@ -48,7 +48,7 @@ export default function Pricing() {
 		<>
 			<div
 				id="pricing"
-				className="min-h-screen relative flex w-full lg:w-[calc(100%+calc(var(--page-pad)*2))] lg:-ml-(--page-pad) items-center justify-center lg:py-24 pb-3"
+				className="min-h-screen relative flex w-full lg:w-[calc(100%+calc(var(--page-pad)*2))] lg:-ml-(--page-pad) items-center justify-center lg:py-24 pb-3 scroll-mt-16"
 			>
 				{/* Desktop Background */}
 				<Image

--- a/apps/website/components/problem.tsx
+++ b/apps/website/components/problem.tsx
@@ -36,16 +36,15 @@ export default function Problem() {
 					<div className="flex flex-col mb-2 gap-3 pl-[28px] xl:pl-[90px] pr-6 xl:pr-8 pt-14 sm:pt-16 xl:pt-16 items-center xl:items-start">
 						<h2 className="font-normal tracking-[-4%] leading-[32px] xl:leading-[40px] mb-2 xl:mb-4 text-center xl:text-left">
 							<span className="block text-[#686868] text-[30px] md:text-[36px] xl:text-[40px]">
-								Hard to ship,
+								Say goodbye to the 
 							</span>
 							<span className="block text-white text-[30px] md:text-[36px] xl:text-[40px]">
-								harder to scale.
+								old way of billing.
 							</span>
 						</h2>
 						<p className="text-[#888888] font-light text-[16px] md:text-[18px] xl:text-[16px] tracking-[-2%] leading-[20px] mb-8 xl:mb-10 max-w-sm md:max-w-lg xl:max-w-sm text-center xl:text-left">
 							Maintaining payment logic, customer balances and feature access
-							across pricing and product changes is months of work and
-							unreliable.
+							across pricing and product changes is months of work.
 							<span className="text-white">
 								{" "}
 								Autumn replaces all the billing code you're building yourself.
@@ -54,36 +53,39 @@ export default function Problem() {
 					</div>
 
 					<div className="mt-auto">
-						<div className="grid grid-cols-2 xl:grid-cols-[max-content_max-content_max-content_auto] border-t border-b border-[#1E1E1E]">
-							{[
-								{ value: "3–6 months", label: "work per year" },
-								{ value: "7+ webhook", label: "events to handle" },
-								{ value: "Edge cases", label: "100s to debug" },
-							].map((stat, i) => (
-								<div
-									key={i}
-									className={`py-6 pr-9 border-[#292929] border-r
+						<div className="grid grid-cols-2 xl:grid-cols-3 border-t border-b border-[#1E1E1E] xl:pl-[66px]">
+						{[
+							{
+								title: "Speed.",
+								description:
+									"Launch faster and maintain less code. Your coding agents will thank you.",
+							},
+							{
+								title: "Flexibility.",
+								description:
+									"Grow revenue by pricing how you want. No code changes needed.",
+							},
+							{
+								title: "Reliability.",
+								description:
+									"Declines, 3DS and edge cases handled. Contracts always accurate.",
+							},
+						].map((stat, i) => (
+							<div
+								key={i}
+								className={`py-6 pr-9 border-[#292929] border-r
       ${i === 2 ? "col-span-2 xl:col-span-1 border-t xl:border-t-0 border-r-0 xl:border-r" : ""}
       ${i === 1 ? "border-r-0 xl:border-r" : ""}
-      ${i === 0 || i === 2 ? "pl-4" : "pl-4"}
-      xl:pl-6 ${i === 0 ? "xl:pl-[90px]" : ""}`}
-								>
-									<p className="text-white tracking-[-5%] font-normal text-[18px] xl:text-[24px] leading-none">
-										{stat.value}
-									</p>
-									<p className="text-[#767676] font-light tracking-[-5%] text-[16px] xl:text-[18px] mt-1.5 leading-[20px] whitespace-nowrap">
-										{stat.label}
-									</p>
-								</div>
-							))}
-							<div className="hidden xl:flex flex-1 items-stretch">
-								{[...Array(4)].map((_, i) => (
-									<div
-										key={i}
-										className={`flex-1 ${i < 3 ? "border-r border-[#292929]" : ""}`}
-									/>
-								))}
+      pl-4 xl:pl-6`}
+							>
+								<p className="text-white tracking-[-5%] font-normal text-[16px] xl:text-[18px] leading-none">
+								{stat.title}
+							</p>
+							<p className="text-[#767676] font-light tracking-[-5%] text-[14px] xl:text-[15px] mt-1.5 leading-[18px]">
+									{stat.description}
+								</p>
 							</div>
+						))}
 						</div>
 
 						<ProblemBgSvg />

--- a/apps/website/components/solution-animation.tsx
+++ b/apps/website/components/solution-animation.tsx
@@ -4,8 +4,6 @@ import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import lottie, { type AnimationItem } from "lottie-web";
 import { useEffect, useRef } from "react";
-import desktopAnimationData from "@/public/animation/solution-desktop.json";
-import mobileAnimationData from "@/public/animation/solution-mobile.json";
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -15,38 +13,53 @@ export default function SolutionAnimation() {
 
 	useEffect(() => {
 		if (!containerRef.current) return;
+		let cancelled = false;
 
 		const isMobile = window.innerWidth < 768;
-		const animationData = isMobile ? mobileAnimationData : desktopAnimationData;
+		const url = isMobile
+			? "/animation/solution-mobile.json"
+			: "/animation/solution-desktop.json";
 
-		const anim = lottie.loadAnimation({
-			container: containerRef.current,
-			renderer: "svg",
-			loop: false,
-			autoplay: false,
-			animationData,
-		});
+		fetch(url)
+			.then((res) => res.json())
+			.then((animationData) => {
+				if (cancelled || !containerRef.current) return;
 
-		animRef.current = anim;
+				const anim = lottie.loadAnimation({
+					container: containerRef.current,
+					renderer: "svg",
+					loop: false,
+					autoplay: false,
+					animationData,
+				});
 
-		const totalFrames = anim.totalFrames;
+				animRef.current = anim;
 
-		const loopStart = Math.floor(totalFrames * 0.2);
+				const totalFrames = anim.totalFrames;
+				const loopStart = Math.floor(totalFrames * 0.2);
 
-		anim.addEventListener("complete", () => {
-			anim.loop = true;
-			anim.playSegments([loopStart, totalFrames], true);
-		});
+				anim.addEventListener("complete", () => {
+					anim.loop = true;
+					anim.playSegments([loopStart, totalFrames], true);
+				});
 
-		const st = ScrollTrigger.create({
-			trigger: containerRef.current,
-			start: "top 75%", // Plays when the top of the animation reaches 75% viewport height
-			onEnter: () => anim.play(),
-		});
+				const st = ScrollTrigger.create({
+					trigger: containerRef.current,
+					start: "top 75%",
+					onEnter: () => anim.play(),
+				});
+
+				cleanupRef.current = () => {
+					st.kill();
+					anim.destroy();
+				};
+			});
+
+		const cleanupRef = { current: () => {} };
 
 		return () => {
-			st.kill();
-			anim.destroy();
+			cancelled = true;
+			cleanupRef.current();
 		};
 	}, []);
 


### PR DESCRIPTION
## Summary
- Fix navbar Pricing link to navigate to `/#pricing` and scroll correctly from any page
- Add retry-based hash scroll in `HomeSections` to handle dynamic component loading
- Update hero/problem section copy and CTA text
- Lazy-load Lottie animation JSON via fetch instead of static import
- Minor cleanup: footer image priority, indentation fixes

## Test plan
- [ ] Click Pricing in navbar from the home page — should smooth-scroll to pricing section
- [ ] Click Pricing from `/blog` — should navigate to home page and land on pricing
- [ ] Verify hero, problem section copy changes render correctly
- [ ] Verify solution animation still plays on scroll

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pricing nav so it always lands on the pricing section with smooth, offset scrolling from any page. Also updates homepage copy and lazy-loads Lottie animations to reduce bundle size.

- **Bug Fixes**
  - Pricing link now routes to `/#pricing` and smooth-scrolls with header offset from both home and other routes.
  - Hash-based scrolling retries after dynamic loads so anchors (like `#pricing`) position correctly.

- **Refactors**
  - Lottie animation JSON is fetched on demand and initialized on scroll to cut JS payload.
  - Simplified hero GSAP timeline; CTA now says “Get a demo”.
  - Updated hero/problem copy and switched problem stats to benefits; minor image priority tweaks and `scroll-mt-16` on `#pricing`.

<sup>Written for commit 4d7a82d3122b006b98c512492dc55ba367fd27bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes several website improvements: fixes the Pricing navbar link to correctly navigate and scroll to `/#pricing` from any page, lazy-loads Lottie animation JSON via `fetch` to reduce initial bundle size, and refreshes hero/problem section copy targeting AI agents.

**Key changes:**
- [Bug fixes] Navbar Pricing link now uses `/#pricing` with `handleClick` scroll logic for desktop and mobile; `HomeSections` adds retry-based hash-scroll to handle dynamically loaded sections
- [Improvements] Lottie animation JSON lazy-loaded via `fetch` instead of static import, with a `cancelled` guard for unmount safety
- [Improvements] Hero GSAP animation refactored from `gsap.set + .to()` to `.from()` pattern; problem section copy replaced with Speed/Flexibility/Reliability benefit cards
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style and best-practice suggestions with no functional impact

All three comments are P2: missing fetch error handling (silent failure, not a crash), cleanupRef declaration order (functionally correct), and hard-coded scroll offset (cosmetic for now). No P0/P1 defects found.

apps/website/components/solution-animation.tsx — cleanupRef placement and missing .catch()

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/components/solution-animation.tsx | Lazy-loads Lottie JSON via fetch instead of static import; missing error handling on fetch and confusing cleanupRef declaration order |
| apps/website/components/navbar.tsx | Pricing link updated to /#pricing with scroll handlers for both desktop and mobile; scroll offset hard-codes 64px navbar height |
| apps/website/components/home-sections.tsx | Adds retry-based hash scroll (100ms/500ms/1200ms) to handle dynamic component loading; straightforward and correct |
| apps/website/components/hero.tsx | Refactors GSAP animation from gsap.set+to pattern to .from() pattern and updates copy; removes opacity-0 CSS class (safe because useGSAP uses useLayoutEffect) |
| apps/website/components/problem.tsx | Copy updates: replaces stat counters with Speed/Flexibility/Reliability benefit cards and updates headline text |
| apps/website/components/animated-footer-image.tsx | Removes priority prop from fixed footer image and introduces indentation inconsistency |
| apps/website/components/pricing.tsx | No significant logic changes; retains id="pricing" anchor needed for hash-scroll navigation |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Navbar
    participant NextRouter
    participant HomeSections
    participant PricingSection

    User->>Navbar: Click "Pricing" (on /blog)
    Navbar->>Navbar: isAnchor=true, querySelector("#pricing")=null
    Navbar->>NextRouter: navigate to /#pricing (default Link behavior)
    NextRouter->>HomeSections: mount home page
    HomeSections->>HomeSections: useEffect detects window.location.hash="#pricing"
    HomeSections->>HomeSections: setTimeout(scrollToHash, 100ms)
    HomeSections->>PricingSection: dynamic import loads
    HomeSections->>HomeSections: setTimeout(scrollToHash, 500ms) — retries
    HomeSections->>PricingSection: scrollTo({ top: el.top + scrollY - 64 })
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/website/components/solution-animation.tsx
Line: 23-56

Comment:
**Missing error handling on `fetch`**

If the animation JSON fails to load (network error, 404, CDN issue), the promise rejects silently with no `.catch()`. The animation will simply never play and the unhandled rejection may surface as a console error. Adding a `.catch()` to at least suppress the noise or log a warning would be defensive.

```suggestion
		fetch(url)
			.then((res) => res.json())
			.then((animationData) => {
				if (cancelled || !containerRef.current) return;

				const anim = lottie.loadAnimation({
					container: containerRef.current,
					renderer: "svg",
					loop: false,
					autoplay: false,
					animationData,
				});

				animRef.current = anim;

				const totalFrames = anim.totalFrames;
				const loopStart = Math.floor(totalFrames * 0.2);

				anim.addEventListener("complete", () => {
					anim.loop = true;
					anim.playSegments([loopStart, totalFrames], true);
				});

				const st = ScrollTrigger.create({
					trigger: containerRef.current,
					start: "top 75%",
					onEnter: () => anim.play(),
				});

				cleanupRef.current = () => {
					st.kill();
					anim.destroy();
				};
			})
			.catch((err) => {
				if (!cancelled) console.warn("Failed to load animation:", err);
			});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/website/components/solution-animation.tsx
Line: 58

Comment:
**`cleanupRef` declared after it's referenced in the `.then()` callback**

`cleanupRef` is used inside the `.then()` callback on line 52 but declared here on line 58. This is safe at runtime because the async callback only executes after the current synchronous code (including this declaration) completes, but it's a confusing read order and creates a temporal-dead-zone footgun if the code is reorganised. Move the declaration above the `fetch()` call to make the data flow clear.

```suggestion
		const cleanupRef = { current: () => {} };
```

Then remove the duplicate declaration on line 58 and place this before the `fetch(url)` call.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/website/components/navbar.tsx
Line: 116-127

Comment:
**Scroll offset hard-codes navbar height**

Both the desktop `handleClick` and the mobile `onClick` handler hard-code `- 64` as the scroll offset for the navbar height. The actual navbar height (`h-[44px]` = 44px, or with the sticky border adjustment ~58–60px) doesn't match this constant. If the navbar height ever changes, this offset will silently be wrong. Deriving the offset from `containerRef.current?.offsetHeight` or a shared constant would be more maintainable.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: website copy updates, fix pricing..."](https://github.com/useautumn/autumn/commit/4d7a82d3122b006b98c512492dc55ba367fd27bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29170347)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->