### PR TITLE
Fix balance edit failing for entity-scoped entitlements without entity selected

### DIFF
--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -78,6 +78,17 @@ export function BalanceEditSheet() {
 			cp.price.entitlement_id === selectedCusEnt.entitlement.id,
 	);
 
+	const derivedEntity = customer?.entities?.find((e: Entity) => {
+		if (selectedCusEnt.internal_entity_id)
+			return e.internal_id === selectedCusEnt.internal_entity_id;
+		return (
+			e.internal_id === cusProduct?.internal_entity_id ||
+			e.id === cusProduct?.entity_id
+		);
+	});
+	const effectiveEntityId =
+		entityId ?? derivedEntity?.id ?? derivedEntity?.internal_id ?? null;
+
 	return (
 		<div className="flex flex-col h-full">
 			<SheetHeader
@@ -92,15 +103,15 @@ export function BalanceEditSheet() {
 
 			{isUnlimited ? (
 				<UnlimitedBalanceInfo
-					customer={customer}
+					entity={derivedEntity}
 					selectedCusEnt={selectedCusEnt}
 					cusProduct={cusProduct}
 				/>
 			) : (
 				<BalanceEditForm
 					selectedCusEnt={selectedCusEnt}
-					entityId={entityId}
-					customer={customer}
+					entity={derivedEntity}
+					entityId={effectiveEntityId}
 					cusProduct={cusProduct}
 					cusPrice={cusPrice}
 					featureId={featureId}
@@ -113,11 +124,11 @@ export function BalanceEditSheet() {
 /* ─── Unlimited Info (no form needed) ─── */
 
 function UnlimitedBalanceInfo({
-	customer,
+	entity,
 	selectedCusEnt,
 	cusProduct,
 }: {
-	customer: any;
+	entity: Entity | undefined;
 	selectedCusEnt: FullCustomerEntitlement;
 	cusProduct: FullCusProduct | undefined;
 }) {
@@ -125,7 +136,7 @@ function UnlimitedBalanceInfo({
 		<div className="flex-1 overflow-y-auto">
 			<SheetSection withSeparator={false}>
 				<EntitlementInfoRows
-					customer={customer}
+					entity={entity}
 					selectedCusEnt={selectedCusEnt}
 					cusProduct={cusProduct}
 					isUnlimited
@@ -140,19 +151,20 @@ function UnlimitedBalanceInfo({
 
 function BalanceEditForm({
 	selectedCusEnt,
+	entity,
 	entityId,
-	customer,
 	cusProduct,
 	cusPrice,
 	featureId,
 }: {
 	selectedCusEnt: FullCustomerEntitlement;
+	entity: Entity | undefined;
 	entityId: string | null;
-	customer: any;
 	cusProduct: FullCusProduct | undefined;
 	cusPrice: FullCustomerPrice | undefined;
 	featureId: string;
 }) {
+	const { customer } = useCusQuery();
 	const form = useBalanceEditForm({
 		selectedCusEnt,
 		entityId,
@@ -162,7 +174,7 @@ function BalanceEditForm({
 		<div className="flex-1 overflow-y-auto">
 			<SheetSection withSeparator>
 				<EntitlementInfoRows
-					customer={customer}
+					entity={entity}
 					selectedCusEnt={selectedCusEnt}
 					cusProduct={cusProduct}
 					isUnlimited={false}
@@ -249,26 +261,16 @@ function RolloversSection({
 /* ─── Entitlement Info Rows ─── */
 
 function EntitlementInfoRows({
-	customer,
+	entity,
 	selectedCusEnt,
 	cusProduct,
 	isUnlimited,
 }: {
-	customer: any;
+	entity: Entity | undefined;
 	selectedCusEnt: FullCustomerEntitlement;
 	cusProduct: FullCusProduct | undefined;
 	isUnlimited: boolean;
 }) {
-	const entity = customer?.entities?.find((e: Entity) => {
-		if (selectedCusEnt.internal_entity_id) {
-			return e.internal_id === selectedCusEnt.internal_entity_id;
-		}
-		return (
-			e.internal_id === cusProduct?.internal_entity_id ||
-			e.id === cusProduct?.entity_id
-		);
-	});
-
 	return (
 		<div className="flex flex-col gap-2 rounded-lg">
 			{selectedCusEnt.external_id && (


### PR DESCRIPTION
## Summary
- Editing an entity-scoped balance from the customer sheet failed with "No balances to update" when no entity was explicitly selected in the top-level entity dropdown, even though the sheet displayed the correct entity.
- The root cause was that `entity_id` was only sourced from the context dropdown (`useCustomerContext`), which is `null` when unset. The backend SQL query excludes entity-scoped customer products when no `entity_id` is provided, so the entitlement was never found.
- The fix derives the entity from the selected customer entitlement's own entity association (`internal_entity_id` / `cusProduct` fields), falling back to the context value. The entity lookup is consolidated in `BalanceEditSheet` and passed down as a prop to keep it DRY — `EntitlementInfoRows` no longer re-derives it internally.

## Type of Change
- [x] Bug fix

## Checklist
- [x] My code follows the code style of this project
- [x] I have tested my changes locally

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes balance edits for entity-scoped entitlements when no entity is selected in the dropdown. We now derive the entity from the selected entitlement or its product, so updates no longer fail with “No balances to update.”

- **Bug Fixes**
  - Derive entity from `selectedCusEnt.internal_entity_id`, then `cusProduct.internal_entity_id`/`cusProduct.entity_id`, then context `entityId` to compute `effectiveEntityId`.
  - Centralize entity lookup in `BalanceEditSheet` (`derivedEntity`, `effectiveEntityId`) and pass `entity`/`entityId` to children; remove duplicate lookup from `EntitlementInfoRows`.
  - Ensures the backend query includes the correct entity-scoped product even when the top-level entity dropdown is unset.

<sup>Written for commit dc24277fc5616e1c08bcf6db7e1de0488e160cf7. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1406?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where editing an entity-scoped balance from the customer sheet failed with \"No balances to update\" when no entity was selected in the top-level dropdown. The entity derivation logic previously lived only in `EntitlementInfoRows` (display-only) and the backend call fell back to a `null` `entity_id`; the fix consolidates derivation at the `BalanceEditSheet` level and threads `effectiveEntityId` through to the submit payload.

**Key changes:**
- [Bug fixes] `effectiveEntityId` now falls back to `derivedEntity?.id` / `derivedEntity?.internal_id` when the context dropdown `entityId` is `null`, ensuring the backend receives a valid entity ID.
- [Improvements] `derivedEntity` lookup is lifted to `BalanceEditSheet` and passed as a typed `Entity | undefined` prop, removing the duplicated find logic from `EntitlementInfoRows`.
- [Improvements] `UnlimitedBalanceInfo` and `BalanceEditForm` now accept `entity` instead of the loosely-typed `customer: any`, improving type safety.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the bug fix is correct and targeted, with only a minor dead-code P2 finding.

All findings are P2 (unused variable). The core bug fix — deriving `effectiveEntityId` from the entitlement's own entity fields and passing it to the backend — is logically sound. No P0 or P1 issues found.

No files require special attention beyond the minor cleanup in `BalanceEditForm`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx | Entity derivation consolidated to `BalanceEditSheet` top level; `effectiveEntityId` now falls back to the entitlement's own entity when the context dropdown is unset; minor leftover unused `customer` variable in `BalanceEditForm` |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BalanceEditSheet] --> B{Derive entity}
    B -- "selectedCusEnt.internal_entity_id set" --> C["Match e.internal_id === internal_entity_id"]
    B -- "fallback" --> D["Match e.internal_id === cusProduct.internal_entity_id\nOR e.id === cusProduct.entity_id"]
    C --> E[derivedEntity]
    D --> E
    E --> F{effectiveEntityId}
    F -- "entityId from context (non-null)" --> G[use context entityId]
    F -- "entityId null" --> H[use derivedEntity.id]
    H -- "no id" --> I[use derivedEntity.internal_id]
    G --> J[BalanceEditForm / UnlimitedBalanceInfo]
    H --> J
    I --> J
    J --> K[SubmitButton → POST /v1/balances/update with entity_id]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
Line: 167

Comment:
**Unused `customer` from `useCusQuery` in `BalanceEditForm`**

`customer` is destructured here but never referenced inside `BalanceEditForm` itself — `SubmitButton` already calls `useCusQuery()` independently on line 526. This is a leftover from the previous `customer` prop and results in a redundant hook invocation and an unused variable.

```suggestion
	const form = useBalanceEditForm({
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix balance edit failing for entity-scop..."](https://github.com/useautumn/autumn/commit/dc24277fc5616e1c08bcf6db7e1de0488e160cf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30177703)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->