### PR TITLE
Fix balance edit failing for entity-scoped entitlements without entity selected

### DIFF
--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -78,6 +78,17 @@ export function BalanceEditSheet() {
 			cp.price.entitlement_id === selectedCusEnt.entitlement.id,
 	);
 
+	const derivedEntity = customer?.entities?.find((e: Entity) => {
+		if (selectedCusEnt.internal_entity_id)
+			return e.internal_id === selectedCusEnt.internal_entity_id;
+		return (
+			e.internal_id === cusProduct?.internal_entity_id ||
+			e.id === cusProduct?.entity_id
+		);
+	});
+	const effectiveEntityId =
+		entityId ?? derivedEntity?.id ?? derivedEntity?.internal_id ?? null;
+
 	return (
 		<div className="flex flex-col h-full">
 			<SheetHeader
@@ -92,15 +103,15 @@ export function BalanceEditSheet() {
 
 			{isUnlimited ? (
 				<UnlimitedBalanceInfo
-					customer={customer}
+					entity={derivedEntity}
 					selectedCusEnt={selectedCusEnt}
 					cusProduct={cusProduct}
 				/>
 			) : (
 				<BalanceEditForm
 					selectedCusEnt={selectedCusEnt}
-					entityId={entityId}
-					customer={customer}
+					entity={derivedEntity}
+					entityId={effectiveEntityId}
 					cusProduct={cusProduct}
 					cusPrice={cusPrice}
 					featureId={featureId}
@@ -113,11 +124,11 @@ export function BalanceEditSheet() {
 /* ─── Unlimited Info (no form needed) ─── */
 
 function UnlimitedBalanceInfo({
-	customer,
+	entity,
 	selectedCusEnt,
 	cusProduct,
 }: {
-	customer: any;
+	entity: Entity | undefined;
 	selectedCusEnt: FullCustomerEntitlement;
 	cusProduct: FullCusProduct | undefined;
 }) {
@@ -125,7 +136,7 @@ function UnlimitedBalanceInfo({
 		<div className="flex-1 overflow-y-auto">
 			<SheetSection withSeparator={false}>
 				<EntitlementInfoRows
-					customer={customer}
+					entity={entity}
 					selectedCusEnt={selectedCusEnt}
 					cusProduct={cusProduct}
 					isUnlimited
@@ -140,19 +151,20 @@ function UnlimitedBalanceInfo({
 
 function BalanceEditForm({
 	selectedCusEnt,
+	entity,
 	entityId,
-	customer,
 	cusProduct,
 	cusPrice,
 	featureId,
 }: {
 	selectedCusEnt: FullCustomerEntitlement;
+	entity: Entity | undefined;
 	entityId: string | null;
-	customer: any;
 	cusProduct: FullCusProduct | undefined;
 	cusPrice: FullCustomerPrice | undefined;
 	featureId: string;
 }) {
+	const { customer } = useCusQuery();
 	const form = useBalanceEditForm({
 		selectedCusEnt,
 		entityId,
@@ -162,7 +174,7 @@ function BalanceEditForm({
 		<div className="flex-1 overflow-y-auto">
 			<SheetSection withSeparator>
 				<EntitlementInfoRows
-					customer={customer}
+					entity={entity}
 					selectedCusEnt={selectedCusEnt}
 					cusProduct={cusProduct}
 					isUnlimited={false}
@@ -249,26 +261,16 @@ function RolloversSection({
 /* ─── Entitlement Info Rows ─── */
 
 function EntitlementInfoRows({
-	customer,
+	entity,
 	selectedCusEnt,
 	cusProduct,
 	isUnlimited,
 }: {
-	customer: any;
+	entity: Entity | undefined;
 	selectedCusEnt: FullCustomerEntitlement;
 	cusProduct: FullCusProduct | undefined;
 	isUnlimited: boolean;
 }) {
-	const entity = customer?.entities?.find((e: Entity) => {
-		if (selectedCusEnt.internal_entity_id) {
-			return e.internal_id === selectedCusEnt.internal_entity_id;
-		}
-		return (
-			e.internal_id === cusProduct?.internal_entity_id ||
-			e.id === cusProduct?.entity_id
-		);
-	});
-
 	return (
 		<div className="flex flex-col gap-2 rounded-lg">
 			{selectedCusEnt.external_id && (


### PR DESCRIPTION
## Summary
Cherry-pick of #1406 onto main.

- Editing an entity-scoped balance from the customer sheet failed with "No balances to update" when no entity was explicitly selected in the top-level entity dropdown, even though the sheet displayed the correct entity.
- The root cause was that `entity_id` was only sourced from the context dropdown (`useCustomerContext`), which is `null` when unset. The backend SQL query excludes entity-scoped customer products when no `entity_id` is provided, so the entitlement was never found.
- The fix derives the entity from the selected customer entitlement's own entity association (`internal_entity_id` / `cusProduct` fields), falling back to the context value. The entity lookup is consolidated in `BalanceEditSheet` and passed down as a prop to keep it DRY.

## Type of Change
- [x] Bug fix

## Checklist
- [x] My code follows the code style of this project
- [x] I have tested my changes locally

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes balance edits for entity‑scoped entitlements when the top-level entity dropdown is unset. We now derive the entity from the selected entitlement so updates no longer fail with “No balances to update.”

- **Bug Fixes**
  - Derive `derivedEntity` from `selectedCusEnt.internal_entity_id` or `cusProduct` (`internal_entity_id`/`entity_id`), and compute `effectiveEntityId` with a context fallback.
  - Pass `entity` and `effectiveEntityId` into `BalanceEditForm` and `UnlimitedBalanceInfo`; `EntitlementInfoRows` now receives `entity` to avoid duplicate lookups.
  - Stop relying solely on `useCustomerContext` for `entity_id` when unset, ensuring entity-scoped products are found by the backend.

<sup>Written for commit e452d6ab123a8c55648e54531998de68d34e4efd. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1407?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where editing an entity-scoped balance from the customer sheet failed with "No balances to update" when no entity was selected in the top-level context dropdown. The fix moves the entity lookup into `BalanceEditSheet` (deriving it from the selected entitlement's own `internal_entity_id` / `cusProduct` fields), computes an `effectiveEntityId` that falls back from the context value through the derived entity, and threads the resolved `entity` and `entityId` down as props — eliminating the duplicated lookup that previously lived in `EntitlementInfoRows`.

**Key changes:**
- **Bug fixes**: Derive `entity` from the selected entitlement's own association (`internal_entity_id` / `cusProduct`) when the context dropdown has no entity selected, so the backend receives a valid `entity_id` and can locate the customer product.
- **Improvements**: Consolidate the entity-lookup logic into the top-level `BalanceEditSheet` component and pass it down as a typed `Entity | undefined` prop, removing the duplicated `customer.entities.find(…)` call from `EntitlementInfoRows`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — targeted fix for a clear regression with a clean implementation; one minor question about internal_id as entity_id fallback.

Only P2-level finding: the internal_id fallback in effectiveEntityId may not be accepted by the backend, but this is an edge case for entities without external IDs and the primary fix (using derivedEntity.id) is correct. The core logic is sound.

No files require special attention beyond the inline note on line 90.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx | Entity lookup consolidated in BalanceEditSheet and derived entity/effectiveEntityId passed as props — fixes the "No balances to update" regression; minor question about internal_id fallback as entity_id in API call |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as BalanceEditSheet
    participant Ctx as useCustomerContext
    participant Q as useCusQuery
    participant Form as BalanceEditForm
    participant API as /v1/balances/update

    UI->>Ctx: entityId (may be null if no dropdown selection)
    UI->>Q: customer (entities, customer_products)
    UI->>UI: cusProduct = customer_products.find(selectedCusEnt)
    UI->>UI: derivedEntity = entities.find() via internal_entity_id or cusProduct fields
    UI->>UI: effectiveEntityId = entityId ?? derivedEntity.id ?? derivedEntity.internal_id
    UI->>Form: entity, entityId=effectiveEntityId
    Form->>API: POST entity_id=effectiveEntityId, customer_entitlement_id, ...
    API-->>Form: 200 OK (entity-scoped balance updated)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
Line: 89-90

Comment:
**`internal_id` fallback as `entity_id` may be rejected by backend**

`effectiveEntityId` falls back to `derivedEntity?.internal_id` when `derivedEntity?.id` is nullish. The API call at line 584 sends this value as `entity_id`. If the `/v1/balances/update` endpoint only accepts external entity IDs (not internal UUIDs), the request would still fail silently in cases where an entity exists in the customer data but has no external `id` set. Worth verifying that the backend endpoint accepts `internal_id` as a valid `entity_id` value.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix balance edit failing for entity-scop..."](https://github.com/useautumn/autumn/commit/e452d6ab123a8c55648e54531998de68d34e4efd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30178330)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->