### PR TITLE
chore: skip schedule

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -259,6 +259,8 @@ export const setupAttachBillingContext = async ({
 		externalId: params.subscription_id,
 
 		skipBillingChanges,
+		skipSubscriptionScheduleUpdates:
+			contextOverride.skipSubscriptionScheduleUpdates,
 
 		anchorResetRefund: setupAnchorResetRefund({
 			billingCycleAnchor: params.billing_cycle_anchor,

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -162,9 +162,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 	});
 
 	checkoutMode =
-		params.redirect_mode === "always" && Boolean(checkoutMode)
-			? checkoutMode
-			: null; // For update subscription, always use autumn_checkout for now
+		params.redirect_mode === "always" && checkoutMode ? checkoutMode : null; // For update subscription, always use autumn_checkout for now
 
 	const intent = setupUpdateSubscriptionIntent({
 		params,
@@ -207,6 +205,8 @@ export const setupUpdateSubscriptionBillingContext = async ({
 			: (customerProduct.billing_version ?? BillingVersion.V2),
 
 		skipBillingChanges,
+		skipSubscriptionScheduleUpdates:
+			contextOverride.skipSubscriptionScheduleUpdates,
 
 		checkoutMode,
 

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionScheduleAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionScheduleAction.ts
@@ -182,6 +182,8 @@ export const buildStripeSubscriptionScheduleAction = ({
 	finalCustomerProducts: FullCusProduct[];
 	trialEndsAt?: number;
 }): StripeSubscriptionScheduleResult => {
+	if (billingContext.skipSubscriptionScheduleUpdates === true) return {};
+
 	const { stripeSubscriptionSchedule, stripeSubscription } = billingContext;
 	const { insertCustomerProducts } = autumnBillingPlan;
 

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
@@ -46,20 +46,16 @@ export const evaluateStripeBillingPlan = async ({
 	});
 
 	// Build stripe subscription schedule action
-	const skipSubscriptionScheduleUpdates =
-		billingContext.skipSubscriptionScheduleUpdates === true;
 	const {
 		scheduleAction: stripeSubscriptionScheduleAction,
 		subscriptionCancelAt,
-	} = skipSubscriptionScheduleUpdates
-		? {}
-		: buildStripeSubscriptionScheduleAction({
-				ctx,
-				billingContext,
-				autumnBillingPlan,
-				finalCustomerProducts: finalFullCustomer.customer_products,
-				trialEndsAt: billingContext.trialContext?.trialEndsAt ?? undefined,
-			});
+	} = buildStripeSubscriptionScheduleAction({
+		ctx,
+		billingContext,
+		autumnBillingPlan,
+		finalCustomerProducts: finalFullCustomer.customer_products,
+		trialEndsAt: billingContext.trialContext?.trialEndsAt ?? undefined,
+	});
 
 	const stripeSubscriptionAction = buildStripeSubscriptionAction({
 		ctx,

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
@@ -46,16 +46,20 @@ export const evaluateStripeBillingPlan = async ({
 	});
 
 	// Build stripe subscription schedule action
+	const skipSubscriptionScheduleUpdates =
+		billingContext.skipSubscriptionScheduleUpdates === true;
 	const {
 		scheduleAction: stripeSubscriptionScheduleAction,
 		subscriptionCancelAt,
-	} = buildStripeSubscriptionScheduleAction({
-		ctx,
-		billingContext,
-		autumnBillingPlan,
-		finalCustomerProducts: finalFullCustomer.customer_products,
-		trialEndsAt: billingContext.trialContext?.trialEndsAt ?? undefined,
-	});
+	} = skipSubscriptionScheduleUpdates
+		? {}
+		: buildStripeSubscriptionScheduleAction({
+				ctx,
+				billingContext,
+				autumnBillingPlan,
+				finalCustomerProducts: finalFullCustomer.customer_products,
+				trialEndsAt: billingContext.trialContext?.trialEndsAt ?? undefined,
+			});
 
 	const stripeSubscriptionAction = buildStripeSubscriptionAction({
 		ctx,

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
@@ -53,6 +53,8 @@ export const executeStripeBillingPlan = async ({
 
 	const resumeAfterSubscriptionAction =
 		resumeAfter === StripeBillingStage.SubscriptionAction;
+	const skipSubscriptionScheduleUpdates =
+		billingContext.skipSubscriptionScheduleUpdates === true;
 
 	if (stripeInvoiceAction && !resumeAfterInvoiceAction) {
 		invoiceResult = await executeStripeInvoiceAction({
@@ -77,7 +79,9 @@ export const executeStripeBillingPlan = async ({
 
 	// For schedule release, we need to release first before updating subscription with cancel_at
 	// Otherwise Stripe rejects the cancel_at update while schedule still manages subscription
-	const isReleaseAction = stripeSubscriptionScheduleAction?.type === "release";
+	const isReleaseAction =
+		!skipSubscriptionScheduleUpdates &&
+		stripeSubscriptionScheduleAction?.type === "release";
 
 	if (isReleaseAction && !resumeAfterSubscriptionAction) {
 		await executeStripeSubscriptionScheduleAction({
@@ -99,7 +103,11 @@ export const executeStripeBillingPlan = async ({
 			subscriptionResult.stripeSubscription ?? stripeSubscription;
 	}
 
-	if (stripeSubscriptionScheduleAction && !isReleaseAction) {
+	if (
+		stripeSubscriptionScheduleAction &&
+		!isReleaseAction &&
+		!skipSubscriptionScheduleUpdates
+	) {
 		const stripeSubscriptionSchedule =
 			await executeStripeSubscriptionScheduleAction({
 				ctx,

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeBillingPlan.ts
@@ -103,11 +103,12 @@ export const executeStripeBillingPlan = async ({
 			subscriptionResult.stripeSubscription ?? stripeSubscription;
 	}
 
-	if (
+	const shouldExecuteScheduleAction =
 		stripeSubscriptionScheduleAction &&
 		!isReleaseAction &&
-		!skipSubscriptionScheduleUpdates
-	) {
+		!skipSubscriptionScheduleUpdates;
+
+	if (shouldExecuteScheduleAction) {
 		const stripeSubscriptionSchedule =
 			await executeStripeSubscriptionScheduleAction({
 				ctx,

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -85,6 +85,7 @@ export interface BillingContext {
 	userMetadata?: Record<string, string>;
 
 	skipBillingChanges?: boolean;
+	skipSubscriptionScheduleUpdates?: boolean;
 
 	checkoutMode?: CheckoutMode;
 

--- a/shared/models/billingModels/context/billingContextOverride.ts
+++ b/shared/models/billingModels/context/billingContextOverride.ts
@@ -36,6 +36,7 @@ export interface BillingContextOverride {
 	transitionConfig?: TransitionConfig;
 	billingVersion?: BillingVersion;
 	endOfCycleMsOverride?: number;
+	skipSubscriptionScheduleUpdates?: boolean;
 }
 
 export interface UpdateSubscriptionBillingContextOverride


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce a `skipSubscriptionScheduleUpdates` flag to bypass Stripe Subscription Schedule actions and allow direct subscription changes when needed. Default behavior is unchanged unless the flag is set.

- **New Features**
  - Added `skipSubscriptionScheduleUpdates` to `BillingContext` and `BillingContextOverride`.
  - Wired the flag through attach and update-subscription setup; also simplified checkout redirect logic (no behavior change).
  - Stripe plan now skips building and executing schedule actions (create/update/release) when the flag is true, and guards release checks accordingly.

<sup>Written for commit 54dec49b2f1914f15bd18121a95bb12bd8a192ac. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1401">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

