### PR TITLE
chore: add early ack on webhooks

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -11,6 +11,7 @@
 		"enumMembers",
 		"duplicates"
 	],
+	"ignore": ["ai/**"],
 	"ignoreWorkspaces": [
 		"packages/atmn",
 		"packages/autumn-js",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"setup": "node scripts/setup/setup.js",
 		"setup:s3-admin": "bun scripts/setup/setupS3Admin.ts",
 		"setup:test": "infisical run --env=dev --recursive -- bun scripts/setup/setup-test.ts",
+		"stripe:link-test": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/setup/link-test-stripe-account.ts",
 		"agent:bootstrap": "bash scripts/setup/agent-bootstrap.sh",
 		"dev:agent": "bash scripts/setup/devAgent.sh",
 		"migrate-functions": "infisical run --env=dev --recursive -- bun scripts/migrations/migrate-functions.ts",

--- a/scripts/setup/STRIPE_TEST_OAUTH.md
+++ b/scripts/setup/STRIPE_TEST_OAUTH.md
@@ -1,0 +1,47 @@
+# Stripe Test OAuth Linking
+
+Use this when local tests say the test org has no linked Stripe account, or when Stripe Connect webhooks are visible in Stripe but Autumn cannot map events back to `unit-test-org`.
+
+The Connect webhook destination should be:
+
+```txt
+https://c.autumn.ngrok.app/webhooks/connect/sandbox
+```
+
+OAuth still needs the Autumn org row to store the connected account ID:
+
+```json
+{ "test_stripe_connect": { "account_id": "acct_..." } }
+```
+
+## Commands
+
+List recent connected accounts for the test org email:
+
+```sh
+bun stripe:link-test -- --list --email=unit-test-org@test.com
+```
+
+Link an explicit account:
+
+```sh
+bun stripe:link-test -- --account-id=acct_...
+```
+
+Link the newest account matching the test org email:
+
+```sh
+bun stripe:link-test -- --latest --email=unit-test-org@test.com
+```
+
+If the org has a direct Stripe secret key, `createStripeCli` will prefer that over OAuth Connect. To force the OAuth account for sandbox tests:
+
+```sh
+bun stripe:link-test -- --account-id=acct_... --clear-secret-key
+```
+
+After linking, rerun a focused checkout test before the full suite:
+
+```sh
+ENV_FILE=.env infisical run --env=dev --recursive -- bun test --timeout 0 server/tests/integration/billing/attach/checkout/stripe-checkout/prepaid/stripe-checkout-prepaid-basic.test.ts
+```

--- a/scripts/setup/link-test-stripe-account.ts
+++ b/scripts/setup/link-test-stripe-account.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env bun
+import { AppEnv, organizations } from "@autumn/shared";
+import { eq } from "drizzle-orm";
+import { initDrizzle } from "@server/db/initDrizzle.js";
+import { createStripeCli } from "@server/external/connect/createStripeCli.js";
+import { initMasterStripe } from "@server/external/connect/initStripeCli.js";
+import { OrgService } from "@server/internal/orgs/OrgService.js";
+import { clearOrgCache } from "@server/internal/orgs/orgUtils/clearOrgCache.js";
+import { loadLocalEnv } from "@server/utils/envUtils.js";
+
+loadLocalEnv();
+
+const args = process.argv.slice(2);
+
+const readFlag = (name: string) => {
+	const inline = args.find((arg) => arg.startsWith(`${name}=`));
+	if (inline) return inline.slice(name.length + 1);
+
+	const idx = args.indexOf(name);
+	return idx === -1 ? undefined : args[idx + 1];
+};
+
+const hasFlag = (name: string) => args.includes(name);
+
+const usage = () => {
+	console.log(`Usage:
+  bun stripe:link-test -- --account-id=acct_...
+  bun stripe:link-test -- --latest --email=unit-test-org@test.com
+  bun stripe:link-test -- --list --email=unit-test-org@test.com
+
+Options:
+  --org=<slug-or-id>       Autumn org to update. Defaults to TESTS_ORG.
+  --env=<sandbox|live>     Stripe environment. Defaults to sandbox.
+  --account-id=<acct_...>  Connected Stripe account ID to link.
+  --email=<email>          Filter Stripe connected accounts by email.
+  --latest                 Link the newest connected account matching --email.
+  --clear-secret-key       Clear the org's direct Stripe key for this env so Connect is used.
+  --list                   Print matching connected accounts without updating.
+`);
+};
+
+if (hasFlag("--help") || hasFlag("-h")) {
+	usage();
+	process.exit(0);
+}
+
+const env =
+	(readFlag("--env") || "sandbox").toLowerCase() === "live"
+		? AppEnv.Live
+		: AppEnv.Sandbox;
+const orgRef = readFlag("--org") || process.env.TESTS_ORG;
+const email = readFlag("--email");
+const accountIdArg = readFlag("--account-id");
+
+if (!orgRef) {
+	throw new Error("Missing org. Pass --org=<slug-or-id> or set TESTS_ORG.");
+}
+
+const { db, client } = initDrizzle();
+
+const getOrg = async () => {
+	const bySlug = await OrgService.getBySlug({ db, slug: orgRef });
+	if (bySlug) return bySlug;
+
+	return await OrgService.get({ db, orgId: orgRef });
+};
+
+const listAccounts = async () => {
+	const stripe = initMasterStripe({ env, skipInstrumentation: true });
+	const accounts = await stripe.accounts.list({ limit: 100 });
+
+	return accounts.data
+		.filter((account) => !email || account.email === email)
+		.sort((a, b) => b.created - a.created);
+};
+
+try {
+	const org = await getOrg();
+	const accounts = await listAccounts();
+
+	if (hasFlag("--list")) {
+		console.log(
+			JSON.stringify(
+				accounts.map((account) => ({
+					id: account.id,
+					email: account.email,
+					created: new Date(account.created * 1000).toISOString(),
+					charges_enabled: account.charges_enabled,
+					details_submitted: account.details_submitted,
+				})),
+				null,
+				2,
+			),
+		);
+		process.exit(0);
+	}
+
+	const accountId =
+		accountIdArg || (hasFlag("--latest") ? accounts[0]?.id : undefined);
+
+	if (!accountId) {
+		throw new Error(
+			"Missing account. Pass --account-id=acct_... or use --latest with --email=...",
+		);
+	}
+
+	const directKeyField =
+		env === AppEnv.Sandbox ? "test_api_key" : "live_api_key";
+	const directWebhookSecretField =
+		env === AppEnv.Sandbox ? "test_webhook_secret" : "live_webhook_secret";
+	const hasDirectKey = Boolean(org.stripe_config?.[directKeyField]);
+
+	if (hasDirectKey && !hasFlag("--clear-secret-key")) {
+		throw new Error(
+			`${org.slug} has stripe_config.${directKeyField}; createStripeCli will prefer that over Connect. Re-run with --clear-secret-key to use the OAuth account.`,
+		);
+	}
+
+	const stripe = initMasterStripe({ env, accountId, skipInstrumentation: true });
+	await stripe.accounts.retrieve();
+
+	await OrgService.updateStripeConnect({
+		db,
+		orgId: org.id,
+		accountId,
+		env,
+	});
+
+	if (hasDirectKey) {
+		await db
+			.update(organizations)
+			.set({
+				stripe_config: {
+					...(org.stripe_config || {}),
+					[directKeyField]: null,
+					[directWebhookSecretField]: null,
+				},
+			})
+			.where(eq(organizations.id, org.id));
+		await clearOrgCache({ db, orgId: org.id });
+	}
+
+	const updatedOrg = await OrgService.get({ db, orgId: org.id });
+	const resolvedStripe = createStripeCli({
+		org: updatedOrg,
+		env,
+		skipInstrumentation: true,
+	});
+	const resolvedAccount = await resolvedStripe.accounts.retrieve();
+
+	console.log(
+		JSON.stringify(
+			{
+				org: { id: updatedOrg.id, slug: updatedOrg.slug },
+				env,
+				linked_account_id: accountId,
+				resolved_account_id: resolvedAccount.id,
+				test_stripe_connect: updatedOrg.test_stripe_connect,
+				live_stripe_connect: updatedOrg.live_stripe_connect,
+			},
+			null,
+			2,
+		),
+	);
+} finally {
+	await client.end();
+}
+
+process.exit(0);

--- a/server/src/external/stripe/stripeWebhookRouter.ts
+++ b/server/src/external/stripe/stripeWebhookRouter.ts
@@ -8,6 +8,7 @@ import { stripeLegacySeederMiddleware } from "./webhookMiddlewares/stripeLegacyS
 import { stripeSyncMiddleware } from "./webhookMiddlewares/stripeSyncMiddleware.js";
 import { stripeToAutumnCustomerMiddleware } from "./webhookMiddlewares/stripeToAutumnCustomerMiddleware.js";
 import type { StripeWebhookHonoEnv } from "./webhookMiddlewares/stripeWebhookContext.js";
+import { stripeWebhookEarlyAckMiddleware } from "./webhookMiddlewares/stripeWebhookEarlyAckMiddleware.js";
 import { stripeWebhookRefreshMiddleware } from "./webhookMiddlewares/stripeWebhookRefreshMiddleware.js";
 
 export const stripeWebhookRouter = new Hono<StripeWebhookHonoEnv>();
@@ -16,12 +17,13 @@ export const stripeWebhookRouter = new Hono<StripeWebhookHonoEnv>();
 stripeWebhookRouter.post(
 	"/webhooks/stripe/:orgId/:env",
 	stripeLegacySeederMiddleware,
+	stripeIdempotencyMiddleware,
+	stripeWebhookEarlyAckMiddleware,
 	stripeWebhookRefreshMiddleware,
 	stripeSyncMiddleware,
 	stripeToAutumnCustomerMiddleware,
 	stripeLoggerMiddleware,
 	traceEnrichMiddleware,
-	stripeIdempotencyMiddleware,
 	handleStripeWebhookEvent,
 );
 
@@ -29,11 +31,12 @@ stripeWebhookRouter.post(
 stripeWebhookRouter.post(
 	"/webhooks/connect/:env",
 	stripeConnectSeederMiddleware,
+	stripeIdempotencyMiddleware,
+	stripeWebhookEarlyAckMiddleware,
 	stripeWebhookRefreshMiddleware,
 	stripeSyncMiddleware,
 	stripeToAutumnCustomerMiddleware,
 	stripeLoggerMiddleware,
 	traceEnrichMiddleware,
-	stripeIdempotencyMiddleware,
 	handleStripeWebhookEvent,
 );

--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts
@@ -1,6 +1,14 @@
 import type { Context, Next } from "hono";
 import type { StripeWebhookHonoEnv } from "./stripeWebhookContext";
 
+const getWaitUntil = (c: Context<StripeWebhookHonoEnv>) => {
+	try {
+		return c.executionCtx.waitUntil.bind(c.executionCtx);
+	} catch {
+		return undefined;
+	}
+};
+
 export const stripeWebhookEarlyAckMiddleware = async (
 	c: Context<StripeWebhookHonoEnv>,
 	next: Next,
@@ -15,9 +23,14 @@ export const stripeWebhookEarlyAckMiddleware = async (
 				});
 			});
 
