### PR TITLE
chore: add more logs bruh

### DIFF
--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -76,6 +76,7 @@ const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 };
 
 if (process.env.NODE_ENV === "development") {
+	registerFatalErrorHandlers();
 	await init({ startupStartedAt: Date.now() });
 	registerShutdownHandlers();
 } else {
@@ -104,9 +105,30 @@ if (process.env.NODE_ENV === "development") {
 
 		registerShutdownHandlers();
 	} else {
+		registerFatalErrorHandlers();
 		await init({ startupStartedAt: Date.now() });
 		registerShutdownHandlers();
 	}
+}
+
+function registerFatalErrorHandlers() {
+	const logFatal = (event: string, error: unknown) => {
+		logger.error(event, {
+			error:
+				error instanceof Error
+					? { name: error.name, message: error.message, stack: error.stack }
+					: error,
+		});
+	};
+
+	process.on("uncaughtException", (error) => {
+		logFatal("WORKER FATAL uncaughtException", error);
+		process.exit(1);
+	});
+	process.on("unhandledRejection", (reason) => {
+		logFatal("WORKER FATAL unhandledRejection", reason);
+		process.exit(1);
+	});
 }
 
 function registerShutdownHandlers() {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add fatal error handlers to log uncaught exceptions and unhandled rejections and then exit, improving crash diagnostics in development and production.

- **Bug Fixes**
  - Introduced registerFatalErrorHandlers() to log structured errors and exit(1) on uncaughtException/unhandledRejection.
  - Registered the handlers before init in both dev and prod paths for early coverage.

<sup>Written for commit 57c4e350f4d9580ace83bc6019aa3cdc206f5759. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds structured fatal-error logging to `server/src/init.ts` by introducing `registerFatalErrorHandlers()`, which catches `uncaughtException` and `unhandledRejection` events and logs them via the structured `logger` before exiting.

- **Improvements**: `registerFatalErrorHandlers()` is correctly wired for the dev path and worker processes, improving observability for fatal crashes in those contexts.
- **Bug fixes**: The primary/master process in production (`cluster.isPrimary` branch) never calls `registerFatalErrorHandlers()`, meaning unhandled crashes there are still silent — this appears to be an oversight given the PR's intent.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the missing registerFatalErrorHandlers() call on the primary process.

One P1 finding: the primary cluster process is left without fatal error handlers, directly contradicting the purpose of this PR. The OTel flush omission is P2. Both are straightforward fixes.

server/src/init.ts — specifically the cluster.isPrimary branch (lines 85–106).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/init.ts | Adds `registerFatalErrorHandlers` for uncaughtException/unhandledRejection with structured logging; one P1 gap — primary process in production never calls this function, so master crashes are still unlogged. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Process starts] --> B{NODE_ENV === development?}
    B -- Yes --> C[registerFatalErrorHandlers ✅]
    C --> D[init]
    D --> E[registerShutdownHandlers]

    B -- No --> F{cluster.isPrimary?}
    F -- Yes --> G[❌ NO registerFatalErrorHandlers]
    G --> H[Fork workers x3]
    H --> I[cluster.on exit → logger.error + fork]
    I --> J[registerShutdownHandlers]

    F -- No --> K[registerFatalErrorHandlers ✅]
    K --> L[init]
    L --> M[registerShutdownHandlers]

    style G fill:#ff6b6b,color:#fff
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/init.ts`, line 85-106 ([link](https://github.com/useautumn/autumn/blob/57c4e350f4d9580ace83bc6019aa3cdc206f5759/server/src/init.ts#L85-L106)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Primary process missing fatal error handlers**

   `registerFatalErrorHandlers()` is called for the development path (line 79) and for worker processes (line 108), but not for the primary/master process in production. If the primary process encounters an uncaught exception or unhandled rejection — e.g. during the `cluster.fork()` loop or in the `cluster.on("exit", …)` callback — it will crash silently without emitting a structured log entry. Since this PR's intent is precisely to ensure fatal errors surface in logs, the primary branch appears to have been overlooked.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/init.ts
   Line: 85-106

   Comment:
   **Primary process missing fatal error handlers**

   `registerFatalErrorHandlers()` is called for the development path (line 79) and for worker processes (line 108), but not for the primary/master process in production. If the primary process encounters an uncaught exception or unhandled rejection — e.g. during the `cluster.fork()` loop or in the `cluster.on("exit", …)` callback — it will crash silently without emitting a structured log entry. Since this PR's intent is precisely to ensure fatal errors surface in logs, the primary branch appears to have been overlooked.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/init.ts
Line: 85-106

Comment:
**Primary process missing fatal error handlers**

`registerFatalErrorHandlers()` is called for the development path (line 79) and for worker processes (line 108), but not for the primary/master process in production. If the primary process encounters an uncaught exception or unhandled rejection — e.g. during the `cluster.fork()` loop or in the `cluster.on("exit", …)` callback — it will crash silently without emitting a structured log entry. Since this PR's intent is precisely to ensure fatal errors surface in logs, the primary branch appears to have been overlooked.

```suggestion
	if (cluster.isPrimary) {
		registerFatalErrorHandlers();
		console.log(`Master ${process.pid} is running`);
		console.log("Number of CPUs", numCPUs);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/init.ts
Line: 124-131

Comment:
**Fatal handlers exit without flushing OTel spans**

Both the `uncaughtException` and `unhandledRejection` handlers call `process.exit(1)` directly after logging, without awaiting `otelSdk.shutdown()`. Any buffered OpenTelemetry spans (including the error log just written) may be silently dropped. The graceful shutdown path already handles this; a quick flush here would improve observability for the cases where it matters most.

```suggestion
	process.on("uncaughtException", async (error) => {
		logFatal("WORKER FATAL uncaughtException", error);
		if (otelSdk) await otelSdk.shutdown().catch(() => {});
		process.exit(1);
	});
	process.on("unhandledRejection", async (reason) => {
		logFatal("WORKER FATAL unhandledRejection", reason);
		if (otelSdk) await otelSdk.shutdown().catch(() => {});
		process.exit(1);
	});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add more logs bruh"](https://github.com/useautumn/autumn/commit/57c4e350f4d9580ace83bc6019aa3cdc206f5759) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29268140)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->