### PR TITLE
Persist last-active org in localStorage to prevent org reset

### DIFF
--- a/vite/src/hooks/common/useOrg.tsx
+++ b/vite/src/hooks/common/useOrg.tsx
@@ -5,11 +5,21 @@ import { authClient, useListOrganizations } from "@/lib/auth-client";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
 
-let lastSwitchedOrgId: string | null = null;
+const LAST_ORG_KEY = "autumn_last_active_org_id";
+
 export const setLastSwitchedOrgId = (id: string) => {
-	lastSwitchedOrgId = id;
+	try {
+		localStorage.setItem(LAST_ORG_KEY, id);
+	} catch {}
 };
-export const getLastSwitchedOrgId = () => lastSwitchedOrgId;
+
+export const getLastSwitchedOrgId = (): string | null => {
+	try {
+		return localStorage.getItem(LAST_ORG_KEY);
+	} catch {
+		return null;
+	}
+};
 
 export const useOrg = (params?: { env?: AppEnv }) => {
 	const currentEnv = useEnv();
@@ -39,17 +49,30 @@ export const useOrg = (params?: { env?: AppEnv }) => {
 	});
 
 	useEffect(() => {
+		if (org?.id) {
+			setLastSwitchedOrgId(org.id);
+		}
+	}, [org?.id]);
+
+	useEffect(() => {
 		const handleNoActiveOrg = async () => {
-			if (orgList && orgList.length > 0) {
-				await authClient.organization.setActive({
-					organizationId: orgList[0].id,
-				});
-				window.location.reload();
-			} else {
+			if (!orgList || orgList.length === 0) {
 				console.log("No org to set active, signing out");
 				await authClient.signOut();
 				window.location.href = "/sign-in";
+				return;
 			}
+
+			const lastOrgId = getLastSwitchedOrgId();
+			const preferredOrg = lastOrgId
+				? orgList.find((o) => o.id === lastOrgId)
+				: null;
+			const targetOrgId = preferredOrg?.id ?? orgList[0].id;
+
+			await authClient.organization.setActive({
+				organizationId: targetOrgId,
+			});
+			window.location.reload();
 		};
 
 		if (!org && !isLoading) {


### PR DESCRIPTION
## Summary
- Customers with multiple orgs reported that opening the dashboard each day would reset them to the wrong org (and consequently the wrong environment), requiring manual org + env switching
- Root cause: when `GET /organization` fails transiently (e.g. during better-auth session refresh after `updateAge`), the `handleNoActiveOrg` fallback in `useOrg` would pick `orgList[0]` (arbitrary order) instead of the user's last-active org
- `setLastSwitchedOrgId` / `getLastSwitchedOrgId` now use `localStorage` instead of an in-memory variable that was lost on every page reload
- The active org ID is also saved to localStorage on every successful org fetch, keeping it always up to date
- The fallback now checks localStorage for the last-active org and verifies membership before falling back to `orgList[0]`

## Test plan
- [ ] Open dashboard, switch to a non-default org, close tab, reopen — should restore the same org
- [ ] Clear session (log out / clear cookies), log back in — fallback should prefer the localStorage org
- [ ] Remove user from the stored org externally, reload — should gracefully fall back to `orgList[0]`
- [ ] User with single org — behavior unchanged

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the user’s last active org and update the fallback in `useOrg` to restore it, preventing random org resets after reloads or transient `/organization` errors.

- **Bug Fixes**
  - Store last active org ID in `localStorage` under `autumn_last_active_org_id` and update it on successful org fetch.
  - On missing active org, prefer the stored org if still a member; otherwise use the first org; sign out if none exist.
  - Eliminates daily dashboard resets caused by transient `GET /organization` failures.

<sup>Written for commit fcc56197a4ec5ba4edbeaa0a163729d5216b5efc. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1368?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the in-memory `lastSwitchedOrgId` variable with `localStorage` so the preferred org survives page reloads, and updates `handleNoActiveOrg` to restore the user's last-active org instead of always falling back to `orgList[0]`.

- **Bug fixes** — `setLastSwitchedOrgId`/`getLastSwitchedOrgId` now persist to `localStorage` so the last-active org is not lost on reload.
- **Bug fixes** — `handleNoActiveOrg` fallback now checks localStorage and verifies membership before defaulting to `orgList[0]`.
- **Improvements** — Active org ID is kept up-to-date in localStorage on every successful org fetch via a new `useEffect`.
</details>

<h3>Confidence Score: 3/5</h3>

The fix is directionally correct but has a P1 race condition where a still-loading orgList can trigger premature signout.

One P1 finding (orgList undefined race leading to incorrect signout) and one P2 (localStorage key not user-scoped) bring the score below the P1 ceiling of 4.

vite/src/hooks/common/useOrg.tsx — specifically the orgList undefined guard in handleNoActiveOrg

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/hooks/common/useOrg.tsx | Converts last-active org tracking from in-memory to localStorage and improves the `handleNoActiveOrg` fallback — P1 race: `orgList === undefined` (still loading) can trigger premature signout; P2: localStorage key is not scoped per user. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useOrg hook mounts] --> B[fetch GET /organization]
    B -->|success - org returned| C[org != null]
    C --> D[useEffect: save org.id to localStorage]
    B -->|failure / null returned| E[org == null & isLoading == false]
    E --> F{orgList defined and non-empty?}
    F -->|No / undefined| G[authClient.signOut redirect to /sign-in]
    F -->|Yes| H{lastOrgId in localStorage?}
    H -->|No| I[targetOrg = orgList0]
    H -->|Yes| J{orgList.find lastOrgId?}
    J -->|Found| K[targetOrg = preferredOrg]
    J -->|Not found - user removed| I
    K --> L[setActive targetOrg - window.location.reload]
    I --> L
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/hooks/common/useOrg.tsx
Line: 59-63

Comment:
**Premature signout when `orgList` is still loading**

`orgList` from `useListOrganizations()` is `undefined` while the list query is in flight. If the org query resolves to `null` (e.g., during the transient auth-session refresh this PR is fixing) *before* `orgList` resolves, `!orgList` is `true` and `handleNoActiveOrg` immediately calls `authClient.signOut()` and redirects to `/sign-in`, even though the user has valid orgs. This was true before, but this PR's fallback logic makes it the only path for a user with no `org` — so the race window is more consequential.

Guard the body of `handleNoActiveOrg` until `orgList` has actually loaded (i.e., is not `undefined`):

```
if (orgList === undefined) return; // still loading
if (orgList.length === 0) {
    console.log("No org to set active, signing out");
    await authClient.signOut();
    window.location.href = "/sign-in";
    return;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/hooks/common/useOrg.tsx
Line: 8-22

Comment:
**localStorage key is not scoped to the current user**

`autumn_last_active_org_id` is stored without any user identifier. On a shared browser, if user A logs out and user B logs in (or the same user shares a device with a colleague who also has an account), `getLastSwitchedOrgId()` will return user A's org ID. If user B happens to be a member of that org, `handleNoActiveOrg` will silently set it as the active org. The membership check prevents an unauthorized switch, but the silent preference is surprising.

Consider appending a hashed/truncated user ID to the key (e.g., `autumn_last_active_org_id_${userId}`) so the stored value is always user-scoped. Alternatively, clear the key on `authClient.signOut()`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Persist last-active org in localStorage ..."](https://github.com/useautumn/autumn/commit/fcc56197a4ec5ba4edbeaa0a163729d5216b5efc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29853126)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->