### PR TITLE
chore: lua script upstash shebang cleanup

### DIFF
--- a/server/src/_luaScriptsV2/luaScriptsV2.ts
+++ b/server/src/_luaScriptsV2/luaScriptsV2.ts
@@ -4,52 +4,52 @@ import { FULL_CUSTOMER_CACHE_VERSION } from "@/internal/customers/cusUtils/fullC
 // HELPER MODULES (imported as text — works with both Bun and esbuild)
 // ============================================================================
 
-import LUA_UTILS from "./luaUtils.lua";
-import FULL_CUSTOMER_UTILS from "./fullCustomer/fullCustomerUtils.lua";
-import READ_BALANCES from "./deductFromCustomerEntitlements/readBalances.lua";
 import CONTEXT_UTILS from "./deductFromCustomerEntitlements/contextUtils.lua";
-import GET_TOTAL_BALANCE from "./deductFromCustomerEntitlements/getTotalBalance.lua";
-import DEDUCT_FROM_ROLLOVERS from "./deductFromCustomerEntitlements/deductFromRollovers.lua";
 import DEDUCT_FROM_MAIN_BALANCE from "./deductFromCustomerEntitlements/deductFromMainBalance.lua";
+import DEDUCT_FROM_ROLLOVERS from "./deductFromCustomerEntitlements/deductFromRollovers.lua";
+import GET_TOTAL_BALANCE from "./deductFromCustomerEntitlements/getTotalBalance.lua";
+import READ_BALANCES from "./deductFromCustomerEntitlements/readBalances.lua";
 import RUN_DEDUCTION_ON_CONTEXT from "./deductFromCustomerEntitlements/runDeductionOnContext.lua";
 import SPEND_LIMIT_UTILS from "./deductFromCustomerEntitlements/spendLimitUtils.lua";
-import MUTATION_ITEM_UTILS from "./deduction/mutationItemUtils.lua";
 import LOCK_RECEIPT_UTILS from "./deduction/lock/lockReceipt.lua";
 import LOCK_STATE_UTILS from "./deduction/lock/lockStateUtils.lua";
 import LOCK_UNWIND_UTILS from "./deduction/lock/unwindLockUtils.lua";
+import MUTATION_ITEM_UTILS from "./deduction/mutationItemUtils.lua";
+import FULL_CUSTOMER_UTILS from "./fullCustomer/fullCustomerUtils.lua";
 import LOCK_UNWIND_UTILS_V2 from "./fullSubjectDeduction/lock/unwindLockV2.lua";
+import LUA_UTILS from "./luaUtils.lua";
 
 // ============================================================================
 // FULL SUBJECT HELPERS (V2 cache scripts)
 // ============================================================================
 
+import adjustSubjectBalanceMainScript from "./fullSubject/adjustSubjectBalance.lua";
 import setCachedFullSubjectScript from "./fullSubject/setCachedFullSubject.lua";
-import updateCustomerDataV2Script from "./fullSubject/updateCustomerDataV2.lua";
-import updateEntityDataV2Script from "./fullSubject/updateEntityDataV2.lua";
 import updateCachedInvoiceV2Script from "./fullSubject/updateCachedInvoice.lua";
+import updateCustomerDataV2Script from "./fullSubject/updateCustomerDataV2.lua";
 import updateCustomerProductOptionsScript from "./fullSubject/updateCustomerProduct/updateCustomerProductOptions.lua";
 import updateCustomerProductV2MainScript from "./fullSubject/updateCustomerProduct/updateCustomerProductV2.lua";
-import adjustSubjectBalanceMainScript from "./fullSubject/adjustSubjectBalance.lua";
+import updateEntityDataV2Script from "./fullSubject/updateEntityDataV2.lua";
 
 // ============================================================================
 // FULL SUBJECT DEDUCTION HELPERS (V2 cache — per-feature hash balances)
 // ============================================================================
 
-import READ_SUBJECT_BALANCES from "./fullSubjectDeduction/readSubjectBalances.lua";
 import CONTEXT_UTILS_V2 from "./fullSubjectDeduction/contextUtilsV2.lua";
-import DEDUCT_FROM_ROLLOVERS_V2 from "./fullSubjectDeduction/deductFromRolloversV2.lua";
 import DEDUCT_FROM_MAIN_BALANCE_V2 from "./fullSubjectDeduction/deductFromMainBalanceV2.lua";
+import DEDUCT_FROM_ROLLOVERS_V2 from "./fullSubjectDeduction/deductFromRolloversV2.lua";
+import DEDUCT_FROM_SUBJECT_BALANCES_MAIN from "./fullSubjectDeduction/deductFromSubjectBalances.lua";
+import READ_SUBJECT_BALANCES from "./fullSubjectDeduction/readSubjectBalances.lua";
 import RUN_DEDUCTION_ON_CONTEXT_V2 from "./fullSubjectDeduction/runDeductionOnContextV2.lua";
 import SPEND_LIMIT_UTILS_V2 from "./fullSubjectDeduction/spendLimitUtilsV2.lua";
 import UPDATE_AGGREGATED_BALANCES from "./fullSubjectDeduction/updateAggregatedBalances.lua";
