### PR TITLE
chore: add worker dying logs

### DIFF
--- a/server/src/db/redactDatabaseUrl.ts
+++ b/server/src/db/redactDatabaseUrl.ts
@@ -3,12 +3,15 @@ import { createHash } from "node:crypto";
 const hash = (value: string) =>
 	createHash("sha256").update(value).digest("hex").slice(0, 12);
 
+const mask = (value: string) =>
+	value.length <= 2 ? "***" : `${value[0]}***${value[value.length - 1]}`;
+
 const auth = (url: URL) => {
 	const username = decodeURIComponent(url.username);
 	const password = decodeURIComponent(url.password);
 	if (!username && !password) return "";
 
-	return `${username}${password ? ":***" : ""}@`;
+	return `${username ? mask(username) : ""}${password ? `:${mask(password)}` : ""}@`;
 };
 
 const formatUrl = (value: string) => {

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -38,6 +38,8 @@ import { startMemoryMonitor } from "./utils/memoryMonitor.js";
 
 checkEnvVars();
 
+let shuttingDown = false;
+
 const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 	logger.info(getRedactedDatabaseUrls(), "DB URLs");
 
@@ -89,8 +91,14 @@ if (process.env.NODE_ENV === "development") {
 			cluster.fork();
 		}
 
-		cluster.on("exit", (worker, _code, _signal) => {
-			logger.error(`WORKER DIED: ${worker.process.pid}`);
+		cluster.on("exit", (worker, code, signal) => {
+			logger.error("WORKER DIED", {
+				pid: worker.process.pid,
+				code,
+				signal,
+				exitedAfterDisconnect: worker.exitedAfterDisconnect,
+			});
+			if (shuttingDown) return;
 			cluster.fork();
 		});
 
@@ -108,6 +116,7 @@ function registerShutdownHandlers() {
 }
 
 async function gracefulShutdown() {
+	shuttingDown = true;
 	console.log("Shutting down worker, flushing telemetry and closing DB...");
 	try {
 		// Flush any buffered OTel spans before shutting down


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves observability and shutdown behaviour in the cluster primary process. Worker exit events now log structured fields (`pid`, `code`, `signal`, `exitedAfterDisconnect`) instead of a plain string, and a `shuttingDown` flag prevents the primary from forking replacement workers once a graceful shutdown has begun.

**Key changes:**
- [Improvements] Structured `logger.error` call on worker exit with `code`, `signal`, and `exitedAfterDisconnect` fields for easier log filtering.
- [Improvements] `shuttingDown` flag set at the top of `gracefulShutdown` ensures workers that die during planned shutdown are not replaced.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive, well-scoped, and fix a real restart-loop risk during shutdown.

No P0/P1 findings. The `shuttingDown` flag is set synchronously as the first statement in `gracefulShutdown`, so there is no race window. Structured logging is strictly additive. All remaining considerations are cosmetic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/init.ts | Adds structured logging for worker exit events and a `shuttingDown` guard to prevent re-forking workers during graceful shutdown. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant OS as OS / Orchestrator
    participant Primary as Cluster Primary
    participant Worker as Worker Process

    OS->>Primary: SIGTERM
    Primary->>Primary: gracefulShutdown() — shuttingDown = true
    Primary->>Worker: (workers receive SIGTERM)
    Worker-->>Primary: cluster "exit" event
    Primary->>Primary: shuttingDown? → skip cluster.fork()
    Primary->>Primary: shutdown DB, OTel, Redis…
    Primary->>Primary: process.exit(0)

    Note over Primary,Worker: Without shuttingDown guard (old behaviour)
    Worker-->>Primary: cluster "exit" event
    Primary->>Primary: cluster.fork() ← unwanted new worker
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add worker dying logs"](https://github.com/useautumn/autumn/commit/25a4ce065b343f696d9c343bea3d4f4407aee8bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29265740)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured worker-exit logs (pid, code, signal, exitedAfterDisconnect) and guard against auto-refork during graceful shutdown. Also harden DB URL redaction by masking usernames and passwords (first/last char with ***) to fix failing tests and keep logs safe.

<sup>Written for commit 23aec5a6f49d9eb15367f0169f8274d15dae710a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

