### PR TITLE
fix: 🐛 a bug with one off coupon retention

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/filterStripeDiscountsForNextCycle.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/filterStripeDiscountsForNextCycle.ts
@@ -44,22 +44,24 @@ const stripeDiscountAppliesToNextCycle = ({
 		end: formatSeconds(discount.end),
 	});
 	console.log("Next cycle start:", formatMs(nextCycleStart));
-	if (discount.id) {
-		if (discount.end == null) return true;
-		return secondsToMs(discount.end) > nextCycleStart;
-	}
 
 	const { coupon } = discount.source;
-
-	if (coupon.duration === "forever") {
-		return true;
-	}
 
 	if (coupon.duration === "once") {
 		return false;
 	}
 
+	if (coupon.duration === "forever") {
+		return true;
+	}
+
 	if (coupon.duration === "repeating") {
+		// Existing discounts have Stripe's own `end` populated — trust it.
+		if (discount.end != null) {
+			return secondsToMs(discount.end) > nextCycleStart;
+		}
+
+		// Fresh repeating discount without an id: compute end from now.
 		const durationInMonths = coupon.duration_in_months ?? 0;
 		if (durationInMonths <= 0) return false;
 

--- a/server/tests/_temp/temp.test.ts
+++ b/server/tests/_temp/temp.test.ts
@@ -1,95 +1,137 @@
-import { test } from "bun:test";
+/**
+ * TDD scratch tests for the `one_off` reward leakage bug.
+ *
+ * Bug: an existing Stripe discount backed by a `once` coupon (with end=null)
+ * is treated as active in next-cycle previews and billing.previewAttach
+ * responses, even when no coupon is passed in the new request.
+ *
+ * Both tests should FAIL on current `dev` and PASS after the fix to
+ * `filterStripeDiscountsForNextCycle.ts`.
+ */
+
+import { expect, test } from "bun:test";
+import type { StripeDiscountWithCoupon } from "@autumn/shared";
 import {
-	type ApiCustomerV5,
-	type AttachParamsV1Input,
-	RolloverExpiryDurationType,
-} from "@autumn/shared";
-import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
-import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
-import { TestFeature } from "@tests/setup/v2Features";
-import { products } from "@tests/utils/fixtures/products.js";
-import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+	applySubscriptionDiscount,
+	createPercentCoupon,
+	getStripeSubscription,
+} from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { expectPreviewNextCycleCorrect } from "@tests/integration/billing/utils/expectPreviewNextCycleCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
-import { constructPrepaidItem } from "@/utils/scriptUtils/constructItem.js";
+import { filterStripeDiscountsForNextCycle } from "@/internal/billing/v2/providers/stripe/utils/discounts/filterStripeDiscountsForNextCycle";
 
