### PR TITLE
fix: 🐛 lots of bugs

### DIFF
--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts
@@ -64,7 +64,7 @@ export const lazyResetSubjectEntitlements = async ({
 
 	const allCustomerEntitlements = fullSubjectToCustomerEntitlements({
 		fullSubject,
-		inStatuses: [CusProductStatus.Active],
+		inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
 	});
 
 	const customerEntitlementsNeedingReset = getResettableCustomerEntitlements({


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include past-due customer entitlements in the V2 lazy reset so their state and cache get refreshed. Previously only active entitlements were reset, leaving past-due accounts stuck.

- Bug Fixes
  - Added `CusProductStatus.PastDue` to `inStatuses` when building `allCustomerEntitlements` in `lazyResetSubjectEntitlements.ts`.

<sup>Written for commit 2e54ce32f8370e4cd361c239751d9bef5f6e4f1c. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1396?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `CusProductStatus.PastDue` to the `inStatuses` filter in `lazyResetSubjectEntitlements`, fixing a bug where customers with past-due subscriptions were excluded from the lazy entitlement reset cycle.

**Key changes:**
- [Bug fixes] Include `CusProductStatus.PastDue` alongside `CusProductStatus.Active` when collecting customer entitlements for reset — aligning with the default behavior of `fullSubjectToCustomerEntitlements`, which already defaults to both statuses.
</details>

<h3>Confidence Score: 5/5</h3>

Clean, targeted one-line bug fix with no risky side effects — safe to merge.

The change simply aligns the explicit inStatuses argument with the function's own default value ([Active, PastDue]), fixing an accidental narrowing of scope. No new logic is introduced and there are no P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts | Adds CusProductStatus.PastDue to the inStatuses filter, matching the default behavior of fullSubjectToCustomerEntitlements and ensuring past-due customers have their entitlements lazily reset. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[lazyResetSubjectEntitlements called] --> B{DB Health OK?}
    B -- No --> C[return false]
    B -- Yes --> D[fullSubjectToCustomerEntitlements\ninStatuses: Active, PastDue]
    D --> E[getResettableCustomerEntitlements]
    E --> F{Any entitlements\nneed reset?}
    F -- No --> G[return false]
    F -- Yes --> H[processReset for each]
    H --> I[resetCusEnts in DB]
    I --> J[applyResetResultsToFullSubject]
    J --> K{normalized\nprovided?}
    K -- Yes --> L[applyResetResultsToNormalized]
    K -- No --> M[resetSubjectCache]
    L --> M
    M --> N[return true]

    style D fill:#90ee90,color:#000
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 lots of bugs"](https://github.com/useautumn/autumn/commit/2e54ce32f8370e4cd361c239751d9bef5f6e4f1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30040542)</sub>

<!-- /greptile_comment -->