### PR TITLE
chore: finalize lock fail open

### DIFF
--- a/server/src/internal/balances/finalizeLock/runFinalizeLock.ts
+++ b/server/src/internal/balances/finalizeLock/runFinalizeLock.ts
@@ -1,21 +1,34 @@
 import { type FinalizeLockParamsV0, notNullish } from "@autumn/shared";
 import { Decimal } from "decimal.js";
+import { withRedisFailOpen } from "@/external/redis/utils/withRedisFailOpen.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { cancelLockExpiry } from "@/internal/balances/utils/lock/cancelLockExpiry.js";
 import { claimLockReceipt } from "@/internal/balances/utils/lock/claimLockReceipt.js";
 import { deleteLockReceipt } from "@/internal/balances/utils/lock/deleteLockReceipt.js";
 import { fetchLockReceipt } from "@/internal/balances/utils/lock/fetchLockReceipt.js";
+import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { buildFinalizeLockContext } from "./buildFinalizeLockContext.js";
 import { runFinalizeLockV2 } from "./runFinalizeLockV2.js";
 import { runRedisFinalizeLock } from "./runRedisFinalizeLock.js";
 
-export const runFinalizeLock = async ({
-	ctx,
-	params,
-}: {
+type RunFinalizeLockArgs = {
 	ctx: AutumnContext;
 	params: FinalizeLockParamsV0;
-}) => {
+};
+
+export const runFinalizeLock = async (args: RunFinalizeLockArgs) => {
+	if (!isFullSubjectRolloutEnabled({ ctx: args.ctx })) {
+		return runFinalizeLockInner(args);
+	}
+
+	return withRedisFailOpen({
+		source: "runFinalizeLock",
+		run: () => runFinalizeLockInner(args),
+		fallback: () => ({ success: true }),
+	});
+};
+
+const runFinalizeLockInner = async ({ ctx, params }: RunFinalizeLockArgs) => {
 	const fetchedReceipt = await fetchLockReceipt({
 		ctx,
 		lockId: params.lock_id,

--- a/server/tests/unit/balances/finalizeLock/runFinalizeLock.test.ts
+++ b/server/tests/unit/balances/finalizeLock/runFinalizeLock.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const mockState = {
+	shouldUseRedis: true,
+	fetchError: null as unknown,
+	finalizeV2Error: null as unknown,
+	fetchCalls: [] as Record<string, unknown>[],
+	finalizeV2Calls: [] as Record<string, unknown>[],
+};
+
+mock.module("@/external/redis/initUtils/redisV2Availability.js", () => ({
+	shouldUseRedisV2: () => mockState.shouldUseRedis,
+}));
+
+mock.module("@/internal/balances/utils/lock/fetchLockReceipt.js", () => ({
+	fetchLockReceipt: async (args: Record<string, unknown>) => {
+		mockState.fetchCalls.push(args);
+		if (mockState.fetchError) throw mockState.fetchError;
+
+		return {
+			source: "redis_v2",
+			receipt: { customer_id: "cus_123", feature_id: "messages", items: [] },
+			lockReceiptKey: "lock:receipt",
+			claimed: true,
+		};
+	},
+}));
+
+mock.module("@/internal/balances/finalizeLock/runFinalizeLockV2.js", () => ({
+	runFinalizeLockV2: async (args: Record<string, unknown>) => {
+		mockState.finalizeV2Calls.push(args);
+		if (mockState.finalizeV2Error) throw mockState.finalizeV2Error;
+
+		return { success: true };
+	},
+}));
+
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import { runFinalizeLock } from "@/internal/balances/finalizeLock/runFinalizeLock.js";
+
+const resetMockState = () => {
+	mockState.shouldUseRedis = true;
+	mockState.fetchError = null;
+	mockState.finalizeV2Error = null;
+	mockState.fetchCalls = [];
+	mockState.finalizeV2Calls = [];
+};
+
+beforeEach(resetMockState);
+afterEach(resetMockState);
+
+const rolloutCtx = {
+	org: { id: "org_123" },
+	env: "sandbox",
+	rolloutSnapshot: {
+		rolloutId: "v2-cache",
+		enabled: true,
+		percent: 100,
+		previousPercent: 0,
+		changedAt: 1,
+		customerBucket: 10,
+	},
+} as never;
+
+const nonRolloutCtx = {
+	org: { id: "org_123" },
+	env: "sandbox",
+	rolloutSnapshot: undefined,
+} as never;
+
+const params = {
+	lock_id: "lock_123",
+	action: "capture",
+} as never;
+
+describe("runFinalizeLock", () => {
+	test("runs finalize v2 when the rollout is enabled", async () => {
+		const result = await runFinalizeLock({ ctx: rolloutCtx, params });
+
+		expect(result).toEqual({ success: true });
+		expect(mockState.fetchCalls).toHaveLength(1);
+		expect(mockState.finalizeV2Calls).toHaveLength(1);
+	});
+
+	test("fails open when Redis is unavailable before fetching the receipt", async () => {
+		mockState.shouldUseRedis = false;
+
+		const result = await runFinalizeLock({ ctx: rolloutCtx, params });
+
+		expect(result).toEqual({ success: true });
+		expect(mockState.fetchCalls).toHaveLength(0);
+		expect(mockState.finalizeV2Calls).toHaveLength(0);
+	});
+
+	test("fails open when fetching the receipt hits a transient Redis error", async () => {
+		mockState.fetchError = new RedisUnavailableError({
+			source: "unit-test",
+			reason: "timeout",
+		});
+
+		const result = await runFinalizeLock({ ctx: rolloutCtx, params });
+
+		expect(result).toEqual({ success: true });
+		expect(mockState.fetchCalls).toHaveLength(1);
+		expect(mockState.finalizeV2Calls).toHaveLength(0);
+	});
+
+	test("fails open when finalize v2 hits a transient Redis error", async () => {
+		mockState.finalizeV2Error = new Error("Command timed out");
+
+		const result = await runFinalizeLock({ ctx: rolloutCtx, params });
+
+		expect(result).toEqual({ success: true });
+		expect(mockState.fetchCalls).toHaveLength(1);
+		expect(mockState.finalizeV2Calls).toHaveLength(1);
+	});
+
+	test("does not fail open when the rollout is disabled", async () => {
+		mockState.fetchError = new RedisUnavailableError({
+			source: "unit-test",
+			reason: "timeout",
+		});
+
+		await expect(runFinalizeLock({ ctx: nonRolloutCtx, params })).rejects.toBe(
+			mockState.fetchError,
+		);
+		expect(mockState.fetchCalls).toHaveLength(1);
+	});
+
+	test("throws non-transient errors", async () => {
+		const error = new Error("application bug");
+		mockState.finalizeV2Error = error;
+
+		await expect(runFinalizeLock({ ctx: rolloutCtx, params })).rejects.toBe(
+			error,
+		);
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add fail-open behavior to finalize lock when Redis v2 is unavailable. When the full subject rollout is on, `runFinalizeLock` returns `{ success: true }` on transient Redis failures to avoid blocking captures.

- **New Features**
  - Gate with `isFullSubjectRolloutEnabled`; when enabled, wrap in `withRedisFailOpen` with fallback `{ success: true }`. Otherwise, run normal path.
  - Added unit tests to cover: success path, pre-fetch unavailability, transient errors in fetch/finalize, rollout disabled, and non-transient errors.

<sup>Written for commit 8ff0ac3d4b039980020e9619c50aab6ac0743fff. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1365?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR finalizes the "lock fail open" feature by gating `runFinalizeLock` behind `isFullSubjectRolloutEnabled`: when the rollout is active the call is wrapped in `withRedisFailOpen` so any transient Redis/DB error resolves to `{ success: true }` instead of propagating; when the rollout is disabled the existing behaviour is preserved. A comprehensive unit test suite is added covering success, fail-open, and non-transient error paths.

**Key changes:**
- [Improvements] Extracted `runFinalizeLockInner` and added rollout-gated `withRedisFailOpen` wrapper to `runFinalizeLock`
- [Improvements] Added unit tests for all fail-open and error-propagation scenarios
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct, rollout gate preserves backward compatibility, and tests cover all branches.

No P0 or P1 issues found. The refactor is clean: rollout-disabled path is unchanged, fail-open path correctly delegates to the existing withRedisFailOpen utility, and the six-scenario test suite validates every branch including non-transient error propagation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/finalizeLock/runFinalizeLock.ts | Extracts inner logic into runFinalizeLockInner, adds rollout-gated fail-open wrapper via withRedisFailOpen; logic is correct and well-structured. |
| server/tests/unit/balances/finalizeLock/runFinalizeLock.test.ts | New unit test covering all key scenarios: success path, Redis unavailable, transient fetch error, transient finalize error, rollout disabled, and non-transient error propagation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runFinalizeLock] --> B{isFullSubjectRolloutEnabled?}
    B -- No --> C[runFinalizeLockInner\ndirect call, errors propagate]
    B -- Yes --> D[withRedisFailOpen]
    D --> E{shouldUseRedisV2?}
    E -- No --> F[throw RedisUnavailableError]
    F --> G[isTransientRedisError? → true]
    G --> H[fallback: return success:true]
    E -- Yes --> I[runFinalizeLockInner]
    I --> J{error?}
    J -- No --> K[return result]
    J -- transient --> H
    J -- non-transient --> L[re-throw error]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: finalize lock fail open"](https://github.com/useautumn/autumn/commit/8ff0ac3d4b039980020e9619c50aab6ac0743fff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29839669)</sub>

<!-- /greptile_comment -->