-test.concurrent(`${chalk.yellowBright("temp: pro annual prepaid credits with rollover carries to pro monthly")}`, async () => {
-	const customerId = "temp-annual-prepaid-rollover";
-	const rolloverConfig = {
-		max_percentage: 50,
-		length: 1,
-		duration: RolloverExpiryDurationType.Month,
-	};
+test.concurrent(
+	`${chalk.yellowBright("temp unit: filterStripeDiscountsForNextCycle excludes existing once discount")}`,
+	() => {
+		const now = Date.now();
+		const nextCycleStart = now + 30 * 24 * 60 * 60 * 1000;
 
-	const annualCreditsItem = constructPrepaidItem({
-		featureId: TestFeature.Credits,
-		includedUsage: 100,
-		billingUnits: 1,
-		price: 0.25,
-		rolloverConfig,
-	});
+		// Mirrors the real-world state reported in the bug:
+		// - discount is already on the subscription (has an id)
+		// - end is null (Stripe doesn't populate end for `once` coupons)
+		// - coupon duration is "once"
+		const existingOnceDiscount = {
+			id: "di_existing_once",
+			end: null,
+			source: {
+				coupon: {
+					id: "coupon_early_bird",
+					object: "coupon",
+					duration: "once",
+					percent_off: 20,
+					amount_off: null,
+					currency: null,
+					valid: true,
+					livemode: false,
+					created: Math.floor(now / 1000),
+					metadata: {},
+					name: "Early Bird",
+					times_redeemed: 1,
+					max_redemptions: null,
+					redeem_by: null,
+					duration_in_months: null,
+					applies_to: undefined,
+				},
+			},
+		} as unknown as StripeDiscountWithCoupon;
 
-	const monthlyCreditsItem = constructPrepaidItem({
-		featureId: TestFeature.Credits,
-		includedUsage: 100,
-		billingUnits: 1,
-		price: 0.25,
-		rolloverConfig,
-	});
+		const result = filterStripeDiscountsForNextCycle({
+			stripeDiscounts: [existingOnceDiscount],
+			currentEpochMs: now,
+			nextCycleStart,
+		});
 
-	const proAnnual = products.proAnnual({
-		id: "pro-annual-rollover",
-		items: [annualCreditsItem],
-	});
+		expect(
+			result.length,
+			"existing `once` discount with end=null must NOT propagate to next cycle",
+		).toBe(0);
+	},
+);
 
-	const pro = products.pro({
-		id: "pro-monthly-rollover",
-		items: [monthlyCreditsItem],
-	});
+test.concurrent(
+	`${chalk.yellowBright("temp integration: existing once discount does not leak into previewAttach next_cycle")}`,
+	async () => {
+		const customerId = "temp-once-discount-leak";
 
-	const { autumnV2_2, ctx } = await initScenario({
-		customerId,
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [proAnnual, pro] }),
-		],
-		actions: [
-			s.billing.attach({
-				productId: proAnnual.id,
-				options: [{ feature_id: TestFeature.Credits, quantity: 1500 }],
-			}),
-			// s.track({ featureId: TestFeature.Action1, value: 10, timeout: 2000 }),
-			s.advanceToNextInvoice(),
-		],
-	});
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
 
-	const customerAfterInvoice =
-		await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
 
-	expectBalanceCorrect({
-		customer: customerAfterInvoice,
-		featureId: TestFeature.Credits,
-		remaining: 1500 + 750,
-		usage: 0,
-		rollovers: [{ balance: 750 }],
-	});
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
 
-	await autumnV2_2.billing.attach<AttachParamsV1Input>({
-		customer_id: customerId,
-		plan_id: pro.id,
-		redirect_mode: "if_required",
-		// feature_quantities: [{ feature_id: TestFeature.Credits, quantity: 750 }],
-	});
+		// Simulate the post-checkout state: a `once` 20% coupon is already
+		// attached to the Stripe subscription (end=null on the discount).
+		const { stripeCli, subscription } = await getStripeSubscription({
+			customerId,
+		});
 
-	const customerAfterSwitch =
-		await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const coupon = await createPercentCoupon({
+			stripeCli,
+			percentOff: 20,
+			duration: "once",
+		});
 
-	expectBalanceCorrect({
-		customer: customerAfterSwitch,
-		featureId: TestFeature.Credits,
-		remaining: 1500 + 750,
-		usage: 0,
-		rollovers: [{ balance: 750 }],
-	});
+		await applySubscriptionDiscount({
+			stripeCli,
+			subscriptionId: subscription.id,
+			couponIds: [coupon.id],
+		});
 
-	await expectStripeSubscriptionCorrect({ ctx, customerId });
-});
+		// No discount passed in the preview request — the once should not
+		// carry over into next-cycle line items or totals.
+		const preview = await autumnV1.billing.previewAttach({
+			customer_id: customerId,
+			product_id: premium.id,
+		});
+
+		const nextCycle = expectPreviewNextCycleCorrect({ preview })!;
+
+		expect(
+			nextCycle.line_items.every(
+				(lineItem) => lineItem.discounts.length === 0,
+			),
+			"no next-cycle line item should carry the consumed once discount",
+		).toBe(true);
+
+		expect(
+			nextCycle.total,
+			"next-cycle total must equal subtotal when no active discount remains",
+		).toBe(nextCycle.subtotal);
+	},
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a bug where a one-off Stripe coupon (`duration: "once"`) was incorrectly retained for the next billing cycle in previews and `billing.previewAttach`. The next cycle now ignores consumed one-off discounts and handles repeating coupons correctly.