-import DEDUCT_FROM_SUBJECT_BALANCES_MAIN from "./fullSubjectDeduction/deductFromSubjectBalances.lua";
 
 // ============================================================================
 // UPDATE SUBJECT BALANCES HELPERS (V2 cache — per-feature hash updates)
 // ============================================================================
 
-import UPDATE_CONTEXT_UTILS from "./fullSubject/updateSubjectBalances/updateContextUtils.lua";
 import APPLY_FIELD_UPDATES from "./fullSubject/updateSubjectBalances/applyFieldUpdates.lua";
+import UPDATE_CONTEXT_UTILS from "./fullSubject/updateSubjectBalances/updateContextUtils.lua";
 import UPDATE_SUBJECT_BALANCES_MAIN from "./fullSubject/updateSubjectBalances/updateSubjectBalances.lua";
 
 // ============================================================================
@@ -113,19 +113,19 @@ export const SET_FULL_CUSTOMER_CACHE_SCRIPT = `${FULL_CUSTOMER_KEY_BUILDERS}
 ${setFullCustomerCacheScript}`;
 
 /** Atomically set a FullSubject cache: subject view + all balance hashes. */
-export const SET_CACHED_FULL_SUBJECT_SCRIPT = `${UPSTASH_KEY_LOCKING_SHEBANG}${setCachedFullSubjectScript}`;
+export const SET_CACHED_FULL_SUBJECT_SCRIPT = `${setCachedFullSubjectScript}`;
 
 /** Atomically update top-level customer fields in the cached FullSubject. */
-export const UPDATE_CUSTOMER_DATA_V2_SCRIPT = `${UPSTASH_KEY_LOCKING_SHEBANG}${updateCustomerDataV2Script}`;
+export const UPDATE_CUSTOMER_DATA_V2_SCRIPT = `${updateCustomerDataV2Script}`;
 
 /** Atomically update top-level entity fields in the cached FullSubject. */
-export const UPDATE_ENTITY_DATA_V2_SCRIPT = `${UPSTASH_KEY_LOCKING_SHEBANG}${updateEntityDataV2Script}`;
+export const UPDATE_ENTITY_DATA_V2_SCRIPT = `${updateEntityDataV2Script}`;
 
 /** Atomically upsert an invoice in the cached FullSubject invoices array. */
-export const UPDATE_CACHED_INVOICE_V2_SCRIPT = `${UPSTASH_KEY_LOCKING_SHEBANG}${updateCachedInvoiceV2Script}`;
+export const UPDATE_CACHED_INVOICE_V2_SCRIPT = `${updateCachedInvoiceV2Script}`;
 
 /** Atomically update customer product fields in the cached FullSubject. */
-export const UPDATE_CUSTOMER_PRODUCT_V2_SCRIPT = `${UPSTASH_KEY_LOCKING_SHEBANG}${updateCustomerProductOptionsScript}
+export const UPDATE_CUSTOMER_PRODUCT_V2_SCRIPT = `${updateCustomerProductOptionsScript}
 ${updateCustomerProductV2MainScript}`;
 
 // ============================================================================
@@ -169,20 +169,24 @@ export const UPDATE_CUSTOMER_DATA_SCRIPT = `${LUA_UTILS}
 ${updateCustomerDataMainScript}`;
 
 import APPEND_ENTITY_TO_CUSTOMER_SCRIPT_RAW from "./customers/appendEntityToCustomer.lua";
-export const APPEND_ENTITY_TO_CUSTOMER_SCRIPT = APPEND_ENTITY_TO_CUSTOMER_SCRIPT_RAW;
+export const APPEND_ENTITY_TO_CUSTOMER_SCRIPT =
+	APPEND_ENTITY_TO_CUSTOMER_SCRIPT_RAW;
 
 import UPDATE_ENTITY_IN_CUSTOMER_SCRIPT_RAW from "./customers/updateEntityInCustomer.lua";
-export const UPDATE_ENTITY_IN_CUSTOMER_SCRIPT = UPDATE_ENTITY_IN_CUSTOMER_SCRIPT_RAW;
+export const UPDATE_ENTITY_IN_CUSTOMER_SCRIPT =
+	UPDATE_ENTITY_IN_CUSTOMER_SCRIPT_RAW;
 
 import UPSERT_INVOICE_IN_CUSTOMER_SCRIPT_RAW from "./customers/upsertInvoice.lua";
-export const UPSERT_INVOICE_IN_CUSTOMER_SCRIPT = UPSERT_INVOICE_IN_CUSTOMER_SCRIPT_RAW;
+export const UPSERT_INVOICE_IN_CUSTOMER_SCRIPT =
+	UPSERT_INVOICE_IN_CUSTOMER_SCRIPT_RAW;
 
 // ============================================================================
 // CUSTOMER PRODUCT SCRIPTS
 // ============================================================================
 
 import UPDATE_CUSTOMER_PRODUCT_SCRIPT_RAW from "./customerProducts/updateCustomerProduct.lua";
-export const UPDATE_CUSTOMER_PRODUCT_SCRIPT = UPDATE_CUSTOMER_PRODUCT_SCRIPT_RAW;
+export const UPDATE_CUSTOMER_PRODUCT_SCRIPT =
+	UPDATE_CUSTOMER_PRODUCT_SCRIPT_RAW;
 
 // ============================================================================
 // FULL SUBJECT DEDUCTION SCRIPT (V2 cache — per-feature hash balances)
@@ -193,7 +197,7 @@ export const UPDATE_CUSTOMER_PRODUCT_SCRIPT = UPDATE_CUSTOMER_PRODUCT_SCRIPT_RAW
  * Reads from per-feature hash fields and writes back touched entitlements.
  * Composed from shared helper modules + V2-specific storage adapters.
  */
-export const DEDUCT_FROM_SUBJECT_BALANCES_SCRIPT = `${UPSTASH_KEY_LOCKING_SHEBANG}${LUA_UTILS}
+export const DEDUCT_FROM_SUBJECT_BALANCES_SCRIPT = `${LUA_UTILS}
 ${READ_SUBJECT_BALANCES}
 ${CONTEXT_UTILS_V2}
 ${GET_TOTAL_BALANCE}
@@ -217,7 +221,7 @@ ${DEDUCT_FROM_SUBJECT_BALANCES_MAIN}`;
  * per-feature hash. Emits entity-level mutation logs so aggregated balances
  * stay in sync.
  */
