### PR TITLE
chore: add more transient error messages

### DIFF
--- a/server/src/db/dbUtils.ts
+++ b/server/src/db/dbUtils.ts
@@ -23,6 +23,14 @@ const getErrorCode = ({ error }: { error: unknown }): string | null => {
 const getErrorMessage = ({ error }: { error: unknown }): string | null =>
 	error instanceof Error ? error.message : null;
 
+const TRANSIENT_DB_ERROR_MESSAGES = new Set([
+	"timeout exceeded when trying to connect",
+	"Query read timeout",
+	"Connection terminated due to connection timeout",
+	"canceling statement due to lock timeout",
+	"canceling statement due to statement timeout",
+]);
+
 /**
  * PostgreSQL SQLSTATE code prefixes that indicate infrastructure issues.
  * - Class 08: Connection Exception (connection lost, refused, broken pipe)
@@ -63,8 +71,8 @@ const RETRYABLE_PG_CODES = new Set([
  */
 export const isTransientDbError = ({ error }: { error: unknown }): boolean => {
 	const code = getErrorCode({ error });
-	if (getErrorMessage({ error }) === "timeout exceeded when trying to connect")
-		return true;
+	const message = getErrorMessage({ error });
+	if (message && TRANSIENT_DB_ERROR_MESSAGES.has(message)) return true;
 	if (!code) return false;
 
 	if (RETRYABLE_PG_CODES.has(code)) return true;

--- a/server/tests/unit/rollouts/fullSubjectRolloutUtils.test.ts
+++ b/server/tests/unit/rollouts/fullSubjectRolloutUtils.test.ts
@@ -10,12 +10,15 @@ describe("fullSubjectRolloutUtils", () => {
 		).toBe(true);
 	});
 
-	test("treats DB connect timeouts without a code as retryable rollout errors", () => {
-		expect(
-			isRetryableFullSubjectRolloutError({
-				error: new Error("timeout exceeded when trying to connect"),
-			}),
-		).toBe(true);
+	test.each([
+		"timeout exceeded when trying to connect",
+		"Query read timeout",
+		"Connection terminated due to connection timeout",
+		"canceling statement due to lock timeout",
+		"canceling statement due to statement timeout",
+	])("treats no-code DB timeout as retryable: %s", (message) => {
+		expect(isRetryableFullSubjectRolloutError({ error: new Error(message) }))
+			.toBe(true);
 	});
 
 	test("treats ioredis max retries as a retryable rollout error", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand transient database error detection to include common timeout messages without SQLSTATE codes so rollouts retry instead of failing. Updated tests to cover these cases.

- **Bug Fixes**
  - Treat these messages as transient via a Set: "timeout exceeded when trying to connect", "Query read timeout", "Connection terminated due to connection timeout", "canceling statement due to lock timeout", "canceling statement due to statement timeout".
  - Parameterized unit tests to assert retry behavior for each message.

<sup>Written for commit 672bddf93c731f59b3c797bceeed89c47a369782. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the transient DB error detection logic in `isTransientDbError` to also match errors by message text (for cases where the error has no SQLSTATE code), adding 5 new message strings to a `TRANSIENT_DB_ERROR_MESSAGES` set. Corresponding tests are added via `fullSubjectRolloutUtils.test.ts`.

**[Improvements]** Added message-based transient error detection for timeout/lock errors that may arrive without a SQLSTATE code (`"canceling statement due to lock timeout"`, `"Query read timeout"`, etc.).

**[Improvements]** Test coverage expanded with `test.each` covering all 5 new messages, ioredis `MaxRetriesPerRequestError`, and a `"Command timed out"` redis case.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive, well-tested, and the logic is correct.

No P0 or P1 issues found. The message-based detection is a straightforward additive guard with exact-string matching, all 5 new messages have corresponding test coverage, and the broader error-detection flow remains unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/dbUtils.ts | Adds TRANSIENT_DB_ERROR_MESSAGES set with 5 message strings; isTransientDbError now checks message match before code match — logic is correct and well-documented. |
| server/tests/unit/rollouts/fullSubjectRolloutUtils.test.ts | Adds test.each covering all 5 new transient message strings plus ioredis error cases; covers the application-error negative case. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[isTransientDbError called] --> B[getErrorCode + getErrorMessage]
    B --> C{message in TRANSIENT_DB_ERROR_MESSAGES?}
    C -- Yes --> D[return true]
    C -- No --> E{code is null?}
    E -- Yes --> F[return false]
    E -- No --> G{code in RETRYABLE_PG_CODES?}
    G -- Yes --> D
    G -- No --> H{code starts with 08 or 53?}
    H -- Yes --> D
    H -- No --> I[return false]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: merge remote-tracking branch &#39;ori..."](https://github.com/useautumn/autumn/commit/672bddf93c731f59b3c797bceeed89c47a369782) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29260320)</sub>

<!-- /greptile_comment -->