### PR TITLE
fix: update sqs queue url

### DIFF
--- a/scripts/setup/AGENT_README.md
+++ b/scripts/setup/AGENT_README.md
@@ -65,7 +65,7 @@ Set these in the process environment before running `bun dev:agent` and they wil
 
 ## SQS isolation
 
-Each agent instance gets its own local ElasticMQ. `SQS_QUEUE_URL` is always hardcoded to `http://localhost:9324/000000000000/autumn.fifo` in `server/.env` — the shared `SQS_QUEUE_URL` from the Capy environment is intentionally ignored to prevent agents from consuming a shared queue.
+Each agent instance gets its own local ElasticMQ. `SQS_QUEUE_URL_V2` is always hardcoded to `http://localhost:9324/000000000000/autumn.fifo` in `server/.env` — the shared `SQS_QUEUE_URL_V2` from the Capy environment is intentionally ignored to prevent agents from consuming a shared queue.
 
 ## Known limitations
 

--- a/scripts/setup/writeAgentEnv.ts
+++ b/scripts/setup/writeAgentEnv.ts
@@ -56,7 +56,7 @@ CACHE_URL_US_EAST=redis://localhost:6379
 REDIS_URL=redis://localhost:6379
 
 # ElasticMQ (local SQS, per-agent isolated queue)
-SQS_QUEUE_URL=http://localhost:9324/000000000000/autumn.fifo
+SQS_QUEUE_URL_V2=http://localhost:9324/000000000000/autumn.fifo
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=x
 AWS_SECRET_ACCESS_KEY=x

--- a/server/src/external/aws/eventbridge/eventBridgeUtils.ts
+++ b/server/src/external/aws/eventbridge/eventBridgeUtils.ts
@@ -8,19 +8,19 @@ import { extractLocalEndpoint } from "@/queue/initSqs.js";
 import { schedulerClient } from "./initEventBridge.js";
 
 const isLocalQueue = (): boolean =>
-	!!extractLocalEndpoint({ queueUrl: process.env.SQS_QUEUE_URL });
+	!!extractLocalEndpoint({ queueUrl: process.env.SQS_QUEUE_URL_V2 });
 
 const SCHEDULE_GROUP = "default";
 const SCHEDULER_ROLE_ARN = process.env.AWS_EVENTBRIDGE_SCHEDULER_ROLE_ARN || "";
 
 /** Derives SQS ARN from URL: https://sqs.<region>.amazonaws.com/<account>/<name> -> arn:aws:sqs:<region>:<account>:<name> */
 const getSqsQueueArn = (): string => {
-	const url = process.env.SQS_QUEUE_URL || "";
+	const url = process.env.SQS_QUEUE_URL_V2 || "";
 	const match = url.match(
 		/^https:\/\/sqs\.([a-z0-9-]+)\.amazonaws\.com\/(\d+)\/(.+)$/,
 	);
 	if (!match)
-		throw new Error(`Cannot derive SQS ARN from SQS_QUEUE_URL: ${url}`);
+		throw new Error(`Cannot derive SQS ARN from SQS_QUEUE_URL_V2: ${url}`);
 	const [, region, accountId, queueName] = match;
 	return `arn:aws:sqs:${region}:${accountId}:${queueName}`;
 };

