### PR TITLE
chore: redis obserability improvements

### DIFF
--- a/server/src/external/redis/initUtils/redisAvailability.ts
+++ b/server/src/external/redis/initUtils/redisAvailability.ts
@@ -4,7 +4,9 @@ import { hasRedisConfig } from "./redisConfig.js";
 
 const REDIS_ERROR_LOG_INTERVAL_MS = 30_000;
 const REDIS_PROBE_INTERVAL_MS = 2_000;
-const REDIS_PROBE_TIMEOUT_MS = 500;
+const REDIS_PROBE_TIMEOUT_MS = 1_000;
+const REDIS_FAILURES_TO_DEGRADE = 3;
+const REDIS_SUCCESSES_TO_RECOVER = 2;
 
 type RedisAvailabilityState = "healthy" | "degraded";
 
@@ -18,6 +20,8 @@ let redisAvailabilityState: RedisAvailabilityState = "degraded";
 let redisMonitorInterval: ReturnType<typeof setInterval> | null = null;
 let redisTickInFlight = false;
 let lastAvailabilityLogAt = 0;
+let consecutiveFailures = 0;
+let consecutiveSuccesses = 0;
 
 const setRedisAvailabilityState = (state: RedisAvailabilityState) => {
 	const shouldLog =
@@ -38,6 +42,16 @@ const setRedisAvailabilityState = (state: RedisAvailabilityState) => {
 			: "[Redis] Unavailable, skipping Redis-backed features",
 		{ redisStatus: redis.status },
 	);
+};
+
+const recordRedisAvailability = (available: boolean) => {
+	consecutiveSuccesses = available ? consecutiveSuccesses + 1 : 0;
+	consecutiveFailures = available ? 0 : consecutiveFailures + 1;
+
+	if (consecutiveSuccesses >= REDIS_SUCCESSES_TO_RECOVER)
+		setRedisAvailabilityState("healthy");
+	if (consecutiveFailures >= REDIS_FAILURES_TO_DEGRADE)
+		setRedisAvailabilityState("degraded");
 };
 
 const pingRedisClient = async () => {
@@ -70,15 +84,15 @@ const tickRedisAvailability = async () => {
 
 	try {
 		if (await pingRedisClient()) {
-			setRedisAvailabilityState("healthy");
+			recordRedisAvailability(true);
 			return;
 		}
 	} catch {}
 
 	await tryReconnectRedis();
-	setRedisAvailabilityState(
-		(await pingRedisClient().catch(() => false)) ? "healthy" : "degraded",
-	);
+	(await pingRedisClient().catch(() => false))
+		? recordRedisAvailability(true)
+		: recordRedisAvailability(false);
 };
 
 export const startRedisMonitor = () => {
@@ -105,6 +119,14 @@ export const stopRedisMonitor = () => {
 
 export const shouldUseRedis = () =>
 	hasRedisConfig && redisAvailabilityState === "healthy";
+
+export const markRedisCommandSuccess = () => {
+	if (hasRedisConfig) recordRedisAvailability(true);
+};
+
+export const markRedisCommandFailure = () => {
+	if (hasRedisConfig) recordRedisAvailability(false);
+};
 
 export const getRedisAvailability = (): RedisAvailabilitySnapshot => ({
 	configured: hasRedisConfig,

--- a/server/src/external/redis/initUtils/redisAvailability.ts
+++ b/server/src/external/redis/initUtils/redisAvailability.ts
@@ -6,6 +6,7 @@ import { hasRedisConfig } from "./redisConfig.js";
 const REDIS_ERROR_LOG_INTERVAL_MS = 30_000;
 const REDIS_PROBE_INTERVAL_MS = 2_000;
 const REDIS_PROBE_TIMEOUT_MS = 1_000;
+const REDIS_STALE_RECONNECT_MS = 5_000;
 const REDIS_FAILURES_TO_DEGRADE = 3;
 const REDIS_SUCCESSES_TO_RECOVER = 2;
 
@@ -23,19 +24,18 @@ let redisTickInFlight = false;
 let lastAvailabilityLogAt = 0;
 let consecutiveFailures = 0;
 let consecutiveSuccesses = 0;
+let reconnectStartedAt: number | null = null;
 
 const setRedisAvailabilityState = (state: RedisAvailabilityState) => {
 	const previousState = redisAvailabilityState;
+	const now = Date.now();
 	const shouldLog =
 		previousState !== state ||
-		(state === "degraded" &&
-			Date.now() - lastAvailabilityLogAt >= REDIS_ERROR_LOG_INTERVAL_MS);
+		(state === "degraded" && now - lastAvailabilityLogAt >= REDIS_ERROR_LOG_INTERVAL_MS);
 	if (!shouldLog) return;
 
 	redisAvailabilityState = state;
 
-	const now = Date.now();
-	if (now - lastAvailabilityLogAt < REDIS_ERROR_LOG_INTERVAL_MS) return;
 	lastAvailabilityLogAt = now;
 
 	logger[state === "healthy" ? "info" : "warn"](
@@ -79,12 +79,22 @@ const pingRedisClient = async () => {
 };
 
 const tryReconnectRedis = async () => {
-	if (!hasRedisConfig || redis.status === "ready" || redis.status === "connecting")
+	if (!hasRedisConfig || redis.status === "ready") {
+		reconnectStartedAt = null;
 		return;
+	}
+
+	if (redis.status === "connecting" || redis.status === "reconnecting") {
+		reconnectStartedAt ??= Date.now();
+		if (Date.now() - reconnectStartedAt < REDIS_STALE_RECONNECT_MS) return;
+	}
 
 	try {
 		redis.disconnect(false);
-		await redis.connect();
+		await withTimeout({
+			timeoutMs: REDIS_PROBE_TIMEOUT_MS,
+			fn: () => redis.connect(),
+		});
 	} catch {
 		// Let the next probe decide whether we recovered.
 	}

--- a/server/src/external/redis/initUtils/redisAvailability.ts
+++ b/server/src/external/redis/initUtils/redisAvailability.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/external/logtail/logtailUtils.js";
 import { withTimeout } from "@/utils/withTimeout.js";
 import { redis } from "./redisClientRegistry.js";
 import { hasRedisConfig } from "./redisConfig.js";
@@ -24,8 +25,9 @@ let consecutiveFailures = 0;
 let consecutiveSuccesses = 0;
 
 const setRedisAvailabilityState = (state: RedisAvailabilityState) => {
+	const previousState = redisAvailabilityState;
 	const shouldLog =
-		redisAvailabilityState !== state ||
+		previousState !== state ||
 		(state === "degraded" &&
 			Date.now() - lastAvailabilityLogAt >= REDIS_ERROR_LOG_INTERVAL_MS);
 	if (!shouldLog) return;
@@ -36,11 +38,20 @@ const setRedisAvailabilityState = (state: RedisAvailabilityState) => {
 	if (now - lastAvailabilityLogAt < REDIS_ERROR_LOG_INTERVAL_MS) return;
 	lastAvailabilityLogAt = now;
 
-	console[state === "healthy" ? "info" : "warn"](
+	logger[state === "healthy" ? "info" : "warn"](
 		state === "healthy"
 			? "[Redis] Recovered"
 			: "[Redis] Unavailable, skipping Redis-backed features",
-		{ redisStatus: redis.status },
+		{
+			type: "redis_availability_state_set",
+			previousState,
+			state,
+			redisStatus: redis.status,
+			consecutiveFailures,
+			consecutiveSuccesses,
+			failuresToDegrade: REDIS_FAILURES_TO_DEGRADE,
+			successesToRecover: REDIS_SUCCESSES_TO_RECOVER,
+		},
 	);
 };
 

--- a/server/src/utils/cacheUtils/cacheUtils.ts
+++ b/server/src/utils/cacheUtils/cacheUtils.ts
@@ -1,6 +1,10 @@
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { redis } from "@/external/redis/initRedis.js";
+import {
+	markRedisCommandFailure,
+	markRedisCommandSuccess,
+} from "@/external/redis/initUtils/redisAvailability.js";
 
 const REDIS_WARNING_INTERVAL_MS = 30_000;
 const lastRedisWarningAtBySource = new Map<string, number>();
@@ -49,14 +53,17 @@ export const tryRedisNx = async <TUnavailable, TSuccess, TExists>({
 
 	try {
 		if (targetRedis.status !== "ready") {
+			markRedisCommandFailure();
 			warnRedisUnavailable({ source: "tryRedisNx:not-ready" });
 			return await onRedisUnavailable();
 		}
 
 		const result = await operation();
+		markRedisCommandSuccess();
 		if (result === "OK") return await onSuccess();
 		return await onKeyAlreadyExists();
 	} catch (error) {
+		markRedisCommandFailure();
 		warnRedisUnavailable({ source: "tryRedisNx:error", error });
 		return await onRedisUnavailable();
 	}
@@ -79,16 +86,19 @@ export const tryRedisWrite = async <T>(
 
 	try {
 		if (targetRedis.status !== "ready") {
+			markRedisCommandFailure();
 			warnRedisUnavailable({ source: "tryRedisWrite:not-ready" });
 			return null as T extends void ? true : T | null;
 		}
 
 		const result = await operation();
+		markRedisCommandSuccess();
 
 		return (result === undefined ? true : result) as T extends void
 			? true
 			: T | null;
 	} catch (error) {
+		markRedisCommandFailure();
 		warnRedisUnavailable({ source: "tryRedisWrite:error", error });
 		return null as T extends void ? true : T | null;
 	}
@@ -110,13 +120,16 @@ export const tryRedisRead = async <T>(
 
 	try {
 		if (targetRedis.status !== "ready") {
+			markRedisCommandFailure();
 			warnRedisUnavailable({ source: "tryRedisRead:not-ready" });
 			return null;
 		}
 
 		const result = await operation();
+		markRedisCommandSuccess();
 		return result;
 	} catch (error) {
+		markRedisCommandFailure();
 		warnRedisUnavailable({ source: "tryRedisRead:error", error });
 		return null;
 	}

--- a/server/src/utils/cacheUtils/cacheUtils.ts
+++ b/server/src/utils/cacheUtils/cacheUtils.ts
@@ -9,6 +9,11 @@ import {
 const REDIS_WARNING_INTERVAL_MS = 30_000;
 const lastRedisWarningAtBySource = new Map<string, number>();
 
+const markDefaultRedisAvailability = (targetRedis: Redis, available: boolean) => {
+	if (targetRedis !== redis) return;
+	available ? markRedisCommandSuccess() : markRedisCommandFailure();
+};
+
 const warnRedisUnavailable = ({
 	source,
 	error,
@@ -53,17 +58,17 @@ export const tryRedisNx = async <TUnavailable, TSuccess, TExists>({
 
 	try {
 		if (targetRedis.status !== "ready") {
-			markRedisCommandFailure();
+			markDefaultRedisAvailability(targetRedis, false);
 			warnRedisUnavailable({ source: "tryRedisNx:not-ready" });
 			return await onRedisUnavailable();
 		}
 
 		const result = await operation();
-		markRedisCommandSuccess();
+		markDefaultRedisAvailability(targetRedis, true);
 		if (result === "OK") return await onSuccess();
 		return await onKeyAlreadyExists();
 	} catch (error) {
-		markRedisCommandFailure();
+		markDefaultRedisAvailability(targetRedis, false);
 		warnRedisUnavailable({ source: "tryRedisNx:error", error });
 		return await onRedisUnavailable();
 	}
@@ -86,19 +91,19 @@ export const tryRedisWrite = async <T>(
 
 	try {
 		if (targetRedis.status !== "ready") {
-			markRedisCommandFailure();
+			markDefaultRedisAvailability(targetRedis, false);
 			warnRedisUnavailable({ source: "tryRedisWrite:not-ready" });
 			return null as T extends void ? true : T | null;
 		}
 
 		const result = await operation();
-		markRedisCommandSuccess();
+		markDefaultRedisAvailability(targetRedis, true);
 
 		return (result === undefined ? true : result) as T extends void
 			? true
 			: T | null;
 	} catch (error) {
-		markRedisCommandFailure();
+		markDefaultRedisAvailability(targetRedis, false);
 		warnRedisUnavailable({ source: "tryRedisWrite:error", error });
 		return null as T extends void ? true : T | null;
 	}
@@ -120,16 +125,16 @@ export const tryRedisRead = async <T>(
 
 	try {
 		if (targetRedis.status !== "ready") {
-			markRedisCommandFailure();
+			markDefaultRedisAvailability(targetRedis, false);
 			warnRedisUnavailable({ source: "tryRedisRead:not-ready" });
 			return null;
 		}
 
 		const result = await operation();
-		markRedisCommandSuccess();
+		markDefaultRedisAvailability(targetRedis, true);
 		return result;
 	} catch (error) {
-		markRedisCommandFailure();
+		markDefaultRedisAvailability(targetRedis, false);
 		warnRedisUnavailable({ source: "tryRedisRead:error", error });
 		return null;
 	}

--- a/server/tests/unit/cache/cache-utils.test.ts
+++ b/server/tests/unit/cache/cache-utils.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const mockState = {
 	warnings: [] as Array<{ message: string; data?: Record<string, unknown> }>,
 };
+const defaultRedis = { status: "ready" };
 
 mock.module("@/external/logtail/logtailUtils.js", () => ({
 	logger: {
@@ -20,10 +21,21 @@ mock.module("@/external/logtail/logtailUtils.js", () => ({
 	},
 }));
 
+mock.module("@/external/redis/initUtils/redisConfig.js", () => ({
+	hasRedisConfig: true,
+}));
+mock.module("@/external/redis/initUtils/redisClientRegistry.js", () => ({
+	redis: defaultRedis,
+}));
+mock.module("@/external/redis/initRedis.js", () => ({
+	redis: defaultRedis,
+}));
+
 import {
 	getRedisAvailability,
-	shouldUseRedis,
-} from "@/external/redis/initRedis.js";
+	markRedisCommandFailure,
+	markRedisCommandSuccess,
+} from "@/external/redis/initUtils/redisAvailability.js";
 import {
 	tryRedisNx,
 	tryRedisRead,
@@ -33,6 +45,26 @@ import {
 describe("cache utils", () => {
 	beforeEach(() => {
 		mockState.warnings = [];
+	});
+
+	test("redis availability uses recovery and degradation thresholds", () => {
+		markRedisCommandFailure();
+		markRedisCommandFailure();
+		markRedisCommandFailure();
+		expect(getRedisAvailability().state).toBe("degraded");
+
+		markRedisCommandSuccess();
+		expect(getRedisAvailability().state).toBe("degraded");
+
+		markRedisCommandSuccess();
+		expect(getRedisAvailability().state).toBe("healthy");
+
+		markRedisCommandFailure();
+		markRedisCommandFailure();
+		expect(getRedisAvailability().state).toBe("healthy");
+
+		markRedisCommandFailure();
+		expect(getRedisAvailability().state).toBe("degraded");
 	});
 
 	test("tryRedisRead returns null and warns when Redis operation throws", async () => {
@@ -52,7 +84,6 @@ describe("cache utils", () => {
 				error: "boom",
 			},
 		});
-		expect(shouldUseRedis()).toBe(false);
 	});
 
 	test("tryRedisWrite returns null and warns when Redis is not ready", async () => {
@@ -69,7 +100,6 @@ describe("cache utils", () => {
 				error: undefined,
 			},
 		});
-		expect(getRedisAvailability().state).toBe("degraded");
 	});
 
 	test("tryRedisNx falls back and warns when Redis operation throws", async () => {
@@ -92,5 +122,20 @@ describe("cache utils", () => {
 				error: "boom",
 			},
 		});
+	});
+
+	test("custom Redis failures do not mark default Redis unavailable", async () => {
+		markRedisCommandSuccess();
+		markRedisCommandSuccess();
+		expect(getRedisAvailability().state).toBe("healthy");
+
+		await tryRedisRead(
+			async () => {
+				throw new Error("custom redis failed");
+			},
+			{ status: "ready" } as never,
+		);
+
+		expect(getRedisAvailability().state).toBe("healthy");
 	});
 });

--- a/server/tests/unit/cache/cache-utils.test.ts
+++ b/server/tests/unit/cache/cache-utils.test.ts
@@ -7,6 +7,7 @@ const defaultRedis = { status: "ready" };
 
 mock.module("@/external/logtail/logtailUtils.js", () => ({
 	logger: {
+		info: () => undefined,
 		warn: (data: Record<string, unknown> | string, message?: string) => {
 			if (typeof data === "string") {
 				mockState.warnings.push({ message: data });

--- a/server/tests/unit/cache/cache-utils.test.ts
+++ b/server/tests/unit/cache/cache-utils.test.ts
@@ -21,6 +21,10 @@ mock.module("@/external/logtail/logtailUtils.js", () => ({
 }));
 
 import {
+	getRedisAvailability,
+	shouldUseRedis,
+} from "@/external/redis/initRedis.js";
+import {
 	tryRedisNx,
 	tryRedisRead,
 	tryRedisWrite,
@@ -48,6 +52,7 @@ describe("cache utils", () => {
 				error: "boom",
 			},
 		});
+		expect(shouldUseRedis()).toBe(false);
 	});
 
 	test("tryRedisWrite returns null and warns when Redis is not ready", async () => {
@@ -64,6 +69,7 @@ describe("cache utils", () => {
 				error: undefined,
 			},
 		});
+		expect(getRedisAvailability().state).toBe("degraded");
 	});
 
 	test("tryRedisNx falls back and warns when Redis operation throws", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved Redis availability tracking with hysteresis, command-level feedback, and safer reconnects to reduce flapping and prevent cross-instance contamination. Switched to structured `logger` events; probe timeout is 1s, and tests now cover thresholds and default-instance isolation.

- **New Features**
  - Hysteresis: degrade after 3 failures, recover after 2 successes; updates flow through `recordRedisAvailability`.
  - Command markers added to `tryRedisRead`/`tryRedisWrite`/`tryRedisNx`, only update when using the default `redis`.
  - Reconnect hardening: connect attempts use a 1s timeout; if `connecting`/`reconnecting` >5s, force disconnect and retry.
  - Structured `logger` events with transition metadata (status, counters).

<sup>Written for commit adb033711fcbea6597afb65e5925d30a72025cf5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves Redis observability by introducing a hysteresis-based availability state machine (3 consecutive failures to degrade, 2 consecutive successes to recover) and wires command-level success/failure feedback from `cacheUtils` back into the availability tracker.

- **[Improvements]** `recordRedisAvailability` replaces direct `setRedisAvailabilityState` calls with a counter-based debounce, reducing flapping on transient errors
- **[Improvements]** `markRedisCommandSuccess` / `markRedisCommandFailure` exported so real command outcomes supplement the periodic probe
- **[Bug fixes]** Probe timeout raised from 500 ms to 1 000 ms to reduce false-degradation under load

**P1**: `markRedisCommandFailure/Success` updates the global availability state unconditionally, even when a custom `redisInstance` is passed to `tryRedisRead`/`tryRedisWrite`/`tryRedisNx`. Errors on a secondary or test instance can incorrectly flip `shouldUseRedis()` to `false` and disable all Redis-backed features.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after resolving the cross-instance availability contamination issue in cacheUtils.

One P1 finding: failures on a custom Redis instance passed to cacheUtils helpers incorrectly update the global availability state, potentially causing unnecessary Redis-feature blackouts. The remaining findings are P2 style/test improvements. The core hysteresis logic itself is sound.

server/src/utils/cacheUtils/cacheUtils.ts — markRedisCommandFailure/Success should only fire for the primary Redis instance

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/redisAvailability.ts | Adds hysteresis-based state machine (3 failures to degrade, 2 successes to recover) and exports markRedisCommandSuccess/Failure for command-level feedback; the two if-branches in recordRedisAvailability are mutually exclusive and could use else-if. |
| server/src/utils/cacheUtils/cacheUtils.ts | Integrates command-level availability reporting; global state markers are called unconditionally regardless of which Redis instance (primary vs custom) was used, which can cause false degradation of the primary instance. |
| server/tests/unit/cache/cache-utils.test.ts | Adds availability assertions after failure paths; assertions pass trivially due to hasRedisConfig being false in the test environment, leaving hysteresis logic untested. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Redis Command in cacheUtils] -->|success| B[markRedisCommandSuccess]
    A -->|not-ready / error| C[markRedisCommandFailure]
    D[Periodic Probe tickRedisAvailability] -->|ping OK| B
    D -->|ping fail / reconnect fail| C

    B --> E[recordRedisAvailability true]
    C --> F[recordRedisAvailability false]

    E --> G{consecutiveSuccesses >= 2?}
    F --> H{consecutiveFailures >= 3?}

    G -->|yes| I[setRedisAvailabilityState healthy]
    G -->|no| J[no state change]
    H -->|yes| K[setRedisAvailabilityState degraded]
    H -->|no| L[no state change]

    I --> M[shouldUseRedis = true]
    K --> N[shouldUseRedis = false]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/utils/cacheUtils/cacheUtils.ts
Line: 55-56

Comment:
**Global availability state updated for non-primary Redis instances**

`markRedisCommandFailure()` and `markRedisCommandSuccess()` update the single global availability state regardless of which Redis instance experienced the outcome. When callers pass a custom `redisInstance` (e.g. a regional or test instance), errors on that instance will decrement the `consecutiveSuccesses` / increment `consecutiveFailures` counters for the *primary* Redis, potentially flipping `shouldUseRedis()` to `false` and disabling all Redis-backed features cluster-wide. Consider guarding these calls so they only fire when the operation is against the default `redis` instance, or pass the instance context into the marker functions.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/external/redis/initUtils/redisAvailability.ts
Line: 51-54

Comment:
**Mutually exclusive branches should use `else if`**

After updating the counters, the two `if` blocks can never both evaluate to `true` in the same call (a success resets `consecutiveFailures` to 0, a failure resets `consecutiveSuccesses` to 0). Using `else if` communicates this invariant clearly and avoids a redundant second condition check.

```suggestion
	if (consecutiveSuccesses >= REDIS_SUCCESSES_TO_RECOVER)
		setRedisAvailabilityState("healthy");
	else if (consecutiveFailures >= REDIS_FAILURES_TO_DEGRADE)
		setRedisAvailabilityState("degraded");
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/tests/unit/cache/cache-utils.test.ts
Line: 55

Comment:
**New assertions test default state, not the new hysteresis logic**

`markRedisCommandFailure` is gated on `hasRedisConfig`, which is `false` in the test environment (no Redis config). This makes it a no-op during tests, so `shouldUseRedis()` returns `false` and `getRedisAvailability().state` is `"degraded"` trivially (their initial/default values). The new assertions pass without exercising `recordRedisAvailability` at all, meaning the 3-failure degradation and 2-success recovery thresholds have no test coverage. Consider injecting or mocking `hasRedisConfig = true` and resetting the module-level counters in `beforeEach` to write a test that actually drives state transitions.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: redis obserability improvements"](https://github.com/useautumn/autumn/commit/3edee09ba4f035fdc1818c114b98cab7de59428f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29247799)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->