### PR TITLE
release

### DIFF
--- a/.github/archived_workflows/test.yml
+++ b/.github/archived_workflows/test.yml
@@ -6,7 +6,7 @@
 #     branches:
 #       - main
 # env:
-#   DATABASE_URL: ${{ secrets.SUPABASE_URL }}
+#   DATABASE_V2_URL: ${{ secrets.SUPABASE_URL }}
 #   UNIT_TEST_AUTUMN_SECRET_KEY: ${{ secrets.AUTUMN_KEY }}
 #   REDIS_URL: redis://localhost:6379
 #   ENCRYPTION_IV: ${{ secrets.ENCRYPTION_IV }}
@@ -92,7 +92,7 @@
 #       - name: Create .env file
 #         run: |
 #           echo "Creating .env file..."
-#           echo "DATABASE_URL=${{ env.DATABASE_URL }}" >> .env
+#           echo "DATABASE_V2_URL=${{ env.DATABASE_V2_URL }}" >> .env
 #           echo "UNIT_TEST_AUTUMN_SECRET_KEY=${{ env.UNIT_TEST_AUTUMN_SECRET_KEY }}" >> .env
 #           echo "REDIS_URL=${{ env.REDIS_URL }}" >> .env
 #           echo "ENCRYPTION_IV=${{ env.ENCRYPTION_IV }}" >> .env

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -65,7 +65,7 @@ services:
     environment:
       - NODE_ENV=development
       - REDIS_URL=redis://valkey:6379
-      - DATABASE_URL=${DATABASE_URL}
+      - DATABASE_V2_URL=${DATABASE_V2_URL}
       - ENCRYPTION_IV=${ENCRYPTION_IV}
       - ENCRYPTION_PASSWORD=${ENCRYPTION_PASSWORD}
       - TESTS_ORG=${TESTS_ORG}

