### PR TITLE
chore: fix checkout ref issue

### DIFF
--- a/apps/checkout/vite.config.ts
+++ b/apps/checkout/vite.config.ts
@@ -7,9 +7,25 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
 	plugins: [react(), tsconfigPaths(), tailwindcss()],
 	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "./src"),
-		},
+		dedupe: ["react", "react-dom"],
+		alias: [
+			{ find: "@", replacement: path.resolve(__dirname, "./src") },
+			{
+				find: /^react$/,
+				replacement: path.resolve(__dirname, "./node_modules/react"),
+			},
+			{
+				find: /^react-dom$/,
+				replacement: path.resolve(__dirname, "./node_modules/react-dom"),
+			},
+			{
+				find: /^react\/jsx-runtime$/,
+				replacement: path.resolve(
+					__dirname,
+					"./node_modules/react/jsx-runtime.js",
+				),
+			},
+		],
 	},
 	optimizeDeps: {
 		exclude: ["@autumn/shared", "zod/v4"],

--- a/apps/checkout/vite.config.ts
+++ b/apps/checkout/vite.config.ts
@@ -1,8 +1,11 @@
+import { createRequire } from "node:module";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+
+const require = createRequire(import.meta.url);
 
 export default defineConfig({
 	plugins: [react(), tsconfigPaths(), tailwindcss()],
@@ -12,18 +15,23 @@ export default defineConfig({
 			{ find: "@", replacement: path.resolve(__dirname, "./src") },
 			{
 				find: /^react$/,
-				replacement: path.resolve(__dirname, "./node_modules/react"),
+				replacement: require.resolve("react"),
 			},
 			{
 				find: /^react-dom$/,
-				replacement: path.resolve(__dirname, "./node_modules/react-dom"),
+				replacement: require.resolve("react-dom"),
+			},
+			{
+				find: /^react-dom\/client$/,
+				replacement: require.resolve("react-dom/client"),
 			},
 			{
 				find: /^react\/jsx-runtime$/,
-				replacement: path.resolve(
-					__dirname,
-					"./node_modules/react/jsx-runtime.js",
-				),
+				replacement: require.resolve("react/jsx-runtime"),
+			},
+			{
+				find: /^react\/jsx-dev-runtime$/,
+				replacement: require.resolve("react/jsx-dev-runtime"),
 			},
 		],
 	},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ref errors in Checkout by enforcing a single `react`/`react-dom` instance via Vite dedupe and Node-resolved aliases. This stabilizes refs and prevents runtime mismatches.

- **Bug Fixes**
  - Add `resolve.dedupe` for `react` and `react-dom`.
  - Use `require.resolve` aliases for `react`, `react-dom`, `react-dom/client`, `react/jsx-runtime`, and `react/jsx-dev-runtime`.
  - Keep `@` alias to `./src` using array `alias` format.

<sup>Written for commit ee95d27044831672e0b9ad0ed971b021e07a1446. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1383?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a duplicate React instance issue in the checkout app by adding `resolve.dedupe` for `react` and `react-dom` and pinning explicit `alias` entries that point to the local `node_modules` copies.

**Key changes:**
- [Bug fixes] Added `resolve.dedupe: ["react", "react-dom"]` and explicit regex-based aliases to enforce a single React copy in the checkout Vite bundle.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the `dedupe` option is the correct primary fix and the aliases are belt-and-suspenders.

Only P2 findings present — the hardcoded `./node_modules/react` paths may silently no-op in a hoisted monorepo, but the `dedupe` option alone is sufficient protection and the change has no production logic impact.

apps/checkout/vite.config.ts — verify React is present in the local node_modules or remove the redundant path aliases.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/checkout/vite.config.ts | Adds `resolve.dedupe` for React/React-DOM and explicit local `node_modules` aliases to fix duplicate-React issues; hardcoded paths may not resolve if packages are hoisted to the workspace root. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Vite resolves import] --> B{Is it react / react-dom / react-jsx-runtime?}
    B -- Yes --> C[resolve.dedupe checks for existing instance]
    C --> D{Already deduped?}
    D -- Yes --> E[Return cached single instance]
    D -- No --> F[Apply alias to ./node_modules/react or react-dom]
    F --> G[Load from apps/checkout/node_modules]
    B -- No --> H[Normal Vite resolution]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/checkout/vite.config.ts
Line: 14-27

Comment:
**Hardcoded local `node_modules` paths may not resolve in the monorepo**

These aliases point to `./node_modules/react` relative to `apps/checkout/`. In a monorepo using pnpm/npm/yarn workspaces, React is often hoisted to the root `node_modules` and may not exist under the local `apps/checkout/node_modules/`. If that's the case, Vite silently falls back to its normal resolution, making these aliases ineffective — and the `dedupe` option alone is already the standard, more reliable fix for the duplicate-React problem. It may also be worth adding a `react-dom/client` alias for React 18's `createRoot` entry point.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix checkout ref issue"](https://github.com/useautumn/autumn/commit/da3395750c9d124535d3e0e9b62d2c80eca29083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29898549)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->