### PR TITLE
feat: optimize entities aggregate

### DIFF
--- a/server/src/_luaScriptsV2/luaScriptsV2.ts
+++ b/server/src/_luaScriptsV2/luaScriptsV2.ts
@@ -16,6 +16,7 @@ import LOCK_STATE_UTILS from "./deduction/lock/lockStateUtils.lua";
 import LOCK_UNWIND_UTILS from "./deduction/lock/unwindLockUtils.lua";
 import MUTATION_ITEM_UTILS from "./deduction/mutationItemUtils.lua";
 import FULL_CUSTOMER_UTILS from "./fullCustomer/fullCustomerUtils.lua";
+import LOCK_RECEIPT_UTILS_V2 from "./fullSubjectDeduction/lock/lockReceiptV2.lua";
 import LOCK_UNWIND_UTILS_V2 from "./fullSubjectDeduction/lock/unwindLockV2.lua";
 import LUA_UTILS from "./luaUtils.lua";
 

--- a/server/src/internal/balances/check/getCheckDataV2.ts
+++ b/server/src/internal/balances/check/getCheckDataV2.ts
@@ -75,8 +75,6 @@ export const getCheckDataV2 = async ({
 				source: "getCheckDataV2",
 			});
 
-	// console.log("Full subject", fullSubject);
-
 	const apiSubject = await getApiSubject({
 		ctx,
 		fullSubject,

--- a/server/src/internal/balances/utils/lockV2/buildClaimMarkerKey.ts
+++ b/server/src/internal/balances/utils/lockV2/buildClaimMarkerKey.ts
@@ -1,0 +1,7 @@
+/**
+ * Per-lock claim marker key. Used by the V2 claim path to atomically race
+ * finalizers via `SET NX EX` — the receipt key itself stays write-once.
+ * `deleteLockReceiptV2` DELs both keys in a single variadic DEL.
+ */
+export const buildClaimMarkerKey = (lockReceiptKey: string): string =>
+	`${lockReceiptKey}:claim`;

--- a/server/src/internal/balances/utils/lockV2/deleteLockReceiptV2.ts
+++ b/server/src/internal/balances/utils/lockV2/deleteLockReceiptV2.ts
@@ -1,0 +1,20 @@
+import type { Redis } from "ioredis";
+import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
+import { buildClaimMarkerKey } from "./buildClaimMarkerKey.js";
+
+/**
+ * V2 delete-lock-receipt. Removes both the receipt key and its claim marker
+ * in a single variadic DEL — one Redis round trip.
+ */
+export const deleteLockReceiptV2 = async ({
+	lockReceiptKey,
+	redisInstance,
+}: {
+	lockReceiptKey: string;
+	redisInstance: Redis;
+}) => {
+	await tryRedisWrite(
+		() => redisInstance.del(lockReceiptKey, buildClaimMarkerKey(lockReceiptKey)),
+		redisInstance,
+	);
+};

--- a/server/src/internal/balances/utils/lockV2/fetchAndClaimLockReceiptV2.ts
+++ b/server/src/internal/balances/utils/lockV2/fetchAndClaimLockReceiptV2.ts
@@ -1,0 +1,122 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+import type { Redis } from "ioredis";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
+import type { LockReceipt } from "@/internal/balances/utils/lock/fetchLockReceipt.js";
+import type { MutationLogItem } from "@/internal/balances/utils/types/mutationLogItem.js";
+import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
+import { buildClaimMarkerKey } from "./buildClaimMarkerKey.js";
+
+/**
+ * Marker TTL is a crash-safety net — the marker is always DEL'd on finalize.
+ * Chosen well above any realistic claim-race window and well below typical
+ * receipt lifetimes so orphans clean up without sticking around forever.
+ */
+const CLAIM_MARKER_TTL_SECONDS = 3600;
+
+type FetchAndClaimResult =
+	| { found: false }
+	| {
+			found: true;
+			claimed: boolean;
+			receipt: LockReceipt;
+			lockReceiptKey: string;
+	  };
+
+const normalizeLockReceiptItems = ({
+	items,
+	lockId,
+}: {
+	items: LockReceipt["items"] | Record<string, never> | null | undefined;
+	lockId: string;
+}): MutationLogItem[] => {
+	if (Array.isArray(items)) return items;
+
+	if (items && typeof items === "object" && Object.keys(items).length === 0) {
+		return [];
+	}
+
+	throw new RecaseError({
+		message: `Lock receipt has invalid items for ID: ${lockId}`,
+		code: ErrCode.InvalidRequest,
+	});
+};
+
+/**
+ * V2 merged fetch-and-claim. Pipelines a plain `GET <receiptKey>` and a
+ * `SET <receiptKey>:claim 1 NX EX` in a single round trip. The receipt
+ * payload is never mutated — claim is encoded entirely by ownership of the
+ * marker key.
+ *
+ * Returns `{ found: false }` when the receipt key is absent on redisV2 (the
+ * dispatcher uses this to fall through to the V1 finalize path). When
+ * `found` is true, `claimed` reports whether this caller won the race; the
+ * dispatcher throws on `found && !claimed` rather than falling through to
+ * V1, because a present-but-contested receipt IS a V2 lock.
+ */
+export const fetchAndClaimLockReceiptV2 = async ({
+	ctx,
+	lockId,
+	redisInstance,
+}: {
+	ctx: AutumnContext;
+	lockId: string;
+	redisInstance: Redis;
+}): Promise<FetchAndClaimResult> => {
+	const hashedKey = Bun.hash(lockId).toString();
+	const lockReceiptKey = buildLockReceiptKey({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		lockKey: hashedKey,
+	});
+	const claimMarkerKey = buildClaimMarkerKey(lockReceiptKey);
+
+	// Pipeline GET + SET NX EX as a single round trip. tryRedisWrite wraps the
+	// whole `.exec()` since any error (or unavailable redis) invalidates both
+	// results atomically from our perspective.
+	const execResult = await tryRedisWrite(
+		() =>
+			redisInstance
+				.pipeline()
+				.get(lockReceiptKey)
+				.set(claimMarkerKey, "1", "EX", CLAIM_MARKER_TTL_SECONDS, "NX")
+				.exec(),
+		redisInstance,
+	);
+
+	if (!execResult) return { found: false };
+
+	const [getReply, setReply] = execResult;
+	const getErr = getReply?.[0];
+	const setErr = setReply?.[0];
+	if (getErr || setErr) return { found: false };
+
+	const raw = getReply?.[1] as string | null | undefined;
+	const claimResult = setReply?.[1] as "OK" | null | undefined;
+
+	if (!raw) return { found: false };
+
+	const receipt = JSON.parse(raw) as LockReceipt;
+
+	const missingField = (["customer_id", "feature_id", "items"] as const).find(
+		(field) => !receipt?.[field],
+	);
+	if (missingField) {
+		throw new RecaseError({
+			message: `Lock receipt is missing ${missingField} for ID: ${lockId}`,
+			code: ErrCode.InvalidRequest,
+		});
+	}
+
+	receipt.items = normalizeLockReceiptItems({
+		items: receipt.items,
+		lockId,
+	});
+
+	return {
+		found: true,
+		claimed: claimResult === "OK",
+		receipt,
+		lockReceiptKey,
+	};
+};

--- a/server/src/internal/balances/utils/lockV2/saveLockReceiptV2.ts
+++ b/server/src/internal/balances/utils/lockV2/saveLockReceiptV2.ts
@@ -1,0 +1,68 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+import type { Redis } from "ioredis";
+import { currentRegion } from "@/external/redis/initRedis.js";
+import type { MutationLogItem } from "@/internal/balances/utils/types/mutationLogItem.js";
+import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
+
+/**
+ * V2 save-lock-receipt. Stores the receipt as a plain JSON string via a single
+ * `SET key value NX EXAT ttl_at` call — one Redis round trip instead of the
+ * V1 `EXISTS` + `JSON.SET` + `EXPIREAT` sequence, and closes the EXISTS/SET
+ * race since the atomic NX guards against concurrent creates.
+ */
+export const saveLockReceiptV2 = async ({
+	lock,
+	customerId,
+	featureId,
+	entityId,
+	items,
+	redisInstance,
+}: {
+	lock: {
+		lock_id?: string;
+		hashed_key?: string;
+		expires_at?: number;
+		redis_receipt_key: string;
+		created_at: number;
+		ttl_at: number;
+	};
+	customerId: string;
+	featureId: string;
+	entityId?: string;
+	items: MutationLogItem[];
+	redisInstance: Redis;
+}) => {
+	const payload = JSON.stringify({
+		lock_id: lock.lock_id ?? null,
+		hashed_key: lock.hashed_key ?? null,
+		status: "pending",
+		region: currentRegion,
+		customer_id: customerId,
+		feature_id: featureId,
+		entity_id: entityId ?? null,
+		expires_at: lock.expires_at ?? null,
+		created_at: lock.created_at,
+		items,
+	});
+
+	const result = await tryRedisWrite(
+		() =>
+			redisInstance.call(
+				"SET",
+				lock.redis_receipt_key,
+				payload,
+				"NX",
+				"EXAT",
+				lock.ttl_at,
+			) as Promise<"OK" | null>,
+		redisInstance,
+	);
+
+	if (result === "OK") return;
+
+	throw new RecaseError({
+		message: "A lock with this ID already exists",
+		code: ErrCode.LockAlreadyExists,
+		statusCode: 409,
+	});
+};

--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/getApiBalancesV2.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/getApiBalancesV2.ts
@@ -1,8 +1,10 @@
 import {
+	type AggregatedSubjectFlag,
 	type ApiBalanceV1,
 	type ApiFlagV0,
 	type Feature,
 	FeatureType,
+	findFeatureByInternalId,
 	type FullAggregatedFeatureBalance,
 	type FullCusEntWithFullCusProduct,
 	type FullSubject,
@@ -19,14 +21,17 @@ type FeatureInput = {
 	feature: Feature;
 	customerEntitlements: FullCusEntWithFullCusProduct[];
 	aggregatedFeatureBalance?: FullAggregatedFeatureBalance;
+	aggregatedSubjectFlag?: AggregatedSubjectFlag;
 };
 
 const getFeatureInputs = ({
 	customerEntitlements,
 	fullSubject,
+	features,
 }: {
 	customerEntitlements: FullCusEntWithFullCusProduct[];
 	fullSubject: FullSubject;
+	features: Feature[];
 }): FeatureInput[] => {
 	const customerEntitlementsByFeatureId: Record<
 		string,
@@ -45,6 +50,8 @@ const getFeatureInputs = ({
 		string,
 		FullAggregatedFeatureBalance
 	> = {};
+	const aggregatedSubjectFlagByFeatureId: Record<string, AggregatedSubjectFlag> =
+		{};
 
 	if (fullSubject.subjectType === "customer") {
 		for (const aggregatedFeatureBalance of fullSubject.aggregated_customer_entitlements ??
@@ -52,11 +59,17 @@ const getFeatureInputs = ({
 			aggregatedFeatureBalanceByFeatureId[aggregatedFeatureBalance.feature_id] =
 				aggregatedFeatureBalance;
 		}
+		for (const [featureId, aggregatedSubjectFlag] of Object.entries(
+			fullSubject.aggregated_subject_flags ?? {},
+		)) {
+			aggregatedSubjectFlagByFeatureId[featureId] = aggregatedSubjectFlag;
+		}
 	}
 
 	const featureIds = new Set([
 		...Object.keys(customerEntitlementsByFeatureId),
 		...Object.keys(aggregatedFeatureBalanceByFeatureId),
+		...Object.keys(aggregatedSubjectFlagByFeatureId),
 	]);
 
 	const featureInputs: FeatureInput[] = [];
@@ -66,9 +79,16 @@ const getFeatureInputs = ({
 			customerEntitlementsByFeatureId[featureId] ?? [];
 		const aggregatedFeatureBalance =
 			aggregatedFeatureBalanceByFeatureId[featureId];
+		const aggregatedSubjectFlag = aggregatedSubjectFlagByFeatureId[featureId];
 		const feature =
 			customerEntitlements[0]?.entitlement.feature ??
-			aggregatedFeatureBalance?.feature;
+			aggregatedFeatureBalance?.feature ??
+			(aggregatedSubjectFlag
+				? findFeatureByInternalId({
+						features,
+						internalId: aggregatedSubjectFlag.internal_feature_id,
+					})
+				: undefined);
 
 		if (!feature) continue;
 
@@ -77,6 +97,7 @@ const getFeatureInputs = ({
 			feature,
 			customerEntitlements,
 			aggregatedFeatureBalance,
+			aggregatedSubjectFlag,
 		});
 	}
 
@@ -102,6 +123,7 @@ export const getApiBalancesV2 = ({
 	const featureInputs = getFeatureInputs({
 		customerEntitlements,
 		fullSubject,
+		features: ctx.features,
 	});
 
 	const apiBalances: Record<string, ApiBalanceV1> = {};
@@ -122,6 +144,7 @@ export const getApiBalancesV2 = ({
 			feature,
 			customerEntitlements,
 			aggregatedFeatureBalance,
+			aggregatedSubjectFlag,
 		} = featureInput;
 
 		if (feature.type === FeatureType.Boolean) {
@@ -129,7 +152,7 @@ export const getApiBalancesV2 = ({
 				ctx: flagScopedCtx,
 				customerEntitlements,
 				feature,
-				aggregatedFeatureBalance,
+				aggregatedSubjectFlag,
 			});
 
 			if (apiFlag) {

--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/getApiFlag.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/getApiFlag.ts
@@ -1,10 +1,10 @@
 import { getApiFlag } from "@api/customers/flags/utils/getApiFlag.js";
 import type { ApiFlagV0 } from "@autumn/shared";
 import {
+	type AggregatedSubjectFlag,
 	dbToApiFeatureV1,
 	expandPathIncludes,
 	type Feature,
-	type FullAggregatedFeatureBalance,
 	type FullCusEntWithFullCusProduct,
 	type SharedContext,
 	scopeExpandForCtx,
@@ -14,12 +14,12 @@ export const getApiFlagV2 = ({
 	ctx,
 	customerEntitlements,
 	feature,
-	aggregatedFeatureBalance,
+	aggregatedSubjectFlag,
 }: {
 	ctx: SharedContext;
 	customerEntitlements: FullCusEntWithFullCusProduct[];
 	feature: Feature;
-	aggregatedFeatureBalance?: FullAggregatedFeatureBalance;
+	aggregatedSubjectFlag?: AggregatedSubjectFlag;
 }): ApiFlagV0 | undefined => {
 	if (customerEntitlements.length > 0) {
 		const { data } = getApiFlag({
@@ -31,29 +31,24 @@ export const getApiFlagV2 = ({
 		return data;
 	}
 
-	if (!aggregatedFeatureBalance) return undefined;
+	// Fallback: no rehydrated cus_ent (e.g. partial cache where booleans
+	// weren't materialized). Build a minimal flag from the aggregated view.
+	if (!aggregatedSubjectFlag) return undefined;
 
-	const featureCtx = scopeExpandForCtx({
-		ctx,
-		prefix: "feature",
-	});
-
+	const featureCtx = scopeExpandForCtx({ ctx, prefix: "feature" });
 	const apiFeature = expandPathIncludes({
 		expand: ctx.expand,
 		includes: ["feature"],
 	})
-		? dbToApiFeatureV1({
-				ctx: featureCtx,
-				dbFeature: aggregatedFeatureBalance.feature,
-			})
+		? dbToApiFeatureV1({ ctx: featureCtx, dbFeature: feature })
 		: undefined;
 
 	return {
 		object: "flag",
-		id: aggregatedFeatureBalance.api_id,
+		id: aggregatedSubjectFlag.api_id,
 		plan_id: null,
 		expires_at: null,
-		feature_id: aggregatedFeatureBalance.feature_id,
+		feature_id: aggregatedSubjectFlag.feature_id,
 		feature: apiFeature,
 	};
 };

--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.ts
@@ -12,6 +12,7 @@ const stripAggregations = ({
 		...fullSubject,
 		aggregated_customer_products: undefined,
 		aggregated_customer_entitlements: undefined,
+		aggregated_subject_flags: undefined,
 	};
 };
 

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectQuery.ts
@@ -232,7 +232,16 @@ export const getFullSubjectQuery = ({
 				ON ce.internal_customer_id = scr.internal_id
 			WHERE ce.customer_product_id IS NULL
 				AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-				AND ce.balance != 0
+				AND (
+					ce.balance != 0
+					OR EXISTS (
+						SELECT 1
+						FROM entitlements e
+						JOIN features f ON f.internal_id = e.internal_feature_id
+						WHERE e.id = ce.entitlement_id
+							AND f.type = 'boolean'
+					)
+				)
 				${extraCustomerEntitlementEntityFilter}
 			LIMIT 20
 		),

--- a/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
+++ b/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
@@ -1,5 +1,7 @@
 import type { FeatureOptions } from "@autumn/shared";
 import {
+	type AggregatedFeatureBalance,
+	type AggregatedSubjectFlag,
 	type Customer,
 	type DbCustomerEntitlement,
 	type DbCustomerPrice,
@@ -188,13 +190,43 @@ export const subjectQueryRowToNormalized = ({
 		partitionCustomerEntitlement(customerEntitlement);
 	}
 
+	// Split the SQL aggregate output by feature type:
+	//   - non-boolean rows → aggregated_customer_entitlements (metered totals)
+	//   - boolean rows     → aggregated_subject_flags (identity-only)
+	// This is the single choke point for keeping booleans out of the cache
+	// writer's per-feature `_aggregated` hashes.
 	let entityAggregations: EntityAggregations | undefined;
 	if (row.entity_aggregations) {
+		const featuresByInternalId = new Map(
+			row.entitlements.map(
+				(entitlement) =>
+					[entitlement.feature.internal_id, entitlement.feature] as const,
+			),
+		);
+
+		const aggregatedMetered: AggregatedFeatureBalance[] = [];
+		const aggregatedSubjectFlags: Record<string, AggregatedSubjectFlag> = {};
+
+		for (const aggregated of row.entity_aggregations
+			.aggregated_customer_entitlements) {
+			const feature = featuresByInternalId.get(aggregated.internal_feature_id);
+			if (feature?.type === FeatureType.Boolean) {
+				aggregatedSubjectFlags[aggregated.feature_id] = {
+					feature_id: aggregated.feature_id,
+					internal_feature_id: aggregated.internal_feature_id,
+					internal_customer_id: aggregated.internal_customer_id,
+					api_id: aggregated.api_id,
+				};
+			} else {
+				aggregatedMetered.push(aggregated);
+			}
+		}
+
 		entityAggregations = {
 			aggregated_customer_products:
 				row.entity_aggregations.aggregated_customer_products,
-			aggregated_customer_entitlements:
-				row.entity_aggregations.aggregated_customer_entitlements,
+			aggregated_customer_entitlements: aggregatedMetered,
+			aggregated_subject_flags: aggregatedSubjectFlags,
 		};
 	}
 

--- a/shared/models/cusModels/fullSubject/fullSubjectModel.ts
+++ b/shared/models/cusModels/fullSubject/fullSubjectModel.ts
@@ -6,6 +6,7 @@ import { SubscriptionSchema } from "../../subModels/subModels.js";
 import { CustomerSchema } from "../cusModels.js";
 import { EntitySchema } from "../entityModels/entityModels.js";
 import { InvoiceSchema } from "../invoiceModels/invoiceModels.js";
+import { AggregatedSubjectFlagSchema } from "./normalizedFullSubjectModel.js";
 
 export const SubjectType = {
 	Customer: "customer",
@@ -33,6 +34,9 @@ export const FullSubjectSchema = z.object({
 	aggregated_customer_products: z.array(FullCusProductSchema).optional(),
 	aggregated_customer_entitlements: z
 		.array(FullAggregatedFeatureBalanceSchema)
+		.optional(),
+	aggregated_subject_flags: z
+		.record(z.string(), AggregatedSubjectFlagSchema)
 		.optional(),
 });
 

--- a/shared/models/cusModels/fullSubject/normalizedFullSubjectModel.ts
+++ b/shared/models/cusModels/fullSubject/normalizedFullSubjectModel.ts
@@ -102,17 +102,41 @@ export type SubjectBalance = {
 };
 
 /**
+ * Identity-only view of a boolean feature aggregated across all entity-level
+ * grants. Sibling of `AggregatedFeatureBalance`, but for booleans — no balance
+ * fields since booleans don't have them. Produced by splitting the entity
+ * aggregate CTE output by feature type.
+ */
+export const AggregatedSubjectFlagSchema = z.object({
+	feature_id: z.string(),
+	internal_feature_id: z.string(),
+	internal_customer_id: z.string(),
+	api_id: z.string(),
+});
+
+export type AggregatedSubjectFlag = {
+	feature_id: string;
+	internal_feature_id: string;
+	internal_customer_id: string;
+	api_id: string;
+};
+
+/**
  * Schema mirror of `EntityAggregations`. Reuses `CusProductSchema` as the Zod
  * mirror of `DbCustomerProduct` for the aggregated customer products array.
  */
 export const EntityAggregationsSchema = z.object({
 	aggregated_customer_products: z.array(CusProductSchema),
 	aggregated_customer_entitlements: z.array(AggregatedFeatureBalanceSchema),
+	aggregated_subject_flags: z
+		.record(z.string(), AggregatedSubjectFlagSchema)
+		.default({}),
 });
 
 export type EntityAggregations = {
 	aggregated_customer_products: DbCustomerProduct[];
 	aggregated_customer_entitlements: AggregatedFeatureBalance[];
+	aggregated_subject_flags: Record<string, AggregatedSubjectFlag>;
 };
 
 /**

--- a/shared/utils/featureUtils/classifyFeature/isBooleanFeature.ts
+++ b/shared/utils/featureUtils/classifyFeature/isBooleanFeature.ts
@@ -1,0 +1,8 @@
+import { FeatureType } from "@models/featureModels/featureEnums";
+import type { Feature } from "@models/featureModels/featureModels";
+
+export const isBooleanFeature = (feature: Feature) => {
+	if (feature.type === FeatureType.Boolean) return true;
+
+	return false;
+};

--- a/shared/utils/fullSubjectUtils/normalizedToFullSubject.ts
+++ b/shared/utils/fullSubjectUtils/normalizedToFullSubject.ts
@@ -3,6 +3,7 @@ import type {
 	SubjectType,
 } from "../../models/cusModels/fullSubject/fullSubjectModel.js";
 import type {
+	AggregatedSubjectFlag,
 	NormalizedFullSubject,
 	SubjectBalance,
 	SubjectFlag,
@@ -81,14 +82,18 @@ const subjectBalanceToFullCustomerEntitlement = ({
 const subjectFlagToFullCustomerEntitlement = ({
 	subjectFlag,
 	fullEntitlement,
+	internalCustomerId,
+	internalEntityId,
 }: {
 	subjectFlag: SubjectFlag;
 	fullEntitlement: FullCustomerEntitlement["entitlement"];
+	internalCustomerId: string;
+	internalEntityId: string | null;
 }): FullCustomerEntitlement => {
 	return {
 		id: subjectFlag.customerEntitlementId,
-		internal_customer_id: subjectFlag.internalCustomerId,
-		internal_entity_id: subjectFlag.internalEntityId,
+		internal_customer_id: internalCustomerId,
+		internal_entity_id: internalEntityId,
 		internal_feature_id: subjectFlag.internalFeatureId,
 		feature_id: subjectFlag.featureId,
 		customer_product_id: subjectFlag.customerProductId,
@@ -245,6 +250,12 @@ export const normalizedToFullSubject = ({
 		}
 	}
 
+	const customerProductsById = new Map(
+		customerProductsInput.map(
+			(customerProduct) => [customerProduct.id, customerProduct] as const,
+		),
+	);
+
 	const booleanCesByCustomerProductId = new Map<
 		string,
 		FullCustomerEntitlement[]
@@ -255,9 +266,15 @@ export const normalizedToFullSubject = ({
 		const entitlement = entitlementsById.get(flag.entitlementId);
 		if (!entitlement) continue;
 
+		const matchingCustomerProduct = flag.customerProductId
+			? customerProductsById.get(flag.customerProductId)
+			: undefined;
+
 		const fullCustomerEntitlement = subjectFlagToFullCustomerEntitlement({
 			subjectFlag: flag,
 			fullEntitlement: entitlement,
+			internalCustomerId: normalized.internalCustomerId,
+			internalEntityId: matchingCustomerProduct?.internal_entity_id ?? null,
 		});
 
 		if (!flag.customerProductId) {
@@ -300,8 +317,11 @@ export const normalizedToFullSubject = ({
 	let aggregatedCustomerEntitlements:
 		| FullAggregatedFeatureBalance[]
 		| undefined;
+	let aggregatedSubjectFlags: Record<string, AggregatedSubjectFlag> | undefined;
 
 	if (normalized.entity_aggregations) {
+		aggregatedSubjectFlags =
+			normalized.entity_aggregations.aggregated_subject_flags;
 		const entityAgg = normalized.entity_aggregations;
 		const aggregatedCustomerProductsInput = getArrayEntries<
 			NonNullable<
@@ -373,6 +393,9 @@ export const normalizedToFullSubject = ({
 			: {}),
 		...(aggregatedCustomerEntitlements
 			? { aggregated_customer_entitlements: aggregatedCustomerEntitlements }
+			: {}),
+		...(aggregatedSubjectFlags
+			? { aggregated_subject_flags: aggregatedSubjectFlags }
 			: {}),
 	} as FullSubject;
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Separate boolean features from metered entity aggregates and surface them in balances to reduce over-fetching and avoid missing flags. Also adds a fast V2 lock-receipt path that pipelines claim and cleanup to cut Redis round trips and prevent finalizer races.

- **New Features**
  - Boolean flags are split into `aggregated_subject_flags` and used by `getApiBalancesV2` when entitlements aren’t hydrated; models, SQL, and normalization updated.
  - V2 lock receipts: `saveLockReceiptV2`/`fetchAndClaimLockReceiptV2`/`deleteLockReceiptV2` with a per-lock `:claim` marker (NX+EX) and a single-round-trip GET+SET pipeline; variadic DEL cleanup.

<sup>Written for commit cb3be5a66c7eea7ebafb3757f2fea805c19746e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

