### PR TITLE
fix: 🐛 renewal bug

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/modifyStripeSubscriptionFromCheckout.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/modifyStripeSubscriptionFromCheckout.ts
@@ -32,6 +32,7 @@ export const modifyStripeSubscriptionFromCheckout = async ({
 
 	await stripeCli.subscriptions.update(updateAction.stripeSubscriptionId, {
 		...updateAction.params,
+		discounts: undefined,
 		payment_behavior: "error_if_incomplete",
 		expand: ["latest_invoice"],
 	});

--- a/server/tests/_temp/temp2.test.ts
+++ b/server/tests/_temp/temp2.test.ts
@@ -1,106 +1,108 @@
+/**
+ * TDD scratch test for the post-checkout `once` re-redemption bug.
+ *
+ * Bug: when a customer attaches a plan via Stripe Checkout with a `once`
+ * coupon, `modifyStripeSubscriptionFromCheckout` runs a post-checkout
+ * subscription update that re-sends the resolved discounts via the
+ * `discounts` param. Stripe treats that as a fresh redemption and attaches
+ * a new `di_xxx` to the subscription, so the next renewal invoice applies
+ * the coupon a second time.
+ *
+ * Expected after fix (`discounts: undefined` in the post-checkout update):
+ *  - First (checkout) invoice = $16 (20% off $20)
+ *  - Renewal invoice = $20 (no residual discount)
+ */
+
 import { test } from "bun:test";
-import type { AttachParamsV1Input } from "@autumn/shared";
-import {
-	applySubscriptionDiscount,
-	createPercentCoupon,
-	getStripeSubscription,
-} from "@tests/integration/billing/utils/discounts/discountTestUtils";
-import { TestFeature } from "@tests/setup/v2Features.js";
-import { items } from "@tests/utils/fixtures/items";
-import { products } from "@tests/utils/fixtures/products";
-import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import type { ApiCustomerV3, AttachParamsV1Input } from "@autumn/shared";
+import { createPercentCoupon } from "@tests/integration/billing/utils/discounts/discountTestUtils.js";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { completeStripeCheckoutFormV2 } from "@tests/utils/browserPool/completeStripeCheckoutFormV2.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 
-/**
- * Repro for Mintlify multi-entity discount bug.
- *
- * Production sequence (from Axiom logs):
- *  1. Entity 1 attaches pro (upgrade from Hobby) — creates subscription
- *  2. Discount applied to subscription
- *  3. Entity 1 cancels pro (end_of_cycle) — creates subscription schedule
- *  4. Entity 1 uncancels pro — schedule modified
- *  5. Entity 2 attaches pro — subscription update succeeds but schedule
- *     creation/update fails: "Discount di_xxx has exceeded its maximum
- *     number of applications and cannot be reused"
- *
- * The error is in stripeDiscountsToPhaseDiscounts which passes
- * { discount: "di_xxx" } to schedule phases — but the discount is bound
- * to the subscription, not the schedule.
- */
-test(`${chalk.yellowBright("bug repro: entity 2 attach after cancel+uncancel with discount on sub")}`, async () => {
-	const customerId = "multi-ent-cancel-uncancel";
+test(
+	`${chalk.yellowBright("temp integration: once coupon does not re-apply on renewal after checkout")}`,
+	async () => {
+		const customerId = "temp-checkout-once-renewal";
 
-	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
-
-	const pro = products.pro({
-		id: "pro",
-		items: [messagesItem],
-	});
-
-	// Step 1: Entity 1 attaches pro
-	const { autumnV2_2, autumnV1, entities } = await initScenario({
-		customerId,
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-			s.entities({ count: 2, featureId: TestFeature.Users }),
-		],
-		actions: [
-			s.billing.attach({ productId: pro.id, entityIndex: 0 }),
-		],
-	});
-
-	// Step 2: Apply a discount to entity 1's subscription
-	const { stripeCli, subscription } = await getStripeSubscription({
-		customerId,
-	});
-
-	const coupon = await createPercentCoupon({
-		stripeCli,
-		percentOff: 10,
-	});
-
-	await applySubscriptionDiscount({
-		stripeCli,
-		subscriptionId: subscription.id,
-		couponIds: [coupon.id],
-	});
-
-	// Step 3: Entity 1 cancels pro (end_of_cycle) — creates subscription schedule
-	console.log("Canceling entity 1 pro (end of cycle)...");
-	await autumnV2_2.subscriptions.update({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: pro.id,
-		cancel_action: "cancel_end_of_cycle",
-	});
-
-	await new Promise((resolve) => setTimeout(resolve, 3000));
-
-	// Step 4: Entity 1 uncancels pro — schedule released/modified
-	console.log("Uncanceling entity 1 pro...");
-	await autumnV2_2.subscriptions.update({
-		customer_id: customerId,
-		entity_id: entities[0].id,
-		plan_id: pro.id,
-		cancel_action: "uncancel",
-	});
-
-	await new Promise((resolve) => setTimeout(resolve, 3000));
-
-	// Step 5: Entity 2 attaches pro
-	console.log("Attaching pro to entity 2...");
-	try {
-		const result = await autumnV2_2.billing.attach<AttachParamsV1Input>({
-			customer_id: customerId,
-			entity_id: entities[1].id,
-			plan_id: pro.id,
-			redirect_mode: "if_required",
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
 		});
-		console.log("Entity 2 result:", JSON.stringify(result, null, 2));
-		console.log(chalk.red("BUG NOT REPRODUCED — entity 2 attach succeeded"));
-	} catch (error: any) {
-		console.log(chalk.green("BUG REPRODUCED — entity 2 attach failed:"));
-		console.log("Error:", JSON.stringify(error, null, 2));
-	}
-});
+
+		// No payment method on the customer → attach will return a checkout URL
+		// instead of charging immediately.
+		const { autumnV1, autumnV2_2, ctx, testClockId } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: true }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		// Stripe `once` 20% coupon — mirrors the merchant's real-world "Free Test"
+		// configuration that originally surfaced this bug.
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 20,
+			duration: "once",
+		});
+
+		// Attach via V2 billing.attach with the coupon as a discount.
+		// With no payment method, this returns a payment_url for Stripe Checkout.
+		const attachResult = await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			discounts: [{ reward_id: coupon.id }],
+		});
+
+		if (!attachResult.payment_url) {
+			throw new Error(
+				"Expected payment_url from V2 attach (customer has no payment method)",
+			);
+		}
+
+		// Complete the Stripe Checkout form via browser automation.
+		await completeStripeCheckoutFormV2({ url: attachResult.payment_url });
+
+		// Wait for checkout.session.completed webhook + modifyStripeSubscriptionFromCheckout.
+		await timeout(12000);
+
+		// Sanity: first invoice reflects the 20% discount (20 * 0.8 = 16).
+		let customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: 16,
+		});
+
+		if (!testClockId) {
+			throw new Error("Expected testClockId from initScenario");
+		}
+
+		// Advance the test clock to the next renewal. Stripe finalizes the
+		// renewal invoice during this advance.
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId,
+		});
+
+		// The renewal invoice must NOT be discounted.
+		// Without the fix: Stripe re-applied the `once` (Autumn re-sent it via
+		// the post-checkout sub update), so this invoice comes in at $16.
+		// With the fix: Stripe consumed the `once` on invoice #1 and the
+		// renewal is the full $20.
+		customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: 20,
+		});
+	},
+);


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a renewal billing bug where a Stripe `once` coupon was being re-applied on post-checkout subscription updates. The fix adds `discounts: undefined` to the `stripeCli.subscriptions.update` call in `modifyStripeSubscriptionFromCheckout`, preventing the spread of `updateAction.params` from forwarding resolved discount references back to Stripe (which treated it as a fresh redemption). The temp test file is replaced with a new scenario that reproduces and validates the fix using browser automation and a Stripe test clock.

