### PR TITLE
chore: fail open track cleanup

### DIFF
--- a/server/src/internal/balances/handlers/handleTrack.ts
+++ b/server/src/internal/balances/handlers/handleTrack.ts
@@ -19,13 +19,15 @@ export const handleTrack = createRoute({
 		const body = c.req.valid("json");
 		const ctx = c.get("ctx");
 		const featureDeductions = getTrackFeatureDeductionsForBody({ ctx, body });
+		const response = await runTrackWithRollout({
+			ctx,
+			body,
+			featureDeductions,
+		});
 
 		return c.json(
-			await runTrackWithRollout({
-				ctx,
-				body,
-				featureDeductions,
-			}),
+			response,
+			ctx.extraLogs.trackQueuedForReplay ? 202 : 200,
 		);
 	},
 });

--- a/server/src/internal/balances/handlers/handleTrack.ts
+++ b/server/src/internal/balances/handlers/handleTrack.ts
@@ -24,10 +24,8 @@ export const handleTrack = createRoute({
 			body,
 			featureDeductions,
 		});
+		const status = ctx.extraLogs.trackQueuedForReplay ? 202 : 200;
 
-		return c.json(
-			response,
-			ctx.extraLogs.trackQueuedForReplay ? 202 : 200,
-		);
+		return c.json(response, status);
 	},
 });

--- a/server/src/internal/balances/track/utils/queueTrack.ts
+++ b/server/src/internal/balances/track/utils/queueTrack.ts
@@ -2,6 +2,7 @@ import type { TrackParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
+import { addToExtraLogs } from "@/utils/logging/addToExtraLogs.js";
 import { getQueuedTrackResponse } from "./getQueuedTrackResponse.js";
 
 export const queueTrack = async ({
@@ -42,6 +43,12 @@ export const queueTrack = async ({
 			event_name: body.event_name,
 			env: ctx.env,
 			queue_name: queueUrl.split("/").pop(),
+		});
+		addToExtraLogs({
+			ctx,
+			extras: {
+				trackQueuedForReplay: true,
+			},
 		});
 
 		return getQueuedTrackResponse({


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return 202 Accepted when a track is queued for replay in the fail-open path; keep 200 when processed inline. Mark `trackQueuedForReplay` in `queueTrack` via `addToExtraLogs`, and have `handleTrack` read `ctx.extraLogs` to set the response status.

<sup>Written for commit 5c939e523ce448c677e09dc46e494cbaa32a65e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the fail-open track path by propagating a `trackQueuedForReplay` flag through `ctx.extraLogs` when a track event is queued to SQS (Redis unavailable), and uses it to return HTTP **202 Accepted** instead of **200 OK** — giving callers a semantic signal that the event was accepted for async processing rather than processed synchronously.

- **Improvements**: `handleTrack` now returns 202 when a track is queued via the SQS fallback, accurately reflecting the async nature of the response.
- **Improvements**: `queueTrack` sets `trackQueuedForReplay: true` in `ctx.extraLogs` after successful enqueue, enabling the handler to inspect this state post-execution.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — small, focused changes with correct semantics and no logic issues.

Both changed files are correct: ctx mutations propagate as expected through the shared reference, the 202 vs 200 distinction is semantically accurate for queued vs synchronous responses, and the SQS queue URL guard remains intact. No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/handlers/handleTrack.ts | Extracts `runTrackWithRollout` result to a variable and returns HTTP 202 when the track was queued for replay, 200 otherwise — clean refactor with no logic issues. |
| server/src/internal/balances/track/utils/queueTrack.ts | Calls `addToExtraLogs` with `trackQueuedForReplay: true` after successfully enqueuing the track to SQS, allowing the handler to distinguish queued vs synchronous responses. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant handleTrack
    participant runTrackWithRollout
    participant withRedisFailOpen
    participant runTrackV3
    participant queueTrack
    participant addToExtraLogs

    Client->>handleTrack: POST /track
    handleTrack->>runTrackWithRollout: run(ctx, body, featureDeductions)
    runTrackWithRollout->>withRedisFailOpen: run=runTrackV3, fallback=queueTrack

    alt Redis/DB available
        withRedisFailOpen->>runTrackV3: execute synchronously
        runTrackV3-->>handleTrack: TrackResponseV3
        handleTrack-->>Client: 200 OK + response
    else Redis/DB unavailable (transient error)
        withRedisFailOpen->>queueTrack: fallback(error)
        queueTrack->>queueTrack: addTaskToQueue (SQS)
        queueTrack->>addToExtraLogs: trackQueuedForReplay = true
        queueTrack-->>handleTrack: QueuedTrackResponse
        handleTrack->>handleTrack: check ctx.extraLogs.trackQueuedForReplay
        handleTrack-->>Client: 202 Accepted + response
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fail open track cleanup again"](https://github.com/useautumn/autumn/commit/5c939e523ce448c677e09dc46e494cbaa32a65e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29636542)</sub>

<!-- /greptile_comment -->