### PR TITLE
chore: enforce redis timeouts

### DIFF
--- a/server/src/external/redis/initRedisV2.ts
+++ b/server/src/external/redis/initRedisV2.ts
@@ -9,6 +9,7 @@ import {
 } from "./initRedis.js";
 import {
 	getRedisV2ConnectionConfig,
+	REDIS_V2_COMMAND_TIMEOUT_MS,
 	supportsUpstashShebangForRedisV2,
 } from "./initUtils/redisV2Config.js";
 
@@ -51,6 +52,7 @@ export const getAlternateRedisV2Instance = (
 		cacheUrl,
 		region: `${currentRegion}:v2:${name}`,
 		supportsUpstashShebang: supportsUpstashShebangForRedisV2(name),
+		commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
 	});
 	instancePool.set(name, instance);
 	return instance;

--- a/server/src/external/redis/initUtils/createRedisClient.ts
+++ b/server/src/external/redis/initUtils/createRedisClient.ts
@@ -13,10 +13,12 @@ export const createRedisClient = ({
 	cacheUrl,
 	region,
 	supportsUpstashShebang = true,
+	commandTimeout = REDIS_COMMAND_TIMEOUT_MS,
 }: {
 	cacheUrl: string;
 	region: string;
 	supportsUpstashShebang?: boolean;
+	commandTimeout?: number;
 }): Redis => {
 	const instance = new Redis(cacheUrl, {
 		tls:
@@ -25,8 +27,8 @@ export const createRedisClient = ({
 				: undefined,
 		family: 4,
 		keepAlive: 10000,
-		commandTimeout: REDIS_COMMAND_TIMEOUT_MS,
-		// Let `commandTimeout` (10s) be the sole bound on how long a command
+		commandTimeout,
+		// Let `commandTimeout` (default 10s) be the sole bound on how long a command
 		// can wait. `maxRetriesPerRequest: null` disables ioredis's default
 		// "flush pending commands after N reconnect attempts" behavior, which
 		// otherwise aborts commands still in the offline queue on any minor

--- a/server/src/external/redis/initUtils/redisV2Config.ts
+++ b/server/src/external/redis/initUtils/redisV2Config.ts
@@ -1,5 +1,7 @@
 import type { RedisV2InstanceName } from "@/internal/misc/redisV2Cache/redisV2CacheSchemas.js";
 
+export const REDIS_V2_COMMAND_TIMEOUT_MS = 1_000;
+
 export const getRedisV2ConnectionConfig = ({
 	cacheV2Url,
 	primaryCacheUrl,
@@ -14,6 +16,7 @@ export const getRedisV2ConnectionConfig = ({
 				cacheUrl: cacheV2Url.trim(),
 				region: `${currentRegion}:v2`,
 				supportsUpstashShebang: supportsUpstashShebangForRedisV2("upstash"),
+				commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
 			}
 		: null;
 

--- a/server/src/utils/cacheUtils/cacheUtils.ts
+++ b/server/src/utils/cacheUtils/cacheUtils.ts
@@ -1,6 +1,8 @@
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { redis } from "@/external/redis/initRedis.js";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import type { UnavailableReason } from "@/external/redis/utils/runRedisOp.js";
 
 const REDIS_WARNING_INTERVAL_MS = 30_000;
 const lastRedisWarningAtBySource = new Map<string, number>();
@@ -26,6 +28,34 @@ const warnRedisUnavailable = ({
 	);
 };
 
+const classifyRedisUnavailable = (
+	targetRedis: Redis,
+	error?: unknown,
+): UnavailableReason | null => {
+	if (targetRedis.status !== "ready") return "not_ready";
+	const message = error instanceof Error ? error.message : String(error);
+	if (/ETIMEDOUT|timeout|timed out/i.test(message)) return "timeout";
+	if (/ECONN|closed|writeable|max retries/i.test(message)) return "connection";
+	return null;
+};
+
+const throwIfRedisUnavailable = ({
+	targetRedis,
+	source,
+	error,
+}: {
+	targetRedis: Redis;
+	source: string;
+	error?: unknown;
+}) => {
+	warnRedisUnavailable({ source, error });
+
+	const reason = classifyRedisUnavailable(targetRedis, error);
+	if (reason) {
+		throw new RedisUnavailableError({ source, reason, cause: error });
+	}
+};
+
 /**
  * Executes a Redis SET ... NX and routes the three possible outcomes to callbacks:
  * - `"OK"` (key was set) → `onSuccess`
@@ -49,7 +79,10 @@ export const tryRedisNx = async <TUnavailable, TSuccess, TExists>({
 
 	try {
 		if (targetRedis.status !== "ready") {
-			warnRedisUnavailable({ source: "tryRedisNx:not-ready" });
+			throwIfRedisUnavailable({
+				targetRedis,
+				source: "tryRedisNx:not-ready",
+			});
 			return await onRedisUnavailable();
 		}
 
@@ -57,7 +90,12 @@ export const tryRedisNx = async <TUnavailable, TSuccess, TExists>({
 		if (result === "OK") return await onSuccess();
 		return await onKeyAlreadyExists();
 	} catch (error) {
-		warnRedisUnavailable({ source: "tryRedisNx:error", error });
+		if (error instanceof RedisUnavailableError) throw error;
+		throwIfRedisUnavailable({
+			targetRedis,
+			source: "tryRedisNx:error",
+			error,
+		});
 		return await onRedisUnavailable();
 	}
 };
@@ -79,7 +117,10 @@ export const tryRedisWrite = async <T>(
 
 	try {
 		if (targetRedis.status !== "ready") {
-			warnRedisUnavailable({ source: "tryRedisWrite:not-ready" });
+			throwIfRedisUnavailable({
+				targetRedis,
+				source: "tryRedisWrite:not-ready",
+			});
 			return null as T extends void ? true : T | null;
 		}
 
@@ -89,7 +130,12 @@ export const tryRedisWrite = async <T>(
 			? true
 			: T | null;
 	} catch (error) {
-		warnRedisUnavailable({ source: "tryRedisWrite:error", error });
+		if (error instanceof RedisUnavailableError) throw error;
+		throwIfRedisUnavailable({
+			targetRedis,
+			source: "tryRedisWrite:error",
+			error,
+		});
 		return null as T extends void ? true : T | null;
 	}
 };
@@ -110,14 +156,22 @@ export const tryRedisRead = async <T>(
 
 	try {
 		if (targetRedis.status !== "ready") {
-			warnRedisUnavailable({ source: "tryRedisRead:not-ready" });
+			throwIfRedisUnavailable({
+				targetRedis,
+				source: "tryRedisRead:not-ready",
+			});
 			return null;
 		}
 
 		const result = await operation();
 		return result;
 	} catch (error) {
-		warnRedisUnavailable({ source: "tryRedisRead:error", error });
+		if (error instanceof RedisUnavailableError) throw error;
+		throwIfRedisUnavailable({
+			targetRedis,
+			source: "tryRedisRead:error",
+			error,
+		});
 		return null;
 	}
 };

--- a/server/tests/unit/cache/cache-utils.test.ts
+++ b/server/tests/unit/cache/cache-utils.test.ts
@@ -32,6 +32,7 @@ mock.module("@/external/redis/initRedis.js", () => ({
 	redis: defaultRedis,
 }));
 
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
 import {
 	tryRedisNx,
 	tryRedisRead,
@@ -62,12 +63,13 @@ describe("cache utils", () => {
 		});
 	});
 
-	test("tryRedisWrite returns null and warns when Redis is not ready", async () => {
-		const result = await tryRedisWrite(async () => "OK", {
+	test("tryRedisWrite throws RedisUnavailableError when Redis is not ready", async () => {
+		const error = await tryRedisWrite(async () => "OK", {
 			status: "connecting",
-		} as never);
+		} as never).catch((caught) => caught);
 
-		expect(result).toBeNull();
+		expect(error).toBeInstanceOf(RedisUnavailableError);
+		expect(error.reason).toBe("not_ready");
 		expect(mockState.warnings).toHaveLength(1);
 		expect(mockState.warnings[0]).toEqual({
 			message: "[redis] operation unavailable",
@@ -76,6 +78,33 @@ describe("cache utils", () => {
 				error: undefined,
 			},
 		});
+	});
+
+	test("tryRedisRead throws RedisUnavailableError when Redis command times out", async () => {
+		const error = await tryRedisRead(
+			async () => {
+				throw new Error("Command timed out");
+			},
+			{ status: "ready" } as never,
+		).catch((caught) => caught);
+
+		expect(error).toBeInstanceOf(RedisUnavailableError);
+		expect(error.reason).toBe("timeout");
+	});
+
+	test("tryRedisNx throws RedisUnavailableError on connection failures", async () => {
+		const error = await tryRedisNx({
+			operation: async () => {
+				throw new Error("Connection is closed.");
+			},
+			redisInstance: { status: "ready" } as never,
+			onRedisUnavailable: () => "fallback",
+			onSuccess: () => "success",
+			onKeyAlreadyExists: () => "exists",
+		}).catch((caught) => caught);
+
+		expect(error).toBeInstanceOf(RedisUnavailableError);
+		expect(error.reason).toBe("connection");
 	});
 
 	test("tryRedisNx falls back and warns when Redis operation throws", async () => {
@@ -90,14 +119,6 @@ describe("cache utils", () => {
 		});
 
 		expect(result).toBe("fallback");
-		expect(mockState.warnings).toHaveLength(1);
-		expect(mockState.warnings[0]).toEqual({
-			message: "[redis] operation unavailable",
-			data: {
-				source: "tryRedisNx:error",
-				error: "boom",
-			},
-		});
 	});
 
 	test("custom Redis failures do not mark default Redis unavailable", async () => {

--- a/server/tests/unit/redis/redis-v2-config.spec.ts
+++ b/server/tests/unit/redis/redis-v2-config.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	getRedisV2ConnectionConfig,
+	REDIS_V2_COMMAND_TIMEOUT_MS,
 	supportsUpstashShebangForRedisV2,
 } from "@/external/redis/initUtils/redisV2Config.js";
 
@@ -16,6 +17,7 @@ describe("redis V2 connection config", () => {
 			cacheUrl: "redis://v2",
 			region: "us-west-2:v2",
 			supportsUpstashShebang: true,
+			commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
 		});
 	});
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces Redis command timeouts and surfaces availability errors so callers can fail open fast. Sets a 1s command timeout for Redis v2 and makes timeouts configurable in the Redis client.

- **Refactors**
  - Add `REDIS_V2_COMMAND_TIMEOUT_MS` (1s) and pass as `commandTimeout` for v2 and alternate instances.
  - Update `createRedisClient` to accept `commandTimeout` (defaults to `REDIS_COMMAND_TIMEOUT_MS`) and forward to `ioredis`.
  - In cache utils, detect not-ready, timeout, and connection failures; throw `RedisUnavailableError` with a reason in `tryRedisNx`, `tryRedisRead`, and `tryRedisWrite`; keep fallbacks for non-availability errors.
  - Update unit tests to assert throwing `RedisUnavailableError` and validate timeout handling.

<sup>Written for commit 5c4d2b5b3a5e22e22d2947b04df5e15bf183a0d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR enforces a tighter 1-second `commandTimeout` on Redis V2 instances (down from the default 10s) and upgrades `tryRedisNx`/`tryRedisWrite`/`tryRedisRead` to throw a typed `RedisUnavailableError` for classifiable failures (timeout, connection, not-ready) instead of silently returning `null`.

- **Bug fixes / Improvements**: `createRedisClient` now accepts a configurable `commandTimeout`, and `redisV2Config` sets it to 1s — but `runRedisOp.ts` (the primary path for V2 operations like `getCachedFullSubject`) uses a regex that does **not** match ioredis's exact `\"Command timed out\"` error string, so V2 timeout errors will be mis-classified as `\"other\"` instead of `\"timeout\"`.
- **Improvements**: `classifyRedisUnavailable` correctly adds `timed out` to its regex and is tested with the real ioredis message, but this fix was not applied to the parallel `classifyErrorReason` in `runRedisOp.ts`.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the timeout regex in runRedisOp.ts — the omission causes V2 timeout errors to surface with the wrong reason label

One P1 finding: the classifyErrorReason regex in runRedisOp.ts misses ioredis's "Command timed out" message, so the newly-enforced 1s V2 timeout won't be classified correctly for callers using that path. The rest of the changes are well-structured and tested.

server/src/external/redis/utils/runRedisOp.ts — classifyErrorReason regex needs "timed out" added to match the rest of the PR

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/redis/utils/runRedisOp.ts | Not directly changed, but its classifyErrorReason regex misses ioredis's "Command timed out" message, causing V2 timeout errors to be mis-classified as "other" instead of "timeout" |
| server/src/utils/cacheUtils/cacheUtils.ts | Adds classifyRedisUnavailable and throwIfRedisUnavailable helpers; upgrades tryRedis* functions to throw RedisUnavailableError for classifiable failures instead of silently returning null; contains minor dead-code in not-ready branches |
| server/src/external/redis/initUtils/redisV2Config.ts | Exports REDIS_V2_COMMAND_TIMEOUT_MS = 1_000 and passes it into V2 Redis connection configs |
| server/src/external/redis/initUtils/createRedisClient.ts | Makes commandTimeout a configurable parameter (defaulting to original 10s), allowing V2 instances to override it |
| server/tests/unit/cache/cache-utils.test.ts | Adds tests for the new throw-on-timeout/connection/not-ready behavior; silently drops warning assertion for unclassified-error path |
| server/src/external/redis/initRedisV2.ts | Threads REDIS_V2_COMMAND_TIMEOUT_MS into alternate V2 instance creation |
| server/tests/unit/redis/redis-v2-config.spec.ts | Adds assertion that commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS is present in V2 connection config |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Redis operation called] --> B{status === ready?}
    B -- No --> C[throwIfRedisUnavailable not_ready reason]
    C --> D[throw RedisUnavailableError]
    B -- Yes --> E[await operation]
    E -- success --> F[return result]
    E -- throws --> G{error instanceof RedisUnavailableError?}
    G -- Yes --> D
    G -- No --> H[classifyRedisUnavailable]
    H --> I{reason?}
    I -- timeout / connection / not_ready --> D
    I -- null unclassified --> J[warn + return null/fallback]

    subgraph runRedisOp_path [runRedisOp used by V2 ops]
        K[await operation] -- throws --> L[classifyErrorReason]
        L --> M{regex match?}
        M -- ETIMEDOUT or timeout matches --> N[reason = timeout]
        M -- Command timed out does NOT match --> O[reason = other]
        N --> P[throw RedisUnavailableError]
        O --> P
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/external/redis/utils/runRedisOp.ts`, line 15 ([link](https://github.com/useautumn/autumn/blob/5c4d2b5b3a5e22e22d2947b04df5e15bf183a0d7/server/src/external/redis/utils/runRedisOp.ts#L15)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`classifyErrorReason` misses ioredis "Command timed out" message**

   `runRedisOp` is the primary path for Redis V2 operations (e.g. `getCachedFullSubject` calls it with `redisV2`). When ioredis fires `commandTimeout`, it throws an error with the exact message `"Command timed out"` — which does **not** contain the substring `"timeout"` (it contains `"timed out"`). The regex `/ETIMEDOUT|timeout/i` therefore falls through to `"other"` for these errors.

   The new `classifyRedisUnavailable` in `cacheUtils.ts` correctly adds `timed out` to its regex (`/ETIMEDOUT|timeout|timed out/i`), but `runRedisOp` was not updated consistently. Any caller that checks `error.reason === "timeout"` (or surfaces the reason in logs/alerts) will see `"other"` instead for V2 timeout events.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/external/redis/utils/runRedisOp.ts
   Line: 15

   Comment:
   **`classifyErrorReason` misses ioredis "Command timed out" message**

   `runRedisOp` is the primary path for Redis V2 operations (e.g. `getCachedFullSubject` calls it with `redisV2`). When ioredis fires `commandTimeout`, it throws an error with the exact message `"Command timed out"` — which does **not** contain the substring `"timeout"` (it contains `"timed out"`). The regex `/ETIMEDOUT|timeout/i` therefore falls through to `"other"` for these errors.

   The new `classifyRedisUnavailable` in `cacheUtils.ts` correctly adds `timed out` to its regex (`/ETIMEDOUT|timeout|timed out/i`), but `runRedisOp` was not updated consistently. Any caller that checks `error.reason === "timeout"` (or surfaces the reason in logs/alerts) will see `"other"` instead for V2 timeout events.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/external/redis/utils/runRedisOp.ts
Line: 15

Comment:
**`classifyErrorReason` misses ioredis "Command timed out" message**

`runRedisOp` is the primary path for Redis V2 operations (e.g. `getCachedFullSubject` calls it with `redisV2`). When ioredis fires `commandTimeout`, it throws an error with the exact message `"Command timed out"` — which does **not** contain the substring `"timeout"` (it contains `"timed out"`). The regex `/ETIMEDOUT|timeout/i` therefore falls through to `"other"` for these errors.

The new `classifyRedisUnavailable` in `cacheUtils.ts` correctly adds `timed out` to its regex (`/ETIMEDOUT|timeout|timed out/i`), but `runRedisOp` was not updated consistently. Any caller that checks `error.reason === "timeout"` (or surfaces the reason in logs/alerts) will see `"other"` instead for V2 timeout events.

```suggestion
	if (/ETIMEDOUT|timeout|timed out/i.test(message)) return "timeout";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/utils/cacheUtils/cacheUtils.ts
Line: 80-87

Comment:
**Unreachable fallback after `throwIfRedisUnavailable` in not-ready path**

When `targetRedis.status !== "ready"`, `classifyRedisUnavailable` always returns `"not_ready"`, so `throwIfRedisUnavailable` always throws. The `return await onRedisUnavailable()` on the following line is dead code and will never execute. Same pattern exists in `tryRedisWrite` and `tryRedisRead`'s not-ready branches. Not a runtime bug, but misleading to readers and should be removed or replaced with a plain throw.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/tests/unit/cache/cache-utils.test.ts
Line: 110-122

Comment:
**Warning assertion silently removed for unclassified errors**

The `"tryRedisNx falls back and warns when Redis operation throws"` test previously verified that a warning was emitted for unclassified errors. That assertion was removed, but `throwIfRedisUnavailable` still calls `warnRedisUnavailable` for these cases — the warning is still generated. Keeping the assertion documents the expected behaviour and protects against future regressions where the warning path is accidentally bypassed.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: enforce redis timeouts"](https://github.com/useautumn/autumn/commit/5c4d2b5b3a5e22e22d2947b04df5e15bf183a0d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29486079)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->