### PR TITLE
fix(tinybird): remove missing promoted MV route

### DIFF
--- a/server/tinybird/pipes/aggregate_groupable.pipe
+++ b/server/tinybird/pipes/aggregate_groupable.pipe
@@ -1,9 +1,8 @@
 DESCRIPTION >
     Aggregate queries with grouping by a property key, customer_id, or entity_id.
     Routes to the smallest viable MV for the query shape:
-      - events_hourly_no_properties_two_mv: customer_id/entity_id grouping with no filters
-      - events_hourly_promoted_mv:           promoted property key (apiKeyId, endpoint, source) with no filters
-      - events_hourly_mv:                    fallback for arbitrary properties or filtered queries
+      - events_hourly_no_properties_two_mv: customer_id/entity_id grouping with no property filters
+      - events_hourly_mv:                    arbitrary properties or filtered queries
     Uses PER-BIN TOP N groups + "AUTUMN_RESERVED" bucket ((N+1) max total per bin).
     N is controlled by the max_groups parameter (default 9).
     Returns unpivoted data: (period, event_name, group_value, total_value, _truncated)
@@ -15,10 +14,8 @@ DESCRIPTION >
     Aggregate raw data by period, event_name, and group_value.
 SQL >
     %
-    {% set no_filters = (not defined(filter_key_0) or String(filter_key_0, '') == '') and (not defined(filter_key_1) or String(filter_key_1, '') == '') and (not defined(filter_key_2) or String(filter_key_2, '') == '') and (not defined(filter_key_3) or String(filter_key_3, '') == '') and (not defined(filter_key_4) or String(filter_key_4, '') == '') %}
-    {% set is_promoted_key = String(property_key, '') in ['apiKeyId', 'endpoint', 'source'] %}
-    {% set use_no_props = (String(group_column, 'property') in ['customer_id', 'entity_id']) and no_filters %}
-    {% set use_promoted = (String(group_column, 'property') == 'property') and is_promoted_key and no_filters %}
+    {% set no_property_filters = (not defined(filter_key_0) or String(filter_key_0, '') == '') and (not defined(filter_key_1) or String(filter_key_1, '') == '') and (not defined(filter_key_2) or String(filter_key_2, '') == '') and (not defined(filter_key_3) or String(filter_key_3, '') == '') and (not defined(filter_key_4) or String(filter_key_4, '') == '') %}
+    {% set use_no_props = (String(group_column, 'property') in ['customer_id', 'entity_id']) and no_property_filters %}
 
     SELECT
         {% if String(bin_size, 'day') == 'hour' %}
@@ -33,8 +30,6 @@ SQL >
         customer_id as group_value,
         {% elif String(group_column, 'property') == 'entity_id' %}
         entity_id as group_value,
-        {% elif use_promoted %}
-        {{ column(String(property_key, '')) }} as group_value,
         {% else %}
         {{ column('properties.' + String(property_key, '')) }}::String as group_value,
         {% end %}
@@ -42,8 +37,6 @@ SQL >
     FROM
         {% if use_no_props %}
         events_hourly_no_properties_two_mv
-        {% elif use_promoted %}
-        events_hourly_promoted_mv
         {% else %}
         events_hourly_mv
         {% end %}
@@ -78,8 +71,6 @@ SQL >
         {# Filter out null/empty grouping values #}
         {% if String(group_column, 'property') == 'entity_id' %}
         AND entity_id IS NOT NULL AND entity_id != ''
-        {% elif use_promoted %}
-        AND {{ column(String(property_key, '')) }} != ''
         {% elif String(group_column, 'property') == 'property' %}
         AND {{ column('properties.' + String(property_key, '')) }}::String IS NOT NULL
         AND {{ column('properties.' + String(property_key, '')) }}::String != ''


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove routing to the missing promoted MV in Tinybird `aggregate_groupable.pipe` to prevent invalid queries and simplify routing.

Now we only route to `events_hourly_no_properties_two_mv` when grouping by `customer_id` or `entity_id` with no property filters, otherwise to `events_hourly_mv`.

<sup>Written for commit 6167c9024058b9e797e546d36d9770f0ee713318. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1389?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

