### PR TITLE
fix: workers requeue 2

### DIFF
--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -33,6 +33,30 @@ const shouldIdleSelfKill = process.env.NODE_ENV !== "development";
 // Per-message processing timeout — must be under VisibilityTimeout (30s)
 const MESSAGE_TIMEOUT_MS = 25_000;
 
+type JobOverride = {
+	ackUpfront: true;
+	dispatch: "inline" | "background";
+};
+
+// Jobs whose handlers can exceed the 30s VisibilityTimeout. ACK upfront to
+// avoid redelivery loops; dispatch mode controls whether the poll loop awaits
+// them (inline → preserves backpressure) or fires in background (→ no
+// backpressure; only safe for genuinely rare, low-volume jobs).
+const JOB_OVERRIDES: Partial<Record<JobName, JobOverride>> = {
+	// Rare (handful per day); fire-and-forget is safe.
+	[JobName.Migration]: { ackUpfront: true, dispatch: "background" },
+	// Can exceed VisibilityTimeout on large orgs; redelivery causes a
+	// self-amplifying Redis UNLINK storm. Inline so one worker's concurrency
+	// stays capped at the receive batch size.
+	[JobName.ClearCreditSystemCustomerCache]: {
+		ackUpfront: true,
+		dispatch: "inline",
+	},
+};
+
+const getJobOverride = (jobName: string): JobOverride | undefined =>
+	JOB_OVERRIDES[jobName as JobName];
+
 // Stale connection detection
 const EMPTY_POLL_THRESHOLD = 9; // ~3 min of empty polls (9 * 20s wait)
 const HEARTBEAT_INTERVAL_MS = ms.minutes(5);
@@ -147,7 +171,7 @@ const startPollingLoop = async ({
 			...(isFifo && { ReceiveRequestAttemptId: generateId("receive") }),
 		});
 