-	try {
-		c.executionCtx.waitUntil(runWebhook());
-	} catch {
+	const waitUntil = getWaitUntil(c);
+	if (waitUntil) {
+		try {
+			waitUntil(runWebhook());
+		} catch (error) {
+			ctx.logger.error(`Stripe webhook waitUntil failed: ${error}`, { error });
+		}
+	} else {
 		setImmediate(() => void runWebhook());
 	}
 

--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts
@@ -1,0 +1,25 @@
+import type { Context, Next } from "hono";
+import type { StripeWebhookHonoEnv } from "./stripeWebhookContext";
+
+export const stripeWebhookEarlyAckMiddleware = async (
+	c: Context<StripeWebhookHonoEnv>,
+	next: Next,
+) => {
+	const ctx = c.get("ctx");
+	const runWebhook = () =>
+		Promise.resolve()
+			.then(next)
+			.catch((error) => {
+				ctx.logger.error(`Stripe webhook background processing failed: ${error}`, {
+					error,
+				});
+			});
+
+	try {
+		c.executionCtx.waitUntil(runWebhook());
+	} catch {
+		setImmediate(() => void runWebhook());
+	}
+
+	return c.json({ received: true }, 200);
+};

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeSubscriptionForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeSubscriptionForBilling.ts
@@ -56,10 +56,7 @@ export const fetchStripeSubscriptionForBilling = async ({
 	if (!subId) return undefined;
 
 	const sub = await stripeCli.subscriptions.retrieve(subId, {
-		expand: [
-			"discounts.source.coupon.applies_to",
-			"latest_invoice.lines.data.discount_amounts",
-		],
+		expand: ["discounts.source.coupon.applies_to"],
 	});
 
 	if (!sub) {

--- a/server/tests/unit/webhooks/stripe-webhook-early-ack.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-early-ack.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Hono } from "hono";
 import { stripeWebhookEarlyAckMiddleware } from "@/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware";
 
-const wait = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitForImmediate = () => new Promise((resolve) => setImmediate(resolve));
 
 const createApp = () => {
 	const app = new Hono();
@@ -72,7 +72,7 @@ describe("stripeWebhookEarlyAckMiddleware", () => {
 		expect(processed).toBe(false);
 
 		resolveProcessing();
-		await wait(5);
+		await waitForImmediate();
 		expect(processed).toBe(true);
 	});
 
@@ -91,7 +91,7 @@ describe("stripeWebhookEarlyAckMiddleware", () => {
 		expect(await response.json()).toEqual({ received: true });
 		expect(started).toBe(false);
 
-		await wait(5);
+		await waitForImmediate();
 		expect(started).toBe(true);
 	});
 });

--- a/server/tests/unit/webhooks/stripe-webhook-early-ack.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-early-ack.test.ts
@@ -47,6 +47,34 @@ describe("stripeWebhookEarlyAckMiddleware", () => {
 		expect(processed).toBe(true);
 	});
 
+	test("does not run downstream twice when waitUntil throws", async () => {
+		const errors: unknown[] = [];
+		let runs = 0;
+		const response = await stripeWebhookEarlyAckMiddleware(
+			{
+				get: () => ({
+					logger: { error: (_message: string, meta: unknown) => errors.push(meta) },
+				}),
+				json: (body: unknown, status: number) =>
+					new Response(JSON.stringify(body), { status }),
+				executionCtx: {
+					waitUntil: () => {
+						throw new Error("waitUntil failed");
+					},
+				},
+			} as never,
+			async () => {
+				runs++;
+			},
+		);
+
+		expect(response.status).toBe(200);
+		await Promise.resolve();
+		await waitForImmediate();
+		expect(runs).toBe(1);
+		expect(errors).toHaveLength(1);
+	});
+
 	test("returns 200 before downstream webhook processing completes", async () => {
 		const app = createApp();
 		let resolveProcessing!: () => void;

--- a/server/tests/unit/webhooks/stripe-webhook-early-ack.test.ts
+++ b/server/tests/unit/webhooks/stripe-webhook-early-ack.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { stripeWebhookEarlyAckMiddleware } from "@/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware";
+
+const wait = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const createApp = () => {
+	const app = new Hono();
+
+	app.use("*", async (c, next) => {
+		(c as any).set("ctx", {
+			logger: {
+				error: () => {},
+			},
+		});
+		await next();
+	});
+
+	return app;
+};
+
+describe("stripeWebhookEarlyAckMiddleware", () => {
+	test("uses executionCtx.waitUntil when the runtime provides it", async () => {
+		const waits: Promise<unknown>[] = [];
+		let processed = false;
+		const response = await stripeWebhookEarlyAckMiddleware(
+			{
+				get: () => ({
+					logger: { error: () => {} },
+				}),
+				json: (body: unknown, status: number) =>
+					new Response(JSON.stringify(body), { status }),
+				executionCtx: {
+					waitUntil: (promise: Promise<unknown>) => waits.push(promise),
+				},
+			} as never,
+			async () => {
+				processed = true;
+			},
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ received: true });
+		expect(waits).toHaveLength(1);
+
+		await waits[0];
+		expect(processed).toBe(true);
+	});
+
+	test("returns 200 before downstream webhook processing completes", async () => {
+		const app = createApp();
+		let resolveProcessing!: () => void;
+		let processed = false;
+		const processing = new Promise<void>((resolve) => {
+			resolveProcessing = resolve;
+		});
+
+		app.post(
+			"/webhook",
+			stripeWebhookEarlyAckMiddleware as never,
+			async (c) => {
+				await processing;
+				processed = true;
+				return c.json({ processed: true }, 200);
+			},
+		);
+
+		const response = await app.request("/webhook", { method: "POST" });
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ received: true });
+		expect(processed).toBe(false);
+
+		resolveProcessing();
+		await wait(5);
+		expect(processed).toBe(true);
+	});
+
+	test("does not run downstream webhook processing before returning", async () => {
+		const app = createApp();
+		let started = false;
+
+		app.post("/webhook", stripeWebhookEarlyAckMiddleware as never, (c) => {
+			started = true;
+			return c.json({ processed: true }, 200);
+		});
+
+		const response = await app.request("/webhook", { method: "POST" });
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ received: true });
+		expect(started).toBe(false);
+
+		await wait(5);
+		expect(started).toBe(true);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 200 immediately on Stripe and Connect webhooks and process events in the background to prevent timeouts and retries. Adds a helper script and docs to link a test Stripe Connect account to an org.

- **New Features**
  - Early-ack middleware (`stripeWebhookEarlyAckMiddleware`) now active on both webhook routes; schedules downstream via `executionCtx.waitUntil` (fallback `setImmediate`) and responds with `{ received: true }`. Unit tests added.
  - Added `scripts/setup/link-test-stripe-account.ts` (`bun stripe:link-test`) and `scripts/setup/STRIPE_TEST_OAUTH.md` to list/link test Connect accounts; supports `--org`, `--env`, `--account-id`/`--latest --email`, `--clear-secret-key`.

- **Refactors**
  - Middleware order: `stripeIdempotencyMiddleware` runs first; early-ack runs before refresh/sync/logging; removed trailing duplicate idempotency.
  - Removed unnecessary `expand` fields in `fetchStripeSubscriptionForBilling` to reduce Stripe API payload.

<sup>Written for commit d7e60fa548791dedcdc30c94c5c04725d4442139. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1397?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `stripeWebhookEarlyAckMiddleware` that immediately returns HTTP 200 to Stripe and runs downstream processing in the background via `executionCtx.waitUntil` (Cloudflare Workers) or `setImmediate` (Node/Bun fallback), along with a new developer utility script for linking test Stripe accounts.

- **[Improvements]** `stripeWebhookEarlyAckMiddleware` and its unit tests are added, but the middleware is not imported or registered in `stripeWebhookRouter.ts`, so no webhook route actually performs early acknowledgement yet.
</details>


<h3>Confidence Score: 3/5</h3>

Safe to merge as infrastructure groundwork, but the advertised early-ack behaviour is not yet active in production.

A P1 finding (middleware not wired into the router) means the PR title's promise is unfulfilled — no webhook route benefits from early ack after this merges. The implementation itself is correct, so there is no regression risk, but the feature is effectively a no-op.

server/src/external/stripe/stripeWebhookRouter.ts — needs the middleware imported and added to both route definitions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts | New early-ack middleware: responds 200 immediately, runs downstream processing via waitUntil (Cloudflare) or setImmediate (Node/Bun). Implementation is correct but never registered in the router. |
| server/tests/unit/webhooks/stripe-webhook-early-ack.test.ts | Unit tests covering waitUntil path, early-response ordering, and setImmediate fallback; 5 ms fixed-delay assertions in tests 2 and 3 could be flaky under load. |
| scripts/setup/link-test-stripe-account.ts | New developer utility script that links a Stripe connected account to an Autumn org; straightforward CLI arg parsing with a db teardown in finally. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Router as stripeWebhookRouter
    participant Idempotency as stripeIdempotencyMiddleware
    participant EarlyAck as stripeWebhookEarlyAckMiddleware
    participant Handler as handleStripeWebhookEvent
    participant BG as Background (waitUntil / setImmediate)

    Stripe->>Router: POST /webhooks/stripe/:orgId/:env
    Router->>Idempotency: run (sync)
    Idempotency-->>Router: key set / duplicate check
    Router->>EarlyAck: run (proposed placement)
    EarlyAck->>BG: schedule next() (handler)
    EarlyAck-->>Stripe: 200 { received: true }
    BG->>Handler: process webhook event
    Handler-->>BG: done (result discarded)
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/external/stripe/stripeWebhookRouter.ts`, line 1-39 ([link](https://github.com/useautumn/autumn/blob/ea9f827f171d9661b9dbbd7f8fcd30082051dcbe/server/src/external/stripe/stripeWebhookRouter.ts#L1-L39)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Middleware not wired into the router**

   `stripeWebhookEarlyAckMiddleware` is implemented and tested but never imported or registered in the webhook router, so the early-ack behaviour described in the PR title is not actually active. Both `stripeWebhookRouter.post` calls need to include the middleware (positioned after `stripeIdempotencyMiddleware` so deduplication still runs synchronously) for the feature to take effect.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/external/stripe/stripeWebhookRouter.ts
   Line: 1-39

   Comment:
   **Middleware not wired into the router**

   `stripeWebhookEarlyAckMiddleware` is implemented and tested but never imported or registered in the webhook router, so the early-ack behaviour described in the PR title is not actually active. Both `stripeWebhookRouter.post` calls need to include the middleware (positioned after `stripeIdempotencyMiddleware` so deduplication still runs synchronously) for the feature to take effect.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: server/src/external/stripe/stripeWebhookRouter.ts
Line: 1-39

Comment:
**Middleware not wired into the router**

`stripeWebhookEarlyAckMiddleware` is implemented and tested but never imported or registered in the webhook router, so the early-ack behaviour described in the PR title is not actually active. Both `stripeWebhookRouter.post` calls need to include the middleware (positioned after `stripeIdempotencyMiddleware` so deduplication still runs synchronously) for the feature to take effect.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server/tests/unit/webhooks/stripe-webhook-early-ack.test.ts
Line: 87-96

Comment:
**Potentially flaky 5 ms timing assertion**

`await wait(5)` then `expect(started).toBe(true)` relies on `setImmediate` completing within 5 ms. Under CI load this can race. Awaiting the queued microtask/macrotask more deterministically (e.g. `await Promise.resolve()` twice, or a `setImmediate`-wrapped promise) would make the assertion reliable without needing a fixed delay.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: hook ack middleware up"](https://github.com/useautumn/autumn/commit/ea9f827f171d9661b9dbbd7f8fcd30082051dcbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30040796)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->