### PR TITLE
fix: cusproduct sorting

### DIFF
--- a/server/src/external/redis/utils/errors.ts
+++ b/server/src/external/redis/utils/errors.ts
@@ -3,6 +3,7 @@ import type { UnavailableReason } from "./runRedisOp.js";
 /** Thrown by `runRedisOp` when Redis is unavailable (timeout, connection,
  *  not-ready, or other classifiable failure). Callers that want to fail open
  *  should catch this at the request/handler boundary (see `withRedisFailOpen`). */
+
 export class RedisUnavailableError extends Error {
 	readonly reason: UnavailableReason;
 	readonly source: string;

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -152,13 +152,13 @@ export class CusService {
 
 				const fullCus = data as FullCustomer;
 
-				if (orgId === "org_2x5sJDcxhpVDjyUSqs4khaaNnxq") {
-					fullCus.customer_products = (
-						fullCus.customer_products as FullCusProduct[]
-					)
-						.sort((a, b) => b.customer_prices.length - a.customer_prices.length)
-						.slice(0, 5);
-				}
+				// if (orgId === "org_2x5sJDcxhpVDjyUSqs4khaaNnxq") {
+				// 	fullCus.customer_products = (
+				// 		fullCus.customer_products as FullCusProduct[]
+				// 	)
+				// 		.sort((a, b) => b.customer_prices.length - a.customer_prices.length)
+				// 		.slice(0, 5);
+				// }
 
 				if (
 					orgId === "GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF" &&

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -27,6 +27,12 @@ const buildOptimizedCusProductsCTE = ({
 		sql`, `,
 	)}]) THEN 0 ELSE 1 END`;
 
+	const hasCustomerPrices = sql`EXISTS (
+    SELECT 1
+    FROM customer_prices cpr_exists
+    WHERE cpr_exists.customer_product_id = cp.id
+  )`;
+
 	return sql`
     customer_products_with_prices AS (
       SELECT 
@@ -92,7 +98,7 @@ const buildOptimizedCusProductsCTE = ({
       ) ft_data ON true
       WHERE cp.internal_customer_id = (SELECT internal_id FROM customer_record)
       ${withStatusFilter()}
-      ORDER BY ${relevantStatusFirst}, prod.is_add_on ASC, cp.created_at DESC
+      ORDER BY ${relevantStatusFirst}, ${hasCustomerPrices} DESC, prod.is_add_on ASC, cp.created_at DESC
       LIMIT ${cusProductLimit}
     )
   `;
@@ -391,7 +397,24 @@ export const getFullCusQuery = ({
 	selectFieldsChunks.push(sql`
     cr.*,
     COALESCE(
-      (SELECT json_agg(cpwp) FROM customer_products_with_prices cpwp),
+      (
+        SELECT json_agg(cpwp ORDER BY
+          CASE WHEN cpwp.status = ANY(ARRAY[${sql.join(
+						RELEVANT_STATUSES.map((status) => sql`${status}`),
+						sql`, `,
+					)}]) THEN 0 ELSE 1 END,
+          (
+            EXISTS (
+              SELECT 1
+              FROM customer_prices cpr_exists
+              WHERE cpr_exists.customer_product_id = cpwp.id
+            )
+          ) DESC,
+          (cpwp.product->>'is_add_on')::boolean ASC,
+          cpwp.created_at DESC
+        )
+        FROM customer_products_with_prices cpwp
+      ),
       '[]'::json
     ) AS customer_products
   `);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix customer product ordering to show relevant statuses first and items with prices before others, with consistent ordering from the DB to the API. Removes org-specific sorting so all orgs use the same rules.

- **Bug Fixes**
  - Added DB ordering in `getFullCusQuery`: relevant status first, has prices DESC, add-on ASC, created_at DESC.
  - Applied the same ordering inside `json_agg` for `customer_products`.
  - Removed org-specific sort/limit in `CusService` to rely on SQL ordering.

<sup>Written for commit 96d7bb7b70784492a8b878f2bf66bd9b2529bac6. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1363?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

