### PR TITLE
feat: 🎸 cross-processor one off products support in attach

### DIFF
--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -10,6 +10,7 @@ import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { CusService } from "@/internal/customers/CusService";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
+import { pricesOnlyOneOff } from "@/internal/products/prices/priceUtils.js";
 import { ProductService } from "@/internal/products/ProductService";
 import { getOrCreateCustomer } from "../../../internal/customers/cusUtils/getOrCreateCustomer";
 
@@ -69,8 +70,16 @@ export const resolveRevenuecatResources = async ({
 				}),
 	]);
 
-	// If the customer has a product from a different processor than RevenueCat and it has no subscriptions, throw an error
+	// If the customer has a product from a different processor than RevenueCat and it has no subscriptions, throw an error.
+	//
+	// Exception: true one-off purchases (no recurring intervals) are safe to mix
+	// across processors because they create a parallel cus_product without
+	// replacing the customer's existing subscription. This lets a Stripe-subscribed
+	// customer buy a one-off pack via RevenueCat (and vice versa).
+	const incomingIsOneOff = pricesOnlyOneOff(product.prices);
+
 	if (
+		!incomingIsOneOff &&
 		customer.customer_products.some(
 			(cp) =>
 				cp.processor?.type !== ProcessorType.RevenueCat &&

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
@@ -16,6 +16,7 @@ import {
 	getEntOptions,
 	getPriceEntitlement,
 	priceIsOneOffAndTiered,
+	pricesOnlyOneOff,
 } from "@/internal/products/prices/priceUtils.js";
 import { notNullish, nullOrUndefined } from "@/utils/genUtils.js";
 import type { AttachParams } from "../../cusProducts/AttachParams.js";
@@ -159,9 +160,26 @@ export const handleCustomPaymentMethodErrors = ({
 
 export const handleExternalPSPErrors = ({
 	attachParams,
+	strict = false,
 }: {
 	attachParams: AttachParams;
+	/**
+	 * When true, never bypass the cross-processor guard. Use for MultiAttach
+	 * where the customer's whole subscription state could change.
+	 */
+	strict?: boolean;
 }) => {
+	// Safe path: a single-product attach for a true one-off product can mix
+	// across processors. One-offs create a parallel cus_product and never
+	// replace an existing subscription, so a customer with an active RC sub
+	// can still buy a Stripe-billed top-up (and vice versa).
+	const oneOffEscape =
+		!strict &&
+		attachParams.products.length === 1 &&
+		pricesOnlyOneOff(attachParams.prices);
+
+	if (oneOffEscape) return;
+
 	if (
 		attachParams.customer.customer_products.some(
 			(cp) => cusProductToProcessorType(cp) !== ProcessorType.Stripe,

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
@@ -3,9 +3,7 @@ import {
 	AttachBranch,
 	type AttachConfig,
 	BillingType,
-	cusProductToProcessorType,
 	ErrCode,
-	ProcessorType,
 	RecaseError,
 	TierBehavior,
 	type UsagePriceConfig,
@@ -16,11 +14,11 @@ import {
 	getEntOptions,
 	getPriceEntitlement,
 	priceIsOneOffAndTiered,
-	pricesOnlyOneOff,
 } from "@/internal/products/prices/priceUtils.js";
 import { notNullish, nullOrUndefined } from "@/utils/genUtils.js";
 import type { AttachParams } from "../../cusProducts/AttachParams.js";
 import type { AttachFlags } from "../models/AttachFlags.js";
+import { handleExternalPSPErrors } from "./handleAttachErrors/handleExternalPSPErrors.js";
 import { handleMultiAttachErrors } from "./handleAttachErrors/handleMultiAttachErrors.js";
 
 const handleNonCheckoutErrors = ({
@@ -151,40 +149,6 @@ export const handleCustomPaymentMethodErrors = ({
 				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
 		});
 	} else if (attachParams.customer.processors?.vercel?.installation_id) {
-		throw new RecaseError({
-			message:
-				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
-		});
-	}
-};
-
-export const handleExternalPSPErrors = ({
-	attachParams,
-	strict = false,
-}: {
-	attachParams: AttachParams;
-	/**
-	 * When true, never bypass the cross-processor guard. Use for MultiAttach
-	 * where the customer's whole subscription state could change.
-	 */
-	strict?: boolean;
-}) => {
-	// Safe path: a single-product attach for a true one-off product can mix
-	// across processors. One-offs create a parallel cus_product and never
-	// replace an existing subscription, so a customer with an active RC sub
-	// can still buy a Stripe-billed top-up (and vice versa).
-	const oneOffEscape =
-		!strict &&
-		attachParams.products.length === 1 &&
-		pricesOnlyOneOff(attachParams.prices);
-
-	if (oneOffEscape) return;
-
-	if (
-		attachParams.customer.customer_products.some(
-			(cp) => cusProductToProcessorType(cp) !== ProcessorType.Stripe,
-		)
-	) {
 		throw new RecaseError({
 			message:
 				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleCheckoutErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleCheckoutErrors.ts
@@ -1,9 +1,7 @@
 import type { AttachBranch } from "@autumn/shared";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
-import {
-	handleCustomPaymentMethodErrors,
-	handleExternalPSPErrors,
-} from "../handleAttachErrors.js";
+import { handleCustomPaymentMethodErrors } from "../handleAttachErrors.js";
+import { handleExternalPSPErrors } from "./handleExternalPSPErrors.js";
 
 export const handleCheckoutErrors = ({
 	attachParams,

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleExternalPSPErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleExternalPSPErrors.ts
@@ -1,0 +1,41 @@
+import {
+	cusProductToProcessorType,
+	ProcessorType,
+	RecaseError,
+} from "@autumn/shared";
+import { pricesOnlyOneOff } from "@/internal/products/prices/priceUtils.js";
+import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
+
+export const handleExternalPSPErrors = ({
+	attachParams,
+	strict = false,
+}: {
+	attachParams: AttachParams;
+	/**
+	 * When true, never bypass the cross-processor guard. Use for MultiAttach
+	 * where the customer's whole subscription state could change.
+	 */
+	strict?: boolean;
+}) => {
+	// Safe path: a single-product attach for a true one-off product can mix
+	// across processors. One-offs create a parallel cus_product and never
+	// replace an existing subscription, so a customer with an active RC sub
+	// can still buy a Stripe-billed top-up (and vice versa).
+	const oneOffEscape =
+		!strict &&
+		attachParams.products.length === 1 &&
+		pricesOnlyOneOff(attachParams.prices);
+
+	if (oneOffEscape) return;
+
+	if (
+		attachParams.customer.customer_products.some(
+			(cp) => cusProductToProcessorType(cp) !== ProcessorType.Stripe,
+		)
+	) {
+		throw new RecaseError({
+			message:
+				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
+		});
+	}
+};

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts
@@ -8,6 +8,7 @@ import {
 } from "@autumn/shared";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
 import RecaseError from "@/utils/errorUtils.js";
+import { handleExternalPSPErrors } from "../handleAttachErrors.js";
 
 export const handleMultiAttachErrors = async ({
 	attachParams,
@@ -19,6 +20,10 @@ export const handleMultiAttachErrors = async ({
 	branch: AttachBranch;
 }) => {
 	const { products, prices, productsList } = attachParams;
+
+	// MultiAttach must stay fully blocked for cross-processor customers — even
+	// for one-off products, because the batch may include recurring main products.
+	handleExternalPSPErrors({ attachParams, strict: true });
 
 	const usagePrice = prices.find((p: Price) => isUsagePrice({ price: p }));
 

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts
@@ -8,7 +8,7 @@ import {
 } from "@autumn/shared";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
 import RecaseError from "@/utils/errorUtils.js";
-import { handleExternalPSPErrors } from "../handleAttachErrors.js";
+import { handleExternalPSPErrors } from "./handleExternalPSPErrors.js";
 
 export const handleMultiAttachErrors = async ({
 	attachParams,

--- a/server/tests/integration/external-psps/revenuecat-cross-processor-oneoff.test.ts
+++ b/server/tests/integration/external-psps/revenuecat-cross-processor-oneoff.test.ts
@@ -1,0 +1,345 @@
+/**
+ * TDD: Allow one-off purchases across processors when the other processor
+ * already manages an active subscription for the customer.
+ *
+ * Today we strictly block any cross-processor activity to avoid edge cases
+ * with mixed subscriptions. One-offs are safe because they don't replace the
+ * existing subscription — they create a parallel cus_product.
+ *
+ * Red-failure mode (current behavior):
+ *  Test 1 — Stripe sub + RC one-off top-up:
+ *    resolveRevenuecatResources() throws "Customer already has a product from
+ *    a different processor than RevenueCat." → webhook returns 500.
+ *
+ *  Test 2 — RC sub + Stripe one-off top-up:
+ *    handleExternalPSPErrors() throws "This customer is billed outside of
+ *    Stripe..." on autumnV1.attach().
+ *
+ *  Test 3 — Negative guards:
+ *    Recurring product cross-processor must STILL be rejected after the fix.
+ *
+ * Green-success criteria (after fix):
+ *  Tests 1 & 2 succeed; both products end up active on the customer.
+ *  Test 3 sub-cases continue to throw the cross-processor error.
+ */
+
+import { expect, test } from "bun:test";
+import { AppEnv, customers } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
+import { OrgService } from "@/internal/orgs/OrgService";
+import { encryptData } from "@/utils/encryptUtils";
+import {
+	expectWebhookSuccess,
+	RevenueCatWebhookClient,
+} from "./utils/revenue-cat-webhook-client";
+
+const RC_WEBHOOK_SECRET = "test_rc_webhook_secret_xproc";
+
+const setupRevenueCatOrg = async () => {
+	if (
+		ctx.org.processor_configs?.revenuecat?.sandbox_webhook_secret !==
+		RC_WEBHOOK_SECRET
+	) {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				processor_configs: {
+					...ctx.org.processor_configs,
+					revenuecat: {
+						api_key: encryptData("mock_rc_api_key_live"),
+						sandbox_api_key: encryptData("mock_rc_api_key_sandbox"),
+						project_id: "mock_project_live",
+						sandbox_project_id: "mock_project_sandbox",
+						webhook_secret: RC_WEBHOOK_SECRET,
+						sandbox_webhook_secret: RC_WEBHOOK_SECRET,
+					},
+				},
+			},
+		});
+	}
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Stripe sub + RC one-off top-up
+//
+// Customer has an active Stripe subscription (proMonthly attached via Stripe).
+// They make a one-off in-app top-up via RevenueCat.
+// Expected (after fix): RC webhook succeeds; both products are active.
+// Currently (red):       resolver guard rejects → 500 from webhook.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("revenuecat cross-processor 1: stripe sub + rc one-off top-up")}`,
+	async () => {
+		const customerId = "rc-xproc-1";
+
+		// RevenueCat product ID for the in-app top-up
+		const RC_TOP_UP_ID = "com.app.rc_xproc_top_up_pack";
+
+		// Autumn products
+		const proMonthly = products.pro({
+			id: "rc-xproc-pro-monthly",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+		// True one-off add-on: pricesOnlyOneOff(prices) === true
+		const topUpPack = products.oneOff({
+			id: "rc-xproc-top-up-pack",
+			items: [items.lifetimeMessages({ includedUsage: 100 })],
+			isAddOn: true,
+		});
+
+		// Setup org with RevenueCat config
+		await setupRevenueCatOrg();
+
+		// Initialize scenario: customer with payment method, Stripe attaches proMonthly
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [proMonthly, topUpPack] }),
+			],
+			actions: [s.attach({ productId: proMonthly.id })],
+		});
+
+		// Map RC product → Autumn one-off top-up product
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: topUpPack.id,
+				revenuecat_product_ids: [RC_TOP_UP_ID],
+			},
+		});
+
+		const rcClient = new RevenueCatWebhookClient({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			webhookSecret: RC_WEBHOOK_SECRET,
+		});
+
+		// Sanity check: customer exists and has the Stripe sub
+		const dbCustomer = await ctx.db.query.customers.findFirst({
+			where: eq(customers.id, customerId),
+		});
+		expect(dbCustomer).toBeDefined();
+
+		// Action: RC fires NON_RENEWING_PURCHASE for the mapped one-off product
+		const result = await rcClient.nonRenewingPurchase({
+			productId: RC_TOP_UP_ID,
+			appUserId: customerId,
+			originalTransactionId: "rc_xproc_1_topup_tx_001",
+		});
+
+		// PRIMARY ASSERTION (red here): webhook should succeed
+		expectWebhookSuccess(result);
+
+		// State assertion: customer now has both products active
+		const customer = await autumnV1.customers.get(customerId);
+		expect(customer.products).toHaveLength(2);
+		const productIds = customer.products
+			.map((p: { id: string }) => p.id)
+			.sort();
+		expect(productIds).toEqual([proMonthly.id, topUpPack.id].sort());
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: RC sub + Stripe one-off top-up
+//
+// Customer has an active RevenueCat subscription (proMonthly via RC webhook).
+// They buy a one-off pack via Stripe (autumnV1.attach).
+// Expected (after fix): attach succeeds; both products are active.
+// Currently (red):       handleExternalPSPErrors throws.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("revenuecat cross-processor 2: rc sub + stripe one-off top-up")}`,
+	async () => {
+		const customerId = "rc-xproc-2";
+
+		const RC_PRO_MONTHLY_ID = "com.app.rc_xproc_pro_monthly";
+
+		// RC-managed recurring product
+		const rcProMonthly = products.pro({
+			id: "rc-xproc-2-pro-monthly",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+		// Stripe-side true one-off add-on
+		const webTopUp = products.oneOff({
+			id: "rc-xproc-2-web-top-up",
+			items: [items.lifetimeMessages({ includedUsage: 100 })],
+			isAddOn: true,
+		});
+
+		await setupRevenueCatOrg();
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [rcProMonthly, webTopUp] }),
+			],
+			actions: [],
+		});
+
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: rcProMonthly.id,
+				revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+			},
+		});
+
+		const rcClient = new RevenueCatWebhookClient({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			webhookSecret: RC_WEBHOOK_SECRET,
+		});
+
+		// Step 1: RC initial purchase puts customer on the RC-managed subscription
+		const rcResult = await rcClient.initialPurchase({
+			productId: RC_PRO_MONTHLY_ID,
+			appUserId: customerId,
+			originalTransactionId: "rc_xproc_2_tx_001",
+		});
+		expectWebhookSuccess(rcResult);
+
+		// Confirm pre-state: 1 product active (RC sub)
+		let customer = await autumnV1.customers.get(customerId);
+		expect(customer.products).toHaveLength(1);
+		expect(customer.products[0].id).toBe(rcProMonthly.id);
+
+		// PRIMARY ACTION (red here): attach the Stripe one-off top-up
+		await autumnV1.attach({
+			customer_id: customerId,
+			product_id: webTopUp.id,
+		});
+
+		customer = await autumnV1.customers.get(customerId);
+		expect(customer.products).toHaveLength(2);
+		const productIds = customer.products
+			.map((p: { id: string }) => p.id)
+			.sort();
+		expect(productIds).toEqual([rcProMonthly.id, webTopUp.id].sort());
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: Negative guards — recurring cross-processor must STILL be blocked
+//
+// Sub-case A: Stripe-subscribed customer → RC INITIAL_PURCHASE for a recurring
+//             RC-mapped Autumn product. Webhook must fail (non-200).
+// Sub-case B: RC-subscribed customer → autumnV1.attach of a recurring Stripe
+//             product. Attach must throw the cross-processor error.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("revenuecat cross-processor 3: negative guards (recurring still blocked)")}`,
+	async () => {
+		// ─── Sub-case A ────────────────────────────────────────────────────────────
+		const customerIdA = "rc-xproc-3a";
+		const RC_RECURRING_ID = "com.app.rc_xproc_3a_recurring";
+
+		const stripeProMonthly = products.pro({
+			id: "rc-xproc-3a-stripe-pro",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+		const rcRecurring = products.pro({
+			id: "rc-xproc-3a-rc-recurring",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		await setupRevenueCatOrg();
+
+		await initScenario({
+			customerId: customerIdA,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [stripeProMonthly, rcRecurring] }),
+			],
+			actions: [s.attach({ productId: stripeProMonthly.id })],
+		});
+
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: rcRecurring.id,
+				revenuecat_product_ids: [RC_RECURRING_ID],
+			},
+		});
+
+		const rcClient = new RevenueCatWebhookClient({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			webhookSecret: RC_WEBHOOK_SECRET,
+		});
+
+		// RC tries to start a recurring sub on a Stripe-subscribed customer → must fail
+		const recurringResult = await rcClient.initialPurchase({
+			productId: RC_RECURRING_ID,
+			appUserId: customerIdA,
+			originalTransactionId: "rc_xproc_3a_tx_001",
+		});
+		expect(recurringResult.response.status).not.toBe(200);
+
+		// ─── Sub-case B ────────────────────────────────────────────────────────────
+		const customerIdB = "rc-xproc-3b";
+		const RC_PRO_ID_B = "com.app.rc_xproc_3b_pro";
+
+		const rcProB = products.pro({
+			id: "rc-xproc-3b-rc-pro",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+		// Recurring add-on (NOT a one-off): cross-processor attach should still throw
+		const stripeRecurringAddOn = products.recurringAddOn({
+			id: "rc-xproc-3b-recurring-addon",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId: customerIdB,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [rcProB, stripeRecurringAddOn] }),
+			],
+			actions: [],
+		});
+
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: rcProB.id,
+				revenuecat_product_ids: [RC_PRO_ID_B],
+			},
+		});
+
+		const rcResult = await rcClient.initialPurchase({
+			productId: RC_PRO_ID_B,
+			appUserId: customerIdB,
+			originalTransactionId: "rc_xproc_3b_tx_001",
+		});
+		expectWebhookSuccess(rcResult);
+
+		// Now attempt to attach a recurring Stripe add-on → must throw
+		await expect(
+			autumnV1.attach({
+				customer_id: customerIdB,
+				product_id: stripeRecurringAddOn.id,
+			}),
+		).rejects.toThrow(/Stripe|RevenueCat|external|managed/i);
+	},
+);

