### PR TITLE
fix: cus cache missing prices

### DIFF
--- a/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
@@ -12,6 +12,7 @@ import { FULL_SUBJECT_EPOCH_TTL_SECONDS } from "../config/fullSubjectCacheConfig
 import {
 	type CachedFullSubject,
 	cachedFullSubjectToNormalized,
+	FULL_SUBJECT_CACHE_SCHEMA_VERSION,
 } from "../fullSubjectCacheModel.js";
 import { sanitizeCachedFullSubject } from "../sanitize/index.js";
 import { invalidateCachedFullSubject } from "./invalidate/invalidateFullSubject.js";
@@ -114,6 +115,22 @@ export const getCachedFullSubject = async ({
 			customerId,
 			entityId,
 			source: "stale-subject-view-epoch",
+		});
+		return {
+			fullSubject: undefined,
+			subjectViewEpoch: currentSubjectViewEpoch,
+		};
+	}
+
+	if (cached._schemaVersion !== FULL_SUBJECT_CACHE_SCHEMA_VERSION) {
+		logger.warn(
+			`[getCachedFullSubject] Stale subject schema version for ${customerId}${entityId ? `:${entityId}` : ""}, cached=${cached._schemaVersion ?? "missing"}, current=${FULL_SUBJECT_CACHE_SCHEMA_VERSION}, source: ${source}`,
+		);
+		await invalidateCachedFullSubjectExact({
+			ctx,
+			customerId,
+			entityId,
+			source: "stale-subject-schema-version",
 		});
 		return {
 			fullSubject: undefined,

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
@@ -14,6 +14,7 @@ import { filterNormalizedFullSubjectByFeatureIds } from "../../filterFullSubject
 import {
 	type CachedFullSubject,
 	cachedFullSubjectToNormalized,
+	FULL_SUBJECT_CACHE_SCHEMA_VERSION,
 } from "../../fullSubjectCacheModel.js";
 import { sanitizeCachedFullSubject } from "../../sanitize/index.js";
 import { tryOrInvalidate } from "../../tryOrInvalidate.js";
@@ -135,6 +136,28 @@ export const getCachedPartialFullSubject = async ({
 		warnMessage: `[getCachedPartialFullSubject] Stale subject view epoch for ${subjectLabel}, cached=${cached.subjectViewEpoch}, current=${currentSubjectViewEpoch}, source: ${source}`,
 	});
 	if (epochOk === undefined) {
+		return {
+			fullSubject: undefined,
+			subjectViewEpoch: currentSubjectViewEpoch,
+		};
+	}
+
+	const schemaOk = await tryOrInvalidate({
+		ctx,
+		operation: () =>
+			cached._schemaVersion === FULL_SUBJECT_CACHE_SCHEMA_VERSION
+				? true
+				: undefined,
+		invalidate: () =>
+			invalidateCachedFullSubjectExact({
+				ctx,
+				customerId,
+				entityId,
+				source: "partial-stale-subject-schema-version",
+			}),
+		warnMessage: `[getCachedPartialFullSubject] Stale subject schema version for ${subjectLabel}, cached=${cached._schemaVersion ?? "missing"}, current=${FULL_SUBJECT_CACHE_SCHEMA_VERSION}, source=${source}`,
+	});
+	if (schemaOk === undefined) {
 		return {
 			fullSubject: undefined,
 			subjectViewEpoch: currentSubjectViewEpoch,

--- a/server/src/internal/customers/cache/fullSubject/fullSubjectCacheModel.ts
+++ b/server/src/internal/customers/cache/fullSubject/fullSubjectCacheModel.ts
@@ -1,6 +1,7 @@
 import {
 	CusProductSchema,
 	CustomerSchema,
+	CustomerPriceSchema,
 	EntitlementWithFeatureSchema,
 	EntityAggregationsSchema,
 	EntitySchema,
@@ -16,13 +17,16 @@ import { z } from "zod/v4";
 
 export type CachedFullSubject = Omit<
 	NormalizedFullSubject,
-	"customer_entitlements" | "customer_prices"
+	"customer_entitlements"
 > & {
+	_schemaVersion: number;
 	_cachedAt: number;
 	meteredFeatures: string[];
 	customerEntitlementIdsByFeatureId: Record<string, string[]>;
 	subjectViewEpoch: number;
 };
+
+export const FULL_SUBJECT_CACHE_SCHEMA_VERSION = 2;
 
 /**
  * Schema mirror of `CachedFullSubject` used by the cache-hole-filling walker
@@ -45,6 +49,7 @@ export const CachedFullSubjectSchema = z.object({
 	entity: EntitySchema.optional(),
 
 	customer_products: z.array(CusProductSchema),
+	customer_prices: z.array(CustomerPriceSchema),
 	flags: z.record(z.string(), SubjectFlagSchema),
 
 	products: z.array(ProductSchema),
@@ -57,6 +62,7 @@ export const CachedFullSubjectSchema = z.object({
 
 	entity_aggregations: EntityAggregationsSchema.optional(),
 
+	_schemaVersion: z.number().optional(),
 	_cachedAt: z.number(),
 	meteredFeatures: z.array(z.string()),
 	customerEntitlementIdsByFeatureId: z.record(z.string(), z.array(z.string())),
@@ -102,6 +108,7 @@ export const normalizedToCachedFullSubject = ({
 		customer: normalized.customer,
 		entity: normalized.entity,
 		customer_products: normalized.customer_products,
+		customer_prices: normalized.customer_prices,
 		flags: normalized.flags,
 		products: normalized.products,
 		entitlements: normalized.entitlements,
@@ -110,6 +117,7 @@ export const normalizedToCachedFullSubject = ({
 		subscriptions: normalized.subscriptions,
 		invoices: normalized.invoices,
 		entity_aggregations: normalized.entity_aggregations,
+		_schemaVersion: FULL_SUBJECT_CACHE_SCHEMA_VERSION,
 		_cachedAt: Date.now(),
 		meteredFeatures,
 		customerEntitlementIdsByFeatureId,
@@ -134,7 +142,7 @@ export const cachedFullSubjectToNormalized = ({
 		entity: cached.entity,
 		customer_products: cached.customer_products,
 		customer_entitlements: customerEntitlements,
-		customer_prices: [],
+		customer_prices: cached.customer_prices,
 		flags: cached.flags,
 		products: cached.products,
 		entitlements: cached.entitlements,

--- a/server/tests/integration/crud/customers/get-customer-cache-subscription.test.ts
+++ b/server/tests/integration/crud/customers/get-customer-cache-subscription.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	ApiCustomerV5Schema,
+} from "@shared/api/customers/apiCustomerV5";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(`${chalk.yellowBright("get-customer: cached recurring plan with one-off usage remains subscription")}`, async () => {
+	const customerId = "get-customer-mixed-recurring-oneoff-cache";
+	const oneOffUsageItem = items.oneOffMessages({
+		billingUnits: 100,
+		price: 10,
+	});
+	const hobby = products.pro({
+		id: "hobby",
+		items: [oneOffUsageItem],
+	});
+
+	const { autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [hobby] }),
+		],
+		actions: [s.billing.attach({ productId: hobby.id })],
+	});
+
+	await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+		keepInternalFields: true,
+	});
+	const cachedCustomer = await autumnV2_2.customers.get<ApiCustomerV5>(
+		customerId,
+		{
+			keepInternalFields: true,
+		},
+	);
+
+	ApiCustomerV5Schema.parse(cachedCustomer);
+	const subscription = cachedCustomer.subscriptions.find(
+		(subscription) => subscription.plan_id === hobby.id,
+	);
+
+	expect(subscription).toBeDefined();
+	expect(subscription!.current_period_start).toBeNumber();
+	expect(subscription!.current_period_end).toBeNumber();
+	expect(
+		cachedCustomer.purchases.find((purchase) => purchase.plan_id === hobby.id),
+	).toBeUndefined();
+
+	await expectStripeSubscriptionCorrect({ ctx, customerId });
+});

--- a/server/tests/unit/full-subject-cache/full-subject-cache-model.test.ts
+++ b/server/tests/unit/full-subject-cache/full-subject-cache-model.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
 	AppEnv,
+	BillingInterval,
+	isCustomerProductOneOff,
 	type NormalizedFullSubject,
+	normalizedToFullSubject,
+	PriceType,
 	SubjectType,
 } from "@autumn/shared";
 import {
 	cachedFullSubjectToNormalized,
+	FULL_SUBJECT_CACHE_SCHEMA_VERSION,
 	normalizedToCachedFullSubject,
 } from "@/internal/customers/cache/fullSubject/fullSubjectCacheModel.js";
 
@@ -105,6 +110,65 @@ const buildNormalized = (): NormalizedFullSubject =>
 		entity_aggregations: undefined,
 	}) as unknown as NormalizedFullSubject;
 
+const buildMixedIntervalNormalized = (): NormalizedFullSubject => {
+	const normalized = buildNormalized();
+	const [customerEntitlement] = normalized.customer_entitlements;
+	if (!customerEntitlement) throw new Error("expected test entitlement");
+	const fixedPrice = {
+		id: "price_fixed",
+		config: {
+			type: PriceType.Fixed,
+			amount: 19,
+			interval: BillingInterval.Month,
+		},
+	};
+	const usagePrice = {
+		id: "price_usage",
+		config: {
+			type: PriceType.Usage,
+			interval: BillingInterval.OneOff,
+			usage_tiers: [{ to: "inf", amount: 9 }],
+		},
+	};
+	const fixedCustomerPrice = {
+		id: "cus_price_fixed",
+		price_id: "price_fixed",
+		customer_product_id: "cp_1",
+	};
+	const usageCustomerPrice = {
+		id: "cus_price_usage",
+		price_id: "price_usage",
+		customer_product_id: "cp_1",
+	};
+
+	return {
+		...normalized,
+		customer_products: [
+			{
+				id: "cp_1",
+				internal_product_id: "prod_int_1",
+				free_trial_id: null,
+			},
+		],
+		customer_entitlements: [
+			{
+				...customerEntitlement,
+				customerPrice: { ...usageCustomerPrice, price: usagePrice },
+			},
+		],
+		customer_prices: [fixedCustomerPrice, usageCustomerPrice],
+		flags: {},
+		products: [
+			{
+				internal_id: "prod_int_1",
+				id: "prod_1",
+				is_add_on: false,
+			},
+		],
+		prices: [fixedPrice, usagePrice],
+	} as unknown as NormalizedFullSubject;
+};
+
 describe("fullSubject cache model", () => {
 	test("stores non-balance data in the top-level subject", () => {
 		const normalized = buildNormalized();
@@ -118,6 +182,7 @@ describe("fullSubject cache model", () => {
 		expect(cached.customerEntitlementIdsByFeatureId).toEqual({
 			feat_1: ["cus_ent_1"],
 		});
+		expect(cached._schemaVersion).toBe(FULL_SUBJECT_CACHE_SCHEMA_VERSION);
 		expect(cached._cachedAt).toBeTypeOf("number");
 	});
 
@@ -170,5 +235,27 @@ describe("fullSubject cache model", () => {
 			normalized.customer_entitlements,
 		);
 		expect(reconstructed.customer_prices).toEqual([]);
+	});
+
+	test("preserves fixed prices without entitlements across cache roundtrip", () => {
+		const normalized = buildMixedIntervalNormalized();
+		const cached = normalizedToCachedFullSubject({
+			normalized,
+			subjectViewEpoch: 0,
+		});
+		const reconstructed = cachedFullSubjectToNormalized({
+			cached,
+			customerEntitlements: normalized.customer_entitlements,
+		});
+		const fullSubject = normalizedToFullSubject({ normalized: reconstructed });
+		const [customerProduct] = fullSubject.customer_products;
+
+		expect(customerProduct).toBeDefined();
+		expect(
+			customerProduct!.customer_prices.map((customerPrice) =>
+				customerPrice.price_id,
+			),
+		).toEqual(["price_fixed", "price_usage"]);
+		expect(isCustomerProductOneOff(customerProduct)).toBe(false);
 	});
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing prices in the customer cache so mixed recurring + one‑off products stay subscriptions when served from cache. Adds schema versioning to auto‑invalidate old cache entries.

- **Bug Fixes**
  - Store `customer_prices` in the cached full subject and restore them on read.
  - Add `_schemaVersion` with `FULL_SUBJECT_CACHE_SCHEMA_VERSION = 2`; invalidate stale cached subjects in `getCachedFullSubject` and `getCachedPartialFullSubject`.
  - Tests cover cache round‑trip price preservation and ensure a cached recurring plan with one‑off usage remains a subscription.

<sup>Written for commit 4ecbaa6e3b7ba63acfb7ea10417c8cf76d6f8368. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1387?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `customer_prices` was excluded from the `CachedFullSubject` type (via `Omit`) and hard-coded to `[]` on cache read-back, causing recurring subscription products with mixed price intervals to be misclassified as one-off purchases when served from cache. The fix stores and restores `customer_prices` correctly, and bumps `_schemaVersion` to `2` so any stale cached entries (missing `customer_prices`) are automatically invalidated on first access.

**Key changes:**
- **Bug fix** [`fullSubjectCacheModel.ts`]: `customer_prices` is no longer omitted from `CachedFullSubject`; `normalizedToCachedFullSubject` now writes prices and `cachedFullSubjectToNormalized` reads them back instead of returning `[]`.
- **Improvements** [`getCachedFullSubject.ts`, `getCachedPartialFullSubject.ts`]: Schema-version guard invalidates and evicts cache entries whose `_schemaVersion` differs from `FULL_SUBJECT_CACHE_SCHEMA_VERSION = 2`, gracefully handling the v1→v2 rollout without manual cache flushes.
- **Improvements** [unit + integration tests]: Roundtrip test covering mixed fixed/usage prices, and an integration test confirming the second (cached) `get-customer` call still returns a subscription rather than a purchase.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fix with no risky side-effects; schema-version bump ensures a clean rollover from stale entries.

No P0/P1 findings. The root cause (prices dropped from cache) is clearly addressed, the version guard provides a safe migration path for existing cached data, and both unit and integration test coverage is added for the fixed code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cache/fullSubject/fullSubjectCacheModel.ts | Core fix: `customer_prices` removed from Omit so it is now stored and restored in cache; `_schemaVersion` added to enable stale-cache detection on schema bumps. |
| server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts | Added schema-version guard before the rollout/balance checks; stale or missing `_schemaVersion` triggers an exact-key invalidation and a cache miss. |
| server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts | Mirrors the schema-version guard added to `getCachedFullSubject.ts`, using the existing `tryOrInvalidate` helper pattern. |
| server/tests/unit/full-subject-cache/full-subject-cache-model.test.ts | Adds `_schemaVersion` assertion to existing test; adds new roundtrip test verifying fixed prices without linked entitlements survive the cache. |
| server/tests/integration/crud/customers/get-customer-cache-subscription.test.ts | New integration test that validates a mixed recurring + one-off product is still surfaced as a subscription (not a purchase) when served from the cache on the second request. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller
    participant GCS as getCachedFullSubject
    participant Redis

    C->>GCS: get(customerId)
    GCS->>Redis: pipeline GET subject + GETEX epoch
    Redis-->>GCS: cachedRaw, epochRaw

    alt No cached entry
        GCS-->>C: {fullSubject: undefined}
    else Cached entry exists
        GCS->>GCS: sanitizeCachedFullSubject(cachedRaw)
        GCS->>GCS: check subjectViewEpoch
        alt Epoch mismatch
            GCS->>Redis: invalidateExact
            GCS-->>C: {fullSubject: undefined}
        end
        GCS->>GCS: check _schemaVersion === 2 (NEW)
        alt Version mismatch / missing
            GCS->>Redis: invalidateExact
            GCS-->>C: {fullSubject: undefined}
        end
        GCS->>Redis: getCachedFeatureBalances
        Redis-->>GCS: balances
        GCS->>GCS: cachedFullSubjectToNormalized (customer_prices now restored)
        GCS-->>C: {fullSubject}
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: cus cache missing prices"](https://github.com/useautumn/autumn/commit/4ecbaa6e3b7ba63acfb7ea10417c8cf76d6f8368) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29986020)</sub>

<!-- /greptile_comment -->