### PR TITLE
release

### DIFF
--- a/scripts/setup/link-unit-test.sh
+++ b/scripts/setup/link-unit-test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/setup/link-test-stripe-account.ts \
+  --org=unit-test-org \
+  --account-id=acct_1TObjo5ch7bV1B9z \
+  --clear-secret-key

--- a/server/src/utils/memoryMonitor.ts
+++ b/server/src/utils/memoryMonitor.ts
@@ -35,10 +35,11 @@ function logMemoryUsage(label: string) {
 
 	const lagMeanMs = Math.round((lagHistogram.mean / 1e6) * 10) / 10;
 	const lagP99Ms = Math.round((lagHistogram.percentile(99) / 1e6) * 10) / 10;
+	const lagMaxMs = Math.round((lagHistogram.max / 1e6) * 10) / 10;
 	lagHistogram.reset();
 
 	logger.info(
-		`memory_log, rss: ${toMB(mem.rss)}MB, heapUsed: ${toMB(mem.heapUsed)}MB, eventLoopLagP99: ${lagP99Ms}ms`,
+		`memory_log, rss: ${toMB(mem.rss)}MB, heapUsed: ${toMB(mem.heapUsed)}MB, eventLoopLagP99: ${lagP99Ms}ms, eventLoopLagMax: ${lagMaxMs}ms`,
 		{
 			type: "memory_log",
 			data: {
@@ -52,6 +53,7 @@ function logMemoryUsage(label: string) {
 				nativeGapMB: toMB(mem.rss - mem.heapTotal - mem.external),
 				eventLoopLagMeanMs: lagMeanMs,
 				eventLoopLagP99Ms: lagP99Ms,
+				eventLoopLagMaxMs: lagMaxMs,
 			},
 		},
 	);

--- a/server/src/utils/memoryMonitor.ts
+++ b/server/src/utils/memoryMonitor.ts
@@ -5,13 +5,28 @@
  * Uses Axiom logger so metrics are queryable via type: "memory_log".
  */
 
-import { monitorEventLoopDelay } from "node:perf_hooks";
+import { monitorEventLoopDelay, PerformanceObserver } from "node:perf_hooks";
 import { logger } from "../external/logtail/logtailUtils.js";
 
 // Event loop lag histogram — samples at 100ms resolution at the C++ level.
 // No JS callbacks involved, negligible overhead.
 const lagHistogram = monitorEventLoopDelay({ resolution: 100 });
 lagHistogram.enable();
+
+// GC pause tracking. observes V8 GC events and accumulates count, max and total
+// pause duration. Reset alongside the lag histogram on each emit so windows align.
+let gcCount = 0;
+let gcMaxMs = 0;
+let gcTotalMs = 0;
+
+const gcObserver = new PerformanceObserver((list) => {
+	for (const entry of list.getEntries()) {
+		gcCount += 1;
+		gcTotalMs += entry.duration;
+		if (entry.duration > gcMaxMs) gcMaxMs = entry.duration;
+	}
+});
+gcObserver.observe({ entryTypes: ["gc"] });
 
 /** Get the current mean event loop lag in milliseconds. */
 export function getEventLoopLagMs(): number {
@@ -38,8 +53,15 @@ function logMemoryUsage(label: string) {
 	const lagMaxMs = Math.round((lagHistogram.max / 1e6) * 10) / 10;
 	lagHistogram.reset();
 
+	const localGcCount = gcCount;
+	const localGcMaxMs = Math.round(gcMaxMs * 10) / 10;
+	const localGcTotalMs = Math.round(gcTotalMs * 10) / 10;
+	gcCount = 0;
+	gcMaxMs = 0;
+	gcTotalMs = 0;
+
 	logger.info(
-		`memory_log, rss: ${toMB(mem.rss)}MB, heapUsed: ${toMB(mem.heapUsed)}MB, eventLoopLagP99: ${lagP99Ms}ms, eventLoopLagMax: ${lagMaxMs}ms`,
+		`memory_log, rss: ${toMB(mem.rss)}MB, heapUsed: ${toMB(mem.heapUsed)}MB, eventLoopLagP99: ${lagP99Ms}ms, eventLoopLagMax: ${lagMaxMs}ms, gcMax: ${localGcMaxMs}ms`,
 		{
 			type: "memory_log",
 			data: {
@@ -54,6 +76,9 @@ function logMemoryUsage(label: string) {
 				eventLoopLagMeanMs: lagMeanMs,
 				eventLoopLagP99Ms: lagP99Ms,
 				eventLoopLagMaxMs: lagMaxMs,
+				gcCount: localGcCount,
+				gcMaxMs: localGcMaxMs,
+				gcTotalMs: localGcTotalMs,
 			},
 		},
 	);

--- a/server/src/utils/memoryMonitor.ts
+++ b/server/src/utils/memoryMonitor.ts
@@ -5,28 +5,13 @@
  * Uses Axiom logger so metrics are queryable via type: "memory_log".
  */
 
-import { monitorEventLoopDelay, PerformanceObserver } from "node:perf_hooks";
+import { monitorEventLoopDelay } from "node:perf_hooks";
 import { logger } from "../external/logtail/logtailUtils.js";
 
 // Event loop lag histogram — samples at 100ms resolution at the C++ level.
 // No JS callbacks involved, negligible overhead.
 const lagHistogram = monitorEventLoopDelay({ resolution: 100 });
 lagHistogram.enable();
-
-// GC pause tracking. observes V8 GC events and accumulates count, max and total
-// pause duration. Reset alongside the lag histogram on each emit so windows align.
-let gcCount = 0;
-let gcMaxMs = 0;
-let gcTotalMs = 0;
-
-const gcObserver = new PerformanceObserver((list) => {
-	for (const entry of list.getEntries()) {
-		gcCount += 1;
-		gcTotalMs += entry.duration;
-		if (entry.duration > gcMaxMs) gcMaxMs = entry.duration;
-	}
-});
-gcObserver.observe({ entryTypes: ["gc"] });
 
 /** Get the current mean event loop lag in milliseconds. */
 export function getEventLoopLagMs(): number {
@@ -53,15 +38,8 @@ function logMemoryUsage(label: string) {
 	const lagMaxMs = Math.round((lagHistogram.max / 1e6) * 10) / 10;
 	lagHistogram.reset();
 
-	const localGcCount = gcCount;
-	const localGcMaxMs = Math.round(gcMaxMs * 10) / 10;
-	const localGcTotalMs = Math.round(gcTotalMs * 10) / 10;
-	gcCount = 0;
-	gcMaxMs = 0;
-	gcTotalMs = 0;
-
 	logger.info(
-		`memory_log, rss: ${toMB(mem.rss)}MB, heapUsed: ${toMB(mem.heapUsed)}MB, eventLoopLagP99: ${lagP99Ms}ms, eventLoopLagMax: ${lagMaxMs}ms, gcMax: ${localGcMaxMs}ms`,
+		`memory_log, rss: ${toMB(mem.rss)}MB, heapUsed: ${toMB(mem.heapUsed)}MB, eventLoopLagP99: ${lagP99Ms}ms, eventLoopLagMax: ${lagMaxMs}ms`,
 		{
 			type: "memory_log",
 			data: {
@@ -76,9 +54,6 @@ function logMemoryUsage(label: string) {
 				eventLoopLagMeanMs: lagMeanMs,
 				eventLoopLagP99Ms: lagP99Ms,
 				eventLoopLagMaxMs: lagMaxMs,
-				gcCount: localGcCount,
-				gcMaxMs: localGcMaxMs,
-				gcTotalMs: localGcTotalMs,
 			},
 		},
 	);


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a max event-loop-lag metric to the memory monitor and introduces a helper shell script for linking a unit-test Stripe account.

**Key changes:**
- [Improvements] `memoryMonitor.ts`: adds `eventLoopLagMaxMs` (derived from `lagHistogram.max`) to both the log string and the structured data payload, giving a worst-case lag data point alongside the existing mean and P99.
- [Improvements] `scripts/setup/link-unit-test.sh`: new convenience script that uses `infisical` to inject dev secrets and runs `link-test-stripe-account.ts` with a fixed org and Stripe account ID for unit-test setup.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are additive and low-risk.

No logic errors, security issues, or breaking changes. The memory monitor change is a straightforward additive metric; the shell script uses existing tooling with non-secret identifiers.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/memoryMonitor.ts | Adds eventLoopLagMax metric (lagHistogram.max) to memory log output and structured data alongside existing mean/P99 metrics. |
| scripts/setup/link-unit-test.sh | New script that invokes infisical + bun to link a unit-test Stripe account; hardcodes a Stripe account ID and org name. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[logMemoryUsage called] --> B[process.memoryUsage]
    A --> C[lagHistogram.mean - lagMeanMs]
    A --> D[lagHistogram.p99 - lagP99Ms]
    A --> E[lagHistogram.max - lagMaxMs]
    C & D & E --> F[lagHistogram.reset]
    F --> G[logger.info with rss, heapUsed, lagP99, lagMax]
    G --> H[structured data with all memory and lag metrics]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1412 from useautumn/..."](https://github.com/useautumn/autumn/commit/5215aa7b02521b45f9c948cc6488d5bb44306d04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30326133)</sub>

<!-- /greptile_comment -->