### PR TITLE
dev

### DIFF
--- a/server/src/honoMiddlewares/traceMiddleware.ts
+++ b/server/src/honoMiddlewares/traceMiddleware.ts
@@ -1,5 +1,6 @@
 import { context, trace } from "@opentelemetry/api";
 import type { Context, Next } from "hono";
+import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 
 /**
@@ -17,7 +18,7 @@ export const traceEnrichMiddleware = async (
 
 	const ctx = c.get("ctx");
 
-	const attrs: Record<string, string> = {
+	const attrs: Record<string, string | boolean> = {
 		req_id: ctx.id,
 	};
 
@@ -32,6 +33,7 @@ export const traceEnrichMiddleware = async (
 
 	if (ctx.customerId) {
 		attrs.customer_id = ctx.customerId;
+		attrs.full_subject_rollout_enabled = isFullSubjectRolloutEnabled({ ctx });
 	}
 
 	span.setAttributes(attrs);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a `full_subject_rollout_enabled` attribute to `@opentelemetry/api` spans in the Hono trace middleware to show the rollout state per request. Allows boolean span attributes and sets the value only when a `customer_id` is present.

<sup>Written for commit e0c4200f226d7f9ee46c88bceab8d81dd9b0c0ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

