### PR TITLE
feat(vite): extract shared EntityScopeSelector for track/check/attach sheets

### DIFF
--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -2,7 +2,6 @@ import type { Entity, FullCustomer } from "@autumn/shared";
 import { PlusIcon } from "@phosphor-icons/react";
 import type { AxiosError } from "axios";
 import { format } from "date-fns";
-import { CheckIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
@@ -26,7 +25,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/v2/buttons/Button";
 import { InlinePlanEditor } from "@/components/v2/inline-custom-plan-editor/InlinePlanEditor";
 import { LineItemsPreview } from "@/components/v2/LineItemsPreview";
-import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
 import {
 	LayoutGroup,
 	SheetFooter,
@@ -42,6 +40,7 @@ import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerContext } from "@/views/customers2/customer/CustomerContext";
 import { CreateEntity } from "@/views/customers2/customer/components/CreateEntity";
 import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
+import { EntityScopeSelector } from "./EntityScopeSelector";
 
 function ReviewPreviewSkeleton() {
 	return (
@@ -219,16 +218,6 @@ function SelectContent() {
 
 	const [createEntityOpen, setCreateEntityOpen] = useState(false);
 
-	const CUSTOMER_LEVEL_VALUE = "";
-	type EntityOption = Entity | null;
-	const entityOptions: EntityOption[] = [null, ...entities];
-
-	const getEntityOptionValue = (option: EntityOption) =>
-		option === null ? CUSTOMER_LEVEL_VALUE : option.id || option.internal_id;
-
-	const getEntityOptionLabel = (option: EntityOption) =>
-		option === null ? "Customer-level" : option.name || option.id || "PENDING";
-
 	return (
 		<>
 			<SheetHeader
@@ -241,77 +230,27 @@ function SelectContent() {
 					<AttachProductSelection />
 
 					{entities.length > 0 && (
-						<div>
-							<div className="text-form-label block mb-1">Select scope</div>
-							<SearchableSelect<EntityOption>
-								value={entityId ?? CUSTOMER_LEVEL_VALUE}
-								onValueChange={(value) =>
-									onScopeChange?.(
-										value === CUSTOMER_LEVEL_VALUE ? undefined : value,
-									)
-								}
-								options={entityOptions}
-								getOptionValue={getEntityOptionValue}
-								getOptionLabel={getEntityOptionLabel}
-								placeholder="Select entity"
-								searchable
-								searchPlaceholder="Search entities..."
-								emptyText="No entities found"
-								triggerClassName="w-full"
-								renderValue={(option) =>
-									option === null || option === undefined ? (
-										<span className="text-t2">Customer-level</span>
-									) : (
-										<span className="text-t2 truncate">
-											{option.name || option.id || "PENDING"}
-										</span>
-									)
-								}
-								renderOption={(option, isSelected) => {
-									if (option === null) {
-										return (
-											<>
-												<span className="text-sm">Customer-level</span>
-												{isSelected && (
-													<CheckIcon className="size-4 shrink-0" />
-												)}
-											</>
-										);
-									}
-									const entityLabel = option.id || "PENDING";
-									return (
-										<>
-											<div className="flex gap-2 items-center min-w-0 flex-1">
-												{option.name && (
-													<span className="text-sm shrink-0">
-														{option.name}
-													</span>
-												)}
-												<span className="truncate text-t3 font-mono text-xs min-w-0">
-													{entityLabel}
-												</span>
-											</div>
-											{isSelected && <CheckIcon className="size-4 shrink-0" />}
-										</>
-									);
-								}}
-								footer={
-									<div className="border-t py-1.5 px-2">
-										<Button
-											variant="muted"
-											className="w-full"
-											onClick={() => setCreateEntityOpen(true)}
-										>
-											<PlusIcon
-												className="size-[14px] text-t2"
-												weight="regular"
-											/>
-											Create new entity
-										</Button>
-									</div>
-								}
-							/>
-						</div>
+						<EntityScopeSelector
+							entities={entities}
+							scopeEntityId={entityId ?? undefined}
+							onScopeChange={(value) => onScopeChange?.(value)}
+							wrapInSection={false}
+							footer={
+								<div className="border-t py-1.5 px-2">
+									<Button
+										variant="muted"
+										className="w-full"
+										onClick={() => setCreateEntityOpen(true)}
+									>
+										<PlusIcon
+											className="size-[14px] text-t2"
+											weight="regular"
+										/>
+										Create new entity
+									</Button>
+								</div>
+							}
+						/>
 					)}
 
 					{entityId ? (

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -1,3 +1,4 @@
+import type { Entity, FullCustomer } from "@autumn/shared";
 import { LATEST_VERSION } from "@autumn/shared";
 import { Spinner } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
@@ -14,30 +15,39 @@ import {
 } from "@/components/v2/sheets/SharedSheetComponents";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useSheetScopeEntityId } from "@/hooks/useSheetScopeEntityId";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { useCustomerContext } from "../../customer/CustomerContext";
+import { EntityScopeSelector } from "./EntityScopeSelector";
 
 export function CheckBalanceSheet() {
 	const sheetData = useSheetStore((s) => s.data);
 	const { customer } = useCusQuery();
-	const { entityId } = useCustomerContext();
+	const [scopeEntityId, setScopeEntityId] = useSheetScopeEntityId(
+		customer as FullCustomer | undefined,
+	);
 	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
 	const buildKey = useQueryKeyFactory();
+
+	const fullCustomer = customer as FullCustomer | null;
+	const entities = fullCustomer?.entities || [];
+	const fullEntity = entities.find(
+		(e: Entity) => e.id === scopeEntityId || e.internal_id === scopeEntityId,
+	);
 
 	const featureId = sheetData?.featureId as string | undefined;
 	const featureName = sheetData?.featureName as string | undefined;
 	const customerId = customer?.id || customer?.internal_id;
 
 	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["check-balance", customerId, featureId, entityId]),
+		queryKey: buildKey(["check-balance", customerId, featureId, scopeEntityId]),
 		queryFn: async () => {
 			const params: Record<string, unknown> = {
 				customer_id: customerId,
 				feature_id: featureId,
 			};
-			if (entityId) params.entity_id = entityId;
+			if (scopeEntityId) params.entity_id = scopeEntityId;
 
 			const { data } = await axiosInstance.post("/v1/check", params);
 			return data;
@@ -54,8 +64,20 @@ export function CheckBalanceSheet() {
 			<div className="flex h-full flex-col overflow-hidden">
 				<SheetHeader
 					title="Check Balance"
-					description={`POST /check for ${featureName ?? featureId}`}
+					description={
+						scopeEntityId
+							? `Tracking for entity ${fullEntity?.name || scopeEntityId}`
+							: `POST /check for ${featureName ?? featureId}`
+					}
 				/>
+
+				{entities.length > 0 && (
+					<EntityScopeSelector
+						entities={entities}
+						scopeEntityId={scopeEntityId}
+						onScopeChange={setScopeEntityId}
+					/>
+				)}
 
 				<div className="flex-1 overflow-hidden flex flex-col px-4 pb-4">
 					{isLoading && (

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -65,10 +65,11 @@ export function CheckBalanceSheet() {
 				<SheetHeader
 					title="Check Balance"
 					description={
+					description={
 						scopeEntityId
-							? `Tracking for entity ${fullEntity?.name || scopeEntityId}`
+							? `Checking balance for entity ${fullEntity?.name || scopeEntityId}`
 							: `POST /check for ${featureName ?? featureId}`
-					}
+						}
 				/>
 
 				{entities.length > 0 && (

--- a/vite/src/views/customers2/components/sheets/EntityScopeSelector.tsx
+++ b/vite/src/views/customers2/components/sheets/EntityScopeSelector.tsx
@@ -1,0 +1,91 @@
+import type { Entity } from "@autumn/shared";
+import { CheckIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
+import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
+
+const CUSTOMER_LEVEL_VALUE = "";
+
+type EntityOption = Entity | null;
+
+export function EntityScopeSelector({
+	entities,
+	scopeEntityId,
+	onScopeChange,
+	footer,
+	withSeparator = true,
+	wrapInSection = true,
+}: {
+	entities: Entity[];
+	scopeEntityId: string | undefined;
+	onScopeChange: (entityId: string | undefined) => void;
+	footer?: ReactNode;
+	withSeparator?: boolean;
+	wrapInSection?: boolean;
+}) {
+	const entityOptions: EntityOption[] = [null, ...entities];
+
+	const getEntityOptionValue = (option: EntityOption) =>
+		option === null ? CUSTOMER_LEVEL_VALUE : option.id || option.internal_id;
+
+	const getEntityOptionLabel = (option: EntityOption) =>
+		option === null ? "Customer-level" : option.name || option.id || "PENDING";
+
+	const select = (
+		<div>
+			<div className="text-form-label block mb-1">Select scope</div>
+			<SearchableSelect<EntityOption>
+				value={scopeEntityId ?? CUSTOMER_LEVEL_VALUE}
+				onValueChange={(value) =>
+					onScopeChange(value === CUSTOMER_LEVEL_VALUE ? undefined : value)
+				}
+				options={entityOptions}
+				getOptionValue={getEntityOptionValue}
+				getOptionLabel={getEntityOptionLabel}
+				placeholder="Select entity"
+				searchable
+				searchPlaceholder="Search entities..."
+				emptyText="No entities found"
+				triggerClassName="w-full"
+				renderValue={(option) =>
+					option === null || option === undefined ? (
+						<span className="text-t2">Customer-level</span>
+					) : (
+						<span className="text-t2 truncate">
+							{option.name || option.id || "PENDING"}
+						</span>
+					)
+				}
+				renderOption={(option, isSelected) => {
+					if (option === null) {
+						return (
+							<>
+								<span className="text-sm">Customer-level</span>
+								{isSelected && <CheckIcon className="size-4 shrink-0" />}
+							</>
+						);
+					}
+					const entityLabel = option.id || "PENDING";
+					return (
+						<>
+							<div className="flex gap-2 items-center min-w-0 flex-1">
+								{option.name && (
+									<span className="text-sm shrink-0">{option.name}</span>
+								)}
+								<span className="truncate text-t3 font-mono text-xs min-w-0">
+									{entityLabel}
+								</span>
+							</div>
+							{isSelected && <CheckIcon className="size-4 shrink-0" />}
+						</>
+					);
+				}}
+				footer={footer}
+			/>
+		</div>
+	);
+
+	if (!wrapInSection) return select;
+
+	return <SheetSection withSeparator={withSeparator}>{select}</SheetSection>;
+}

--- a/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
@@ -1,3 +1,4 @@
+import type { Entity, FullCustomer } from "@autumn/shared";
 import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -12,18 +13,27 @@ import {
 	SheetSection,
 } from "@/components/v2/sheets/SharedSheetComponents";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useSheetScopeEntityId } from "@/hooks/useSheetScopeEntityId";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { useCustomerContext } from "../../customer/CustomerContext";
+import { EntityScopeSelector } from "./EntityScopeSelector";
 
 export function RecordUsageSheet() {
 	const closeSheet = useSheetStore((s) => s.closeSheet);
 	const sheetData = useSheetStore((s) => s.data);
 	const { customer } = useCusQuery();
-	const { entityId } = useCustomerContext();
+	const [scopeEntityId, setScopeEntityId] = useSheetScopeEntityId(
+		customer as FullCustomer | undefined,
+	);
 	const axiosInstance = useAxiosInstance();
 	const queryClient = useQueryClient();
+
+	const fullCustomer = customer as FullCustomer | null;
+	const entities = fullCustomer?.entities || [];
+	const fullEntity = entities.find(
+		(e: Entity) => e.id === scopeEntityId || e.internal_id === scopeEntityId,
+	);
 
 	const featureId = sheetData?.featureId as string | undefined;
 	const featureName = sheetData?.featureName as string | undefined;
@@ -82,7 +92,7 @@ export function RecordUsageSheet() {
 			value: parsedValue,
 		};
 
-		if (entityId) params.entity_id = entityId;
+		if (scopeEntityId) params.entity_id = scopeEntityId;
 
 		const filteredProperties = properties.filter((p) => p.key.trim());
 		if (filteredProperties.length > 0) {
@@ -113,8 +123,20 @@ export function RecordUsageSheet() {
 			<div className="flex h-full flex-col overflow-y-auto">
 				<SheetHeader
 					title="Record Usage"
-					description={`Record usage for ${featureName ?? featureId}`}
+					description={
+						scopeEntityId
+							? `Tracking for entity ${fullEntity?.name || scopeEntityId}`
+							: `Record usage for ${featureName ?? featureId}`
+					}
 				/>
+
+				{entities.length > 0 && (
+					<EntityScopeSelector
+						entities={entities}
+						scopeEntityId={scopeEntityId}
+						onScopeChange={setScopeEntityId}
+					/>
+				)}
 
 				<SheetSection withSeparator>
 					<FormLabel>Value</FormLabel>


### PR DESCRIPTION
## Summary
- Extract duplicated entity scope dropdown into a shared `EntityScopeSelector` component
- Add entity scope selector to `RecordUsageSheet` and `CheckBalanceSheet` (previously only in attach)
- Update description text to show "Tracking for entity {name}" when an entity is selected
- DRY up ~90 lines of repeated selector code from `AttachProductSheet`

## Test plan
- [ ] Open customer page with entities, open Record Usage sheet — verify scope selector appears and entity_id is sent in track call
- [ ] Open customer page with entities, open Check Balance sheet — verify scope selector appears and entity_id is sent in check call
- [ ] Open Attach Product sheet — verify scope selector still works with "Create new entity" footer
- [ ] Open any sheet on a customer without entities — verify no scope selector is shown

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared EntityScopeSelector and added entity scoping to Record Usage, Check Balance, and Attach Product sheets. This removes duplicate code and ensures `entity_id` is sent for scoped actions.

- **New Features**
  - Shared EntityScopeSelector used across all three sheets; Attach Product includes a “Create new entity” footer; selector hides if the customer has no entities.
  - Selecting an entity scopes API calls and query keys with `entity_id`; Record Usage header shows “Tracking for entity {name}”.
  - Added `useSheetScopeEntityId` to manage per-sheet scope.

- **Bug Fixes**
  - Check Balance header now reads “Checking balance for entity {name}” instead of “Tracking for entity …”.

<sup>Written for commit eb497e87e57a0a7047e0093e7c45d2a7081a7ae1. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1380?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts a shared `EntityScopeSelector` component from `AttachProductSheet` and adds entity-scope selection to `RecordUsageSheet` and `CheckBalanceSheet`, backed by a new `useSheetScopeEntityId` hook that seeds the initial scope from the URL param or a smart plan-based default.

**Key changes:**
- [Improvements] New `EntityScopeSelector` component DRYs up ~90 lines of repeated selector code across all three sheets.
- [Improvements] `RecordUsageSheet` and `CheckBalanceSheet` now expose entity-scope selection and forward `entity_id` in API calls.
- [Bug fixes] `CheckBalanceSheet` description copy reads `\"Tracking for entity …\"` instead of `\"Checking balance for entity …\"` — it reuses the wording from `RecordUsageSheet` where it is correct.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; the only functional concerns are a misleading description string and an edge-case initialization gap in the new hook.

All findings are P2. The extraction is clean and the API call paths (track/check with entity_id) are correct. The 'Tracking for entity' copy bug in CheckBalanceSheet is user-facing but not a data-correctness issue. The useState-initialization gap in useSheetScopeEntityId is a real edge case but unlikely in practice since the customer page pre-loads the data.

vite/src/hooks/useSheetScopeEntityId.ts — smart-default initialization is fragile if customer data isn't cached at sheet mount time.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/EntityScopeSelector.tsx | New shared component extracted from AttachProductSheet — clean extraction with configurable `wrapInSection`/`withSeparator`/`footer` props; logic is faithful to the original. |
| vite/src/hooks/useSheetScopeEntityId.ts | New hook seeds scope from URL param or smart plan default, but `useState` captures the initial value only once — smart default is silently skipped if `customer` is still loading on mount. |
| vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx | Adopts `useSheetScopeEntityId` and `EntityScopeSelector`; query key now includes scope so balance re-fetches on entity change. Description copy says "Tracking for entity" when it should say "Checking balance for entity". |
| vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx | Adopts `useSheetScopeEntityId` and `EntityScopeSelector`; `entity_id` is correctly forwarded to the track call; description copy is semantically correct. |
| vite/src/views/customers2/components/sheets/AttachProductSheet.tsx | ~70 lines of inline selector replaced by `EntityScopeSelector` with `wrapInSection={false}` and a custom "Create new entity" footer; behavior is preserved. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Sheet
    participant useSheetScopeEntityId
    participant EntityScopeSelector
    participant API

    User->>Sheet: Open sheet (Record/Check/Attach)
    Sheet->>useSheetScopeEntityId: init(customer)
    useSheetScopeEntityId-->>Sheet: scopeEntityId (URL param OR smart default)
    Sheet->>EntityScopeSelector: render(entities, scopeEntityId)
    User->>EntityScopeSelector: Select entity
    EntityScopeSelector->>Sheet: onScopeChange(entityId)
    Sheet->>Sheet: Update scopeEntityId state
    Sheet->>API: POST /track or /check with entity_id
    API-->>Sheet: Response
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/hooks/useSheetScopeEntityId.ts`, line 31-33 ([link](https://github.com/useautumn/autumn/blob/47bb196eed51947c2bc4406506978b59b393e884/vite/src/hooks/useSheetScopeEntityId.ts#L31-L33)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Smart default silently skipped when customer loads asynchronously**

   `useState` captures its initial value only on the very first render. If `useCusQuery()` hasn't resolved by the time the sheet mounts (cache miss, direct URL navigation, post-invalidation re-open), `customer` is `undefined`, `pickDefaultScopeEntityId` returns `undefined`, and the smart entity default is never applied — even after the data arrives.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/hooks/useSheetScopeEntityId.ts
   Line: 31-33

   Comment:
   **Smart default silently skipped when customer loads asynchronously**

   `useState` captures its initial value only on the very first render. If `useCusQuery()` hasn't resolved by the time the sheet mounts (cache miss, direct URL navigation, post-invalidation re-open), `customer` is `undefined`, `pickDefaultScopeEntityId` returns `undefined`, and the smart entity default is never applied — even after the data arrives.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
Line: 68-71

Comment:
**Misleading copy in Check Balance description**

The description says `"Tracking for entity …"` but this sheet performs a `/check` call, not a track. The same `"Tracking for entity"` wording is reused from `RecordUsageSheet` where it is correct, but here it misrepresents the action to the user.

```suggestion
					description={
						scopeEntityId
							? `Checking balance for entity ${fullEntity?.name || scopeEntityId}`
							: `POST /check for ${featureName ?? featureId}`
						}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/hooks/useSheetScopeEntityId.ts
Line: 31-33

Comment:
**Smart default silently skipped when customer loads asynchronously**

`useState` captures its initial value only on the very first render. If `useCusQuery()` hasn't resolved by the time the sheet mounts (cache miss, direct URL navigation, post-invalidation re-open), `customer` is `undefined`, `pickDefaultScopeEntityId` returns `undefined`, and the smart entity default is never applied — even after the data arrives.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
Line: 33-37

Comment:
**Duplicated entity-lookup block across sheets**

The same three lines (`fullCustomer`, `entities`, `fullEntity`) appear verbatim in both `RecordUsageSheet` and `CheckBalanceSheet`. Extracting them into `useSheetScopeEntityId` (or a small `useSheetEntities` helper) would keep the sheets thinner and make any future type-assertion changes a single-file edit.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(vite): extract shared EntityScopeSe..."](https://github.com/useautumn/autumn/commit/47bb196eed51947c2bc4406506978b59b393e884) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29888513)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->