### PR TITLE
fix: rollout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5644,6 +5644,8 @@
 
     "@autumn/server/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@autumn/server/@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260423.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260423.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260423.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260423.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg=="],
+
     "@autumn/server/autumn-js": ["autumn-js@0.1.85", "", { "dependencies": { "query-string": "^9.2.2", "rou3": "^0.6.1", "swr": "^2.3.3", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": "^1.3.17", "better-call": "^1.0.12", "convex": "^1.25.4" }, "optionalPeers": ["better-auth", "better-call", "convex"] }, "sha512-PDud/t8z5bDJcD7ptyHzTaoJ0A8zkxvQ4TYcJ48RtgKDdOkVY36D1T6udVLwLDnWw4J5KXwJgEuGxHdd+cuABw=="],
 
     "@autumn/server/ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
@@ -6437,6 +6439,8 @@
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "@useautumn/sdk/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@useautumn/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@vercel/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -7255,6 +7259,20 @@
     "@asyncapi/parser/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "@autumn/server/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wbLr6o5fROaCYt6cOpFhbe92FJAOdhAHwm/s8I/IyN5HbL1ULgel/wHaZiR+ws+27rgruNUiCENzTUg9vSz2bA=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-13MpNT+4MgkgrfiW2u03rnER5aB3yz9fA0bWEYh6IH3rIqA2AR3Dntp3QXW4sQrZf0SriXqHe2R7X3HCT5xmqA=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "arm" }, "sha512-CxUA15qbPQRvz2nanBpiv1h4tgXTCJJwqOtgKMSdIuPkow8dyYW3ba5oLoH/jZhS4792XislX659hlFrfiU6CQ=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-ICIkJDTqmn0R4Vs811+Ht2RYTk1OCrAhHCu0JthmhR216T1Tqgi5DWRoCprp3RL1qU6fLnxxrIpEbNlNN7XFYA=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cWLFS4R8dOU1YuUJ/2VLeGMVIjgI3GGb/f9rRY5MbWHq5l3NNZh8y1QwAOrTh3+g3q6+znArfxVnD2hZHUz8Mw=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-OWaGUI4+dHqYZv+k6sITx9Y27FNy3XzNFk4OrOiYtBkIO/xrb9TPMP4A5XI4n5zwRLIv3xne9g039xgRbaeyoQ=="],
+
+    "@autumn/server/@typescript/native-preview/@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5MQjO/qdLwXpjW7Dy/1lNv7Vtpvo6bhCkbjan4PoRN5/eeyqEqDWxdf8AGE4btLmHqyIjEHRuYf7kp2tlAr6lQ=="],
 
     "@autumn/server/autumn-js/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -22,6 +22,7 @@ import { handleUpsertAdminOrgRequestBlock } from "./handleUpsertAdminOrgRequestB
 import { handleUpsertAdminRequestBlockConfig } from "./handleUpsertAdminRequestBlockConfig";
 import { handleUpsertAdminRedisV2CacheConfig } from "./handleUpsertAdminRedisV2CacheConfig";
 import { handleUpsertAdminStripeSyncConfig } from "./handleUpsertAdminStripeSyncConfig";
+import { handleDeleteRollout } from "./rollouts/handleDeleteRollout";
 import { handleDeleteRolloutOrg } from "./rollouts/handleDeleteRolloutOrg";
 import { handleGetRollouts } from "./rollouts/handleGetRollouts";
 import { handleUpdateRollout } from "./rollouts/handleUpdateRollout";
@@ -90,6 +91,7 @@ honoAdminRouter.put(
 	"/rollouts/:rollout_id/orgs/:org_id",
 	...handleUpdateRolloutOrg,
 );