- **Bug Fixes**
  - Updated `filterStripeDiscountsForNextCycle.ts` to never carry over `once` coupons; `forever` always applies; for `repeating`, trust `discount.end` if present, otherwise compute from `duration_in_months`.
  - Added tests (`temp.test.ts`): a unit test that excludes existing `once` discounts and an integration test ensuring `previewAttach` next-cycle totals/line items show no leaked discount.

<sup>Written for commit 85ce0200e62caff30d9abde34243b68f4bf9f74d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where an existing Stripe discount backed by a `once` coupon (with `end=null`) was incorrectly carried forward into next-cycle previews and billing. The fix removes the early-return on `discount.id` that caused `once` coupons with a null `end` to always be treated as active, instead checking `coupon.duration` first so that `once` coupons are unconditionally excluded from the next cycle.

**Key changes:**
- **Bug fixes** — `filterStripeDiscountsForNextCycle.ts`: reorders duration checks so `"once"` is evaluated before the `end`-date comparison, correcting the leakage
- **Bug fixes** — `repeating` discounts now fall back to computing end from `duration_in_months` only when Stripe hasn't yet populated `discount.end`, preserving correct behaviour for both fresh and existing repeating discounts
- **Improvements** — `temp.test.ts`: adds a focused unit test and an integration test that reproduce the exact failure mode and verify the fix
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, targeted, and well-tested with both a unit and integration test.

The change is a straightforward reordering and simplification of the duration-check logic. The `once` case now correctly returns `false` before any `end`-date inspection, eliminating the leakage. No regressions are introduced: `forever` and `repeating` paths remain logically equivalent to before for all real-world Stripe states. All remaining observations are P2.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/discounts/filterStripeDiscountsForNextCycle.ts | Fixes the once-coupon retention bug by checking coupon.duration first before consulting discount.end; removes the discount.id guard that caused once coupons with end=null to be incorrectly treated as active in the next cycle. |
| server/tests/_temp/temp.test.ts | Replaces the previous rollover temp test with two new TDD scratch tests (one unit, one integration) targeting the once-coupon leakage bug; integration test depends on helper utilities that must exist in the test suite. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[stripeDiscountAppliesToNextCycle] --> B{coupon.duration?}
    B -->|once| C[return false ✅ fixed]
    B -->|forever| D[return true]
    B -->|repeating| E{discount.end != null?}
    E -->|yes - trust Stripe end| F{end > nextCycleStart?}
    F -->|yes| G[return true]
    F -->|no| H[return false]
    E -->|no - compute from coupon| I{duration_in_months > 0?}
    I -->|no| J[return false]
    I -->|yes| K{addMonths now > nextCycleStart?}
    K -->|yes| L[return true]
    K -->|no| M[return false]
    B -->|unknown| N[return false]
    style C fill:#c8f7c5,stroke:#27ae60
    style D fill:#c8f7c5,stroke:#27ae60
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/billing/v2/providers/stripe/utils/discounts/filterStripeDiscountsForNextCycle.ts
Line: 64

Comment:
**Misleading comment — condition is on `end`, not `id`**

The comment says "Fresh repeating discount without an id" but the guard on line 60 only checks `discount.end != null`, not `!discount.id`. An existing (id-bearing) repeating discount that Stripe hasn't yet populated with an `end` would also reach this branch and have its end recomputed from `duration_in_months`. In practice Stripe always sets `end` for active repeating discounts, so this is harmless, but the comment may mislead future readers.

```suggestion
		// No Stripe-populated end yet: compute end from now.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 a bug with one off coupon retent..."](https://github.com/useautumn/autumn/commit/85ce0200e62caff30d9abde34243b68f4bf9f74d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29453804)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->