--- a/server/tests/integration/external-psps/utils/revenuecatWebhooks.test.ts
+++ b/server/tests/integration/external-psps/utils/revenuecatWebhooks.test.ts
@@ -4,11 +4,12 @@ import {
 	AppEnv,
 	CusProductStatus,
 	customers,
+	revenuecatMappings,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import chalk from "chalk";
-import { eq } from "drizzle-orm";
+import { and, arrayOverlaps, eq } from "drizzle-orm";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService.js";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
@@ -176,13 +177,50 @@ describe(chalk.yellowBright("rc1: RevenueCat webhook integration"), () => {
 			webhookSecret: RC_WEBHOOK_SECRET,
 		});
 
-		// 2-4. Create products, mappings, and customer concurrently
+		// IMPORTANT: clean up stale RC mappings before re-upserting.
+		//
+		// `addPrefixToProducts` was changed in Jan from prefix-style
+		// (`${prefix}_${id}`) to suffix-style (`${id}_${prefix}`). Old runs left
+		// rows in `revenuecat_mappings` keyed by the prefix-style autumn_product_id
+		// (e.g. `rc1_rc1-pro-monthly`). The mapping table PK includes
+		// `autumn_product_id`, so a fresh upsert under the new ID does NOT
+		// overwrite the stale row. The resolver's `arrayContains` lookup can then
+		// return the stale row, causing `ProductNotFoundError`.
+		//
+		// Clear by `revenuecat_product_ids` overlap so the cleanup is independent
+		// of whatever stale autumn_product_id format was used previously.
+		await ctx.db
+			.delete(revenuecatMappings)
+			.where(
+				and(
+					eq(revenuecatMappings.org_id, ctx.org.id),
+					eq(revenuecatMappings.env, AppEnv.Sandbox),
+					arrayOverlaps(revenuecatMappings.revenuecat_product_ids, [
+						RC_PRO_MONTHLY_ID,
+						RC_PRO_YEARLY_ID,
+						RC_ADD_ON_ID,
+					]),
+				),
+			);
+
+		// Create products + customer concurrently. Products must finish before
+		// we read their (post-prefix) IDs for the mappings below.
 		await Promise.all([
 			initProductsV0({
 				ctx,
 				products: [proMonthly, proYearly, addOnPack],
 				prefix: testCase,
 			}),
+			initCustomerV3({
+				ctx,
+				customerId,
+				withTestClock: false,
+			}),
+		]);
+
+		// Now that initProductsV0 has mutated the product IDs (suffix-style),
+		// upsert mappings with the final, correct autumn_product_id values.
+		await Promise.all([
 			RCMappingService.upsert({
 				db: ctx.db,
 				data: {
@@ -209,11 +247,6 @@ describe(chalk.yellowBright("rc1: RevenueCat webhook integration"), () => {
 					autumn_product_id: proYearly.id,
 					revenuecat_product_ids: [RC_PRO_YEARLY_ID],
 				},
-			}),
-			initCustomerV3({
-				ctx,
-				customerId,
-				withTestClock: false,
 			}),
 		]);
 


### PR DESCRIPTION
- **fix: 🐛 save changes bar not showing for past due**
- **feat: 🎸 allow cross-processor one-off product purchases**
- **fix: 🐛 broken test for revcat**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow cross‑processor one‑off purchases: customers with an active Stripe or RevenueCat subscription can now buy true one‑off add‑ons from the other processor without conflicts. Recurring cross‑processor purchases remain blocked.

- New Features
  - Allow single‑product, true one‑off purchases to bypass the cross‑processor guard in `attach` and RevenueCat webhooks using `pricesOnlyOneOff`.
  - Keep MultiAttach strict (no cross‑processor mixing), even if one item is one‑off.
  - Add integration tests covering Stripe↔RevenueCat one‑off scenarios and ensure recurring mixes still reject.

- Bug Fixes
  - Show the “Save changes” bar when only config changes by including `configSame` in `useProductStore`.
  - Stabilize RevenueCat webhook tests by clearing stale mappings and aligning product ID suffix handling to prevent false “product not found” errors.
  - Fix circular import in attach error handlers by extracting `handleExternalPSPErrors` into its own module and updating imports.

<sup>Written for commit 7f365ba1a88f3a05a634fc1347ca714663fcaf95. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1392?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows true one-off product purchases to cross processor boundaries (Stripe ↔ RevenueCat), while keeping recurring-product cross-processor restrictions fully in place. It also fixes the save-changes bar missing on product config edits and repairs a flaky RevenueCat integration test caused by stale mapping rows.

**Key changes:**
- **Improvements** — `resolveRevenuecatResources` and `handleExternalPSPErrors` now detect `pricesOnlyOneOff` and bypass the cross-processor guard for single one-off attach requests; MultiAttach is kept fully blocked via a new `strict: true` parameter.
- **Bug fixes** — `useHasChanges` in `useProductStore` now includes `!comparison.configSame` so the save bar appears when product config fields (e.g. past-due settings) change.
- **Bug fixes** — RevenueCat webhook integration test cleans up stale `revenuecat_mappings` rows (by `revenuecat_product_ids` overlap) and correctly sequences product init before mapping upsert to avoid `ProductNotFoundError`.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — all P2 findings; logic is correct and existing guards are preserved.

Only P2 style issues found: a new circular import between handleAttachErrors.ts and handleMultiAttachErrors.ts (works at runtime in ESM but is a code smell), and a minor double-call redundancy for MultiAttach. The core one-off escape logic and strict guard are both correct, and the new integration tests cover positive and negative cases.

server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts and handleAttachErrors.ts — circular import and redundant double-call worth revisiting.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/misc/resolveRevenuecatResources.ts | Adds `incomingIsOneOff` guard so the cross-processor check is skipped for true one-off products, preserving the existing subscription-IDs filter for recurring products. |
| server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts | Introduces `strict` param and `oneOffEscape` in `handleExternalPSPErrors`; correct behavior but the non-strict call at the top of `handleAttachErrors` is now redundant for MultiAttach. |
| server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts | Adds strict cross-processor guard for MultiAttach, but creates a circular import with its parent module `handleAttachErrors.ts`. |
| server/tests/integration/external-psps/revenuecat-cross-processor-oneoff.test.ts | New integration test covering RC+Stripe one-off cross-processor scenarios, including negative guard tests; fixtures exist and structure looks correct. |
| server/tests/integration/external-psps/utils/revenuecatWebhooks.test.ts | Fixes stale RC mapping rows using `arrayOverlaps` delete before re-upsert, and correctly sequentialises product init before mapping creation. |
| vite/src/hooks/stores/useProductStore.ts | Adds `!comparison.configSame` to `useHasChanges` so the save-changes bar appears when product config fields change; `configSame` is a valid field returned by `productsAreSame`. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[attach / RC webhook] --> B{One-off product?}
    B -- Yes --> C{MultiAttach?}
    B -- No --> D[Cross-processor check\nstrict guard]
    C -- Yes --> E[handleMultiAttachErrors\nstrict: true\nAlways blocked]
    C -- No --> F[oneOffEscape = true\nBypass cross-processor check\nAllow RC ↔ Stripe one-off]
    D -- Customer has\nnon-native processor --> G[Throw RecaseError]
    D -- Same processor --> H[Proceed with attach]
    E --> G
    F --> H
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts`, line 229-232 ([link](https://github.com/useautumn/autumn/blob/48b2c2fb95bd0289614f1651aeea4829fccd9538/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts#L229-L232)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`handleExternalPSPErrors` called twice for MultiAttach**

   For the `AttachBranch.MultiAttach` path, `handleExternalPSPErrors` is invoked once here (non-strict) and a second time inside `handleMultiAttachErrors` (strict). The behavior is correct — a single one-off product passes the first call then is caught by the strict second call — but the first call does no useful work for MultiAttach and makes the logic harder to reason about.

   Consider skipping the top-level call for MultiAttach so the `strict: true` call inside `handleMultiAttachErrors` is the single authoritative gate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
   Line: 229-232

   Comment:
   **`handleExternalPSPErrors` called twice for MultiAttach**

   For the `AttachBranch.MultiAttach` path, `handleExternalPSPErrors` is invoked once here (non-strict) and a second time inside `handleMultiAttachErrors` (strict). The behavior is correct — a single one-off product passes the first call then is caught by the strict second call — but the first call does no useful work for MultiAttach and makes the logic harder to reason about.

   Consider skipping the top-level call for MultiAttach so the `strict: true` call inside `handleMultiAttachErrors` is the single authoritative gate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts
Line: 11

Comment:
**Circular module dependency introduced**

`handleMultiAttachErrors.ts` is imported by `handleAttachErrors.ts`, and this change makes `handleMultiAttachErrors.ts` import back from `handleAttachErrors.ts`, creating a cycle: `handleAttachErrors` → `handleMultiAttachErrors` → `handleAttachErrors`.

In Bun's ESM runtime this works at runtime because `handleExternalPSPErrors` is consumed inside a function body (live binding resolves before any call), but the circular graph can silently break if import order changes, surprises bundlers/tree-shakers, and makes both modules harder to unit-test in isolation.

Consider extracting `handleExternalPSPErrors` (and its `pricesOnlyOneOff` dependency) into a small standalone file (e.g. `attachUtils/handleExternalPSPErrors.ts`) and importing it from there in both `handleAttachErrors.ts` and `handleMultiAttachErrors.ts`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
Line: 229-232

Comment:
**`handleExternalPSPErrors` called twice for MultiAttach**

For the `AttachBranch.MultiAttach` path, `handleExternalPSPErrors` is invoked once here (non-strict) and a second time inside `handleMultiAttachErrors` (strict). The behavior is correct — a single one-off product passes the first call then is caught by the strict second call — but the first call does no useful work for MultiAttach and makes the logic harder to reason about.

Consider skipping the top-level call for MultiAttach so the `strict: true` call inside `handleMultiAttachErrors` is the single authoritative gate.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 broken test for revcat"](https://github.com/useautumn/autumn/commit/48b2c2fb95bd0289614f1651aeea4829fccd9538) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30000900)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->