+honoAdminRouter.delete("/rollouts/:rollout_id", ...handleDeleteRollout);
 honoAdminRouter.delete(
 	"/rollouts/:rollout_id/orgs/:org_id",
 	...handleDeleteRolloutOrg,

--- a/server/src/internal/admin/rollouts/handleDeleteRollout.ts
+++ b/server/src/internal/admin/rollouts/handleDeleteRollout.ts
@@ -1,0 +1,16 @@
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { deleteRollout } from "@/internal/misc/rollouts/rolloutConfigStore.js";
+
+export const handleDeleteRollout = createRoute({
+	params: z.object({
+		rollout_id: z.string().min(1),
+	}),
+	handler: async (c) => {
+		const { rollout_id: rolloutId } = c.req.param();
+
+		const config = await deleteRollout({ rolloutId });
+
+		return c.json({ success: true, rolloutId, rollouts: config.rollouts });
+	},
+});

--- a/server/src/internal/balances/utils/sync/syncItemV3.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV3.ts
@@ -205,6 +205,7 @@ export const syncItemV3 = async ({
 		ctx,
 		customerId,
 		redisInstance,
+		skipRolloutCheck: true,
 	});
 
 	if (!fullCustomer) {

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts
@@ -126,11 +126,13 @@ export const getCachedFullCustomer = async ({
 	customerId,
 	entityId,
 	redisInstance,
+	skipRolloutCheck = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	redisInstance?: Redis;
+	skipRolloutCheck?: boolean;
 }): Promise<FullCustomer | undefined> => {
 	const { org, env } = ctx;
 	const cacheKey = buildFullCustomerCacheKey({
@@ -151,6 +153,7 @@ export const getCachedFullCustomer = async ({
 	delete parsed._cachedAt;
 
 	if (
+		!skipRolloutCheck &&
 		ctx.rolloutSnapshot &&
 		isSnapshotCacheStale({
 			snapshot: ctx.rolloutSnapshot,

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/setCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/setCachedFullCustomer.ts
@@ -102,7 +102,7 @@ export const setCachedFullCustomer = async ({
 	});
 	const pathIndexJson = JSON.stringify(pathIndexEntries);
 
-	const payload = { ...fullCustomer, _cachedAt: Date.now() };
+	const payload = { ...fullCustomerForCache, _cachedAt: Date.now() };
 
 	const result = await tryRedisWrite(async () => {
 		return await redis.setFullCustomerCache(
@@ -112,7 +112,7 @@ export const setCachedFullCustomer = async ({
 			customerId,
 			String(fetchTimeMs),
 			String(FULL_CUSTOMER_CACHE_TTL_SECONDS),
-			JSON.stringify(fullCustomerForCache),
+			JSON.stringify(payload),
 			String(overwrite),
 			pathIndexJson,
 		);

--- a/server/src/internal/events/handlers/handleExternalAggregateEvents.ts
+++ b/server/src/internal/events/handlers/handleExternalAggregateEvents.ts
@@ -35,17 +35,6 @@ export const handleExternalAggregateEvents = createRoute({
 			max_groups,
 		} = c.req.valid("json");
 
-		console.log("handleAggregateEvents", {
-			customer_id,
-			entity_id,
-			feature_id,
-			group_by,
-			range,
-			bin_size,
-			custom_range,
-			filter_by,
-		});
-
 		let customer: Awaited<ReturnType<typeof CusService.getFull>> | undefined;
 		let aggregateAll = false;
 

--- a/server/src/internal/misc/rollouts/rolloutConfigStore.ts
+++ b/server/src/internal/misc/rollouts/rolloutConfigStore.ts
@@ -81,3 +81,19 @@ export const removeRolloutOrg = async ({
 
 	return config;
 };
+
+/**
+ * Delete a rollout entry entirely. Use this instead of setting percent to 0
+ * when you want to reset the staleness window (previousPercent/changedAt)
+ * without triggering cache invalidation for affected customers.
+ */
+export const deleteRollout = async ({
+	rolloutId,
+}: {
+	rolloutId: string;
+}) => {
+	const config = await store.readFromSource();
+	delete config.rollouts[rolloutId];
+	await store.writeToSource({ config });
+	return config;
+};

--- a/server/src/internal/misc/rollouts/rolloutUtils.ts
+++ b/server/src/internal/misc/rollouts/rolloutUtils.ts
@@ -104,6 +104,7 @@ export const isSnapshotCacheStale = ({
 
 	const wasEnabled = snapshot.customerBucket < snapshot.previousPercent;
 	const isEnabled = snapshot.customerBucket < snapshot.percent;
+
 	if (wasEnabled === isEnabled) return false;
 
 	if (!cachedAt) return true;

--- a/vite/src/views/admin/edge-config/EdgeConfigView.tsx
+++ b/vite/src/views/admin/edge-config/EdgeConfigView.tsx
@@ -141,6 +141,7 @@ const RolloutCard = ({
 	onUpdateGlobal,
 	onUpdateOrg,
 	onDeleteOrg,
+	onDeleteRollout,
 	onAddOrg,
 }: {
 	rolloutId: string;
@@ -168,6 +169,7 @@ const RolloutCard = ({
 		rolloutId: string;
 		orgId: string;
 	}) => void;
+	onDeleteRollout: ({ rolloutId }: { rolloutId: string }) => void;
 	onAddOrg: ({ rolloutId }: { rolloutId: string }) => void;
 }) => {
 	const [expanded, setExpanded] = useState(true);
@@ -239,6 +241,12 @@ const RolloutCard = ({
 						>
 							Save
 						</Button>
+						<IconButton
+							icon={<Trash2 className="w-3.5 h-3.5" />}
+							variant="secondary"
+							size="sm"
+							onClick={() => onDeleteRollout({ rolloutId })}
+						/>
 					</div>
 				</div>
 			</CardHeader>
@@ -376,6 +384,24 @@ export const EdgeConfigView = () => {
 		onError: (error) =>
 			toast.error(getBackendErr(error, "Failed to remove org override")),
 	});
+
+	const deleteRolloutMutation = useMutation({
+		mutationFn: async ({ rolloutId }: { rolloutId: string }) => {
+			await axiosInstance.delete(`/admin/rollouts/${rolloutId}`);
+		},
+		onSuccess: () => {
+			toast.success("Rollout deleted");
+			refetch();
+		},
+		onError: (error) =>
+			toast.error(getBackendErr(error, "Failed to delete rollout")),
+	});
+
+	const handleDeleteRollout = ({ rolloutId }: { rolloutId: string }) => {
+		if (!confirm(`Delete rollout "${rolloutId}"? This resets the staleness window.`))
+			return;
+		deleteRolloutMutation.mutate({ rolloutId });
+	};
 
 	const handleDeleteOrg = ({
 		rolloutId,
@@ -536,6 +562,7 @@ export const EdgeConfigView = () => {
 							updateOrgMutation.mutate({ rolloutId, orgId, percent })
 						}
 						onDeleteOrg={handleDeleteOrg}
+						onDeleteRollout={handleDeleteRollout}
 						onAddOrg={({ rolloutId }) => setAddOrgRolloutId(rolloutId)}
 					/>
 				))}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a delete rollout API and admin UI action to fully remove a rollout and reset its staleness window without invalidating customer caches. Also fixes full-customer cache writes and lets balance sync bypass rollout staleness checks.

- **New Features**
  - Server: `DELETE /admin/rollouts/:rollout_id` with `deleteRollout()` to remove a rollout and reset staleness tracking.
  - UI: Adds a trash button in Edge Config Rollout cards with confirm; calls the new endpoint and refreshes the list.

- **Bug Fixes**
  - Cache: `setCachedFullCustomer` now stores the processed payload with `_cachedAt`.
  - Cache: `getCachedFullCustomer` supports `skipRolloutCheck`; `syncItemV3` uses it to avoid unnecessary invalidations during sync.
  - Cleanup: Removes noisy console logs from the external aggregate events handler.

<sup>Written for commit c924d755af52e4c44c0d67da23a26c7f97880f89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

