### PR TITLE
chore: add transient redis error handling

### DIFF
--- a/server/src/external/redis/utils/isTransientRedisError.ts
+++ b/server/src/external/redis/utils/isTransientRedisError.ts
@@ -1,0 +1,15 @@
+import { RedisUnavailableError } from "./errors.js";
+
+const TRANSIENT_REDIS_ERROR_MESSAGES = new Set(["Command timed out"]);
+const TRANSIENT_REDIS_ERROR_NAMES = new Set(["MaxRetriesPerRequestError"]);
+
+export const isTransientRedisError = ({
+	error,
+}: {
+	error: unknown;
+}): boolean => {
+	if (error instanceof RedisUnavailableError) return true;
+	if (!(error instanceof Error)) return false;
+	if (TRANSIENT_REDIS_ERROR_MESSAGES.has(error.message)) return true;
+	return TRANSIENT_REDIS_ERROR_NAMES.has(error.name);
+};

--- a/server/src/external/redis/utils/withRedisFailOpen.ts
+++ b/server/src/external/redis/utils/withRedisFailOpen.ts
@@ -1,6 +1,7 @@
 import { isTransientDbError } from "@/db/dbUtils.js";
 import { shouldUseRedis } from "@/external/redis/initRedis.js";
 import { RedisUnavailableError } from "./errors.js";
+import { isTransientRedisError } from "./isTransientRedisError.js";
 
 /** Runs `run`. If Redis is unavailable or a transient DB error occurs,
  *  calls `fallback`. Any other error propagates. */
@@ -20,7 +21,7 @@ export const withRedisFailOpen = async <T>({
 
 		return await run();
 	} catch (error) {
-		if (error instanceof RedisUnavailableError || isTransientDbError({ error })) {
+		if (isTransientRedisError({ error }) || isTransientDbError({ error })) {
 			return await fallback(error);
 		}
 

--- a/server/src/internal/misc/rollouts/fullSubjectRolloutUtils.ts
+++ b/server/src/internal/misc/rollouts/fullSubjectRolloutUtils.ts
@@ -1,9 +1,8 @@
 import { isTransientDbError } from "@/db/dbUtils.js";
-import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import { isTransientRedisError } from "@/external/redis/utils/isTransientRedisError.js";
 import type { AutumnContext, RolloutSnapshot } from "@/honoUtils/HonoEnv.js";
 
 export const FULL_SUBJECT_ROLLOUT_ID = "v2-cache";
-const RETRYABLE_REDIS_ERROR_NAMES = new Set(["MaxRetriesPerRequestError"]);
 
 export const isFullSubjectRolloutEnabled = ({
 	ctx,
@@ -26,9 +25,4 @@ export const isRetryableFullSubjectRolloutError = ({
 	error,
 }: {
 	error: unknown;
-}) =>
-	error instanceof RedisUnavailableError ||
-	isTransientDbError({ error }) ||
-	(error instanceof Error &&
-		(RETRYABLE_REDIS_ERROR_NAMES.has(error.name) ||
-			error.message === "Command timed out"));
+}) => isTransientRedisError({ error }) || isTransientDbError({ error });

--- a/server/tests/unit/balances/check-v2/runCheckWithRollout.test.ts
+++ b/server/tests/unit/balances/check-v2/runCheckWithRollout.test.ts
@@ -146,6 +146,10 @@ describe("runCheckWithRollout", () => {
 				reason: "timeout",
 			}),
 		},
+		{
+			name: "Redis command timeout",
+			error: new Error("Command timed out"),
+		},
 	])("returns fail-open fallback on $name", async ({ error }) => {
 		mockState.v2Error = error;
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts duplicated transient Redis error detection into a single `isTransientRedisError` utility and wires it into both `withRedisFailOpen` and `isRetryableFullSubjectRolloutError`, replacing the previously scattered inline checks. As a side effect, `withRedisFailOpen` now also catches `MaxRetriesPerRequestError` and `"Command timed out"` errors (previously only `RedisUnavailableError` was handled there), which is the intended improvement.

**Key changes:**
- [Improvements] New `isTransientRedisError` utility consolidates `RedisUnavailableError`, `MaxRetriesPerRequestError`, and `"Command timed out"` detection in one place.
- [Improvements] `withRedisFailOpen` and `fullSubjectRolloutUtils` now share the same error-detection logic, eliminating divergence risk.
- [Improvements] New `"Redis command timeout"` test case added to the fail-open parametrised suite.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — clean refactor with no logic regressions and an expanded test suite.

All changes are a straightforward extraction of duplicated logic into a shared utility. No P0/P1 issues found; the only finding is a P2 suggestion to add a test case for the MaxRetriesPerRequestError name-based branch.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/utils/isTransientRedisError.ts | New utility that centralises transient Redis error detection (RedisUnavailableError, MaxRetriesPerRequestError, "Command timed out"). |
| server/src/external/redis/utils/withRedisFailOpen.ts | Replaces inline RedisUnavailableError instanceof check with isTransientRedisError, expanding fail-open coverage to MaxRetriesPerRequestError and command timeouts. |
| server/src/internal/misc/rollouts/fullSubjectRolloutUtils.ts | Removes duplicate inline error-detection logic (RETRYABLE_REDIS_ERROR_NAMES set) and delegates to the new shared isTransientRedisError utility. |
| server/tests/unit/balances/check-v2/runCheckWithRollout.test.ts | Adds "Redis command timeout" test case to the fail-open parametrised test suite; coverage for MaxRetriesPerRequestError is absent but non-blocking. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Redis operation throws] --> B{isTransientRedisError?}
    B -->|RedisUnavailableError| C[fail-open fallback]
    B -->|error.message == 'Command timed out'| C
    B -->|error.name == 'MaxRetriesPerRequestError'| C
    B -->|No| D{isTransientDbError?}
    D -->|Yes| C
    D -->|No| E[re-throw error]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/tests/unit/balances/check-v2/runCheckWithRollout.test.ts
Line: 149-152

Comment:
**Missing test case for `MaxRetriesPerRequestError`**

`isTransientRedisError` now also matches errors whose `.name` is `"MaxRetriesPerRequestError"`, but there is no test case exercising that path. Adding one would give the same coverage symmetry as the new "Command timed out" case and guard against future regressions in the name-based branch.

```suggestion
		{
			name: "Redis command timeout",
			error: new Error("Command timed out"),
		},
		{
			name: "Redis MaxRetriesPerRequestError",
			error: Object.assign(new Error("max retries exceeded"), {
				name: "MaxRetriesPerRequestError",
			}),
		},
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add transient redis error handlin..."](https://github.com/useautumn/autumn/commit/4bb1425e48d7e9cc914603bebbfa80cbdbae95fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29501423)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `isTransientRedisError` helper and wires it into Redis fail-open and rollout logic to handle more transient Redis failures. This reduces duplicated checks and ensures fail-open covers timeouts and max-retry errors.

- **Refactors**
  - Introduced `isTransientRedisError` to detect `RedisUnavailableError`, `"Command timed out"`, and `MaxRetriesPerRequestError`.
  - Updated `withRedisFailOpen` and `isRetryableFullSubjectRolloutError` to use the new helper alongside DB transient checks.
  - Added a test case for Redis command timeouts in the rollout fail-open suite.

<sup>Written for commit 4bb1425e48d7e9cc914603bebbfa80cbdbae95fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