**Key Changes:**
- **Bug fixes**: Adds `discounts: undefined` override in `modifyStripeSubscriptionFromCheckout.ts` to prevent re-application of `once` coupons on post-checkout subscription updates.
- **Improvements**: Replaces outdated scratch test with a TDD scenario that directly exercises the fixed bug path including checkout form completion and renewal invoice assertion.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line fix is correct and the only remaining finding is a P2 test reliability concern in a _temp scratch file.

The production fix (`discounts: undefined`) is minimal, targeted, and correct: it prevents the spread of `updateAction.params` from forwarding coupon references back to Stripe on the post-checkout subscription update without touching any other behavior. The only open finding is a hardcoded `timeout` in a temporary test file, which is a P2 style/reliability concern and does not affect correctness of the fix.

No production files require special attention; the hardcoded `timeout` in `server/tests/_temp/temp2.test.ts` is worth revisiting before promoting this test out of the `_temp` directory.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/modifyStripeSubscriptionFromCheckout.ts | Adds `discounts: undefined` to post-checkout subscription update to prevent re-applying already-redeemed `once` coupons — minimal and targeted fix. |
| server/tests/_temp/temp2.test.ts | Replaces a previous multi-entity cancel/uncancel repro test with a new TDD scenario reproducing the once-coupon re-redemption bug; uses a hardcoded 12 s timeout to wait for the checkout webhook. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Customer
    participant A as Autumn API
    participant S as Stripe
    participant W as Webhook Handler

    C->>A: billing.attach (with once coupon)
    A->>S: Create Checkout Session (discounts: [coupon])
    S-->>A: payment_url
    A-->>C: payment_url
    C->>S: Complete Checkout Form
    S->>W: checkout.session.completed webhook
    W->>W: evaluateStripeBillingPlan()
    Note over W: updateAction.params may include discounts from plan evaluation
    W->>S: subscriptions.update(...params, discounts: undefined)
    Note over S: discounts field omitted — Stripe keeps already-applied once coupon, does NOT create new di_xxx
    S-->>W: Updated subscription
    Note over S: Renewal invoice: full price (once coupon consumed on first invoice only)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/tests/_temp/temp2.test.ts
Line: 76

Comment:
**Hardcoded timeout for webhook delivery**

`timeout(12000)` is a fixed 12-second wait for the `checkout.session.completed` webhook to arrive and be processed. In a CI environment under load, this window may not be sufficient and the test will produce a false negative (first invoice assertion passes but renewal assertion fails because the subscription was never actually updated). Consider polling `expectCustomerInvoiceCorrect` with retries, or waiting for a deterministic signal, rather than a wall-clock sleep.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 renewal bug"](https://github.com/useautumn/autumn/commit/95bf955e064debfb17f1f0b854f7950336017db2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29464584)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a renewal billing bug where a Stripe `once` coupon from Checkout was re-applied during the post-checkout subscription update, leading to discounted renewals. The update now omits discounts so the coupon is only used on the first invoice.

- **Bug Fixes**
  - Set `discounts: undefined` in `modifyStripeSubscriptionFromCheckout` when calling `stripeCli.subscriptions.update` to prevent re-sending resolved discounts.
  - Added an integration test that completes Stripe Checkout and verifies: first invoice discounted, renewal at full price (via test clock).

<sup>Written for commit 95bf955e064debfb17f1f0b854f7950336017db2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

