### PR TITLE
fix: missing entity

### DIFF
--- a/server/src/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.ts
@@ -58,10 +58,17 @@ export const getOrCreateCachedFullSubject = async ({
 	}
 
 	if (!fullSubject && customerId) {
+		// Probe customer with entity fallback: if the customer exists but the
+		// requested entity doesn't, return a customer-scoped subject so the
+		// downstream autoCreateEntity branch handles the missing entity
+		// (either creating it when entity_data.feature_id is set, or throwing
+		// the descriptive error). This prevents falling through to
+		// createWithDefaults on an already-existing customer.
 		normalizedResult = await getFullSubjectNormalized({
 			ctx,
 			customerId,
 			entityId,
+			allowMissingEntity: true,
 		});
 		if (normalizedResult) {
 			fullSubject = normalizedResult.fullSubject;

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -20,11 +20,13 @@ export async function getFullSubject({
 	customerId,
 	entityId,
 	inStatuses = RELEVANT_STATUSES,
+	allowMissingEntity = false,
 }: {
 	ctx: AutumnContext;
 	customerId?: string;
 	entityId?: string;
 	inStatuses?: CusProductStatus[];
+	allowMissingEntity?: boolean;
 }): Promise<FullSubject | undefined> {
 	const { db, org, env } = ctx;
 
@@ -35,6 +37,7 @@ export async function getFullSubject({
 			customerId,
 			entityId,
 			inStatuses,
+			allowMissingEntity,
 		}),
 	);
 
@@ -42,6 +45,8 @@ export async function getFullSubject({
 
 	const fullSubject = resultToFullSubject({
 		row: result[0] as unknown as SubjectQueryRow,
+		entityIdRequested: !!entityId,
+		allowMissingEntity,
 	});
 	await lazyResetSubjectEntitlements({ ctx, fullSubject });
 	return fullSubject;
@@ -54,11 +59,13 @@ export async function getFullSubjectNormalized({
 	customerId,
 	entityId,
 	inStatuses = RELEVANT_STATUSES,
+	allowMissingEntity = false,
 }: {
 	ctx: AutumnContext;
 	customerId?: string;
 	entityId?: string;
 	inStatuses?: CusProductStatus[];
+	allowMissingEntity?: boolean;
 }): Promise<
 	{ normalized: NormalizedFullSubject; fullSubject: FullSubject } | undefined
 > {
@@ -71,6 +78,7 @@ export async function getFullSubjectNormalized({
 			customerId,
 			entityId,
 			inStatuses,
+			allowMissingEntity,
 		}),
 	);
 
@@ -78,6 +86,8 @@ export async function getFullSubjectNormalized({
 
 	const normalized = subjectQueryRowToNormalized({
 		row: result[0] as unknown as SubjectQueryRow,
+		entityIdRequested: !!entityId,
+		allowMissingEntity,
 	});
 
 	const fullSubject = normalizedToFullSubject({ normalized });

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectQuery.ts
@@ -78,6 +78,7 @@ export const getFullSubjectQuery = ({
 		offset: 0,
 	},
 	inStatuses = RELEVANT_STATUSES,
+	allowMissingEntity = false,
 }: {
 	orgId: string;
 	env: AppEnv;
@@ -88,6 +89,10 @@ export const getFullSubjectQuery = ({
 		offset?: number;
 	};
 	inStatuses?: CusProductStatus[];
+	// When true and both customerId + entityId are provided, return the
+	// customer-scoped row even if the entity does not exist. No-op when
+	// customerId is absent (entity-only lookup has no customer anchor).
+	allowMissingEntity?: boolean;
 }) => {
 	const page = pagination.page ?? 50;
 	const offset = pagination.offset ?? 0;
@@ -135,15 +140,19 @@ export const getFullSubjectQuery = ({
 		statusFilter,
 	});
 
-	const subjectCustomerFilter = entityId
-		? sql`
+	const allowEntityFallback =
+		allowMissingEntity && !!customerId && !entityOnlyLookup;
+
+	const subjectCustomerFilter =
+		entityId && !allowEntityFallback
+			? sql`
 			WHERE scr.internal_id = (
 				SELECT internal_customer_id
 				FROM entity_record
 				LIMIT 1
 			)
 		`
-		: sql``;
+			: sql``;
 
 	const extraCustomerEntitlementEntityFilter = entityId
 		? sql`

--- a/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
+++ b/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
@@ -15,6 +15,7 @@ import {
 	FeatureType,
 	type FullCustomerPrice,
 	type FullSubject,
+	InternalError,
 	type NormalizedFullSubject,
 	normalizedToFullSubject,
 	type Replaceable,
@@ -31,12 +32,24 @@ import {
  */
 export const subjectQueryRowToNormalized = ({
 	row,
+	entityIdRequested = false,
+	allowMissingEntity = false,
 }: {
 	row: SubjectQueryRow;
+	entityIdRequested?: boolean;
+	allowMissingEntity?: boolean;
 }): NormalizedFullSubject => {
 	const customer = row.customer as unknown as Customer;
 	const entity = row.entity as Entity | undefined;
 	const isEntitySubject = !!entity;
+
+	if (entityIdRequested && !entity && !allowMissingEntity) {
+		throw new InternalError({
+			message:
+				"subjectQueryRowToNormalized received a row with no entity when an entityId was requested and allowMissingEntity is false",
+			code: "subject_row_missing_entity",
+		});
+	}
 
 	const entitlementsByEntitlementId = new Map(
 		row.entitlements.map((e) => [e.id, e] as const),
@@ -259,9 +272,17 @@ export const subjectQueryRowToNormalized = ({
 /** Convert raw DB query row to FullSubject via NormalizedFullSubject. */
 export const resultToFullSubject = ({
 	row,
+	entityIdRequested = false,
+	allowMissingEntity = false,
 }: {
 	row: SubjectQueryRow;
+	entityIdRequested?: boolean;
+	allowMissingEntity?: boolean;
 }): FullSubject => {
-	const normalized = subjectQueryRowToNormalized({ row });
+	const normalized = subjectQueryRowToNormalized({
+		row,
+		entityIdRequested,
+		allowMissingEntity,
+	});
 	return normalizedToFullSubject({ normalized });
 };

--- a/server/tests/integration/balances/utils/lockUtils/deleteLock.ts
+++ b/server/tests/integration/balances/utils/lockUtils/deleteLock.ts
@@ -1,6 +1,7 @@
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { redis } from "@/external/redis/initRedis.js";
 import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
+import { buildClaimMarkerKey } from "@/internal/balances/utils/lockV2/buildClaimMarkerKey.js";
 
 export const deleteLock = async ({
 	ctx,
@@ -15,9 +16,10 @@ export const deleteLock = async ({
 		env: ctx.env,
 		lockKey: hashedKey,
 	});
+	const claimMarkerKey = buildClaimMarkerKey(redisReceiptKey);
 
 	await Promise.all([
 		redis.del(redisReceiptKey),
-		ctx.redisV2.del(redisReceiptKey),
+		ctx.redisV2.del(redisReceiptKey, claimMarkerKey),
 	]);
 };

--- a/server/tests/integration/crud/entities/get-entity.test.ts
+++ b/server/tests/integration/crud/entities/get-entity.test.ts
@@ -281,6 +281,73 @@ test.concurrent(`${chalk.yellowBright("get-entity: created boolean balance is re
 	expect(entity.balances[TestFeature.Dashboard]).toBeUndefined();
 });
 
+test.concurrent(`${chalk.yellowBright("get-entity: throws when entity does not exist on existing customer")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const baseProduct = products.base({
+		id: "missing-entity-base",
+		items: [messagesItem],
+	});
+	const customerId = "get-entity-missing-entity";
+
+	const { autumnV1, autumnV2_1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [baseProduct] }),
+		],
+		actions: [s.billing.attach({ productId: baseProduct.id })],
+	});
+
+	const missingEntityId = "entity-that-does-not-exist";
+
+	// get-entity: legacy (FullCustomer cache) + V2.1 (FullSubject cache) both throw
+	await expect(
+		autumnV1.entities.get<ApiEntityV0>(customerId, missingEntityId),
+	).rejects.toThrow();
+
+	await expect(
+		autumnV2_1.entities.get<ApiEntityV2>(customerId, missingEntityId),
+	).rejects.toThrow();
+
+	// check: legacy path previously mis-routed to createWithDefaults on missing
+	// entity; should now surface the entity-not-found error directly without
+	// running CusService.getFull or logging "Customer already exists".
+	await expect(
+		autumnV1.check({
+			customer_id: customerId,
+			entity_id: missingEntityId,
+			feature_id: TestFeature.Messages,
+		}),
+	).rejects.toThrow();
+
+	await expect(
+		autumnV2_1.check({
+			customer_id: customerId,
+			entity_id: missingEntityId,
+			feature_id: TestFeature.Messages,
+		}),
+	).rejects.toThrow();
+
+	// track: same legacy/V2.1 split as check.
+	await expect(
+		autumnV1.track({
+			customer_id: customerId,
+			entity_id: missingEntityId,
+			feature_id: TestFeature.Messages,
+			value: 1,
+		}),
+	).rejects.toThrow();
+
+	await expect(
+		autumnV2_1.track({
+			customer_id: customerId,
+			entity_id: missingEntityId,
+			feature_id: TestFeature.Messages,
+			value: 1,
+		}),
+	).rejects.toThrow();
+});
+
 test.concurrent(`${chalk.yellowBright("get-entity: entity cache updates after customer attach across repeated reads")}`, async () => {
 	const dashboardItem = items.dashboard();
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes entity lookups so requests for a non-existent entity on an existing customer no longer call create-with-defaults and now return a clear “entity not found” error. Ensures `entities.get`, `check`, and `track` throw instead of silently auto-provisioning.

- **Bug Fixes**
  - Added `allowMissingEntity` to `getFullSubject`, `getFullSubjectQuery`, and normalization to probe the customer while allowing an absent entity.
  - `subjectQueryRowToNormalized` now throws `InternalError` when an `entityId` is requested but missing (unless `allowMissingEntity` is true).
  - Updated `getOrCreateCachedFullSubject` to probe with `allowMissingEntity: true` to avoid falling into customer `createWithDefaults`.
  - Adjusted query to skip customer-by-entity filter when fallback is allowed.
  - Added integration tests verifying both legacy and v2.1 paths throw on missing entity; fixed test lock cleanup to also remove the claim marker key.

<sup>Written for commit 23adad1e6add8d38ed1c9b1d970cab6ae8edefc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

