### PR TITLE
chore: update rollout ui

### DIFF
--- a/server/src/internal/admin/rollouts/handleGetRollouts.ts
+++ b/server/src/internal/admin/rollouts/handleGetRollouts.ts
@@ -1,3 +1,5 @@
+import { organizations } from "@autumn/shared";
+import { inArray } from "drizzle-orm";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import {
 	getRolloutConfigFromSource,
@@ -6,11 +8,31 @@ import {
 
 export const handleGetRollouts = createRoute({
 	handler: async (c) => {
+		const { db } = c.get("ctx");
 		const status = getRolloutConfigStatus();
 		const config = await getRolloutConfigFromSource();
+		const orgIds = [
+			...new Set(
+				Object.values(config.rollouts).flatMap((rollout) =>
+					Object.keys(rollout.orgs),
+				),
+			),
+		];
+		const orgs =
+			orgIds.length > 0
+				? await db
+						.select({
+							id: organizations.id,
+							name: organizations.name,
+							slug: organizations.slug,
+						})
+						.from(organizations)
+						.where(inArray(organizations.id, orgIds))
+				: [];
 
 		return c.json({
 			rollouts: config.rollouts,
+			orgsById: Object.fromEntries(orgs.map((org) => [org.id, org])),
 			configHealthy: status.healthy,
 			configConfigured: status.configured,
 			lastSuccessAt: status.lastSuccessAt ?? null,

--- a/vite/src/views/admin/edge-config/EdgeConfigView.tsx
+++ b/vite/src/views/admin/edge-config/EdgeConfigView.tsx
@@ -40,8 +40,15 @@ type RolloutEntry = RolloutPercent & {
 	orgs: Record<string, RolloutPercent>;
 };
 
+type RolloutOrg = {
+	id: string;
+	name: string;
+	slug: string;
+};
+
 type RolloutsResponse = {
 	rollouts: Record<string, RolloutEntry>;
+	orgsById: Record<string, RolloutOrg>;
 	configHealthy: boolean;
 	configConfigured: boolean;
 	lastSuccessAt: string | null;
@@ -68,12 +75,14 @@ const formatPercent = (percent: number) => `${percent}%`;
 const RolloutOrgRow = ({
 	rolloutId,
 	orgId,
+	org,
 	orgEntry,
 	onUpdate,
 	onDelete,
 }: {
 	rolloutId: string;
 	orgId: string;
+	org?: RolloutOrg;
 	orgEntry: RolloutPercent;
 	onUpdate: ({
 		rolloutId,
@@ -97,7 +106,12 @@ const RolloutOrgRow = ({
 	return (
 		<div className="grid gap-3 rounded-xl border border-border bg-muted/20 p-3 md:grid-cols-[minmax(0,1fr)_220px_auto] md:items-center">
 			<div className="min-w-0">
-				<p className="truncate font-mono text-xs text-foreground">{orgId}</p>
+				<p className="truncate text-sm font-medium text-foreground">
+					{org?.name ?? orgId}
+				</p>
+				<p className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
+					{org ? `${org.slug} | ${org.id}` : "Unknown org"}
+				</p>
 				<p className="mt-1 text-[11px] text-muted-foreground">
 					prev: {formatPercent(orgEntry.previousPercent)} | changed:{" "}
 					{formatTimestamp(orgEntry.changedAt)}
@@ -142,9 +156,11 @@ const RolloutCard = ({
 	onUpdateOrg,
 	onDeleteOrg,
 	onAddOrg,
+	orgsById,
 }: {
 	rolloutId: string;
 	entry: RolloutEntry;
+	orgsById: Record<string, RolloutOrg>;
 	onUpdateGlobal: ({
 		rolloutId,
 		percent,
@@ -283,6 +299,7 @@ const RolloutCard = ({
 								key={orgId}
 								rolloutId={rolloutId}
 								orgId={orgId}
+								org={orgsById[orgId]}
 								orgEntry={orgEntry}
 								onUpdate={onUpdateOrg}
 								onDelete={onDeleteOrg}
@@ -399,6 +416,7 @@ export const EdgeConfigView = () => {
 	if (!isAdmin) return <DefaultView />;
 
 	const rollouts = data?.rollouts ?? {};
+	const orgsById = data?.orgsById ?? {};
 	const rolloutEntries = Object.entries(rollouts);
 	const rolloutSource = source?.configs.find((config) => config.id === "rollouts");
 
@@ -529,6 +547,7 @@ export const EdgeConfigView = () => {
 						key={rolloutId}
 						rolloutId={rolloutId}
 						entry={entry}
+						orgsById={orgsById}
 						onUpdateGlobal={({ rolloutId, percent }) =>
 							updateGlobalMutation.mutate({ rolloutId, percent })
 						}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show readable org names and slugs in the rollouts admin UI by returning organization metadata from the rollouts API. No changes to rollout logic; display-only improvement.

- **New Features**
  - API now returns `orgsById` map (id, name, slug) for orgs referenced in rollouts, fetched via `@autumn/shared` and `drizzle-orm`.
  - UI displays org name, plus slug and id; falls back to the raw org ID when unknown.
  - Skips DB query when no org IDs are present.

<sup>Written for commit d44b8924d2d852ef1c3f560dbbf901bccf27130d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enriches the rollout admin UI by fetching organization details (name, slug, id) from the database and displaying them alongside raw org IDs in the rollout configuration view. The backend endpoint now performs a batched DB lookup for all org IDs present in the rollout config, and the frontend threads the resulting `orgsById` map down to each `RolloutOrgRow` with graceful fallbacks.

**Key changes:**
- [Improvements] Backend batches org lookup with an `inArray` guard on empty input, returning `orgsById` in the rollout response.
- [Improvements] Frontend displays org name, slug, and ID in `RolloutOrgRow`, falling back to raw `orgId`/`"Unknown org"` when the org isn't in the DB.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive UI improvements with proper guards and fallbacks.

No P0 or P1 issues found. The empty-array guard on inArray is correct, the optional org prop is handled gracefully in the UI, and the data flow is straightforward prop-drilling. All remaining observations are P2 or lower.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/admin/rollouts/handleGetRollouts.ts | Adds batched DB lookup of org name/slug for all org IDs in the rollout config; correctly guards against empty inArray and returns orgsById map. |
| vite/src/views/admin/edge-config/EdgeConfigView.tsx | Adds RolloutOrg type, threads orgsById through RolloutCard to RolloutOrgRow, displaying org name and slug with safe fallbacks when org is not found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as EdgeConfigView
    participant API as handleGetRollouts
    participant Store as rolloutConfigStore
    participant DB as Database (organizations)

    UI->>API: GET /admin/rollouts
    API->>Store: getRolloutConfigStatus()
    Store-->>API: status
    API->>Store: getRolloutConfigFromSource()
    Store-->>API: config (rollouts with orgs)
    API->>API: extract unique orgIds from config
    alt orgIds.length > 0
        API->>DB: SELECT id, name, slug WHERE id IN (orgIds)
        DB-->>API: org records
    else
        API-->>API: orgs = []
    end
    API-->>UI: { rollouts, orgsById, configHealthy, ... }
    UI->>UI: pass orgsById → RolloutCard → RolloutOrgRow
    UI->>UI: display org.name / org.slug with fallback to orgId
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update rollout ui"](https://github.com/useautumn/autumn/commit/d44b8924d2d852ef1c3f560dbbf901bccf27130d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29454290)</sub>

<!-- /greptile_comment -->