### PR TITLE
chore: fix checkout ref issue

### DIFF
--- a/apps/checkout/vite.config.ts
+++ b/apps/checkout/vite.config.ts
@@ -7,9 +7,25 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
 	plugins: [react(), tsconfigPaths(), tailwindcss()],
 	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "./src"),
-		},
+		dedupe: ["react", "react-dom"],
+		alias: [
+			{ find: "@", replacement: path.resolve(__dirname, "./src") },
+			{
+				find: /^react$/,
+				replacement: path.resolve(__dirname, "./node_modules/react"),
+			},
+			{
+				find: /^react-dom$/,
+				replacement: path.resolve(__dirname, "./node_modules/react-dom"),
+			},
+			{
+				find: /^react\/jsx-runtime$/,
+				replacement: path.resolve(
+					__dirname,
+					"./node_modules/react/jsx-runtime.js",
+				),
+			},
+		],
 	},
 	optimizeDeps: {
 		exclude: ["@autumn/shared", "zod/v4"],

--- a/apps/checkout/vite.config.ts
+++ b/apps/checkout/vite.config.ts
@@ -1,8 +1,11 @@
+import { createRequire } from "node:module";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+
+const require = createRequire(import.meta.url);
 
 export default defineConfig({
 	plugins: [react(), tsconfigPaths(), tailwindcss()],
@@ -12,18 +15,23 @@ export default defineConfig({
 			{ find: "@", replacement: path.resolve(__dirname, "./src") },
 			{
 				find: /^react$/,
-				replacement: path.resolve(__dirname, "./node_modules/react"),
+				replacement: require.resolve("react"),
 			},
 			{
 				find: /^react-dom$/,
-				replacement: path.resolve(__dirname, "./node_modules/react-dom"),
+				replacement: require.resolve("react-dom"),
+			},
+			{
+				find: /^react-dom\/client$/,
+				replacement: require.resolve("react-dom/client"),
 			},
 			{
 				find: /^react\/jsx-runtime$/,
-				replacement: path.resolve(
-					__dirname,
-					"./node_modules/react/jsx-runtime.js",
-				),
+				replacement: require.resolve("react/jsx-runtime"),
+			},
+			{
+				find: /^react\/jsx-dev-runtime$/,
+				replacement: require.resolve("react/jsx-dev-runtime"),
 			},
 		],
 	},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ref errors in Checkout by enforcing a single `react` instance across the monorepo. Uses Vite dedupe and dynamic alias resolution to prevent duplicate React and JSX runtimes.

- **Bug Fixes**
  - Added `resolve.dedupe` for `react` and `react-dom`.
  - Switched to `require.resolve`-based aliases and added entries for `react`, `react-dom`, `react-dom/client`, `react/jsx-runtime`, and `react/jsx-dev-runtime`; kept `@` → `./src`.

<sup>Written for commit 5696839fc00e67736a9069a8f36e2b64950e773f. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1384?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a React \"multiple instances\" issue in the `apps/checkout` Vite config, which was likely causing invalid hook call or ref errors when using shared packages. It adds `resolve.dedupe` for `react` and `react-dom`, and converts the `alias` field from an object to an array to support regex-based aliases that force all React imports to resolve to the same local copy.

**Key changes:**
- [Bug fixes] Added `resolve.dedupe: [\"react\", \"react-dom\"]` and explicit regex aliases for `react`, `react-dom`, and `react/jsx-runtime` to guarantee a single React instance across the monorepo checkout app.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — single config file change with a well-known Vite deduplication pattern; one minor fragility concern with hard-coded paths.

Only P2 findings; change is a targeted build config fix with no logic or security implications.

apps/checkout/vite.config.ts — verify local node_modules/react exists or switch to a path-safe resolution strategy.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/checkout/vite.config.ts | Adds resolve.dedupe for React and explicit node_modules aliases to prevent multiple React instance issues in the monorepo checkout app |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Import react or react-dom or react-jsx-runtime] --> B{Vite resolve.alias array}
    B -->|regex react| C["./node_modules/react"]
    B -->|regex react-dom| D["./node_modules/react-dom"]
    B -->|regex jsx-runtime| E["./node_modules/react/jsx-runtime.js"]
    B -->|string at-sign| F["./src/..."]
    C --> G["resolve.dedupe: single React instance"]
    D --> G
    E --> G
    G --> H[No duplicate React instance errors]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/checkout/vite.config.ts
Line: 14-27

Comment:
**Hard-coded local node_modules paths may break in hoisted monorepos**

These aliases resolve React packages to `./node_modules/react` (relative to `apps/checkout/`). In a monorepo where the package manager hoists React to the root `node_modules`, this local path won't exist, causing a build failure. The `resolve.dedupe` option added on line 10 is the idiomatic Vite solution for deduplication on its own — the explicit aliases are typically only needed when `dedupe` isn't sufficient. If you do keep the aliases, consider using `require.resolve` to locate the packages dynamically rather than hardcoding the path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix checkout ref issue"](https://github.com/useautumn/autumn/commit/dee15870477946090bfbcc24508a60ddc31f9366) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29898685)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->