### PR TITLE
chore: no middleware on health endpoint

### DIFF
--- a/server/src/db/dbUtils.ts
+++ b/server/src/db/dbUtils.ts
@@ -20,6 +20,9 @@ const getErrorCode = ({ error }: { error: unknown }): string | null => {
 	return typeof code === "string" ? code : null;
 };
 
+const getErrorMessage = ({ error }: { error: unknown }): string | null =>
+	error instanceof Error ? error.message : null;
+
 /**
  * PostgreSQL SQLSTATE code prefixes that indicate infrastructure issues.
  * - Class 08: Connection Exception (connection lost, refused, broken pipe)
@@ -60,6 +63,8 @@ const RETRYABLE_PG_CODES = new Set([
  */
 export const isRetryableDbError = ({ error }: { error: unknown }): boolean => {
 	const code = getErrorCode({ error });
+	if (getErrorMessage({ error }) === "timeout exceeded when trying to connect")
+		return true;
 	if (!code) return false;
 
 	if (RETRYABLE_PG_CODES.has(code)) return true;

--- a/server/src/db/dbUtils.ts
+++ b/server/src/db/dbUtils.ts
@@ -61,7 +61,7 @@ const RETRYABLE_PG_CODES = new Set([
  * resolve on retry (connection lost, timeout, resource exhaustion, etc.).
  * Returns false for application errors (constraint violations, syntax errors, etc.).
  */
-export const isRetryableDbError = ({ error }: { error: unknown }): boolean => {
+export const isTransientDbError = ({ error }: { error: unknown }): boolean => {
 	const code = getErrorCode({ error });
 	if (getErrorMessage({ error }) === "timeout exceeded when trying to connect")
 		return true;

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -83,6 +83,7 @@ export const createHonoApp = () => {
 
 	app.get("/stripe/oauth_callback", handleOAuthCallback);
 	app.get("/ready/:token", handleReadyCheck);
+	app.get("/", handleHealthCheck);
 
 	// Step 1: OTel HTTP span + base middleware + span enrichment
 	app.use(
@@ -95,8 +96,6 @@ export const createHonoApp = () => {
 	app.use("*", baseMiddleware);
 	app.use("*", replicaDbMiddleware);
 	app.use("*", traceEnrichMiddleware);
-
-	app.get("/", handleHealthCheck);
 
 	// Public endpoint to get OAuth client name (for consent page)
 	app.get("/oauth/client/:client_id", async (c) => {

--- a/server/src/internal/api/check/checkUtils/getCheckDataOrFallbackResponse.ts
+++ b/server/src/internal/api/check/checkUtils/getCheckDataOrFallbackResponse.ts
@@ -1,5 +1,5 @@
 import type { CheckParams, ParsedCheckParams } from "@autumn/shared";
-import { isRetryableDbError } from "@/db/dbUtils.js";
+import { isTransientDbError } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { CheckData } from "../checkTypes/CheckData.js";
 import { getCheckFailOpenFallback } from "./getCheckFailOpenFallback.js";
@@ -36,7 +36,7 @@ export const getCheckDataOrFallbackResponse = async ({
 			fallbackResponse: null,
 		};
 	} catch (error) {
-		if (!isRetryableDbError({ error })) {
+		if (!isTransientDbError({ error })) {
 			throw error;
 		}
 

--- a/server/src/internal/misc/rollouts/fullSubjectRolloutUtils.ts
+++ b/server/src/internal/misc/rollouts/fullSubjectRolloutUtils.ts
@@ -1,4 +1,4 @@
-import { isRetryableDbError } from "@/db/dbUtils.js";
+import { isTransientDbError } from "@/db/dbUtils.js";
 import type { AutumnContext, RolloutSnapshot } from "@/honoUtils/HonoEnv.js";
 
 export const FULL_SUBJECT_ROLLOUT_ID = "v2-cache";
@@ -26,7 +26,7 @@ export const isRetryableFullSubjectRolloutError = ({
 }: {
 	error: unknown;
 }) =>
-	isRetryableDbError({ error }) ||
+	isTransientDbError({ error }) ||
 	(error instanceof Error &&
 		(RETRYABLE_REDIS_ERROR_NAMES.has(error.name) ||
 			error.message === "Command timed out"));

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -2,7 +2,7 @@ import type { Message } from "@aws-sdk/client-sqs";
 import * as Sentry from "@sentry/bun";
 import chalk from "chalk";
 import type { Logger } from "pino";
-import { isRetryableDbError } from "@/db/dbUtils.js";
+import { isTransientDbError } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -279,7 +279,7 @@ export const processMessage = async ({
 		if (
 			(job.name === JobName.SyncBalanceBatchV3 ||
 				job.name === JobName.SyncBalanceBatchV4) &&
-			isRetryableDbError({ error })
+			isTransientDbError({ error })
 		) {
 			Sentry.captureException(error);
 			errorLogger.error(`[${job.name}] Retryable DB error, keeping in SQS`, {

--- a/server/tests/unit/rollouts/fullSubjectRolloutUtils.test.ts
+++ b/server/tests/unit/rollouts/fullSubjectRolloutUtils.test.ts
@@ -10,6 +10,14 @@ describe("fullSubjectRolloutUtils", () => {
 		).toBe(true);
 	});
 
+	test("treats DB connect timeouts without a code as retryable rollout errors", () => {
+		expect(
+			isRetryableFullSubjectRolloutError({
+				error: new Error("timeout exceeded when trying to connect"),
+			}),
+		).toBe(true);
+	});
+
 	test("treats ioredis max retries as a retryable rollout error", () => {
 		expect(
 			isRetryableFullSubjectRolloutError({


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the `GET /` health check route registration to before the middleware stack (OTel instrumentation, `baseMiddleware`, `replicaDbMiddleware`, `traceEnrichMiddleware`), matching the pattern already used for `/stripe/oauth_callback` and `/ready/:token`. Since `handleHealthCheck` simply returns a static text response with no dependency on middleware-injected context, the change is safe and reduces unnecessary overhead on every load-balancer probe.

**Key changes:**
- [Improvements] Exempts the `GET /` health check endpoint from OTel, base, replica DB, and trace-enrich middleware overhead
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, intentional route-ordering change with no logic impact.

The only changed file moves a static health-check route before the middleware block. The handler has no dependency on any middleware-injected context, so there is no risk of runtime errors. No P0/P1 findings were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/initHono.ts | Moves `app.get("/", handleHealthCheck)` registration to before the middleware stack; handler uses no middleware context so the change is safe and reduces overhead on health probes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant LB as Load Balancer
    participant App as Hono App

    note over App: CORS middleware (*) always runs

    LB->>App: GET /
    note over App: Route matched BEFORE middleware stack
    App-->>LB: 200 "Hello from Autumn 🍂🍂🍂"

    note over App: OTel / baseMiddleware / replicaDb / traceEnrich skipped for GET /

    LB->>App: GET /ready/:token
    note over App: Also matched BEFORE middleware stack
    App-->>LB: 200 (ready response)

    LB->>App: GET /v1/...
    note over App: Passes through full middleware stack
    App-->>LB: response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: no middleware on health endpoint"](https://github.com/useautumn/autumn/commit/0b1deca75aa8846c886608829398f736ba589c1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29257369)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the `"/"` health check route before middleware so it runs with no middleware. Renamed the DB error helper to `isTransientDbError` and now treat "timeout exceeded when trying to connect" as transient (with unit test) to prevent rollout failures from flaky connections.

<sup>Written for commit ab0eaca220b2a56e528195394cbb1d31f3ac928b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

