### PR TITLE
chore: cache local checks with turbo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ supabase.sh
 **/dist/
 **/.next/
 **/.vercel/
+**/.turbo/
 **/.DS_Store
 **/.env*
 tests/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,9 +5,9 @@ changed_files="$(git diff --cached --name-only)"
 bun knip
 
 if printf '%s\n' "$changed_files" | grep -q '^server/'; then
-	(cd server && bun ts)
+	bunx turbo run ts --filter=@autumn/server
 fi
 
 if printf '%s\n' "$changed_files" | grep -q '^vite/'; then
-	(cd vite && bunx tsc --noEmit)
+	bunx turbo run ts --filter=@autumn/vite
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -18,9 +18,9 @@ changed_files="$(
 )"
 
 if printf '%s\n' "$changed_files" | grep -q '^server/'; then
-	(cd server && bun test tests/unit)
+	bunx turbo run test:unit --filter=@autumn/server
 fi
 
 if printf '%s\n' "$changed_files" | grep -q '^vite/'; then
-	(cd vite && bun test tests/)
+	bunx turbo run test:unit --filter=@autumn/vite
 fi

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "inquirer": "^12.10.0",
         "knip": "^6.7.0",
         "ts-to-zod": "^5.1.0",
+        "turbo": "^2.9.6",
       },
     },
     "apps/checkout": {
@@ -2173,6 +2174,18 @@
     "@tsconfig/node14": ["@tsconfig/node14@1.0.3", "", {}, "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="],
 
     "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.6", "", { "os": "linux", "cpu": "x64" }, "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.6", "", { "os": "win32", "cpu": "x64" }, "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -5445,6 +5458,8 @@
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "autumn",
 	"private": true,
+	"packageManager": "bun@1.3.10",
 	"workspaces": {
 		"packages": [
 			"server",
@@ -143,6 +144,7 @@
 		"husky": "^9.1.7",
 		"inquirer": "^12.10.0",
 		"knip": "^6.7.0",
-		"ts-to-zod": "^5.1.0"
+		"ts-to-zod": "^5.1.0",
+		"turbo": "^2.9.6"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"site": "cd apps/website && bun dev && cd ../..",
 		"docs": "bun -F @autumn/docs dev",
 		"docs:build": "bun -F @autumn/docs build",
-		"ts": "bun -F @autumn/server ts && bun -F autumn-js ts && bun -F @autumn/openapi ts && bun -F atmn ts && bun -F checkout ts",
+		"ts": "turbo run ts --filter=@autumn/server --filter=autumn-js --filter=@autumn/openapi --filter=atmn --filter=checkout",
 		"atmn:build": "bun -F atmn build",
 		"openapi:ts": "bun -F @autumn/openapi ts",
 		"js:ts": "bun -F autumn-js ts",

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
 		"clear-master": "ENV_FILE=.env infisical run --env=dev --recursive -- bun tests/clearMasterOrg.ts",
 		"cm": "ENV_FILE=.env infisical run --env=dev --recursive -- bun tests/clearMaster.ts",
 		"ts": "bunx tsgo --build --noEmit",
+		"test:unit": "bun test tests/unit",
 		"test:integration": "ENV_FILE=.env infisical run --env=dev --recursive -- bun test --timeout 0 --preload ./tests/setup-integration-tests.ts",
 		"loadtest": "ENV_FILE=.env infisical run --env=dev --recursive -- npx artillery run perf/load-test/artillery.yml",
 		"loadtest:leak": "ENV_FILE=.env infisical run --env=dev --recursive -- bun perf/load-test/runLeakTest.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://turbo.build/schema.json",
+	"tasks": {
+		"ts": {
+			"outputs": []
+		},
+		"test:unit": {
+			"outputs": []
+		}
+	}
+}

--- a/vite/package.json
+++ b/vite/package.json
@@ -6,8 +6,10 @@
 	"scripts": {
 		"dev": "vite --host",
 		"build": "tsc && vite build",
+		"ts": "tsc --noEmit",
 		"start": "serve -s dist",
 		"lint": "eslint .",
+		"test:unit": "bun test tests/",
 		"preview": "vite preview",
 		"dev:bun": "bunx --bun vite --port 3000 --host",
 		"build:bun": "tsc && bunx --bun vite build",


### PR DESCRIPTION
## Summary
- add Turbo config and dependency for cached local hook tasks
- route pre-commit typechecks and pre-push unit tests through Turbo
- add Vite/server package scripts used by the hooks
- ignore Turbo cache directories

## Validation
- JSON parse check for edited package/config files
- shell syntax check for Husky hooks
- Turbo dry-runs for server unit tests and Vite typecheck
- real Turbo cache smoke test on @autumn/ksuid
- pre-push hook ran server and Vite unit tests successfully during push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache local type checks and unit tests with `turbo`, and route Husky hooks and the root typecheck through it to speed up pre-commit, pre-push, and dev runs. Adds minimal scripts and ignores the Turbo cache.

- **Refactors**
  - Route Husky hooks and root `ts` script through `turbo` with filters for `@autumn/server`, `@autumn/vite`, `autumn-js`, `@autumn/openapi`, `atmn`, `checkout`.
  - Add `ts` and `test:unit` scripts in `server` and `vite`.
  - Add `turbo.json` with `ts` and `test:unit` tasks.
  - Ignore `**/.turbo/` and set `packageManager` to `bun@1.3.10`.

- **Dependencies**
  - Add `turbo@^2.9.6` and update `bun.lock`.

<sup>Written for commit 94bba6953ee0bd9c181054d0c86e7daf12bac88b. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1398?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

