### PR TITLE
feat: add passkeys and 2FA support

### DIFF
--- a/apps/sdk-test/lib/auth-client.ts
+++ b/apps/sdk-test/lib/auth-client.ts
@@ -1,10 +1,14 @@
 "use client";
 
-import { organizationClient } from "better-auth/client/plugins";
+import { passkeyClient } from "@better-auth/passkey/client";
+import {
+  organizationClient,
+  twoFactorClient,
+} from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
-  plugins: [organizationClient()],
+  plugins: [organizationClient(), twoFactorClient(), passkeyClient()],
 });
 
 export const { signIn, signUp, signOut, useSession } = authClient;

--- a/apps/sdk-test/lib/auth.ts
+++ b/apps/sdk-test/lib/auth.ts
@@ -1,9 +1,11 @@
+import { passkey } from "@better-auth/passkey";
 import { autumn } from "autumn-js/better-auth";
 import { betterAuth } from "better-auth";
-import { organization } from "better-auth/plugins";
+import { organization, twoFactor } from "better-auth/plugins";
 import { db } from "./db";
 
 export const auth = betterAuth({
+  appName: "Autumn SDK Test",
   database: {
     db,
     type: "postgres",
@@ -13,6 +15,8 @@ export const auth = betterAuth({
   },
   plugins: [
     organization(),
+    twoFactor({ allowPasswordless: true }),
+    passkey({ rpName: "Autumn SDK Test" }),
     autumn({
       secretKey: process.env.AUTUMN_SECRET_KEY,
       autumnURL: "http://localhost:8080",

--- a/apps/sdk-test/package.json
+++ b/apps/sdk-test/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "atmn": "workspace:*",
     "autumn-js": "workspace:*",
+    "@better-auth/passkey": "catalog:",
     "better-auth": "catalog:",
     "kysely": "^0.28.11",
     "next": "16.1.6",

--- a/bun.lock
+++ b/bun.lock
@@ -530,6 +530,7 @@
         "nanoid": "^5.1.6",
         "nuqs": "^2.4.3",
         "posthog-js": "^1.230.4",
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.2.0",
@@ -4751,6 +4752,8 @@
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
     "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@aws-sdk/client-sqs": "^3.985.0",
         "@better-auth/core": "catalog:",
         "@better-auth/oauth-provider": "catalog:",
+        "@better-auth/passkey": "catalog:",
         "@wooorm/starry-night": "^3.8.0",
         "ag-charts-react": "^12.3.0",
         "better-auth": "catalog:",
@@ -82,6 +83,7 @@
       "name": "sdk-test",
       "version": "0.1.0",
       "dependencies": {
+        "@better-auth/passkey": "catalog:",
         "atmn": "workspace:*",
         "autumn-js": "workspace:*",
         "better-auth": "catalog:",
@@ -332,6 +334,7 @@
         "@axiomhq/pino": "^1.3.1",
         "@better-auth/dash": "catalog:",
         "@better-auth/oauth-provider": "catalog:",
+        "@better-auth/passkey": "catalog:",
         "@chronark/zod-bird": "0.3.10",
         "@clickhouse/client": "^1.11.2",
         "@date-fns/tz": "^1.2.0",
@@ -475,6 +478,7 @@
         "@ai-sdk/react": "^3.0.25",
         "@autumn/shared": "workspace:*",
         "@better-auth/dash": "catalog:",
+        "@better-auth/passkey": "catalog:",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@monaco-editor/react": "^4.7.0",
@@ -570,6 +574,7 @@
   ],
   "overrides": {
     "@better-auth/core": "1.6.5",
+    "@better-auth/passkey": "1.6.5",
     "@isaacs/brace-expansion": "5.0.1",
     "@modelcontextprotocol/sdk": "1.26.0",
     "@smithy/config-resolver": "^4.4.0",
@@ -584,6 +589,7 @@
     "@better-auth/core": "1.6.5",
     "@better-auth/dash": "0.1.6",
     "@better-auth/oauth-provider": "1.6.5",
+    "@better-auth/passkey": "1.6.5",
     "@clickhouse/client": "1.11.2",
     "@date-fns/utc": "2.1.0",
     "@orpc/client": "^1.0.0",
@@ -916,6 +922,8 @@
 
     "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.6.5", "", { "dependencies": { "jose": "^6.1.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "better-auth": "^1.6.5", "better-call": "1.3.5" } }, "sha512-j/LzpR1tkzY+MIDebXbmGYQfxu81PPEGXwO8rbNXufwmR5wLFD0B0negwygiaC4q8lX+crnIFmG2R1JedLez/g=="],
 
+    "@better-auth/passkey": ["@better-auth/passkey@1.6.5", "", { "dependencies": { "@simplewebauthn/browser": "^13.2.2", "@simplewebauthn/server": "^13.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "better-auth": "^1.6.5", "better-call": "1.3.5", "nanostores": "^1.0.1" } }, "sha512-x9d0Y4eJp6aWMiNcTM4vS9f5NUJyV2fX8ZsbUQdcTGPk8xn6ZF+04B6CamxxJ1ktUx6/r3WGGCeojSfBCBXcjA=="],
+
     "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.5", "", { "peerDependencies": { "@better-auth/core": "^1.6.5", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-d7PUO5XoimYYDEG/DoYVbOSbyVYJBDuZgvY9pjf8INccBTCD1BzcyEJ9NQil4huXWj4fcNaGOt2FG0OI8NtWOA=="],
 
     "@better-auth/telemetry": ["@better-auth/telemetry@1.4.21", "", { "dependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.4.21" } }, "sha512-LX+FGMZnhR2KQZ0idHH1+UwlXvkOl6P8w3Gne4TtjvUCt3QjG9FKIuP9JD3MAmEEkwGt0SoAPHPJEGTjUl3ydg=="],
@@ -1096,6 +1104,8 @@
 
     "@hatchet-dev/typescript-sdk": ["@hatchet-dev/typescript-sdk@1.14.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.2.5", "@types/qs": "^6.9.18", "abort-controller-x": "^0.4.3", "axios": "^1.13.5", "long": "^5.3.1", "nice-grpc": "^2.1.12", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0", "qs": "^6.14.2", "semver": "^7.7.1", "yaml": "^2.7.1", "zod": "^3.24.2", "zod-to-json-schema": "^3.24.1" }, "optionalDependencies": { "prom-client": "^15.1.3" } }, "sha512-exj+wcNBOL/H60le4O5phczrTRWeiRQ2LfF7MJoYZWxICKvmb8DjUKWzH14E66yi/HXrtjehN89cL8o8344Vgg=="],
 
+    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
+
     "@hono-rate-limiter/redis": ["@hono-rate-limiter/redis@0.1.4", "", { "peerDependencies": { "hono-rate-limiter": "^0.2.1" } }, "sha512-RSrVX5N2Oo/xXApskegu667cBVHyr8RXGWnbRDGjU2py8pN4BttEKSHA0iKi3BAwh1xSkENgDRng4tpFD9DbKg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
@@ -1243,6 +1253,8 @@
     "@langchain/langgraph-sdk": ["@langchain/langgraph-sdk@1.8.9", "", { "dependencies": { "@types/json-schema": "^7.0.15", "p-queue": "^9.0.1", "p-retry": "^7.1.1", "uuid": "^13.0.0" }, "peerDependencies": { "@langchain/core": "^1.1.16", "react": "^18 || ^19", "react-dom": "^18 || ^19", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@langchain/core", "react", "react-dom", "svelte", "vue"] }, "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw=="],
 
     "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
+
+    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -1493,6 +1505,30 @@
     "@oslojs/jwt": ["@oslojs/jwt@0.2.0", "", { "dependencies": { "@oslojs/encoding": "0.4.1" } }, "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
+
+    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.6.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/asn1-x509-attr": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.6.1", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.1", "@peculiar/asn1-pkcs8": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.6.1", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.1", "@peculiar/asn1-pfx": "^2.6.1", "@peculiar/asn1-pkcs8": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/asn1-x509-attr": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.6.0", "", { "dependencies": { "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "asn1js": "^3.0.6", "pvtsutils": "^1.3.6", "tslib": "^2.8.1" } }, "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
@@ -1829,6 +1865,10 @@
     "@sideway/formula": ["@sideway/formula@3.0.1", "", {}, "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="],
 
     "@sideway/pinpoint": ["@sideway/pinpoint@2.0.0", "", {}, "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
+
+    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.0", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
@@ -2565,6 +2605,8 @@
     "artillery-plugin-slack": ["artillery-plugin-slack@1.19.0", "", { "dependencies": { "debug": "^4.4.3", "got": "^11.8.5" } }, "sha512-Xn+pb0+Lc7GGNUamYaS2NiV/jOVJqXEL9ToH442XaaqeAWyhlsg+fzAWOS8mX9xEZ+rR3wKgZSy1biRssykCIw=="],
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -4706,6 +4748,10 @@
 
     "puppeteer-core": ["puppeteer-core@24.42.0", "", { "dependencies": { "@puppeteer/browsers": "2.13.0", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1595872", "typed-query-selector": "^2.12.1", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.19.0" } }, "sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
@@ -4803,6 +4849,8 @@
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -5335,6 +5383,8 @@
     "tsutils": ["tsutils@3.21.0", "", { "dependencies": { "tslib": "^1.8.1" }, "peerDependencies": { "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta" } }, "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -5877,6 +5927,10 @@
     "@better-auth/oauth-provider/@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
 
     "@better-auth/oauth-provider/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@better-auth/passkey/@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
+
+    "@better-auth/passkey/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@better-auth/prisma-adapter/@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
 
@@ -7113,6 +7167,8 @@
     "tshy/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 			"@better-auth/core": "1.6.5",
 			"@better-auth/dash": "0.1.6",
 			"@better-auth/oauth-provider": "1.6.5",
+			"@better-auth/passkey": "1.6.5",
 			"better-auth": "1.6.5",
 			"@orpc/contract": "^1.0.0",
 			"@orpc/client": "^1.0.0",
@@ -45,6 +46,7 @@
 	},
 	"overrides": {
 		"@better-auth/core": "1.6.5",
+		"@better-auth/passkey": "1.6.5",
 		"better-auth": "1.6.5",
 		"@modelcontextprotocol/sdk": "1.26.0",
 		"@isaacs/brace-expansion": "5.0.1",
@@ -57,6 +59,7 @@
 	},
 	"resolutions": {
 		"@better-auth/core": "1.6.5",
+		"@better-auth/passkey": "1.6.5",
 		"better-auth": "1.6.5",
 		"@modelcontextprotocol/sdk": "1.26.0",
 		"@isaacs/brace-expansion": "5.0.1",
@@ -124,6 +127,7 @@
 		"@aws-sdk/client-sqs": "^3.985.0",
 		"@better-auth/core": "catalog:",
 		"@better-auth/oauth-provider": "catalog:",
+		"@better-auth/passkey": "catalog:",
 		"@wooorm/starry-night": "^3.8.0",
 		"ag-charts-react": "^12.3.0",
 		"better-auth": "catalog:",

--- a/server/package.json
+++ b/server/package.json
@@ -54,6 +54,7 @@
 		"@axiomhq/pino": "^1.3.1",
 		"@better-auth/dash": "catalog:",
 		"@better-auth/oauth-provider": "catalog:",
+		"@better-auth/passkey": "catalog:",
 		"@chronark/zod-bird": "0.3.10",
 		"@clickhouse/client": "^1.11.2",
 		"@date-fns/tz": "^1.2.0",

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 
 import { ALL_SCOPES, invitation, schemas } from "@autumn/shared";
 import { oauthProvider } from "@better-auth/oauth-provider";
+import { passkey } from "@better-auth/passkey";
 import { betterAuth, type User } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import {
@@ -10,6 +11,7 @@ import {
 	jwt,
 	type Organization,
 	organization,
+	twoFactor,
 } from "better-auth/plugins";
 import { eq } from "drizzle-orm";
 import { db } from "@/db/initDrizzle.js";
@@ -26,6 +28,7 @@ import { ADMIN_USER_IDs } from "./constants.js";
 
 export const auth = betterAuth({
 	baseURL: process.env.BETTER_AUTH_URL,
+	appName: "Autumn",
 	telemetry: {
 		enabled: false,
 	},
@@ -202,6 +205,17 @@ export const auth = betterAuth({
 					await afterOrgCreated({ org: organization, user });
 				},
 			},
+		}),
+
+		twoFactor({
+			issuer: "Autumn",
+			allowPasswordless: true,
+		}),
+
+		passkey({
+			rpName: "Autumn",
+			rpID: process.env.PASSKEY_RP_ID || undefined,
+			origin: process.env.PASSKEY_ORIGIN || undefined,
 		}),
 	],
 });

--- a/shared/db/auth-schema.ts
+++ b/shared/db/auth-schema.ts
@@ -3,6 +3,7 @@ import {
 	boolean,
 	foreignKey,
 	index,
+	integer,
 	jsonb,
 	pgTable,
 	text,
@@ -35,6 +36,7 @@ export const user = pgTable(
 		banExpires: timestamp("ban_expires", { withTimezone: true }),
 		createdBy: text("created_by"),
 		lastActiveAt: timestamp("last_active_at", { withTimezone: true }),
+		twoFactorEnabled: boolean("two_factor_enabled").$defaultFn(() => false),
 	},
 	(table) => [
 		index("idx_user_name_trgm")
@@ -261,6 +263,32 @@ export const bannedUser = pgTable("banned_user", {
 	revokedAt: timestamp("revoked_at", { withTimezone: true }),
 }).enableRLS();
 
+export const twoFactor = pgTable("two_factor", {
+	id: text("id").primaryKey(),
+	secret: text("secret").notNull(),
+	backupCodes: text("backup_codes").notNull(),
+	userId: text("user_id")
+		.notNull()
+		.references(() => user.id, { onDelete: "cascade" }),
+	verified: boolean("verified").$defaultFn(() => true),
+}).enableRLS();
+
+export const passkey = pgTable("passkey", {
+	id: text("id").primaryKey(),
+	name: text("name"),
+	publicKey: text("public_key").notNull(),
+	userId: text("user_id")
+		.notNull()
+		.references(() => user.id, { onDelete: "cascade" }),
+	credentialID: text("credential_i_d").notNull(),
+	counter: integer("counter").notNull(),
+	deviceType: text("device_type").notNull(),
+	backedUp: boolean("backed_up").notNull(),
+	transports: text("transports"),
+	createdAt: timestamp("created_at", { withTimezone: true }),
+	aaguid: text("aaguid"),
+}).enableRLS();
+
 export const authSchema = {
 	user,
 	session,
@@ -275,6 +303,8 @@ export const authSchema = {
 	oauthRefreshToken,
 	oauthAccessToken,
 	oauthConsent,
+	twoFactor,
+	passkey,
 };
 
 export type User = typeof user.$inferSelect;

--- a/shared/db/schema.ts
+++ b/shared/db/schema.ts
@@ -82,7 +82,9 @@ import {
 	oauthClient,
 	oauthConsent,
 	oauthRefreshToken,
+	passkey,
 	session,
+	twoFactor,
 	user,
 	verification,
 } from "./auth-schema.js";
@@ -129,6 +131,8 @@ export {
 	verification,
 	member,
 	invitation,
+	twoFactor,
+	passkey,
 	// OAuth Provider
 	jwks,
 	oauthClient,

--- a/vite/package.json
+++ b/vite/package.json
@@ -20,6 +20,7 @@
 		"@ai-sdk/react": "^3.0.25",
 		"@autumn/shared": "workspace:*",
 		"@better-auth/dash": "catalog:",
+		"@better-auth/passkey": "catalog:",
 		"@fortawesome/free-brands-svg-icons": "^6.7.2",
 		"@fortawesome/react-fontawesome": "^0.2.2",
 		"@monaco-editor/react": "^4.7.0",

--- a/vite/package.json
+++ b/vite/package.json
@@ -72,6 +72,7 @@
 		"nanoid": "^5.1.6",
 		"nuqs": "^2.4.3",
 		"posthog-js": "^1.230.4",
+		"qrcode.react": "^4.2.0",
 		"react": "^18.2.0",
 		"react-day-picker": "^8.10.1",
 		"react-dom": "^18.2.0",

--- a/vite/src/lib/auth-client.ts
+++ b/vite/src/lib/auth-client.ts
@@ -1,8 +1,10 @@
 import { oauthProviderClient } from "@better-auth/oauth-provider/client";
+import { passkeyClient } from "@better-auth/passkey/client";
 import {
 	adminClient,
 	emailOTPClient,
 	organizationClient,
+	twoFactorClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
@@ -13,6 +15,8 @@ export const authClient = createAuthClient({
 		organizationClient(),
 		adminClient(),
 		oauthProviderClient(),
+		twoFactorClient(),
+		passkeyClient(),
 	],
 });
 

--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -10,6 +10,9 @@ import { Input } from "@/components/v2/inputs/Input";
 import { authClient, signIn, useSession } from "@/lib/auth-client";
 import { getBackendErr } from "@/utils/genUtils";
 import { OTPSignIn } from "./components/OTPSignIn";
+import { TwoFactorGate } from "./components/TwoFactorGate";
+
+type TwoFactorMethod = "totp" | "otp";
 
 /**
  * Check if URL has OAuth parameters (from OAuth provider redirect)
@@ -35,6 +38,9 @@ export const SignIn = () => {
 	const [googleLoading, setGoogleLoading] = useState(false);
 	const [sendOtpLoading, setSendOtpLoading] = useState(false);
 	const [otpSent, setOtpSent] = useState(false);
+	const [twoFactorMethods, setTwoFactorMethods] = useState<
+		TwoFactorMethod[] | null
+	>(null);
 
 	const { data: session } = useSession();
 	const navigate = useNavigate();
@@ -66,6 +72,38 @@ export const SignIn = () => {
 			navigate("/", { replace: true });
 		}
 	}, [session, navigate, oauthRedirectUrl]);
+
+	// Preload passkeys via WebAuthn conditional mediation so the browser
+	// can show a native passkey picker as soon as the email field is focused.
+	useEffect(() => {
+		if (otpSent || twoFactorMethods || session) return;
+		if (typeof window === "undefined") return;
+		if (
+			typeof window.PublicKeyCredential === "undefined" ||
+			!window.PublicKeyCredential.isConditionalMediationAvailable
+		) {
+			return;
+		}
+		let cancelled = false;
+		window.PublicKeyCredential.isConditionalMediationAvailable()
+			.then((available) => {
+				if (cancelled || !available) return;
+				void authClient.signIn.passkey({
+					autoFill: true,
+					fetchOptions: {
+						onSuccess: () => {
+							window.location.href = callbackPath;
+						},
+					},
+				});
+			})
+			.catch(() => {
+				/* ignore — passkey autofill is best-effort */
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [otpSent, twoFactorMethods, session, callbackPath]);
 
 	const handleEmailSignIn = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -105,13 +143,20 @@ export const SignIn = () => {
 			const googleNewUserUrl =
 				oauthRedirectUrl || `${frontendUrl}${defaultNewPath}`;
 
-			const { error } = await signIn.social({
+			const { data, error } = await signIn.social({
 				provider: "google",
 				callbackURL: googleCallbackUrl,
 				newUserCallbackURL: googleNewUserUrl,
 			});
 			if (error) {
 				toast.error(error.message || "Failed to sign in with Google");
+				return;
+			}
+			if (data && "twoFactorRedirect" in data && data.twoFactorRedirect) {
+				const methods =
+					(data as { twoFactorMethods?: TwoFactorMethod[] }).twoFactorMethods ??
+					(["totp"] as TwoFactorMethod[]);
+				setTwoFactorMethods(methods);
 			}
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to sign in with Google"));
@@ -138,15 +183,24 @@ export const SignIn = () => {
 					</h1>
 				</div>
 
-				{otpSent && (
-					<OTPSignIn
-						email={email}
+				{twoFactorMethods && (
+					<TwoFactorGate
+						methods={twoFactorMethods}
 						newPath={newPath}
 						callbackPath={callbackPath}
 					/>
 				)}
 
-				{!otpSent && (
+				{!twoFactorMethods && otpSent && (
+					<OTPSignIn
+						email={email}
+						newPath={newPath}
+						callbackPath={callbackPath}
+						onTwoFactorRequired={setTwoFactorMethods}
+					/>
+				)}
+
+				{!twoFactorMethods && !otpSent && (
 					<div className="space-y-6">
 						{/* Google Sign In Button */}
 						<IconButton
@@ -185,7 +239,7 @@ export const SignIn = () => {
 								}}
 								required
 								className="text-base !w-full"
-								autoComplete="email"
+								autoComplete="email webauthn"
 							/>
 
 							{/* Sign In Button */}

--- a/vite/src/views/auth/components/OTPSignIn.tsx
+++ b/vite/src/views/auth/components/OTPSignIn.tsx
@@ -12,14 +12,18 @@ import {
 import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
+type TwoFactorMethod = "totp" | "otp";
+
 export const OTPSignIn = ({
 	email,
 	newPath,
 	callbackPath,
+	onTwoFactorRequired,
 }: {
 	email: string;
 	newPath: string;
 	callbackPath: string;
+	onTwoFactorRequired?: (methods: TwoFactorMethod[]) => void;
 }) => {
 	const [otp, setOtp] = useState("");
 	const [resending, setResending] = useState(false);
@@ -48,12 +52,24 @@ export const OTPSignIn = ({
 				return;
 			}
 
-			const user = data.user;
+			if (data && "twoFactorRedirect" in data && data.twoFactorRedirect) {
+				const methods =
+					(data as { twoFactorMethods?: TwoFactorMethod[] }).twoFactorMethods ??
+					(["totp"] as TwoFactorMethod[]);
+				onTwoFactorRequired?.(methods);
+				setVerifying(false);
+				return;
+			}
 
-			console.log("Data:", data);
+			const user = (data as { user?: { createdAt?: string | Date } } | null)
+				?.user;
+
+			if (!user?.createdAt) {
+				window.location.href = callbackPath;
+				return;
+			}
 
 			// Ensure we're comparing UTC timestamps
-
 			const userCreatedAtUTC = new Date(user.createdAt);
 			const nowUTC = new Date();
 			const diffSeconds = differenceInSeconds(nowUTC, userCreatedAtUTC);
@@ -68,7 +84,6 @@ export const OTPSignIn = ({
 		} catch {
 			toast.error("Failed to verify code");
 		}
-		console.log("OTP verified");
 		setVerifying(false);
 	};
 

--- a/vite/src/views/auth/components/TwoFactorGate.tsx
+++ b/vite/src/views/auth/components/TwoFactorGate.tsx
@@ -1,0 +1,285 @@
+import { differenceInSeconds } from "date-fns";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+	InputOTP,
+	InputOTPGroup,
+	InputOTPSeparator,
+	InputOTPSlot,
+} from "@/components/ui/input-otp";
+import { Button } from "@/components/v2/buttons/Button";
+import { Input } from "@/components/v2/inputs/Input";
+import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+import { getBackendErr } from "@/utils/genUtils";
+
+type TwoFactorMethod = "totp" | "otp";
+
+type Mode = "totp" | "otp" | "backup";
+
+const redirectAfterVerify = ({
+	user,
+	newPath,
+	callbackPath,
+}: {
+	user: { createdAt?: string | Date } | null | undefined;
+	newPath: string;
+	callbackPath: string;
+}) => {
+	if (!user?.createdAt) {
+		window.location.href = callbackPath;
+		return;
+	}
+	const userCreatedAtUTC = new Date(user.createdAt);
+	const nowUTC = new Date();
+	const diffSeconds = differenceInSeconds(nowUTC, userCreatedAtUTC);
+	window.location.href = diffSeconds < 20 ? newPath : callbackPath;
+};
+
+export const TwoFactorGate = ({
+	newPath,
+	callbackPath,
+	methods,
+}: {
+	newPath: string;
+	callbackPath: string;
+	methods: TwoFactorMethod[];
+}) => {
+	const initialMode: Mode = methods.includes("totp") ? "totp" : "otp";
+	const [mode, setMode] = useState<Mode>(initialMode);
+	const [otp, setOtp] = useState("");
+	const [backupCode, setBackupCode] = useState("");
+	const [verifying, setVerifying] = useState(false);
+	const [sendingOtp, setSendingOtp] = useState(false);
+	const [otpSent, setOtpSent] = useState(false);
+
+	const hasTotp = methods.includes("totp");
+	const hasOtp = methods.includes("otp");
+
+	const handleVerifyTotp = async (code: string) => {
+		setVerifying(true);
+		try {
+			const { data, error } = await authClient.twoFactor.verifyTotp({
+				code,
+				trustDevice: true,
+			});
+			if (error) {
+				toast.error(error.message || "Invalid code");
+				setOtp("");
+				return;
+			}
+			redirectAfterVerify({
+				user: (data as { user?: { createdAt?: string | Date } } | null)?.user,
+				newPath,
+				callbackPath,
+			});
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to verify code"));
+			setOtp("");
+		} finally {
+			setVerifying(false);
+		}
+	};
+
+	const handleVerifyOtp = async (code: string) => {
+		setVerifying(true);
+		try {
+			const { data, error } = await authClient.twoFactor.verifyOtp({
+				code,
+				trustDevice: true,
+			});
+			if (error) {
+				toast.error(error.message || "Invalid code");
+				setOtp("");
+				return;
+			}
+			redirectAfterVerify({
+				user: (data as { user?: { createdAt?: string | Date } } | null)?.user,
+				newPath,
+				callbackPath,
+			});
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to verify code"));
+			setOtp("");
+		} finally {
+			setVerifying(false);
+		}
+	};
+
+	const handleSendOtp = async () => {
+		setSendingOtp(true);
+		try {
+			const { error } = await authClient.twoFactor.sendOtp();
+			if (error) {
+				toast.error(error.message || "Failed to send code");
+				return;
+			}
+			setOtpSent(true);
+			toast.success("Verification code sent to your email");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to send code"));
+		} finally {
+			setSendingOtp(false);
+		}
+	};
+
+	const handleVerifyBackup = async () => {
+		if (!backupCode.trim()) return;
+		setVerifying(true);
+		try {
+			const { data, error } = await authClient.twoFactor.verifyBackupCode({
+				code: backupCode.trim(),
+				trustDevice: true,
+			});
+			if (error) {
+				toast.error(error.message || "Invalid backup code");
+				return;
+			}
+			redirectAfterVerify({
+				user: (data as { user?: { createdAt?: string | Date } } | null)?.user,
+				newPath,
+				callbackPath,
+			});
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to verify backup code"));
+		} finally {
+			setVerifying(false);
+		}
+	};
+
+	const subtitle =
+		mode === "totp"
+			? "Open your authenticator app and enter the 6-digit code"
+			: mode === "otp"
+				? otpSent
+					? "Check your email for the 6-digit code"
+					: "Send a verification code to your email"
+				: "Enter one of your backup codes";
+
+	return (
+		<div className="text-center flex flex-col items-center justify-center gap-6">
+			<div className="flex flex-col gap-1">
+				<p className="text-sm text-t1 font-medium">Two-factor authentication</p>
+				<p className="text-sm text-muted-foreground">{subtitle}</p>
+			</div>
+
+			{mode === "totp" && (
+				<div className={cn(verifying && "shimmer")}>
+					<InputOTP
+						maxLength={6}
+						value={otp}
+						onChange={setOtp}
+						onComplete={handleVerifyTotp}
+						disabled={verifying}
+					>
+						<InputOTPGroup>
+							<InputOTPSlot index={0} />
+							<InputOTPSlot index={1} />
+							<InputOTPSlot index={2} />
+						</InputOTPGroup>
+						<InputOTPSeparator />
+						<InputOTPGroup>
+							<InputOTPSlot index={3} />
+							<InputOTPSlot index={4} />
+							<InputOTPSlot index={5} />
+						</InputOTPGroup>
+					</InputOTP>
+				</div>
+			)}
+
+			{mode === "otp" && !otpSent && (
+				<Button
+					variant="primary"
+					onClick={handleSendOtp}
+					isLoading={sendingOtp}
+				>
+					Send verification code
+				</Button>
+			)}
+
+			{mode === "otp" && otpSent && (
+				<div className={cn(verifying && "shimmer")}>
+					<InputOTP
+						maxLength={6}
+						value={otp}
+						onChange={setOtp}
+						onComplete={handleVerifyOtp}
+						disabled={verifying}
+					>
+						<InputOTPGroup>
+							<InputOTPSlot index={0} />
+							<InputOTPSlot index={1} />
+							<InputOTPSlot index={2} />
+						</InputOTPGroup>
+						<InputOTPSeparator />
+						<InputOTPGroup>
+							<InputOTPSlot index={3} />
+							<InputOTPSlot index={4} />
+							<InputOTPSlot index={5} />
+						</InputOTPGroup>
+					</InputOTP>
+				</div>
+			)}
+
+			{mode === "backup" && (
+				<div className="flex flex-col gap-2 w-full">
+					<Input
+						value={backupCode}
+						onChange={(e) => setBackupCode(e.target.value)}
+						placeholder="Backup code"
+						autoComplete="one-time-code"
+						onKeyDown={(e) => {
+							if (e.key === "Enter") void handleVerifyBackup();
+						}}
+					/>
+					<Button
+						variant="primary"
+						onClick={handleVerifyBackup}
+						isLoading={verifying}
+						disabled={!backupCode.trim()}
+						className="w-full"
+					>
+						Verify backup code
+					</Button>
+				</div>
+			)}
+
+			<div className="flex flex-col items-center gap-1 text-xs">
+				{mode !== "totp" && hasTotp && (
+					<Button
+						variant="skeleton"
+						size="sm"
+						onClick={() => {
+							setMode("totp");
+							setOtp("");
+						}}
+					>
+						Use authenticator app instead
+					</Button>
+				)}
+				{mode !== "otp" && hasOtp && (
+					<Button
+						variant="skeleton"
+						size="sm"
+						onClick={() => {
+							setMode("otp");
+							setOtp("");
+							setOtpSent(false);
+						}}
+					>
+						Use email code instead
+					</Button>
+				)}
+				{mode !== "backup" && (
+					<Button
+						variant="skeleton"
+						size="sm"
+						onClick={() => setMode("backup")}
+					>
+						Use a backup code
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+};

--- a/vite/src/views/main-sidebar/components/AccountSettings.tsx
+++ b/vite/src/views/main-sidebar/components/AccountSettings.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/v2/dialogs/Dialog";
+import { PasskeysSection } from "./account-settings/PasskeysSection";
+import { TwoFactorSection } from "./account-settings/TwoFactorSection";
+
+type AccountSettingsTab = "security";
+
+const tabsContentClassName = "h-full overflow-y-auto focus-visible:ring-0";
+
+export const AccountSettings = ({
+	open,
+	setOpen,
+}: {
+	open: boolean;
+	setOpen: (open: boolean) => void;
+}) => {
+	const [currentTab, setCurrentTab] = useState<AccountSettingsTab>("security");
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild></DialogTrigger>
+			<DialogContent className="gap-0 p-0 rounded-xs w-[90%] max-w-[750px] h-[550px] flex flex-col justify-between">
+				<div className="flex flex-col gap-6 overflow-hidden h-full">
+					<DialogHeader className="px-6 pt-6">
+						<DialogTitle>Account</DialogTitle>
+					</DialogHeader>
+					<div className="flex flex-col gap-6 h-full overflow-hidden">
+						<Tabs
+							className="flex flex-col h-full focus-visible:ring-none"
+							value={currentTab}
+							onValueChange={setCurrentTab as (val: string) => void}
+						>
+							<div className="flex justify-between items-center px-6">
+								<TabsList className="p-0 flex gap-4 justify-start w-fit bg-transparent!">
+									<TabsTrigger value="security">Security</TabsTrigger>
+								</TabsList>
+							</div>
+
+							<TabsContent value="security" className={tabsContentClassName}>
+								<div className="px-6 pt-1.5 pb-6 w-full h-full flex flex-col gap-8">
+									<PasskeysSection />
+									<TwoFactorSection />
+								</div>
+							</TabsContent>
+						</Tabs>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/vite/src/views/main-sidebar/components/AccountSettings.tsx
+++ b/vite/src/views/main-sidebar/components/AccountSettings.tsx
@@ -26,7 +26,7 @@ export const AccountSettings = ({
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild></DialogTrigger>
-			<DialogContent className="gap-0 p-0 rounded-xs w-[90%] max-w-[750px] h-[550px] flex flex-col justify-between">
+			<DialogContent className="top-1/2 gap-0 p-0 rounded-xs w-[90%] max-w-[750px] min-h-[420px] max-h-[85vh] flex flex-col justify-between">
 				<div className="flex flex-col gap-6 overflow-hidden h-full">
 					<DialogHeader className="px-6 pt-6">
 						<DialogTitle>Account</DialogTitle>

--- a/vite/src/views/main-sidebar/components/OrgDropdown.tsx
+++ b/vite/src/views/main-sidebar/components/OrgDropdown.tsx
@@ -40,6 +40,7 @@ import { OrgLogo } from "../org-dropdown/components/OrgLogo";
 import { useMemberships } from "../org-dropdown/hooks/useMemberships";
 import { useSidebarContext } from "../SidebarContext";
 import { AdminDropdownItems } from "./AdminDropdownItems";
+import { AccountSettings } from "./AccountSettings";
 import { CreateNewOrg } from "./CreateNewOrg";
 import { LogOutItem } from "./LogOutItem";
 import { ManageOrg } from "./ManageOrg";
@@ -67,11 +68,16 @@ export const OrgDropdown = () => {
 	useMemberships();
 	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const [manageOpen, setManageOpen] = useState(false);
+	const [accountSettingsOpen, setAccountSettingsOpen] = useState(false);
 
 	if (isLoading)
 		return (
 			<>
 				<ManageOrg open={manageOpen} setOpen={setManageOpen} />
+				<AccountSettings
+					open={accountSettingsOpen}
+					setOpen={setAccountSettingsOpen}
+				/>
 				<div className="h-7 w-32 px-4 flex items-center gap-2">
 					<Skeleton className="min-w-5 h-5" />
 					<Skeleton className="w-32 h-5" />
@@ -80,11 +86,23 @@ export const OrgDropdown = () => {
 		);
 
 	if (!org || error)
-		return <ManageOrg open={manageOpen} setOpen={setManageOpen} />;
+		return (
+			<>
+				<ManageOrg open={manageOpen} setOpen={setManageOpen} />
+				<AccountSettings
+					open={accountSettingsOpen}
+					setOpen={setAccountSettingsOpen}
+				/>
+			</>
+		);
 
 	return (
 		<div className={cn("flex px-3")}>
 			<ManageOrg open={manageOpen} setOpen={setManageOpen} />
+			<AccountSettings
+				open={accountSettingsOpen}
+				setOpen={setAccountSettingsOpen}
+			/>
 			<CreateNewOrg dialogType={dialogType} setDialogType={setDialogType} />
 
 			<DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
@@ -125,7 +143,14 @@ export const OrgDropdown = () => {
 					className="border-1 border-zinc-200 shadow-sm w-48"
 				>
 					<AdminDropdownItems />
-					<DropdownMenuItem className="flex justify-between w-full items-center gap-2 text-t2">
+					<DropdownMenuItem
+						onClick={(e) => {
+							e.preventDefault();
+							setAccountSettingsOpen(true);
+							setDropdownOpen(false);
+						}}
+						className="flex justify-between w-full items-center gap-2 text-t2 cursor-pointer"
+					>
 						<div className="flex flex-col">
 							<span>{session?.user?.name}</span>
 							<span className="text-xs text-zinc-500 break-all hyphens-auto">

--- a/vite/src/views/main-sidebar/components/account-settings/PasskeysSection.tsx
+++ b/vite/src/views/main-sidebar/components/account-settings/PasskeysSection.tsx
@@ -1,0 +1,169 @@
+import { KeyRound, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/v2/buttons/Button";
+import { Input } from "@/components/v2/inputs/Input";
+import { authClient } from "@/lib/auth-client";
+import { getBackendErr } from "@/utils/genUtils";
+
+type Passkey = {
+	id: string;
+	name: string | null;
+	createdAt: string | Date | null;
+};
+
+const formatDate = (value: string | Date | null | undefined) => {
+	if (!value) return "";
+	const date = typeof value === "string" ? new Date(value) : value;
+	if (Number.isNaN(date.getTime())) return "";
+	return date.toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+};
+
+export const PasskeysSection = () => {
+	const [passkeys, setPasskeys] = useState<Passkey[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [name, setName] = useState("");
+	const [adding, setAdding] = useState(false);
+	const [deletingId, setDeletingId] = useState<string | null>(null);
+
+	const refetch = useCallback(async () => {
+		try {
+			setLoading(true);
+			const { data, error } = await authClient.passkey.listUserPasskeys();
+			if (error) {
+				toast.error(error.message || "Failed to load passkeys");
+				setPasskeys([]);
+				return;
+			}
+			setPasskeys((data as Passkey[] | null) ?? []);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to load passkeys"));
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		void refetch();
+	}, [refetch]);
+
+	const handleAdd = async () => {
+		setAdding(true);
+		try {
+			const result = await authClient.passkey.addPasskey({
+				name: name.trim() || undefined,
+			});
+			if (result && "error" in result && result.error) {
+				toast.error(result.error.message || "Failed to add passkey");
+				return;
+			}
+			toast.success("Passkey added");
+			setName("");
+			await refetch();
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to add passkey"));
+		} finally {
+			setAdding(false);
+		}
+	};
+
+	const handleDelete = async (id: string) => {
+		setDeletingId(id);
+		try {
+			const { error } = await authClient.passkey.deletePasskey({ id });
+			if (error) {
+				toast.error(error.message || "Failed to delete passkey");
+				return;
+			}
+			toast.success("Passkey removed");
+			await refetch();
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to delete passkey"));
+		} finally {
+			setDeletingId(null);
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex flex-col gap-1">
+				<h3 className="text-sm font-medium text-t1">Passkeys</h3>
+				<p className="text-xs text-t3">
+					Passwordless sign-in using biometrics, a PIN, or a security key.
+				</p>
+			</div>
+
+			<div className="border border-border rounded-xl bg-card overflow-hidden">
+				<div className="divide-y divide-border">
+					{loading ? (
+						<div className="px-4 py-8 text-center text-sm text-t3">
+							<span className="shimmer">Loading passkeys...</span>
+						</div>
+					) : passkeys.length === 0 ? (
+						<div className="px-4 py-8 text-center">
+							<KeyRound className="w-6 h-6 mx-auto mb-2 text-t4" />
+							<p className="text-sm text-t3">No passkeys yet</p>
+							<p className="text-xs text-t4 mt-1">
+								Add one below to sign in without a password.
+							</p>
+						</div>
+					) : (
+						passkeys.map((pk) => (
+							<div
+								key={pk.id}
+								className="px-4 py-3 flex items-center justify-between gap-4"
+							>
+								<div className="flex items-center gap-3 min-w-0">
+									<KeyRound className="w-4 h-4 text-t3 shrink-0" />
+									<div className="flex flex-col min-w-0">
+										<span className="text-sm text-t1 truncate">
+											{pk.name || "Unnamed passkey"}
+										</span>
+										{pk.createdAt && (
+											<span className="text-xs text-t3">
+												Added on {formatDate(pk.createdAt)}
+											</span>
+										)}
+									</div>
+								</div>
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => handleDelete(pk.id)}
+									isLoading={deletingId === pk.id}
+									className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-950/30"
+								>
+									<Trash2 className="w-3.5 h-3.5" />
+								</Button>
+							</div>
+						))
+					)}
+				</div>
+
+				<div className="px-4 py-3 border-t border-border bg-muted/30 flex items-center gap-2">
+					<Input
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						placeholder="Passkey name (optional)"
+						className="flex-1"
+						onKeyDown={(e) => {
+							if (e.key === "Enter") void handleAdd();
+						}}
+					/>
+					<Button
+						variant="secondary"
+						onClick={handleAdd}
+						isLoading={adding}
+						className="shrink-0"
+					>
+						Add passkey
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/vite/src/views/main-sidebar/components/account-settings/TwoFactorSection.tsx
+++ b/vite/src/views/main-sidebar/components/account-settings/TwoFactorSection.tsx
@@ -1,6 +1,14 @@
-import { ShieldCheck } from "lucide-react";
+import {
+	AlertTriangle,
+	CheckCircle2,
+	ChevronDown,
+	ChevronUp,
+	ShieldCheck,
+} from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { Checkbox } from "@/components/v2/checkboxes/Checkbox";
 import {
 	InputOTP,
 	InputOTPGroup,
@@ -9,48 +17,112 @@ import {
 } from "@/components/ui/input-otp";
 import { Button } from "@/components/v2/buttons/Button";
 import { CopyButton } from "@/components/v2/buttons/CopyButton";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/v2/dialogs/Dialog";
 import { Input } from "@/components/v2/inputs/Input";
 import { authClient, useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import { getBackendErr } from "@/utils/genUtils";
 
-type EnableState =
-	| { step: "password" }
-	| { step: "verify"; totpURI: string; backupCodes: string[] }
-	| { step: "done" };
+type Mode =
+	| { kind: "idle" }
+	| { kind: "enabling-password" }
+	| { kind: "enabling-verify"; totpURI: string; backupCodes: string[] }
+	| { kind: "enabling-backup-codes"; backupCodes: string[] }
+	| { kind: "disabling" };
 
-const EnableDialog = ({
-	open,
-	setOpen,
-	onEnabled,
+const PanelShell = ({
+	children,
+	className,
 }: {
-	open: boolean;
-	setOpen: (open: boolean) => void;
-	onEnabled: () => void;
+	children: React.ReactNode;
+	className?: string;
+}) => (
+	<div
+		className={cn(
+			"border border-border rounded-xl bg-card p-4 flex flex-col gap-4",
+			className,
+		)}
+	>
+		{children}
+	</div>
+);
+
+const PanelHeader = ({
+	title,
+	description,
+	icon,
+	iconClassName,
+}: {
+	title: string;
+	description?: string;
+	icon?: React.ReactNode;
+	iconClassName?: string;
+}) => (
+	<div className="flex items-start gap-3">
+		{icon && (
+			<div className={cn("shrink-0 mt-0.5", iconClassName)}>{icon}</div>
+		)}
+		<div className="flex flex-col gap-0.5 min-w-0">
+			<h4 className="text-sm font-medium text-t1">{title}</h4>
+			{description && <p className="text-xs text-t3">{description}</p>}
+		</div>
+	</div>
+);
+
+const IdlePanel = ({
+	enabled,
+	onEnable,
+	onDisable,
+}: {
+	enabled: boolean;
+	onEnable: () => void;
+	onDisable: () => void;
+}) => (
+	<div className="border border-border rounded-xl bg-card px-4 py-3 flex items-center justify-between gap-4">
+		<div className="flex items-center gap-3">
+			<ShieldCheck
+				className={cn(
+					"w-5 h-5 shrink-0",
+					enabled ? "text-green-500" : "text-t4",
+				)}
+			/>
+			<div className="flex flex-col">
+				<span className="text-sm text-t1">
+					{enabled ? "2FA is enabled" : "2FA is not enabled"}
+				</span>
+				<span className="text-xs text-t3">
+					{enabled
+						? "You'll be prompted for a code when signing in."
+						: "Protect sign-ins with a TOTP authenticator app."}
+				</span>
+			</div>
+		</div>
+		{enabled ? (
+			<Button
+				variant="secondary"
+				onClick={onDisable}
+				className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-950/30"
+			>
+				Disable
+			</Button>
+		) : (
+			<Button variant="primary" onClick={onEnable}>
+				Enable 2FA
+			</Button>
+		)}
+	</div>
+);
+
+const PasswordPanel = ({
+	onCancel,
+	onSuccess,
+}: {
+	onCancel: () => void;
+	onSuccess: (data: { totpURI: string; backupCodes: string[] }) => void;
 }) => {
 	const [password, setPassword] = useState("");
-	const [state, setState] = useState<EnableState>({ step: "password" });
-	const [otp, setOtp] = useState("");
 	const [loading, setLoading] = useState(false);
-	const [verifying, setVerifying] = useState(false);
 
-	const reset = () => {
-		setPassword("");
-		setOtp("");
-		setState({ step: "password" });
-		setLoading(false);
-		setVerifying(false);
-	};
-
-	const handleEnable = async () => {
+	const handleContinue = async () => {
 		setLoading(true);
 		try {
 			const { data, error } = await authClient.twoFactor.enable({
@@ -64,8 +136,7 @@ const EnableDialog = ({
 				toast.error("Failed to enable 2FA");
 				return;
 			}
-			setState({
-				step: "verify",
+			onSuccess({
 				totpURI: data.totpURI,
 				backupCodes: data.backupCodes,
 			});
@@ -76,6 +147,54 @@ const EnableDialog = ({
 		}
 	};
 
+	return (
+		<PanelShell>
+			<PanelHeader
+				title="Enable two-factor authentication"
+				description="Confirm your password to generate a TOTP secret and backup codes."
+			/>
+			<Input
+				type="password"
+				placeholder="Current password (leave blank if you don't have one)"
+				value={password}
+				onChange={(e) => setPassword(e.target.value)}
+				autoComplete="current-password"
+				onKeyDown={(e) => {
+					if (e.key === "Enter" && !loading) void handleContinue();
+				}}
+			/>
+			<div className="flex justify-end gap-2">
+				<Button variant="secondary" onClick={onCancel} disabled={loading}>
+					Cancel
+				</Button>
+				<Button
+					variant="primary"
+					onClick={handleContinue}
+					isLoading={loading}
+				>
+					Continue
+				</Button>
+			</div>
+		</PanelShell>
+	);
+};
+
+const VerifyPanel = ({
+	totpURI,
+	backupCodes,
+	onCancel,
+	onVerified,
+}: {
+	totpURI: string;
+	backupCodes: string[];
+	onCancel: () => void;
+	onVerified: (codes: string[]) => void;
+}) => {
+	const [otp, setOtp] = useState("");
+	const [verifying, setVerifying] = useState(false);
+	const [showSetupKey, setShowSetupKey] = useState(false);
+	const [cancelling, setCancelling] = useState(false);
+
 	const handleVerify = async (code: string) => {
 		setVerifying(true);
 		try {
@@ -85,10 +204,7 @@ const EnableDialog = ({
 				setOtp("");
 				return;
 			}
-			toast.success("Two-factor authentication enabled");
-			onEnabled();
-			setOpen(false);
-			setTimeout(reset, 300);
+			onVerified(backupCodes);
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to verify code"));
 			setOtp("");
@@ -97,127 +213,189 @@ const EnableDialog = ({
 		}
 	};
 
+	const handleCancel = async () => {
+		// 2FA is provisioned server-side but not yet verified. Roll it back so
+		// the session doesn't end up in a half-enabled state.
+		setCancelling(true);
+		try {
+			await authClient.twoFactor.disable({ password: "" });
+		} catch {
+			// best-effort cleanup
+		} finally {
+			setCancelling(false);
+			onCancel();
+		}
+	};
+
 	return (
-		<Dialog
-			open={open}
-			onOpenChange={(next) => {
-				setOpen(next);
-				if (!next) setTimeout(reset, 300);
-			}}
-		>
-			<DialogContent className="max-w-[440px]">
-				<DialogHeader>
-					<DialogTitle>Enable two-factor authentication</DialogTitle>
-					<DialogDescription>
-						{state.step === "password"
-							? "Confirm your password to generate a TOTP secret and backup codes."
-							: "Scan the URI with your authenticator app, then enter the 6-digit code to finish."}
-					</DialogDescription>
-				</DialogHeader>
+		<PanelShell>
+			<PanelHeader
+				title="Scan with your authenticator"
+				description="Open your authenticator app (1Password, Authy, Google Authenticator, etc.) and scan the code."
+			/>
 
-				{state.step === "password" && (
-					<div className="flex flex-col gap-3 py-2">
-						<Input
-							type="password"
-							placeholder="Current password (leave blank if you don't have one)"
-							value={password}
-							onChange={(e) => setPassword(e.target.value)}
-							autoComplete="current-password"
-						/>
+			<div className="flex flex-col items-center gap-3 w-full min-w-0">
+				<div className="shrink-0 rounded-lg bg-white p-3 border border-border">
+					<QRCodeSVG
+						value={totpURI}
+						size={176}
+						level="M"
+						bgColor="#ffffff"
+						fgColor="#000000"
+					/>
+				</div>
+
+				<button
+					type="button"
+					onClick={() => setShowSetupKey((v) => !v)}
+					className="flex items-center gap-1 text-xs text-t3 hover:text-t2"
+				>
+					{showSetupKey ? (
+						<ChevronUp className="w-3.5 h-3.5" />
+					) : (
+						<ChevronDown className="w-3.5 h-3.5" />
+					)}
+					{showSetupKey ? "Hide setup key" : "Can't scan? Show setup key"}
+				</button>
+
+				{showSetupKey && (
+					<div className="flex flex-col gap-2 bg-muted/50 rounded-md p-3 min-w-0 w-full">
+						<p className="text-xs text-t3">
+							Paste this into your authenticator app:
+						</p>
+						<code className="text-xs text-t2 font-mono break-all whitespace-normal leading-relaxed">
+							{totpURI}
+						</code>
+						<CopyButton text={totpURI} className="self-start">
+							Copy setup key
+						</CopyButton>
 					</div>
 				)}
+			</div>
 
-				{state.step === "verify" && (
-					<div className="flex flex-col gap-4 py-2">
-						<div className="flex flex-col gap-2">
-							<p className="text-xs text-t3">
-								Scan or paste this URI into your authenticator app:
-							</p>
-							<div className="flex items-center gap-2 bg-muted/50 rounded-md p-2">
-								<code className="text-xs text-t2 break-all flex-1 font-mono">
-									{state.totpURI}
-								</code>
-								<CopyButton text={state.totpURI} />
-							</div>
-						</div>
+			<div className="flex flex-col items-center gap-2 pt-1">
+				<p className="text-xs text-t3">
+					Enter the 6-digit code from your authenticator
+				</p>
+				<div className={cn(verifying && "shimmer")}>
+					<InputOTP
+						maxLength={6}
+						value={otp}
+						onChange={setOtp}
+						onComplete={handleVerify}
+						disabled={verifying}
+						autoFocus
+					>
+						<InputOTPGroup>
+							<InputOTPSlot index={0} />
+							<InputOTPSlot index={1} />
+							<InputOTPSlot index={2} />
+						</InputOTPGroup>
+						<InputOTPSeparator />
+						<InputOTPGroup>
+							<InputOTPSlot index={3} />
+							<InputOTPSlot index={4} />
+							<InputOTPSlot index={5} />
+						</InputOTPGroup>
+					</InputOTP>
+				</div>
+			</div>
 
-						<div className="flex flex-col gap-2">
-							<p className="text-xs text-t3">
-								Save these backup codes in a safe place. Each can be used once.
-							</p>
-							<div className="grid grid-cols-2 gap-1 bg-muted/50 rounded-md p-2 font-mono text-xs text-t2">
-								{state.backupCodes.map((code) => (
-									<span key={code}>{code}</span>
-								))}
-							</div>
-							<CopyButton
-								text={state.backupCodes.join("\n")}
-								className="self-start"
-							>
-								Copy all codes
-							</CopyButton>
-						</div>
-
-						<div className="flex flex-col items-center gap-2 pt-1">
-							<p className="text-xs text-t3">Enter your first 6-digit code</p>
-							<div className={cn(verifying && "shimmer")}>
-								<InputOTP
-									maxLength={6}
-									value={otp}
-									onChange={setOtp}
-									onComplete={handleVerify}
-									disabled={verifying}
-								>
-									<InputOTPGroup>
-										<InputOTPSlot index={0} />
-										<InputOTPSlot index={1} />
-										<InputOTPSlot index={2} />
-									</InputOTPGroup>
-									<InputOTPSeparator />
-									<InputOTPGroup>
-										<InputOTPSlot index={3} />
-										<InputOTPSlot index={4} />
-										<InputOTPSlot index={5} />
-									</InputOTPGroup>
-								</InputOTP>
-							</div>
-						</div>
-					</div>
-				)}
-
-				<DialogFooter>
-					{state.step === "password" && (
-						<>
-							<Button variant="secondary" onClick={() => setOpen(false)}>
-								Cancel
-							</Button>
-							<Button
-								variant="primary"
-								onClick={handleEnable}
-								isLoading={loading}
-							>
-								Continue
-							</Button>
-						</>
-					)}
-					{state.step === "verify" && (
-						<Button variant="secondary" onClick={() => setOpen(false)}>
-							Close
-						</Button>
-					)}
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+			<div className="flex justify-end gap-2">
+				<Button
+					variant="secondary"
+					onClick={handleCancel}
+					isLoading={cancelling}
+					disabled={verifying}
+				>
+					Cancel
+				</Button>
+			</div>
+		</PanelShell>
 	);
 };
 
-const DisableDialog = ({
-	open,
-	setOpen,
+const BackupCodesPanel = ({
+	backupCodes,
+	onDone,
+}: {
+	backupCodes: string[];
+	onDone: () => void;
+}) => {
+	const [acknowledged, setAcknowledged] = useState(false);
+
+	const handleDownload = () => {
+		const blob = new Blob(
+			[
+				`Autumn two-factor backup codes\nGenerated: ${new Date().toISOString()}\n\n${backupCodes.join("\n")}\n\nEach code can only be used once.`,
+			],
+			{ type: "text/plain" },
+		);
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = "autumn-backup-codes.txt";
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+	};
+
+	return (
+		<PanelShell>
+			<PanelHeader
+				title="Two-factor authentication enabled"
+				description="Save these backup codes now. You'll need one if you ever lose access to your authenticator."
+				icon={<CheckCircle2 className="w-5 h-5 text-green-500" />}
+			/>
+
+			<div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-amber-900 dark:text-amber-200">
+				<AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+				<p className="text-xs">
+					Each backup code can only be used once. Store them in a password
+					manager or somewhere safe. You won't be able to see them again.
+				</p>
+			</div>
+
+			<div className="grid grid-cols-2 gap-x-6 gap-y-1 bg-muted/50 rounded-md p-4 font-mono text-xs text-t2">
+				{backupCodes.map((code) => (
+					<span key={code}>{code}</span>
+				))}
+			</div>
+
+			<div className="flex flex-wrap items-center gap-2">
+				<CopyButton text={backupCodes.join("\n")}>Copy all codes</CopyButton>
+				<Button variant="secondary" size="sm" onClick={handleDownload}>
+					Download as .txt
+				</Button>
+			</div>
+
+			<label className="flex items-center gap-2 text-xs text-t2 cursor-pointer select-none">
+				<Checkbox
+					checked={acknowledged}
+					onCheckedChange={(v) => setAcknowledged(v === true)}
+				/>
+				I've saved my backup codes somewhere safe
+			</label>
+
+			<div className="flex justify-end">
+				<Button
+					variant="primary"
+					onClick={onDone}
+					disabled={!acknowledged}
+				>
+					Done
+				</Button>
+			</div>
+		</PanelShell>
+	);
+};
+
+const DisablePanel = ({
+	onCancel,
 	onDisabled,
 }: {
-	open: boolean;
-	setOpen: (open: boolean) => void;
+	onCancel: () => void;
 	onDisabled: () => void;
 }) => {
 	const [password, setPassword] = useState("");
@@ -235,8 +413,6 @@ const DisableDialog = ({
 			}
 			toast.success("Two-factor authentication disabled");
 			onDisabled();
-			setOpen(false);
-			setPassword("");
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to disable 2FA"));
 		} finally {
@@ -245,42 +421,35 @@ const DisableDialog = ({
 	};
 
 	return (
-		<Dialog
-			open={open}
-			onOpenChange={(next) => {
-				setOpen(next);
-				if (!next) setPassword("");
-			}}
-		>
-			<DialogContent className="max-w-[420px]">
-				<DialogHeader>
-					<DialogTitle>Disable two-factor authentication</DialogTitle>
-					<DialogDescription>
-						Your account will no longer require a second factor. Confirm your
-						password to continue.
-					</DialogDescription>
-				</DialogHeader>
-				<Input
-					type="password"
-					placeholder="Current password (leave blank if you don't have one)"
-					value={password}
-					onChange={(e) => setPassword(e.target.value)}
-					autoComplete="current-password"
-				/>
-				<DialogFooter>
-					<Button variant="secondary" onClick={() => setOpen(false)}>
-						Cancel
-					</Button>
-					<Button
-						variant="destructive"
-						onClick={handleDisable}
-						isLoading={loading}
-					>
-						Disable 2FA
-					</Button>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+		<PanelShell>
+			<PanelHeader
+				title="Disable two-factor authentication"
+				description="Your account will no longer require a second factor to sign in. Confirm your password to continue."
+				icon={<AlertTriangle className="w-5 h-5 text-red-500" />}
+			/>
+			<Input
+				type="password"
+				placeholder="Current password (leave blank if you don't have one)"
+				value={password}
+				onChange={(e) => setPassword(e.target.value)}
+				autoComplete="current-password"
+				onKeyDown={(e) => {
+					if (e.key === "Enter" && !loading) void handleDisable();
+				}}
+			/>
+			<div className="flex justify-end gap-2">
+				<Button variant="secondary" onClick={onCancel} disabled={loading}>
+					Cancel
+				</Button>
+				<Button
+					variant="destructive"
+					onClick={handleDisable}
+					isLoading={loading}
+				>
+					Disable 2FA
+				</Button>
+			</div>
+		</PanelShell>
 	);
 };
 
@@ -291,8 +460,9 @@ export const TwoFactorSection = () => {
 			?.twoFactorEnabled,
 	);
 
-	const [enableOpen, setEnableOpen] = useState(false);
-	const [disableOpen, setDisableOpen] = useState(false);
+	const [mode, setMode] = useState<Mode>({ kind: "idle" });
+
+	const goIdle = () => setMode({ kind: "idle" });
 
 	return (
 		<div className="flex flex-col gap-3">
@@ -305,54 +475,55 @@ export const TwoFactorSection = () => {
 				</p>
 			</div>
 
-			<div className="border border-border rounded-xl bg-card px-4 py-3 flex items-center justify-between gap-4">
-				<div className="flex items-center gap-3">
-					<ShieldCheck
-						className={cn(
-							"w-5 h-5 shrink-0",
-							enabled ? "text-green-500" : "text-t4",
-						)}
-					/>
-					<div className="flex flex-col">
-						<span className="text-sm text-t1">
-							{enabled ? "2FA is enabled" : "2FA is not enabled"}
-						</span>
-						<span className="text-xs text-t3">
-							{enabled
-								? "You'll be prompted for a code when signing in."
-								: "Protect sign-ins with a TOTP authenticator app."}
-						</span>
-					</div>
-				</div>
-				{enabled ? (
-					<Button
-						variant="secondary"
-						onClick={() => setDisableOpen(true)}
-						className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-950/30"
-					>
-						Disable
-					</Button>
-				) : (
-					<Button variant="primary" onClick={() => setEnableOpen(true)}>
-						Enable 2FA
-					</Button>
-				)}
-			</div>
+			{mode.kind === "idle" && (
+				<IdlePanel
+					enabled={enabled}
+					onEnable={() => setMode({ kind: "enabling-password" })}
+					onDisable={() => setMode({ kind: "disabling" })}
+				/>
+			)}
 
-			<EnableDialog
-				open={enableOpen}
-				setOpen={setEnableOpen}
-				onEnabled={() => {
-					void refetch();
-				}}
-			/>
-			<DisableDialog
-				open={disableOpen}
-				setOpen={setDisableOpen}
-				onDisabled={() => {
-					void refetch();
-				}}
-			/>
+			{mode.kind === "enabling-password" && (
+				<PasswordPanel
+					onCancel={goIdle}
+					onSuccess={({ totpURI, backupCodes }) =>
+						setMode({ kind: "enabling-verify", totpURI, backupCodes })
+					}
+				/>
+			)}
+
+			{mode.kind === "enabling-verify" && (
+				<VerifyPanel
+					totpURI={mode.totpURI}
+					backupCodes={mode.backupCodes}
+					onCancel={() => {
+						void refetch();
+						goIdle();
+					}}
+					onVerified={(codes) => {
+						void refetch();
+						toast.success("Two-factor authentication enabled");
+						setMode({ kind: "enabling-backup-codes", backupCodes: codes });
+					}}
+				/>
+			)}
+
+			{mode.kind === "enabling-backup-codes" && (
+				<BackupCodesPanel
+					backupCodes={mode.backupCodes}
+					onDone={goIdle}
+				/>
+			)}
+
+			{mode.kind === "disabling" && (
+				<DisablePanel
+					onCancel={goIdle}
+					onDisabled={() => {
+						void refetch();
+						goIdle();
+					}}
+				/>
+			)}
 		</div>
 	);
 };

--- a/vite/src/views/main-sidebar/components/account-settings/TwoFactorSection.tsx
+++ b/vite/src/views/main-sidebar/components/account-settings/TwoFactorSection.tsx
@@ -1,0 +1,358 @@
+import { ShieldCheck } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+	InputOTP,
+	InputOTPGroup,
+	InputOTPSeparator,
+	InputOTPSlot,
+} from "@/components/ui/input-otp";
+import { Button } from "@/components/v2/buttons/Button";
+import { CopyButton } from "@/components/v2/buttons/CopyButton";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { Input } from "@/components/v2/inputs/Input";
+import { authClient, useSession } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+import { getBackendErr } from "@/utils/genUtils";
+
+type EnableState =
+	| { step: "password" }
+	| { step: "verify"; totpURI: string; backupCodes: string[] }
+	| { step: "done" };
+
+const EnableDialog = ({
+	open,
+	setOpen,
+	onEnabled,
+}: {
+	open: boolean;
+	setOpen: (open: boolean) => void;
+	onEnabled: () => void;
+}) => {
+	const [password, setPassword] = useState("");
+	const [state, setState] = useState<EnableState>({ step: "password" });
+	const [otp, setOtp] = useState("");
+	const [loading, setLoading] = useState(false);
+	const [verifying, setVerifying] = useState(false);
+
+	const reset = () => {
+		setPassword("");
+		setOtp("");
+		setState({ step: "password" });
+		setLoading(false);
+		setVerifying(false);
+	};
+
+	const handleEnable = async () => {
+		setLoading(true);
+		try {
+			const { data, error } = await authClient.twoFactor.enable({
+				password: password || "",
+			});
+			if (error) {
+				toast.error(error.message || "Failed to enable 2FA");
+				return;
+			}
+			if (!data) {
+				toast.error("Failed to enable 2FA");
+				return;
+			}
+			setState({
+				step: "verify",
+				totpURI: data.totpURI,
+				backupCodes: data.backupCodes,
+			});
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to enable 2FA"));
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleVerify = async (code: string) => {
+		setVerifying(true);
+		try {
+			const { error } = await authClient.twoFactor.verifyTotp({ code });
+			if (error) {
+				toast.error(error.message || "Invalid code");
+				setOtp("");
+				return;
+			}
+			toast.success("Two-factor authentication enabled");
+			onEnabled();
+			setOpen(false);
+			setTimeout(reset, 300);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to verify code"));
+			setOtp("");
+		} finally {
+			setVerifying(false);
+		}
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(next) => {
+				setOpen(next);
+				if (!next) setTimeout(reset, 300);
+			}}
+		>
+			<DialogContent className="max-w-[440px]">
+				<DialogHeader>
+					<DialogTitle>Enable two-factor authentication</DialogTitle>
+					<DialogDescription>
+						{state.step === "password"
+							? "Confirm your password to generate a TOTP secret and backup codes."
+							: "Scan the URI with your authenticator app, then enter the 6-digit code to finish."}
+					</DialogDescription>
+				</DialogHeader>
+
+				{state.step === "password" && (
+					<div className="flex flex-col gap-3 py-2">
+						<Input
+							type="password"
+							placeholder="Current password (leave blank if you don't have one)"
+							value={password}
+							onChange={(e) => setPassword(e.target.value)}
+							autoComplete="current-password"
+						/>
+					</div>
+				)}
+
+				{state.step === "verify" && (
+					<div className="flex flex-col gap-4 py-2">
+						<div className="flex flex-col gap-2">
+							<p className="text-xs text-t3">
+								Scan or paste this URI into your authenticator app:
+							</p>
+							<div className="flex items-center gap-2 bg-muted/50 rounded-md p-2">
+								<code className="text-xs text-t2 break-all flex-1 font-mono">
+									{state.totpURI}
+								</code>
+								<CopyButton text={state.totpURI} />
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-2">
+							<p className="text-xs text-t3">
+								Save these backup codes in a safe place. Each can be used once.
+							</p>
+							<div className="grid grid-cols-2 gap-1 bg-muted/50 rounded-md p-2 font-mono text-xs text-t2">
+								{state.backupCodes.map((code) => (
+									<span key={code}>{code}</span>
+								))}
+							</div>
+							<CopyButton
+								text={state.backupCodes.join("\n")}
+								className="self-start"
+							>
+								Copy all codes
+							</CopyButton>
+						</div>
+
+						<div className="flex flex-col items-center gap-2 pt-1">
+							<p className="text-xs text-t3">Enter your first 6-digit code</p>
+							<div className={cn(verifying && "shimmer")}>
+								<InputOTP
+									maxLength={6}
+									value={otp}
+									onChange={setOtp}
+									onComplete={handleVerify}
+									disabled={verifying}
+								>
+									<InputOTPGroup>
+										<InputOTPSlot index={0} />
+										<InputOTPSlot index={1} />
+										<InputOTPSlot index={2} />
+									</InputOTPGroup>
+									<InputOTPSeparator />
+									<InputOTPGroup>
+										<InputOTPSlot index={3} />
+										<InputOTPSlot index={4} />
+										<InputOTPSlot index={5} />
+									</InputOTPGroup>
+								</InputOTP>
+							</div>
+						</div>
+					</div>
+				)}
+
+				<DialogFooter>
+					{state.step === "password" && (
+						<>
+							<Button variant="secondary" onClick={() => setOpen(false)}>
+								Cancel
+							</Button>
+							<Button
+								variant="primary"
+								onClick={handleEnable}
+								isLoading={loading}
+							>
+								Continue
+							</Button>
+						</>
+					)}
+					{state.step === "verify" && (
+						<Button variant="secondary" onClick={() => setOpen(false)}>
+							Close
+						</Button>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+const DisableDialog = ({
+	open,
+	setOpen,
+	onDisabled,
+}: {
+	open: boolean;
+	setOpen: (open: boolean) => void;
+	onDisabled: () => void;
+}) => {
+	const [password, setPassword] = useState("");
+	const [loading, setLoading] = useState(false);
+
+	const handleDisable = async () => {
+		setLoading(true);
+		try {
+			const { error } = await authClient.twoFactor.disable({
+				password: password || "",
+			});
+			if (error) {
+				toast.error(error.message || "Failed to disable 2FA");
+				return;
+			}
+			toast.success("Two-factor authentication disabled");
+			onDisabled();
+			setOpen(false);
+			setPassword("");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to disable 2FA"));
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(next) => {
+				setOpen(next);
+				if (!next) setPassword("");
+			}}
+		>
+			<DialogContent className="max-w-[420px]">
+				<DialogHeader>
+					<DialogTitle>Disable two-factor authentication</DialogTitle>
+					<DialogDescription>
+						Your account will no longer require a second factor. Confirm your
+						password to continue.
+					</DialogDescription>
+				</DialogHeader>
+				<Input
+					type="password"
+					placeholder="Current password (leave blank if you don't have one)"
+					value={password}
+					onChange={(e) => setPassword(e.target.value)}
+					autoComplete="current-password"
+				/>
+				<DialogFooter>
+					<Button variant="secondary" onClick={() => setOpen(false)}>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={handleDisable}
+						isLoading={loading}
+					>
+						Disable 2FA
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export const TwoFactorSection = () => {
+	const { data: session, refetch } = useSession();
+	const enabled = Boolean(
+		(session?.user as { twoFactorEnabled?: boolean } | undefined)
+			?.twoFactorEnabled,
+	);
+
+	const [enableOpen, setEnableOpen] = useState(false);
+	const [disableOpen, setDisableOpen] = useState(false);
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex flex-col gap-1">
+				<h3 className="text-sm font-medium text-t1">
+					Two-Factor Authentication
+				</h3>
+				<p className="text-xs text-t3">
+					Add an extra layer of security with an authenticator app.
+				</p>
+			</div>
+
+			<div className="border border-border rounded-xl bg-card px-4 py-3 flex items-center justify-between gap-4">
+				<div className="flex items-center gap-3">
+					<ShieldCheck
+						className={cn(
+							"w-5 h-5 shrink-0",
+							enabled ? "text-green-500" : "text-t4",
+						)}
+					/>
+					<div className="flex flex-col">
+						<span className="text-sm text-t1">
+							{enabled ? "2FA is enabled" : "2FA is not enabled"}
+						</span>
+						<span className="text-xs text-t3">
+							{enabled
+								? "You'll be prompted for a code when signing in."
+								: "Protect sign-ins with a TOTP authenticator app."}
+						</span>
+					</div>
+				</div>
+				{enabled ? (
+					<Button
+						variant="secondary"
+						onClick={() => setDisableOpen(true)}
+						className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-950/30"
+					>
+						Disable
+					</Button>
+				) : (
+					<Button variant="primary" onClick={() => setEnableOpen(true)}>
+						Enable 2FA
+					</Button>
+				)}
+			</div>
+
+			<EnableDialog
+				open={enableOpen}
+				setOpen={setEnableOpen}
+				onEnabled={() => {
+					void refetch();
+				}}
+			/>
+			<DisableDialog
+				open={disableOpen}
+				setOpen={setDisableOpen}
+				onDisabled={() => {
+					void refetch();
+				}}
+			/>
+		</div>
+	);
+};


### PR DESCRIPTION
This PR adds full support for WebAuthn passkeys and TOTP-based two-factor authentication using Better Auth@1.6.5. The implementation spans server configuration, shared schema changes, client-side plugin wiring, new account settings UI components, and updated sign-in flows for both autofill and 2FA gating.

### Server / Schema

- **Server Configuration**: Add `twoFactor({ issuer: "Autumn", allowPasswordless: true })` and `passkey({ rpName: "Autumn", ... })` plugins to the Better Auth instance at `server/src/utils/auth.ts`. Updated imports to include `twoFactor` and `passkey` from core and `@better-auth/passkey`.

- **Schema Changes**: Create `twoFactor` and `passkey` tables in `shared/db/auth-schema.ts` with proper foreign keys to `user.id`, cascade deletes, and RLS enabled. Added `twoFactorEnabled` column (boolean) to the `user` table with a default of `false`. Added `twoFactor` and `passkey` to the `authSchema` export.

- **Migration**: A new Drizzle migration (`0001_equal_franklin_richards.sql`) is generated to create the `passkey` table, `twoFactor` table, and add the `two_factor_enabled` column to `user`.

### Client Plugins

- **Vite Dashboard**: Add `twoFactorClient()` and `passkeyClient()` to `vite/src/lib/auth-client.ts`. Imports now include `@better-auth/passkey/client` and `twoFactorClient` from `better-auth/client/plugins`.

- **SDK Test**: Mirror the client plugin additions in `apps/sdk-test/lib/auth-client.ts` and `apps/sdk-test/lib/auth.ts`. The server instance in `apps/sdk-test/lib/auth.ts` also receives the `twoFactor` and `passkey` plugins for completeness.

### UI: Account Settings OrgDropdown Entry

- Clicking the user profile item in the `OrgDropdown` now opens a new `AccountSettings` dialog.

- `vite/src/views/main-sidebar/components/AccountSettings.tsx` introduces a new dialog component with a single "Security" tab, following the same Dialog/Tab primitives as `ManageOrg`.

- `account-settings/PasskeysSection.tsx` displays the user's registered passkeys with name and creation date, allows adding new passkeys with an optional name input, and provides delete functionality. Includes loading shimmer and empty states.

- `account-settings/TwoFactorSection.tsx` manages 2FA enable/disable flows. Enable flow prompts for password (skip if passwordless), shows TOTP URI as copyable text (no QR library installed) with backup codes, and verifies the first TOTP code via `InputOTP`. Disable flow confirms password before calling `authClient.twoFactor.disable`.

### UI: Sign-In Flows

- **Passkey Autofill**: Added a conditional-mediation `useEffect` to `SignIn.tsx` that calls `authClient.signIn.passkey({ autoFill: true })` when `PublicKeyCredential.isConditionalMediationAvailable` is true, allowing browsers to show a native passkey picker on email focus. Effect is gated when `otpSent` or `session` or `twoFactorMethods` are present.

- **Email Input Autocomplete**: Updated the email input in `SignIn.tsx` to include `autoComplete="email webauthn"` so password managers can autofill passkey credentials.

- **Two-Factor Gate**: Created `vite/src/views/auth/components/TwoFactorGate.tsx` to handle post-sign-in 2FA verification. Supports TOTP (default), OTP (email code), and backup code modes. Shows `InputOTP` for codes and switches modes via helper buttons. Calls `verifyTotp({ trustDevice: true })` or `verifyBackupCode` accordingly, then redirects based on `createdRecently` logic.

- **2FA Wiring**: Updated `SignIn.tsx` to add `twoFactorMethods` state and render `TwoFactorGate` when methods exist. Google OAuth `handleGoogleSignIn` checks for `data.twoFactorRedirect` and sets `twoFactorMethods` if present. `OTPSignIn.tsx` now accepts an optional `onTwoFactorRequired` callback and checks `data.twoFactorRedirect` after OTP verification to bubble up the required methods back to `SignIn.tsx`.

### Dependencies

- Added `@better-auth/passkey@1.6.5` to the root `package.json` `catalog`, `overrides`, and `resolutions` sections.
- Added `"@better-auth/passkey": "catalog:"` to `dependencies` in `server/package.json`, `vite/package.json`, and `apps/sdk-test/package.json`.
-Ran `bun install` to resolve the new workspace dependency.

The changes are localized to auth utilities and UI components, with no breaking changes to existing authentication flows. Passkey autofill is additive, and 2FA gates only appear after a user has explicitly enabled 2FA in their account settings.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/c50962bf-22f8-48af-b45a-5ae5021864e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-023" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/c50962bf-22f8-48af-b45a-5ae5021864e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-023&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-023"><img alt="SCO-023" src="https://capy.ai/api/badge/thread.svg?label=SCO-023"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WebAuthn passkeys and TOTP-based 2FA using Better Auth 1.6.5 across server, schema, client, and UI. Users can sign in with passkeys, enable 2FA with backup codes, and complete gated sign-ins via TOTP, email OTP, or backup codes.

- **New Features**
  - Server: enabled `twoFactor` and `passkey` plugins in `server/src/utils/auth.ts` (issuer/rpName “Autumn”; supports `PASSKEY_RP_ID` and `PASSKEY_ORIGIN`).
  - Schema: added `twoFactor` and `passkey` tables plus `user.twoFactorEnabled` (default false); exported via `authSchema`.
  - Clients: wired `twoFactorClient()` and `passkeyClient()` in `vite` and `apps/sdk-test`; mirrored server plugins in `apps/sdk-test`.
  - UI: Account Settings (Security) now manages Passkeys (list/add/delete) and Two‑Factor; TOTP setup shows a QR code with a copyable fallback, verifies the first code, and displays backup codes with copy/download.
  - Sign-in: passkey autofill via conditional mediation; `TwoFactorGate` handles TOTP/email OTP/backup codes (including Google OAuth and OTP flows); improved email autocomplete for WebAuthn.

- **Migration**
  - Run the new Drizzle migration to create `twoFactor`/`passkey` tables and add `user.two_factor_enabled`.
  - Set env vars for passkeys: `PASSKEY_RP_ID` (e.g., your domain) and `PASSKEY_ORIGIN` (e.g., https://your-domain).
  - Ensure `@better-auth/passkey@1.6.5` is installed and referenced in workspace catalogs/overrides/resolutions; `vite` adds `qrcode.react` for the TOTP QR code UI.

<sup>Written for commit a64657c080a80c7e92afa4e474706ef0505e8ae4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR integrates WebAuthn passkeys and TOTP-based 2FA into Autumn using Better Auth 1.6.5, spanning server plugin configuration, Drizzle schema additions, client plugin wiring, new Account Settings UI, and updated sign-in flows. The implementation is well-structured and additive — existing auth flows are unaffected.

**Key changes:**
- [Improvements] Server-side `twoFactor` and `passkey` plugins added to Better Auth, with new `twoFactor` and `passkey` Drizzle tables and a `twoFactorEnabled` column on `user`.
- [Improvements] New `AccountSettings` dialog with `PasskeysSection` and `TwoFactorSection` components for managing passkeys and enabling/disabling TOTP 2FA.
- [Improvements] `SignIn.tsx` gains passkey conditional-mediation autofill and a `TwoFactorGate` component for post-sign-in TOTP/OTP/backup-code verification; `OTPSignIn` propagates `twoFactorRedirect` responses upstream.

One item worth verifying before merge: the `passkey` schema maps `credentialID` to the column name `credential_i_d` — confirm this matches what `@better-auth/passkey` expects internally or passkey verification will fail at runtime.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge once the credential_i_d column name is verified against Better Auth's internal schema expectations.

One P1 concern exists: the passkey schema column name `credential_i_d` is non-standard and could cause runtime failures during passkey verification if Better Auth queries `credential_id` internally. All other findings are P2 (debug logs, QR code UX, non-abortable autofill). A quick check against the Better Auth passkey plugin's generated schema resolves the blocker.

shared/db/auth-schema.ts — verify `credentialID: text("credential_i_d")` column name matches what @better-auth/passkey expects.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/db/auth-schema.ts | Adds twoFactor and passkey tables; passkey.credentialID maps to column "credential_i_d" which may not match the column name Better Auth queries internally. |
| server/src/utils/auth.ts | Adds twoFactor and passkey plugins to the Better Auth instance; rpID/origin fall back to undefined (runtime-derived) if env vars are absent. |
| vite/src/views/auth/SignIn.tsx | Adds passkey conditional-mediation autofill effect and twoFactorMethods state; autofill request cannot be aborted once initiated if callbackPath changes. |
| vite/src/views/auth/components/OTPSignIn.tsx | Adds twoFactorRedirect handling to bubble methods up to SignIn; two debug console.log statements left in the resend handler. |
| vite/src/views/auth/components/TwoFactorGate.tsx | New component handling post-sign-in TOTP, OTP email, and backup-code verification flows; logic and redirect handling look correct. |
| vite/src/views/main-sidebar/components/account-settings/TwoFactorSection.tsx | Enable/disable 2FA dialogs with password confirmation; TOTP URI shown as copyable text with no QR code, which degrades setup UX. |
| vite/src/views/main-sidebar/components/account-settings/PasskeysSection.tsx | List, add, and delete passkeys UI; loading/empty states handled correctly. |
| vite/src/views/main-sidebar/components/AccountSettings.tsx | New dialog wrapping PasskeysSection and TwoFactorSection under a Security tab; contains an empty DialogTrigger (harmless since dialog is externally controlled). |
| vite/src/views/main-sidebar/components/OrgDropdown.tsx | Wires AccountSettings dialog open state to the user profile dropdown item; no issues. |
| vite/src/lib/auth-client.ts | Adds twoFactorClient and passkeyClient plugins to the vite auth client; straightforward. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant SI as SignIn.tsx
    participant OTP as OTPSignIn.tsx
    participant TFG as TwoFactorGate.tsx
    participant BA as Better Auth Server

    Note over SI: Passkey autofill (conditional mediation)
    SI->>BA: signIn.passkey({ autoFill: true })
    BA-->>SI: session → redirect to callbackPath

    Note over SI: Email OTP flow
    U->>SI: Enter email → Continue
    SI->>BA: emailOtp.sendVerificationOtp
    BA-->>SI: ok
    SI->>OTP: render OTPSignIn
    U->>OTP: Enter 6-digit code
    OTP->>BA: signIn.emailOtp
    alt 2FA required
        BA-->>OTP: twoFactorRedirect + twoFactorMethods
        OTP-->>SI: onTwoFactorRequired(methods)
        SI->>TFG: render TwoFactorGate
        U->>TFG: Enter TOTP / OTP / backup code
        TFG->>BA: verifyTotp / verifyOtp / verifyBackupCode
        BA-->>TFG: user session
        TFG-->>U: redirect
    else No 2FA
        BA-->>OTP: user session
        OTP-->>U: redirect
    end

    Note over SI: Google OAuth flow
    U->>SI: Continue with Google
    SI->>BA: signIn.social(google)
    alt 2FA required
        BA-->>SI: twoFactorRedirect + twoFactorMethods
        SI->>TFG: render TwoFactorGate
    else No 2FA
        BA-->>SI: redirect to callbackURL
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/auth/components/OTPSignIn.tsx`, line 98-99 ([link](https://github.com/useautumn/autumn/blob/8a44e946be5d6cfd05cc0685b22f817ed9089237/vite/src/views/auth/components/OTPSignIn.tsx#L98-L99)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Debug `console.log` left in production**

   Two debug logging statements were left in the resend handler and will appear in production browser consoles. These should be removed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/auth/components/OTPSignIn.tsx
   Line: 98-99

   Comment:
   **Debug `console.log` left in production**

   Two debug logging statements were left in the resend handler and will appear in production browser consoles. These should be removed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/views/auth/components/OTPSignIn.tsx
Line: 98-99

Comment:
**Debug `console.log` left in production**

Two debug logging statements were left in the resend handler and will appear in production browser consoles. These should be removed.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/auth/SignIn.tsx
Line: 87-106

Comment:
**Passkey autofill request cannot be aborted once initiated**

The cleanup function sets `cancelled = true` which prevents the `signIn.passkey` call from starting, but once it has been called (e.g., before the effect cleans up due to `callbackPath` changing), the in-flight WebAuthn conditional mediation ceremony cannot be cancelled. If `callbackPath` changes mid-flight, a stale autofill ceremony remains active in the background. Consider keeping the dependency array to only truly stable values.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: shared/db/auth-schema.ts
Line: 283

Comment:
**Unusual column name `credential_i_d`**

The column mapping `text("credential_i_d")` produces a database column named `credential_i_d` rather than the conventional `credential_id`. If Better Auth's passkey plugin internally queries by the column name `credential_id`, this mismatch will cause runtime errors when verifying passkeys. Verify that the Better Auth `@better-auth/passkey` schema generator produces this exact column name, or correct it to `credential_id`.

```suggestion
	credentialID: text("credential_id").notNull(),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/main-sidebar/components/account-settings/TwoFactorSection.tsx
Line: 130-145

Comment:
**TOTP setup lacks a QR code**

The TOTP URI is exposed as raw copyable text rather than a rendered QR code. Most authenticator apps (Google Authenticator, Authy, 1Password) present "Scan QR code" as their primary setup flow — manually pasting a URI is unfamiliar to most users and error-prone. Consider adding a lightweight library such as `qrcode.react` (~5 KB) to render the URI as a scannable code alongside the copy fallback.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Better Auth passkeys and two-f..."](https://github.com/useautumn/autumn/commit/8a44e946be5d6cfd05cc0685b22f817ed9089237) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29483858)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->