### PR TITLE
chore: no flakely errors on redis

### DIFF
--- a/server/src/utils/cacheUtils/cacheUtils.ts
+++ b/server/src/utils/cacheUtils/cacheUtils.ts
@@ -14,6 +14,12 @@ const markDefaultRedisAvailability = (targetRedis: Redis, available: boolean) =>
 	available ? markRedisCommandSuccess() : markRedisCommandFailure();
 };
 
+const isRedisAvailabilityError = (targetRedis: Redis, error: unknown) => {
+	if (targetRedis.status !== "ready") return true;
+	const message = error instanceof Error ? error.message : String(error);
+	return /ECONN|ETIMEDOUT|timeout|closed|writeable|max retries/i.test(message);
+};
+
 const warnRedisUnavailable = ({
 	source,
 	error,
@@ -68,7 +74,8 @@ export const tryRedisNx = async <TUnavailable, TSuccess, TExists>({
 		if (result === "OK") return await onSuccess();
 		return await onKeyAlreadyExists();
 	} catch (error) {
-		markDefaultRedisAvailability(targetRedis, false);
+		if (isRedisAvailabilityError(targetRedis, error))
+			markDefaultRedisAvailability(targetRedis, false);
 		warnRedisUnavailable({ source: "tryRedisNx:error", error });
 		return await onRedisUnavailable();
 	}
@@ -103,7 +110,8 @@ export const tryRedisWrite = async <T>(
 			? true
 			: T | null;
 	} catch (error) {
-		markDefaultRedisAvailability(targetRedis, false);
+		if (isRedisAvailabilityError(targetRedis, error))
+			markDefaultRedisAvailability(targetRedis, false);
 		warnRedisUnavailable({ source: "tryRedisWrite:error", error });
 		return null as T extends void ? true : T | null;
 	}
@@ -134,7 +142,8 @@ export const tryRedisRead = async <T>(
 		markDefaultRedisAvailability(targetRedis, true);
 		return result;
 	} catch (error) {
-		markDefaultRedisAvailability(targetRedis, false);
+		if (isRedisAvailabilityError(targetRedis, error))
+			markDefaultRedisAvailability(targetRedis, false);
 		warnRedisUnavailable({ source: "tryRedisRead:error", error });
 		return null;
 	}

--- a/server/tests/unit/cache/cache-utils.test.ts
+++ b/server/tests/unit/cache/cache-utils.test.ts
@@ -139,4 +139,16 @@ describe("cache utils", () => {
 
 		expect(getRedisAvailability().state).toBe("healthy");
 	});
+
+	test("Redis command errors do not mark Redis unavailable", async () => {
+		markRedisCommandSuccess();
+		markRedisCommandSuccess();
+		expect(getRedisAvailability().state).toBe("healthy");
+
+		await tryRedisWrite(async () => {
+			throw new Error("ERR user_script:2: unexpected symbol near '#'");
+		});
+
+		expect(getRedisAvailability().state).toBe("healthy");
+	});
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop marking Redis as unavailable for command-level errors. Health now only degrades on real availability issues like connection errors and timeouts.

- **Bug Fixes**
  - Added `isRedisAvailabilityError` to gate availability updates in `tryRedisNx`, `tryRedisWrite`, and `tryRedisRead`.
  - Only mark unavailable when Redis is not ready or errors match connection/timeout patterns.
  - Added a unit test to ensure script/command errors do not flip availability to unhealthy.

<sup>Written for commit 86b5281e8624d309d60d9a63f6d2bd0b35b6aecc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refines Redis error handling in `cacheUtils.ts` by introducing `isRedisAvailabilityError`, which classifies errors as connectivity-related (ECONN, ETIMEDOUT, timeout, closed, writeable, max retries) vs. generic Redis command errors. Only connectivity errors now trigger `markDefaultRedisAvailability(false)`, preventing flaky availability state transitions caused by Lua script errors or other transient command failures. Corresponding unit tests are added to validate the new guard and the recovery/degradation threshold logic.

- **[Bug fixes]** `isRedisAvailabilityError` prevents non-connectivity Redis command errors (e.g. Lua script errors) from incorrectly marking Redis as unavailable.
- **[Improvements]** New unit test suite covers availability thresholds, `tryRedisRead` / `tryRedisWrite` / `tryRedisNx` fallback paths, and isolation of custom vs. default Redis instances.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/test-quality suggestions that do not affect runtime correctness.

The core logic change — guarding `markDefaultRedisAvailability` behind `isRedisAvailabilityError` — is correct and well-tested. Remaining comments are about a potentially misleading log line and test robustness, neither of which blocks production behavior.

No files require special attention; all issues are non-blocking P2 suggestions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/utils/cacheUtils/cacheUtils.ts | Adds `isRedisAvailabilityError` to distinguish connectivity failures from command errors, preventing flaky availability state changes; `warnRedisUnavailable` is still called unconditionally in all catch paths which can produce misleading log messages for non-availability errors. |
| server/tests/unit/cache/cache-utils.test.ts | New unit tests cover availability thresholds, read/write/NX fallback paths, and the new command-error guard; missing warning assertion in the command-error test and no reset of the module-level throttle map between tests creates implicit ordering coupling. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Redis operation called] --> B{targetRedis.status === ready?}
    B -- No --> C[markDefaultRedisAvailability false]
    C --> D[warnRedisUnavailable not-ready]
    D --> E[return onRedisUnavailable / null / fallback]
    B -- Yes --> F[execute operation]
    F --> G{Success?}
    G -- Yes --> H[markDefaultRedisAvailability true]
    H --> I[return result / onSuccess / onKeyAlreadyExists]
    G -- No --> J[isRedisAvailabilityError?]
    J -- Yes --> K[markDefaultRedisAvailability false]
    K --> L[warnRedisUnavailable error]
    J -- No --> L
    L --> E
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/tests/unit/cache/cache-utils.test.ts`, line 47-49 ([link](https://github.com/useautumn/autumn/blob/86b5281e8624d309d60d9a63f6d2bd0b35b6aecc/server/tests/unit/cache/cache-utils.test.ts#L47-L49)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`lastRedisWarningAtBySource` not reset between tests**

   `cacheUtils.ts` throttles repeated warnings via the module-level `lastRedisWarningAtBySource` map (30-second window). `beforeEach` resets `mockState.warnings` but not that map, so if any two tests share the same `source` string, the second test will silently swallow the warning and the `toHaveLength(1)` assertions will fail. Current sources are all unique, so tests pass today, but this is a fragile implicit coupling. Consider exporting a `resetCacheUtilsState()` test-helper (or using bun module isolation) to reset the throttle map before each test.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/tests/unit/cache/cache-utils.test.ts
   Line: 47-49

   Comment:
   **`lastRedisWarningAtBySource` not reset between tests**

   `cacheUtils.ts` throttles repeated warnings via the module-level `lastRedisWarningAtBySource` map (30-second window). `beforeEach` resets `mockState.warnings` but not that map, so if any two tests share the same `source` string, the second test will silently swallow the warning and the `toHaveLength(1)` assertions will fail. Current sources are all unique, so tests pass today, but this is a fragile implicit coupling. Consider exporting a `resetCacheUtilsState()` test-helper (or using bun module isolation) to reset the throttle map before each test.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/utils/cacheUtils/cacheUtils.ts
Line: 76-81

Comment:
**`warnRedisUnavailable` called for command errors, not just availability errors**

`warnRedisUnavailable` is invoked in every `catch` block unconditionally, so a Lua script error (or any other Redis command error that is explicitly excluded from marking Redis unavailable) still produces a `"[redis] operation unavailable"` log entry. This can be misleading — Redis is healthy, but the log implies it isn't. Consider guarding the warn call the same way `markDefaultRedisAvailability` is guarded, or using a different log message/source when the error is a command error rather than a connectivity error.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/tests/unit/cache/cache-utils.test.ts
Line: 143-153

Comment:
**Missing warning assertion for command-error test**

The test verifies the availability state stays `"healthy"` when a non-connectivity Redis error is thrown, but it doesn't assert whether `mockState.warnings` was populated. Since `beforeEach` resets `mockState.warnings`, it is easy to add an assertion here. If the intent is that command errors should *not* emit a `"[redis] operation unavailable"` warning (only availability errors should), add `expect(mockState.warnings).toHaveLength(0)`. If warning is acceptable, add `expect(mockState.warnings).toHaveLength(1)` to at least pin the behavior explicitly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/tests/unit/cache/cache-utils.test.ts
Line: 47-49

Comment:
**`lastRedisWarningAtBySource` not reset between tests**

`cacheUtils.ts` throttles repeated warnings via the module-level `lastRedisWarningAtBySource` map (30-second window). `beforeEach` resets `mockState.warnings` but not that map, so if any two tests share the same `source` string, the second test will silently swallow the warning and the `toHaveLength(1)` assertions will fail. Current sources are all unique, so tests pass today, but this is a fragile implicit coupling. Consider exporting a `resetCacheUtilsState()` test-helper (or using bun module isolation) to reset the throttle map before each test.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: no flakely errors on redis"](https://github.com/useautumn/autumn/commit/86b5281e8624d309d60d9a63f6d2bd0b35b6aecc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29252186)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->