### PR TITLE
fix: limit entities in expand

### DIFF
--- a/server/src/internal/api/entities/EntityService.ts
+++ b/server/src/internal/api/entities/EntityService.ts
@@ -125,11 +125,13 @@ export class EntityService {
 		internalCustomerId,
 		inFeatureIds,
 		isDeleted,
+		limit,
 	}: {
 		db: DrizzleCli;
 		internalCustomerId: string;
 		inFeatureIds?: string[];
 		isDeleted?: boolean;
+		limit?: number;
 	}) {
 		return (await db.query.entities.findMany({
 			where: (entities, { eq }) =>
@@ -140,6 +142,7 @@ export class EntityService {
 						: undefined,
 					isDeleted ? eq(entities.deleted, isDeleted) : undefined,
 				),
+			limit,
 		})) as Entity[];
 	}
 

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpandV2.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpandV2.ts
@@ -52,6 +52,7 @@ export const getApiCustomerExpandV2 = async ({
 		const entities = await EntityService.list({
 			db: ctx.db,
 			internalCustomerId: fullCus.internal_id,
+			limit: 1000,
 		});
 
 		return entities.map((e) =>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit entity expansion to 1000 items to avoid unbounded queries and reduce memory/latency spikes. Added an optional limit argument to EntityService.list and applied it in getApiCustomerExpandV2.

<sup>Written for commit fe0aa0cbe09c87879f87053543221adde77cc9b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