-	const deleteMigrationJobImmediately = async ({
+	const ackMessageUpfront = async ({
 		sqs,
 		message,
 		job,
@@ -157,7 +181,7 @@ const startPollingLoop = async ({
 		job: SqsJob;
 	}) => {
 		logger.info(
-			`Returning success immediately for migration job ${job.data.migrationJobId}`,
+			`ACKing ${job.name} upfront (messageId=${message.MessageId})`,
 		);
 		await sqs.send(
 			new DeleteMessageCommand({
@@ -179,25 +203,13 @@ const startPollingLoop = async ({
 		if (!isRunning || !message.Body) return null;
 
 		const job: SqsJob = JSON.parse(message.Body);
+		const override = getJobOverride(job.name);
 
-		// Migration jobs: delete IMMEDIATELY before processing (long-running, avoid timeout redelivery)
-		if (job.name === JobName.Migration) {
-			await deleteMigrationJobImmediately({ sqs, message, job });
+		if (override?.ackUpfront) {
+			await ackMessageUpfront({ sqs, message, job });
 		}
 
-		// ClearCreditSystemCustomerCache: ACK upfront (handler can exceed
-		// VisibilityTimeout when clearing many customers, and redelivery
-		// causes a self-amplifying Redis UNLINK storm), but still await
-		// inline so worker concurrency stays capped at the receive batch
-		// size (avoids firing a huge burst of cache clears at once).
-		if (job.name === JobName.ClearCreditSystemCustomerCache) {
-			await deleteMigrationJobImmediately({ sqs, message, job });
-		}
-
-		const isMigration = job.name === JobName.Migration;
-		const isAckedUpfront =
-			isMigration || job.name === JobName.ClearCreditSystemCustomerCache;
-		if (isAckedUpfront) {
+		if (override) {
 			await processMessage({ message, db });
 		} else {
 			await withTimeout({
@@ -210,8 +222,7 @@ const startPollingLoop = async ({
 		messagesProcessed++;
 		totalMessagesProcessed++;
 
-		// Return delete info (skip jobs already deleted upfront)
-		if (message.ReceiptHandle && !isAckedUpfront) {
+		if (message.ReceiptHandle && !override?.ackUpfront) {
 			return { id: message.MessageId!, receiptHandle: message.ReceiptHandle };
 		}
 		return null;
@@ -308,12 +319,13 @@ const startPollingLoop = async ({
 				for (const message of messages) {
 					if (!message.Body) continue;
 					const job: SqsJob = JSON.parse(message.Body);
-					if (job.name === JobName.Migration) {
+					const override = getJobOverride(job.name);
+					if (override?.dispatch === "background") {
 						activeMigrationJobs++;
 						handleSingleMessage({ sqs, message, db })
 							.catch((error) => {
 								console.error(
-									`${prefix} Migration job failed:`,
+									`${prefix} Background job ${job.name} failed:`,
 									error instanceof Error ? error.message : error,
 								);
 								Sentry.captureException(error);

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -33,16 +33,6 @@ const shouldIdleSelfKill = process.env.NODE_ENV !== "development";
 // Per-message processing timeout — must be under VisibilityTimeout (30s)
 const MESSAGE_TIMEOUT_MS = 25_000;
 
-// Jobs that can exceed the 30s VisibilityTimeout. We ACK the SQS message
-// before processing so it is never redelivered mid-flight. These jobs must
-// be idempotency-tolerant since a worker crash means the work is lost.
-const LONG_RUNNING_JOBS = new Set<JobName>([
-	JobName.Migration,
-	JobName.RewardMigration,
-	JobName.ClearCreditSystemCustomerCache,
-	JobName.BatchResetCusEnts,
-]);
-
 // Stale connection detection
 const EMPTY_POLL_THRESHOLD = 9; // ~3 min of empty polls (9 * 20s wait)
 const HEARTBEAT_INTERVAL_MS = ms.minutes(5);
@@ -74,7 +64,7 @@ const startPollingLoop = async ({
 	let messagesProcessed = 0;
 	let totalMessagesProcessed = 0;
 	let lastStatsTime = Date.now();
-	let activeLongRunningJobs = 0;
+	let activeMigrationJobs = 0;
 	let consecutiveEmptyPolls = 0;
 	let lastHeartbeatTime = Date.now();
 	let consecutiveZeroMessageIntervals = 0;
@@ -99,9 +89,9 @@ const startPollingLoop = async ({
 			return;
 		}
 
-		if (activeLongRunningJobs > 0) {
+		if (activeMigrationJobs > 0) {
 			console.log(
-				`${prefix} Recycle deferred at ${totalMessagesProcessed} messages because ${activeLongRunningJobs} long-running job(s) are still running`,
+				`${prefix} Recycle deferred at ${totalMessagesProcessed} messages because ${activeMigrationJobs} migration job(s) are still running`,
 			);
 			return;
 		}
@@ -128,7 +118,7 @@ const startPollingLoop = async ({
 				shouldIdleSelfKill &&
 				consecutiveZeroMessageIntervals >= IDLE_SELF_KILL_THRESHOLD &&
 				totalMessagesProcessed > 0 &&
-				activeLongRunningJobs === 0
+				activeMigrationJobs === 0
 			) {
 				console.log(
 					`${prefix} Idle self-kill: 0 messages for ${consecutiveZeroMessageIntervals} intervals after processing ${totalMessagesProcessed} total. Exiting for cluster respawn.`,
@@ -157,7 +147,7 @@ const startPollingLoop = async ({
 			...(isFifo && { ReceiveRequestAttemptId: generateId("receive") }),
 		});
 
-	const deleteMessageImmediately = async ({
+	const deleteMigrationJobImmediately = async ({
 		sqs,
 		message,
 		job,
@@ -167,7 +157,7 @@ const startPollingLoop = async ({
 		job: SqsJob;
 	}) => {
 		logger.info(
-			`Returning success immediately for long-running job ${job.name} (messageId=${message.MessageId})`,
+			`Returning success immediately for migration job ${job.data.migrationJobId}`,
 		);
 		await sqs.send(
 			new DeleteMessageCommand({
@@ -190,16 +180,24 @@ const startPollingLoop = async ({
 
 		const job: SqsJob = JSON.parse(message.Body);
 
-		// Long-running jobs: delete IMMEDIATELY before processing to avoid
-		// visibility-timeout redelivery loops (the handler can take longer than
-		// VisibilityTimeout, so SQS would otherwise re-dispatch the same message
-		// to other workers while the first one is still running).
-		const isLongRunning = LONG_RUNNING_JOBS.has(job.name as JobName);
-		if (isLongRunning) {
-			await deleteMessageImmediately({ sqs, message, job });
+		// Migration jobs: delete IMMEDIATELY before processing (long-running, avoid timeout redelivery)
+		if (job.name === JobName.Migration) {
+			await deleteMigrationJobImmediately({ sqs, message, job });
 		}
 
-		if (isLongRunning) {
+		// ClearCreditSystemCustomerCache: ACK upfront (handler can exceed
+		// VisibilityTimeout when clearing many customers, and redelivery
+		// causes a self-amplifying Redis UNLINK storm), but still await
+		// inline so worker concurrency stays capped at the receive batch
+		// size (avoids firing a huge burst of cache clears at once).
+		if (job.name === JobName.ClearCreditSystemCustomerCache) {
+			await deleteMigrationJobImmediately({ sqs, message, job });
+		}
+
+		const isMigration = job.name === JobName.Migration;
+		const isAckedUpfront =
+			isMigration || job.name === JobName.ClearCreditSystemCustomerCache;
+		if (isAckedUpfront) {
 			await processMessage({ message, db });
 		} else {
 			await withTimeout({
@@ -212,8 +210,8 @@ const startPollingLoop = async ({
 		messagesProcessed++;
 		totalMessagesProcessed++;
 
-		// Return delete info (skip long-running jobs - already deleted)
-		if (message.ReceiptHandle && !isLongRunning) {
+		// Return delete info (skip jobs already deleted upfront)
+		if (message.ReceiptHandle && !isAckedUpfront) {
 			return { id: message.MessageId!, receiptHandle: message.ReceiptHandle };
 		}
 		return null;
@@ -310,17 +308,17 @@ const startPollingLoop = async ({
 				for (const message of messages) {
 					if (!message.Body) continue;
 					const job: SqsJob = JSON.parse(message.Body);
-					if (LONG_RUNNING_JOBS.has(job.name as JobName)) {
-						activeLongRunningJobs++;
+					if (job.name === JobName.Migration) {
+						activeMigrationJobs++;
 						handleSingleMessage({ sqs, message, db })
 							.catch((error) => {
 								console.error(
-									`${prefix} Long-running job ${job.name} failed:`,
+									`${prefix} Migration job failed:`,
 									error instanceof Error ? error.message : error,
 								);
 								Sentry.captureException(error);
 							})
-							.finally(() => activeLongRunningJobs--);
+							.finally(() => activeMigrationJobs--);
 					} else {
 						regularMessages.push(message);
 					}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops SQS requeues by ACKing `Migration` and `ClearCreditSystemCustomerCache` upfront. Migrations run in the background; cache clears run inline to cap concurrency and prevent Redis UNLINK storms.

- **Bug Fixes**
  - Add `JOB_OVERRIDES` for per-job ACK/dispatch: `Migration` = ACK + background; `ClearCreditSystemCustomerCache` = ACK + inline.
  - Track `activeMigrationJobs` and defer recycle/idle self-kill while they run. Keep timeouts and post-process deletes for regular jobs; skip deletes for ACKed messages.
  - Improve background job logging and update `ai` submodule pointer.

<sup>Written for commit 8e3ed4935af9919e8705de0dedabdf2652239b19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

