### PR TITLE
chore: remove added invoice call in attach

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 	"scripts": {
 		"dev": "bun scripts/dev.ts",
 		"vite:build": "bun -F @autumn/vite build:bun",
-		"t": "infisical run --env=dev --recursive -- bun scripts/testScripts/testDispatcher.ts",
+		"t": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/testScripts/testDispatcher.ts",
 		"cm": "cd server && bun cm",
 		"d": "lsof -ti:8080 -ti:3000 | xargs kill -9 2>/dev/null || true; ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dev.ts",
 		"d:prod": "lsof -ti:8080 -ti:3000 | xargs kill -9 2>/dev/null || true; ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dev.ts --production",

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -119,7 +119,7 @@ export const createInvoiceForBilling = async ({
 
 	return payStripeInvoice({
 		stripeCli,
-		invoiceId: finalizedInvoice.id,
+		invoice: finalizedInvoice,
 		paymentMethod: billingContext.paymentMethod,
 	});
 };

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts
@@ -18,7 +18,7 @@ export type PayInvoiceResult = {
 
 type PayStripeInvoiceParams = {
 	stripeCli: Stripe;
-	invoiceId: string;
+	invoice: Stripe.Invoice;
 	paymentMethod?: Stripe.PaymentMethod | null;
 };
 
@@ -28,13 +28,10 @@ type PayStripeInvoiceParams = {
 
 export const payStripeInvoice = async ({
 	stripeCli,
-	invoiceId,
+	invoice,
 	paymentMethod,
 }: PayStripeInvoiceParams): Promise<PayInvoiceResult> => {
-	// 1. Retrieve invoice to check status
-	const invoice = await stripeCli.invoices.retrieve(invoiceId);
-
-	// 2. Already paid - return success
+	// 1. Already paid - return success
 	if (invoice.status === "paid") {
 		return {
 			paid: true,
@@ -42,7 +39,7 @@ export const payStripeInvoice = async ({
 		};
 	}
 
-	// 3. No payment method - return failure
+	// 2. No payment method - return failure
 	if (!paymentMethod) {
 		return handleInvoicePaymentFailure({
 			invoice,
@@ -50,9 +47,9 @@ export const payStripeInvoice = async ({
 		});
 	}
 
-	// 4. Attempt payment
+	// 3. Attempt payment
 	const { data: paidInvoice, error } = await tryCatch(
-		stripeCli.invoices.pay(invoiceId, {
+		stripeCli.invoices.pay(invoice.id, {
 			payment_method: paymentMethod.id,
 		}),
 	);

--- a/server/tests/unit/billing/payStripeInvoice.test.ts
+++ b/server/tests/unit/billing/payStripeInvoice.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { payStripeInvoice } from "@/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice";
+
+describe("payStripeInvoice", () => {
+	test("pays the provided invoice without retrieving it first", async () => {
+		const invoice = { id: "in_123", status: "open" };
+		const paymentMethod = { id: "pm_123" };
+		let retrieveCalls = 0;
+		let payCalls = 0;
+
+		const result = await payStripeInvoice({
+			stripeCli: {
+				invoices: {
+					retrieve: async () => {
+						retrieveCalls += 1;
+						throw new Error("invoice retrieve should not be called");
+					},
+					pay: async (invoiceId: string, params: { payment_method: string }) => {
+						payCalls += 1;
+						expect(invoiceId).toBe(invoice.id);
+						expect(params.payment_method).toBe(paymentMethod.id);
+						return { id: invoice.id, status: "paid" };
+					},
+				},
+			} as never,
+			invoice: invoice as never,
+			paymentMethod: paymentMethod as never,
+		});
+
+		expect(result.paid).toBe(true);
+		expect(result.invoice.id).toBe("in_123");
+		expect(result.invoice.status).toBe("paid");
+		expect(retrieveCalls).toBe(0);
+		expect(payCalls).toBe(1);
+	});
+});

--- a/server/tests/unit/redis/redis-v2-config.spec.ts
+++ b/server/tests/unit/redis/redis-v2-config.spec.ts
@@ -6,32 +6,17 @@ import {
 } from "@/external/redis/initUtils/redisV2Config.js";
 
 describe("redis V2 connection config", () => {
-	test("uses a distinct Upstash CACHE_V2_UPSTASH_URL with the Upstash shebang", () => {
+	test("uses a distinct CACHE_V2_UPSTASH_URL with the Upstash shebang", () => {
 		expect(
 			getRedisV2ConnectionConfig({
-				cacheV2Url: " rediss://example.upstash.io:6379 ",
+				cacheV2Url: " redis://v2 ",
 				primaryCacheUrl: "redis://primary",
 				currentRegion: "us-west-2",
 			}),
 		).toEqual({
-			cacheUrl: "rediss://example.upstash.io:6379",
+			cacheUrl: "redis://v2",
 			region: "us-west-2:v2",
 			supportsUpstashShebang: true,
-			commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
-		});
-	});
-
-	test("does not use the Upstash shebang for local CACHE_V2_UPSTASH_URL overrides", () => {
-		expect(
-			getRedisV2ConnectionConfig({
-				cacheV2Url: " redis://localhost:6379/1 ",
-				primaryCacheUrl: "redis://localhost:6379",
-				currentRegion: "us-west-2",
-			}),
-		).toEqual({
-			cacheUrl: "redis://localhost:6379/1",
-			region: "us-west-2:v2",
-			supportsUpstashShebang: false,
 			commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
 		});
 	});

--- a/server/tests/unit/redis/redis-v2-config.spec.ts
+++ b/server/tests/unit/redis/redis-v2-config.spec.ts
@@ -6,17 +6,32 @@ import {
 } from "@/external/redis/initUtils/redisV2Config.js";
 
 describe("redis V2 connection config", () => {
-	test("uses a distinct CACHE_V2_UPSTASH_URL with the Upstash shebang", () => {
+	test("uses a distinct Upstash CACHE_V2_UPSTASH_URL with the Upstash shebang", () => {
 		expect(
 			getRedisV2ConnectionConfig({
-				cacheV2Url: " redis://v2 ",
+				cacheV2Url: " rediss://example.upstash.io:6379 ",
 				primaryCacheUrl: "redis://primary",
 				currentRegion: "us-west-2",
 			}),
 		).toEqual({
-			cacheUrl: "redis://v2",
+			cacheUrl: "rediss://example.upstash.io:6379",
 			region: "us-west-2:v2",
 			supportsUpstashShebang: true,
+			commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
+		});
+	});
+
+	test("does not use the Upstash shebang for local CACHE_V2_UPSTASH_URL overrides", () => {
+		expect(
+			getRedisV2ConnectionConfig({
+				cacheV2Url: " redis://localhost:6379/1 ",
+				primaryCacheUrl: "redis://localhost:6379",
+				currentRegion: "us-west-2",
+			}),
+		).toEqual({
+			cacheUrl: "redis://localhost:6379/1",
+			region: "us-west-2:v2",
+			supportsUpstashShebang: false,
 			commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
 		});
 	});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the extra Stripe invoice retrieval in the attach flow by paying the finalized invoice directly. This cuts one Stripe API call and reduces rate-limit usage.

- **Refactors**
  - `payStripeInvoice` now takes an `invoice` object and skips `invoices.retrieve`.
  - `createInvoiceForBilling` passes the finalized invoice to `payStripeInvoice`.
  - Added a unit test verifying no retrieval and that `pay` is called once.
  - Updated the `t` script in `package.json` to load `.env`.

<sup>Written for commit 294d71f39bae57ecfbc3f82a8d896bb8a81d9b6d. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1375?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes a redundant `stripeCli.invoices.retrieve()` call from `payStripeInvoice` by accepting a full `Stripe.Invoice` object instead of an `invoiceId` string, since callers already hold the invoice. It also ships a unit test for this refactor and hardens the Redis V2 config test suite.

- **Bug fixes / Improvements**: `payStripeInvoice` now accepts `invoice: Stripe.Invoice` directly, eliminating one extra Stripe API round-trip per billing attach flow.
- **Improvements**: `payStripeInvoice.test.ts` added to assert `retrieve` is never called and `pay` is invoked with the correct arguments.
- **Improvements**: Redis V2 config test updated to use a realistic `rediss://` Upstash URL, and a new case added for local Redis — but the corresponding implementation change in `getRedisV2ConnectionConfig` is missing, so that new test will fail.
</details>

<h3>Confidence Score: 3/5</h3>

The billing refactor is clean and safe, but a new Redis config test asserts behavior the implementation doesn't support and will fail.

The core change (removing the redundant retrieve call) is correct and well-tested. However, the new redis-v2-config.spec.ts test case expects supportsUpstashShebang: false for a local Redis URL while getRedisV2ConnectionConfig unconditionally returns true, making that test a guaranteed failure. A failing test is a P1 defect.

server/tests/unit/redis/redis-v2-config.spec.ts and server/src/external/redis/initUtils/redisV2Config.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts | Refactored to accept a full `Stripe.Invoice` object instead of `invoiceId`, eliminating the redundant `invoices.retrieve()` API call. |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts | Updated the `payStripeInvoice` call site to pass the already-available `finalizedInvoice` object directly instead of its id. |
| server/tests/unit/billing/payStripeInvoice.test.ts | New unit test verifying that `retrieve` is never called and `pay` is called exactly once with the correct arguments. |
| server/tests/unit/redis/redis-v2-config.spec.ts | Adds a new test case expecting `supportsUpstashShebang: false` for local Redis URLs, but the implementation always returns `true`; this test will fail. |
| package.json | Adds `ENV_FILE=.env` to the `t` test script to match the pattern of other scripts. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as createInvoiceForBilling
    participant S as Stripe API
    participant P as payStripeInvoice

    C->>S: createStripeInvoice()
    S-->>C: draftInvoice
    C->>S: addStripeInvoiceLines()
    S-->>C: invoiceWithLines
    C->>S: finalizeStripeInvoice()
    S-->>C: finalizedInvoice

    Note over C,P: Before: passed invoiceId (string)
    Note over C,P: After: passes invoice object directly

    C->>P: payStripeInvoice({ invoice: finalizedInvoice })
    Note over P: No retrieve() call needed
    P->>S: invoices.pay(invoice.id)
    S-->>P: paidInvoice
    P-->>C: PayInvoiceResult
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/tests/unit/redis/redis-v2-config.spec.ts
Line: 20-35

Comment:
**New test will always fail**

The new test asserts `supportsUpstashShebang: false` for a local `redis://localhost` URL, but `getRedisV2ConnectionConfig` always calls `supportsUpstashShebangForRedisV2("upstash")` — which unconditionally returns `true` regardless of the URL. The implementation was never updated to inspect the URL, so this test will fail as written.

Either the implementation in `redisV2Config.ts` needs to be updated to return `false` when the URL is not an Upstash endpoint (e.g., not `rediss://` or not matching `upstash.io`), or this test is a placeholder for a future change that wasn't included here.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove added invoice call in atta..."](https://github.com/useautumn/autumn/commit/ddf2aca51b6f6a7ac81d6c7b38d483fbf5130df7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29871344)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->