### PR TITLE
chore: add redis v2 health check

### DIFF
--- a/server/src/external/redis/initUtils/redisV2Availability.ts
+++ b/server/src/external/redis/initUtils/redisV2Availability.ts
@@ -2,17 +2,34 @@ import {
 	hasRedisV2Config,
 	redisV2,
 } from "../initRedisV2.js";
-import { createRedisAvailability } from "./createRedisAvailability.js";
-import { shouldUseRedis } from "./redisAvailability.js";
+import {
+	createRedisAvailability,
+	type RedisAvailabilitySnapshot,
+} from "./createRedisAvailability.js";
+import {
+	getRedisAvailability,
+	shouldUseRedis,
+} from "./redisAvailability.js";
 import { redis as primaryRedis } from "./redisClientRegistry.js";
 
 const usesPrimaryRedis = redisV2 === primaryRedis;
 const noop = () => {};
+const getPrimaryBackedRedisV2Availability = (): RedisAvailabilitySnapshot => {
+	const availability = getRedisAvailability();
+
+	return {
+		configured: hasRedisV2Config,
+		state: availability.state,
+		status: availability.status,
+	};
+};
+
 const redisV2Availability = usesPrimaryRedis
 	? {
 			startMonitor: noop,
 			stopMonitor: noop,
 			shouldUseRedis,
+			getRedisAvailability: getPrimaryBackedRedisV2Availability,
 		}
 	: createRedisAvailability({
 			redis: redisV2,
@@ -25,6 +42,12 @@ const {
 	startMonitor: startRedisV2Monitor,
 	stopMonitor: stopRedisV2Monitor,
 	shouldUseRedis: shouldUseRedisV2,
+	getRedisAvailability: getRedisV2Availability,
 } = redisV2Availability;
 
-export { startRedisV2Monitor, stopRedisV2Monitor, shouldUseRedisV2 };
+export {
+	getRedisV2Availability,
+	startRedisV2Monitor,
+	stopRedisV2Monitor,
+	shouldUseRedisV2,
+};

--- a/server/src/honoUtils/handleReadyCheck.ts
+++ b/server/src/honoUtils/handleReadyCheck.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono";
 import { clientCritical } from "@/db/initDrizzle.js";
 import { getPgHealthState } from "@/db/pgHealthMonitor.js";
 import { getRedisAvailability } from "@/external/redis/initRedis.js";
+import { getRedisV2Availability } from "@/external/redis/initUtils/redisV2Availability.js";
 import type { HonoEnv } from "./HonoEnv.js";
 
 const POSTGRES_TIMEOUT_MS = 1_000;
@@ -45,6 +46,7 @@ export const handleReadyCheck = async (c: Context<HonoEnv>) => {
 
 	const postgres = await checkPostgresReady();
 	const redis = getRedisAvailability();
+	const redisV2 = getRedisV2Availability();
 	const ok = postgres.ok;
 	const status = ok ? 200 : 503;
 
@@ -54,6 +56,7 @@ export const handleReadyCheck = async (c: Context<HonoEnv>) => {
 			checks: {
 				postgres,
 				redis,
+				redisV2,
 			},
 		},
 		status,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Redis v2 health check and exposes `getRedisV2Availability` so the readiness endpoint reports v2 status alongside Postgres and Redis.

- **New Features**
  - Added `getRedisV2Availability` to `redisV2Availability`; when `redisV2` uses the primary client, it proxies to the primary availability state.
  - Updated `/ready` to include a `redisV2` check in the response.

<sup>Written for commit 38e550af39d83277d9f0efc51f55c73966eb862a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a Redis V2 health check to the existing ready-check endpoint by exporting `getRedisV2Availability` from the `redisV2Availability` module and including its snapshot under `checks.redisV2` in the response.

**Key changes:**
- [Improvements] `redisV2Availability.ts` — exposes `getRedisV2Availability`, correctly delegating to the primary Redis monitor (with overridden `configured` flag) when both clients share the same instance, or to the independent `createRedisAvailability` machinery otherwise.
- [Improvements] `handleReadyCheck.ts` — includes `redisV2` in the `checks` payload, consistent with how `redis` (primary) is already reported.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — additive, well-scoped change that follows the existing availability-monitor pattern exactly.

No P0/P1 findings. The `getPrimaryBackedRedisV2Availability` proxy correctly re-uses the primary Redis state while overriding the `configured` flag. The health-check handler's `ok` field intentionally ignores Redis (as it did before), keeping the change fully consistent with existing behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/redisV2Availability.ts | Adds `getRedisV2Availability` export: proxies primary Redis snapshot (with overridden `configured` flag) when redisV2 shares the same client instance, or delegates to `createRedisAvailability` for an independent client. |
| server/src/honoUtils/handleReadyCheck.ts | Wires `getRedisV2Availability()` into the ready-check response under `checks.redisV2`; consistent with existing `redis` handling and does not affect the `ok`/status code logic. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant handleReadyCheck
    participant checkPostgresReady
    participant getRedisAvailability
    participant getRedisV2Availability
    participant getPrimaryBackedRedisV2Availability

    Client->>handleReadyCheck: GET /ready/:token
    handleReadyCheck->>checkPostgresReady: SELECT 1 (1s timeout)
    checkPostgresReady-->>handleReadyCheck: { ok, ...pgHealthState }
    handleReadyCheck->>getRedisAvailability: getRedisAvailability()
    getRedisAvailability-->>handleReadyCheck: { configured, state, status }
    handleReadyCheck->>getRedisV2Availability: getRedisV2Availability()
    alt usesPrimaryRedis == true
        getRedisV2Availability->>getPrimaryBackedRedisV2Availability: delegate
        getPrimaryBackedRedisV2Availability->>getRedisAvailability: getRedisAvailability()
        getRedisAvailability-->>getPrimaryBackedRedisV2Availability: { state, status }
        getPrimaryBackedRedisV2Availability-->>getRedisV2Availability: { configured: hasRedisV2Config, state, status }
    else independent redisV2 client
        getRedisV2Availability-->>getRedisV2Availability: createRedisAvailability snapshot
    end
    getRedisV2Availability-->>handleReadyCheck: RedisAvailabilitySnapshot
    handleReadyCheck-->>Client: { ok, checks: { postgres, redis, redisV2 } } 200/503
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add redis v2 health check"](https://github.com/useautumn/autumn/commit/38e550af39d83277d9f0efc51f55c73966eb862a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29581858)</sub>

<!-- /greptile_comment -->