-export const ADJUST_SUBJECT_BALANCE_SCRIPT = `${UPSTASH_KEY_LOCKING_SHEBANG}${LUA_UTILS}
+export const ADJUST_SUBJECT_BALANCE_SCRIPT = `${LUA_UTILS}
 ${UPDATE_CONTEXT_UTILS}
 ${UPDATE_AGGREGATED_BALANCES}
 ${adjustSubjectBalanceMainScript}`;
@@ -229,7 +233,7 @@ ${adjustSubjectBalanceMainScript}`;
  * aggregated balance propagation.
  * Called once per feature via pipeline.
  */
-export const UPDATE_SUBJECT_BALANCES_SCRIPT = `${UPSTASH_KEY_LOCKING_SHEBANG}${LUA_UTILS}
+export const UPDATE_SUBJECT_BALANCES_SCRIPT = `${LUA_UTILS}
 ${UPDATE_CONTEXT_UTILS}
 ${APPLY_FIELD_UPDATES}
 ${UPDATE_AGGREGATED_BALANCES}

--- a/server/src/external/redis/initRedisV2.ts
+++ b/server/src/external/redis/initRedisV2.ts
@@ -8,8 +8,8 @@ import {
 	waitForRedisReady,
 } from "./initRedis.js";
 import {
-	getAlternateRedisV2ConnectionConfig,
 	getRedisV2ConnectionConfig,
+	supportsUpstashShebangForRedisV2,
 } from "./initUtils/redisV2Config.js";
 
 const redisV2Config = getRedisV2ConnectionConfig({
@@ -47,9 +47,11 @@ export const getAlternateRedisV2Instance = (
 	const existing = instancePool.get(name);
 	if (existing) return existing;
 
-	const instance = createRedisConnection(
-		getAlternateRedisV2ConnectionConfig({ name, cacheUrl, currentRegion })!,
-	);
+	const instance = createRedisConnection({
+		cacheUrl,
+		region: `${currentRegion}:v2:${name}`,
+		supportsUpstashShebang: supportsUpstashShebangForRedisV2(name),
+	});
 	instancePool.set(name, instance);
 	return instance;
 };

--- a/server/src/external/redis/initRedisV2.ts
+++ b/server/src/external/redis/initRedisV2.ts
@@ -7,18 +7,20 @@ import {
 	redis,
 	waitForRedisReady,
 } from "./initRedis.js";
+import {
+	getAlternateRedisV2ConnectionConfig,
+	getRedisV2ConnectionConfig,
+} from "./initUtils/redisV2Config.js";
 
-const cacheV2Url = process.env.CACHE_V2_URL?.trim();
-const primaryCacheUrl = process.env.CACHE_URL?.trim();
+const redisV2Config = getRedisV2ConnectionConfig({
+	cacheV2Url: process.env.CACHE_V2_URL,
+	primaryCacheUrl: process.env.CACHE_URL,
+	currentRegion,
+});
 
-export const redisV2: Redis =
-	cacheV2Url && cacheV2Url !== primaryCacheUrl
-		? createRedisConnection({
-				cacheUrl: cacheV2Url,
-				region: `${currentRegion}:v2`,
-				supportsUpstashShebang: false,
-			})
-		: redis;
+export const redisV2: Redis = redisV2Config
+	? createRedisConnection(redisV2Config)
+	: redis;
 
 const alternateInstanceUrls: Partial<Record<RedisV2InstanceName, string>> = {
 	canary: process.env.CACHE_V2_CANARY_URL?.trim() || undefined,
@@ -45,11 +47,9 @@ export const getAlternateRedisV2Instance = (
 	const existing = instancePool.get(name);
 	if (existing) return existing;
 
-	const instance = createRedisConnection({
-		cacheUrl,
-		region: `${currentRegion}:v2:${name}`,
-		supportsUpstashShebang: name === "canary",
-	});
+	const instance = createRedisConnection(
+		getAlternateRedisV2ConnectionConfig({ name, cacheUrl, currentRegion })!,
+	);
 	instancePool.set(name, instance);
 	return instance;
 };

--- a/server/src/external/redis/initUtils/redisV2Config.ts
+++ b/server/src/external/redis/initUtils/redisV2Config.ts
@@ -1,0 +1,35 @@
+import type { RedisV2InstanceName } from "@/internal/misc/redisV2Cache/redisV2CacheSchemas.js";
+
+export const getRedisV2ConnectionConfig = ({
+	cacheV2Url,
+	primaryCacheUrl,
+	currentRegion,
+}: {
+	cacheV2Url?: string;
+	primaryCacheUrl?: string;
+	currentRegion: string;
+}) =>
+	cacheV2Url?.trim() && cacheV2Url.trim() !== primaryCacheUrl?.trim()
+		? {
+				cacheUrl: cacheV2Url.trim(),
+				region: `${currentRegion}:v2`,
+				supportsUpstashShebang: false,
+			}
+		: null;
+
+export const getAlternateRedisV2ConnectionConfig = ({
+	name,
+	cacheUrl,
+	currentRegion,
+}: {
+	name: RedisV2InstanceName;
+	cacheUrl?: string;
+	currentRegion: string;
+}) =>
+	cacheUrl?.trim()
+		? {
+				cacheUrl: cacheUrl.trim(),
+				region: `${currentRegion}:v2:${name}`,
+				supportsUpstashShebang: name === "canary",
+			}
+		: null;

--- a/server/src/external/redis/initUtils/redisV2Config.ts
+++ b/server/src/external/redis/initUtils/redisV2Config.ts
@@ -17,19 +17,5 @@ export const getRedisV2ConnectionConfig = ({
 			}
 		: null;
 
-export const getAlternateRedisV2ConnectionConfig = ({
-	name,
-	cacheUrl,
-	currentRegion,
-}: {
-	name: RedisV2InstanceName;
-	cacheUrl?: string;
-	currentRegion: string;
-}) =>
-	cacheUrl?.trim()
-		? {
-				cacheUrl: cacheUrl.trim(),
-				region: `${currentRegion}:v2:${name}`,
-				supportsUpstashShebang: name === "canary",
-			}
-		: null;
+export const supportsUpstashShebangForRedisV2 = (name: RedisV2InstanceName) =>
+	name === "canary";

--- a/server/src/external/redis/initUtils/registerRedisCommands.ts
+++ b/server/src/external/redis/initUtils/registerRedisCommands.ts
@@ -50,9 +50,7 @@ export const registerRedisCommands = ({
 	supportsUpstashShebang?: boolean;
 }): Redis => {
 	const prepareScript = (script: string): string =>
-		supportsUpstashShebang || !script.startsWith(UPSTASH_KEY_LOCKING_SHEBANG)
-			? script
-			: script.slice(UPSTASH_KEY_LOCKING_SHEBANG.length);
+		supportsUpstashShebang ? `${UPSTASH_KEY_LOCKING_SHEBANG}${script}` : script;
 	const batchDeductionScript = getBatchDeductionScript();
 
 	redisInstance.defineCommand("batchDeduction", {

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -112,6 +112,7 @@ if (process.env.NODE_ENV === "development") {
 }
 
 function registerFatalErrorHandlers() {
+	const exitAfterLog = () => setTimeout(() => process.exit(1), 100);
 	const logFatal = (event: string, error: unknown) => {
 		logger.error(event, {
 			error:
@@ -123,11 +124,11 @@ function registerFatalErrorHandlers() {
 
 	process.on("uncaughtException", (error) => {
 		logFatal("WORKER FATAL uncaughtException", error);
-		process.exit(1);
+		exitAfterLog();
 	});
 	process.on("unhandledRejection", (reason) => {
 		logFatal("WORKER FATAL unhandledRejection", reason);
-		process.exit(1);
+		exitAfterLog();
 	});
 }
 

--- a/server/src/internal/balances/track/utils/handleRedisTrackError.ts
+++ b/server/src/internal/balances/track/utils/handleRedisTrackError.ts
@@ -11,6 +11,7 @@ import {
 	RedisDeductionError,
 	RedisDeductionErrorCode,
 } from "../../utils/types/redisDeductionError.js";
+import { queueTrack } from "./queueTrack.js";
 import { runPostgresTrack } from "./runPostgresTrack.js";
 /**
  * Handles errors from Redis deduction.
@@ -49,6 +50,12 @@ export const handleRedisTrackError = async ({
 			code: ErrCode.LockAlreadyExists,
 			statusCode: 409,
 		});
+	}
+
+	if (error.isRedisUnavailable()) {
+		const queuedResponse = await queueTrack({ ctx, body });
+		if (queuedResponse) return queuedResponse;
+		throw error;
 	}
 
 	// Fallback to Postgres for recoverable errors

--- a/server/src/internal/balances/track/v3/handleRedisTrackErrorV3.ts
+++ b/server/src/internal/balances/track/v3/handleRedisTrackErrorV3.ts
@@ -12,6 +12,7 @@ import {
 	RedisDeductionError,
 	RedisDeductionErrorCode,
 } from "../../utils/types/redisDeductionError.js";
+import { queueTrack } from "../utils/queueTrack.js";
 import { runPostgresTrackV3 } from "./runPostgresTrackV3.js";
 
 /** Handles errors from V2 Redis deduction. Falls back to Postgres V3 path. */
@@ -44,6 +45,12 @@ export const handleRedisTrackErrorV3 = async ({
 			code: ErrCode.LockAlreadyExists,
 			statusCode: 409,
 		});
+	}
+
+	if (error.isRedisUnavailable()) {
+		const queuedResponse = await queueTrack({ ctx, body });
+		if (queuedResponse) return queuedResponse;
+		throw error;
 	}
 
 	if (error.shouldFallback()) {

--- a/server/src/internal/balances/utils/deduction/executeRedisDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/executeRedisDeduction.ts
@@ -161,7 +161,7 @@ export const executeRedisDeduction = async ({
 		if (!result) {
 			throw new RedisDeductionError({
 				message: "Redis not ready for deduction",
-				code: RedisDeductionErrorCode.CustomerNotFound,
+				code: RedisDeductionErrorCode.RedisUnavailable,
 			});
 		}
 

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -178,7 +178,7 @@ export const executeRedisDeductionV2 = async ({
 		if (!result) {
 			throw new RedisDeductionError({
 				message: "Redis not ready for deduction",
-				code: RedisDeductionErrorCode.SubjectBalanceNotFound,
+				code: RedisDeductionErrorCode.RedisUnavailable,
 			});
 		}
 

--- a/server/src/internal/balances/utils/types/redisDeductionError.ts
+++ b/server/src/internal/balances/utils/types/redisDeductionError.ts
@@ -1,5 +1,6 @@
 /** Error codes returned by the Lua deduction script */
 export enum RedisDeductionErrorCode {
+	RedisUnavailable = "REDIS_UNAVAILABLE",
 	CustomerNotFound = "CUSTOMER_NOT_FOUND",
 	NoCustomerProducts = "NO_CUSTOMER_PRODUCTS",
 	SubjectBalanceNotFound = "SUBJECT_BALANCE_NOT_FOUND",
@@ -32,6 +33,10 @@ export class RedisDeductionError extends Error {
 		super(message);
 		this.name = "RedisDeductionError";
 		this.code = code;
+	}
+
+	isRedisUnavailable(): boolean {
+		return this.code === RedisDeductionErrorCode.RedisUnavailable;
 	}
 
 	/** Check if this error should trigger a Postgres fallback */

--- a/server/tests/unit/balances/track-v3/handleRedisTrackErrorV3.test.ts
+++ b/server/tests/unit/balances/track-v3/handleRedisTrackErrorV3.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	RedisDeductionError,
+	RedisDeductionErrorCode,
+} from "@/internal/balances/utils/types/redisDeductionError.js";
+
+const mockState = {
+	queueCalls: [] as Record<string, unknown>[],
+	postgresCalls: [] as Record<string, unknown>[],
+};
+
+mock.module("@/internal/balances/track/utils/queueTrack.js", () => ({
+	queueTrack: async (args: Record<string, unknown>) => {
+		mockState.queueCalls.push(args);
+		return {
+			customer_id: "cus_123",
+			feature_id: "messages",
+			balance: null,
+		};
+	},
+}));
+
+mock.module(
+	"@/internal/balances/track/v3/runPostgresTrackV3.js",
+	() => ({
+		runPostgresTrackV3: async (args: Record<string, unknown>) => {
+			mockState.postgresCalls.push(args);
+			return { customer_id: "cus_123", balance: 1 };
+		},
+	}),
+);
+
+import { handleRedisTrackErrorV3 } from "@/internal/balances/track/v3/handleRedisTrackErrorV3.js";
+
+const ctx = {
+	org: { id: "org_123" },
+	env: AppEnv.Sandbox,
+	apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+	logger: {
+		warn: mock(() => {}),
+	},
+} as unknown as AutumnContext;
+
+describe("handleRedisTrackErrorV3", () => {
+	beforeEach(() => {
+		mockState.queueCalls = [];
+		mockState.postgresCalls = [];
+	});
+
+	test("queues track instead of falling back to Postgres when Redis is unavailable", async () => {
+		const response = await handleRedisTrackErrorV3({
+			ctx,
+			error: new RedisDeductionError({
+				message: "Redis not ready for deduction",
+				code: RedisDeductionErrorCode.RedisUnavailable,
+			}),
+			body: {
+				customer_id: "cus_123",
+				feature_id: "messages",
+				value: 1,
+			},
+			fullSubject: {} as never,
+			featureDeductions: [],
+		});
+
+		expect(mockState.queueCalls).toHaveLength(1);
+		expect(mockState.postgresCalls).toHaveLength(0);
+		expect(response).toMatchObject({
+			customer_id: "cus_123",
+			balance: null,
+		});
+	});
+});

--- a/server/tests/unit/balances/track/handle-track-queue-fallback.test.ts
+++ b/server/tests/unit/balances/track/handle-track-queue-fallback.test.ts
@@ -10,6 +10,12 @@ const mockState = {
 };
 
 mock.module("@/external/redis/initRedis.js", () => ({
+	redis: {},
+	shouldUseRedis: () => mockState.shouldUseRedis,
+}));
+
+mock.module("@/external/redis/initRedis", () => ({
+	redis: {},
 	shouldUseRedis: () => mockState.shouldUseRedis,
 }));
 
@@ -94,7 +100,11 @@ describe("handleTrack queue fallback", () => {
 	});
 
 	afterEach(() => {
-		process.env.TRACK_SQS_QUEUE_URL = originalTrackQueueUrl;
+		if (originalTrackQueueUrl) {
+			process.env.TRACK_SQS_QUEUE_URL = originalTrackQueueUrl;
+		} else {
+			delete process.env.TRACK_SQS_QUEUE_URL;
+		}
 	});
 
 	test("queues track and returns the legacy success shape when Redis is unavailable", async () => {

--- a/server/tests/unit/balances/track/handle-track-queue-fallback.test.ts
+++ b/server/tests/unit/balances/track/handle-track-queue-fallback.test.ts
@@ -6,7 +6,6 @@ const mockState = {
 	shouldUseRedis: true,
 	queueCalls: [] as Record<string, unknown>[],
 	runTrackCalls: [] as Record<string, unknown>[],
-	warnCalls: [] as unknown[][],
 };
 
 mock.module("@/external/redis/initRedis.js", () => ({
@@ -19,9 +18,18 @@ mock.module("@/external/redis/initRedis", () => ({
 	shouldUseRedis: () => mockState.shouldUseRedis,
 }));
 
-mock.module("@/queue/queueUtils.js", () => ({
-	addTaskToQueue: async (args: Record<string, unknown>) => {
+mock.module("@/internal/balances/track/utils/queueTrack.js", () => ({
+	queueTrack: async (args: Record<string, unknown>) => {
 		mockState.queueCalls.push(args);
+		if (!process.env.TRACK_SQS_QUEUE_URL) return null;
+
+		const body = args.body as { customer_id: string; feature_id: string };
+		return {
+			id: "placeholder",
+			code: "event_received",
+			customer_id: body.customer_id,
+			feature_id: body.feature_id,
+		};
 	},
 }));
 
@@ -33,7 +41,6 @@ mock.module("@/internal/balances/track/runTrackWithRollout.js", () => ({
 }));
 
 import { handleTrack } from "@/internal/balances/handlers/handleTrack.js";
-import { JobName } from "@/queue/JobName.js";
 
 const wrappedHandler = handleTrack[handleTrack.length - 1] as unknown as (
 	c: ReturnType<typeof makeContext>,
@@ -47,9 +54,7 @@ const makeCtx = ({ apiVersion }: { apiVersion: ApiVersion }) =>
 		env: AppEnv.Sandbox,
 		apiVersion: new ApiVersionClass(apiVersion),
 		logger: {
-			warn: (...args: unknown[]) => {
-				mockState.warnCalls.push(args);
-			},
+			warn: () => undefined,
 		},
 		features: [
 			{
@@ -96,7 +101,6 @@ describe("handleTrack queue fallback", () => {
 		mockState.shouldUseRedis = false;
 		mockState.queueCalls = [];
 		mockState.runTrackCalls = [];
-		mockState.warnCalls = [];
 	});
 
 	afterEach(() => {
@@ -125,20 +129,11 @@ describe("handleTrack queue fallback", () => {
 
 		expect(mockState.queueCalls).toHaveLength(1);
 		expect(mockState.runTrackCalls).toHaveLength(0);
-		expect(mockState.warnCalls).toContainEqual([
-			"[track] Redis unavailable, queued track fallback",
-			expect.objectContaining({
-				type: "track_queue_fallback",
-				feature_id: "messages",
-				queue_name: "track-dev.fifo",
-			}),
-		]);
 		expect(mockState.queueCalls[0]).toMatchObject({
-			jobName: JobName.Track,
-			queueUrl:
-				"https://sqs.eu-west-1.amazonaws.com/123456789012/track-dev.fifo",
-			messageGroupId: "org_123:sandbox:cus_123",
-			messageDeduplicationId: "idem_123",
+			body: {
+				customer_id: "cus_123",
+				feature_id: "messages",
+			},
 		});
 
 		expect(response.status).toBe(200);
@@ -163,7 +158,7 @@ describe("handleTrack queue fallback", () => {
 			}),
 		);
 
-		expect(mockState.queueCalls).toHaveLength(0);
+		expect(mockState.queueCalls).toHaveLength(1);
 		expect(mockState.runTrackCalls).toHaveLength(1);
 		expect(response.status).toBe(200);
 	});

--- a/server/tests/unit/redis/redis-v2-config.spec.ts
+++ b/server/tests/unit/redis/redis-v2-config.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getAlternateRedisV2ConnectionConfig,
+	getRedisV2ConnectionConfig,
+} from "@/external/redis/initUtils/redisV2Config.js";
+
+describe("redis V2 connection config", () => {
+	test("uses a distinct CACHE_V2_URL without the Upstash shebang", () => {
+		expect(
+			getRedisV2ConnectionConfig({
+				cacheV2Url: " redis://v2 ",
+				primaryCacheUrl: "redis://primary",
+				currentRegion: "us-west-2",
+			}),
+		).toEqual({
+			cacheUrl: "redis://v2",
+			region: "us-west-2:v2",
+			supportsUpstashShebang: false,
+		});
+	});
+
+	test("falls back to primary Redis when CACHE_V2_URL is absent or primary", () => {
+		expect(
+			getRedisV2ConnectionConfig({
+				cacheV2Url: undefined,
+				primaryCacheUrl: "redis://primary",
+				currentRegion: "us-west-2",
+			}),
+		).toBeNull();
+		expect(
+			getRedisV2ConnectionConfig({
+				cacheV2Url: " redis://primary ",
+				primaryCacheUrl: "redis://primary",
+				currentRegion: "us-west-2",
+			}),
+		).toBeNull();
+	});
+
+	test("enables the Upstash shebang only for the canary alternate", () => {
+		expect(
+			getAlternateRedisV2ConnectionConfig({
+				name: "canary",
+				cacheUrl: " redis://canary ",
+				currentRegion: "us-west-2",
+			}),
+		).toEqual({
+			cacheUrl: "redis://canary",
+			region: "us-west-2:v2:canary",
+			supportsUpstashShebang: true,
+		});
+		expect(
+			getAlternateRedisV2ConnectionConfig({
+				name: "dragonfly",
+				cacheUrl: "redis://dragonfly",
+				currentRegion: "us-west-2",
+			}),
+		).toEqual({
+			cacheUrl: "redis://dragonfly",
+			region: "us-west-2:v2:dragonfly",
+			supportsUpstashShebang: false,
+		});
+	});
+
+	test("ignores blank alternate Redis V2 URLs", () => {
+		expect(
+			getAlternateRedisV2ConnectionConfig({
+				name: "canary",
+				cacheUrl: " ",
+				currentRegion: "us-west-2",
+			}),
+		).toBeNull();
+	});
+});

--- a/server/tests/unit/redis/redis-v2-config.spec.ts
+++ b/server/tests/unit/redis/redis-v2-config.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
-	getAlternateRedisV2ConnectionConfig,
 	getRedisV2ConnectionConfig,
+	supportsUpstashShebangForRedisV2,
 } from "@/external/redis/initUtils/redisV2Config.js";
 
 describe("redis V2 connection config", () => {
@@ -37,37 +37,7 @@ describe("redis V2 connection config", () => {
 	});
 
 	test("enables the Upstash shebang only for the canary alternate", () => {
-		expect(
-			getAlternateRedisV2ConnectionConfig({
-				name: "canary",
-				cacheUrl: " redis://canary ",
-				currentRegion: "us-west-2",
-			}),
-		).toEqual({
-			cacheUrl: "redis://canary",
-			region: "us-west-2:v2:canary",
-			supportsUpstashShebang: true,
-		});
-		expect(
-			getAlternateRedisV2ConnectionConfig({
-				name: "dragonfly",
-				cacheUrl: "redis://dragonfly",
-				currentRegion: "us-west-2",
-			}),
-		).toEqual({
-			cacheUrl: "redis://dragonfly",
-			region: "us-west-2:v2:dragonfly",
-			supportsUpstashShebang: false,
-		});
-	});
-
-	test("ignores blank alternate Redis V2 URLs", () => {
-		expect(
-			getAlternateRedisV2ConnectionConfig({
-				name: "canary",
-				cacheUrl: " ",
-				currentRegion: "us-west-2",
-			}),
-		).toBeNull();
+		expect(supportsUpstashShebangForRedisV2("canary")).toBe(true);
+		expect(supportsUpstashShebangForRedisV2("dragonfly")).toBe(false);
 	});
 });

--- a/server/tests/unit/redis/register-redis-commands.spec.ts
+++ b/server/tests/unit/redis/register-redis-commands.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { UPSTASH_KEY_LOCKING_SHEBANG } from "@/_luaScriptsV2/luaScriptsV2.js";
+import { registerRedisCommands } from "@/external/redis/initUtils/registerRedisCommands.js";
+
+type RegisteredCommand = {
+	lua: string;
+	numberOfKeys?: number;
+};
+
+const upstashLockedCommands = new Set([
+	"deductFromSubjectBalances",
+	"updateSubjectBalances",
+	"setCachedFullSubject",
+	"updateFullSubjectCustomerDataV2",
+	"updateFullSubjectEntityDataV2",
+	"updateFullSubjectCustomerProductV2",
+	"upsertInvoiceInFullSubjectV2",
+	"adjustSubjectBalance",
+]);
+
+const registerCommands = (supportsUpstashShebang: boolean) => {
+	const commands = new Map<string, RegisteredCommand>();
+	const redis = {
+		defineCommand: (name: string, command: RegisteredCommand) => {
+			commands.set(name, command);
+		},
+		on: () => undefined,
+	};
+
+	registerRedisCommands({
+		redisInstance: redis as never,
+		supportsUpstashShebang,
+	});
+
+	return commands;
+};
+
+const shebangCount = (script: string) =>
+	script.split(UPSTASH_KEY_LOCKING_SHEBANG).length - 1;
+
+describe("registerRedisCommands", () => {
+	test("adds the Upstash key-locking shebang only to commands that need it", () => {
+		const commands = registerCommands(true);
+
+		expect(
+			[...upstashLockedCommands].filter((command) => !commands.has(command)),
+		).toEqual([]);
+
+		for (const [name, { lua }] of commands) {
+			const expectedCount = upstashLockedCommands.has(name) ? 1 : 0;
+			expect(shebangCount(lua), name).toBe(expectedCount);
+			expect(lua.startsWith(UPSTASH_KEY_LOCKING_SHEBANG), name).toBe(
+				expectedCount === 1,
+			);
+		}
+	});
+
+	test("does not add Upstash key-locking shebangs for non-Upstash Redis", () => {
+		const commands = registerCommands(false);
+
+		for (const [name, { lua }] of commands) {
+			expect(shebangCount(lua), name).toBe(0);
+			expect(lua.startsWith(UPSTASH_KEY_LOCKING_SHEBANG), name).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes embedded Upstash key-locking shebangs from V2 Lua scripts and injects them at command registration only for instances that support it. Adds a track queue fallback when Redis is unavailable to improve reliability.

- **Refactors**
  - Removed `${UPSTASH_KEY_LOCKING_SHEBANG}` from V2 script exports; `registerRedisCommands` now prefixes it only when `supportsUpstashShebang` is true and only for commands that need key locking.
  - Centralized V2 connection config in `getRedisV2ConnectionConfig`; default opts out of the shebang, `canary` opts in via `supportsUpstashShebangForRedisV2`. Updated `initRedisV2`. Added unit tests for config and selective shebang injection.

- **Bug Fixes**
  - Queue track requests when Redis is unavailable (V2 and V3) using new `REDIS_UNAVAILABLE`; fall back to Postgres only for other recoverable errors. Added V3 queue fallback test.
  - Ensure fatal error logs flush by exiting shortly after logging in fatal handlers.

<sup>Written for commit fba67f9f3e871311c5054d7c78d77e2e6d04977f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a runtime error on non-Upstash Redis backends (`ERR Unexpected flag in script shebang`) by moving the `#!lua flags=allow-key-locking` shebang out of the Lua script string constants and injecting it at command-registration time only when `supportsUpstashShebang` is true. The default V2 connection and non-canary alternates set this flag to `false`; the `canary` Upstash alternate sets it to `true`.

- **Bug fixes / Improvements**: Removed embedded shebang from all V2 script exports; `registerRedisCommands` now applies it via `prepareScript` only to the 8 FullSubject V2 commands that require per-key locking.
- **Improvements**: Centralized V2 connection config in `getRedisV2ConnectionConfig` and `supportsUpstashShebangForRedisV2`, replacing scattered inline config.
- **Improvements**: Added unit tests verifying exactly which commands receive the shebang (once, as the first line) and that non-Upstash Redis instances receive no shebangs at all.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped, well-tested, and fixes a real runtime error on non-Upstash backends with no regressions on Upstash.

All findings are P2 or lower. The logic is correct: the primary Redis (Upstash) retains the default supportsUpstashShebang=true, the default V2 instance explicitly opts out, and the canary alternate explicitly opts in. Unit tests verify shebang presence/absence per command exhaustively.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/_luaScriptsV2/luaScriptsV2.ts | Removed embedded shebang from all V2 script exports; UPSTASH_KEY_LOCKING_SHEBANG constant is now only used by registerRedisCommands, keeping script bodies clean. |
| server/src/external/redis/initUtils/registerRedisCommands.ts | Introduces prepareScript helper that conditionally prepends the shebang; correctly applies it to 8 FullSubject V2 commands and omits it from V1/non-key-locking commands. |
| server/src/external/redis/initUtils/redisV2Config.ts | Centralizes V2 connection config; default V2 instance gets supportsUpstashShebang: false; canary alternate gets true via supportsUpstashShebangForRedisV2. |
| server/src/external/redis/initRedisV2.ts | Consumes getRedisV2ConnectionConfig and supportsUpstashShebangForRedisV2 cleanly; alternate instance creation is straightforward. |
| server/tests/unit/redis/redis-v2-config.spec.ts | Unit tests for getRedisV2ConnectionConfig and supportsUpstashShebangForRedisV2; covers URL trimming, fallback-to-null, and canary/dragonfly shebang flags. |
| server/tests/unit/redis/register-redis-commands.spec.ts | Tests verify exactly which commands receive the shebang (and that it appears exactly once) and that no shebangs are added for non-Upstash Redis. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createRedisConnection called] --> B{supportsUpstashShebang?}
    B -- "default=true (primary/Upstash)" --> C[registerRedisCommands\nsupportsUpstashShebang=true]
    B -- "false (default V2 / Dragonfly)" --> D[registerRedisCommands\nsupportsUpstashShebang=false]
    B -- "canary → supportsUpstashShebangForRedisV2=true" --> C
    C --> E{prepareScript called?}
    D --> F[all scripts: no shebang]
    E -- "FullSubject V2 commands (8)" --> G["script = SHEBANG + script"]
    E -- "V1 / non-key-locking commands" --> H["script = script as-is"]
    G --> I[defineCommand on Redis instance]
    H --> I
    F --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add track sqs backup on v3"](https://github.com/useautumn/autumn/commit/168c81efa86d331469efe88fd78140753142fcb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29290511)</sub>

<!-- /greptile_comment -->