### PR TITLE
fix: customer config for v2

### DIFF
--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerBaseV2.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerBaseV2.ts
@@ -69,6 +69,11 @@ export const getApiCustomerBaseV2 = async ({
 			usage_alerts: customer.usage_alerts ?? undefined,
 			overage_allowed: customer.overage_allowed ?? undefined,
 		},
+		config: customer.config
+			? {
+					disable_pooled_balance: customer.config.disable_pooled_balance,
+				}
+			: undefined,
 		invoices:
 			fullSubject.invoices && ctx.expand.includes(CustomerExpand.Invoices)
 				? invoicesToResponse({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose customer config in v2 customer API responses by returning the optional config.disable_pooled_balance field when present. Fixes missing config data for v2 consumers.

<sup>Written for commit 5393e67e5cf09437ebb1a32c4d5542eee61f3a9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

