### PR TITLE
fix: 🐛 network errors swallowed by fail open, add debug log

### DIFF
--- a/packages/sdk/src/hooks/failOpenHook.ts
+++ b/packages/sdk/src/hooks/failOpenHook.ts
@@ -74,10 +74,14 @@ export class FailOpenHook implements SDKInitHook, AfterErrorHook {
 			fetcher: async (input, init) => {
 				try {
 					return init == null ? await fetch(input) : await fetch(input, init);
-				} catch {
+				} catch (error) {
+					console.log(error);
+					console.log(
+						`Network failed to reach Autumn: ${error}. Returning 555 Network Error.`,
+					);
 					return new Response(null, {
-						status: 503,
-						statusText: "Autumn Unreachable",
+						status: 555,
+						statusText: "Network Error",
 					});
 				}
 			},


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Network failures to Autumn were being swallowed by the fail-open fetcher. We now log the error and return a 555 Network Error instead of 503 to make issues visible.

- **Bug Fixes**
  - In `packages/sdk/src/hooks/failOpenHook.ts`, log caught network errors for debugging.
  - Return `Response` with status 555 and statusText "Network Error" (replaces 503 "Autumn Unreachable").

<sup>Written for commit 5845a9a0866b1833c2177b05e3d08671fc98abe7. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1404?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where network-level errors thrown by `fetch()` were silently swallowed by the fail-open hook without any logging. It also changes the synthetic fallback status code from `503` to `555` to better distinguish injected network-error responses from real server `503`s.

**Key changes:**
- [Bug fixes] Network errors in the `fetcher` catch block are now surfaced via `console.log` instead of being silently discarded.
- [Improvements] Synthetic fallback status changed from `503` → `555` so a genuine server `503` is not confused with a local network failure in downstream code.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; only a P2 style inconsistency with `console.log` vs `console.error` and redundant error logging.

No P0/P1 issues. The 555 status code is still ≥ 500, so `afterError` correctly triggers fail-open for all covered operations. The only finding is a P2 style issue (wrong log level, duplicate logging).

No files require special attention beyond the minor logging concern in `failOpenHook.ts`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sdk/src/hooks/failOpenHook.ts | Catches network errors, logs them, and returns a synthetic 555 response so `afterError` can trigger fail-open; logging uses `console.log` instead of the file's established `console.error` pattern and duplicates the error value. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant FailOpenHook
    participant Fetch as fetch()
    participant Autumn as Autumn API

    App->>FailOpenHook: HTTP request (check / track / etc.)
    FailOpenHook->>Fetch: fetch(input, init)
    alt Network reachable
        Fetch->>Autumn: request
        Autumn-->>Fetch: real HTTP response
        Fetch-->>FailOpenHook: response
        FailOpenHook-->>App: response (normal path)
    else Network error (catch)
        Fetch-->>FailOpenHook: throws Error
        FailOpenHook->>FailOpenHook: console.log(error) x2 [NEW]
        FailOpenHook-->>FailOpenHook: synthetic Response(null, {status:555}) [WAS 503]
        FailOpenHook->>FailOpenHook: afterError() — status >= 500, operationID in set
        FailOpenHook-->>App: Response(JSON.stringify(FAIL_OPEN_BODY), {status:200})
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/sdk/src/hooks/failOpenHook.ts
Line: 78-81

Comment:
**Use `console.error` and avoid logging the error object twice**

The existing `afterError` method uses `console.error` for all error logging. These two lines use `console.log` (which goes to stdout rather than stderr) and log the same `error` value twice — once as a raw object and once interpolated into the message string. Prefer a single `console.error` call for consistency and to reduce duplicate noise.

```suggestion
				console.error(
					`[Autumn] Network failed to reach Autumn: ${error}. Returning 555 Network Error.`,
					error,
				);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 network errors swallowed by fail..."](https://github.com/useautumn/autumn/commit/5845a9a0866b1833c2177b05e3d08671fc98abe7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30154302)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->