--- a/scripts/db/pull.ts
+++ b/scripts/db/pull.ts
@@ -184,7 +184,7 @@ async function getCustomerCount(
 }
 
 /**
- * Read DATABASE_URL from server/.env file
+ * Read DATABASE_V2_URL from server/.env file
  */
 function readLocalDatabaseUrl(): string | null {
 	try {
@@ -194,8 +194,8 @@ function readLocalDatabaseUrl(): string | null {
 
 		for (const line of lines) {
 			const trimmed = line.trim();
-			if (trimmed.startsWith("DATABASE_URL=")) {
-				const url = trimmed.replace(/^DATABASE_URL=/, "").trim();
+			if (trimmed.startsWith("DATABASE_V2_URL=")) {
+				const url = trimmed.replace(/^DATABASE_V2_URL=/, "").trim();
 				// Remove quotes if present
 				return url.replace(/^["']|["']$/g, "");
 			}
@@ -237,7 +237,7 @@ async function pullDatabase({
 	if (!localUrl) {
 		console.error("❌ Could not find local database URL");
 		console.error("   Options:");
-		console.error("   1. Ensure server/.env exists and contains DATABASE_URL");
+		console.error("   1. Ensure server/.env exists and contains DATABASE_V2_URL");
 		console.error("   2. Pass local URL as second argument");
 		console.error("   3. Set LOCAL_DATABASE_URL environment variable");
 		process.exit(1);
@@ -359,7 +359,7 @@ if (!remoteUrl) {
 		"  local-database-url   (optional) Local database URL to pull into",
 	);
 	console.log(
-		"                        If not provided, reads from server/.env DATABASE_URL\n",
+		"                        If not provided, reads from server/.env DATABASE_V2_URL\n",
 	);
 	console.log("Environment variables:");
 	console.log("  REMOTE_DATABASE_URL  Remote database URL");
@@ -370,7 +370,7 @@ if (!remoteUrl) {
 	console.log('  REMOTE_DATABASE_URL="postgresql://..." bun db:pull\n');
 	console.log("⚠️  Important: URLs must be quoted to prevent shell expansion\n");
 	console.log(
-		"By default, the script reads DATABASE_URL from server/.env for the local database.\n",
+		"By default, the script reads DATABASE_V2_URL from server/.env for the local database.\n",
 	);
 	process.exit(1);
 }

--- a/scripts/db/set-critical-role-timeouts.ts
+++ b/scripts/db/set-critical-role-timeouts.ts
@@ -71,9 +71,9 @@ const main = async () => {
 
 	loadInfisicalEnv(env);
 
-	const criticalDatabaseUrl = process.env.DATABASE_CRITICAL_URL;
+	const criticalDatabaseUrl = process.env.DATABASE_V2_CRITICAL_URL;
 	if (!criticalDatabaseUrl) {
-		throw new Error(`DATABASE_CRITICAL_URL is not set in Infisical env "${env}"`);
+		throw new Error(`DATABASE_V2_CRITICAL_URL is not set in Infisical env "${env}"`);
 	}
 
 	const client = new Pool({
@@ -106,7 +106,7 @@ const main = async () => {
 		});
 
 		try {
-			console.log("Verified in a new DATABASE_CRITICAL_URL session:");
+			console.log("Verified in a new DATABASE_V2_CRITICAL_URL session:");
 			for (const key of Object.keys(ROLE_SETTINGS)) {
 				const verifyResult = await verifyClient.query<Record<string, string>>(
 					`SHOW ${key}`,

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -14,13 +14,13 @@ database_url="${database_base_url%/*}/${database_name}${database_query}"
 logged_database_url="$(printf '%s' "${database_url}" | sed -E 's#(postgres(ql)?://[^:/?]+):[^@/]*@#\1:***@#')"
 cache_url="${LOCAL_CACHE_URL:-redis://localhost:6379}"
 
-echo "dev-local: overriding Infisical DATABASE_URL/CACHE_URL with local values and disabling CACHE_CERT"
-echo "dev-local: DATABASE_URL=${logged_database_url}"
+echo "dev-local: overriding Infisical DATABASE_V2_URL/CACHE_URL with local values and disabling CACHE_CERT"
+echo "dev-local: DATABASE_V2_URL=${logged_database_url}"
 
 exec infisical run --env=prod -- env \
 	ENV_FILE=.env.prod \
 	NODE_ENV=development \
-	DATABASE_URL="${database_url}" \
+	DATABASE_V2_URL="${database_url}" \
 	CACHE_URL="${cache_url}" \
 	CACHE_URL_US_EAST="${cache_url}" \
 	CACHE_CERT="" \

--- a/scripts/migrations/migrate-functions.ts
+++ b/scripts/migrations/migrate-functions.ts
@@ -10,7 +10,7 @@ export const migrateFunctions = async () => {
 	);
 	const databaseUrl = process.env.DATABASE_URL;
 
-	if (databaseUrl?.includes("us-west-3")) {
+	if (databaseUrl?.includes("us-east-2")) {
 		const { confirm } = await inquirer.prompt([
 			{
 				type: "confirm",

--- a/scripts/migrations/migrate-functions.ts
+++ b/scripts/migrations/migrate-functions.ts
@@ -8,7 +8,7 @@ export const migrateFunctions = async () => {
 	const { initializeDatabaseFunctions } = await import(
 		"@server/db/initializeDatabaseFunctions"
 	);
-	const databaseUrl = process.env.DATABASE_URL;
+	const databaseUrl = process.env.DATABASE_V2_URL;
 
 	if (databaseUrl?.includes("us-west-3")) {
 		const { confirm } = await inquirer.prompt([

--- a/scripts/setup/setup.js
+++ b/scripts/setup/setup.js
@@ -177,10 +177,10 @@ const generateSupabaseDatabaseUrl = async () => {
 	const projectId = found.id;
 	const region = found.region;
 
-	// Step 8: Construct DATABASE_URL
+	// Step 8: Construct DATABASE_V2_URL
 	const databaseUrl = `postgresql://postgres.${projectId}:${dbPassword}@aws-1-${region}.pooler.supabase.com:5432/postgres`;
 	console.log(chalk.greenBright(`\nGenerated DB password: ${dbPassword}\n`));
-	console.log(chalk.greenBright(`\nYour DATABASE_URL is:\n${databaseUrl}\n`));
+	console.log(chalk.greenBright(`\nYour DATABASE_V2_URL is:\n${databaseUrl}\n`));
 	console.log(chalk.yellow("--------------------------------"));
 
 	// Step 9: Prompt to run docker compose up
@@ -208,8 +208,8 @@ const handleDatabaseSetup = async () => {
 			message: chalk.cyan("How do you want to set up your database?"),
 			choices: [
 				{ name: "Set up Supabase (Cloud) for Autumn", value: "supabase" },
-				{ name: "Paste in your own DATABASE_URL", value: "paste" },
-				{ name: "Paste in your own DATABASE_URL later", value: "later" },
+				{ name: "Paste in your own DATABASE_V2_URL", value: "paste" },
+				{ name: "Paste in your own DATABASE_V2_URL later", value: "later" },
 			],
 			default: "supabase",
 		},
@@ -224,7 +224,7 @@ const handleDatabaseSetup = async () => {
 			{
 				type: "input",
 				name: "databaseUrl",
-				message: "Paste in your DATABASE_URL:",
+				message: "Paste in your DATABASE_V2_URL:",
 				validate: (input) => input && input.length > 5,
 			},
 		]);
@@ -285,7 +285,7 @@ async function main() {
 
 	// Database section
 	if (databaseUrl) {
-		envSections.push("# Database", `DATABASE_URL=${databaseUrl}`, "");
+		envSections.push("# Database", `DATABASE_V2_URL=${databaseUrl}`, "");
 	}
 
 	// Stripe Webhooks section

--- a/scripts/setup/setupci.js
+++ b/scripts/setup/setupci.js
@@ -26,7 +26,7 @@ async function main() {
 		STRIPE_WEBHOOK_URL: process.env.STRIPE_WEBHOOK_URL,
 	};
 
-	const databaseUrl = process.env.DATABASE_URL;
+	const databaseUrl = process.env.DATABASE_V2_URL;
 	const stripeWebhookVars = [];
 	// stripeWebhookVars = await handleLocalRunSetup();
 
@@ -57,7 +57,7 @@ async function main() {
 
 	// Database section
 	if (databaseUrl) {
-		envSections.push("# Database", `DATABASE_URL=${databaseUrl}`, "");
+		envSections.push("# Database", `DATABASE_V2_URL=${databaseUrl}`, "");
 	}
 
 	// Stripe Webhooks section

--- a/scripts/setup/writeAgentEnv.ts
+++ b/scripts/setup/writeAgentEnv.ts
@@ -50,7 +50,7 @@ ENCRYPTION_IV=${genUrlSafeBase64({ bytes: 16 })}
 ENCRYPTION_PASSWORD=${genUrlSafeBase64({ bytes: 64 })}
 
 # Local services
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/autumn
+DATABASE_V2_URL=postgresql://postgres:postgres@localhost:5432/autumn
 CACHE_URL=redis://localhost:6379
 CACHE_URL_US_EAST=redis://localhost:6379
 REDIS_URL=redis://localhost:6379

--- a/server/.env.example
+++ b/server/.env.example
@@ -18,7 +18,7 @@ LOCALTUNNEL_RESERVED_KEY=
 # DATABASE
 # You can grab this from the Supabase dashboard by pressing the "Connect" button in the upper navbar, or pass in your own connection string to a postgres instance
 
-DATABASE_URL=
+DATABASE_V2_URL=
 CRITICAL_DATABASE_URL=
 
 # ------------------------------------------------------------------------

--- a/server/src/db/dbUtils.ts
+++ b/server/src/db/dbUtils.ts
@@ -113,12 +113,12 @@ export const isConnectionDropError = ({
 	return CONNECTION_DROP_CODES.has(code);
 };
 
-/** Throws if DATABASE_URL looks like a production database. Single source of truth for this check. */
+/** Throws if DATABASE_V2_URL looks like a production database. Single source of truth for this check. */
 export const assertNotProductionDb = () => {
-	const url = process.env.DATABASE_URL || "";
-	if (url.includes("us-west-3")) {
+	const url = process.env.DATABASE_V2_URL || "";
+	if (url.includes("us-east-2")) {
 		throw new Error(
-			"Refusing to run against production database (DATABASE_URL contains us-west)",
+			"Refusing to run against production database (DATABASE_V2_URL contains us-east-2)",
 		);
 	}
 };

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -53,8 +53,8 @@ export const initDrizzle = ({
 	poolConfig?: PoolConfig;
 } = {}) => {
 	const envDbUrl = replica
-		? process.env.DATABASE_REPLICA_URL
-		: process.env.DATABASE_URL;
+		? process.env.DATABASE_V2_REPLICA_URL
+		: process.env.DATABASE_V2_URL;
 
 	const dbUrl = databaseUrl || envDbUrl || "";
 
@@ -86,10 +86,10 @@ export const initDrizzle = ({
 export const { db: dbCritical, client: clientCritical } = initDrizzle({
 	maxConnections: 5,
 	connectTimeout: 2,
-	databaseUrl: process.env.DATABASE_CRITICAL_URL,
+	databaseUrl: process.env.DATABASE_V2_CRITICAL_URL,
 	poolConfig: {
 		application_name: "autumn-critical",
-		// Server-side timeout is configured on the DATABASE_CRITICAL_URL role.
+		// Server-side timeout is configured on the DATABASE_V2_CRITICAL_URL role.
 		query_timeout: 2_000,
 	},
 });
@@ -100,8 +100,8 @@ export const { db: dbGeneral, client: clientGeneral } = initDrizzle({
 });
 
 // -- Replica pool: used as fallback when primary is degraded --
-// Only created if DATABASE_REPLICA_URL is configured.
-const replicaResult = process.env.DATABASE_REPLICA_URL
+// Only created if DATABASE_V2_REPLICA_URL is configured.
+const replicaResult = process.env.DATABASE_V2_REPLICA_URL
 	? initDrizzle({ replica: true, maxConnections: 5, connectTimeout: null })
 	: null;
 export const dbReplica = replicaResult?.db ?? null;

--- a/server/src/db/pgHealthMonitor.ts
+++ b/server/src/db/pgHealthMonitor.ts
@@ -247,7 +247,7 @@ export const getPgHealthState = (): {
 	failureCount,
 	probeActive: probeInterval !== null,
 	firstProbeSuccessAt,
-	hasReplica: !!process.env.DATABASE_REPLICA_URL,
+	hasReplica: !!process.env.DATABASE_V2_REPLICA_URL,
 });
 
 /** Force DEGRADED state (for testing). Does NOT start the recovery probe. */

--- a/server/src/db/redactDatabaseUrl.ts
+++ b/server/src/db/redactDatabaseUrl.ts
@@ -33,9 +33,9 @@ export const redactDatabaseUrl = (databaseUrl?: string) => {
 };
 
 export const getRedactedDatabaseUrls = () => ({
-	primary: redactDatabaseUrl(process.env.DATABASE_URL),
-	replica: redactDatabaseUrl(process.env.DATABASE_REPLICA_URL),
+	primary: redactDatabaseUrl(process.env.DATABASE_V2_URL),
+	replica: redactDatabaseUrl(process.env.DATABASE_V2_REPLICA_URL),
 	critical: redactDatabaseUrl(
-		process.env.DATABASE_CRITICAL_URL || process.env.DATABASE_URL,
+		process.env.DATABASE_V2_CRITICAL_URL || process.env.DATABASE_V2_URL,
 	),
 });

--- a/server/src/external/aws/awsRegionUtils.ts
+++ b/server/src/external/aws/awsRegionUtils.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_AWS_REGION = "us-west-2";
+export const DEFAULT_AWS_REGION = "us-east-2";
 
 /** Extracts the AWS region from a queue URL. */
 export const extractRegionFromQueueUrl = ({

--- a/server/src/internal/misc/debug/debugRouter.ts
+++ b/server/src/internal/misc/debug/debugRouter.ts
@@ -85,7 +85,7 @@ debugRouter.post("/pool-test", async (c) => {
 		return c.json({ error: "Forbidden" }, 403);
 	}
 
-	if (process.env.DATABASE_URL?.includes("us-west")) {
+	if (process.env.DATABASE_V2_URL?.includes("us-east-2")) {
 		return c.json({ error: "Not available against production database" }, 403);
 	}
 

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -13,6 +13,7 @@ export const ADMIN_USER_IDs = [
 	"user_2sB3tBXsnVVLlTKliQIqvvM2xfB", // j
 	"ZsDswIXyOGMP9y1V1At4dAZNaiggClSs", // t
 	"NqNuL3MtS7MR2WYoqx2b28iY9vmfAs8h", // c
+	"y7xV3rybEkhoPfJe45dymZB1dXxvsolG", // o
 	"NqNuL3MtS7MR2WYoqx2b28iY9vmfAs8h", // charlie prod
 
 	// Sandbox:

--- a/server/src/utils/initUtils.ts
+++ b/server/src/utils/initUtils.ts
@@ -2,8 +2,8 @@ import { logger } from "@/external/logtail/logtailUtils.js";
 import "dotenv/config";
 
 export const checkEnvVars = () => {
-	if (!process.env.DATABASE_URL) {
-		console.error(`DATABASE_URL is not set`);
+	if (!process.env.DATABASE_V2_URL) {
+		console.error(`DATABASE_V2_URL is not set`);
 		process.exit(1);
 	}
 

--- a/server/tests/clearMasterOrg.ts
+++ b/server/tests/clearMasterOrg.ts
@@ -21,11 +21,11 @@ export const clearMasterOrg = async () => {
 			process.exit(1);
 		}
 
-		const databaseUrl = process.env.DATABASE_URL ?? "";
+		const databaseUrl = process.env.DATABASE_V2_URL ?? "";
 		if (databaseUrl.toLowerCase().includes("fancy-duckling")) {
 			console.error(
 				chalk.red(
-					"\n❌ Refusing to run clearMasterOrg against prod-like DATABASE_URL (contains 'fancy-duckling').\n",
+					"\n❌ Refusing to run clearMasterOrg against prod-like DATABASE_V2_URL (contains 'fancy-duckling').\n",
 				),
 			);
 			process.exit(1);

--- a/server/tests/infra/criticalDbTimeout.test.ts
+++ b/server/tests/infra/criticalDbTimeout.test.ts
@@ -47,8 +47,8 @@ test("db connect timeout fails fast when postgres accepts tcp but never responds
 		throw new Error("Failed to bind test TCP server");
 	}
 
-	const databaseUrl = process.env.DATABASE_URL;
-	process.env.DATABASE_URL = `postgres://user:password@127.0.0.1:${address.port}/db`;
+	const databaseUrl = process.env.DATABASE_V2_URL;
+	process.env.DATABASE_V2_URL = `postgres://user:password@127.0.0.1:${address.port}/db`;
 
 	const { client: deadClient } = initDrizzle({ connectTimeout: 1 });
 	const startedAt = Date.now();
@@ -58,7 +58,7 @@ test("db connect timeout fails fast when postgres accepts tcp but never responds
 
 		expect(Date.now() - startedAt).toBeLessThan(2_000);
 	} finally {
-		process.env.DATABASE_URL = databaseUrl;
+		process.env.DATABASE_V2_URL = databaseUrl;
 		await deadClient.end().catch(() => {});
 		await new Promise<void>((resolve, reject) => {
 			server.close((error) => (error ? reject(error) : resolve()));

--- a/server/tests/infra/pgFailover.test.ts
+++ b/server/tests/infra/pgFailover.test.ts
@@ -317,7 +317,7 @@ test(`${chalk.yellowBright("pg failover: critical endpoints failover to replica 
 			}
 		} else {
 			console.log(
-				"\n--- Step 5: SKIPPED (no DATABASE_REPLICA_URL configured) ---",
+				"\n--- Step 5: SKIPPED (no DATABASE_V2_REPLICA_URL configured) ---",
 			);
 		}
 

--- a/shared/drizzle.config.ts
+++ b/shared/drizzle.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
 	out: "./drizzle",
 	schema: "./db/schema.ts",
 	dbCredentials: {
-		url: process.env.DATABASE_URL!,
+		url: process.env.DATABASE_V2_URL!,
 	},
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a new admin user ID (`y7xV3rybEkhoPfJe45dymZB1dXxvsolG`) for user "o" to the `ADMIN_USER_IDs` allowlist in `server/src/utils/constants.ts`.

**Key changes:**
- [Improvements] New admin user entry added to the production admin ID list.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — trivial allowlist addition with no logic changes.

Single-line addition to a static admin ID list; no logic, no security boundary changes, no duplicate introduced by this PR.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/constants.ts | Adds a new admin user ID ("y7xV3rybEkhoPfJe45dymZB1dXxvsolG" // o) to the ADMIN_USER_IDs allowlist; no logic changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{User ID in ADMIN_USER_IDs?}
    B -- Yes --> C[Grant Admin Access]
    B -- No --> D[Standard Access]
    C --> E[Admin Routes / Privileged Actions]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;dev&#39; of https://github.com..."](https://github.com/useautumn/autumn/commit/d84de9a7ffa799cf2a15351aabcd014748749d87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29824212)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames database env vars to the `DATABASE_V2_*` set and updates all scripts, tests, and configs. Switches default AWS region to `us-east-2`, updates production checks/migration prompts, and adds admin ID `y7xV3rybEkhoPfJe45dymZB1dXxvsolG`.

- **Migration**
  - Replace `DATABASE_URL` with `DATABASE_V2_URL` in `.env`, CI, and compose files; if used, also rename `DATABASE_REPLICA_URL` → `DATABASE_V2_REPLICA_URL` and `DATABASE_CRITICAL_URL` → `DATABASE_V2_CRITICAL_URL`.
  - Regenerate or update local setup via scripts so they write/read `DATABASE_V2_*`.
  - Prod guards now check for `us-east-2`; ensure regions and DB URLs reflect this.

<sup>Written for commit 59c2a43623eec28bccd9f93b1305edcd3738f031. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

