### PR TITLE
[needs testing] fix: anchor billing cycle to stripe trial end on trial upgrade

### DIFF
--- a/server/src/internal/billing/v2/setup/setupBillingCycleAnchor.ts
+++ b/server/src/internal/billing/v2/setup/setupBillingCycleAnchor.ts
@@ -54,12 +54,15 @@ export const setupBillingCycleAnchor = ({
 		? secondsToMs(stripeSubscription?.trial_end)
 		: undefined;
 
-	const newIsTrialing =
-		(trialContext?.trialEndsAt && trialContext.trialEndsAt > currentEpochMs) ??
-		stripeTrialEndsAtMs;
+	// Prefer the new product's trial context when it has a future end,
+	// otherwise inherit the trialing Stripe subscription's trial_end.
+	const trialEndsAtMs =
+		trialContext?.trialEndsAt && trialContext.trialEndsAt > currentEpochMs
+			? trialContext.trialEndsAt
+			: stripeTrialEndsAtMs;
 
 	// Billing cycle anchor = trial ends at if exists
-	if (newIsTrialing) return trialContext?.trialEndsAt ?? "now";
+	if (trialEndsAtMs) return trialEndsAtMs;
 
 	return secondsToMs(stripeSubscription?.billing_cycle_anchor) ?? "now";
 };

--- a/server/tests/unit/billing/setup-billing-cycle-anchor/setup-billing-cycle-anchor.spec.ts
+++ b/server/tests/unit/billing/setup-billing-cycle-anchor/setup-billing-cycle-anchor.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import type { TrialContext } from "@autumn/shared";
+import { prices } from "@tests/utils/fixtures/db/prices";
+import { products } from "@tests/utils/fixtures/db/products";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
+
+const NOW_MS = 1_700_000_000_000;
+const TRIAL_END_S = Math.floor(NOW_MS / 1000) + 7 * 24 * 60 * 60;
+const TRIAL_END_MS = TRIAL_END_S * 1000;
+const ANCHOR_S = Math.floor(NOW_MS / 1000) + 30 * 24 * 60 * 60;
+const ANCHOR_MS = ANCHOR_S * 1000;
+
+const paidProduct = products.createFull({
+	id: "pro",
+	prices: [prices.createFixed({ id: "price_pro" })],
+});
+
+const trialingSub = {
+	id: "sub_trialing",
+	status: "trialing",
+	trial_end: TRIAL_END_S,
+	billing_cycle_anchor: ANCHOR_S,
+} as Stripe.Subscription;
+
+const activeSub = {
+	id: "sub_active",
+	status: "active",
+	billing_cycle_anchor: ANCHOR_S,
+} as Stripe.Subscription;
+
+describe(chalk.yellowBright("setupBillingCycleAnchor"), () => {
+	test("respects explicit requestedBillingCycleAnchor", () => {
+		const result = setupBillingCycleAnchor({
+			newFullProduct: paidProduct,
+			currentEpochMs: NOW_MS,
+			requestedBillingCycleAnchor: 12345,
+		});
+		expect(result).toBe(12345);
+	});
+
+	test("returns trialContext.trialEndsAt when it's in the future", () => {
+		const trialContext: TrialContext = {
+			freeTrial: null,
+			trialEndsAt: TRIAL_END_MS,
+			appliesToBilling: true,
+			cardRequired: false,
+		};
+
+		const result = setupBillingCycleAnchor({
+			newFullProduct: paidProduct,
+			currentEpochMs: NOW_MS,
+			trialContext,
+		});
+		expect(result).toBe(TRIAL_END_MS);
+	});
+
+	test("inherits Stripe sub's trial_end when sub is trialing and no trialContext", () => {
+		const result = setupBillingCycleAnchor({
+			newFullProduct: paidProduct,
+			currentEpochMs: NOW_MS,
+			stripeSubscription: trialingSub,
+		});
+		expect(result).toBe(TRIAL_END_MS);
+	});
+
+	test("REGRESSION: inherits Stripe sub's trial_end when sub is trialing and trialContext.trialEndsAt is null (upgrade-while-trialing to product without its own trial)", () => {
+		// Repro of the blank-checkout bug for trial-upgrade-same-plan-group.
+		// applyProductTrialConfig returns {trialEndsAt: null, ...} when the
+		// new product has no free_trial config but the customer's current
+		// Stripe sub is already trialing. The anchor must still be inherited
+		// from the Stripe sub so billingPlanToNextCyclePreview can populate
+		// next_cycle (otherwise it returns next_cycle: undefined and the
+		// hosted checkout page renders without next-cycle data).
+		const trialContext: TrialContext = {
+			freeTrial: null,
+			trialEndsAt: null,
+			appliesToBilling: true,
+			cardRequired: false,
+		};
+
+		const result = setupBillingCycleAnchor({
+			newFullProduct: paidProduct,
+			currentEpochMs: NOW_MS,
+			stripeSubscription: trialingSub,
+			trialContext,
+		});
+
+		expect(result).not.toBe("now");
+		expect(result).toBe(TRIAL_END_MS);
+	});
+
+	test("REGRESSION: inherits Stripe sub's trial_end when sub is trialing and trialContext is undefined", () => {
+		const result = setupBillingCycleAnchor({
+			newFullProduct: paidProduct,
+			currentEpochMs: NOW_MS,
+			stripeSubscription: trialingSub,
+			trialContext: undefined,
+		});
+
+		expect(result).not.toBe("now");
+		expect(result).toBe(TRIAL_END_MS);
+	});
+
+	test("falls back to Stripe sub's billing_cycle_anchor when no trial info", () => {
+		const result = setupBillingCycleAnchor({
+			newFullProduct: paidProduct,
+			currentEpochMs: NOW_MS,
+			stripeSubscription: activeSub,
+		});
+		expect(result).toBe(ANCHOR_MS);
+	});
+
+	test("falls back to 'now' when nothing is configured", () => {
+		const result = setupBillingCycleAnchor({
+			newFullProduct: paidProduct,
+			currentEpochMs: NOW_MS,
+		});
+		expect(result).toBe("now");
+	});
+
+	test("prefers trialContext over Stripe trial when both have future ends", () => {
+		const trialContext: TrialContext = {
+			freeTrial: null,
+			trialEndsAt: TRIAL_END_MS + 1_000_000,
+			appliesToBilling: true,
+			cardRequired: false,
+		};
+
+		const result = setupBillingCycleAnchor({
+			newFullProduct: paidProduct,
+			currentEpochMs: NOW_MS,
+			stripeSubscription: trialingSub,
+			trialContext,
+		});
+		expect(result).toBe(TRIAL_END_MS + 1_000_000);
+	});
+});


### PR DESCRIPTION
## Summary

setupBillingCycleAnchor returned "now" when applyProductTrialConfig produced a trialContext with a null trialEndsAt while the customer's Stripe subscription was already trialing. The chained nullish-coalescing made the trialing branch fire but then returned trialContext?.trialEndsAt ?? "now", which short-circuited to "now" because trialEndsAt was null. That cascaded into billingPlanToNextCyclePreview returning next_cycle: undefined for customers upgrading within the same plan group while still on a Stripe trial, and the hosted Autumn checkout page rendered without next-cycle data. The fix replaces the chain with a ternary that prefers the new product's trial context end when it's in the future and falls back to the trialing Stripe sub's trial_end.

## Related Issues

None linked. Surfaced from a customer report of a blank hosted checkout page when upgrading from a trialing basic plan to a paid plan in the same plan group with redirect_mode set to always.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)

## Additional Context

The behavior change is isolated to the trial-upgrade path. Existing branches that already returned the right anchor (future trialContext.trialEndsAt, non-trialing sub with billing_cycle_anchor, free-to-free, one-off-to-one-off) are preserved. Coverage is in server/tests/unit/billing/setup-billing-cycle-anchor/setup-billing-cycle-anchor.spec.ts, including two explicit regression cases for trialContext.trialEndsAt = null and trialContext = undefined while the Stripe sub is trialing. The fix has not been exercised end-to-end against a live Stripe account or the hosted checkout app yet.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing cycle anchoring on trial upgrades by using the correct trial end date. Prevents missing next-cycle data and blank hosted checkout when upgrading during an existing `Stripe` trial.

- Bug Fixes
  - Prefer the new product’s trial end when it’s in the future; otherwise use the `Stripe` subscription `trial_end`.
  - Avoid returning "now" when `trialContext.trialEndsAt` is null but the subscription is still trialing.
  - Preserve existing non-trial behavior and explicit anchors; added unit tests, including regression cases.

<sup>Written for commit 6ed0bcfad0bc6e318ca92f497cd137109adc05e4. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1376?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

