### PR TITLE
fix: customer config for v2

### DIFF
--- a/server/src/honoMiddlewares/refreshCacheConfigs.ts
+++ b/server/src/honoMiddlewares/refreshCacheConfigs.ts
@@ -19,6 +19,14 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 		method: "DELETE",
 		url: "/customers/:customer_id",
 	}),
+	route({
+		method: "POST",
+		url: "/customers/:customer_id",
+	}),
+	route({
+		method: "PATCH",
+		url: "/customers/:customer_id",
+	}),
 
 	route({
 		method: "POST",
@@ -124,6 +132,11 @@ export const REFRESH_CACHE_ROUTE_CONFIGS: RefreshCacheRouteConfig[] = [
 	route({
 		method: "POST",
 		url: "/customers.delete",
+	}),
+
+	route({
+		method: "POST",
+		url: "/customers.update",
 	}),
 ];
 

--- a/server/src/honoMiddlewares/routeHandler.ts
+++ b/server/src/honoMiddlewares/routeHandler.ts
@@ -148,12 +148,12 @@ export function createRoute<
 		//   - Public keys (by design bypass the scope system)
 		//   - Cached API key payloads from before the deploy
 		if (!granted || granted.length === 0) {
-			ctx.logger?.warn("Scope check skipped: no scopes on request auth", {
-				path: c.req.path,
-				method: c.req.method,
-				required: opts.scopes,
-				authType: ctx.authType,
-			});
+			// ctx.logger?.warn("Scope check skipped: no scopes on request auth", {
+			// 	path: c.req.path,
+			// 	method: c.req.method,
+			// 	required: opts.scopes,
+			// 	authType: ctx.authType,
+			// });
 			return next();
 		}
 

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -17,9 +17,6 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { triggerAutoTopUpsOnEnabled } from "@/internal/balances/autoTopUp/triggerAutoTopUpsOnEnabled";
 import { CusService } from "@/internal/customers/CusService";
-import { invalidateCachedFullSubject } from "../../cache/fullSubject/actions/invalidate/invalidateFullSubject";
-import { updateCachedCustomerData as updateCachedCustomerDataV2 } from "../../cache/fullSubject/actions/updateCachedCustomerData";
-import { updateCachedCustomerData } from "../../cusUtils/fullCustomerCacheUtils/updateCachedCustomerData";
 import { getApiCustomerByRollout } from "../getApiCustomerByRollout";
 
 export const updateCustomer = async ({
@@ -186,27 +183,27 @@ export const updateCustomer = async ({
 
 	const originalCustomerId =
 		originalCustomer.id || originalCustomer.internal_id;
-	const updatedCustomerId = newCustomerId ?? customerId;
+	// const updatedCustomerId = newCustomerId ?? customerId;
 
-	if (updatedCustomerId !== originalCustomerId) {
-		await invalidateCachedFullSubject({
-			ctx,
-			customerId: originalCustomerId,
-			source: "updateCustomer:id_changed",
-		});
-	}
+	// if (updatedCustomerId !== originalCustomerId) {
+	// 	await invalidateCachedFullSubject({
+	// 		ctx,
+	// 		customerId: originalCustomerId,
+	// 		source: "updateCustomer:id_changed",
+	// 	});
+	// }
 
 	await Promise.all([
-		updateCachedCustomerData({
-			ctx,
-			customerId: originalCustomerId,
-			updates: updateData,
-		}),
-		updateCachedCustomerDataV2({
-			ctx,
-			customerId: originalCustomerId,
-			updates: updateData,
-		}),
+		// updateCachedCustomerData({
+		// 	ctx,
+		// 	customerId: originalCustomerId,
+		// 	updates: updateData,
+		// }),
+		// updateCachedCustomerDataV2({
+		// 	ctx,
+		// 	customerId: originalCustomerId,
+		// 	updates: updateData,
+		// }),
 	]);
 
 	ctx.skipCache = true;

--- a/server/src/internal/customers/handlers/handleUpdateCustomer/handleUpdateCustomerV2.ts
+++ b/server/src/internal/customers/handlers/handleUpdateCustomer/handleUpdateCustomerV2.ts
@@ -1,4 +1,8 @@
-import { AffectedResource, UpdateCustomerParamsV1Schema, Scopes } from "@autumn/shared";
+import {
+	AffectedResource,
+	Scopes,
+	UpdateCustomerParamsV1Schema,
+} from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { customerActions } from "@/internal/customers/actions/index.js";
 

--- a/server/tests/integration/balances/utils/overage-allowed-utils/customerOverageAllowedUtils.ts
+++ b/server/tests/integration/balances/utils/overage-allowed-utils/customerOverageAllowedUtils.ts
@@ -1,5 +1,6 @@
 import type { CustomerBillingControls } from "@autumn/shared";
 import type { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import { timeout } from "@/utils/genUtils";
 
 type AutumnV2_1Client = Awaited<ReturnType<typeof initScenario>>["autumnV2_1"];
 
@@ -23,7 +24,9 @@ export const setCustomerOverageAllowed = async ({
 		],
 	};
 
+	await timeout(2000);
 	await autumn.customers.update(customerId, {
 		billing_controls: billingControls,
 	});
+	await timeout(2000);
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes cache invalidation for customer updates in v2 so changes are reflected immediately. Caches now refresh on `POST`/`PATCH /customers/:customer_id` and `POST /customers.update`, preventing stale reads.

- **Bug Fixes**
  - Added refresh rules for `POST`/`PATCH` `/customers/:customer_id` and `POST` `customers.update`.
  - Removed direct cache update/invalidation in `updateCustomer`; set `ctx.skipCache = true` to force fresh reads.
  - Silenced noisy "no scopes on request auth" warning in `createRoute` middleware.
  - Stabilized tests by adding short delays around `customers.update` to account for eventual consistency.

<sup>Written for commit 8af9ab5bde5299a903d75b64bf0f54fe1d4aeef5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

