### PR TITLE
feat(vite): extract shared EntityScopeSelector for track/check/attach sheets

### DIFF
--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -2,7 +2,6 @@ import type { Entity, FullCustomer } from "@autumn/shared";
 import { PlusIcon } from "@phosphor-icons/react";
 import type { AxiosError } from "axios";
 import { format } from "date-fns";
-import { CheckIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
@@ -26,7 +25,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/v2/buttons/Button";
 import { InlinePlanEditor } from "@/components/v2/inline-custom-plan-editor/InlinePlanEditor";
 import { LineItemsPreview } from "@/components/v2/LineItemsPreview";
-import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
 import {
 	LayoutGroup,
 	SheetFooter,
@@ -42,6 +40,7 @@ import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerContext } from "@/views/customers2/customer/CustomerContext";
 import { CreateEntity } from "@/views/customers2/customer/components/CreateEntity";
 import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
+import { EntityScopeSelector } from "./EntityScopeSelector";
 
 function ReviewPreviewSkeleton() {
 	return (
@@ -219,16 +218,6 @@ function SelectContent() {
 
 	const [createEntityOpen, setCreateEntityOpen] = useState(false);
 
-	const CUSTOMER_LEVEL_VALUE = "";
-	type EntityOption = Entity | null;
-	const entityOptions: EntityOption[] = [null, ...entities];
-
-	const getEntityOptionValue = (option: EntityOption) =>
-		option === null ? CUSTOMER_LEVEL_VALUE : option.id || option.internal_id;
-
-	const getEntityOptionLabel = (option: EntityOption) =>
-		option === null ? "Customer-level" : option.name || option.id || "PENDING";
-
 	return (
 		<>
 			<SheetHeader
@@ -241,77 +230,27 @@ function SelectContent() {
 					<AttachProductSelection />
 
 					{entities.length > 0 && (
-						<div>
-							<div className="text-form-label block mb-1">Select scope</div>
-							<SearchableSelect<EntityOption>
-								value={entityId ?? CUSTOMER_LEVEL_VALUE}
-								onValueChange={(value) =>
-									onScopeChange?.(
-										value === CUSTOMER_LEVEL_VALUE ? undefined : value,
-									)
-								}
-								options={entityOptions}
-								getOptionValue={getEntityOptionValue}
-								getOptionLabel={getEntityOptionLabel}
-								placeholder="Select entity"
-								searchable
-								searchPlaceholder="Search entities..."
-								emptyText="No entities found"
-								triggerClassName="w-full"
-								renderValue={(option) =>
-									option === null || option === undefined ? (
-										<span className="text-t2">Customer-level</span>
-									) : (
-										<span className="text-t2 truncate">
-											{option.name || option.id || "PENDING"}
-										</span>
-									)
-								}
-								renderOption={(option, isSelected) => {
-									if (option === null) {
-										return (
-											<>
-												<span className="text-sm">Customer-level</span>
-												{isSelected && (
-													<CheckIcon className="size-4 shrink-0" />
-												)}
-											</>
-										);
-									}
-									const entityLabel = option.id || "PENDING";
-									return (
-										<>
-											<div className="flex gap-2 items-center min-w-0 flex-1">
-												{option.name && (
-													<span className="text-sm shrink-0">
-														{option.name}
-													</span>
-												)}
-												<span className="truncate text-t3 font-mono text-xs min-w-0">
-													{entityLabel}
-												</span>
-											</div>
-											{isSelected && <CheckIcon className="size-4 shrink-0" />}
-										</>
-									);
-								}}
-								footer={
-									<div className="border-t py-1.5 px-2">
-										<Button
-											variant="muted"
-											className="w-full"
-											onClick={() => setCreateEntityOpen(true)}
-										>
-											<PlusIcon
-												className="size-[14px] text-t2"
-												weight="regular"
-											/>
-											Create new entity
-										</Button>
-									</div>
-								}
-							/>
-						</div>
+						<EntityScopeSelector
+							entities={entities}
+							scopeEntityId={entityId ?? undefined}
+							onScopeChange={(value) => onScopeChange?.(value)}
+							wrapInSection={false}
+							footer={
+								<div className="border-t py-1.5 px-2">
+									<Button
+										variant="muted"
+										className="w-full"
+										onClick={() => setCreateEntityOpen(true)}
+									>
+										<PlusIcon
+											className="size-[14px] text-t2"
+											weight="regular"
+										/>
+										Create new entity
+									</Button>
+								</div>
+							}
+						/>
 					)}
 
 					{entityId ? (

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -1,3 +1,4 @@
+import type { Entity, FullCustomer } from "@autumn/shared";
 import { LATEST_VERSION } from "@autumn/shared";
 import { Spinner } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
@@ -14,30 +15,39 @@ import {
 } from "@/components/v2/sheets/SharedSheetComponents";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useSheetScopeEntityId } from "@/hooks/useSheetScopeEntityId";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { useCustomerContext } from "../../customer/CustomerContext";
+import { EntityScopeSelector } from "./EntityScopeSelector";
 
 export function CheckBalanceSheet() {
 	const sheetData = useSheetStore((s) => s.data);
 	const { customer } = useCusQuery();
-	const { entityId } = useCustomerContext();
+	const [scopeEntityId, setScopeEntityId] = useSheetScopeEntityId(
+		customer as FullCustomer | undefined,
+	);
 	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
 	const buildKey = useQueryKeyFactory();
+
+	const fullCustomer = customer as FullCustomer | null;
+	const entities = fullCustomer?.entities || [];
+	const fullEntity = entities.find(
+		(e: Entity) => e.id === scopeEntityId || e.internal_id === scopeEntityId,
+	);
 
 	const featureId = sheetData?.featureId as string | undefined;
 	const featureName = sheetData?.featureName as string | undefined;
 	const customerId = customer?.id || customer?.internal_id;
 
 	const { data, isLoading, error } = useQuery({
-		queryKey: buildKey(["check-balance", customerId, featureId, entityId]),
+		queryKey: buildKey(["check-balance", customerId, featureId, scopeEntityId]),
 		queryFn: async () => {
 			const params: Record<string, unknown> = {
 				customer_id: customerId,
 				feature_id: featureId,
 			};
-			if (entityId) params.entity_id = entityId;
+			if (scopeEntityId) params.entity_id = scopeEntityId;
 
 			const { data } = await axiosInstance.post("/v1/check", params);
 			return data;
@@ -54,8 +64,20 @@ export function CheckBalanceSheet() {
 			<div className="flex h-full flex-col overflow-hidden">
 				<SheetHeader
 					title="Check Balance"
-					description={`POST /check for ${featureName ?? featureId}`}
+					description={
+						scopeEntityId
+							? `Tracking for entity ${fullEntity?.name || scopeEntityId}`
+							: `POST /check for ${featureName ?? featureId}`
+					}
 				/>
+
+				{entities.length > 0 && (
+					<EntityScopeSelector
+						entities={entities}
+						scopeEntityId={scopeEntityId}
+						onScopeChange={setScopeEntityId}
+					/>
+				)}
 
 				<div className="flex-1 overflow-hidden flex flex-col px-4 pb-4">
 					{isLoading && (

--- a/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
@@ -66,7 +66,7 @@ export function CheckBalanceSheet() {
 					title="Check Balance"
 					description={
 						scopeEntityId
-							? `Tracking for entity ${fullEntity?.name || scopeEntityId}`
+						? `Checking balance for entity ${fullEntity?.name || scopeEntityId}`
 							: `POST /check for ${featureName ?? featureId}`
 					}
 				/>

--- a/vite/src/views/customers2/components/sheets/EntityScopeSelector.tsx
+++ b/vite/src/views/customers2/components/sheets/EntityScopeSelector.tsx
@@ -1,0 +1,91 @@
+import type { Entity } from "@autumn/shared";
+import { CheckIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
+import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
+
+const CUSTOMER_LEVEL_VALUE = "";
+
+type EntityOption = Entity | null;
+
+export function EntityScopeSelector({
+	entities,
+	scopeEntityId,
+	onScopeChange,
+	footer,
+	withSeparator = true,
+	wrapInSection = true,
+}: {
+	entities: Entity[];
+	scopeEntityId: string | undefined;
+	onScopeChange: (entityId: string | undefined) => void;
+	footer?: ReactNode;
+	withSeparator?: boolean;
+	wrapInSection?: boolean;
+}) {
+	const entityOptions: EntityOption[] = [null, ...entities];
+
+	const getEntityOptionValue = (option: EntityOption) =>
+		option === null ? CUSTOMER_LEVEL_VALUE : option.id || option.internal_id;
+
+	const getEntityOptionLabel = (option: EntityOption) =>
+		option === null ? "Customer-level" : option.name || option.id || "PENDING";
+
+	const select = (
+		<div>
+			<div className="text-form-label block mb-1">Select scope</div>
+			<SearchableSelect<EntityOption>
+				value={scopeEntityId ?? CUSTOMER_LEVEL_VALUE}
+				onValueChange={(value) =>
+					onScopeChange(value === CUSTOMER_LEVEL_VALUE ? undefined : value)
+				}
+				options={entityOptions}
+				getOptionValue={getEntityOptionValue}
+				getOptionLabel={getEntityOptionLabel}
+				placeholder="Select entity"
+				searchable
+				searchPlaceholder="Search entities..."
+				emptyText="No entities found"
+				triggerClassName="w-full"
+				renderValue={(option) =>
+					option === null || option === undefined ? (
+						<span className="text-t2">Customer-level</span>
+					) : (
+						<span className="text-t2 truncate">
+							{option.name || option.id || "PENDING"}
+						</span>
+					)
+				}
+				renderOption={(option, isSelected) => {
+					if (option === null) {
+						return (
+							<>
+								<span className="text-sm">Customer-level</span>
+								{isSelected && <CheckIcon className="size-4 shrink-0" />}
+							</>
+						);
+					}
+					const entityLabel = option.id || "PENDING";
+					return (
+						<>
+							<div className="flex gap-2 items-center min-w-0 flex-1">
+								{option.name && (
+									<span className="text-sm shrink-0">{option.name}</span>
+								)}
+								<span className="truncate text-t3 font-mono text-xs min-w-0">
+									{entityLabel}
+								</span>
+							</div>
+							{isSelected && <CheckIcon className="size-4 shrink-0" />}
+						</>
+					);
+				}}
+				footer={footer}
+			/>
+		</div>
+	);
+
+	if (!wrapInSection) return select;
+
+	return <SheetSection withSeparator={withSeparator}>{select}</SheetSection>;
+}

--- a/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
@@ -1,3 +1,4 @@
+import type { Entity, FullCustomer } from "@autumn/shared";
 import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -12,18 +13,27 @@ import {
 	SheetSection,
 } from "@/components/v2/sheets/SharedSheetComponents";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useSheetScopeEntityId } from "@/hooks/useSheetScopeEntityId";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { useCustomerContext } from "../../customer/CustomerContext";
+import { EntityScopeSelector } from "./EntityScopeSelector";
 
 export function RecordUsageSheet() {
 	const closeSheet = useSheetStore((s) => s.closeSheet);
 	const sheetData = useSheetStore((s) => s.data);
 	const { customer } = useCusQuery();
-	const { entityId } = useCustomerContext();
+	const [scopeEntityId, setScopeEntityId] = useSheetScopeEntityId(
+		customer as FullCustomer | undefined,
+	);
 	const axiosInstance = useAxiosInstance();
 	const queryClient = useQueryClient();
+
+	const fullCustomer = customer as FullCustomer | null;
+	const entities = fullCustomer?.entities || [];
+	const fullEntity = entities.find(
+		(e: Entity) => e.id === scopeEntityId || e.internal_id === scopeEntityId,
+	);
 
 	const featureId = sheetData?.featureId as string | undefined;
 	const featureName = sheetData?.featureName as string | undefined;
@@ -82,7 +92,7 @@ export function RecordUsageSheet() {
 			value: parsedValue,
 		};
 
-		if (entityId) params.entity_id = entityId;
+		if (scopeEntityId) params.entity_id = scopeEntityId;
 
 		const filteredProperties = properties.filter((p) => p.key.trim());
 		if (filteredProperties.length > 0) {
@@ -113,8 +123,20 @@ export function RecordUsageSheet() {
 			<div className="flex h-full flex-col overflow-y-auto">
 				<SheetHeader
 					title="Record Usage"
-					description={`Record usage for ${featureName ?? featureId}`}
+					description={
+						scopeEntityId
+							? `Tracking for entity ${fullEntity?.name || scopeEntityId}`
+							: `Record usage for ${featureName ?? featureId}`
+					}
 				/>
+
+				{entities.length > 0 && (
+					<EntityScopeSelector
+						entities={entities}
+						scopeEntityId={scopeEntityId}
+						onScopeChange={setScopeEntityId}
+					/>
+				)}
 
 				<SheetSection withSeparator>
 					<FormLabel>Value</FormLabel>


### PR DESCRIPTION
## Summary
Cherry-pick of #1380 onto main.

- Extract duplicated entity scope dropdown into a shared `EntityScopeSelector` component
- Add entity scope selector to `RecordUsageSheet` and `CheckBalanceSheet` (previously only in attach)
- Update description text to show "Tracking for entity {name}" when an entity is selected
- DRY up ~90 lines of repeated selector code from `AttachProductSheet`

## Test plan
- [ ] Open customer page with entities, open Record Usage sheet — verify scope selector appears and entity_id is sent in track call
- [ ] Open customer page with entities, open Check Balance sheet — verify scope selector appears and entity_id is sent in check call
- [ ] Open Attach Product sheet — verify scope selector still works with "Create new entity" footer
- [ ] Open any sheet on a customer without entities — verify no scope selector is shown

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared entity scope dropdown and wired it into Record Usage and Check Balance for per-entity actions, while cleaning up the Attach Product sheet and fixing Check Balance copy.

- **New Features**
  - Entity scope selector shows only when the customer has entities; headers read “Tracking for entity {name}” in Record Usage and “Checking balance for entity {name}” in Check Balance.
  - Selected `entity_id` is sent in `/track` and `/check` requests.

- **Refactors**
  - Moved duplicated selector logic into `EntityScopeSelector`, preserving the “Create new entity” footer and removing ~80+ lines from `AttachProductSheet`.
  - Switched Record Usage and Check Balance to `useSheetScopeEntityId` for sheet-local scope.

<sup>Written for commit e41a2aae7a1d5f1932142c34dbbfd180acc24602. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1381?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts a shared `EntityScopeSelector` component from `AttachProductSheet` and adds it to `RecordUsageSheet` and `CheckBalanceSheet`, eliminating ~90 lines of duplicated selector code. Both new sheets switch from reading a global `entityId` via `useCustomerContext` to sheet-local state managed by `useSheetScopeEntityId`.

**Key changes:**
- [Improvements] Extract `EntityScopeSelector` as a reusable component with `wrapInSection`/`footer` props
- [Improvements] Add entity scope selector to `RecordUsageSheet` and `CheckBalanceSheet`
- [Bug fixes] `CheckBalanceSheet` description reads `\"Tracking for entity …\"` — \"Tracking\" describes a `/track` call and is misleading here; it should say `\"Checking balance for entity …\"`
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with a minor copy fix in CheckBalanceSheet.

Only P2 findings present; the refactor is clean and the shared component faithfully replicates the original logic. The one copy issue is cosmetic and does not affect functionality.

vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx — incorrect description copy on line 69.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/EntityScopeSelector.tsx | New shared component extracted from AttachProductSheet; faithfully preserves the original rendering logic with a clean wrapInSection/footer API. |
| vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx | Adds entity scope selector and switches from CustomerContext to useSheetScopeEntityId; description text reads 'Tracking for entity' which is wrong for a check-balance action. |
| vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx | Adds entity scope selector and migrates to useSheetScopeEntityId; description text and entity_id forwarding look correct. |
| vite/src/views/customers2/components/sheets/AttachProductSheet.tsx | Replaces ~60 lines of inline selector code with EntityScopeSelector; retains the 'Create new entity' footer correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Sheet as RecordUsage / CheckBalance Sheet
    participant ESS as EntityScopeSelector
    participant Hook as useSheetScopeEntityId
    participant API as Backend API

    User->>Sheet: Open sheet
    Sheet->>Hook: initialise(customer)
    Hook-->>Sheet: scopeEntityId (URL param or smart default)
    Sheet->>ESS: render(entities, scopeEntityId)
    User->>ESS: Select entity
    ESS-->>Sheet: onScopeChange(entityId)
    Sheet->>Sheet: setScopeEntityId(entityId)
    User->>Sheet: Submit
    Sheet->>API: POST /v1/track or /v1/check (with entity_id if set)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/CheckBalanceSheet.tsx
Line: 69

Comment:
**Misleading description copy for Check Balance**

The description `"Tracking for entity …"` was copied from `RecordUsageSheet` but doesn't reflect what this sheet does. "Tracking" implies recording usage (a `/track` call), while `CheckBalanceSheet` posts to `/v1/check`. A user opening this sheet would see a description that describes the wrong action.

```suggestion
						? `Checking balance for entity ${fullEntity?.name || scopeEntityId}`
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(vite): extract shared EntityScopeSe..."](https://github.com/useautumn/autumn/commit/21e09aac2fb922136966e3180e8ceec8e9aecd27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29888569)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->