### PR TITLE
fix(website): migrate blog from next-mdx-remote to @next/mdx

### DIFF
--- a/apps/website/app/blog/[slug]/page.tsx
+++ b/apps/website/app/blog/[slug]/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { MDXRemote } from "next-mdx-remote/rsc";
 import { mdxComponents } from "@/components/blogComponents";
 import { getAllPosts, getPostBySlug } from "@/lib/blogUtils";
 import type { BlogParams } from "@/lib/types";
@@ -45,10 +44,22 @@ function formatDate(dateString: string | null) {
 	});
 }
 
+async function loadMdxContent({ slug }: { slug: string }) {
+	try {
+		const mod = await import(`@/content/blog/${slug}.mdx`);
+		return mod.default as React.ComponentType<{ components?: Record<string, React.ComponentType> }>;
+	} catch {
+		return null;
+	}
+}
+
 export default async function BlogPostPage({ params }: { params: BlogParams }) {
 	const { slug } = await params;
 	const post = getPostBySlug({ slug });
 	if (!post) notFound();
+
+	const Content = await loadMdxContent({ slug });
+	if (!Content) notFound();
 
 	return (
 		<div className="py-16 md:py-24 bg-[#0F0F0F]">
@@ -109,7 +120,7 @@ export default async function BlogPostPage({ params }: { params: BlogParams }) {
 				<hr className="border-[#292929] mb-12" />
 
 				<article className="prose prose-invert prose-lg max-w-none">
-					<MDXRemote source={post.source} components={mdxComponents} />
+					<Content components={mdxComponents} />
 				</article>
 			</div>
 		</div>

--- a/apps/website/mdx-components.tsx
+++ b/apps/website/mdx-components.tsx
@@ -1,0 +1,6 @@
+import type { MDXComponents } from "mdx/types";
+import { mdxComponents } from "@/components/blogComponents";
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+	return { ...mdxComponents, ...components };
+}

--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -1,5 +1,10 @@
+import createMDX from "@next/mdx";
+
+const isProd = process.env.NODE_ENV === "production";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  pageExtensions: ["ts", "tsx", "md", "mdx"],
   allowedDevOrigins: ["*.ngrok-free.dev"],
   experimental: {
     optimizePackageImports: ["framer-motion", "motion", "gsap", "@gsap/react"],
@@ -11,10 +16,9 @@ const nextConfig = {
    // formats: ["image/avif", "image/webp"],
   },
   async headers() {
+    if (!isProd) return [];
+
     return [
-      // Next.js chunks include a content hash in their filename, so they are
-      // safe to cache indefinitely. Vercel sets this automatically on its CDN,
-      // but the explicit header also covers self-hosted deployments.
       {
         source: "/_next/static/(.*)",
         headers: [
@@ -24,8 +28,6 @@ const nextConfig = {
           },
         ],
       },
-      // Lottie JSON files are large (1.4–2.6 MB each) and change infrequently.
-      // A 1-year cache means repeat visitors skip the expensive re-download.
       {
         source: "/animation/(.*)",
         headers: [
@@ -35,8 +37,6 @@ const nextConfig = {
           },
         ],
       },
-      // Public images: 7-day TTL with a 1-day stale-while-revalidate window
-      // so content updates eventually propagate without blocking visitors.
       {
         source: "/images/(.*)",
         headers: [
@@ -76,4 +76,10 @@ const nextConfig = {
   },
 };
 
-export default nextConfig;
+const withMDX = createMDX({
+  options: {
+    remarkPlugins: ["remark-frontmatter"],
+  },
+});
+
+export default withMDX(nextConfig);

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -10,6 +10,11 @@
 	},
 	"dependencies": {
 		"@gsap/react": "^2.1.2",
+		"@mdx-js/loader": "^3.1.1",
+		"@mdx-js/mdx": "^3.1.1",
+		"@mdx-js/react": "^3.1.1",
+		"@next/mdx": "^16.2.4",
+		"@types/react": "^19.2.14",
 		"@vercel/analytics": "^2.0.1",
 		"framer-motion": "^12.38.0",
 		"gray-matter": "^4.0.3",
@@ -19,12 +24,11 @@
 		"matter-js": "^0.20.0",
 		"motion": "^12.38.0",
 		"next": "16.2.4",
-		"next-mdx-remote": "^6.0.0",
 		"ngrok": "^5.0.0-beta.2",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
 		"react-syntax-highlighter": "^16.1.1",
-		"@types/react": "^19.2.14"
+		"remark-frontmatter": "^5.0.0"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -107,6 +107,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@gsap/react": "^2.1.2",
+        "@mdx-js/loader": "^3.1.1",
+        "@mdx-js/mdx": "^3.1.1",
+        "@mdx-js/react": "^3.1.1",
+        "@next/mdx": "^16.2.4",
         "@types/react": "^19.2.14",
         "@vercel/analytics": "^2.0.1",
         "framer-motion": "^12.38.0",
@@ -117,11 +121,11 @@
         "matter-js": "^0.20.0",
         "motion": "^12.38.0",
         "next": "16.2.4",
-        "next-mdx-remote": "^6.0.0",
         "ngrok": "^5.0.0-beta.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-syntax-highlighter": "^16.1.1",
+        "remark-frontmatter": "^5.0.0",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
@@ -1248,6 +1252,8 @@
 
     "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
 
+    "@mdx-js/loader": ["@mdx-js/loader@3.1.1", "", { "dependencies": { "@mdx-js/mdx": "^3.0.0", "source-map": "^0.7.0" }, "peerDependencies": { "webpack": ">=5" }, "optionalPeers": ["webpack"] }, "sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ=="],
+
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
@@ -1303,6 +1309,8 @@
     "@next/env": ["@next/env@16.2.4", "", {}, "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.1", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA=="],
+
+    "@next/mdx": ["@next/mdx@16.2.4", "", { "dependencies": { "source-map": "^0.7.0" }, "peerDependencies": { "@mdx-js/loader": ">=0.15.0", "@mdx-js/react": ">=0.15.0" }, "optionalPeers": ["@mdx-js/loader", "@mdx-js/react"] }, "sha512-e/3bgla+/oF3vDlndI0eFPa0bnP47HPVA0InsAJi7Jr3DwV8WpEGuOcm/3PdI5/93FfNiBhMVeVHZpm1sFlmJw=="],
 
     "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A=="],
 
@@ -4369,8 +4377,6 @@
     "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
 
     "next": ["next@16.2.4", "", { "dependencies": { "@next/env": "16.2.4", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.4", "@next/swc-darwin-x64": "16.2.4", "@next/swc-linux-arm64-gnu": "16.2.4", "@next/swc-linux-arm64-musl": "16.2.4", "@next/swc-linux-x64-gnu": "16.2.4", "@next/swc-linux-x64-musl": "16.2.4", "@next/swc-win32-arm64-msvc": "16.2.4", "@next/swc-win32-x64-msvc": "16.2.4", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q=="],
-
-    "next-mdx-remote": ["next-mdx-remote@6.0.0", "", { "dependencies": { "@babel/code-frame": "^7.23.5", "@mdx-js/mdx": "^3.0.1", "@mdx-js/react": "^3.0.1", "unist-util-remove": "^4.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.1", "vfile-matter": "^5.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ=="],
 
     "next-mdx-remote-client": ["next-mdx-remote-client@1.1.7", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@mdx-js/mdx": "^3.1.1", "@mdx-js/react": "^3.1.1", "remark-mdx-remove-esm": "^1.3.1", "serialize-error": "^13.0.1", "vfile": "^6.0.3", "vfile-matter": "^5.0.1" }, "peerDependencies": { "react": ">= 18.3.0 < 19.0.0", "react-dom": ">= 18.3.0 < 19.0.0" } }, "sha512-12Ap5Z/tFIETMXFSBTH2IFEhJAso7MvOJ5ICyesA4q6FM4vtAcmb+4ZKa4tV1IVQJLBVqOhaEfIESZzdwjmrQQ=="],
 


### PR DESCRIPTION
## Summary
Cherry-pick of #1377 onto main.

- Replaced `next-mdx-remote` with `@next/mdx` + `@mdx-js/mdx` + `@mdx-js/loader` — MDX is now compiled through Next.js's bundler pipeline, fixing the "older React element" build error caused by React version mismatch between `next-mdx-remote`'s runtime eval and Next.js 16's internal React canary.
- Blog posts are loaded via dynamic `import()` instead of `MDXRemote` with raw source strings.
- Added `remark-frontmatter` so the MDX compiler skips YAML frontmatter blocks.
- Gated cache/CSP headers to production only — the `immutable` Cache-Control on `/_next/static` was poisoning dev browser cache.

## Test plan
- [ ] `bun run build` passes in `apps/website/`
- [ ] Blog posts render correctly at `/blog/<slug>`
- [ ] Blog listing page still works

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate blog MDX from `next-mdx-remote` to `@next/mdx`, compiling through Next.js and rendering via dynamic imports. This fixes the React version mismatch build error and prevents dev cache issues by gating cache/CSP headers to production.

- **Refactors**
  - Replace `next-mdx-remote` with `@next/mdx` + `@mdx-js/mdx` + `@mdx-js/loader`; enable `md/mdx` in `pageExtensions`; add `useMDXComponents`.
  - Load blog posts with dynamic `import()` and render the MDX default export instead of `MDXRemote`.
  - Configure MDX with `remark-frontmatter` to ignore YAML frontmatter.

- **Bug Fixes**
  - Resolve build failures by compiling MDX via Next’s bundler pipeline.
  - Limit cache/CSP headers to production to avoid dev “immutable” cache poisoning.

<sup>Written for commit 3fed1a27df72d5e3171c6fec7349fa126a0ff2da. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates the blog rendering pipeline from `next-mdx-remote` (runtime eval) to `@next/mdx` (bundler-time compilation), fixing a React version mismatch build error with Next.js 16. It also gates cache/CSP response headers to production only to prevent dev browser cache poisoning.

- **Bug fix**: Replace `next-mdx-remote` runtime eval with `@next/mdx` bundler compilation to fix React "older element" error on Next.js 16. _(Bug fixes)_
- **Bug fix**: Gate `immutable` Cache-Control and CSP headers to `NODE_ENV === "production"` to stop dev cache poisoning. _(Bug fixes)_
- **Improvement**: Blog content loaded via static `import()` instead of raw string + `MDXRemote`; `mdx-components.tsx` added as required by `@next/mdx`. _(Improvements)_
</details>


<h3>Confidence Score: 3/5</h3>

Not safe to merge until the `remark-frontmatter` plugin is imported correctly — without it, YAML frontmatter in every blog post will cause build failures or broken renders.

One P1 finding: `remarkPlugins` receives a string `"remark-frontmatter"` instead of an imported function, meaning the plugin never runs and MDX compilation of all blog posts is likely broken. The P2 slug-path mismatch is latent but not currently triggered by any existing content.

`apps/website/next.config.mjs` — the `remarkPlugins` string argument needs to be replaced with an imported function reference before the build will work correctly.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/website/next.config.mjs | Adds `@next/mdx` integration and gates cache/CSP headers to production — but `remarkPlugins` is passed a string instead of an imported function, which will break frontmatter stripping at build time. |
| apps/website/app/blog/[slug]/page.tsx | Replaces `MDXRemote` with a dynamic `import()` of the compiled MDX module; import path is constructed from URL slug, which diverges from frontmatter-based slug resolution in `blogUtils`. |
| apps/website/mdx-components.tsx | New `useMDXComponents` hook required by `@next/mdx`; delegates to existing `mdxComponents` map correctly. |
| apps/website/package.json | Removes `next-mdx-remote`, adds `@next/mdx`, `@mdx-js/loader`, `@mdx-js/mdx`, `@mdx-js/react`, and `remark-frontmatter` — dependency set looks correct for the new setup. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant Next.js
    participant blogUtils
    participant MDXModule

    Browser->>Next.js: GET /blog/:slug
    Next.js->>blogUtils: getPostBySlug({ slug })
    blogUtils-->>Next.js: BlogPost (metadata, resolved via frontmatter slug or filename)
    Next.js->>MDXModule: import(`@/content/blog/${slug}.mdx`)
    MDXModule-->>Next.js: React component (compiled by @next/mdx bundler)
    Next.js-->>Browser: Rendered blog post HTML
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/website/lib/blogUtils.ts`, line 16-18 ([link](https://github.com/useautumn/autumn/blob/3fed1a27df72d5e3171c6fec7349fa126a0ff2da/apps/website/lib/blogUtils.ts#L16-L18)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`source` field on `BlogPost` is now dead code**

   `BlogPost` still declares and populates `source: string` (the raw content after frontmatter is stripped), but the `MDXRemote` call that consumed it was removed in `page.tsx`. The field is no longer read anywhere. Consider removing `source` from the type and the `getPostBySlug` return value to avoid confusion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/website/lib/blogUtils.ts
   Line: 16-18

   Comment:
   **`source` field on `BlogPost` is now dead code**

   `BlogPost` still declares and populates `source: string` (the raw content after frontmatter is stripped), but the `MDXRemote` call that consumed it was removed in `page.tsx`. The field is no longer read anywhere. Consider removing `source` from the type and the `getPostBySlug` return value to avoid confusion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/website/next.config.mjs
Line: 79-83

Comment:
**`remark-frontmatter` passed as a string, not a plugin function**

`@mdx-js/mdx` (used internally by `@next/mdx`) expects `remarkPlugins` to be a `PluggableList` — an array of plugin *functions* (or `[plugin, options]` tuples), not strings. Passing `"remark-frontmatter"` as a string is not a valid `Pluggable` value and will either throw at build time or silently do nothing. Without the plugin actually running, YAML frontmatter blocks in the `.mdx` files will be interpreted as MDX content, likely causing compilation errors or broken renders for every blog post.

```
import remarkFrontmatter from "remark-frontmatter";
// ...
remarkPlugins: [remarkFrontmatter],
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/website/app/blog/[slug]/page.tsx
Line: 47-54

Comment:
**Dynamic import path assumes filename equals slug**

`loadMdxContent` builds the import path as `@/content/blog/${slug}.mdx`, where `slug` comes from the URL. However, `getPostBySlug` resolves slugs from frontmatter `data.slug` first (`data.slug || filename.replace(/\.mdx$/, "")`). If a post ever has a frontmatter `slug` that differs from its filename, `getPostBySlug` will find the post metadata, but `loadMdxContent` will fail to import and fall through to `notFound()`. The two lookups should be keyed on the same value — consider storing the canonical filename alongside the slug.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/website/lib/blogUtils.ts
Line: 16-18

Comment:
**`source` field on `BlogPost` is now dead code**

`BlogPost` still declares and populates `source: string` (the raw content after frontmatter is stripped), but the `MDXRemote` call that consumed it was removed in `page.tsx`. The field is no longer read anywhere. Consider removing `source` from the type and the `getPostBySlug` return value to avoid confusion.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(website): migrate blog from next-mdx..."](https://github.com/useautumn/autumn/commit/3fed1a27df72d5e3171c6fec7349fa126a0ff2da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29875531)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->