--- a/server/src/external/aws/eventbridge/initEventBridge.ts
+++ b/server/src/external/aws/eventbridge/initEventBridge.ts
@@ -7,7 +7,7 @@ import {
 const getSchedulerClientConfig = () => ({
 	region:
 		extractRegionFromQueueUrl({
-			queueUrl: process.env.SQS_QUEUE_URL,
+			queueUrl: process.env.SQS_QUEUE_URL_V2,
 		}) || DEFAULT_AWS_REGION,
 	credentials: {
 		accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",

--- a/server/src/queue/initSqs.ts
+++ b/server/src/queue/initSqs.ts
@@ -23,7 +23,7 @@ export const extractLocalEndpoint = ({
 };
 
 const getSqsClientConfig = () => {
-	const queueUrl = process.env.SQS_QUEUE_URL;
+	const queueUrl = process.env.SQS_QUEUE_URL_V2;
 	const endpoint = extractLocalEndpoint({ queueUrl });
 	return {
 		region:
@@ -51,4 +51,4 @@ export const recreateSqsClient = (): SQSClient => {
 /** Get the current SQS client (use this instead of direct sqs export for refreshable access) */
 export const getSqsClient = (): SQSClient => sqsClient;
 
-export const QUEUE_URL = process.env.SQS_QUEUE_URL || "";
+export const QUEUE_URL = process.env.SQS_QUEUE_URL_V2 || "";

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -121,7 +121,7 @@ export const addTaskToQueue = async <T extends keyof Payloads>({
 	delayMs?: number;
 	queueUrl?: string;
 }) => {
-	const resolvedQueueUrl = queueUrl || process.env.SQS_QUEUE_URL;
+	const resolvedQueueUrl = queueUrl || process.env.SQS_QUEUE_URL_V2;
 
 	if (resolvedQueueUrl) {
 		const sqsClient = getSqsClient();
@@ -172,5 +172,5 @@ export const addTaskToQueue = async <T extends keyof Payloads>({
 		return;
 	}
 
-	throw new Error("No queue configured. Set either SQS_QUEUE_URL or QUEUE_URL");
+	throw new Error("No queue configured. Set either SQS_QUEUE_URL_V2 or QUEUE_URL");
 };

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -27,7 +27,7 @@ if (cluster.isPrimary) {
 	// await initHatchetWorker();
 
 	console.log(`Starting ${NUM_PROCESSES} worker processes`);
-	console.log(`SQS URL: ${process.env.SQS_QUEUE_URL}`);
+	console.log(`SQS URL: ${process.env.SQS_QUEUE_URL_V2}`);
 
 	// Fork workers
 	for (let i = 0; i < NUM_PROCESSES; i++) {

--- a/server/tests/integration/balances/utils/spend-limit-utils/customerSpendLimitUtils.ts
+++ b/server/tests/integration/balances/utils/spend-limit-utils/customerSpendLimitUtils.ts
@@ -1,4 +1,5 @@
 import type { CustomerBillingControls } from "@autumn/shared";
+import { timeout } from "@/utils/genUtils.js";
 import type { AutumnV2_1Client } from "./entitySpendLimitUtils.js";
 
 export const setCustomerSpendLimit = async ({
@@ -24,7 +25,9 @@ export const setCustomerSpendLimit = async ({
 		],
 	};
 
+	await timeout(2000);
 	await autumn.customers.update(customerId, {
 		billing_controls: billingControls,
 	});
+	await timeout(2000);
 };

--- a/server/tests/unit/queue/queue-utils.test.ts
+++ b/server/tests/unit/queue/queue-utils.test.ts
@@ -12,7 +12,7 @@ import { getSqsClient } from "@/queue/initSqs.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
 
 describe("addTaskToQueue queue override", () => {
-	const originalSqsQueueUrl = process.env.SQS_QUEUE_URL;
+	const originalSqsQueueUrl = process.env.SQS_QUEUE_URL_V2;
 	const originalQueueUrl = process.env.QUEUE_URL;
 
 	beforeEach(() => {
@@ -23,7 +23,7 @@ describe("addTaskToQueue queue override", () => {
 			mockState.commands.push(command.input);
 			return {};
 		}) as typeof sqsClient.send;
-		delete process.env.SQS_QUEUE_URL;
+		delete process.env.SQS_QUEUE_URL_V2;
 		delete process.env.QUEUE_URL;
 	});
 
@@ -32,7 +32,7 @@ describe("addTaskToQueue queue override", () => {
 			const sqsClient = getSqsClient();
 			sqsClient.send = mockState.originalSend as typeof sqsClient.send;
 		}
-		process.env.SQS_QUEUE_URL = originalSqsQueueUrl;
+		process.env.SQS_QUEUE_URL_V2 = originalSqsQueueUrl;
 		process.env.QUEUE_URL = originalQueueUrl;
 	});
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized SQS config to use `SQS_QUEUE_URL_V2` across the app, fixing queue selection and keeping agent queues isolated. Also added small waits to stabilize a spend-limit test.

- **Bug Fixes**
  - Switched all SQS reads to `SQS_QUEUE_URL_V2` in queue utils, worker startup logs, and EventBridge utils (region extraction and ARN derivation).
  - Updated error message to reference `SQS_QUEUE_URL_V2`.
  - Updated setup script and `AGENT_README` to write/document `SQS_QUEUE_URL_V2` for local ElasticMQ.
  - Stabilized `setCustomerSpendLimit` test with short `timeout` calls.
  - Adjusted unit tests to use `SQS_QUEUE_URL_V2`.

<sup>Written for commit 23734fad956a29a84074a428b4822eba12954400. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

