### PR TITLE
fix: undo hydrate schedule

### DIFF
--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.ts
@@ -10,7 +10,6 @@ import { customerActions } from "@/internal/customers/actions/index.js";
 import { autoCreateEntity } from "@/internal/entities/handlers/handleCreateEntity/autoCreateEntity.js";
 import { CusService } from "../../CusService.js";
 import { updateCustomerDetails } from "../cusUtils.js";
-import { hydrateFullCustomerSchedule } from "../getFullCustomerSchedule.js";
 import { getCachedFullCustomer } from "./getCachedFullCustomer.js";
 import { setCachedFullCustomer } from "./setCachedFullCustomer.js";
 
@@ -114,10 +113,10 @@ export const getOrCreateCachedFullCustomer = async ({
 		}
 	}
 
-	fullCustomer = await hydrateFullCustomerSchedule({
-		ctx,
-		fullCustomer,
-	});
+	// fullCustomer = await hydrateFullCustomerSchedule({
+	// 	ctx,
+	// 	fullCustomer,
+	// });
 
 	// 6. Set cache (await to ensure it's ready before Redis deduction)
 	if (!skipCache && setCache) {

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer.ts
@@ -6,7 +6,6 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "../../CusService.js";
-import { hydrateFullCustomerSchedule } from "../getFullCustomerSchedule.js";
 import { getCachedFullCustomer } from "./getCachedFullCustomer.js";
 import { setCachedFullCustomer } from "./setCachedFullCustomer.js";
 
@@ -80,16 +79,16 @@ export const getOrSetCachedFullCustomer = async ({
 		}
 	}
 
-	const hydratedFullCustomer = await hydrateFullCustomerSchedule({
-		ctx,
-		fullCustomer,
-	});
+	// const hydratedFullCustomer = await hydrateFullCustomerSchedule({
+	// 	ctx,
+	// 	fullCustomer,
+	// });
 
 	// 3. Set cache (fire and forget)
 	if (!skipCache) {
 		await setCachedFullCustomer({
 			ctx,
-			fullCustomer: hydratedFullCustomer,
+			fullCustomer,
 			customerId,
 			fetchTimeMs,
 			source,
@@ -102,5 +101,5 @@ export const getOrSetCachedFullCustomer = async ({
 		// });
 	}
 
-	return hydratedFullCustomer;
+	return fullCustomer;
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable schedule hydration in full customer caching to prevent regressions and return the raw `fullCustomer` object.
Both `getOrCreateCachedFullCustomer` and `getOrSetCachedFullCustomer` now skip `hydrateFullCustomerSchedule`, cache the unhydrated data, and return it directly.

<sup>Written for commit ba26a09b1738f4b48d9fbf580b9fbb13939ebfbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

