### PR TITLE
chore: optimize query

### DIFF
--- a/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
@@ -109,83 +109,6 @@ const buildEntityRolloverCtes = ({
 		)
 `;
 
-const buildEntityEntitiesCtes = ({
-	statusFilter,
-}: {
-	statusFilter: SQL;
-}) => sql`
-		entity_entities_rows AS (
-			SELECT
-				ce.internal_feature_id,
-				ce.internal_customer_id,
-				cp.internal_entity_id AS entity_key,
-				ce.balance::numeric AS entity_balance,
-				COALESCE(ce.adjustment, 0)::numeric AS entity_adjustment,
-				COALESCE(ce.additional_balance, 0)::numeric AS entity_additional_balance
-			FROM customer_entitlements ce
-			JOIN entity_cus_products_for_options cp ON ce.customer_product_id = cp.id
-
-			UNION ALL
-
-			SELECT
-				ce.internal_feature_id,
-				ce.internal_customer_id,
-				kv.entity_key AS entity_key,
-				COALESCE((kv.entity_value->>'balance')::numeric, 0) AS entity_balance,
-				COALESCE((kv.entity_value->>'adjustment')::numeric, 0) AS entity_adjustment,
-				COALESCE((kv.entity_value->>'additional_balance')::numeric, 0) AS entity_additional_balance
-			FROM customer_entitlements ce
-			JOIN entity_cus_products_for_options cp ON ce.customer_product_id = cp.id
-			CROSS JOIN LATERAL jsonb_each(ce.entities) AS kv(entity_key, entity_value)
-			WHERE jsonb_typeof(ce.entities) = 'object'
-
-			UNION ALL
-
-			SELECT
-				ce.internal_feature_id,
-				ce.internal_customer_id,
-				kv.entity_key AS entity_key,
-				COALESCE((kv.entity_value->>'balance')::numeric, 0) AS entity_balance,
-				COALESCE((kv.entity_value->>'adjustment')::numeric, 0) AS entity_adjustment,
-				COALESCE((kv.entity_value->>'additional_balance')::numeric, 0) AS entity_additional_balance
-			FROM customer_entitlements ce
-			CROSS JOIN LATERAL jsonb_each(ce.entities) AS kv(entity_key, entity_value)
-			WHERE ce.internal_customer_id IN (SELECT internal_id FROM subject_customer_records)
-				AND ce.customer_product_id IS NULL
-				AND ce.internal_entity_id IS NOT NULL
-				AND jsonb_typeof(ce.entities) = 'object'
-				AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-
-			UNION ALL
-
-			SELECT
-				ce.internal_feature_id,
-				ce.internal_customer_id,
-				ce.internal_entity_id AS entity_key,
-				ce.balance::numeric AS entity_balance,
-				COALESCE(ce.adjustment, 0)::numeric AS entity_adjustment,
-				COALESCE(ce.additional_balance, 0)::numeric AS entity_additional_balance
-			FROM customer_entitlements ce
-			WHERE ce.internal_customer_id IN (SELECT internal_id FROM subject_customer_records)
-				AND ce.customer_product_id IS NULL
-				AND ce.internal_entity_id IS NOT NULL
-				AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-		),
-
-		entity_entities_aggregate_keys AS (
-			SELECT
-				internal_feature_id,
-				internal_customer_id,
-				entity_key,
-				SUM(entity_balance) AS balance,
-				SUM(entity_adjustment) AS adjustment,
-				SUM(entity_additional_balance) AS additional_balance
-			FROM entity_entities_rows
-			WHERE entity_key IS NOT NULL
-			GROUP BY internal_feature_id, internal_customer_id, entity_key
-		)
-`;
-
 export const getEntityAggregateFragments = ({
 	entityId,
 	statusFilter,
@@ -351,7 +274,18 @@ export const getEntityAggregateFragments = ({
 
 		${buildEntityRolloverCtes({ statusFilter })},
 
-		${buildEntityEntitiesCtes({ statusFilter })},
+		entity_balance_keys AS (
+			SELECT
+				internal_feature_id,
+				internal_customer_id,
+				entity_key,
+				SUM(entity_balance) AS balance,
+				SUM(entity_adjustment) AS adjustment,
+				SUM(entity_additional_balance) AS additional_balance
+			FROM entity_balance_rows
+			WHERE entity_key IS NOT NULL
+			GROUP BY internal_feature_id, internal_customer_id, entity_key
+		),
 
 		entity_aggregate_map AS (
 			SELECT
@@ -368,7 +302,28 @@ export const getEntityAggregateFragments = ({
 						'rollover_usage', COALESCE(erk.rollover_usage, 0)
 					)
 				) AS entities
-			FROM entity_entities_aggregate_keys ejk
+			FROM (
+				SELECT *
+				FROM entity_balance_keys
+
+				UNION ALL
+
+				SELECT
+					erk.internal_feature_id,
+					erk.internal_customer_id,
+					erk.entity_key,
+					0::numeric AS balance,
+					0::numeric AS adjustment,
+					0::numeric AS additional_balance
+				FROM entity_rollover_keys erk
+				WHERE NOT EXISTS (
+					SELECT 1
+					FROM entity_balance_keys ebk
+					WHERE ebk.internal_feature_id = erk.internal_feature_id
+						AND ebk.internal_customer_id = erk.internal_customer_id
+						AND ebk.entity_key = erk.entity_key
+				)
+			) ejk
 			LEFT JOIN entity_rollover_keys erk
 				ON erk.internal_feature_id = ejk.internal_feature_id
 				AND erk.internal_customer_id = ejk.internal_customer_id
@@ -376,37 +331,50 @@ export const getEntityAggregateFragments = ({
 			GROUP BY ejk.internal_feature_id, ejk.internal_customer_id
 		),
 
-		entity_aggregated_cus_entitlements AS (
+		entity_aggregate_totals AS (
 			SELECT
 				MIN(ebr.api_id) AS api_id,
 				ebr.internal_feature_id,
 				ebr.internal_customer_id,
 				MIN(ebr.feature_id) AS feature_id,
 				SUM(ebr.allowance) AS allowance_total,
-				COALESCE(MAX(epgo.prepaid_grant_from_options), 0) AS prepaid_grant_from_options,
 				SUM(ebr.balance) AS balance,
 				SUM(ebr.adjustment) AS adjustment,
 				SUM(ebr.additional_balance) AS additional_balance,
-				COALESCE(MAX(erf.rollover_balance), 0) AS rollover_balance,
-				COALESCE(MAX(erf.rollover_usage), 0) AS rollover_usage,
 				BOOL_OR(ebr.unlimited) AS unlimited,
 				BOOL_OR(ebr.usage_allowed) AS usage_allowed,
-				COUNT(DISTINCT ebr.entity_key) FILTER (WHERE ebr.entity_key IS NOT NULL) AS entity_count,
-				eam.entities
+				COUNT(DISTINCT ebr.entity_key) FILTER (WHERE ebr.entity_key IS NOT NULL) AS entity_count
 			FROM entity_balance_rows ebr
-			LEFT JOIN entity_aggregate_map eam
-				ON eam.internal_feature_id = ebr.internal_feature_id
-				AND eam.internal_customer_id = ebr.internal_customer_id
-			LEFT JOIN entity_rollover_feature erf
-				ON erf.internal_feature_id = ebr.internal_feature_id
-				AND erf.internal_customer_id = ebr.internal_customer_id
-			LEFT JOIN entity_prepaid_grant_from_options epgo
-				ON epgo.internal_feature_id = ebr.internal_feature_id
-				AND epgo.internal_customer_id = ebr.internal_customer_id
-			GROUP BY
-				ebr.internal_feature_id,
-				ebr.internal_customer_id,
+			GROUP BY ebr.internal_feature_id, ebr.internal_customer_id
+		),
+
+		entity_aggregated_cus_entitlements AS (
+			SELECT
+				eat.api_id,
+				eat.internal_feature_id,
+				eat.internal_customer_id,
+				eat.feature_id,
+				eat.allowance_total,
+				COALESCE(epgo.prepaid_grant_from_options, 0) AS prepaid_grant_from_options,
+				eat.balance,
+				eat.adjustment,
+				eat.additional_balance,
+				COALESCE(erf.rollover_balance, 0) AS rollover_balance,
+				COALESCE(erf.rollover_usage, 0) AS rollover_usage,
+				eat.unlimited,
+				eat.usage_allowed,
+				eat.entity_count,
 				eam.entities
+			FROM entity_aggregate_totals eat
+			LEFT JOIN entity_aggregate_map eam
+				ON eam.internal_feature_id = eat.internal_feature_id
+				AND eam.internal_customer_id = eat.internal_customer_id
+			LEFT JOIN entity_rollover_feature erf
+				ON erf.internal_feature_id = eat.internal_feature_id
+				AND erf.internal_customer_id = eat.internal_customer_id
+			LEFT JOIN entity_prepaid_grant_from_options epgo
+				ON epgo.internal_feature_id = eat.internal_feature_id
+				AND epgo.internal_customer_id = eat.internal_customer_id
 		)
 	`;
 

--- a/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
@@ -109,18 +109,24 @@ const buildEntityRolloverCtes = ({
 		)
 `;
 
-/**
- * Per-feature/per-entity aggregates sourced strictly from `ce.entities` JSON.
- * This powers the `entities` map in customer-level aggregates and intentionally
- * excludes top-level entity attribution paths.
- */
 const buildEntityEntitiesCtes = ({
 	statusFilter,
 }: {
 	statusFilter: SQL;
 }) => sql`
 		entity_entities_rows AS (
-			-- Product-attached entitlements: aggregate directly from ce.entities keys
+			SELECT
+				ce.internal_feature_id,
+				ce.internal_customer_id,
+				cp.internal_entity_id AS entity_key,
+				ce.balance::numeric AS entity_balance,
+				COALESCE(ce.adjustment, 0)::numeric AS entity_adjustment,
+				COALESCE(ce.additional_balance, 0)::numeric AS entity_additional_balance
+			FROM customer_entitlements ce
+			JOIN entity_cus_products_for_options cp ON ce.customer_product_id = cp.id
+
+			UNION ALL
+
 			SELECT
 				ce.internal_feature_id,
 				ce.internal_customer_id,
@@ -129,16 +135,12 @@ const buildEntityEntitiesCtes = ({
 				COALESCE((kv.entity_value->>'adjustment')::numeric, 0) AS entity_adjustment,
 				COALESCE((kv.entity_value->>'additional_balance')::numeric, 0) AS entity_additional_balance
 			FROM customer_entitlements ce
-			JOIN customer_products cp ON ce.customer_product_id = cp.id
+			JOIN entity_cus_products_for_options cp ON ce.customer_product_id = cp.id
 			CROSS JOIN LATERAL jsonb_each(ce.entities) AS kv(entity_key, entity_value)
-			WHERE ce.internal_customer_id IN (SELECT internal_id FROM subject_customer_records)
-				AND cp.internal_entity_id IS NOT NULL
-				AND jsonb_typeof(ce.entities) = 'object'
-				${statusFilter}
+			WHERE jsonb_typeof(ce.entities) = 'object'
 
 			UNION ALL
 
-			-- Loose entitlements: aggregate directly from ce.entities keys
 			SELECT
 				ce.internal_feature_id,
 				ce.internal_customer_id,
@@ -152,6 +154,21 @@ const buildEntityEntitiesCtes = ({
 				AND ce.customer_product_id IS NULL
 				AND ce.internal_entity_id IS NOT NULL
 				AND jsonb_typeof(ce.entities) = 'object'
+				AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+
+			UNION ALL
+
+			SELECT
+				ce.internal_feature_id,
+				ce.internal_customer_id,
+				ce.internal_entity_id AS entity_key,
+				ce.balance::numeric AS entity_balance,
+				COALESCE(ce.adjustment, 0)::numeric AS entity_adjustment,
+				COALESCE(ce.additional_balance, 0)::numeric AS entity_additional_balance
+			FROM customer_entitlements ce
+			WHERE ce.internal_customer_id IN (SELECT internal_id FROM subject_customer_records)
+				AND ce.customer_product_id IS NULL
+				AND ce.internal_entity_id IS NOT NULL
 				AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
 		),
 
@@ -336,34 +353,6 @@ export const getEntityAggregateFragments = ({
 
 		${buildEntityEntitiesCtes({ statusFilter })},
 
-		entity_aggregate_keys AS (
-			SELECT
-				COALESCE(ebk.internal_feature_id, erk.internal_feature_id) AS internal_feature_id,
-				COALESCE(ebk.internal_customer_id, erk.internal_customer_id) AS internal_customer_id,
-				COALESCE(ebk.entity_key, erk.entity_key) AS entity_key,
-				COALESCE(ebk.balance, 0) AS balance,
-				COALESCE(ebk.adjustment, 0) AS adjustment,
-				COALESCE(ebk.additional_balance, 0) AS additional_balance,
-				COALESCE(erk.rollover_balance, 0) AS rollover_balance,
-				COALESCE(erk.rollover_usage, 0) AS rollover_usage
-			FROM (
-				SELECT
-					internal_feature_id,
-					internal_customer_id,
-					entity_key,
-					SUM(entity_balance) AS balance,
-					SUM(entity_adjustment) AS adjustment,
-					SUM(entity_additional_balance) AS additional_balance
-				FROM entity_balance_rows
-				WHERE entity_key IS NOT NULL
-				GROUP BY internal_feature_id, internal_customer_id, entity_key
-			) ebk
-			FULL OUTER JOIN entity_rollover_keys erk
-				ON erk.internal_feature_id = ebk.internal_feature_id
-				AND erk.internal_customer_id = ebk.internal_customer_id
-				AND erk.entity_key = ebk.entity_key
-		),
-
 		entity_aggregate_map AS (
 			SELECT
 				ejk.internal_feature_id,
@@ -434,7 +423,8 @@ export const getEntityAggregateFragments = ({
 			ce.entitlement_id
 		FROM customer_entitlements ce
 		JOIN customer_products cp ON ce.customer_product_id = cp.id
-		WHERE cp.internal_entity_id IS NOT NULL
+		WHERE ce.internal_customer_id IN (SELECT internal_id FROM subject_customer_records)
+			AND cp.internal_entity_id IS NOT NULL
 			${statusFilter}
 
 		UNION
@@ -442,7 +432,8 @@ export const getEntityAggregateFragments = ({
 			ce.internal_customer_id,
 			ce.entitlement_id
 		FROM customer_entitlements ce
-		WHERE ce.customer_product_id IS NULL
+		WHERE ce.internal_customer_id IN (SELECT internal_id FROM subject_customer_records)
+			AND ce.customer_product_id IS NULL
 			AND ce.internal_entity_id IS NOT NULL
 			AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
 	`;

--- a/shared/models/cusProductModels/cusEntModels/cusEntTable.ts
+++ b/shared/models/cusProductModels/cusEntModels/cusEntTable.ts
@@ -93,6 +93,11 @@ export const customerEntitlements = pgTable(
 		index("idx_customer_entitlements_loose_customer_expires")
 			.on(table.internal_customer_id, table.expires_at)
 			.where(sql`${table.customer_product_id} IS NULL`),
+		index("idx_ce_customer_product_entities_object")
+			.on(table.internal_customer_id)
+			.where(
+				sql`${table.customer_product_id} IS NOT NULL AND jsonb_typeof(${table.entities}) = 'object'`,
+			),
 	],
 );
 

--- a/shared/models/cusProductModels/cusEntModels/cusEntTable.ts
+++ b/shared/models/cusProductModels/cusEntModels/cusEntTable.ts
@@ -93,11 +93,6 @@ export const customerEntitlements = pgTable(
 		index("idx_customer_entitlements_loose_customer_expires")
 			.on(table.internal_customer_id, table.expires_at)
 			.where(sql`${table.customer_product_id} IS NULL`),
-		index("idx_ce_customer_product_entities_object")
-			.on(table.internal_customer_id)
-			.where(
-				sql`${table.customer_product_id} IS NOT NULL AND jsonb_typeof(${table.entities}) = 'object'`,
-			),
 	],
 );
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized entity aggregate SQL and added a targeted index to speed up entitlement lookups for subject customers. The query now preserves rollover-only entities and strictly scopes entitlement refs to the current subject, reducing JSON work, joins, and scans.

- **Bug Fixes**
  - Scope `entitlementRefsUnion` to the current subject in both UNION branches to prevent cross-customer refs.

- **Refactors**
  - Consolidate aggregation via `entity_balance_rows`, and union missing `entity_rollover_keys` to include rollover-only entities; compute totals in `entity_aggregate_totals` and the map in `entity_aggregate_map`.
  - Swap joins to `entity_cus_products_for_options` and add partial index `idx_ce_customer_product_entities_object` to speed product-entity lookups while reducing `jsonb_each` scans and skipping expired rows.

<sup>Written for commit a8f465d75d45f2cb41dfdc932c9d0b3079192326. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR optimizes entity-level balance queries by introducing dedicated `entity_entities_rows` branches (product-attached top-level, product-attached per-entity JSON, loose per-entity JSON, and loose top-level) to replace the old `entity_aggregate_keys` CTE that sourced from `entity_balance_rows`. It also adds a customer-scoping guard to `entitlementRefsUnion` and a new partial index on `customer_entitlements` to support the refactored query path.

- **Bug fixes / Improvements**: `entitlementRefsUnion` now correctly filters both UNION branches by `subject_customer_records`, preventing potential cross-customer entitlement leakage in the returned refs.
- **Improvements**: The old `entity_aggregate_keys` FULL OUTER JOIN (balance rows ⟷ rollover keys) is replaced by a LEFT JOIN in `entity_aggregate_map` — verify that rollover-only entities (no active balance) are intentionally excluded from the `entities` map.
- **Improvements**: New partial index `idx_ce_customer_product_entities_object` on `internal_customer_id` should be validated with `EXPLAIN ANALYZE` to confirm it is chosen by the planner for the new join on `customer_product_id`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/speculative concerns with no definitive correctness breakage.

The entitlementRefsUnion customer-scoping fix is a clear improvement. The FULL OUTER JOIN → LEFT JOIN change is a behavioral narrowing but is sound given rollovers are always backed by active entitlements. The index utility question is advisory only. No P0/P1 issues identified.

getEntityAggregateFragments.ts — confirm the FULL OUTER JOIN → LEFT JOIN semantic change is intentional for rollover-only edge cases; cusEntTable.ts — validate new index is used by the planner.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts | Refactors entity aggregate CTEs: replaces entity_aggregate_keys (FULL OUTER JOIN) with entity_entities_rows/entity_entities_aggregate_keys (LEFT JOIN); adds top-level balance branches to entity_entities_rows; fixes entitlementRefsUnion to scope by subject_customer_records. Semantic change from FULL OUTER JOIN to LEFT JOIN warrants attention. |
| shared/models/cusProductModels/cusEntModels/cusEntTable.ts | Adds partial index idx_ce_customer_product_entities_object on internal_customer_id WHERE customer_product_id IS NOT NULL AND jsonb_typeof(entities) = 'object'; index utility for the new join pattern should be verified via EXPLAIN ANALYZE. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SCR[subject_customer_records]

    subgraph entity_cus_products_for_options
        ECPFO["customer_products cp\n(filtered by SCR + statusFilter\n+ internal_entity_id IS NOT NULL)"]
    end

    subgraph entity_entities_rows["entity_entities_rows (4 branches)"]
        B1["Branch 1: Product-attached top-level\nce.balance → cp.internal_entity_id\n(via entity_cus_products_for_options)"]
        B2["Branch 2: Product-attached per-entity JSON\nce.entities keys → kv.entity_key\n(via entity_cus_products_for_options)"]
        B3["Branch 3: Loose per-entity JSON\nce.entities keys → kv.entity_key\n(WHERE customer_product_id IS NULL)"]
        B4["Branch 4: Loose top-level\nce.balance → ce.internal_entity_id\n(WHERE customer_product_id IS NULL)"]
    end

    ECPFO --> B1
    ECPFO --> B2
    SCR --> B3
    SCR --> B4

    B1 & B2 & B3 & B4 --> EEAK["entity_entities_aggregate_keys\n(GROUP BY feature + customer + entity_key)"]

    EEAK --> EAM["entity_aggregate_map\n(LEFT JOIN entity_rollover_keys)\n→ entities JSONB"]

    EAM --> EACE["entity_aggregated_cus_entitlements\n(final output: .entities field)"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts`, line 356-377 ([link](https://github.com/useautumn/autumn/blob/24465c8140f8a23e7bead73eb59b612ad44f8d02/server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts#L356-L377)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **FULL OUTER JOIN → LEFT JOIN changes semantics for rollover-only entities**

   The removed `entity_aggregate_keys` CTE used a `FULL OUTER JOIN` between the balance aggregates and `entity_rollover_keys`, meaning an entity that has rollover data but **no** balance row would still appear in the `entities` JSONB map (with `balance = 0`). The new `entity_aggregate_map` uses `FROM entity_entities_aggregate_keys ejk LEFT JOIN entity_rollover_keys erk`, so a rollover-only entity would be silently dropped from the map.

   In practice rollovers are always backed by an entitlement, so this edge case likely never fires — but if it can occur (e.g., after a data-migration or entitlement deletion), the rollover credit becomes invisible to callers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
   Line: 356-377

   Comment:
   **FULL OUTER JOIN → LEFT JOIN changes semantics for rollover-only entities**

   The removed `entity_aggregate_keys` CTE used a `FULL OUTER JOIN` between the balance aggregates and `entity_rollover_keys`, meaning an entity that has rollover data but **no** balance row would still appear in the `entities` JSONB map (with `balance = 0`). The new `entity_aggregate_map` uses `FROM entity_entities_aggregate_keys ejk LEFT JOIN entity_rollover_keys erk`, so a rollover-only entity would be silently dropped from the map.

   In practice rollovers are always backed by an entitlement, so this edge case likely never fires — but if it can occur (e.g., after a data-migration or entitlement deletion), the rollover credit becomes invisible to callers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
Line: 117-141

Comment:
**Missing `statusFilter` guard in branch 2 of `entity_entities_rows`**

Branch 2 (product-attached per-entity JSON) drops the explicit `statusFilter` from its WHERE clause and relies entirely on the join to `entity_cus_products_for_options`. That CTE does apply `statusFilter` to its own WHERE clause (line 240), so the filter is correctly inherited — but it's worth confirming this assumption holds if `entity_cus_products_for_options` ever changes. No action required if the invariant is intentional.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/customers/repos/getFullSubject/getEntityAggregateFragments.ts
Line: 356-377

Comment:
**FULL OUTER JOIN → LEFT JOIN changes semantics for rollover-only entities**

The removed `entity_aggregate_keys` CTE used a `FULL OUTER JOIN` between the balance aggregates and `entity_rollover_keys`, meaning an entity that has rollover data but **no** balance row would still appear in the `entities` JSONB map (with `balance = 0`). The new `entity_aggregate_map` uses `FROM entity_entities_aggregate_keys ejk LEFT JOIN entity_rollover_keys erk`, so a rollover-only entity would be silently dropped from the map.

In practice rollovers are always backed by an entitlement, so this edge case likely never fires — but if it can occur (e.g., after a data-migration or entitlement deletion), the rollover credit becomes invisible to callers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: shared/models/cusProductModels/cusEntModels/cusEntTable.ts
Line: 96-100

Comment:
**New partial index may not be used for the target join pattern**

`idx_ce_customer_product_entities_object` is defined on `internal_customer_id` (only), with a WHERE guard of `customer_product_id IS NOT NULL AND jsonb_typeof(entities) = 'object'`. The branch of `entity_entities_rows` it is intended to support joins `customer_entitlements` to `entity_cus_products_for_options` on `ce.customer_product_id = cp.id`. The planner is likely to use the existing `idx_customer_entitlements_product_id` for that join rather than this new index. Consider whether the index should include `customer_product_id` as the leading column (with `jsonb_typeof(entities) = 'object'` as the partial predicate) to actually support the intended access path, or verify via `EXPLAIN ANALYZE` that it is being picked up.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: optimize query"](https://github.com/useautumn/autumn/commit/24465c8140f8a23e7bead73eb59b612ad44f8d02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29173843)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->