### PR TITLE
chore: redis reconnection issues

### DIFF
--- a/server/src/external/redis/initUtils/createRedisAvailability.ts
+++ b/server/src/external/redis/initUtils/createRedisAvailability.ts
@@ -86,26 +86,14 @@ export const createRedisAvailability = ({
 		return redis.status === "ready" && pong === "PONG";
 	};
 
-	const tryReconnectRedis = async () => {
-		if (!hasConfig || redis.status === "ready") {
-			reconnectStartedAt = null;
-			return;
-		}
-
-		if (
-			redis.status === "connecting" ||
-			redis.status === "reconnecting"
-		) {
-			reconnectStartedAt ??= Date.now();
-			if (Date.now() - reconnectStartedAt < REDIS_STALE_RECONNECT_MS) return;
-		}
-
+	const reconnectRedis = async () => {
 		try {
 			redis.disconnect(false);
 			await withTimeout({
 				timeoutMs: REDIS_PROBE_TIMEOUT_MS,
 				fn: () => redis.connect(),
 			});
+			reconnectStartedAt = null;
 		} catch {
 			// Let the next probe decide whether we recovered.
 		}
@@ -114,14 +102,37 @@ export const createRedisAvailability = ({
 	const tickRedisAvailability = async () => {
 		if (!hasConfig) return;
 
+		let failedWhileReady = false;
 		try {
 			if (await pingRedisClient()) {
 				recordRedisAvailability(true);
 				return;
 			}
-		} catch {}
+			failedWhileReady = redis.status === "ready";
+		} catch {
+			failedWhileReady = redis.status === "ready";
+		}
 
-		await tryReconnectRedis();
+		const shouldReconnectReadyClient =
+			failedWhileReady &&
+			consecutiveFailures + 1 >= REDIS_FAILURES_TO_DEGRADE;
+
+		if (shouldReconnectReadyClient) {
+			await reconnectRedis();
+		} else if (redis.status !== "ready") {
+			if (
+				redis.status === "connecting" ||
+				redis.status === "reconnecting"
+			) {
+				reconnectStartedAt ??= Date.now();
+				if (Date.now() - reconnectStartedAt < REDIS_STALE_RECONNECT_MS) {
+					recordRedisAvailability(false);
+					return;
+				}
+			}
+
+			await reconnectRedis();
+		}
 		(await pingRedisClient().catch(() => false))
 			? recordRedisAvailability(true)
 			: recordRedisAvailability(false);

--- a/server/tests/unit/redis/create-redis-availability.spec.ts
+++ b/server/tests/unit/redis/create-redis-availability.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { createRedisAvailability } from "@/external/redis/initUtils/createRedisAvailability.js";
+
+class FakeRedis {
+	status = "ready";
+	connectCalls = 0;
+	disconnectCalls: Array<boolean | undefined> = [];
+	pingCalls = 0;
+
+	async ping() {
+		this.pingCalls++;
+		if (this.pingCalls <= 9) {
+			return await new Promise<string>(() => {});
+		}
+
+		return "PONG";
+	}
+
+	disconnect(reconnect?: boolean) {
+		this.disconnectCalls.push(reconnect);
+		this.status = "end";
+	}
+
+	async connect() {
+		this.connectCalls++;
+		this.status = "ready";
+	}
+}
+
+const wait = (ms: number) =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitUntil = async (check: () => boolean, timeoutMs: number) => {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < timeoutMs) {
+		if (check()) return;
+		await wait(50);
+	}
+
+	throw new Error(`Condition not met within ${timeoutMs}ms`);
+};
+
+describe("createRedisAvailability", () => {
+	test(
+		"reconnects after repeated probe failures while the client still reports ready",
+		async () => {
+			const redis = new FakeRedis();
+			const availability = createRedisAvailability({
+				redis: redis as never,
+				hasConfig: true,
+				logPrefix: "RedisV2",
+				logType: "redis_v2_availability_state_set",
+			});
+
+			availability.startMonitor();
+			await waitUntil(() => redis.connectCalls > 0, 22_000);
+			availability.stopMonitor();
+
+			expect(redis.disconnectCalls).toContain(false);
+		},
+		30_000,
+	);
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Redis reconnection so we recover when the client is “ready” but ping hangs, reducing long degraded periods. Adds a unit test to cover reconnect on probe failure.

- **Bug Fixes**
  - Throttles reconnects during “connecting”/“reconnecting” using the stale window; resets the timer on successful connect.
  - Consolidates reconnect flow into `reconnectRedis` with a timeout for clean disconnect/connect.
  - Adds a unit test that simulates hung pings and verifies a reconnect is attempted.

<sup>Written for commit f62b1c7ca0fdbcdefa162f3a75c79d80524778b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Redis reconnection bug where a client reporting `status === "ready"` but not actually responding to pings was never force-reconnected, because the old `tryReconnectRedis` guard returned early on `ready` status. The refactor splits the logic into a clean `reconnectRedis()` helper (always disconnects + reconnects) and moves the reconnect-decision into `tickRedisAvailability`, adding a dedicated `shouldReconnectReadyClient` path that triggers after `REDIS_FAILURES_TO_DEGRADE` consecutive probe failures on a stale-ready client. A new unit test exercises this path end-to-end.

**Key changes:**
- **Bug fixes** – `reconnectRedis()` replaces `tryReconnectRedis()`, removing the early-return guard that prevented reconnecting a `"ready"`-but-unresponsive client.
- **Improvements** – Reconnect decision logic is now explicitly separated into two cases: stale-ready client vs. client already in a non-ready state (connecting/reconnecting/end).
- **Improvements** – `reconnectStartedAt` is now reset only upon a successful `connect()`, giving the stale-reconnect timer more accurate semantics.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is well-scoped, logically sound, and covered by a new unit test; the sole finding is a minor race window with no production impact.

All findings are P2 (style/minor improvement). The core reconnect logic correctly handles the previously-unhandled stale-ready case, the stale-reconnect timeout guard is preserved for the connecting/reconnecting path, and the test validates the end-to-end reconnect flow.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/createRedisAvailability.ts | Refactors reconnect logic to handle the "ready-but-unresponsive" case: the old `tryReconnectRedis` returned early when `status === "ready"`, so a stale-ready client was never force-reconnected; the new code explicitly checks `failedWhileReady && consecutiveFailures+1 >= REDIS_FAILURES_TO_DEGRADE` to trigger a reconnect in that scenario. |
| server/tests/unit/redis/create-redis-availability.spec.ts | New unit test covering the `shouldReconnectReadyClient` path: a `FakeRedis` whose `ping` hangs for 9 calls simulates a stale-ready client; the test verifies that `disconnect(false)` + `connect()` is eventually called after enough consecutive probe failures. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tickRedisAvailability] --> B{hasConfig?}
    B -- No --> Z[return]
    B -- Yes --> C[pingRedisClient]
    C -- PONG --> D[recordAvailability true\nreturn]
    C -- false/timeout --> E[failedWhileReady = status === 'ready']
    E --> F{failedWhileReady &&\nconsecutiveFailures+1 >= 5?}
    F -- Yes: shouldReconnectReadyClient --> G[reconnectRedis\ndisconnect + connect]
    F -- No --> H{redis.status !== 'ready'?}
    H -- No --> I[final pingRedisClient]
    H -- Yes --> J{status === connecting\nor reconnecting?}
    J -- Yes --> K{reconnectStartedAt\n< 5s ago?}
    K -- Yes: not stale --> L[recordAvailability false\nreturn]
    K -- No: stale --> G
    J -- No --> G
    G --> I
    I -- PONG --> M[recordAvailability true]
    I -- fail/timeout --> N[recordAvailability false]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/external/redis/initUtils/createRedisAvailability.ts
Line: 111-114

Comment:
**`failedWhileReady` sampled after async ping**

`redis.status` is read *after* the async `pingRedisClient()` awaitable resolves or throws, which means the status could have already transitioned away from `"ready"` (e.g. to `"disconnecting"` or `"end"`) while the ping was in-flight or timing out. In that case `failedWhileReady` would be `false` even though the client *was* `"ready"` when the probe started, silently skipping the `shouldReconnectReadyClient` path for that tick and deferring to the slower stale-reconnect branch. In practice this is only a one-tick delay before the next branch handles it, but capturing the status before the await would make the intent more explicit and race-free.

```suggestion
		failedWhileReady = statusBeforePing === "ready";
	} catch {
		failedWhileReady = statusBeforePing === "ready";
	}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: redis reconnection issues"](https://github.com/useautumn/autumn/commit/f62b1c7ca0fdbcdefa162f3a75c79d80524778b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29586674)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->