### PR TITLE
feat/auto tax

### DIFF
--- a/server/src/external/stripe/stripeSubUtils/updateStripeSub/createProrationinvoice.ts
+++ b/server/src/external/stripe/stripeSubUtils/updateStripeSub/createProrationinvoice.ts
@@ -16,29 +16,26 @@ const undoSubUpdate = async ({
 	curSub: Stripe.Subscription;
 	updatedSub: Stripe.Subscription;
 }) => {
-	// For each price in the old subscription, find the corresponding item in the updated subscription
-	// and update it back to the old quantity, or delete it if it doesn't exist in the old sub
+	// Revert each updated item to the old quantity, or delete if missing from old sub.
 	const itemsToUpdate = updatedSub.items.data.map((updatedItem) => {
 		const oldItem = curSub.items.data.find(
 			(item) => item.price.id === updatedItem.price.id,
 		);
 
 		if (oldItem) {
-			// Item exists in both old and new - revert to old quantity
 			return {
 				id: updatedItem.id,
 				price: oldItem.price.id,
 				quantity: oldItem.quantity,
 			};
 		}
-		// Item only exists in updated sub - delete it
 		return {
 			id: updatedItem.id,
 			deleted: true,
 		};
 	});
 
-	// For prices that existed in old sub but were removed in the update, we need to add them back
+	// Re-add prices that were removed in the update.
 	const itemsToAdd = curSub.items.data
 		.filter(
 			(oldItem) =>
@@ -90,18 +87,9 @@ export const createProrationInvoice = async ({
 		};
 	}
 
-	// EXCEPTION TO THE INVOICE-MODE SKIP RULE: this is the proration invoice
-	// we charge IMMEDIATELY off the customer's PM (default
-	// `charge_automatically`). It is never emitted as
-	// `collection_method: send_invoice` — even when `invoiceOnly` is true on
-	// the parent attach, that flag controls whether we return the invoice
-	// for the buyer to pay manually, not the collection method on this
-	// invoice itself. So auto_tax is safe here.
-	//
-	// A proration invoice implies the customer already has a sub, which
-	// means they went through Checkout (or attach) at least once and Stripe
-	// has a location for them via its waterfall (customer.address →
-	// recent checkout / IP / predicted location). We trust that to resolve.
+	// Proration invoice always uses charge_automatically (parent's
+	// `invoiceOnly` only affects whether we return the invoice for manual
+	// payment, not this invoice's collection_method), so auto_tax is safe.
 	const wantsAutoTax = !!ctx.org.config.automatic_tax;
 	const invoice = await stripeCli.invoices.create({
 		customer: customer.processor.id,

--- a/server/src/external/stripe/stripeSubUtils/updateStripeSub/createProrationinvoice.ts
+++ b/server/src/external/stripe/stripeSubUtils/updateStripeSub/createProrationinvoice.ts
@@ -90,10 +90,24 @@ export const createProrationInvoice = async ({
 		};
 	}
 
+	// EXCEPTION TO THE INVOICE-MODE SKIP RULE: this is the proration invoice
+	// we charge IMMEDIATELY off the customer's PM (default
+	// `charge_automatically`). It is never emitted as
+	// `collection_method: send_invoice` — even when `invoiceOnly` is true on
+	// the parent attach, that flag controls whether we return the invoice
+	// for the buyer to pay manually, not the collection method on this
+	// invoice itself. So auto_tax is safe here.
+	//
+	// A proration invoice implies the customer already has a sub, which
+	// means they went through Checkout (or attach) at least once and Stripe
+	// has a location for them via its waterfall (customer.address →
+	// recent checkout / IP / predicted location). We trust that to resolve.
+	const wantsAutoTax = !!ctx.org.config.automatic_tax;
 	const invoice = await stripeCli.invoices.create({
 		customer: customer.processor.id,
 		auto_advance: false,
 		pending_invoice_items_behavior: "include",
+		...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 	});
 
 	if (invoiceOnly)

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
@@ -73,7 +73,21 @@ export const buildStripeCheckoutSessionAction = ({
 		? stripeDiscountsToCheckoutParams({ stripeDiscounts })
 		: undefined;
 
-	// 7. Build params (only variable params - static params added in execute)
+	// 7. Build params (only variable params - static params added in execute).
+	// Tax policy is part of the action shape (org config decides), so it
+	// lives here in the build step rather than being injected at execute
+	// time. Same rationale as `buildStripeSubscriptionUpdateAction`: the
+	// action object should be self-describing in logs / EXTRA LOGS.
+	const autumnAutoTax: Partial<Stripe.Checkout.SessionCreateParams> = org
+		.config.automatic_tax
+		? {
+				automatic_tax: { enabled: true },
+				billing_address_collection: "required",
+				customer_update: { address: "auto", name: "auto" },
+				tax_id_collection: { enabled: true },
+			}
+		: {};
+
 	const params: Stripe.Checkout.SessionCreateParams = {
 		customer: stripeCustomer?.id ?? "none",
 		mode,
@@ -81,6 +95,7 @@ export const buildStripeCheckoutSessionAction = ({
 		subscription_data: subscriptionData,
 		success_url: billingContext.successUrl ?? orgToReturnUrl({ org, env }),
 		discounts,
+		...autumnAutoTax,
 	};
 
 	return {

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
@@ -73,11 +73,8 @@ export const buildStripeCheckoutSessionAction = ({
 		? stripeDiscountsToCheckoutParams({ stripeDiscounts })
 		: undefined;
 
-	// 7. Build params (only variable params - static params added in execute).
-	// Tax policy is part of the action shape (org config decides), so it
-	// lives here in the build step rather than being injected at execute
-	// time. Same rationale as `buildStripeSubscriptionUpdateAction`: the
-	// action object should be self-describing in logs / EXTRA LOGS.
+	// 7. Build params. Tax policy is baked in here (not at execute time) so
+	// the action object is self-describing in logs/EXTRA_LOGS.
 	const autumnAutoTax: Partial<Stripe.Checkout.SessionCreateParams> = org
 		.config.automatic_tax
 		? {

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeCheckoutSessionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeCheckoutSessionAction.ts
@@ -40,12 +40,9 @@ export const executeStripeCheckoutSessionAction = async ({
 		expiresAt: addDays(Date.now(), 10).getTime(),
 	});
 
-	// 2. Build full checkout params (merge variable + static params).
-	// `automatic_tax`, `billing_address_collection`, `customer_update`, and
-	// `tax_id_collection` are part of `checkoutSessionAction.params` —
-	// `buildStripeCheckoutSessionAction` decides them from org config and
-	// bakes them into the action shape so the object is self-describing
-	// in logs.
+	// 2. Build full checkout params. Tax-related fields (automatic_tax,
+	// billing_address_collection, customer_update, tax_id_collection) are
+	// already baked into action.params by buildStripeCheckoutSessionAction.
 	const fullParams = buildCheckoutSessionParams({
 		params: checkoutSessionAction.params,
 		checkoutSessionParams: checkoutSessionAction.checkoutSessionParams,

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeCheckoutSessionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeCheckoutSessionAction.ts
@@ -40,7 +40,12 @@ export const executeStripeCheckoutSessionAction = async ({
 		expiresAt: addDays(Date.now(), 10).getTime(),
 	});
 
-	// 2. Build full checkout params (merge variable + static params)
+	// 2. Build full checkout params (merge variable + static params).
+	// `automatic_tax`, `billing_address_collection`, `customer_update`, and
+	// `tax_id_collection` are part of `checkoutSessionAction.params` —
+	// `buildStripeCheckoutSessionAction` decides them from org config and
+	// bakes them into the action shape so the object is self-describing
+	// in logs.
 	const fullParams = buildCheckoutSessionParams({
 		params: checkoutSessionAction.params,
 		checkoutSessionParams: checkoutSessionAction.checkoutSessionParams,

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -81,11 +81,9 @@ export const createInvoiceForBilling = async ({
 		stripeDiscounts: billingContext.stripeDiscounts ?? [],
 	});
 
-	// Skip auto_tax in invoice mode — Stripe rejects when the resulting
-	// invoice is `send_invoice` (no buyer-facing address-collection UI).
-	// For charge_automatically paths we trust Stripe's waterfall
-	// (customer.address → recent checkout / IP / predicted location) to
-	// resolve a jurisdiction.
+	// Skip auto_tax in invoice mode: send_invoice has no address-collection
+	// UI so Stripe Tax rejects. charge_automatically relies on Stripe's
+	// address waterfall.
 	const wantsAutoTax = !!ctx.org.config.automatic_tax && !isInvoiceMode;
 	const draftInvoice = await createStripeInvoice({
 		stripeCli,

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -81,6 +81,12 @@ export const createInvoiceForBilling = async ({
 		stripeDiscounts: billingContext.stripeDiscounts ?? [],
 	});
 
+	// Skip auto_tax in invoice mode — Stripe rejects when the resulting
+	// invoice is `send_invoice` (no buyer-facing address-collection UI).
+	// For charge_automatically paths we trust Stripe's waterfall
+	// (customer.address → recent checkout / IP / predicted location) to
+	// resolve a jurisdiction.
+	const wantsAutoTax = !!ctx.org.config.automatic_tax && !isInvoiceMode;
 	const draftInvoice = await createStripeInvoice({
 		stripeCli,
 		stripeCusId: billingContext.stripeCustomer?.id ?? "none",
@@ -92,6 +98,7 @@ export const createInvoiceForBilling = async ({
 		discounts: stripeDiscountsToInvoiceParams({
 			stripeDiscounts: invoiceEligibleStripeDiscounts,
 		}),
+		automaticTax: wantsAutoTax,
 	});
 
 	const invoiceWithLines = await addStripeInvoiceLines({

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts
@@ -16,6 +16,7 @@ type CreateInvoiceParams = {
 	daysUntilDue?: number;
 	description?: string;
 	metadata?: Stripe.InvoiceCreateParams["metadata"];
+	automaticTax?: boolean;
 };
 
 export const createStripeInvoice = async ({
@@ -28,6 +29,7 @@ export const createStripeInvoice = async ({
 	description,
 	metadata,
 	discounts,
+	automaticTax,
 }: CreateInvoiceParams): Promise<Stripe.Invoice> => {
 	const invoice = await stripeCli.invoices.create({
 		customer: stripeCusId,
@@ -40,6 +42,7 @@ export const createStripeInvoice = async ({
 		days_until_due:
 			collectionMethod === "send_invoice" ? (daysUntilDue ?? 30) : undefined,
 		...(discounts ? { discounts } : {}),
+		...(automaticTax ? { automatic_tax: { enabled: true } } : {}),
 	});
 
 	return invoice;

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
@@ -36,8 +36,8 @@ export const buildStripeSubscriptionUpdateAction = ({
 
 	const trialEndsAt = trialContext?.trialEndsAt;
 
-	// When a schedule manages the subscription, don't set trial_end or cancel_at_period_end
-	// The schedule controls these via phase-level settings
+	// When a schedule manages the sub, leave trial_end/cancel alone — the
+	// schedule sets those via phase-level settings.
 	const scheduleManagesSubscription = !!stripeSubscriptionScheduleAction;
 
 	const appliesToBilling = trialContext?.appliesToBilling;
@@ -52,7 +52,7 @@ export const buildStripeSubscriptionUpdateAction = ({
 		shouldUnsetTrialEnd = !scheduleManagesSubscription && trialEndsAt === null;
 	}
 
-	// Determine cancel_at: null = clear, number = set, undefined = don't touch
+	// cancel_at: null = clear, number = set, undefined = unchanged.
 	const currentCancelAt = stripeSubscription.cancel_at;
 	const shouldClearCancelAt =
 		subscriptionCancelAt === null && currentCancelAt !== null;
@@ -94,26 +94,18 @@ export const buildStripeSubscriptionUpdateAction = ({
 			},
 		}),
 
-		// Tax policy lives in the org config — when on, every sub.update we
-		// dispatch propagates `automatic_tax: { enabled: true }` so existing
-		// subs catch up to the org's tax setting on their next mutation.
-		// Owning this here (not at execute time) keeps the action object
-		// self-describing in logs / EXTRA LOGS / debug snapshots.
-		//
-		// Skip when invoice mode — Stripe rejects auto_tax on invoices that
-		// can't collect customer address. If the resulting sub.update emits
-		// an invoice with `collection_method: send_invoice`, the hosted
-		// invoice page has no address form and Stripe Tax errors out.
+		// Propagate auto_tax onto every sub.update so existing subs catch up
+		// when the org flag flips. Baked in here (not execute) for log
+		// self-description. Skipped in invoice mode: send_invoice invoices
+		// can't collect address, so Stripe Tax rejects.
 		...(ctx.org.config.automatic_tax && !billingContext.invoiceMode
 			? { automatic_tax: { enabled: true } }
 			: {}),
 	};
 
-	// Note: `automatic_tax` is intentionally excluded from this check.
-	// It's only attached to update params that ALREADY have a real reason
-	// to fire (items/trial/cancel/discounts changed). We don't fire a
-	// sub.update purely to propagate the auto_tax flag — that would create
-	// noise on every flag flip.
+	// `automatic_tax` is excluded from this check: we only ride along on
+	// updates that have a real reason to fire, never trigger one just to
+	// propagate the flag.
 	const hasNoUpdates = [
 		params.items,
 		params.trial_end,

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
@@ -11,7 +11,6 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { stripeDiscountsToParams } from "@/internal/billing/v2/providers/stripe/utils/discounts/stripeDiscountsToParams";
 
 export const buildStripeSubscriptionUpdateAction = ({
-	// biome-ignore lint/correctness/noUnusedFunctionParameters: might be used in the future
 	ctx,
 	billingContext,
 	// biome-ignore lint/correctness/noUnusedFunctionParameters: might be used in the future
@@ -94,8 +93,27 @@ export const buildStripeSubscriptionUpdateAction = ({
 				},
 			},
 		}),
+
+		// Tax policy lives in the org config — when on, every sub.update we
+		// dispatch propagates `automatic_tax: { enabled: true }` so existing
+		// subs catch up to the org's tax setting on their next mutation.
+		// Owning this here (not at execute time) keeps the action object
+		// self-describing in logs / EXTRA LOGS / debug snapshots.
+		//
+		// Skip when invoice mode — Stripe rejects auto_tax on invoices that
+		// can't collect customer address. If the resulting sub.update emits
+		// an invoice with `collection_method: send_invoice`, the hosted
+		// invoice page has no address form and Stripe Tax errors out.
+		...(ctx.org.config.automatic_tax && !billingContext.invoiceMode
+			? { automatic_tax: { enabled: true } }
+			: {}),
 	};
 
+	// Note: `automatic_tax` is intentionally excluded from this check.
+	// It's only attached to update params that ALREADY have a real reason
+	// to fire (items/trial/cancel/discounts changed). We don't fire a
+	// sub.update purely to propagate the auto_tax flag — that would create
+	// noise on every flag flip.
 	const hasNoUpdates = [
 		params.items,
 		params.trial_end,

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -51,6 +51,14 @@ export const executeStripeSubscriptionOperation = async ({
 		userMetadata: billingContext.userMetadata,
 	});
 
+	// Skip auto_tax in invoice mode — Stripe rejects when the resulting
+	// invoice is `send_invoice` (no buyer-facing address-collection UI).
+	// For charge_automatically paths we trust Stripe's waterfall
+	// (customer.address → recent checkout / IP / predicted location) to
+	// resolve a jurisdiction.
+	const wantsAutoTax =
+		!!ctx.org.config.automatic_tax && !billingContext.invoiceMode;
+
 	switch (subscriptionAction.type) {
 		case "update": {
 			let stripeSubscription = billingContext.stripeSubscription;
@@ -71,15 +79,15 @@ export const executeStripeSubscriptionOperation = async ({
 				stripeSubscription?.default_payment_method;
 			const shouldResetBillingCycleAnchorNow =
 				billingContext.requestedBillingCycleAnchor === "now";
-			// const shouldSkipResetForProrationNone =
-			// 	billingContext.requestedProrationBehavior === "none" &&
-			// 	!billingContext.anchorResetRefund?.noPartialRefund;
 
 			if (shouldResetBillingCycleAnchorNow) {
 				stripeSubscription = await stripeClient.subscriptions.update(
 					subscriptionAction.stripeSubscriptionId,
 					{
-						...(subscriptionHasDefaultPm ? {} : fallbackPaymentMethodParams),
+						...(subscriptionHasDefaultPm
+							? {}
+							: fallbackPaymentMethodParams),
+						...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 						billing_cycle_anchor: "now",
 						proration_behavior: "none",
 						payment_behavior: "error_if_incomplete",
@@ -88,13 +96,22 @@ export const executeStripeSubscriptionOperation = async ({
 				);
 			}
 
+			// `automatic_tax` is in `subscriptionAction.params` from
+			// `buildStripeSubscriptionUpdateAction`. Strip it from the spread
+			// so we can re-add it conditionally based on `wantsAutoTax` here.
+			const { automatic_tax: _builtAutoTax, ...paramsWithoutAutoTax } =
+				subscriptionAction.params;
+
 			return await stripeClient.subscriptions.update(
 				subscriptionAction.stripeSubscriptionId,
 				{
-					...subscriptionAction.params,
-					...(subscriptionHasDefaultPm ? {} : fallbackPaymentMethodParams),
+					...paramsWithoutAutoTax,
+					...(subscriptionHasDefaultPm
+						? {}
+						: fallbackPaymentMethodParams),
 					...(updateWillCreateInvoice ? invoiceModeParams : {}),
 					...(userMeta && { metadata: userMeta }),
+					...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 					payment_behavior: "error_if_incomplete",
 					expand: ["latest_invoice"],
 				},
@@ -106,6 +123,7 @@ export const executeStripeSubscriptionOperation = async ({
 				...invoiceModeParams,
 				...fallbackPaymentMethodParams,
 				...(userMeta && { metadata: userMeta }),
+				...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 
 				billing_mode: { type: "flexible" },
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -30,15 +30,13 @@ export const executeStripeSubscriptionOperation = async ({
 		stripeSubscriptionAction: subscriptionAction,
 	});
 
-	// default incomplete used so that payment failure / 3ds errors are clearly handled
+	// default_incomplete surfaces payment/3DS errors clearly.
 	const createPaymentBehavior =
 		nullish(paymentMethod) || paymentMethod?.type === "custom"
 			? "default_incomplete"
 			: "allow_incomplete";
 
-	// If customer's invoice_settings.default_payment_method is null but we
-	// resolved a payment method from the customer's attached PMs, pass it
-	// explicitly so Stripe knows which PM to charge.
+	// Pass resolved PM explicitly when customer has no default PM set.
 	const customerHasDefaultPm =
 		billingContext.stripeCustomer?.invoice_settings?.default_payment_method;
 
@@ -51,11 +49,8 @@ export const executeStripeSubscriptionOperation = async ({
 		userMetadata: billingContext.userMetadata,
 	});
 
-	// Skip auto_tax in invoice mode — Stripe rejects when the resulting
-	// invoice is `send_invoice` (no buyer-facing address-collection UI).
-	// For charge_automatically paths we trust Stripe's waterfall
-	// (customer.address → recent checkout / IP / predicted location) to
-	// resolve a jurisdiction.
+	// Skip auto_tax in invoice mode: send_invoice has no address-collection
+	// UI so Stripe Tax rejects.
 	const wantsAutoTax =
 		!!ctx.org.config.automatic_tax && !billingContext.invoiceMode;
 
@@ -96,9 +91,8 @@ export const executeStripeSubscriptionOperation = async ({
 				);
 			}
 
-			// `automatic_tax` is in `subscriptionAction.params` from
-			// `buildStripeSubscriptionUpdateAction`. Strip it from the spread
-			// so we can re-add it conditionally based on `wantsAutoTax` here.
+			// Strip `automatic_tax` from the action params so we can re-apply
+			// it here conditioned on `wantsAutoTax` (invoice-mode skip).
 			const { automatic_tax: _builtAutoTax, ...paramsWithoutAutoTax } =
 				subscriptionAction.params;
 

--- a/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
+++ b/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
@@ -4,46 +4,17 @@ import type {
 	UpdateSubscriptionV1Params,
 } from "@autumn/shared";
 
-// Legacy V0 invoice-mode fields are still accepted on V1 attach/update
-// schemas (see billingParamsBaseV1.ts). When `invoice_mode` is omitted but
-// the legacy `invoice` flag is set, promote the flat fields into the
-// structured shape so `billingContext.invoiceMode` is populated correctly.
-type InvoiceModeLegacyAliases = {
-	invoice?: boolean;
-	enable_product_immediately?: boolean;
-	finalize_invoice?: boolean;
-};
-
 export const setupInvoiceModeContext = ({
 	params,
 }: {
-	params:
-		| (UpdateSubscriptionV1Params & InvoiceModeLegacyAliases)
-		| (AttachParamsV1 & InvoiceModeLegacyAliases)
-		| MultiAttachParamsV0;
+	params: UpdateSubscriptionV1Params | AttachParamsV1 | MultiAttachParamsV0;
 }) => {
-	const structured = params?.invoice_mode;
-	const legacyParams = params as InvoiceModeLegacyAliases;
-	const legacyEnabled = legacyParams.invoice === true;
-
-	const enabled = structured?.enabled === true || legacyEnabled;
-	if (!enabled) {
+	if (params?.invoice_mode?.enabled !== true) {
 		return undefined;
 	}
 
-	// Match `InvoiceModeParamsSchema` defaults (`finalize: true`,
-	// `enable_plan_immediately: false`) when the legacy aliases are used so
-	// downstream code sees the same shape regardless of which input form
-	// the caller used.
-	const finalizeInvoice =
-		structured?.finalize ?? legacyParams.finalize_invoice ?? true;
-	const enableProductImmediately =
-		structured?.enable_plan_immediately ??
-		legacyParams.enable_product_immediately ??
-		false;
-
 	return {
-		finalizeInvoice,
-		enableProductImmediately,
+		finalizeInvoice: params.invoice_mode?.finalize,
+		enableProductImmediately: params.invoice_mode?.enable_plan_immediately,
 	};
 };

--- a/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
+++ b/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
@@ -4,17 +4,46 @@ import type {
 	UpdateSubscriptionV1Params,
 } from "@autumn/shared";
 
+// Legacy V0 invoice-mode fields are still accepted on V1 attach/update
+// schemas (see billingParamsBaseV1.ts). When `invoice_mode` is omitted but
+// the legacy `invoice` flag is set, promote the flat fields into the
+// structured shape so `billingContext.invoiceMode` is populated correctly.
+type InvoiceModeLegacyAliases = {
+	invoice?: boolean;
+	enable_product_immediately?: boolean;
+	finalize_invoice?: boolean;
+};
+
 export const setupInvoiceModeContext = ({
 	params,
 }: {
-	params: UpdateSubscriptionV1Params | AttachParamsV1 | MultiAttachParamsV0;
+	params:
+		| (UpdateSubscriptionV1Params & InvoiceModeLegacyAliases)
+		| (AttachParamsV1 & InvoiceModeLegacyAliases)
+		| MultiAttachParamsV0;
 }) => {
-	if (params?.invoice_mode?.enabled !== true) {
+	const structured = params?.invoice_mode;
+	const legacyParams = params as InvoiceModeLegacyAliases;
+	const legacyEnabled = legacyParams.invoice === true;
+
+	const enabled = structured?.enabled === true || legacyEnabled;
+	if (!enabled) {
 		return undefined;
 	}
 
+	// Match `InvoiceModeParamsSchema` defaults (`finalize: true`,
+	// `enable_plan_immediately: false`) when the legacy aliases are used so
+	// downstream code sees the same shape regardless of which input form
+	// the caller used.
+	const finalizeInvoice =
+		structured?.finalize ?? legacyParams.finalize_invoice ?? true;
+	const enableProductImmediately =
+		structured?.enable_plan_immediately ??
+		legacyParams.enable_product_immediately ??
+		false;
+
 	return {
-		finalizeInvoice: params.invoice_mode?.finalize,
-		enableProductImmediately: params.invoice_mode?.enable_plan_immediately,
+		finalizeInvoice,
+		enableProductImmediately,
 	};
 };

--- a/server/src/internal/customers/add-product/handleCreateCheckout.ts
+++ b/server/src/internal/customers/add-product/handleCreateCheckout.ts
@@ -139,6 +139,23 @@ export const handleCreateCheckout = async ({
 
 		...rewardData,
 		...(attachParams.checkoutSessionParams || {}),
+		// Autumn-injected automatic_tax wins over user-supplied
+		// checkoutSessionParams: when the org has automatic_tax enabled,
+		// every checkout session should collect tax, force a full billing
+		// address form (not just country), and write the captured address
+		// back to the customer record so future renewal invoices have a
+		// tax-resolvable address. `billing_address_collection: "required"`
+		// is the key bit that forces the full form — without it, Stripe
+		// defaults to "auto" and only collects country, which leaves
+		// `automatic_tax.status` stuck at `requires_location_inputs`.
+		...(org.config.automatic_tax
+			? {
+					automatic_tax: { enabled: true },
+					billing_address_collection: "required" as const,
+					customer_update: { address: "auto", name: "auto" },
+					tax_id_collection: { enabled: true },
+				}
+			: {}),
 		metadata: {
 			...(attachParams.metadata ? attachParams.metadata : {}),
 			...(checkoutParams?.metadata || {}),
@@ -159,6 +176,14 @@ export const handleCreateCheckout = async ({
 			success_url: successUrl || toSuccessUrl({ org, env: customer.env }),
 			currency: org.default_currency || "usd",
 			...checkoutParams,
+			...(org.config.automatic_tax
+				? {
+						automatic_tax: { enabled: true },
+						billing_address_collection: "required" as const,
+						customer_update: { address: "auto", name: "auto" },
+						tax_id_collection: { enabled: true },
+					}
+				: {}),
 			metadata: {
 				...(checkoutParams?.metadata || {}),
 				autumn_metadata_id: metadata.id,

--- a/server/src/internal/customers/add-product/handleCreateCheckout.ts
+++ b/server/src/internal/customers/add-product/handleCreateCheckout.ts
@@ -139,15 +139,11 @@ export const handleCreateCheckout = async ({
 
 		...rewardData,
 		...(attachParams.checkoutSessionParams || {}),
-		// Autumn-injected automatic_tax wins over user-supplied
-		// checkoutSessionParams: when the org has automatic_tax enabled,
-		// every checkout session should collect tax, force a full billing
-		// address form (not just country), and write the captured address
-		// back to the customer record so future renewal invoices have a
-		// tax-resolvable address. `billing_address_collection: "required"`
-		// is the key bit that forces the full form — without it, Stripe
-		// defaults to "auto" and only collects country, which leaves
-		// `automatic_tax.status` stuck at `requires_location_inputs`.
+		// Autumn auto_tax wins over user-supplied checkoutSessionParams.
+		// `billing_address_collection: "required"` is required: with "auto"
+		// Stripe only collects country, leaving auto_tax stuck at
+		// `requires_location_inputs`. `customer_update.address` writes the
+		// captured address back to the customer for future renewals.
 		...(org.config.automatic_tax
 			? {
 					automatic_tax: { enabled: true },

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -47,11 +47,6 @@ export const createStripeSub2 = async ({
 		paymentMethodData = {
 			default_payment_method: paymentMethod.id,
 		};
-		// if (paymentMethod.type === "alipay") {
-
-		// } else {
-
-		// }
 	}
 
 	const { subItems, invoiceItems, usageFeatures } = itemSet;
@@ -60,16 +55,12 @@ export const createStripeSub2 = async ({
 		? rewards.map((reward) => ({ coupon: reward.id }))
 		: undefined;
 
-	// Check if using custom payment method (Vercel, etc.)
+	// Custom PMs (Vercel, etc.) use external payment confirmation.
 	const isCustomPaymentMethod = paymentMethod?.type === "custom";
 
 	try {
-		// Skip auto_tax in invoice mode — `invoiceOnly` here means
-		// `collection_method: send_invoice` on the resulting sub, whose
-		// hosted invoice page has no buyer-facing address-collection UI.
-		// For charge_automatically sub creates we trust Stripe's waterfall
-		// (customer.address → recent checkout / IP / predicted location)
-		// to resolve a jurisdiction.
+		// Skip auto_tax in invoice mode: send_invoice has no
+		// address-collection UI so Stripe Tax rejects.
 		const wantsAutoTax =
 			!!org.config.automatic_tax && !attachParams.invoiceOnly;
 
@@ -80,8 +71,8 @@ export const createStripeSub2 = async ({
 			...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 
 			billing_mode: { type: "flexible" },
-			// For custom payment methods (e.g., Vercel), start subscription as incomplete.
-			// The subscription will become active after external payment is confirmed via Payment Records API.
+			// Custom PMs activate the sub after external payment confirmation
+			// via the Payment Records API.
 			payment_behavior: isCustomPaymentMethod
 				? "default_incomplete"
 				: "allow_incomplete",
@@ -98,12 +89,11 @@ export const createStripeSub2 = async ({
 			discounts,
 			expand: ["latest_invoice"],
 
-			// Pass metadata from attachParams (e.g., Vercel installation/billing plan IDs)
+			// e.g. Vercel installation/billing plan IDs.
 			metadata: metadata || undefined,
 
-			// For custom payment methods, save the payment method on
-			// the subscription so it's available in webhook handlers
-			// and for future renewals.
+			// Save the custom PM on the sub so webhook handlers and renewals
+			// can find it.
 			...(isCustomPaymentMethod && {
 				payment_settings: {
 					save_default_payment_method: "on_subscription",

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -64,21 +64,32 @@ export const createStripeSub2 = async ({
 	const isCustomPaymentMethod = paymentMethod?.type === "custom";
 
 	try {
+		// Skip auto_tax in invoice mode — `invoiceOnly` here means
+		// `collection_method: send_invoice` on the resulting sub, whose
+		// hosted invoice page has no buyer-facing address-collection UI.
+		// For charge_automatically sub creates we trust Stripe's waterfall
+		// (customer.address → recent checkout / IP / predicted location)
+		// to resolve a jurisdiction.
+		const wantsAutoTax =
+			!!org.config.automatic_tax && !attachParams.invoiceOnly;
+
 		const subscription = await stripeCli.subscriptions.create({
 			...paymentMethodData,
 			customer: customer.processor.id,
 			items: sanitizeSubItems(subItems),
+			...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 
 			billing_mode: { type: "flexible" },
-			// For custom payment methods (e.g., Vercel), start subscription as incomplete
-			// The subscription will become active after external payment is confirmed via Payment Records API
+			// For custom payment methods (e.g., Vercel), start subscription as incomplete.
+			// The subscription will become active after external payment is confirmed via Payment Records API.
 			payment_behavior: isCustomPaymentMethod
 				? "default_incomplete"
 				: "allow_incomplete",
-			// payment_behavior: "default_incomplete",
 
 			add_invoice_items: invoiceItems,
-			collection_method: invoiceOnly ? "send_invoice" : "charge_automatically",
+			collection_method: invoiceOnly
+				? "send_invoice"
+				: "charge_automatically",
 			days_until_due: invoiceOnly ? 30 : undefined,
 			billing_cycle_anchor: billingCycleAnchorUnix
 				? Math.floor(billingCycleAnchorUnix / 1000)
@@ -90,26 +101,24 @@ export const createStripeSub2 = async ({
 			// Pass metadata from attachParams (e.g., Vercel installation/billing plan IDs)
 			metadata: metadata || undefined,
 
-			// For custom payment methods, save the payment method on the subscription
-			// so it's available in webhook handlers and for future renewals
+			// For custom payment methods, save the payment method on
+			// the subscription so it's available in webhook handlers
+			// and for future renewals.
 			...(isCustomPaymentMethod && {
 				payment_settings: {
 					save_default_payment_method: "on_subscription",
 				},
 			}),
 
-			...{
-				trial_settings:
-					freeTrial && !freeTrial.card_required
-						? {
-								end_behavior: {
-									missing_payment_method: "cancel",
-								},
-							}
-						: undefined,
-
-				trial_end: freeTrialToStripeTimestamp({ freeTrial, now }),
-			},
+			trial_settings:
+				freeTrial && !freeTrial.card_required
+					? {
+							end_behavior: {
+								missing_payment_method: "cancel",
+							},
+						}
+					: undefined,
+			trial_end: freeTrialToStripeTimestamp({ freeTrial, now }),
 		});
 
 		const latestInvoice = subscription.latest_invoice as Stripe.Invoice;

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
@@ -132,14 +132,29 @@ export const handleOneOffFunction = async ({
 
 	// Create invoice
 	logger.info("1. Creating invoice");
+
+	// Skip auto_tax in invoice mode — `invoiceOnly` sets
+	// `collection_method: send_invoice`, whose hosted invoice page has no
+	// buyer-facing address-collection UI for Stripe Tax to source from.
+	// For charge_automatically one-off invoices we trust Stripe's
+	// waterfall (customer.address → recent checkout / IP / predicted
+	// location) to resolve a jurisdiction.
+	const wantsAutoTax =
+		!!org.config.automatic_tax && !attachParams.invoiceOnly;
+
 	let stripeInvoice = await stripeCli.invoices.create({
 		customer: customer.processor.id!,
 		auto_advance: false,
 		currency: orgToCurrency({ org }),
-		discounts: rewards ? rewards.map((r) => ({ coupon: r.id })) : undefined,
-		collection_method: attachParams.invoiceOnly ? "send_invoice" : undefined,
+		discounts: rewards
+			? rewards.map((r) => ({ coupon: r.id }))
+			: undefined,
+		collection_method: attachParams.invoiceOnly
+			? "send_invoice"
+			: undefined,
 		days_until_due: attachParams.invoiceOnly ? 30 : undefined,
 		...(shouldMemo ? { description: invoiceMemo } : {}),
+		...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 	});
 
 	logger.info("2. Creating invoice items");

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
@@ -133,12 +133,8 @@ export const handleOneOffFunction = async ({
 	// Create invoice
 	logger.info("1. Creating invoice");
 
-	// Skip auto_tax in invoice mode — `invoiceOnly` sets
-	// `collection_method: send_invoice`, whose hosted invoice page has no
-	// buyer-facing address-collection UI for Stripe Tax to source from.
-	// For charge_automatically one-off invoices we trust Stripe's
-	// waterfall (customer.address → recent checkout / IP / predicted
-	// location) to resolve a jurisdiction.
+	// Skip auto_tax in invoice mode: send_invoice has no
+	// address-collection UI so Stripe Tax rejects.
 	const wantsAutoTax =
 		!!org.config.automatic_tax && !attachParams.invoiceOnly;
 

--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -66,7 +66,6 @@ export const updateStripeSub2 = async ({
 				: undefined;
 
 	// 1. Update subscription
-
 	const updatedSub = await stripeCli.subscriptions.update(curSub.id, {
 		items: sanitizeSubItems(itemSet.subItems),
 		proration_behavior:

--- a/server/src/internal/customers/internalHandlers/handleGetInvoiceLineItems.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetInvoiceLineItems.ts
@@ -1,5 +1,6 @@
+import { Scopes, stripeToAtmnAmount } from "@autumn/shared";
 import { z } from "zod/v4";
-import { Scopes } from "@autumn/shared";
+import { createStripeCli } from "@/external/connect/createStripeCli";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { InvoiceService } from "@/internal/invoices/InvoiceService";
 import { invoiceLineItemRepo } from "@/internal/invoices/lineItems/repos/index.js";
@@ -26,8 +27,57 @@ export const handleGetInvoiceLineItems = createRoute({
 			invoiceIds: invoice_ids,
 		});
 
-		return c.json({
-			line_items: lineItems,
-		});
+		if (ctx.org.config.automatic_tax) {
+			const stripe = createStripeCli({
+				org: ctx.org,
+				env: ctx.env,
+			});
+			const autumnInvoices = await InvoiceService.getMany({
+				db,
+				ids: invoice_ids,
+			});
+			const stripeInvoices = [];
+			for (const invoice of autumnInvoices) {
+				// Sleep for 20ms before each retrieve
+				await new Promise((res) => setTimeout(res, 20));
+				stripeInvoices.push({
+					autumnInvoiceId: invoice.id,
+					stripeInvoice: await stripe.invoices.retrieve(invoice.stripe_id),
+				});
+			}
+
+			// Check if any invoice has automatic_tax.enabled
+			const anyAutomaticTax = stripeInvoices.some(
+				({ stripeInvoice }) => stripeInvoice.automatic_tax?.enabled,
+			);
+
+			if (anyAutomaticTax) {
+				const tax_info: Record<string, { taxed_amount: number }> = {};
+				for (const { autumnInvoiceId, stripeInvoice } of stripeInvoices) {
+					tax_info[autumnInvoiceId] = {
+						taxed_amount: stripeToAtmnAmount({
+							amount:
+								stripeInvoice.total_taxes?.reduce(
+									(acc, curr) => acc + curr.amount,
+									0,
+								) ?? 0,
+							currency: stripeInvoice.currency,
+						}),
+					};
+				}
+				return c.json({
+					line_items: lineItems,
+					tax_info,
+				});
+			} else {
+				return c.json({
+					line_items: lineItems,
+				});
+			}
+		} else {
+			return c.json({
+				line_items: lineItems,
+			});
+		}
 	},
 });

--- a/server/src/internal/customers/internalHandlers/handleGetInvoiceLineItems.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetInvoiceLineItems.ts
@@ -38,7 +38,7 @@ export const handleGetInvoiceLineItems = createRoute({
 			});
 			const stripeInvoices = [];
 			for (const invoice of autumnInvoices) {
-				// Sleep for 20ms before each retrieve
+				// Throttle to avoid Stripe rate limits.
 				await new Promise((res) => setTimeout(res, 20));
 				stripeInvoices.push({
 					autumnInvoiceId: invoice.id,
@@ -46,7 +46,6 @@ export const handleGetInvoiceLineItems = createRoute({
 				});
 			}
 
-			// Check if any invoice has automatic_tax.enabled
 			const anyAutomaticTax = stripeInvoices.some(
 				({ stripeInvoice }) => stripeInvoice.automatic_tax?.enabled,
 			);

--- a/server/src/internal/invoices/invoiceUtils/createAndFinalizeInvoice.ts
+++ b/server/src/internal/invoices/invoiceUtils/createAndFinalizeInvoice.ts
@@ -10,6 +10,7 @@ export const createAndFinalizeInvoice = async ({
 	errorOnPaymentFail = true,
 	voidIfFailed = true,
 	chargeAutomatically = true,
+	automaticTax = false,
 	logger,
 }: {
 	stripeCli: Stripe;
@@ -20,8 +21,15 @@ export const createAndFinalizeInvoice = async ({
 	errorOnPaymentFail?: boolean;
 	voidIfFailed?: boolean;
 	chargeAutomatically?: boolean;
+	automaticTax?: boolean;
 	logger?: any;
 }) => {
+	// Skip auto_tax in send_invoice mode — Stripe rejects on invoices that
+	// can't collect customer address (the hosted invoice page has no
+	// address-collection UI). The helper enforces this regardless of what
+	// the caller passes so future callers can't accidentally bypass it.
+	const wantsAutoTax = automaticTax && chargeAutomatically;
+
 	const invoice = await stripeCli.invoices.create({
 		customer: stripeCusId,
 		auto_advance: false,
@@ -30,6 +38,7 @@ export const createAndFinalizeInvoice = async ({
 			? "charge_automatically"
 			: "send_invoice",
 		days_until_due: chargeAutomatically ? undefined : 30,
+		...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 	});
 
 	if (invoiceItems) {

--- a/server/src/internal/invoices/invoiceUtils/createAndFinalizeInvoice.ts
+++ b/server/src/internal/invoices/invoiceUtils/createAndFinalizeInvoice.ts
@@ -24,10 +24,8 @@ export const createAndFinalizeInvoice = async ({
 	automaticTax?: boolean;
 	logger?: any;
 }) => {
-	// Skip auto_tax in send_invoice mode — Stripe rejects on invoices that
-	// can't collect customer address (the hosted invoice page has no
-	// address-collection UI). The helper enforces this regardless of what
-	// the caller passes so future callers can't accidentally bypass it.
+	// Skip auto_tax in send_invoice mode: no address-collection UI.
+	// Enforced here regardless of caller input.
 	const wantsAutoTax = automaticTax && chargeAutomatically;
 
 	const invoice = await stripeCli.invoices.create({

--- a/server/src/internal/orgs/deleteOrg/deletePlatformSubOrg.ts
+++ b/server/src/internal/orgs/deleteOrg/deletePlatformSubOrg.ts
@@ -1,0 +1,82 @@
+import {
+	AppEnv,
+	customers,
+	ErrCode,
+	member,
+	organizations,
+	type Organization,
+	RecaseError,
+} from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import type { DrizzleCli } from "@server/db/initDrizzle.js";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import {
+	deleteStripeAccounts,
+	deleteStripeWebhooks,
+	deleteSvixWebhooks,
+} from "@/internal/orgs/orgUtils/deleteOrgUtils.js";
+
+/**
+ * Deletes a platform-created sub-org: svix webhooks, stripe webhooks,
+ * stripe accounts, sandbox customers, members, then the `organizations` row.
+ *
+ * Used by the `DELETE /platform/organizations` route handler and by the
+ * test cleanup script (`clearMasterOrg.ts`).
+ *
+ * When `skipLiveCustomerCheck` is true, bypasses the `OrgHasCustomers` guard
+ * (test cleanup needs this since it's a clean-everything operation).
+ */
+export const deletePlatformSubOrg = async ({
+	db,
+	org,
+	logger,
+	skipLiveCustomerCheck = false,
+}: {
+	db: DrizzleCli;
+	org: Organization;
+	logger: Logger;
+	skipLiveCustomerCheck?: boolean;
+}): Promise<void> => {
+	// Check if any live customers exist
+	if (!skipLiveCustomerCheck) {
+		const hasCustomers = await db.query.customers.findFirst({
+			where: and(eq(customers.org_id, org.id), eq(customers.env, AppEnv.Live)),
+		});
+
+		if (hasCustomers) {
+			throw new RecaseError({
+				message: "Cannot delete org with production mode customers",
+				code: ErrCode.OrgHasCustomers,
+				statusCode: 400,
+			});
+		}
+	}
+
+	// Delete svix webhooks
+	logger.info("1. Deleting svix webhooks");
+	await deleteSvixWebhooks({ org, logger });
+
+	// Delete stripe webhooks
+	logger.info("2. Deleting stripe webhooks");
+	await deleteStripeWebhooks({ org, logger });
+
+	// Delete stripe accounts
+	logger.info("3. Deleting stripe accounts");
+	await deleteStripeAccounts({ org, logger });
+
+	// Delete all sandbox customers
+	logger.info("4. Deleting sandbox customers");
+	await db
+		.delete(customers)
+		.where(
+			and(eq(customers.org_id, org.id), eq(customers.env, AppEnv.Sandbox)),
+		);
+
+	// Delete memberships
+	logger.info("5. Deleting org memberships");
+	await db.delete(member).where(eq(member.organizationId, org.id));
+
+	// Delete the organization itself
+	logger.info("6. Deleting organization");
+	await db.delete(organizations).where(eq(organizations.id, org.id));
+};

--- a/server/src/internal/orgs/deleteOrg/deletePlatformSubOrg.ts
+++ b/server/src/internal/orgs/deleteOrg/deletePlatformSubOrg.ts
@@ -17,14 +17,10 @@ import {
 } from "@/internal/orgs/orgUtils/deleteOrgUtils.js";
 
 /**
- * Deletes a platform-created sub-org: svix webhooks, stripe webhooks,
- * stripe accounts, sandbox customers, members, then the `organizations` row.
+ * Deletes a platform-created sub-org and all its dependencies.
+ * Used by `DELETE /platform/organizations` and `clearMasterOrg.ts`.
  *
- * Used by the `DELETE /platform/organizations` route handler and by the
- * test cleanup script (`clearMasterOrg.ts`).
- *
- * When `skipLiveCustomerCheck` is true, bypasses the `OrgHasCustomers` guard
- * (test cleanup needs this since it's a clean-everything operation).
+ * `skipLiveCustomerCheck` bypasses the `OrgHasCustomers` guard (test cleanup).
  */
 export const deletePlatformSubOrg = async ({
 	db,
@@ -37,7 +33,6 @@ export const deletePlatformSubOrg = async ({
 	logger: Logger;
 	skipLiveCustomerCheck?: boolean;
 }): Promise<void> => {
-	// Check if any live customers exist
 	if (!skipLiveCustomerCheck) {
 		const hasCustomers = await db.query.customers.findFirst({
 			where: and(eq(customers.org_id, org.id), eq(customers.env, AppEnv.Live)),
@@ -52,19 +47,15 @@ export const deletePlatformSubOrg = async ({
 		}
 	}
 
-	// Delete svix webhooks
 	logger.info("1. Deleting svix webhooks");
 	await deleteSvixWebhooks({ org, logger });
 
-	// Delete stripe webhooks
 	logger.info("2. Deleting stripe webhooks");
 	await deleteStripeWebhooks({ org, logger });
 
-	// Delete stripe accounts
 	logger.info("3. Deleting stripe accounts");
 	await deleteStripeAccounts({ org, logger });
 
-	// Delete all sandbox customers
 	logger.info("4. Deleting sandbox customers");
 	await db
 		.delete(customers)
@@ -72,11 +63,9 @@ export const deletePlatformSubOrg = async ({
 			and(eq(customers.org_id, org.id), eq(customers.env, AppEnv.Sandbox)),
 		);
 
-	// Delete memberships
 	logger.info("5. Deleting org memberships");
 	await db.delete(member).where(eq(member.organizationId, org.id));
 
-	// Delete the organization itself
 	logger.info("6. Deleting organization");
 	await db.delete(organizations).where(eq(organizations.id, org.id));
 };

--- a/server/src/internal/platform/platformBeta/handlers/handleDeletePlatformOrg.ts
+++ b/server/src/internal/platform/platformBeta/handlers/handleDeletePlatformOrg.ts
@@ -8,10 +8,7 @@ const deleteOrgSchema = z.object({
 	slug: z.string().min(1, "Organization slug is required"),
 });
 
-/**
- * DELETE /organizations
- * Deletes a platform organization by slug (for test cleanup)
- */
+/** DELETE /organizations — deletes a platform sub-org by slug (test cleanup). */
 export const handleDeletePlatformOrg = createRoute({
 	scopes: [Scopes.Platform.Write],
 	body: deleteOrgSchema,
@@ -21,8 +18,7 @@ export const handleDeletePlatformOrg = createRoute({
 
 		const { slug } = c.req.valid("json");
 
-		// Platform API creates orgs with format: {slug}|{masterOrgId}
-		// So we need to find the org with this pattern
+		// Platform API uses `{slug}|{masterOrgId}` format.
 		const fullSlug = `${slug}|${masterOrg.id}`;
 
 		const org = await OrgService.getBySlug({ db, slug: fullSlug });

--- a/server/src/internal/platform/platformBeta/handlers/handleDeletePlatformOrg.ts
+++ b/server/src/internal/platform/platformBeta/handlers/handleDeletePlatformOrg.ts
@@ -1,20 +1,7 @@
-import {
-	AppEnv,
-	customers,
-	ErrCode,
-	member,
-	organizations,
-	RecaseError,
-	Scopes,
-} from "@autumn/shared";
-import { and, eq } from "drizzle-orm";
+import { RecaseError, Scopes } from "@autumn/shared";
 import { z } from "zod/v4";
+import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
-import {
-	deleteStripeAccounts,
-	deleteStripeWebhooks,
-	deleteSvixWebhooks,
-} from "@/internal/orgs/orgUtils/deleteOrgUtils.js";
 import { createRoute } from "../../../../honoMiddlewares/routeHandler.js";
 
 const deleteOrgSchema = z.object({
@@ -45,46 +32,7 @@ export const handleDeletePlatformOrg = createRoute({
 			});
 		}
 
-		// Check if any live customers exist
-		const hasCustomers = await db.query.customers.findFirst({
-			where: and(eq(customers.org_id, org.id), eq(customers.env, AppEnv.Live)),
-		});
-
-		if (hasCustomers) {
-			throw new RecaseError({
-				message: "Cannot delete org with production mode customers",
-				code: ErrCode.OrgHasCustomers,
-				statusCode: 400,
-			});
-		}
-
-		// Delete svix webhooks
-		logger.info("1. Deleting svix webhooks");
-		await deleteSvixWebhooks({ org, logger });
-
-		// Delete stripe webhooks
-		logger.info("2. Deleting stripe webhooks");
-		await deleteStripeWebhooks({ org, logger });
-
-		// Delete stripe accounts
-		logger.info("3. Deleting stripe accounts");
-		await deleteStripeAccounts({ org, logger });
-
-		// Delete all sandbox customers
-		logger.info("4. Deleting sandbox customers");
-		await db
-			.delete(customers)
-			.where(
-				and(eq(customers.org_id, org.id), eq(customers.env, AppEnv.Sandbox)),
-			);
-
-		// Delete memberships
-		logger.info("5. Deleting org memberships");
-		await db.delete(member).where(eq(member.organizationId, org.id));
-
-		// Delete the organization itself
-		logger.info("6. Deleting organization");
-		await db.delete(organizations).where(eq(organizations.id, org.id));
+		await deletePlatformSubOrg({ db, org, logger });
 
 		return c.json({
 			success: true,

--- a/server/src/utils/scriptUtils/testUtils/initCustomerV3.ts
+++ b/server/src/utils/scriptUtils/testUtils/initCustomerV3.ts
@@ -1,5 +1,6 @@
 import { ApiVersion, type CustomerData } from "@autumn/shared";
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import type Stripe from "stripe";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { attachPaymentMethod } from "../initCustomer.js";
@@ -18,6 +19,7 @@ export const initCustomerV3 = async ({
 	sendEmailReceipts,
 	nameOverride,
 	emailOverride,
+	stripeCustomerOverrides,
 }: {
 	ctx: TestContext;
 	customerId: string;
@@ -31,6 +33,7 @@ export const initCustomerV3 = async ({
 	sendEmailReceipts?: boolean;
 	nameOverride?: string | null;
 	emailOverride?: string | null;
+	stripeCustomerOverrides?: Partial<Stripe.CustomerCreateParams>;
 }) => {
 	// Use override if provided (including null), otherwise default to customerId-based values
 	const name =
@@ -59,6 +62,7 @@ export const initCustomerV3 = async ({
 		email,
 		name,
 		test_clock: testClockId,
+		...(stripeCustomerOverrides ?? {}),
 	});
 
 	// 2. Create customer

--- a/server/src/utils/scriptUtils/testUtils/initCustomerV3.ts
+++ b/server/src/utils/scriptUtils/testUtils/initCustomerV3.ts
@@ -5,7 +5,7 @@ import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { attachPaymentMethod } from "../initCustomer.js";
 
-// V3 initializes the customer in Stripe, then creates the customer in Autumn
+// Creates the Stripe customer first, then the Autumn customer linked to it.
 export const initCustomerV3 = async ({
 	ctx,
 	customerId,
@@ -35,7 +35,7 @@ export const initCustomerV3 = async ({
 	emailOverride?: string | null;
 	stripeCustomerOverrides?: Partial<Stripe.CustomerCreateParams>;
 }) => {
-	// Use override if provided (including null), otherwise default to customerId-based values
+	// Use override if provided (including null), otherwise default from customerId.
 	const name =
 		nameOverride !== undefined ? (nameOverride ?? undefined) : customerId;
 	const email =
@@ -57,7 +57,7 @@ export const initCustomerV3 = async ({
 		testClockId = testClock.id;
 	}
 
-	// 1. Create stripe customer
+	// 1. Stripe customer.
 	const stripeCus = await stripeCli.customers.create({
 		email,
 		name,
@@ -65,8 +65,7 @@ export const initCustomerV3 = async ({
 		...(stripeCustomerOverrides ?? {}),
 	});
 
-	// 2. Create customer
-
+	// 2. Autumn customer.
 	try {
 		await autumn.customers.delete(customerId);
 	} catch (_error) {}
@@ -81,13 +80,12 @@ export const initCustomerV3 = async ({
 		config: customerData?.config,
 		internalOptions: {
 			disable_defaults: !withDefault,
-			// Only pass default_group when defaults are enabled
 			...(withDefault && { default_group: defaultGroup }),
 		},
 		skipWebhooks,
 	});
 
-	// 3. Attach payment method
+	// 3. Payment method.
 	if (attachPm) {
 		await attachPaymentMethod({
 			stripeCli,

--- a/server/tests/clearMasterOrg.ts
+++ b/server/tests/clearMasterOrg.ts
@@ -4,11 +4,16 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-import { AppEnv } from "@autumn/shared";
+import { AppEnv, type Organization, organizations } from "@autumn/shared";
 
 import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
 import { redis } from "@/external/redis/initRedis.js";
 import { redisV2 } from "@/external/redis/initRedisV2.js";
+import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 import { clearOrg } from "./utils/setup/clearOrg.js";
 import { setupOrg } from "./utils/setup/setupOrg.js";
 
@@ -29,6 +34,72 @@ export const clearMasterOrg = async () => {
 				),
 			);
 			process.exit(1);
+		}
+
+		// Clean up any platform sub-orgs created by this master org first.
+		// IMPORTANT: this is the ONLY path that auto-deletes platform sub-orgs.
+		// Tests created via `s.platform.create(...)` do NOT clean up after
+		// themselves — sub-orgs accumulate across test runs and are only
+		// cleared here, when an operator explicitly invokes `bun cm`. Each
+		// `s.platform.create(...)` defaults to a randomized slug so the buildup
+		// doesn't cause slug collisions between runs.
+		{
+			const { db, client } = initDrizzle();
+			try {
+				const masterOrg = await OrgService.getBySlug({
+					db,
+					slug: process.env.TESTS_ORG,
+				});
+
+				if (!masterOrg) {
+					console.log(
+						chalk.yellow(
+							`\n⚠️  Master org '${process.env.TESTS_ORG}' not found; skipping sub-org cleanup.\n`,
+						),
+					);
+				} else {
+					const subOrgs = (await db.query.organizations.findMany({
+						where: eq(organizations.created_by, masterOrg.id),
+					})) as Organization[];
+
+					console.log(
+						chalk.blue(
+							`\n🧹 Found ${subOrgs.length} platform sub-org(s) to delete...\n`,
+						),
+					);
+
+					const BATCH_SIZE = 10;
+					for (let i = 0; i < subOrgs.length; i += BATCH_SIZE) {
+						const batch = subOrgs.slice(i, i + BATCH_SIZE);
+						await Promise.all(
+							batch.map(async (subOrg) => {
+								try {
+									await deletePlatformSubOrg({
+										db,
+										org: subOrg,
+										logger,
+										skipLiveCustomerCheck: true,
+									});
+									console.log(
+										chalk.green(
+											`   ✅ Deleted sub-org ${subOrg.slug} (${subOrg.id})`,
+										),
+									);
+								} catch (err) {
+									console.error(
+										chalk.red(
+											`   ❌ Failed to delete sub-org ${subOrg.slug} (${subOrg.id}):`,
+										),
+										err,
+									);
+								}
+							}),
+						);
+					}
+				}
+			} finally {
+				await client.end();
+			}
 		}
 
 		const org = await clearOrg({

--- a/server/tests/clearMasterOrg.ts
+++ b/server/tests/clearMasterOrg.ts
@@ -36,13 +36,9 @@ export const clearMasterOrg = async () => {
 			process.exit(1);
 		}
 
-		// Clean up any platform sub-orgs created by this master org first.
-		// IMPORTANT: this is the ONLY path that auto-deletes platform sub-orgs.
-		// Tests created via `s.platform.create(...)` do NOT clean up after
-		// themselves — sub-orgs accumulate across test runs and are only
-		// cleared here, when an operator explicitly invokes `bun cm`. Each
-		// `s.platform.create(...)` defaults to a randomized slug so the buildup
-		// doesn't cause slug collisions between runs.
+		// This is the only path that deletes platform sub-orgs. Tests using
+		// `s.platform.create(...)` rely on `bun cm` for cleanup; randomized
+		// slugs prevent collisions between runs.
 		{
 			const { db, client } = initDrizzle();
 			try {
@@ -118,7 +114,7 @@ export const clearMasterOrg = async () => {
 		const isRegionalRedisUrl = (url: string | undefined) =>
 			(url ?? "").toLowerCase().includes("redis-17710.mc1716-0.us");
 
-		// Flush primary cache if not pointed at regional Redis
+		// Flush primary cache unless pointed at regional Redis.
 		const redisUrl = process.env.REDIS_URL ?? process.env.BUN_REDIS_URL ?? "";
 		if (!isRegionalRedisUrl(redisUrl)) await redis.flushall();
 		else
@@ -128,7 +124,7 @@ export const clearMasterOrg = async () => {
 				),
 			);
 
-		// Flush v2 cache (CACHE_V2_URL) if it's a distinct, non-regional connection
+		// Flush v2 cache when distinct and non-regional.
 		const cacheV2Url = process.env.CACHE_V2_UPSTASH_URL?.trim();
 		if (redisV2 !== redis && cacheV2Url) {
 			if (!isRegionalRedisUrl(cacheV2Url)) {

--- a/server/tests/integration/billing/tax/automatic-tax-checkout-session.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-checkout-session.test.ts
@@ -1,33 +1,11 @@
 /**
- * TDD test for `automatic_tax` + `customer_update.address: "auto"` on
- * Stripe Checkout sessions (Cycle 6). Customers without a payment method
- * are routed to a Stripe-hosted checkout session — that session needs to
- * (a) collect tax, (b) write the entered address back to the Stripe
- * customer record so future charges have a tax-resolvable address.
+ * `automatic_tax` + `customer_update.address: "auto"` on Stripe Checkout.
+ * Asserts both v1 (`/v1/attach` → handleCreateCheckout) and v2
+ * (`/v1/billing.attach` → executeStripeCheckoutSessionAction) inject
+ * auto_tax + address-collection when `org.config.automatic_tax` is on.
  *
- * Exercises BOTH attach paths concurrently:
- *  - v1 legacy `/v1/attach` → handleCreateCheckout
- *  - v2 `/v1/billing.attach` → executeStripeCheckoutSessionAction
- *
- * Red-failure mode (current behavior, pre-fix):
- *  - Both checkout paths call `stripeCli.checkout.sessions.create({...})`
- *    WITHOUT `automatic_tax` or `customer_update`.
- *  - Result: session.automatic_tax.enabled is false. Mintlify (and any
- *    auto-tax org) would have to manually pass these via
- *    `checkout_session_params` on every attach call.
- *
- * Green-success criteria (after fix):
- *  - Both checkout paths inject `automatic_tax: { enabled: true }` and
- *    `customer_update: { address: "auto" }` when `org.config.automatic_tax`
- *    is true. Mintlify gets this for free without any client-side work.
- *
- * No invoice-total assertion here: the customer hasn't completed checkout,
- * so there's no invoice yet. Total-validation is covered by Cycles 2–5.
- *
- * Note: customer_update is a create-only param and is NOT echoed back in
- * the Session response object. The customer_update fix is applied in
- * production code; the integration test asserts only the observable
- * `session.automatic_tax.enabled`.
+ * `customer_update` is create-only and not echoed in the Session response;
+ * the test asserts only the observable `session.automatic_tax.enabled`.
  */
 
 import { expect, test } from "bun:test";
@@ -72,7 +50,7 @@ test.concurrent(
 					configOverrides: { automatic_tax: true },
 					taxRegistrations: ["AU"],
 				}),
-				// NO paymentMethod — forces checkout-URL branch on attach.
+				// No PM forces the checkout-URL branch.
 				s.customer({
 					testClock: false,
 					stripeCustomerOverrides: { address: auAddress },
@@ -120,7 +98,7 @@ test.concurrent(
 			plan_id: `pro_${customerId}`,
 		})) as { payment_url?: string };
 
-		// V2 returns the URL via `payment_url` (not `checkout_url`).
+		// V2 uses `payment_url`, not `checkout_url`.
 		expect(result.payment_url).toBeDefined();
 		expect(typeof result.payment_url).toBe("string");
 		await assertCheckoutSessionTaxed({

--- a/server/tests/integration/billing/tax/automatic-tax-checkout-session.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-checkout-session.test.ts
@@ -1,0 +1,132 @@
+/**
+ * TDD test for `automatic_tax` + `customer_update.address: "auto"` on
+ * Stripe Checkout sessions (Cycle 6). Customers without a payment method
+ * are routed to a Stripe-hosted checkout session — that session needs to
+ * (a) collect tax, (b) write the entered address back to the Stripe
+ * customer record so future charges have a tax-resolvable address.
+ *
+ * Exercises BOTH attach paths concurrently:
+ *  - v1 legacy `/v1/attach` → handleCreateCheckout
+ *  - v2 `/v1/billing.attach` → executeStripeCheckoutSessionAction
+ *
+ * Red-failure mode (current behavior, pre-fix):
+ *  - Both checkout paths call `stripeCli.checkout.sessions.create({...})`
+ *    WITHOUT `automatic_tax` or `customer_update`.
+ *  - Result: session.automatic_tax.enabled is false. Mintlify (and any
+ *    auto-tax org) would have to manually pass these via
+ *    `checkout_session_params` on every attach call.
+ *
+ * Green-success criteria (after fix):
+ *  - Both checkout paths inject `automatic_tax: { enabled: true }` and
+ *    `customer_update: { address: "auto" }` when `org.config.automatic_tax`
+ *    is true. Mintlify gets this for free without any client-side work.
+ *
+ * No invoice-total assertion here: the customer hasn't completed checkout,
+ * so there's no invoice yet. Total-validation is covered by Cycles 2–5.
+ *
+ * Note: customer_update is a create-only param and is NOT echoed back in
+ * the Session response object. The customer_update fix is applied in
+ * production code; the integration test asserts only the observable
+ * `session.automatic_tax.enabled`.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import { products } from "@tests/utils/fixtures/products.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+const auAddress = {
+	country: "AU",
+	line1: "1 Test St",
+	city: "Sydney",
+	postal_code: "2000",
+	state: "NSW",
+};
+
+async function assertCheckoutSessionTaxed({
+	ctx,
+	checkoutUrl,
+}: {
+	ctx: TestContext;
+	checkoutUrl: string;
+}) {
+	const sessionIdMatch = checkoutUrl.match(/cs_(test|live)_[A-Za-z0-9]+/);
+	expect(sessionIdMatch).not.toBeNull();
+	const sessionId = sessionIdMatch![0];
+
+	const session = await ctx.stripeCli.checkout.sessions.retrieve(sessionId);
+	expect(session.automatic_tax.enabled).toBe(true);
+}
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-checkout-session (v1 legacy /v1/attach): no payment method returns checkout session with auto_tax")}`,
+	async () => {
+		const customerId = "tax-checkout-v1";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				// NO paymentMethod — forces checkout-URL branch on attach.
+				s.customer({
+					testClock: false,
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const result = (await autumnV1.attach({
+			customer_id: customerId,
+			product_id: `pro_${customerId}`,
+		})) as { checkout_url?: string };
+
+		expect(result.checkout_url).toBeDefined();
+		await assertCheckoutSessionTaxed({ ctx, checkoutUrl: result.checkout_url! });
+	},
+	240_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-checkout-session (v2 /v1/billing.attach): no payment method returns checkout session with auto_tax")}`,
+	async () => {
+		const customerId = "tax-checkout-v2";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const result = (await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: `pro_${customerId}`,
+		})) as { payment_url?: string };
+
+		// V2 returns the URL via `payment_url` (not `checkout_url`).
+		expect(result.payment_url).toBeDefined();
+		expect(typeof result.payment_url).toBe("string");
+		await assertCheckoutSessionTaxed({
+			ctx,
+			checkoutUrl: result.payment_url!,
+		});
+	},
+	240_000,
+);

--- a/server/tests/integration/billing/tax/automatic-tax-default-off.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-default-off.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression guard for the default-off behavior (Cycle 8).
+ *
+ * NOT a TDD red→green cycle — this test is GREEN at the start. It exists
+ * to lock in the contract that:
+ *  - Orgs without `automatic_tax: true` in their config get the legacy
+ *    behavior: `automatic_tax: { enabled: false }` on Stripe writes.
+ *  - The flag is OPT-IN, not opt-out, so adding the field to OrgConfig
+ *    does not retroactively start taxing every existing org's customers.
+ *
+ * Exercises BOTH attach paths concurrently:
+ *  - v1 legacy `/v1/attach`
+ *  - v2 `/v1/billing.attach`
+ *
+ * Runs against the master test org (no `s.platform.create`), which has
+ * `automatic_tax` falsy in its config (the schema default kicks in only
+ * on .parse(); the raw DB jsonb may have `undefined`). Asserts that
+ * resulting Stripe subscription has `automatic_tax.enabled === false`
+ * after attach via either path.
+ *
+ * If a future change accidentally hardcodes `automatic_tax: { enabled: true }`
+ * unconditionally (i.e. without checking org.config.automatic_tax), this
+ * test will fail and surface the regression at PR time.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import { products } from "@tests/utils/fixtures/products.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+async function assertSubNotTaxed({
+	ctx,
+	stripeCusId,
+}: {
+	ctx: TestContext;
+	stripeCusId: string;
+}) {
+	expect(ctx.org.config.automatic_tax).toBeFalsy();
+
+	const subs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(subs.data.length).toBeGreaterThan(0);
+	expect(subs.data[0].automatic_tax.enabled).toBe(false);
+}
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-default-off (v1 legacy /v1/attach): master org without auto_tax config does NOT enable Stripe Tax")}`,
+	async () => {
+		const customerId = "tax-default-off-v1";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		// Master org (no s.platform.create). Config has automatic_tax falsy.
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [proProd] }),
+			],
+			actions: [s.attach({ productId: "pro" })],
+		});
+
+		await assertSubNotTaxed({
+			ctx,
+			stripeCusId: customer!.processor!.id!,
+		});
+	},
+	120_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-default-off (v2 /v1/billing.attach): master org without auto_tax config does NOT enable Stripe Tax")}`,
+	async () => {
+		const customerId = "tax-default-off-v2";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [proProd] }),
+			],
+			actions: [s.billing.attach({ productId: "pro" })],
+		});
+
+		await assertSubNotTaxed({
+			ctx,
+			stripeCusId: customer!.processor!.id!,
+		});
+	},
+	120_000,
+);

--- a/server/tests/integration/billing/tax/automatic-tax-default-off.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-default-off.test.ts
@@ -1,26 +1,7 @@
 /**
- * Regression guard for the default-off behavior (Cycle 8).
- *
- * NOT a TDD red→green cycle — this test is GREEN at the start. It exists
- * to lock in the contract that:
- *  - Orgs without `automatic_tax: true` in their config get the legacy
- *    behavior: `automatic_tax: { enabled: false }` on Stripe writes.
- *  - The flag is OPT-IN, not opt-out, so adding the field to OrgConfig
- *    does not retroactively start taxing every existing org's customers.
- *
- * Exercises BOTH attach paths concurrently:
- *  - v1 legacy `/v1/attach`
- *  - v2 `/v1/billing.attach`
- *
- * Runs against the master test org (no `s.platform.create`), which has
- * `automatic_tax` falsy in its config (the schema default kicks in only
- * on .parse(); the raw DB jsonb may have `undefined`). Asserts that
- * resulting Stripe subscription has `automatic_tax.enabled === false`
- * after attach via either path.
- *
- * If a future change accidentally hardcodes `automatic_tax: { enabled: true }`
- * unconditionally (i.e. without checking org.config.automatic_tax), this
- * test will fail and surface the regression at PR time.
+ * Regression guard: orgs without `automatic_tax` in config must NOT have
+ * Stripe Tax enabled on attach (auto_tax is opt-in). Runs against the master
+ * test org via both v1 `/v1/attach` and v2 `/v1/billing.attach`.
  */
 
 import { expect, test } from "bun:test";
@@ -52,7 +33,7 @@ test.concurrent(
 		const customerId = "tax-default-off-v1";
 		const proProd = products.pro({ id: "pro", items: [] });
 
-		// Master org (no s.platform.create). Config has automatic_tax falsy.
+		// Master org (no s.platform.create) with automatic_tax falsy.
 		const { ctx, customer } = await initScenario({
 			customerId,
 			setup: [

--- a/server/tests/integration/billing/tax/automatic-tax-invoice-one-off.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-invoice-one-off.test.ts
@@ -1,27 +1,8 @@
 /**
- * TDD test for `automatic_tax` on one-off product invoices (Cycle 2).
- *
- * Exercises BOTH attach paths concurrently:
- *  - v1 legacy `/v1/attach` via `s.attach(...)` → handleOneOffFunction
- *  - v2 `/v1/billing.attach` via `s.billing.attach(...)` → v2 invoice helpers
- *
- * Red-failure mode (current behavior, pre-fix):
- *  - The v1 path's `handleOneOffFunction` calls `stripeCli.invoices.create({...})`
- *    WITHOUT passing `automatic_tax: { enabled: true }` even when the org has
- *    `org.config.automatic_tax === true`.
- *  - The v2 path uses helpers in the v2 stack that may or may not pass the flag.
- *  - Result on either path: invoice.total stays at the pre-tax amount,
- *    invoice.automatic_tax.enabled is false.
- *
- * Green-success criteria (after fix):
- *  - Both paths pass `automatic_tax: { enabled: true }` when org config is on.
- *  - Stripe Tax computes 10% AU GST on the customer's $10 line item.
- *  - invoice.total = 1100 cents ($11.00).
- *
- * Why invoice.total is the primary red signal: asserting only
- * `automatic_tax.enabled` proves we sent the flag, but doesn't prove tax
- * actually landed on what the customer pays. The customer's actual complaint
- * is "the invoice total didn't include VAT" — we mirror that exactly here.
+ * `automatic_tax` on one-off product invoices, both v1 (handleOneOffFunction)
+ * and v2 (v2 invoice helpers). Asserts invoice.total = 1100 ($10 + 10% AU GST)
+ * — checking total (not just `enabled`) catches cases where the flag is set
+ * but tax didn't actually land.
  */
 
 import { expect, test } from "bun:test";
@@ -41,7 +22,7 @@ test.concurrent(
 	`${chalk.yellowBright("automatic-tax-invoice-one-off (v1 legacy /v1/attach): $10 + AU GST = $11")}`,
 	async () => {
 		const customerId = "tax-one-off-v1";
-		// constructProduct auto-adds a $10 one-off base price for type "one_off".
+		// `oneOff` auto-adds a $10 base price.
 		const oneOffProd = products.oneOff({ id: "oneOff", items: [] });
 
 		const { ctx, customer } = await initScenario({

--- a/server/tests/integration/billing/tax/automatic-tax-invoice-one-off.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-invoice-one-off.test.ts
@@ -1,0 +1,117 @@
+/**
+ * TDD test for `automatic_tax` on one-off product invoices (Cycle 2).
+ *
+ * Exercises BOTH attach paths concurrently:
+ *  - v1 legacy `/v1/attach` via `s.attach(...)` → handleOneOffFunction
+ *  - v2 `/v1/billing.attach` via `s.billing.attach(...)` → v2 invoice helpers
+ *
+ * Red-failure mode (current behavior, pre-fix):
+ *  - The v1 path's `handleOneOffFunction` calls `stripeCli.invoices.create({...})`
+ *    WITHOUT passing `automatic_tax: { enabled: true }` even when the org has
+ *    `org.config.automatic_tax === true`.
+ *  - The v2 path uses helpers in the v2 stack that may or may not pass the flag.
+ *  - Result on either path: invoice.total stays at the pre-tax amount,
+ *    invoice.automatic_tax.enabled is false.
+ *
+ * Green-success criteria (after fix):
+ *  - Both paths pass `automatic_tax: { enabled: true }` when org config is on.
+ *  - Stripe Tax computes 10% AU GST on the customer's $10 line item.
+ *  - invoice.total = 1100 cents ($11.00).
+ *
+ * Why invoice.total is the primary red signal: asserting only
+ * `automatic_tax.enabled` proves we sent the flag, but doesn't prove tax
+ * actually landed on what the customer pays. The customer's actual complaint
+ * is "the invoice total didn't include VAT" — we mirror that exactly here.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+const auAddress = {
+	country: "AU",
+	line1: "1 Test St",
+	city: "Sydney",
+	postal_code: "2000",
+	state: "NSW",
+};
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-invoice-one-off (v1 legacy /v1/attach): $10 + AU GST = $11")}`,
+	async () => {
+		const customerId = "tax-one-off-v1";
+		// constructProduct auto-adds a $10 one-off base price for type "one_off".
+		const oneOffProd = products.oneOff({ id: "oneOff", items: [] });
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [oneOffProd] }),
+			],
+			actions: [s.attach({ productId: "oneOff" })],
+		});
+
+		const stripeCusId = customer!.processor!.id!;
+		const invoices = await ctx.stripeCli.invoices.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		expect(invoices.data.length).toBeGreaterThan(0);
+		const invoice = invoices.data[0];
+
+		expect(invoice.total).toBe(1100);
+		expect(invoice.automatic_tax.enabled).toBe(true);
+		expect(invoice.subtotal).toBe(1000);
+		expect(invoice.total - invoice.subtotal).toBe(100);
+	},
+	240_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-invoice-one-off (v2 /v1/billing.attach): $10 + AU GST = $11")}`,
+	async () => {
+		const customerId = "tax-one-off-v2";
+		const oneOffProd = products.oneOff({ id: "oneOff", items: [] });
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [oneOffProd] }),
+			],
+			actions: [s.billing.attach({ productId: "oneOff" })],
+		});
+
+		const stripeCusId = customer!.processor!.id!;
+		const invoices = await ctx.stripeCli.invoices.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		expect(invoices.data.length).toBeGreaterThan(0);
+		const invoice = invoices.data[0];
+
+		expect(invoice.total).toBe(1100);
+		expect(invoice.automatic_tax.enabled).toBe(true);
+		expect(invoice.subtotal).toBe(1000);
+		expect(invoice.total - invoice.subtotal).toBe(100);
+	},
+	240_000,
+);

--- a/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
@@ -1,0 +1,117 @@
+/**
+ * TDD test for the negative guard when `automatic_tax: true` but the
+ * customer has no tax-resolvable address (Cycle 7).
+ *
+ * Why: Stripe Tax can't compute tax without knowing the customer's
+ * jurisdiction. If `automatic_tax: { enabled: true }` is passed alongside
+ * a customer with no address, Stripe responds with
+ * `customer_tax_location_invalid`. Without a clean error path, this surfaces
+ * as an opaque 500 to the integrator.
+ *
+ * Exercises BOTH attach paths concurrently:
+ *  - v1 legacy `/v1/attach`
+ *  - v2 `/v1/billing.attach`
+ *
+ * Red-failure mode (current behavior, pre-fix):
+ *  - Stripe throws `customer_tax_location_invalid`, but the error bubbles
+ *    up wrapped in a generic 500 with no actionable code or message.
+ *
+ * Green-success criteria (after fix):
+ *  - The API surfaces a clearly-attributable error: either Stripe's exact
+ *    `customer_tax_location_invalid` code, OR a typed `RecaseError` with a
+ *    tax-related message.
+ *
+ * As of writing: both paths already surface a tax/address-attributable
+ * error message via the existing AutumnError plumbing, so this is
+ * effectively a regression guard (GREEN at start) — locks in the contract
+ * that no-address attach with auto_tax produces an actionable error.
+ */
+
+import { expect, test } from "bun:test";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+function hasActionableTaxSignal(err: unknown): boolean {
+	const errorString = JSON.stringify(err, [
+		"message",
+		"code",
+		"name",
+		"type",
+	]).toLowerCase();
+	return (
+		errorString.includes("tax") ||
+		errorString.includes("address") ||
+		errorString.includes("location")
+	);
+}
+
+test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v1 legacy /v1/attach): customer without address surfaces actionable error")}`, async () => {
+	const customerId = "tax-no-address-v1";
+	const proProd = products.pro({ id: "pro", items: [] });
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.platform.create({
+				configOverrides: { automatic_tax: true },
+				taxRegistrations: ["AU"],
+			}),
+			// No stripeCustomerOverrides => no address.
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+			}),
+			s.products({ list: [proProd] }),
+		],
+		actions: [],
+	});
+
+	let caughtError: unknown;
+	try {
+		await autumnV1.attach({
+			customer_id: customerId,
+			product_id: `pro_${customerId}`,
+		});
+	} catch (err) {
+		caughtError = err;
+		console.log("caughtError", caughtError);
+	}
+
+	expect(caughtError).toBeDefined();
+	expect(hasActionableTaxSignal(caughtError)).toBe(true);
+}, 240_000);
+
+test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v2 /v1/billing.attach): customer without address surfaces actionable error")}`, async () => {
+	const customerId = "tax-no-address-v2";
+	const proProd = products.pro({ id: "pro", items: [] });
+
+	const { autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.platform.create({
+				configOverrides: { automatic_tax: true },
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+			}),
+			s.products({ list: [proProd] }),
+		],
+		actions: [],
+	});
+
+	let caughtError: unknown;
+	try {
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: `pro_${customerId}`,
+		});
+	} catch (err) {
+		caughtError = err;
+	}
+
+	expect(caughtError).toBeDefined();
+	expect(hasActionableTaxSignal(caughtError)).toBe(true);
+}, 240_000);

--- a/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
@@ -1,30 +1,8 @@
 /**
- * TDD test for the negative guard when `automatic_tax: true` but the
- * customer has no tax-resolvable address (Cycle 7).
- *
- * Why: Stripe Tax can't compute tax without knowing the customer's
- * jurisdiction. If `automatic_tax: { enabled: true }` is passed alongside
- * a customer with no address, Stripe responds with
- * `customer_tax_location_invalid`. Without a clean error path, this surfaces
- * as an opaque 500 to the integrator.
- *
- * Exercises BOTH attach paths concurrently:
- *  - v1 legacy `/v1/attach`
- *  - v2 `/v1/billing.attach`
- *
- * Red-failure mode (current behavior, pre-fix):
- *  - Stripe throws `customer_tax_location_invalid`, but the error bubbles
- *    up wrapped in a generic 500 with no actionable code or message.
- *
- * Green-success criteria (after fix):
- *  - The API surfaces a clearly-attributable error: either Stripe's exact
- *    `customer_tax_location_invalid` code, OR a typed `RecaseError` with a
- *    tax-related message.
- *
- * As of writing: both paths already surface a tax/address-attributable
- * error message via the existing AutumnError plumbing, so this is
- * effectively a regression guard (GREEN at start) — locks in the contract
- * that no-address attach with auto_tax produces an actionable error.
+ * Regression guard: when `automatic_tax: true` but the customer has no
+ * address, attach must surface an actionable tax/address error (Stripe's
+ * `customer_tax_location_invalid` or a typed RecaseError) instead of a
+ * generic 500. Covers both v1 `/v1/attach` and v2 `/v1/billing.attach`.
  */
 
 import { expect, test } from "bun:test";
@@ -57,7 +35,6 @@ test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v1 legacy
 				configOverrides: { automatic_tax: true },
 				taxRegistrations: ["AU"],
 			}),
-			// No stripeCustomerOverrides => no address.
 			s.customer({
 				testClock: false,
 				paymentMethod: "success",
@@ -75,7 +52,6 @@ test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v1 legacy
 		});
 	} catch (err) {
 		caughtError = err;
-		console.log("caughtError", caughtError);
 	}
 
 	expect(caughtError).toBeDefined();

--- a/server/tests/integration/billing/tax/automatic-tax-no-address-existing-customer.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-no-address-existing-customer.test.ts
@@ -1,45 +1,15 @@
 /**
- * Three concurrent scenarios for the existing-customer-with-no-address
- * problem after `org.config.automatic_tax` is flipped on.
+ * Existing-customer-no-address scenarios after `automatic_tax` is flipped on.
  *
- * Real Mintlify scenario: ~700 customers were created BEFORE
- * `automatic_tax` was enabled. Most have no address on their Stripe
- * customer record. When the flag flips on, what happens next time those
- * customers are charged or upgraded?
+ * Background: ~700 Mintlify customers were created BEFORE auto_tax was
+ * enabled. Free→Pro via Checkout works (Checkout collects address);
+ * Pro→Premium via invoice-mode failed with "customer's location isn't
+ * recognized" because send_invoice has no address-collection UI. Fix:
+ * invoice-mode mutations skip auto_tax.
  *
- * The user verified two paths in production (Mintlify org via `bun p`):
- *   1. Free → Pro via Stripe Checkout WORKS — Stripe Checkout collects
- *      address, Stripe Tax computes via Sphere.
- *   2. Pro → Premium via invoice-mode attach FAILED with
- *      "The customer's location isn't recognized." because invoice-mode
- *      invoices (collection_method: send_invoice) have no buyer-facing
- *      address-collection UI.
- *
- * The fix landed in this PR: invoice-mode subs/invoices skip auto_tax.
- * These tests pin down the resulting behavior:
- *
- * Scenario A — Free → Pro via Checkout, no address (PROD-VERIFIED OK)
- *   STRONG ASSERT: session has auto_tax + billing_address_collection +
- *   customer_update + tax_id_collection. The buyer-facing form behavior is
- *   Stripe's territory; we observe-and-warn the Playwright run.
- *
- * Scenario B — Pre-config-flip Checkout-purchased customer, then upgrade.
- *   The realistic prod path: a customer bought Pro via Checkout BEFORE
- *   the org enabled `automatic_tax`. After the flip, an upgrade to
- *   Premium via charge_automatically `billing.attach` MUST succeed with
- *   tax computed — Stripe's waterfall (customer.address → recent
- *   checkout / IP / predicted location) has plenty to go on because the
- *   customer went through Checkout once and Stripe captured an address.
- *   STRONG ASSERT: upgrade succeeds, resulting sub has auto_tax enabled,
- *   and the proration invoice has `automatic_tax.status === "complete"`.
- *
- * Scenario C — Existing customer with PM but no address, INVOICE-MODE upgrade
- *   (PROD-FAILURE-FIXED). Pre-fix: Stripe rejected because invoice-mode
- *   invoices can't collect address. Post-fix: we skip auto_tax entirely
- *   for invoice-mode mutations, so the upgrade SUCCEEDS — just without
- *   tax. STRONG ASSERT: upgrade returns success AND the resulting sub has
- *   `automatic_tax.enabled === false` (skipped due to invoice mode), even
- *   though the org's auto_tax flag is on.
+ * A — Checkout, no address: session has auto_tax + address-collection + tax_id.
+ * B — Pre-flip Checkout, then charge_automatically upgrade succeeds WITH tax.
+ * C — Existing customer, INVOICE-MODE upgrade succeeds WITHOUT tax (the fix).
  */
 
 import { expect, test } from "bun:test";
@@ -49,121 +19,105 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 
-test.concurrent
-	.skip(`${chalk.yellowBright(
-		"automatic-tax-no-address (Scenario A — checkout, no address): session forces full address collection + auto_tax",
-	)}`, async () => {
-		const customerId = "tax-no-addr-checkout";
-		const proProd = products.pro({ id: "pro", items: [] });
+test.concurrent(`${chalk.yellowBright(
+	"automatic-tax-no-address (Scenario A — checkout, no address): session forces full address collection + auto_tax",
+)}`, async () => {
+	const customerId = "tax-no-addr-checkout";
+	const proProd = products.pro({ id: "pro", items: [] });
 
-		// Sub-org with auto_tax already on. Customer is fresh (no PM, no address).
-		const { ctx, customer, autumnV1 } = await initScenario({
-			customerId,
-			setup: [
-				s.platform.create({
-					configOverrides: { automatic_tax: true },
-					taxRegistrations: ["AU"],
-				}),
-				// No paymentMethod -> forces checkout-URL branch.
-				// No stripeCustomerOverrides -> no address on the Stripe customer.
-				s.customer({ testClock: false }),
-				s.products({ list: [proProd] }),
-			],
-			actions: [],
+	// Sub-org with auto_tax on. Fresh customer: no PM, no address.
+	const { ctx, customer, autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.platform.create({
+				configOverrides: { automatic_tax: true },
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({ testClock: false }),
+			s.products({ list: [proProd] }),
+		],
+		actions: [],
+	});
+
+	const stripeCusId = customer!.processor!.id!;
+
+	const stripeCusBefore = await ctx.stripeCli.customers.retrieve(stripeCusId);
+	const addressBefore =
+		"address" in stripeCusBefore ? stripeCusBefore.address : null;
+	expect(addressBefore).toBeNull();
+	console.log("[scenario-A] pre-checkout: stripe customer address = null");
+
+	const result = (await autumnV1.attach({
+		customer_id: customerId,
+		product_id: `pro_${customerId}`,
+	})) as { checkout_url?: string };
+	expect(result.checkout_url).toBeDefined();
+
+	// Assert the session was created with the full set of
+	// address-collection params our fix injects. `customer_update` is
+	// create-only and not echoed in the retrieved Session — that path
+	// is asserted indirectly via automatic-tax-checkout-session.test.ts.
+	const sessionId = result.checkout_url!.match(
+		/cs_(test|live)_[A-Za-z0-9]+/,
+	)?.[0];
+	expect(sessionId).toBeDefined();
+	const session = await ctx.stripeCli.checkout.sessions.retrieve(sessionId!);
+
+	expect(session.automatic_tax.enabled).toBe(true);
+	expect(session.billing_address_collection).toBe("required");
+	expect(session.tax_id_collection?.enabled).toBe(true);
+
+	console.log(
+		`[scenario-A] checkout session OK: id=${session.id} auto_tax=${session.automatic_tax.enabled} ` +
+			`billing_address_collection=${session.billing_address_collection} ` +
+			`tax_id_collection=${session.tax_id_collection?.enabled}`,
+	);
+
+	// Best-effort browser drive. Form fields vary by country; we warn
+	// on Playwright failure since the session contract is already asserted.
+	try {
+		await completeStripeCheckoutFormV2({
+			url: result.checkout_url!,
+			billingAddress: {
+				country: "AU",
+				line1: "1 Test St",
+				city: "Sydney",
+				state: "NSW",
+				postal_code: "2000",
+			},
 		});
-
-		const stripeCusId = customer!.processor!.id!;
-
-		// Sanity: customer was created without an address.
-		const stripeCusBefore = await ctx.stripeCli.customers.retrieve(stripeCusId);
-		const addressBefore =
-			"address" in stripeCusBefore ? stripeCusBefore.address : null;
-		expect(addressBefore).toBeNull();
-		console.log("[scenario-A] pre-checkout: stripe customer address = null");
-
-		// Attach -> returns checkout URL (no PM available).
-		const result = (await autumnV1.attach({
-			customer_id: customerId,
-			product_id: `pro_${customerId}`,
-		})) as { checkout_url?: string };
-		expect(result.checkout_url).toBeDefined();
-
-		// PRIMARY ASSERTIONS: the Stripe session itself was created with
-		// the full set of address-collection params our fix injects when
-		// `org.config.automatic_tax` is on. This is the contract our
-		// integration is responsible for — what the buyer does with the
-		// form is Stripe's territory.
-		const sessionId = result.checkout_url!.match(
-			/cs_(test|live)_[A-Za-z0-9]+/,
-		)?.[0];
-		expect(sessionId).toBeDefined();
-		const session = await ctx.stripeCli.checkout.sessions.retrieve(sessionId!);
-
-		// Strong assertions: every observable field that matters for tax
-		// to land. Note: `customer_update` is a create-only param and is
-		// NOT echoed back on the retrieved Session — we assert it
-		// indirectly via the production code path (the v1 + v2 checkout
-		// builders both include `customer_update: { address: "auto" }`)
-		// and via the unit/integration coverage in
-		// automatic-tax-checkout-session.test.ts.
-		expect(session.automatic_tax.enabled).toBe(true);
-		expect(session.billing_address_collection).toBe("required");
-		expect(session.tax_id_collection?.enabled).toBe(true);
-
-		console.log(
-			`[scenario-A] checkout session OK: id=${session.id} auto_tax=${session.automatic_tax.enabled} ` +
-				`billing_address_collection=${session.billing_address_collection} ` +
-				`tax_id_collection=${session.tax_id_collection?.enabled}`,
+	} catch (err) {
+		console.warn(
+			"[scenario-A] browser checkout helper threw — likely a form-fill issue, not a logic bug. Session-level assertions already passed:",
+			err instanceof Error ? err.message : err,
 		);
+	}
 
-		// Best-effort browser drive. Stripe's Checkout form fields for
-		// address vary by country + test mode; if Playwright can't find
-		// the AU address fields it will throw, and we just warn — the
-		// session-level contract is already asserted above.
-		try {
-			await completeStripeCheckoutFormV2({
-				url: result.checkout_url!,
-				billingAddress: {
-					country: "AU",
-					line1: "1 Test St",
-					city: "Sydney",
-					state: "NSW",
-					postal_code: "2000",
-				},
-			});
-		} catch (err) {
-			console.warn(
-				"[scenario-A] browser checkout helper threw — likely a form-fill issue, not a logic bug. Session-level assertions already passed:",
-				err instanceof Error ? err.message : err,
-			);
-		}
+	// Wait for Stripe webhook + back-write (best-effort).
+	await new Promise((r) => setTimeout(r, 5000));
 
-		// Give Stripe up to 5s for webhook + back-write (best-effort observation).
-		await new Promise((r) => setTimeout(r, 5000));
+	const subs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	const stripeCusAfter = await ctx.stripeCli.customers.retrieve(stripeCusId);
+	const addressAfter =
+		"address" in stripeCusAfter ? stripeCusAfter.address : null;
 
-		const subs = await ctx.stripeCli.subscriptions.list({
-			customer: stripeCusId,
-			limit: 1,
-		});
-		const stripeCusAfter = await ctx.stripeCli.customers.retrieve(stripeCusId);
-		const addressAfter =
-			"address" in stripeCusAfter ? stripeCusAfter.address : null;
+	console.log(
+		`[scenario-A] post-checkout: subs=${subs.data.length} ` +
+			`subAutoTax=${subs.data[0]?.automatic_tax.enabled ?? "N/A"} ` +
+			`customerAddress=${JSON.stringify(addressAfter)}`,
+	);
 
-		console.log(
-			`[scenario-A] post-checkout: subs=${subs.data.length} ` +
-				`subAutoTax=${subs.data[0]?.automatic_tax.enabled ?? "N/A"} ` +
-				`customerAddress=${JSON.stringify(addressAfter)}`,
-		);
-
-		// If the Playwright form-fill happened to succeed and a sub got
-		// created, verify the chain held end-to-end. Otherwise we don't
-		// fail the test — session-level contract was already asserted.
-		if (subs.data.length > 0) {
-			expect(subs.data[0].automatic_tax.enabled).toBe(true);
-			expect(addressAfter).not.toBeNull();
-			expect(addressAfter?.country).toBe("AU");
-		}
-	}, 600_000);
+	// If Playwright form-fill succeeded and produced a sub, verify the
+	// end-to-end chain. Otherwise the session-level contract suffices.
+	if (subs.data.length > 0) {
+		expect(subs.data[0].automatic_tax.enabled).toBe(true);
+		expect(addressAfter).not.toBeNull();
+		expect(addressAfter?.country).toBe("AU");
+	}
+}, 600_000);
 
 test.concurrent(`${chalk.yellowBright(
 	"automatic-tax-no-address (Scenario B — pre-flip Checkout, then charge_automatically upgrade): waterfall resolves location, upgrade succeeds WITH tax",
@@ -172,13 +126,12 @@ test.concurrent(`${chalk.yellowBright(
 	const proProd = products.pro({ id: "pro", items: [] });
 	const premiumProd = products.premium({ id: "premium", items: [] });
 
-	// Sub-org starts WITH auto_tax OFF. Customer is fresh (no PM, no
-	// address) which forces the attach-returns-checkout-URL branch.
+	// auto_tax OFF, fresh customer (no PM, no address) so attach returns
+	// a checkout URL.
 	const { ctx, customer, autumnV1, autumnV2_2 } = await initScenario({
 		customerId,
 		setup: [
 			s.platform.create({
-				// No configOverrides -> automatic_tax starts off.
 				taxRegistrations: ["AU"],
 			}),
 			s.customer({ testClock: false }),
@@ -189,20 +142,13 @@ test.concurrent(`${chalk.yellowBright(
 
 	const stripeCusId = customer!.processor!.id!;
 
-	// Sanity: address is null on the Stripe customer pre-checkout.
 	const stripeCusBefore = await ctx.stripeCli.customers.retrieve(stripeCusId);
 	const addressBefore =
 		"address" in stripeCusBefore ? stripeCusBefore.address : null;
 	expect(addressBefore).toBeNull();
 
-	// Step 1: buy Pro via Stripe Checkout BEFORE the org enables
-	// automatic_tax. Drive the Playwright helper with a real AU
-	// billing address. This seeds:
-	//   - the Stripe customer's `address` field
-	//   - Stripe's internal waterfall (IP / predicted location)
-	// so that any subsequent charge_automatically mutation has a
-	// jurisdiction available even without an explicit `automatic_tax`
-	// param on Checkout itself (the org flag is OFF here).
+	// Step 1: Pro via Checkout BEFORE auto_tax flip. Seeds the Stripe
+	// customer's `address` and Stripe's location waterfall.
 	const proResult = (await autumnV1.attach({
 		customer_id: customerId,
 		product_id: `pro_${customerId}`,
@@ -220,7 +166,7 @@ test.concurrent(`${chalk.yellowBright(
 		},
 	});
 
-	// Give Stripe webhook + back-write a moment to land the sub.
+	// Wait for Stripe webhook + back-write to land the sub.
 	await new Promise((r) => setTimeout(r, 5000));
 
 	const proSubs = await ctx.stripeCli.subscriptions.list({
@@ -229,10 +175,8 @@ test.concurrent(`${chalk.yellowBright(
 	});
 	expect(proSubs.data.length).toBeGreaterThan(0);
 
-	// Step 2: flip the org config to enable automatic_tax. This DB write
-	// also invalidates the secret-key cache via OrgService.update's
-	// internal clearOrgCache call, so the next API request re-reads the
-	// fresh config.
+	// Step 2: flip auto_tax on. OrgService.update invalidates the
+	// secret-key cache so the next request reads fresh config.
 	await OrgService.update({
 		db: ctx.db,
 		orgId: ctx.org.id,
@@ -240,21 +184,18 @@ test.concurrent(`${chalk.yellowBright(
 			config: { ...ctx.org.config, automatic_tax: true },
 		},
 	});
-	// Small delay to let multi-region Redis invalidation settle.
+	// Wait for multi-region Redis invalidation to settle.
 	await new Promise((r) => setTimeout(r, 500));
 
-	// Step 3: upgrade Pro -> Premium via charge_automatically
-	// `billing.attach` (the V2_2 path). Stripe's waterfall has the
-	// AU address from Checkout, so auto_tax MUST land cleanly with
-	// tax computed.
+	// Step 3: charge_automatically upgrade. Stripe's waterfall has the
+	// AU address from Checkout, so auto_tax lands cleanly.
 	await autumnV2_2.billing.attach({
 		customer_id: customerId,
 		plan_id: `premium_${customerId}`,
 	});
 
-	// STRONG ASSERTIONS: upgrade succeeded (no throw), resulting sub
-	// has auto_tax enabled, and the proration invoice has tax fully
-	// resolved (`status: "complete"`).
+	// Upgrade succeeded; sub has auto_tax enabled; proration invoice has
+	// tax fully resolved.
 	const upgradedSubs = await ctx.stripeCli.subscriptions.list({
 		customer: stripeCusId,
 		limit: 1,
@@ -267,8 +208,7 @@ test.concurrent(`${chalk.yellowBright(
 		customer: stripeCusId,
 		limit: 5,
 	});
-	// The most recent invoice should be the proration invoice from
-	// the upgrade.
+	// Most recent invoice = proration invoice from the upgrade.
 	const prorationInvoice = invoices.data[0];
 	expect(prorationInvoice).toBeDefined();
 	expect(prorationInvoice.automatic_tax.enabled).toBe(true);
@@ -282,131 +222,103 @@ test.concurrent(`${chalk.yellowBright(
 	);
 }, 600_000);
 
-test.concurrent
-	.skip(`${chalk.yellowBright(
-		"automatic-tax-no-address (Scenario C — INVOICE-MODE upgrade, no address): post-fix MUST succeed without tax",
-	)}`, async () => {
-		const customerId = "tax-no-addr-invoice-mode";
-		const proProd = products.pro({ id: "pro", items: [] });
-		const premiumProd = products.premium({ id: "premium", items: [] });
+test.concurrent(`${chalk.yellowBright(
+	"automatic-tax-no-address (Scenario C — INVOICE-MODE upgrade, no address): post-fix MUST succeed without tax",
+)}`, async () => {
+	const customerId = "tax-no-addr-invoice-mode";
+	const proProd = products.pro({ id: "pro", items: [] });
+	const premiumProd = products.premium({ id: "premium", items: [] });
 
-		// Sub-org starts WITH auto_tax OFF so the initial Pro attach
-		// succeeds (auto_tax + no address would fail at create time even
-		// for a fresh customer). Customer has PM but no address.
-		const { ctx, customer, autumnV2_2 } = await initScenario({
-			customerId,
-			setup: [
-				s.platform.create({
-					// No configOverrides -> automatic_tax starts off.
-					taxRegistrations: ["AU"],
-				}),
-				s.customer({
-					testClock: false,
-					paymentMethod: "success",
-					// NO stripeCustomerOverrides — Stripe customer has no address.
-				}),
-				s.products({ list: [proProd, premiumProd] }),
-			],
-			actions: [s.billing.attach({ productId: "pro" })],
-		});
+	// auto_tax OFF so initial Pro attach succeeds (auto_tax + no
+	// address would fail at create even for a fresh customer).
+	// Customer has PM but no address.
+	const { ctx, customer, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.platform.create({
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+			}),
+			s.products({ list: [proProd, premiumProd] }),
+		],
+		actions: [s.billing.attach({ productId: "pro" })],
+	});
 
-		const stripeCusId = customer!.processor!.id!;
+	const stripeCusId = customer!.processor!.id!;
 
-		// Sanity: customer has no address; initial Pro sub has no auto_tax.
-		const stripeCusBefore = await ctx.stripeCli.customers.retrieve(stripeCusId);
-		const addressBefore =
-			"address" in stripeCusBefore ? stripeCusBefore.address : null;
-		expect(addressBefore).toBeNull();
+	const stripeCusBefore = await ctx.stripeCli.customers.retrieve(stripeCusId);
+	const addressBefore =
+		"address" in stripeCusBefore ? stripeCusBefore.address : null;
+	expect(addressBefore).toBeNull();
 
-		const initialSubs = await ctx.stripeCli.subscriptions.list({
-			customer: stripeCusId,
-			limit: 1,
-		});
-		expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
-		console.log(
-			"[scenario-C] pre-flip: customer address=null, initial sub auto_tax=false",
-		);
+	const initialSubs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
+	console.log(
+		"[scenario-C] pre-flip: customer address=null, initial sub auto_tax=false",
+	);
 
-		// Flip the org config to enable automatic_tax.
-		await OrgService.update({
-			db: ctx.db,
-			orgId: ctx.org.id,
-			updates: {
-				config: { ...ctx.org.config, automatic_tax: true },
-			},
-		});
+	// Flip auto_tax on.
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...ctx.org.config, automatic_tax: true },
+		},
+	});
 
-		// Trigger an upgrade Pro -> Premium via INVOICE-MODE billing.attach.
-		// This is the prod-failure case the user hit on Mintlify.
-		//
-		// PRE-FIX BEHAVIOR: Stripe rejected the sub.update with
-		//   "The customer's location isn't recognized. Set a valid
-		//    customer address in order to automatically calculate tax."
-		// because invoice-mode invoices (collection_method: send_invoice)
-		// have no hosted address-collection UI.
-		//
-		// POST-FIX BEHAVIOR (this test): we skip `automatic_tax` entirely
-		// for invoice-mode mutations in
-		//   - executeStripeSubscriptionOperation (sub.create + sub.update)
-		//   - buildStripeSubscriptionUpdateAction (sub.update params)
-		//   - createInvoiceForBilling (invoice.create)
-		//   - createStripeSub2 (legacy v1 sub.create)
-		//   - handleOneOffFunction (legacy v1 invoice.create)
-		// So the upgrade succeeds — the resulting sub/invoice just won't
-		// have tax computed (which is the design choice we landed on:
-		// Stripe Tax simply can't compute tax without an address, and
-		// invoice mode has no way to collect one).
-		// V2_2 schema uses `invoice_mode: { enabled: true }`. The legacy
-		// `invoice: true` alias is V0/V1_Beta only and isn't on the V2_2
-		// AttachParamsV1Schema — passing it would silently no-op the
-		// invoice-mode discriminator (`billingContext.invoiceMode` would
-		// stay falsy) and then `automatic_tax: { enabled: true }` would
-		// leak through to a `charge_automatically` Stripe call, hitting
-		// the "customer's location isn't recognized" error we're trying
-		// to avoid. This is exactly what failed before.
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: `premium_${customerId}`,
-			invoice_mode: { enabled: true },
-		});
+	// INVOICE-MODE upgrade (the Mintlify prod-failure case).
+	// Pre-fix: Stripe rejected with "customer's location isn't recognized"
+	// since send_invoice has no address-collection UI. Post-fix: we skip
+	// auto_tax for invoice-mode mutations so the upgrade succeeds without
+	// tax computed.
+	//
+	// Use V2_2's `invoice_mode: { enabled: true }`; the legacy `invoice`
+	// alias isn't on V2_2, so passing it would silently no-op the
+	// discriminator and leak auto_tax into a charge_automatically call.
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: `premium_${customerId}`,
+		invoice_mode: { enabled: true },
+	});
 
-		// STRONG ASSERTIONS: upgrade succeeded (no exception above) and
-		// the resulting sub has auto_tax disabled.
-		//
-		// Note: the SUB itself stays in its original collection_method
-		// (charge_automatically) because the upgrade only flips invoice
-		// mode for the PRORATION INVOICE, not the existing sub. We assert
-		// the invoice-level discriminator below.
-		const updatedSubs = await ctx.stripeCli.subscriptions.list({
-			customer: stripeCusId,
-			limit: 1,
-		});
-		const upgradedSub = updatedSubs.data[0];
-		expect(upgradedSub).toBeDefined();
-		expect(upgradedSub.automatic_tax.enabled).toBe(false);
-		console.log(
-			`[scenario-C] upgrade succeeded: sub_id=${upgradedSub.id} ` +
-				`collection_method=${upgradedSub.collection_method} ` +
-				`sub_auto_tax=${upgradedSub.automatic_tax.enabled}`,
-		);
+	// Upgrade succeeded; resulting sub has auto_tax disabled.
+	// The sub stays charge_automatically (invoice-mode only flips for
+	// the proration invoice); we assert the invoice-level discriminator below.
+	const updatedSubs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	const upgradedSub = updatedSubs.data[0];
+	expect(upgradedSub).toBeDefined();
+	expect(upgradedSub.automatic_tax.enabled).toBe(false);
+	console.log(
+		`[scenario-C] upgrade succeeded: sub_id=${upgradedSub.id} ` +
+			`collection_method=${upgradedSub.collection_method} ` +
+			`sub_auto_tax=${upgradedSub.automatic_tax.enabled}`,
+	);
 
-		// At least one of the resulting invoices is in send_invoice mode
-		// (the proration invoice for the upgrade), and every send_invoice
-		// invoice has auto_tax disabled — this is the prod-failure-fix
-		// proper discriminator.
-		const invoices = await ctx.stripeCli.invoices.list({
-			customer: stripeCusId,
-			limit: 10,
-		});
-		const sendInvoiceInvoices = invoices.data.filter(
-			(inv) => inv.collection_method === "send_invoice",
-		);
-		expect(sendInvoiceInvoices.length).toBeGreaterThan(0);
-		for (const inv of sendInvoiceInvoices) {
-			expect(inv.automatic_tax.enabled).toBe(false);
-		}
-		console.log(
-			`[scenario-C] send_invoice invoices: ${sendInvoiceInvoices.length} ` +
-				`found (out of ${invoices.data.length} total), all with auto_tax=false`,
-		);
-	}, 300_000);
+	// At least one resulting invoice is send_invoice (the upgrade's
+	// proration invoice), and every send_invoice invoice has auto_tax
+	// disabled — the prod-failure-fix discriminator.
+	const invoices = await ctx.stripeCli.invoices.list({
+		customer: stripeCusId,
+		limit: 10,
+	});
+	const sendInvoiceInvoices = invoices.data.filter(
+		(inv) => inv.collection_method === "send_invoice",
+	);
+	expect(sendInvoiceInvoices.length).toBeGreaterThan(0);
+	for (const inv of sendInvoiceInvoices) {
+		expect(inv.automatic_tax.enabled).toBe(false);
+	}
+	console.log(
+		`[scenario-C] send_invoice invoices: ${sendInvoiceInvoices.length} ` +
+			`found (out of ${invoices.data.length} total), all with auto_tax=false`,
+	);
+}, 300_000);

--- a/server/tests/integration/billing/tax/automatic-tax-no-address-existing-customer.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-no-address-existing-customer.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Three concurrent scenarios for the existing-customer-with-no-address
+ * problem after `org.config.automatic_tax` is flipped on.
+ *
+ * Real Mintlify scenario: ~700 customers were created BEFORE
+ * `automatic_tax` was enabled. Most have no address on their Stripe
+ * customer record. When the flag flips on, what happens next time those
+ * customers are charged or upgraded?
+ *
+ * The user verified two paths in production (Mintlify org via `bun p`):
+ *   1. Free → Pro via Stripe Checkout WORKS — Stripe Checkout collects
+ *      address, Stripe Tax computes via Sphere.
+ *   2. Pro → Premium via invoice-mode attach FAILED with
+ *      "The customer's location isn't recognized." because invoice-mode
+ *      invoices (collection_method: send_invoice) have no buyer-facing
+ *      address-collection UI.
+ *
+ * The fix landed in this PR: invoice-mode subs/invoices skip auto_tax.
+ * These tests pin down the resulting behavior:
+ *
+ * Scenario A — Free → Pro via Checkout, no address (PROD-VERIFIED OK)
+ *   STRONG ASSERT: session has auto_tax + billing_address_collection +
+ *   customer_update + tax_id_collection. The buyer-facing form behavior is
+ *   Stripe's territory; we observe-and-warn the Playwright run.
+ *
+ * Scenario B — Pre-config-flip Checkout-purchased customer, then upgrade.
+ *   The realistic prod path: a customer bought Pro via Checkout BEFORE
+ *   the org enabled `automatic_tax`. After the flip, an upgrade to
+ *   Premium via charge_automatically `billing.attach` MUST succeed with
+ *   tax computed — Stripe's waterfall (customer.address → recent
+ *   checkout / IP / predicted location) has plenty to go on because the
+ *   customer went through Checkout once and Stripe captured an address.
+ *   STRONG ASSERT: upgrade succeeds, resulting sub has auto_tax enabled,
+ *   and the proration invoice has `automatic_tax.status === "complete"`.
+ *
+ * Scenario C — Existing customer with PM but no address, INVOICE-MODE upgrade
+ *   (PROD-FAILURE-FIXED). Pre-fix: Stripe rejected because invoice-mode
+ *   invoices can't collect address. Post-fix: we skip auto_tax entirely
+ *   for invoice-mode mutations, so the upgrade SUCCEEDS — just without
+ *   tax. STRONG ASSERT: upgrade returns success AND the resulting sub has
+ *   `automatic_tax.enabled === false` (skipped due to invoice mode), even
+ *   though the org's auto_tax flag is on.
+ */
+
+import { expect, test } from "bun:test";
+import { completeStripeCheckoutFormV2 } from "@tests/utils/browserPool/completeStripeCheckoutFormV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+
+test.concurrent
+	.skip(`${chalk.yellowBright(
+		"automatic-tax-no-address (Scenario A — checkout, no address): session forces full address collection + auto_tax",
+	)}`, async () => {
+		const customerId = "tax-no-addr-checkout";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		// Sub-org with auto_tax already on. Customer is fresh (no PM, no address).
+		const { ctx, customer, autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				// No paymentMethod -> forces checkout-URL branch.
+				// No stripeCustomerOverrides -> no address on the Stripe customer.
+				s.customer({ testClock: false }),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const stripeCusId = customer!.processor!.id!;
+
+		// Sanity: customer was created without an address.
+		const stripeCusBefore = await ctx.stripeCli.customers.retrieve(stripeCusId);
+		const addressBefore =
+			"address" in stripeCusBefore ? stripeCusBefore.address : null;
+		expect(addressBefore).toBeNull();
+		console.log("[scenario-A] pre-checkout: stripe customer address = null");
+
+		// Attach -> returns checkout URL (no PM available).
+		const result = (await autumnV1.attach({
+			customer_id: customerId,
+			product_id: `pro_${customerId}`,
+		})) as { checkout_url?: string };
+		expect(result.checkout_url).toBeDefined();
+
+		// PRIMARY ASSERTIONS: the Stripe session itself was created with
+		// the full set of address-collection params our fix injects when
+		// `org.config.automatic_tax` is on. This is the contract our
+		// integration is responsible for — what the buyer does with the
+		// form is Stripe's territory.
+		const sessionId = result.checkout_url!.match(
+			/cs_(test|live)_[A-Za-z0-9]+/,
+		)?.[0];
+		expect(sessionId).toBeDefined();
+		const session = await ctx.stripeCli.checkout.sessions.retrieve(sessionId!);
+
+		// Strong assertions: every observable field that matters for tax
+		// to land. Note: `customer_update` is a create-only param and is
+		// NOT echoed back on the retrieved Session — we assert it
+		// indirectly via the production code path (the v1 + v2 checkout
+		// builders both include `customer_update: { address: "auto" }`)
+		// and via the unit/integration coverage in
+		// automatic-tax-checkout-session.test.ts.
+		expect(session.automatic_tax.enabled).toBe(true);
+		expect(session.billing_address_collection).toBe("required");
+		expect(session.tax_id_collection?.enabled).toBe(true);
+
+		console.log(
+			`[scenario-A] checkout session OK: id=${session.id} auto_tax=${session.automatic_tax.enabled} ` +
+				`billing_address_collection=${session.billing_address_collection} ` +
+				`tax_id_collection=${session.tax_id_collection?.enabled}`,
+		);
+
+		// Best-effort browser drive. Stripe's Checkout form fields for
+		// address vary by country + test mode; if Playwright can't find
+		// the AU address fields it will throw, and we just warn — the
+		// session-level contract is already asserted above.
+		try {
+			await completeStripeCheckoutFormV2({
+				url: result.checkout_url!,
+				billingAddress: {
+					country: "AU",
+					line1: "1 Test St",
+					city: "Sydney",
+					state: "NSW",
+					postal_code: "2000",
+				},
+			});
+		} catch (err) {
+			console.warn(
+				"[scenario-A] browser checkout helper threw — likely a form-fill issue, not a logic bug. Session-level assertions already passed:",
+				err instanceof Error ? err.message : err,
+			);
+		}
+
+		// Give Stripe up to 5s for webhook + back-write (best-effort observation).
+		await new Promise((r) => setTimeout(r, 5000));
+
+		const subs = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		const stripeCusAfter = await ctx.stripeCli.customers.retrieve(stripeCusId);
+		const addressAfter =
+			"address" in stripeCusAfter ? stripeCusAfter.address : null;
+
+		console.log(
+			`[scenario-A] post-checkout: subs=${subs.data.length} ` +
+				`subAutoTax=${subs.data[0]?.automatic_tax.enabled ?? "N/A"} ` +
+				`customerAddress=${JSON.stringify(addressAfter)}`,
+		);
+
+		// If the Playwright form-fill happened to succeed and a sub got
+		// created, verify the chain held end-to-end. Otherwise we don't
+		// fail the test — session-level contract was already asserted.
+		if (subs.data.length > 0) {
+			expect(subs.data[0].automatic_tax.enabled).toBe(true);
+			expect(addressAfter).not.toBeNull();
+			expect(addressAfter?.country).toBe("AU");
+		}
+	}, 600_000);
+
+test.concurrent(`${chalk.yellowBright(
+	"automatic-tax-no-address (Scenario B — pre-flip Checkout, then charge_automatically upgrade): waterfall resolves location, upgrade succeeds WITH tax",
+)}`, async () => {
+	const customerId = "tax-no-addr-existing";
+	const proProd = products.pro({ id: "pro", items: [] });
+	const premiumProd = products.premium({ id: "premium", items: [] });
+
+	// Sub-org starts WITH auto_tax OFF. Customer is fresh (no PM, no
+	// address) which forces the attach-returns-checkout-URL branch.
+	const { ctx, customer, autumnV1, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.platform.create({
+				// No configOverrides -> automatic_tax starts off.
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({ testClock: false }),
+			s.products({ list: [proProd, premiumProd] }),
+		],
+		actions: [],
+	});
+
+	const stripeCusId = customer!.processor!.id!;
+
+	// Sanity: address is null on the Stripe customer pre-checkout.
+	const stripeCusBefore = await ctx.stripeCli.customers.retrieve(stripeCusId);
+	const addressBefore =
+		"address" in stripeCusBefore ? stripeCusBefore.address : null;
+	expect(addressBefore).toBeNull();
+
+	// Step 1: buy Pro via Stripe Checkout BEFORE the org enables
+	// automatic_tax. Drive the Playwright helper with a real AU
+	// billing address. This seeds:
+	//   - the Stripe customer's `address` field
+	//   - Stripe's internal waterfall (IP / predicted location)
+	// so that any subsequent charge_automatically mutation has a
+	// jurisdiction available even without an explicit `automatic_tax`
+	// param on Checkout itself (the org flag is OFF here).
+	const proResult = (await autumnV1.attach({
+		customer_id: customerId,
+		product_id: `pro_${customerId}`,
+	})) as { checkout_url?: string };
+	expect(proResult.checkout_url).toBeDefined();
+
+	await completeStripeCheckoutFormV2({
+		url: proResult.checkout_url!,
+		billingAddress: {
+			country: "AU",
+			line1: "1 Test St",
+			city: "Sydney",
+			state: "NSW",
+			postal_code: "2000",
+		},
+	});
+
+	// Give Stripe webhook + back-write a moment to land the sub.
+	await new Promise((r) => setTimeout(r, 5000));
+
+	const proSubs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(proSubs.data.length).toBeGreaterThan(0);
+
+	// Step 2: flip the org config to enable automatic_tax. This DB write
+	// also invalidates the secret-key cache via OrgService.update's
+	// internal clearOrgCache call, so the next API request re-reads the
+	// fresh config.
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...ctx.org.config, automatic_tax: true },
+		},
+	});
+	// Small delay to let multi-region Redis invalidation settle.
+	await new Promise((r) => setTimeout(r, 500));
+
+	// Step 3: upgrade Pro -> Premium via charge_automatically
+	// `billing.attach` (the V2_2 path). Stripe's waterfall has the
+	// AU address from Checkout, so auto_tax MUST land cleanly with
+	// tax computed.
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: `premium_${customerId}`,
+	});
+
+	// STRONG ASSERTIONS: upgrade succeeded (no throw), resulting sub
+	// has auto_tax enabled, and the proration invoice has tax fully
+	// resolved (`status: "complete"`).
+	const upgradedSubs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(upgradedSubs.data.length).toBeGreaterThan(0);
+	const upgradedSub = upgradedSubs.data[0];
+	expect(upgradedSub.automatic_tax.enabled).toBe(true);
+
+	const invoices = await ctx.stripeCli.invoices.list({
+		customer: stripeCusId,
+		limit: 5,
+	});
+	// The most recent invoice should be the proration invoice from
+	// the upgrade.
+	const prorationInvoice = invoices.data[0];
+	expect(prorationInvoice).toBeDefined();
+	expect(prorationInvoice.automatic_tax.enabled).toBe(true);
+	expect(prorationInvoice.automatic_tax.status).toBe("complete");
+
+	console.log(
+		`[scenario-B] upgrade succeeded with tax: ` +
+			`sub_auto_tax=${upgradedSub.automatic_tax.enabled}, ` +
+			`proration_invoice_auto_tax_status=${prorationInvoice.automatic_tax.status}, ` +
+			`proration_invoice_total_tax=${prorationInvoice.total_taxes?.[0]?.amount ?? "N/A"}`,
+	);
+}, 600_000);
+
+test.concurrent
+	.skip(`${chalk.yellowBright(
+		"automatic-tax-no-address (Scenario C — INVOICE-MODE upgrade, no address): post-fix MUST succeed without tax",
+	)}`, async () => {
+		const customerId = "tax-no-addr-invoice-mode";
+		const proProd = products.pro({ id: "pro", items: [] });
+		const premiumProd = products.premium({ id: "premium", items: [] });
+
+		// Sub-org starts WITH auto_tax OFF so the initial Pro attach
+		// succeeds (auto_tax + no address would fail at create time even
+		// for a fresh customer). Customer has PM but no address.
+		const { ctx, customer, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					// No configOverrides -> automatic_tax starts off.
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					// NO stripeCustomerOverrides — Stripe customer has no address.
+				}),
+				s.products({ list: [proProd, premiumProd] }),
+			],
+			actions: [s.billing.attach({ productId: "pro" })],
+		});
+
+		const stripeCusId = customer!.processor!.id!;
+
+		// Sanity: customer has no address; initial Pro sub has no auto_tax.
+		const stripeCusBefore = await ctx.stripeCli.customers.retrieve(stripeCusId);
+		const addressBefore =
+			"address" in stripeCusBefore ? stripeCusBefore.address : null;
+		expect(addressBefore).toBeNull();
+
+		const initialSubs = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
+		console.log(
+			"[scenario-C] pre-flip: customer address=null, initial sub auto_tax=false",
+		);
+
+		// Flip the org config to enable automatic_tax.
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				config: { ...ctx.org.config, automatic_tax: true },
+			},
+		});
+
+		// Trigger an upgrade Pro -> Premium via INVOICE-MODE billing.attach.
+		// This is the prod-failure case the user hit on Mintlify.
+		//
+		// PRE-FIX BEHAVIOR: Stripe rejected the sub.update with
+		//   "The customer's location isn't recognized. Set a valid
+		//    customer address in order to automatically calculate tax."
+		// because invoice-mode invoices (collection_method: send_invoice)
+		// have no hosted address-collection UI.
+		//
+		// POST-FIX BEHAVIOR (this test): we skip `automatic_tax` entirely
+		// for invoice-mode mutations in
+		//   - executeStripeSubscriptionOperation (sub.create + sub.update)
+		//   - buildStripeSubscriptionUpdateAction (sub.update params)
+		//   - createInvoiceForBilling (invoice.create)
+		//   - createStripeSub2 (legacy v1 sub.create)
+		//   - handleOneOffFunction (legacy v1 invoice.create)
+		// So the upgrade succeeds — the resulting sub/invoice just won't
+		// have tax computed (which is the design choice we landed on:
+		// Stripe Tax simply can't compute tax without an address, and
+		// invoice mode has no way to collect one).
+		// V2_2 schema uses `invoice_mode: { enabled: true }`. The legacy
+		// `invoice: true` alias is V0/V1_Beta only and isn't on the V2_2
+		// AttachParamsV1Schema — passing it would silently no-op the
+		// invoice-mode discriminator (`billingContext.invoiceMode` would
+		// stay falsy) and then `automatic_tax: { enabled: true }` would
+		// leak through to a `charge_automatically` Stripe call, hitting
+		// the "customer's location isn't recognized" error we're trying
+		// to avoid. This is exactly what failed before.
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: `premium_${customerId}`,
+			invoice_mode: { enabled: true },
+		});
+
+		// STRONG ASSERTIONS: upgrade succeeded (no exception above) and
+		// the resulting sub has auto_tax disabled.
+		//
+		// Note: the SUB itself stays in its original collection_method
+		// (charge_automatically) because the upgrade only flips invoice
+		// mode for the PRORATION INVOICE, not the existing sub. We assert
+		// the invoice-level discriminator below.
+		const updatedSubs = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		const upgradedSub = updatedSubs.data[0];
+		expect(upgradedSub).toBeDefined();
+		expect(upgradedSub.automatic_tax.enabled).toBe(false);
+		console.log(
+			`[scenario-C] upgrade succeeded: sub_id=${upgradedSub.id} ` +
+				`collection_method=${upgradedSub.collection_method} ` +
+				`sub_auto_tax=${upgradedSub.automatic_tax.enabled}`,
+		);
+
+		// At least one of the resulting invoices is in send_invoice mode
+		// (the proration invoice for the upgrade), and every send_invoice
+		// invoice has auto_tax disabled — this is the prod-failure-fix
+		// proper discriminator.
+		const invoices = await ctx.stripeCli.invoices.list({
+			customer: stripeCusId,
+			limit: 10,
+		});
+		const sendInvoiceInvoices = invoices.data.filter(
+			(inv) => inv.collection_method === "send_invoice",
+		);
+		expect(sendInvoiceInvoices.length).toBeGreaterThan(0);
+		for (const inv of sendInvoiceInvoices) {
+			expect(inv.automatic_tax.enabled).toBe(false);
+		}
+		console.log(
+			`[scenario-C] send_invoice invoices: ${sendInvoiceInvoices.length} ` +
+				`found (out of ${invoices.data.length} total), all with auto_tax=false`,
+		);
+	}, 300_000);

--- a/server/tests/integration/billing/tax/automatic-tax-proration.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-proration.test.ts
@@ -1,28 +1,11 @@
 /**
- * TDD test for `automatic_tax` on proration invoices for mid-cycle plan
- * changes (Cycle 5.5). Mirrors the Mintlify customer scenario:
- *  - Customer mid-cycle, upgrades or downgrades.
- *  - Stripe prorates with TWO line items: a negative credit refunding
- *    unused old-plan time, a positive charge for new-plan remaining time.
- *  - BOTH lines must be taxed for the math to be correct.
+ * `automatic_tax` on proration invoices (mid-cycle plan changes).
+ * Stripe prorates with negative credit + positive charge lines; both must
+ * be taxed for totals to balance.
  *
- * Exercises BOTH attach paths concurrently:
- *  - v1 legacy /v1/attach upgrade Pro -> Premium (downgrade omitted: the
- *    legacy attach path auto-schedules downgrades to end-of-cycle by default,
- *    so there is no immediate proration invoice to assert tax on; the v2
- *    path with `plan_schedule: "immediate"` is the right surface for that)
- *  - v2 /v1/billing.attach upgrade Pro -> Premium
- *  - v2 /v1/billing.attach downgrade Premium -> Pro (immediate)
- *
- * Red-failure mode (current behavior, pre-fix):
- *  - Proration invoice has automatic_tax.enabled === false.
- *  - Lines have no taxes; total === subtotal.
- *
- * Green-success criteria (after fix):
- *  - Proration invoice has automatic_tax.enabled === true.
- *  - Every line item has at least one tax entry.
- *  - Credit line tax is itself negative (refunded GST).
- *  - Total = subtotal × 1.10 within ±1 cent rounding.
+ * Covers v1 upgrade, v2 upgrade, and v2 immediate downgrade. (v1 downgrade
+ * omitted: legacy attach auto-schedules to end-of-cycle, so no immediate
+ * proration invoice to assert.)
  */
 
 import { expect, test } from "bun:test";

--- a/server/tests/integration/billing/tax/automatic-tax-proration.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-proration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * TDD test for `automatic_tax` on proration invoices for mid-cycle plan
+ * changes (Cycle 5.5). Mirrors the Mintlify customer scenario:
+ *  - Customer mid-cycle, upgrades or downgrades.
+ *  - Stripe prorates with TWO line items: a negative credit refunding
+ *    unused old-plan time, a positive charge for new-plan remaining time.
+ *  - BOTH lines must be taxed for the math to be correct.
+ *
+ * Exercises BOTH attach paths concurrently:
+ *  - v1 legacy /v1/attach upgrade Pro -> Premium (downgrade omitted: the
+ *    legacy attach path auto-schedules downgrades to end-of-cycle by default,
+ *    so there is no immediate proration invoice to assert tax on; the v2
+ *    path with `plan_schedule: "immediate"` is the right surface for that)
+ *  - v2 /v1/billing.attach upgrade Pro -> Premium
+ *  - v2 /v1/billing.attach downgrade Premium -> Pro (immediate)
+ *
+ * Red-failure mode (current behavior, pre-fix):
+ *  - Proration invoice has automatic_tax.enabled === false.
+ *  - Lines have no taxes; total === subtotal.
+ *
+ * Green-success criteria (after fix):
+ *  - Proration invoice has automatic_tax.enabled === true.
+ *  - Every line item has at least one tax entry.
+ *  - Credit line tax is itself negative (refunded GST).
+ *  - Total = subtotal × 1.10 within ±1 cent rounding.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { products } from "@tests/utils/fixtures/products.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+const auAddress = {
+	country: "AU",
+	line1: "1 Test St",
+	city: "Sydney",
+	postal_code: "2000",
+	state: "NSW",
+};
+
+async function assertProrationTaxed({
+	ctx,
+	stripeCusId,
+	expectSubtotalSign,
+}: {
+	ctx: TestContext;
+	stripeCusId: string;
+	expectSubtotalSign: "positive" | "negative";
+}) {
+	const invoices = await ctx.stripeCli.invoices.list({
+		customer: stripeCusId,
+		limit: 5,
+	});
+	const prorationInvoice = invoices.data[0];
+
+	expect(prorationInvoice.automatic_tax.enabled).toBe(true);
+
+	const lines = prorationInvoice.lines.data;
+	const negativeLines = lines.filter((l: Stripe.InvoiceLineItem) => l.amount < 0);
+	const positiveLines = lines.filter((l: Stripe.InvoiceLineItem) => l.amount > 0);
+	expect(negativeLines.length).toBeGreaterThan(0);
+	expect(positiveLines.length).toBeGreaterThan(0);
+
+	for (const line of lines) {
+		expect(line.taxes).not.toBeNull();
+		expect(line.taxes!.length).toBeGreaterThan(0);
+	}
+
+	if (expectSubtotalSign === "negative") {
+		expect(prorationInvoice.subtotal).toBeLessThan(0);
+	}
+
+	const expectedTotal = Math.round(prorationInvoice.subtotal * 1.1);
+	expect(prorationInvoice.total).toBeGreaterThanOrEqual(expectedTotal - 1);
+	expect(prorationInvoice.total).toBeLessThanOrEqual(expectedTotal + 1);
+}
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-proration (v1 legacy /v1/attach upgrade): Pro->Premium taxes BOTH credit and charge lines")}`,
+	async () => {
+		const customerId = "tax-prorate-v1-upgrade";
+		const proProd = products.pro({ id: "pro", items: [] });
+		const premiumProd = products.premium({ id: "premium", items: [] });
+
+		const { ctx, customer, autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: true,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd, premiumProd] }),
+			],
+			actions: [
+				s.attach({ productId: "pro" }),
+				s.advanceTestClock({ days: 15 }),
+			],
+		});
+
+		await autumnV1.attach({
+			customer_id: customerId,
+			product_id: `premium_${customerId}`,
+		});
+
+		await assertProrationTaxed({
+			ctx,
+			stripeCusId: customer!.processor!.id!,
+			expectSubtotalSign: "positive",
+		});
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-proration (v2 /v1/billing.attach upgrade): Pro->Premium taxes BOTH credit and charge lines")}`,
+	async () => {
+		const customerId = "tax-prorate-v2-upgrade";
+		const proProd = products.pro({ id: "pro", items: [] });
+		const premiumProd = products.premium({ id: "premium", items: [] });
+
+		const { ctx, customer, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: true,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd, premiumProd] }),
+			],
+			actions: [
+				s.billing.attach({ productId: "pro" }),
+				s.advanceTestClock({ days: 15 }),
+			],
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: `premium_${customerId}`,
+		});
+
+		await assertProrationTaxed({
+			ctx,
+			stripeCusId: customer!.processor!.id!,
+			expectSubtotalSign: "positive",
+		});
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-proration (v2 /v1/billing.attach downgrade): Premium->Pro taxes BOTH credit and charge lines (subtotal < 0)")}`,
+	async () => {
+		const customerId = "tax-prorate-v2-downgrade";
+		const proProd = products.pro({ id: "pro", items: [] });
+		const premiumProd = products.premium({ id: "premium", items: [] });
+
+		const { ctx, customer, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: true,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd, premiumProd] }),
+			],
+			actions: [
+				s.billing.attach({ productId: "premium" }),
+				s.advanceTestClock({ days: 15 }),
+			],
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: `pro_${customerId}`,
+			plan_schedule: "immediate",
+		});
+
+		await assertProrationTaxed({
+			ctx,
+			stripeCusId: customer!.processor!.id!,
+			expectSubtotalSign: "negative",
+		});
+	},
+	300_000,
+);

--- a/server/tests/integration/billing/tax/automatic-tax-spray-jurisdictions.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-spray-jurisdictions.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Spray test exercising `automatic_tax: true` across a representative spread
+ * of tax jurisdictions, all sharing ONE platform sub-org. The sub-org
+ * registers Stripe Tax in every covered country at once, then provisions a
+ * customer per jurisdiction (each with an address in that country) and
+ * attaches the same recurring product.
+ *
+ * Why one sub-org instead of N: real platform tenants register multiple
+ * jurisdictions on a single Stripe Connect account. This test verifies the
+ * factory's `taxRegistrations: [...]` array correctly handles multi-country
+ * setup AND that Stripe Tax routes the right rate to each customer based
+ * on customer address + merchant nexus.
+ *
+ * Jurisdictions covered:
+ *  - United Kingdom (GB) — 20% VAT
+ *  - Canada (CA) — federal GST/HST simplified, ~5%
+ *  - California / United States (US) — ~7-9% state sales tax (note: SaaS
+ *    is generally NOT taxable in CA, so tax may legitimately compute as $0)
+ *  - Australia (AU) — 10% GST
+ *  - France (FR) — 20% VAT (EU standard)
+ *  - Germany (DE) — 19% VAT (EU standard)
+ *  - Saudi Arabia (SA) — 15% VAT (simplified)
+ *  - Russia (RU) — 20% VAT (simplified)
+ *
+ * What this test asserts:
+ *  - Every jurisdiction's Stripe Tax registration succeeds in the factory
+ *    (no SDK shape mismatch, no rejected `country_options`).
+ *  - The resulting Stripe subscription for each per-jurisdiction customer
+ *    has `automatic_tax.enabled === true`.
+ *  - The factory's head-office-address bootstrap supports all 8 in one go.
+ *
+ * What this test does NOT assert:
+ *  - Specific tax rates per country. Stripe Tax rate depends on customer
+ *    address + product tax_code + merchant nexus; rate can legitimately be
+ *    $0 in some jurisdictions for SaaS (CA most notably), so a strict
+ *    `tax > 0` would be false-positive prone.
+ *  - That Stripe Tax has accurate registrations for every test-mode
+ *    jurisdiction. If a registration genuinely fails (Stripe doesn't
+ *    support it in test mode, sanctions, etc.), the factory swallows the
+ *    error with a warning — eyeball the run logs for any "Failed to
+ *    register Stripe Tax" warnings.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+
+type Jurisdiction = {
+	label: string;
+	country: "GB" | "CA" | "US" | "AU" | "FR" | "DE" | "SA" | "RU";
+	address: Stripe.AddressParam;
+};
+
+const jurisdictions: Jurisdiction[] = [
+	{
+		label: "UK VAT",
+		country: "GB",
+		address: {
+			country: "GB",
+			line1: "10 Downing Street",
+			city: "London",
+			postal_code: "SW1A 2AA",
+		},
+	},
+	{
+		label: "Canada GST/HST",
+		country: "CA",
+		address: {
+			country: "CA",
+			line1: "1 Yonge Street",
+			city: "Toronto",
+			postal_code: "M5E 1W7",
+			state: "ON",
+		},
+	},
+	{
+		label: "California / US sales tax",
+		country: "US",
+		address: {
+			country: "US",
+			line1: "1 Market Street",
+			city: "San Francisco",
+			postal_code: "94105",
+			state: "CA",
+		},
+	},
+	{
+		label: "Australia GST",
+		country: "AU",
+		address: {
+			country: "AU",
+			line1: "1 Test St",
+			city: "Sydney",
+			postal_code: "2000",
+			state: "NSW",
+		},
+	},
+	{
+		label: "France VAT",
+		country: "FR",
+		address: {
+			country: "FR",
+			line1: "1 Avenue des Champs-Elysees",
+			city: "Paris",
+			postal_code: "75008",
+		},
+	},
+	{
+		label: "Germany VAT",
+		country: "DE",
+		address: {
+			country: "DE",
+			line1: "1 Brandenburger Tor",
+			city: "Berlin",
+			postal_code: "10117",
+		},
+	},
+	{
+		label: "Saudi Arabia VAT",
+		country: "SA",
+		address: {
+			country: "SA",
+			line1: "1 Al Olaya Street",
+			city: "Riyadh",
+			postal_code: "11564",
+		},
+	},
+	{
+		label: "Russia VAT",
+		country: "RU",
+		address: {
+			country: "RU",
+			line1: "1 Tverskaya Street",
+			city: "Moscow",
+			postal_code: "125009",
+		},
+	},
+];
+
+test(
+	`${chalk.yellowBright("automatic-tax-spray: ONE sub-org with 8 tax registrations, customer per jurisdiction, every sub has automatic_tax.enabled=true")}`,
+	async () => {
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		// ONE sub-org. Registers Stripe Tax for all 8 countries up front.
+		// No primary `s.customer(...)` — we'll provision per-jurisdiction
+		// customers manually inside the test body to keep them in lock-step
+		// against the same Connect account.
+		const { ctx, autumnV1 } = await initScenario({
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: jurisdictions.map((j) => j.country),
+				}),
+				s.products({ list: [proProd], prefix: "spray" }),
+			],
+			actions: [],
+		});
+
+		// Provision a customer per jurisdiction in parallel, then attach the
+		// pro product, then fetch the resulting Stripe subscription. Returns
+		// a tuple of (jurisdiction, sub) per concurrent unit.
+		const results = await Promise.all(
+			jurisdictions.map(async (j) => {
+				const customerId = `tax-spray-${j.country.toLowerCase()}`;
+
+				// initCustomerV3 creates the Stripe customer with the address
+				// override, attaches a successful payment method, and registers
+				// the Autumn customer linked to that Stripe customer.
+				const { customer } = await initCustomerV3({
+					ctx,
+					customerId,
+					attachPm: "success",
+					withTestClock: false,
+					withDefault: false,
+					stripeCustomerOverrides: { address: j.address },
+				});
+
+				// Attach the pro product via the legacy /v1/attach path.
+				await autumnV1.attach({
+					customer_id: customerId,
+					product_id: "pro_spray",
+				});
+
+				const stripeCusId = customer!.processor!.id!;
+				const subs = await ctx.stripeCli.subscriptions.list({
+					customer: stripeCusId,
+					limit: 1,
+				});
+
+				return { jurisdiction: j, sub: subs.data[0] };
+			}),
+		);
+
+		// Assert every jurisdiction's resulting subscription has
+		// automatic_tax.enabled === true. Log the actual computed tax for
+		// visibility (rates differ by country and SaaS is sometimes $0).
+		for (const { jurisdiction, sub } of results) {
+			expect(sub).toBeDefined();
+			expect(sub.automatic_tax.enabled).toBe(true);
+
+			const latestInvoiceId =
+				typeof sub.latest_invoice === "string"
+					? sub.latest_invoice
+					: sub.latest_invoice?.id;
+			if (latestInvoiceId) {
+				const invoice = await ctx.stripeCli.invoices.retrieve(latestInvoiceId);
+				const taxAmount = invoice.total - invoice.subtotal;
+				console.log(
+					`[spray ${jurisdiction.country} ${jurisdiction.label}] subtotal=${invoice.subtotal} total=${invoice.total} tax=${taxAmount}`,
+				);
+			}
+		}
+	},
+	600_000,
+);

--- a/server/tests/integration/billing/tax/automatic-tax-spray-jurisdictions.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-spray-jurisdictions.test.ts
@@ -1,44 +1,14 @@
 /**
- * Spray test exercising `automatic_tax: true` across a representative spread
- * of tax jurisdictions, all sharing ONE platform sub-org. The sub-org
- * registers Stripe Tax in every covered country at once, then provisions a
- * customer per jurisdiction (each with an address in that country) and
- * attaches the same recurring product.
+ * Spray test: `automatic_tax: true` across 8 jurisdictions on ONE sub-org.
+ * Verifies that the factory's `taxRegistrations: [...]` array correctly
+ * handles multi-country registration and that every per-jurisdiction
+ * customer's resulting sub has auto_tax enabled.
  *
- * Why one sub-org instead of N: real platform tenants register multiple
- * jurisdictions on a single Stripe Connect account. This test verifies the
- * factory's `taxRegistrations: [...]` array correctly handles multi-country
- * setup AND that Stripe Tax routes the right rate to each customer based
- * on customer address + merchant nexus.
+ * Coverage: GB, CA, US/CA, AU, FR, DE, SA, RU.
  *
- * Jurisdictions covered:
- *  - United Kingdom (GB) — 20% VAT
- *  - Canada (CA) — federal GST/HST simplified, ~5%
- *  - California / United States (US) — ~7-9% state sales tax (note: SaaS
- *    is generally NOT taxable in CA, so tax may legitimately compute as $0)
- *  - Australia (AU) — 10% GST
- *  - France (FR) — 20% VAT (EU standard)
- *  - Germany (DE) — 19% VAT (EU standard)
- *  - Saudi Arabia (SA) — 15% VAT (simplified)
- *  - Russia (RU) — 20% VAT (simplified)
- *
- * What this test asserts:
- *  - Every jurisdiction's Stripe Tax registration succeeds in the factory
- *    (no SDK shape mismatch, no rejected `country_options`).
- *  - The resulting Stripe subscription for each per-jurisdiction customer
- *    has `automatic_tax.enabled === true`.
- *  - The factory's head-office-address bootstrap supports all 8 in one go.
- *
- * What this test does NOT assert:
- *  - Specific tax rates per country. Stripe Tax rate depends on customer
- *    address + product tax_code + merchant nexus; rate can legitimately be
- *    $0 in some jurisdictions for SaaS (CA most notably), so a strict
- *    `tax > 0` would be false-positive prone.
- *  - That Stripe Tax has accurate registrations for every test-mode
- *    jurisdiction. If a registration genuinely fails (Stripe doesn't
- *    support it in test mode, sanctions, etc.), the factory swallows the
- *    error with a warning — eyeball the run logs for any "Failed to
- *    register Stripe Tax" warnings.
+ * Does NOT assert specific tax rates — SaaS is sometimes $0 (e.g. CA), so
+ * `tax > 0` would be false-positive prone. Watch run logs for any
+ * "Failed to register Stripe Tax" warnings (factory swallows them).
  */
 
 import { expect, test } from "bun:test";
@@ -145,10 +115,9 @@ test(
 	async () => {
 		const proProd = products.pro({ id: "pro", items: [] });
 
-		// ONE sub-org. Registers Stripe Tax for all 8 countries up front.
-		// No primary `s.customer(...)` — we'll provision per-jurisdiction
-		// customers manually inside the test body to keep them in lock-step
-		// against the same Connect account.
+		// ONE sub-org with all 8 tax registrations. No primary customer —
+		// we provision per-jurisdiction customers in the test body so they
+		// share the same Connect account.
 		const { ctx, autumnV1 } = await initScenario({
 			setup: [
 				s.platform.create({
@@ -160,16 +129,11 @@ test(
 			actions: [],
 		});
 
-		// Provision a customer per jurisdiction in parallel, then attach the
-		// pro product, then fetch the resulting Stripe subscription. Returns
-		// a tuple of (jurisdiction, sub) per concurrent unit.
+		// Per-jurisdiction customer + attach + fetch sub, in parallel.
 		const results = await Promise.all(
 			jurisdictions.map(async (j) => {
 				const customerId = `tax-spray-${j.country.toLowerCase()}`;
 
-				// initCustomerV3 creates the Stripe customer with the address
-				// override, attaches a successful payment method, and registers
-				// the Autumn customer linked to that Stripe customer.
 				const { customer } = await initCustomerV3({
 					ctx,
 					customerId,
@@ -179,7 +143,6 @@ test(
 					stripeCustomerOverrides: { address: j.address },
 				});
 
-				// Attach the pro product via the legacy /v1/attach path.
 				await autumnV1.attach({
 					customer_id: customerId,
 					product_id: "pro_spray",
@@ -195,9 +158,8 @@ test(
 			}),
 		);
 
-		// Assert every jurisdiction's resulting subscription has
-		// automatic_tax.enabled === true. Log the actual computed tax for
-		// visibility (rates differ by country and SaaS is sometimes $0).
+		// Every jurisdiction's sub has auto_tax enabled. Log computed tax
+		// for visibility (SaaS is sometimes $0).
 		for (const { jurisdiction, sub } of results) {
 			expect(sub).toBeDefined();
 			expect(sub.automatic_tax.enabled).toBe(true);

--- a/server/tests/integration/billing/tax/automatic-tax-subscription-update.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-subscription-update.test.ts
@@ -1,0 +1,148 @@
+/**
+ * TDD test for `automatic_tax` propagation via subscriptions.update on the
+ * mid-life config flip scenario (Cycle 5).
+ *
+ * Real Mintlify scenario:
+ *  - Sub was originally created BEFORE Mintlify enabled `automatic_tax: true`
+ *    on their org config.
+ *  - Mintlify flips the config flag.
+ *  - Subsequent updates to the subscription must propagate
+ *    `automatic_tax: { enabled: true }` so the existing sub starts taxing.
+ *
+ * Exercises BOTH attach paths concurrently:
+ *  - v1 legacy `/v1/attach` for both initial attach and upgrade
+ *  - v2 `/v1/billing.attach` for both initial attach and upgrade
+ *
+ * Red-failure mode (current behavior, pre-fix):
+ *  - Both paths' `subscriptions.update` calls omit `automatic_tax: { enabled: true }`.
+ *  - Result: even after flipping `org.config.automatic_tax = true`, an
+ *    upgrade goes through and the resulting subscription still has
+ *    `automatic_tax.enabled === false`.
+ *
+ * Green-success criteria (after fix):
+ *  - Both paths' `subscriptions.update` calls pass automatic_tax when
+ *    `org.config.automatic_tax` is true.
+ *  - After the upgrade, the resulting Stripe subscription has
+ *    `automatic_tax.enabled === true`.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import { products } from "@tests/utils/fixtures/products.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+const auAddress = {
+	country: "AU",
+	line1: "1 Test St",
+	city: "Sydney",
+	postal_code: "2000",
+	state: "NSW",
+};
+
+async function flipConfigOn(ctx: TestContext) {
+	const existingConfig = ctx.org.config;
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...existingConfig, automatic_tax: true },
+		},
+	});
+}
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-subscription-update (v1 legacy /v1/attach): mid-life flip propagates auto_tax on upgrade")}`,
+	async () => {
+		const customerId = "tax-mid-life-flip-v1";
+		const proProd = products.pro({ id: "pro", items: [] });
+		const premiumProd = products.premium({ id: "premium", items: [] });
+
+		const { ctx, customer, autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					// No configOverrides — automatic_tax starts at default (false).
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd, premiumProd] }),
+			],
+			actions: [s.attach({ productId: "pro" })],
+		});
+
+		const stripeCusId = customer!.processor!.id!;
+		const initialSubs = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
+
+		await flipConfigOn(ctx);
+
+		// Upgrade via legacy /v1/attach.
+		await autumnV1.attach({
+			customer_id: customerId,
+			product_id: `premium_${customerId}`,
+		});
+
+		const updatedSubs = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		expect(updatedSubs.data[0].automatic_tax.enabled).toBe(true);
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-subscription-update (v2 /v1/billing.attach): mid-life flip propagates auto_tax on upgrade")}`,
+	async () => {
+		const customerId = "tax-mid-life-flip-v2";
+		const proProd = products.pro({ id: "pro", items: [] });
+		const premiumProd = products.premium({ id: "premium", items: [] });
+
+		const { ctx, customer, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd, premiumProd] }),
+			],
+			actions: [s.billing.attach({ productId: "pro" })],
+		});
+
+		const stripeCusId = customer!.processor!.id!;
+		const initialSubs = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
+
+		await flipConfigOn(ctx);
+
+		// Upgrade via /v1/billing.attach (V2_2 client uses plan_id schema).
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: `premium_${customerId}`,
+		});
+
+		const updatedSubs = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCusId,
+			limit: 1,
+		});
+		expect(updatedSubs.data[0].automatic_tax.enabled).toBe(true);
+	},
+	300_000,
+);

--- a/server/tests/integration/billing/tax/automatic-tax-subscription-update.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-subscription-update.test.ts
@@ -1,37 +1,15 @@
 /**
- * TDD test for `automatic_tax` propagation via subscriptions.update on the
- * mid-life config flip scenario (Cycle 5).
- *
- * Real Mintlify scenario:
- *  - Sub was originally created BEFORE Mintlify enabled `automatic_tax: true`
- *    on their org config.
- *  - Mintlify flips the config flag.
- *  - Subsequent updates to the subscription must propagate
- *    `automatic_tax: { enabled: true }` so the existing sub starts taxing.
- *
- * Exercises BOTH attach paths concurrently:
- *  - v1 legacy `/v1/attach` for both initial attach and upgrade
- *  - v2 `/v1/billing.attach` for both initial attach and upgrade
- *
- * Red-failure mode (current behavior, pre-fix):
- *  - Both paths' `subscriptions.update` calls omit `automatic_tax: { enabled: true }`.
- *  - Result: even after flipping `org.config.automatic_tax = true`, an
- *    upgrade goes through and the resulting subscription still has
- *    `automatic_tax.enabled === false`.
- *
- * Green-success criteria (after fix):
- *  - Both paths' `subscriptions.update` calls pass automatic_tax when
- *    `org.config.automatic_tax` is true.
- *  - After the upgrade, the resulting Stripe subscription has
- *    `automatic_tax.enabled === true`.
+ * Mid-life flip: a sub created before `automatic_tax` was enabled must
+ * pick up auto_tax on its next sub.update after the flag flips. Covers
+ * both v1 `/v1/attach` and v2 `/v1/billing.attach`.
  */
 
 import { expect, test } from "bun:test";
-import chalk from "chalk";
 import { products } from "@tests/utils/fixtures/products.js";
-import { OrgService } from "@/internal/orgs/OrgService.js";
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 
 const auAddress = {
 	country: "AU",
@@ -52,97 +30,87 @@ async function flipConfigOn(ctx: TestContext) {
 	});
 }
 
-test.concurrent(
-	`${chalk.yellowBright("automatic-tax-subscription-update (v1 legacy /v1/attach): mid-life flip propagates auto_tax on upgrade")}`,
-	async () => {
-		const customerId = "tax-mid-life-flip-v1";
-		const proProd = products.pro({ id: "pro", items: [] });
-		const premiumProd = products.premium({ id: "premium", items: [] });
+test.concurrent(`${chalk.yellowBright("automatic-tax-subscription-update (v1 legacy /v1/attach): mid-life flip propagates auto_tax on upgrade")}`, async () => {
+	const customerId = "tax-mid-life-flip-v1";
+	const proProd = products.pro({ id: "pro", items: [] });
+	const premiumProd = products.premium({ id: "premium", items: [] });
 
-		const { ctx, customer, autumnV1 } = await initScenario({
-			customerId,
-			setup: [
-				s.platform.create({
-					// No configOverrides — automatic_tax starts at default (false).
-					taxRegistrations: ["AU"],
-				}),
-				s.customer({
-					testClock: false,
-					paymentMethod: "success",
-					stripeCustomerOverrides: { address: auAddress },
-				}),
-				s.products({ list: [proProd, premiumProd] }),
-			],
-			actions: [s.attach({ productId: "pro" })],
-		});
+	const { ctx, customer, autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.platform.create({
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+				stripeCustomerOverrides: { address: auAddress },
+			}),
+			s.products({ list: [proProd, premiumProd] }),
+		],
+		actions: [s.attach({ productId: "pro" })],
+	});
 
-		const stripeCusId = customer!.processor!.id!;
-		const initialSubs = await ctx.stripeCli.subscriptions.list({
-			customer: stripeCusId,
-			limit: 1,
-		});
-		expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
+	const stripeCusId = customer!.processor!.id!;
+	const initialSubs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
 
-		await flipConfigOn(ctx);
+	await flipConfigOn(ctx);
 
-		// Upgrade via legacy /v1/attach.
-		await autumnV1.attach({
-			customer_id: customerId,
-			product_id: `premium_${customerId}`,
-		});
+	await autumnV1.attach({
+		customer_id: customerId,
+		product_id: `premium_${customerId}`,
+	});
 
-		const updatedSubs = await ctx.stripeCli.subscriptions.list({
-			customer: stripeCusId,
-			limit: 1,
-		});
-		expect(updatedSubs.data[0].automatic_tax.enabled).toBe(true);
-	},
-	300_000,
-);
+	const updatedSubs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(updatedSubs.data[0].automatic_tax.enabled).toBe(true);
+}, 300_000);
 
-test.concurrent(
-	`${chalk.yellowBright("automatic-tax-subscription-update (v2 /v1/billing.attach): mid-life flip propagates auto_tax on upgrade")}`,
-	async () => {
-		const customerId = "tax-mid-life-flip-v2";
-		const proProd = products.pro({ id: "pro", items: [] });
-		const premiumProd = products.premium({ id: "premium", items: [] });
+test.concurrent(`${chalk.yellowBright("automatic-tax-subscription-update (v2 /v1/billing.attach): mid-life flip propagates auto_tax on upgrade")}`, async () => {
+	const customerId = "tax-mid-life-flip-v2";
+	const proProd = products.pro({ id: "pro", items: [] });
+	const premiumProd = products.premium({ id: "premium", items: [] });
 
-		const { ctx, customer, autumnV2_2 } = await initScenario({
-			customerId,
-			setup: [
-				s.platform.create({
-					taxRegistrations: ["AU"],
-				}),
-				s.customer({
-					testClock: false,
-					paymentMethod: "success",
-					stripeCustomerOverrides: { address: auAddress },
-				}),
-				s.products({ list: [proProd, premiumProd] }),
-			],
-			actions: [s.billing.attach({ productId: "pro" })],
-		});
+	const { ctx, customer, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.platform.create({
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+				stripeCustomerOverrides: { address: auAddress },
+			}),
+			s.products({ list: [proProd, premiumProd] }),
+		],
+		actions: [s.billing.attach({ productId: "pro" })],
+	});
 
-		const stripeCusId = customer!.processor!.id!;
-		const initialSubs = await ctx.stripeCli.subscriptions.list({
-			customer: stripeCusId,
-			limit: 1,
-		});
-		expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
+	const stripeCusId = customer!.processor!.id!;
+	const initialSubs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(initialSubs.data[0].automatic_tax.enabled).toBe(false);
 
-		await flipConfigOn(ctx);
+	await flipConfigOn(ctx);
 
-		// Upgrade via /v1/billing.attach (V2_2 client uses plan_id schema).
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: `premium_${customerId}`,
-		});
+	// V2_2 uses `plan_id`.
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: `premium_${customerId}`,
+	});
 
-		const updatedSubs = await ctx.stripeCli.subscriptions.list({
-			customer: stripeCusId,
-			limit: 1,
-		});
-		expect(updatedSubs.data[0].automatic_tax.enabled).toBe(true);
-	},
-	300_000,
-);
+	const updatedSubs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(updatedSubs.data[0].automatic_tax.enabled).toBe(true);
+}, 300_000);

--- a/server/tests/integration/billing/tax/automatic-tax-subscription.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-subscription.test.ts
@@ -1,22 +1,6 @@
 /**
- * TDD test for `automatic_tax` on recurring subscriptions (Cycles 3 + 4).
- *
- * Exercises BOTH attach paths concurrently:
- *  - v1 legacy `/v1/attach` via `s.attach(...)` → createStripeSub2
- *  - v2 `/v1/billing.attach` via `s.billing.attach(...)` → executeStripeSubscriptionOperation
- *
- * Red-failure mode (current behavior, pre-fix):
- *  - Both paths' `subscriptions.create` calls omit `automatic_tax: { enabled: true }`.
- *  - Result: subscription.automatic_tax.enabled is false, latest invoice
- *    total stays at the pre-tax base amount.
- *
- * Green-success criteria (after fix):
- *  - Both paths pass `automatic_tax: { enabled: true }` when org config is on.
- *  - Subscription.automatic_tax.enabled === true on both.
- *  - Latest invoice total = base price + 10% AU GST.
- *
- * Pro product is auto-priced at $20/mo by `constructProduct`. Expected total
- * with AU GST: $22.00 = 2200 cents.
+ * `automatic_tax` on recurring subs, both v1 (createStripeSub2) and v2
+ * (executeStripeSubscriptionOperation). Pro is $20/mo + 10% AU GST = $22 (2200 cents).
  */
 
 import { expect, test } from "bun:test";

--- a/server/tests/integration/billing/tax/automatic-tax-subscription.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-subscription.test.ts
@@ -1,0 +1,122 @@
+/**
+ * TDD test for `automatic_tax` on recurring subscriptions (Cycles 3 + 4).
+ *
+ * Exercises BOTH attach paths concurrently:
+ *  - v1 legacy `/v1/attach` via `s.attach(...)` → createStripeSub2
+ *  - v2 `/v1/billing.attach` via `s.billing.attach(...)` → executeStripeSubscriptionOperation
+ *
+ * Red-failure mode (current behavior, pre-fix):
+ *  - Both paths' `subscriptions.create` calls omit `automatic_tax: { enabled: true }`.
+ *  - Result: subscription.automatic_tax.enabled is false, latest invoice
+ *    total stays at the pre-tax base amount.
+ *
+ * Green-success criteria (after fix):
+ *  - Both paths pass `automatic_tax: { enabled: true }` when org config is on.
+ *  - Subscription.automatic_tax.enabled === true on both.
+ *  - Latest invoice total = base price + 10% AU GST.
+ *
+ * Pro product is auto-priced at $20/mo by `constructProduct`. Expected total
+ * with AU GST: $22.00 = 2200 cents.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { products } from "@tests/utils/fixtures/products.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+const auAddress = {
+	country: "AU",
+	line1: "1 Test St",
+	city: "Sydney",
+	postal_code: "2000",
+	state: "NSW",
+};
+
+async function assertSubscriptionTaxed({
+	ctx,
+	stripeCusId,
+}: {
+	ctx: TestContext;
+	stripeCusId: string;
+}) {
+	const subs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCusId,
+		limit: 1,
+	});
+	expect(subs.data.length).toBeGreaterThan(0);
+	const sub = subs.data[0];
+	expect(sub.automatic_tax.enabled).toBe(true);
+
+	const latestInvoiceId =
+		typeof sub.latest_invoice === "string"
+			? sub.latest_invoice
+			: (sub.latest_invoice as Stripe.Invoice).id!;
+	const invoice = await ctx.stripeCli.invoices.retrieve(latestInvoiceId);
+	expect(invoice.total).toBe(2200);
+	expect(invoice.subtotal).toBe(2000);
+	expect(invoice.total - invoice.subtotal).toBe(200);
+}
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-subscription (v1 legacy /v1/attach): pro $20/mo + AU GST = $22 on first invoice")}`,
+	async () => {
+		const customerId = "tax-sub-v1";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [s.attach({ productId: "pro" })],
+		});
+
+		await assertSubscriptionTaxed({
+			ctx,
+			stripeCusId: customer!.processor!.id!,
+		});
+	},
+	240_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-subscription (v2 /v1/billing.attach): pro $20/mo + AU GST = $22 on first invoice")}`,
+	async () => {
+		const customerId = "tax-sub-v2";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [s.billing.attach({ productId: "pro" })],
+		});
+
+		await assertSubscriptionTaxed({
+			ctx,
+			stripeCusId: customer!.processor!.id!,
+		});
+	},
+	240_000,
+);

--- a/server/tests/integration/platform/platform-suborg-smoke.test.ts
+++ b/server/tests/integration/platform/platform-suborg-smoke.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Smoke test for the s.platform.create DSL + createSubOrgTestContext factory.
+ *
+ * NOT a TDD test — verifies that the Phase 0 test infrastructure works:
+ *  - POST /platform/organizations creates a fresh sub-org under the master.
+ *  - The returned ctx points to the sub-org (not master).
+ *  - configOverrides are merged into the sub-org's config jsonb.
+ *  - taxRegistrations land on the sub-org's Stripe Connect account.
+ *
+ * If this test fails, every Phase 1 tax test that uses s.platform.create
+ * will fail too — this guards the harness itself.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+test(
+	`${chalk.yellowBright("platform-suborg-smoke: s.platform.create provisions sub-org with config overrides + AU tax registration")}`,
+	async () => {
+		const { ctx } = await initScenario({
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+			],
+			actions: [],
+		});
+
+		// 1. Sub-org should be a different org from the master test org.
+		expect(ctx.org.id).not.toBe(defaultCtx.org.id);
+
+		// 2. The sub-org's slug should follow the platform router format
+		//    `<userSlug>|<masterOrgId>`.
+		expect(ctx.org.slug).toContain("|");
+		expect(ctx.org.slug.endsWith(`|${defaultCtx.org.id}`)).toBe(true);
+
+		// 3. Config override merged through to the org row.
+		expect(ctx.org.config.automatic_tax).toBe(true);
+
+		// 4. AU tax registration was created on the sub-org's Stripe Connect account.
+		const registrations = await ctx.stripeCli.tax.registrations.list({
+			status: "active",
+		});
+		const auReg = registrations.data.find((r) => r.country === "AU");
+		expect(auReg).toBeDefined();
+
+		// 5. The sub-org's secret key is wired into ctx.orgSecretKey and is a
+		//    test-mode key (not the master's, not a live key).
+		expect(ctx.orgSecretKey).toMatch(/^am_sk_test/);
+		expect(ctx.orgSecretKey).not.toBe(defaultCtx.orgSecretKey);
+	},
+	120_000, // 2min: platform create + connect account creation + tax registration
+);

--- a/server/tests/integration/platform/platform-suborg-smoke.test.ts
+++ b/server/tests/integration/platform/platform-suborg-smoke.test.ts
@@ -1,14 +1,9 @@
 /**
- * Smoke test for the s.platform.create DSL + createSubOrgTestContext factory.
- *
- * NOT a TDD test — verifies that the Phase 0 test infrastructure works:
- *  - POST /platform/organizations creates a fresh sub-org under the master.
- *  - The returned ctx points to the sub-org (not master).
- *  - configOverrides are merged into the sub-org's config jsonb.
- *  - taxRegistrations land on the sub-org's Stripe Connect account.
- *
- * If this test fails, every Phase 1 tax test that uses s.platform.create
- * will fail too — this guards the harness itself.
+ * Smoke test guarding the s.platform.create DSL + createSubOrgTestContext.
+ * Verifies POST /platform/organizations creates a sub-org, the returned ctx
+ * points at it, configOverrides are merged, and taxRegistrations land on the
+ * sub-org's Connect account. If this fails, every tax test using
+ * s.platform.create will too.
  */
 
 import { expect, test } from "bun:test";
@@ -29,28 +24,24 @@ test(
 			actions: [],
 		});
 
-		// 1. Sub-org should be a different org from the master test org.
+		// Sub-org is distinct from master with `<slug>|<masterOrgId>` format.
 		expect(ctx.org.id).not.toBe(defaultCtx.org.id);
-
-		// 2. The sub-org's slug should follow the platform router format
-		//    `<userSlug>|<masterOrgId>`.
 		expect(ctx.org.slug).toContain("|");
 		expect(ctx.org.slug.endsWith(`|${defaultCtx.org.id}`)).toBe(true);
 
-		// 3. Config override merged through to the org row.
+		// Config override merged.
 		expect(ctx.org.config.automatic_tax).toBe(true);
 
-		// 4. AU tax registration was created on the sub-org's Stripe Connect account.
+		// AU tax registration landed on sub-org's Connect account.
 		const registrations = await ctx.stripeCli.tax.registrations.list({
 			status: "active",
 		});
 		const auReg = registrations.data.find((r) => r.country === "AU");
 		expect(auReg).toBeDefined();
 
-		// 5. The sub-org's secret key is wired into ctx.orgSecretKey and is a
-		//    test-mode key (not the master's, not a live key).
+		// ctx.orgSecretKey is a sub-org test-mode key, not the master's.
 		expect(ctx.orgSecretKey).toMatch(/^am_sk_test/);
 		expect(ctx.orgSecretKey).not.toBe(defaultCtx.orgSecretKey);
 	},
-	120_000, // 2min: platform create + connect account creation + tax registration
+	120_000,
 );

--- a/server/tests/setup-integration-tests.ts
+++ b/server/tests/setup-integration-tests.ts
@@ -1,9 +1,9 @@
 import { execSync } from "node:child_process";
 import { loadLocalEnv } from "@/utils/envUtils";
-
-const isUnitTest = () => {
-	return process.argv.some((arg) => arg.includes("unit"));
-};
+import {
+	createTestContext,
+	type TestContext,
+} from "./utils/testInitUtils/createTestContext";
 
 const loadInfisicalSecrets = async () => {
 	try {
@@ -27,15 +27,54 @@ const loadInfisicalSecrets = async () => {
 };
 
 /**
- * Bun test preload script for integration tests.
- * Loads environment variables before any test file runs.
+ * Bun test preload script — runs ONCE per `bun test` invocation, BEFORE any
+ * test file evaluates.
+ *
+ * Loads environment variables AND eagerly initializes the master-org
+ * `TestContext` once, stashing it on `globalThis.__autumnTestContext`.
+ * `createTestContext.ts`'s default export is a Proxy that reads this stash
+ * lazily on property access — by deferring the lookup until first read,
+ * we eliminate both the top-level-await TDZ and the import-order race
+ * (the preload imports `createTestContext` to call its function, which
+ * would normally evaluate the module BEFORE the preload populated the
+ * stash; the Proxy makes that order irrelevant).
+ *
+ * Why we always run integration setup (no unit-vs-integration branch):
+ *
+ *  - When `bun test` is invoked with multiple paths, `process.argv` only
+ *    contains the FIRST one — bun strips the rest before invoking the
+ *    preload. Conditioning on argv is unreliable: a unit test listed
+ *    first would skip the setup that the subsequent integration tests
+ *    need, and they would fail with `defaultCtx is not initialized`.
+ *
+ *  - The createTestContext call is wrapped in try/catch so pure-unit
+ *    environments (e.g. CI lanes that don't set TESTS_ORG) still complete
+ *    the preload cleanly. Unit tests don't read the default ctx anyway,
+ *    so a missing stash is fine for them.
+ *
+ *  - Cost for unit-only runs: ~1-2s (DB fetch + Stripe client init). The
+ *    `bun t` test dispatcher (`scripts/testScripts/testDispatcher.ts`)
+ *    already separates unit and integration runs in practice, so this
+ *    overhead only hits direct-bun-test mixed runs.
  */
 
-if (isUnitTest()) {
-	console.log("--- Skipping integration setup for unit tests ---");
-} else {
-	console.log("--- Setup integration tests ---");
-	await loadInfisicalSecrets();
-	loadLocalEnv({ force: true });
+declare global {
+	// biome-ignore lint/style/noVar: required for global declaration in TS
+	var __autumnTestContext: TestContext | null | undefined;
+}
+
+console.log("--- Setup integration tests ---");
+await loadInfisicalSecrets();
+loadLocalEnv({ force: true });
+
+try {
+	globalThis.__autumnTestContext = await createTestContext();
 	console.log("--- Setup integration tests complete ---");
+} catch (err) {
+	console.warn(
+		"[preload] Skipping master-org TestContext initialization. " +
+			"Integration tests that read the default ctx will fail with a clear " +
+			"error. Reason:",
+		err instanceof Error ? err.message : err,
+	);
 }

--- a/server/tests/setup-integration-tests.ts
+++ b/server/tests/setup-integration-tests.ts
@@ -27,35 +27,16 @@ const loadInfisicalSecrets = async () => {
 };
 
 /**
- * Bun test preload script — runs ONCE per `bun test` invocation, BEFORE any
- * test file evaluates.
+ * Bun test preload — runs once per `bun test` before any test file evaluates.
+ * Loads env vars and eagerly creates the master-org `TestContext`, stashing
+ * it on `globalThis.__autumnTestContext`. `createTestContext.ts`'s default
+ * export is a Proxy that reads the stash lazily, sidestepping import-order
+ * races and top-level-await TDZ.
  *
- * Loads environment variables AND eagerly initializes the master-org
- * `TestContext` once, stashing it on `globalThis.__autumnTestContext`.
- * `createTestContext.ts`'s default export is a Proxy that reads this stash
- * lazily on property access — by deferring the lookup until first read,
- * we eliminate both the top-level-await TDZ and the import-order race
- * (the preload imports `createTestContext` to call its function, which
- * would normally evaluate the module BEFORE the preload populated the
- * stash; the Proxy makes that order irrelevant).
- *
- * Why we always run integration setup (no unit-vs-integration branch):
- *
- *  - When `bun test` is invoked with multiple paths, `process.argv` only
- *    contains the FIRST one — bun strips the rest before invoking the
- *    preload. Conditioning on argv is unreliable: a unit test listed
- *    first would skip the setup that the subsequent integration tests
- *    need, and they would fail with `defaultCtx is not initialized`.
- *
- *  - The createTestContext call is wrapped in try/catch so pure-unit
- *    environments (e.g. CI lanes that don't set TESTS_ORG) still complete
- *    the preload cleanly. Unit tests don't read the default ctx anyway,
- *    so a missing stash is fine for them.
- *
- *  - Cost for unit-only runs: ~1-2s (DB fetch + Stripe client init). The
- *    `bun t` test dispatcher (`scripts/testScripts/testDispatcher.ts`)
- *    already separates unit and integration runs in practice, so this
- *    overhead only hits direct-bun-test mixed runs.
+ * `createTestContext` is wrapped in try/catch so pure-unit lanes (no
+ * TESTS_ORG) still preload cleanly — unit tests don't read the default ctx.
+ * argv-based unit/integration branching isn't reliable (bun only passes the
+ * first path).
  */
 
 declare global {

--- a/server/tests/unit/billing/automatic-tax-config-schema.test.ts
+++ b/server/tests/unit/billing/automatic-tax-config-schema.test.ts
@@ -1,23 +1,8 @@
 /**
- * TDD test for the `automatic_tax` field on OrgConfigSchema.
- *
- * Red-failure mode (current behavior, pre-fix):
- *  - OrgConfigSchema does not declare an `automatic_tax` field.
- *  - Zod strips unknown keys by default, so `OrgConfigSchema.parse({ automatic_tax: true })`
- *    returns an object whose `.automatic_tax` is `undefined`.
- *  - Result: `expect(parsed.automatic_tax).toBe(false)` fails.
- *
- * Green-success criteria (after fix):
- *  - OrgConfigSchema includes `automatic_tax: z.boolean().default(false)`.
- *  - Parsing `{}` yields `{ ..., automatic_tax: false }`.
- *  - Parsing `{ automatic_tax: true }` yields `{ ..., automatic_tax: true }`.
- *  - Parsing `{ automatic_tax: "yes" }` (non-boolean) throws.
- *
- * Why this matters: every downstream Phase 1 cycle uses
- * `s.platform.create({ configOverrides: { automatic_tax: true } })`. If the
- * schema doesn't know about the field, Zod silently drops it during parse and
- * the org's runtime config never has `automatic_tax: true` — making the rest
- * of the rollout impossible to test.
+ * OrgConfigSchema must declare `automatic_tax: z.boolean().default(false)`.
+ * Without this, Zod strips the field on parse and downstream tests using
+ * `s.platform.create({ configOverrides: { automatic_tax: true } })` silently
+ * lose the override.
  */
 
 import { describe, expect, test } from "bun:test";

--- a/server/tests/unit/billing/automatic-tax-config-schema.test.ts
+++ b/server/tests/unit/billing/automatic-tax-config-schema.test.ts
@@ -1,0 +1,46 @@
+/**
+ * TDD test for the `automatic_tax` field on OrgConfigSchema.
+ *
+ * Red-failure mode (current behavior, pre-fix):
+ *  - OrgConfigSchema does not declare an `automatic_tax` field.
+ *  - Zod strips unknown keys by default, so `OrgConfigSchema.parse({ automatic_tax: true })`
+ *    returns an object whose `.automatic_tax` is `undefined`.
+ *  - Result: `expect(parsed.automatic_tax).toBe(false)` fails.
+ *
+ * Green-success criteria (after fix):
+ *  - OrgConfigSchema includes `automatic_tax: z.boolean().default(false)`.
+ *  - Parsing `{}` yields `{ ..., automatic_tax: false }`.
+ *  - Parsing `{ automatic_tax: true }` yields `{ ..., automatic_tax: true }`.
+ *  - Parsing `{ automatic_tax: "yes" }` (non-boolean) throws.
+ *
+ * Why this matters: every downstream Phase 1 cycle uses
+ * `s.platform.create({ configOverrides: { automatic_tax: true } })`. If the
+ * schema doesn't know about the field, Zod silently drops it during parse and
+ * the org's runtime config never has `automatic_tax: true` — making the rest
+ * of the rollout impossible to test.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { OrgConfigSchema } from "@autumn/shared";
+
+describe("OrgConfigSchema.automatic_tax", () => {
+	test("defaults to false when not specified", () => {
+		const parsed = OrgConfigSchema.parse({});
+		expect(parsed.automatic_tax).toBe(false);
+	});
+
+	test("accepts true when explicitly set", () => {
+		const parsed = OrgConfigSchema.parse({ automatic_tax: true });
+		expect(parsed.automatic_tax).toBe(true);
+	});
+
+	test("accepts false when explicitly set", () => {
+		const parsed = OrgConfigSchema.parse({ automatic_tax: false });
+		expect(parsed.automatic_tax).toBe(false);
+	});
+
+	test("rejects non-boolean values", () => {
+		expect(() => OrgConfigSchema.parse({ automatic_tax: "yes" })).toThrow();
+		expect(() => OrgConfigSchema.parse({ automatic_tax: 1 })).toThrow();
+	});
+});

--- a/server/tests/unit/cache/cache-utils.test.ts
+++ b/server/tests/unit/cache/cache-utils.test.ts
@@ -5,11 +5,8 @@ const mockState = {
 };
 const defaultRedis = { status: "ready" };
 
-// Stub logger must match the full `Logger` shape from logtailUtils.ts because
-// `mock.module` is process-wide in Bun: any other unit test loaded later in the
-// same `bun test` run gets this stub instead of the real logger. Missing
-// methods (e.g. `debug`) would crash unrelated code paths like
-// getOrSetCachedFullSubject.
+// Stub the full `Logger` shape — Bun's `mock.module` is process-wide, so
+// later unit tests inherit this stub. Missing methods crash unrelated code.
 const mockLogger = {
 	debug: () => undefined,
 	info: () => undefined,

--- a/server/tests/unit/cache/cache-utils.test.ts
+++ b/server/tests/unit/cache/cache-utils.test.ts
@@ -5,21 +5,31 @@ const mockState = {
 };
 const defaultRedis = { status: "ready" };
 
-mock.module("@/external/logtail/logtailUtils.js", () => ({
-	logger: {
-		info: () => undefined,
-		warn: (data: Record<string, unknown> | string, message?: string) => {
-			if (typeof data === "string") {
-				mockState.warnings.push({ message: data });
-				return;
-			}
+// Stub logger must match the full `Logger` shape from logtailUtils.ts because
+// `mock.module` is process-wide in Bun: any other unit test loaded later in the
+// same `bun test` run gets this stub instead of the real logger. Missing
+// methods (e.g. `debug`) would crash unrelated code paths like
+// getOrSetCachedFullSubject.
+const mockLogger = {
+	debug: () => undefined,
+	info: () => undefined,
+	warn: (data: Record<string, unknown> | string, message?: string) => {
+		if (typeof data === "string") {
+			mockState.warnings.push({ message: data });
+			return;
+		}
 
-			mockState.warnings.push({
-				message: message || "",
-				data,
-			});
-		},
+		mockState.warnings.push({
+			message: message || "",
+			data,
+		});
 	},
+	error: () => undefined,
+	child: () => mockLogger,
+};
+
+mock.module("@/external/logtail/logtailUtils.js", () => ({
+	logger: mockLogger,
 }));
 
 mock.module("@/external/redis/initUtils/redisConfig.js", () => ({

--- a/server/tests/unit/full-subject-cache/invalidateCachedFullSubject.test.ts
+++ b/server/tests/unit/full-subject-cache/invalidateCachedFullSubject.test.ts
@@ -151,7 +151,7 @@ describeDb("invalidateCachedFullSubject", () => {
 
 		expect(await ctx.redisV2.exists(entityBKey)).toBe(1);
 
-		const cachedEntityB = await getCachedFullSubject({
+		const { fullSubject: cachedEntityB } = await getCachedFullSubject({
 			ctx,
 			customerId: scenario.ids.customerId,
 			entityId: scenario.ids.entityIds[1],

--- a/server/tests/unit/rate-limits/rate-limit-factory.test.ts
+++ b/server/tests/unit/rate-limits/rate-limit-factory.test.ts
@@ -10,10 +10,8 @@ mock.module("@/external/redis/initRedis", () => ({
 	shouldUseRedis: () => mockState.shouldUseRedis,
 }));
 
-// Stub logger must match the full `Logger` shape from logtailUtils.ts because
-// `mock.module` is process-wide in Bun: any other unit test loaded later in the
-// same `bun test` run gets this stub instead of the real logger. Missing
-// methods (e.g. `debug`) would crash unrelated code paths.
+// Stub the full `Logger` shape — Bun's `mock.module` is process-wide, so
+// later unit tests inherit this stub. Missing methods crash unrelated code.
 const mockLogger = {
 	debug: () => undefined,
 	info: () => undefined,

--- a/server/tests/unit/rate-limits/rate-limit-factory.test.ts
+++ b/server/tests/unit/rate-limits/rate-limit-factory.test.ts
@@ -10,12 +10,22 @@ mock.module("@/external/redis/initRedis", () => ({
 	shouldUseRedis: () => mockState.shouldUseRedis,
 }));
 
-mock.module("@/external/logtail/logtailUtils.js", () => ({
-	logger: {
-		warn: (message: string) => {
-			mockState.warnings.push(message);
-		},
+// Stub logger must match the full `Logger` shape from logtailUtils.ts because
+// `mock.module` is process-wide in Bun: any other unit test loaded later in the
+// same `bun test` run gets this stub instead of the real logger. Missing
+// methods (e.g. `debug`) would crash unrelated code paths.
+const mockLogger = {
+	debug: () => undefined,
+	info: () => undefined,
+	warn: (message: string) => {
+		mockState.warnings.push(message);
 	},
+	error: () => undefined,
+	child: () => mockLogger,
+};
+
+mock.module("@/external/logtail/logtailUtils.js", () => ({
+	logger: mockLogger,
 }));
 
 import { rateLimitFactory } from "@/internal/misc/rateLimiter/rateLimitFactory.js";

--- a/server/tests/utils/browserPool/completeStripeCheckoutFormV2.ts
+++ b/server/tests/utils/browserPool/completeStripeCheckoutFormV2.ts
@@ -1,22 +1,35 @@
 import { USE_KERNEL } from "./browserConfig.js";
 import { browserPool } from "./browserPool.js";
 import { kernelExecute } from "./kernelExecute.js";
-import { stripeCheckout } from "./playwright/stripeCheckout.js";
+import {
+	stripeCheckout,
+	type StripeCheckoutBillingAddress,
+} from "./playwright/stripeCheckout.js";
 import { playwrightPool } from "./playwrightPool.js";
+
+export type { StripeCheckoutBillingAddress };
 
 /**
  * Complete a Stripe Checkout session form.
  * Kernel mode: serializes stripeCheckout via fn.toString() and runs in-VM.
  * Local mode: runs stripeCheckout directly with a local Playwright browser.
+ *
+ * @param billingAddress - Optional billing address override. Required when
+ *   the session was created with `customer_update: { address: "auto" }`
+ *   (which makes Stripe Checkout collect a FULL address: line1, city, state,
+ *   country, postal_code). When omitted, defaults to US / 10001 — preserving
+ *   historical behavior for sessions that only collect postal code.
  */
 export const completeStripeCheckoutFormV2 = async ({
 	url,
 	overrideQuantity,
 	promoCode,
+	billingAddress,
 }: {
 	url: string;
 	overrideQuantity?: number;
 	promoCode?: string;
+	billingAddress?: StripeCheckoutBillingAddress;
 }): Promise<void> => {
 	const concurrency = Number(process.env.TEST_FILE_CONCURRENCY || "0");
 	const timeout = concurrency > 1 ? 10000 : 0; // additional 10 seconds if concurrency
@@ -28,7 +41,7 @@ export const completeStripeCheckoutFormV2 = async ({
 		await kernelExecute({
 			sessionId,
 			fn: stripeCheckout,
-			args: { url, overrideQuantity, promoCode },
+			args: { url, overrideQuantity, promoCode, billingAddress },
 		});
 		console.log("[completeStripeCheckoutFormV2] Done");
 
@@ -42,7 +55,7 @@ export const completeStripeCheckoutFormV2 = async ({
 	console.log("[completeStripeCheckoutFormV2] Using local Playwright...");
 	await playwrightPool.runInPage({
 		fn: stripeCheckout,
-		args: { url, overrideQuantity, promoCode },
+		args: { url, overrideQuantity, promoCode, billingAddress },
 	});
 
 	// If concurrency, wait for 10 more seconds

--- a/server/tests/utils/browserPool/completeStripeCheckoutFormV2.ts
+++ b/server/tests/utils/browserPool/completeStripeCheckoutFormV2.ts
@@ -10,15 +10,10 @@ import { playwrightPool } from "./playwrightPool.js";
 export type { StripeCheckoutBillingAddress };
 
 /**
- * Complete a Stripe Checkout session form.
- * Kernel mode: serializes stripeCheckout via fn.toString() and runs in-VM.
- * Local mode: runs stripeCheckout directly with a local Playwright browser.
- *
- * @param billingAddress - Optional billing address override. Required when
- *   the session was created with `customer_update: { address: "auto" }`
- *   (which makes Stripe Checkout collect a FULL address: line1, city, state,
- *   country, postal_code). When omitted, defaults to US / 10001 — preserving
- *   historical behavior for sessions that only collect postal code.
+ * Complete a Stripe Checkout session form (Kernel VM or local Playwright).
+ * Pass `billingAddress` when the session was created with
+ * `customer_update: { address: "auto" }` (full address form). Defaults to
+ * US / 10001 (postal-code-only sessions).
  */
 export const completeStripeCheckoutFormV2 = async ({
 	url,
@@ -32,7 +27,7 @@ export const completeStripeCheckoutFormV2 = async ({
 	billingAddress?: StripeCheckoutBillingAddress;
 }): Promise<void> => {
 	const concurrency = Number(process.env.TEST_FILE_CONCURRENCY || "0");
-	const timeout = concurrency > 1 ? 10000 : 0; // additional 10 seconds if concurrency
+	const timeout = concurrency > 1 ? 10000 : 0;
 	if (USE_KERNEL) {
 		console.log(
 			"[completeStripeCheckoutFormV2] Using Kernel Playwright execution...",
@@ -51,14 +46,12 @@ export const completeStripeCheckoutFormV2 = async ({
 		return;
 	}
 
-	// Local — run the same Playwright function with a local browser
 	console.log("[completeStripeCheckoutFormV2] Using local Playwright...");
 	await playwrightPool.runInPage({
 		fn: stripeCheckout,
 		args: { url, overrideQuantity, promoCode, billingAddress },
 	});
 
-	// If concurrency, wait for 10 more seconds
 	if (timeout > 0) {
 		await new Promise((resolve) => setTimeout(resolve, timeout));
 	}

--- a/server/tests/utils/browserPool/playwright/stripeCheckout.ts
+++ b/server/tests/utils/browserPool/playwright/stripeCheckout.ts
@@ -1,15 +1,10 @@
 import type { Page } from "playwright-core";
 
 /**
- * Optional billing address override for the checkout form. When omitted, the
- * helper defaults to a US address with postal code 10001 (the historical
- * behavior). Supply this when the test needs Stripe Checkout to collect a
- * specific country/region — typically required when the merchant has
- * `automatic_tax: { enabled: true }` and `customer_update: { address: "auto" }`,
- * which makes Stripe present a FULL address form (line1, city, state,
- * postal_code, country) rather than just postal code.
- *
- * Field names mirror Stripe.AddressParam.
+ * Billing address override (defaults to US / 10001). Supply when the
+ * session uses auto_tax + `customer_update: { address: "auto" }`, which
+ * makes Stripe present a full address form. Field names mirror
+ * Stripe.AddressParam.
  */
 export type StripeCheckoutBillingAddress = {
 	country?: string;
@@ -20,17 +15,12 @@ export type StripeCheckoutBillingAddress = {
 };
 
 /**
- * Self-contained Playwright function for completing a Stripe Checkout session page.
- * NO external imports — this function must be serializable via fn.toString()
- * for Kernel Playwright Execution. (type imports are fine — Bun strips them)
+ * Self-contained Playwright function for completing a Stripe Checkout page.
+ * NO runtime imports — must be serializable via `fn.toString()` for Kernel
+ * Playwright Execution (type imports are fine; Bun strips them).
  *
- * Handles checkout.stripe.com pages which have:
- * 1. Direct DOM selectors (#cardNumber, #cardExpiry, #cardCvc, #billingName)
- * 2. Optional adjustable quantity (.AdjustableQuantitySelector)
- * 3. Optional promo code (#promotionCode)
- * 4. Optional full billing address form (line1, city, state) when the
- *    session was created with `customer_update: { address: "auto" }`.
- * 5. Submit button (.SubmitButton-TextContainer)
+ * Handles card fields, optional quantity selector, promo code, optional
+ * full billing address (when `customer_update.address: "auto"`), and submit.
  */
 export const stripeCheckout = async ({
 	page,
@@ -48,12 +38,10 @@ export const stripeCheckout = async ({
 	await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
 	console.log("[stripeCheckout] Page loaded");
 
-	// Wait for the checkout page to render
 	await page.waitForTimeout(3000);
 
-	// Select the Card payment method. The radio input is hidden behind an
-	// AccordionButton overlay with expandedClickArea. Use JS click on the
-	// data-testid button, with a fallback to the radio input directly.
+	// Select Card. The radio is hidden by an AccordionButton overlay; click
+	// the data-testid button via JS, fall back to the radio.
 	try {
 		const cardBtn = page.locator('[data-testid="card-accordion-item-button"]');
 		if ((await cardBtn.count()) > 0) {
@@ -71,12 +59,11 @@ export const stripeCheckout = async ({
 			await page.waitForTimeout(500);
 		}
 	} catch {
-		// Card might already be selected or not present
+		// Card may already be selected or absent.
 	}
 
-	// Stripe's card inputs are custom components that require individual key events.
-	// .fill() sets the value programmatically and skips keydown/keypress/keyup,
-	// so Stripe never registers the input. Use .pressSequentially() instead.
+	// Card fields require real key events — `.fill()` skips keydown/up so
+	// Stripe never registers the input. Use `.pressSequentially()`.
 	const cardNumber = page.locator("#cardNumber");
 	await cardNumber.waitFor({ timeout: 120000 });
 	await cardNumber.pressSequentially("4242424242424242");
@@ -104,11 +91,10 @@ export const stripeCheckout = async ({
 			console.log("[stripeCheckout] Email filled");
 		}
 	} catch {
-		// Email field not present
+		// Email field absent.
 	}
 
-	// Resolve billing address fields. Defaults preserve historical behavior
-	// (US / 10001) when no explicit billingAddress is supplied.
+	// Address fields. Defaults: US / 10001.
 	const country = billingAddress?.country ?? "US";
 	const postalCode = billingAddress?.postal_code ?? "10001";
 	const line1 = billingAddress?.line1;
@@ -123,13 +109,11 @@ export const stripeCheckout = async ({
 			await page.waitForTimeout(500);
 		}
 	} catch {
-		// Country selector not present
+		// Country selector absent.
 	}
 
-	// When `customer_update: { address: "auto" }` was set on the session,
-	// Stripe Checkout shows a full billing address form (line1, city, state)
-	// rather than just postal code. These fields are optional — they only
-	// appear when address collection is enabled, so we feature-detect each.
+	// Full address form (line1/city/state) appears only when the session
+	// uses `customer_update: { address: "auto" }`. Feature-detect each.
 	if (line1) {
 		try {
 			const line1Field = page.locator("#billingAddressLine1");
@@ -137,9 +121,7 @@ export const stripeCheckout = async ({
 				await line1Field.pressSequentially(line1);
 				console.log(`[stripeCheckout] Address line 1 filled: ${line1}`);
 			}
-		} catch {
-			// Line 1 not present
-		}
+		} catch {}
 	}
 
 	if (city) {
@@ -149,17 +131,14 @@ export const stripeCheckout = async ({
 				await cityField.pressSequentially(city);
 				console.log(`[stripeCheckout] City filled: ${city}`);
 			}
-		} catch {
-			// City not present
-		}
+		} catch {}
 	}
 
 	if (state) {
 		try {
 			const stateField = page.locator("#billingAdministrativeArea");
 			if ((await stateField.count()) > 0) {
-				// State is a select on US / CA / AU; try selectOption first,
-				// fall back to typing.
+				// State is a select on US/CA/AU; fall back to typing.
 				try {
 					await stateField.selectOption(state);
 				} catch {
@@ -167,9 +146,7 @@ export const stripeCheckout = async ({
 				}
 				console.log(`[stripeCheckout] State filled: ${state}`);
 			}
-		} catch {
-			// State not present
-		}
+		} catch {}
 	}
 
 	try {
@@ -178,11 +155,8 @@ export const stripeCheckout = async ({
 			await postalField.pressSequentially(postalCode);
 			console.log(`[stripeCheckout] Postal code filled: ${postalCode}`);
 		}
-	} catch {
-		// Postal code field not present
-	}
+	} catch {}
 
-	// Handle adjustable quantity if requested
 	if (overrideQuantity !== undefined && overrideQuantity !== null) {
 		const quantityBtn = page.locator(".AdjustableQuantitySelector").first();
 		if ((await quantityBtn.count()) === 0) {
@@ -208,7 +182,6 @@ export const stripeCheckout = async ({
 		await page.waitForTimeout(1000);
 	}
 
-	// Handle promo code if provided
 	if (promoCode) {
 		const promoInput = page.locator("#promotionCode");
 		await promoInput.waitFor({ timeout: 60000 });
@@ -219,8 +192,8 @@ export const stripeCheckout = async ({
 		await page.waitForTimeout(5000);
 	}
 
-	// Click submit button — use force:true because Stripe overlays (Link, phone number)
-	// can obscure the button and cause Playwright's actionability checks to time out.
+	// Submit via JS click — Stripe overlays (Link, phone) can obscure the
+	// button and break Playwright's actionability check.
 	const submitBtn = page.locator(".SubmitButton-TextContainer").first();
 	if ((await submitBtn.count()) === 0) {
 		throw new Error(".SubmitButton-TextContainer not found");
@@ -228,7 +201,7 @@ export const stripeCheckout = async ({
 	await submitBtn.evaluate((el) => (el as HTMLElement).click());
 	console.log("[stripeCheckout] Submit clicked");
 
-	// Wait for checkout to process + webhook delivery
+	// Wait for checkout processing + webhook delivery.
 	await page.waitForTimeout(20000);
 	console.log("[stripeCheckout] Checkout complete");
 };

--- a/server/tests/utils/browserPool/playwright/stripeCheckout.ts
+++ b/server/tests/utils/browserPool/playwright/stripeCheckout.ts
@@ -1,6 +1,25 @@
 import type { Page } from "playwright-core";
 
 /**
+ * Optional billing address override for the checkout form. When omitted, the
+ * helper defaults to a US address with postal code 10001 (the historical
+ * behavior). Supply this when the test needs Stripe Checkout to collect a
+ * specific country/region — typically required when the merchant has
+ * `automatic_tax: { enabled: true }` and `customer_update: { address: "auto" }`,
+ * which makes Stripe present a FULL address form (line1, city, state,
+ * postal_code, country) rather than just postal code.
+ *
+ * Field names mirror Stripe.AddressParam.
+ */
+export type StripeCheckoutBillingAddress = {
+	country?: string;
+	line1?: string;
+	city?: string;
+	state?: string;
+	postal_code?: string;
+};
+
+/**
  * Self-contained Playwright function for completing a Stripe Checkout session page.
  * NO external imports — this function must be serializable via fn.toString()
  * for Kernel Playwright Execution. (type imports are fine — Bun strips them)
@@ -9,18 +28,22 @@ import type { Page } from "playwright-core";
  * 1. Direct DOM selectors (#cardNumber, #cardExpiry, #cardCvc, #billingName)
  * 2. Optional adjustable quantity (.AdjustableQuantitySelector)
  * 3. Optional promo code (#promotionCode)
- * 4. Submit button (.SubmitButton-TextContainer)
+ * 4. Optional full billing address form (line1, city, state) when the
+ *    session was created with `customer_update: { address: "auto" }`.
+ * 5. Submit button (.SubmitButton-TextContainer)
  */
 export const stripeCheckout = async ({
 	page,
 	url,
 	overrideQuantity,
 	promoCode,
+	billingAddress,
 }: {
 	page: Page;
 	url: string;
 	overrideQuantity?: number;
 	promoCode?: string;
+	billingAddress?: StripeCheckoutBillingAddress;
 }) => {
 	await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
 	console.log("[stripeCheckout] Page loaded");
@@ -84,23 +107,76 @@ export const stripeCheckout = async ({
 		// Email field not present
 	}
 
-	// Force country to US so a postal code input is always shown
+	// Resolve billing address fields. Defaults preserve historical behavior
+	// (US / 10001) when no explicit billingAddress is supplied.
+	const country = billingAddress?.country ?? "US";
+	const postalCode = billingAddress?.postal_code ?? "10001";
+	const line1 = billingAddress?.line1;
+	const city = billingAddress?.city;
+	const state = billingAddress?.state;
+
 	try {
 		const countrySelect = page.locator("#billingCountry");
 		if ((await countrySelect.count()) > 0) {
-			await countrySelect.selectOption("US");
-			console.log("[stripeCheckout] Country set to US");
+			await countrySelect.selectOption(country);
+			console.log(`[stripeCheckout] Country set to ${country}`);
 			await page.waitForTimeout(500);
 		}
 	} catch {
 		// Country selector not present
 	}
 
+	// When `customer_update: { address: "auto" }` was set on the session,
+	// Stripe Checkout shows a full billing address form (line1, city, state)
+	// rather than just postal code. These fields are optional — they only
+	// appear when address collection is enabled, so we feature-detect each.
+	if (line1) {
+		try {
+			const line1Field = page.locator("#billingAddressLine1");
+			if ((await line1Field.count()) > 0) {
+				await line1Field.pressSequentially(line1);
+				console.log(`[stripeCheckout] Address line 1 filled: ${line1}`);
+			}
+		} catch {
+			// Line 1 not present
+		}
+	}
+
+	if (city) {
+		try {
+			const cityField = page.locator("#billingLocality");
+			if ((await cityField.count()) > 0) {
+				await cityField.pressSequentially(city);
+				console.log(`[stripeCheckout] City filled: ${city}`);
+			}
+		} catch {
+			// City not present
+		}
+	}
+
+	if (state) {
+		try {
+			const stateField = page.locator("#billingAdministrativeArea");
+			if ((await stateField.count()) > 0) {
+				// State is a select on US / CA / AU; try selectOption first,
+				// fall back to typing.
+				try {
+					await stateField.selectOption(state);
+				} catch {
+					await stateField.pressSequentially(state);
+				}
+				console.log(`[stripeCheckout] State filled: ${state}`);
+			}
+		} catch {
+			// State not present
+		}
+	}
+
 	try {
-		const postalCode = page.locator("#billingPostalCode");
-		if ((await postalCode.count()) > 0) {
-			await postalCode.pressSequentially("10001");
-			console.log("[stripeCheckout] Postal code filled");
+		const postalField = page.locator("#billingPostalCode");
+		if ((await postalField.count()) > 0) {
+			await postalField.pressSequentially(postalCode);
+			console.log(`[stripeCheckout] Postal code filled: ${postalCode}`);
 		}
 	} catch {
 		// Postal code field not present

--- a/server/tests/utils/testInitUtils/createSubOrgTestContext.ts
+++ b/server/tests/utils/testInitUtils/createSubOrgTestContext.ts
@@ -1,0 +1,231 @@
+import {
+	ApiVersionClass,
+	AppEnv,
+	AuthType,
+	LATEST_VERSION,
+	type OrgConfig,
+} from "@autumn/shared";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { logger } from "../../../src/external/logtail/logtailUtils.js";
+import { generateId } from "../../../src/utils/genUtils.js";
+import type { TestContext } from "./createTestContext.js";
+
+export type TaxRegistrationCountry =
+	| "AU"
+	| "GB"
+	| "US"
+	| "CA"
+	| "DE"
+	| "FR"
+	| "SA"
+	| "RU";
+
+export const createSubOrgTestContext = async ({
+	subOrgSlug,
+	testSecretKey,
+	configOverrides,
+	taxRegistrations,
+}: {
+	subOrgSlug: string;
+	testSecretKey: string;
+	configOverrides?: Partial<OrgConfig>;
+	taxRegistrations?: TaxRegistrationCountry[];
+}): Promise<TestContext> => {
+	const { db } = initDrizzle();
+
+	// 1. Resolve sub-org from DB.
+	let subOrg = await OrgService.getBySlug({ db, slug: subOrgSlug });
+	if (!subOrg) {
+		throw new Error(
+			`Sub-org with slug "${subOrgSlug}" not found. ` +
+				`Caller must create the sub-org via POST /platform/organizations first.`,
+		);
+	}
+
+	// 2. Apply config overrides (if any).
+	// OrgService.update replaces the whole `config` jsonb (it does
+	// `db.update(organizations).set(updates)`), so we merge in JS first.
+	if (configOverrides && Object.keys(configOverrides).length > 0) {
+		const existingConfig = (subOrg.config ?? {}) as OrgConfig;
+		const mergedConfig: OrgConfig = {
+			...existingConfig,
+			...configOverrides,
+		};
+
+		await OrgService.update({
+			db,
+			orgId: subOrg.id,
+			updates: { config: mergedConfig },
+		});
+
+		// Re-fetch so the returned context has the merged config.
+		const refetched = await OrgService.getBySlug({ db, slug: subOrgSlug });
+		if (!refetched) {
+			throw new Error(
+				`Sub-org with slug "${subOrgSlug}" disappeared after config update`,
+			);
+		}
+		subOrg = refetched;
+	}
+
+	// 3. Build Stripe client scoped to sub-org's connect account.
+	const subStripeCli = createStripeCli({ org: subOrg, env: AppEnv.Sandbox });
+
+	// 4. Register Stripe Tax jurisdictions (if any).
+	//    Stripe requires a head office address on the merchant's Tax Settings
+	//    BEFORE any tax.registrations.create call. Test sub-orgs are fresh
+	//    Connect accounts with no settings, so we set a default US head office
+	//    once before iterating registrations.
+	if (taxRegistrations && taxRegistrations.length > 0) {
+		try {
+			await subStripeCli.tax.settings.update({
+				defaults: {
+					tax_behavior: "exclusive",
+					tax_code: "txcd_10000000", // General services
+				},
+				head_office: {
+					address: {
+						country: "US",
+						line1: "1 Test Way",
+						city: "San Francisco",
+						postal_code: "94103",
+						state: "CA",
+					},
+				},
+			});
+		} catch (err) {
+			const stripeErr = err as {
+				message?: string;
+				code?: string;
+				type?: string;
+			};
+			logger.warn(
+				`Failed to set Stripe Tax head office address on sub-org "${subOrgSlug}": ` +
+					`${stripeErr.message ?? "(no message)"} ` +
+					`[type=${stripeErr.type ?? "unknown"}, code=${stripeErr.code ?? "unknown"}]. ` +
+					`Tax registrations will likely fail.`,
+			);
+		}
+
+		for (const country of taxRegistrations) {
+			try {
+				if (country === "AU") {
+					await subStripeCli.tax.registrations.create({
+						country: "AU",
+						country_options: { au: { type: "standard" } },
+						active_from: "now",
+					});
+				} else if (country === "GB") {
+					await subStripeCli.tax.registrations.create({
+						country: "GB",
+						country_options: { gb: { type: "standard" } },
+						active_from: "now",
+					});
+				} else if (country === "US") {
+					// California state sales tax. Note SaaS / digital services are
+					// often NOT taxable in CA, so a CA customer may still see $0
+					// tax on a recurring subscription invoice — by design.
+					await subStripeCli.tax.registrations.create({
+						country: "US",
+						country_options: {
+							us: { state: "CA", type: "state_sales_tax" },
+						},
+						active_from: "now",
+					});
+				} else if (country === "CA") {
+					// Federal GST/HST simplified registration (covers all CA provinces).
+					await subStripeCli.tax.registrations.create({
+						country: "CA",
+						country_options: { ca: { type: "simplified" } },
+						active_from: "now",
+					});
+				} else if (country === "DE") {
+					// EU standard VAT for Germany.
+					await subStripeCli.tax.registrations.create({
+						country: "DE",
+						country_options: {
+							de: {
+								type: "standard",
+								standard: { place_of_supply_scheme: "standard" },
+							},
+						},
+						active_from: "now",
+					});
+				} else if (country === "FR") {
+					// EU standard VAT for France.
+					await subStripeCli.tax.registrations.create({
+						country: "FR",
+						country_options: {
+							fr: {
+								type: "standard",
+								standard: { place_of_supply_scheme: "standard" },
+							},
+						},
+						active_from: "now",
+					});
+				} else if (country === "SA") {
+					// Saudi Arabia simplified VAT.
+					await subStripeCli.tax.registrations.create({
+						country: "SA",
+						country_options: { sa: { type: "simplified" } },
+						active_from: "now",
+					});
+				} else if (country === "RU") {
+					// Russia simplified VAT.
+					await subStripeCli.tax.registrations.create({
+						country: "RU",
+						country_options: { ru: { type: "simplified" } },
+						active_from: "now",
+					});
+				}
+			} catch (err) {
+				// Idempotency: if a registration already exists, Stripe throws.
+				// Log and continue so a retried test setup doesn't fail.
+				const stripeErr = err as {
+					message?: string;
+					code?: string;
+					type?: string;
+				};
+				logger.warn(
+					`Failed to register Stripe Tax for country "${country}" on sub-org "${subOrgSlug}": ` +
+						`${stripeErr.message ?? "(no message)"} ` +
+						`[type=${stripeErr.type ?? "unknown"}, code=${stripeErr.code ?? "unknown"}]. ` +
+						`This may be expected if the registration already exists.`,
+				);
+			}
+		}
+	}
+
+	// 5. Build features list for the sub-org.
+	const features = await FeatureService.list({
+		db,
+		orgId: subOrg.id,
+		env: AppEnv.Sandbox,
+	});
+
+	// 6. Return a TestContext matching createTestContext.ts's return shape exactly.
+	return {
+		org: subOrg,
+		env: AppEnv.Sandbox,
+		stripeCli: subStripeCli,
+		db,
+		dbGeneral: db,
+		features,
+		logger,
+		redisV2: resolveRedisV2(),
+		orgSecretKey: testSecretKey,
+		id: generateId("test"),
+		isPublic: false,
+		authType: AuthType.Unknown,
+		apiVersion: new ApiVersionClass(LATEST_VERSION),
+		timestamp: Date.now(),
+		scopes: [],
+		skipCache: false,
+		expand: [],
+		extraLogs: {},
+	} satisfies TestContext;
+};

--- a/server/tests/utils/testInitUtils/createSubOrgTestContext.ts
+++ b/server/tests/utils/testInitUtils/createSubOrgTestContext.ts
@@ -37,7 +37,7 @@ export const createSubOrgTestContext = async ({
 }): Promise<TestContext> => {
 	const { db } = initDrizzle();
 
-	// 1. Resolve sub-org from DB.
+	// 1. Resolve sub-org.
 	let subOrg = await OrgService.getBySlug({ db, slug: subOrgSlug });
 	if (!subOrg) {
 		throw new Error(
@@ -46,9 +46,8 @@ export const createSubOrgTestContext = async ({
 		);
 	}
 
-	// 2. Apply config overrides (if any).
-	// OrgService.update replaces the whole `config` jsonb (it does
-	// `db.update(organizations).set(updates)`), so we merge in JS first.
+	// 2. Apply config overrides. OrgService.update replaces the whole
+	// `config` jsonb, so we merge in JS first.
 	if (configOverrides && Object.keys(configOverrides).length > 0) {
 		const existingConfig = (subOrg.config ?? {}) as OrgConfig;
 		const mergedConfig: OrgConfig = {
@@ -62,7 +61,7 @@ export const createSubOrgTestContext = async ({
 			updates: { config: mergedConfig },
 		});
 
-		// Re-fetch so the returned context has the merged config.
+		// Re-fetch with merged config.
 		const refetched = await OrgService.getBySlug({ db, slug: subOrgSlug });
 		if (!refetched) {
 			throw new Error(
@@ -72,20 +71,17 @@ export const createSubOrgTestContext = async ({
 		subOrg = refetched;
 	}
 
-	// 3. Build Stripe client scoped to sub-org's connect account.
+	// 3. Stripe client scoped to the sub-org's connect account.
 	const subStripeCli = createStripeCli({ org: subOrg, env: AppEnv.Sandbox });
 
-	// 4. Register Stripe Tax jurisdictions (if any).
-	//    Stripe requires a head office address on the merchant's Tax Settings
-	//    BEFORE any tax.registrations.create call. Test sub-orgs are fresh
-	//    Connect accounts with no settings, so we set a default US head office
-	//    once before iterating registrations.
+	// 4. Stripe Tax jurisdictions. Stripe requires a head office address
+	// on Tax Settings before any tax.registrations.create.
 	if (taxRegistrations && taxRegistrations.length > 0) {
 		try {
 			await subStripeCli.tax.settings.update({
 				defaults: {
 					tax_behavior: "exclusive",
-					tax_code: "txcd_10000000", // General services
+					tax_code: "txcd_10000000",
 				},
 				head_office: {
 					address: {
@@ -126,9 +122,8 @@ export const createSubOrgTestContext = async ({
 						active_from: "now",
 					});
 				} else if (country === "US") {
-					// California state sales tax. Note SaaS / digital services are
-					// often NOT taxable in CA, so a CA customer may still see $0
-					// tax on a recurring subscription invoice — by design.
+					// CA state sales tax. SaaS often isn't taxable in CA, so $0
+					// tax on the resulting invoice is expected.
 					await subStripeCli.tax.registrations.create({
 						country: "US",
 						country_options: {
@@ -137,14 +132,12 @@ export const createSubOrgTestContext = async ({
 						active_from: "now",
 					});
 				} else if (country === "CA") {
-					// Federal GST/HST simplified registration (covers all CA provinces).
 					await subStripeCli.tax.registrations.create({
 						country: "CA",
 						country_options: { ca: { type: "simplified" } },
 						active_from: "now",
 					});
 				} else if (country === "DE") {
-					// EU standard VAT for Germany.
 					await subStripeCli.tax.registrations.create({
 						country: "DE",
 						country_options: {
@@ -156,7 +149,6 @@ export const createSubOrgTestContext = async ({
 						active_from: "now",
 					});
 				} else if (country === "FR") {
-					// EU standard VAT for France.
 					await subStripeCli.tax.registrations.create({
 						country: "FR",
 						country_options: {
@@ -168,14 +160,12 @@ export const createSubOrgTestContext = async ({
 						active_from: "now",
 					});
 				} else if (country === "SA") {
-					// Saudi Arabia simplified VAT.
 					await subStripeCli.tax.registrations.create({
 						country: "SA",
 						country_options: { sa: { type: "simplified" } },
 						active_from: "now",
 					});
 				} else if (country === "RU") {
-					// Russia simplified VAT.
 					await subStripeCli.tax.registrations.create({
 						country: "RU",
 						country_options: { ru: { type: "simplified" } },
@@ -183,8 +173,8 @@ export const createSubOrgTestContext = async ({
 					});
 				}
 			} catch (err) {
-				// Idempotency: if a registration already exists, Stripe throws.
-				// Log and continue so a retried test setup doesn't fail.
+				// Tolerate already-registered (Stripe throws); retried setups
+				// shouldn't fail.
 				const stripeErr = err as {
 					message?: string;
 					code?: string;
@@ -200,14 +190,14 @@ export const createSubOrgTestContext = async ({
 		}
 	}
 
-	// 5. Build features list for the sub-org.
+	// 5. Sub-org features.
 	const features = await FeatureService.list({
 		db,
 		orgId: subOrg.id,
 		env: AppEnv.Sandbox,
 	});
 
-	// 6. Return a TestContext matching createTestContext.ts's return shape exactly.
+	// 6. TestContext with sub-org rebinding (matches createTestContext shape).
 	return {
 		org: subOrg,
 		env: AppEnv.Sandbox,

--- a/server/tests/utils/testInitUtils/createTestContext.ts
+++ b/server/tests/utils/testInitUtils/createTestContext.ts
@@ -38,8 +38,7 @@ export interface TestContext extends AutumnContext {
 export const createTestContext = async () => {
 	const { db } = initDrizzle();
 
-	// Support dynamic org slug from environment (for parallel test groups)
-	// Falls back to TESTS_ORG for legacy tests
+	// TESTS_ORG is set by the test runner (per parallel group).
 	const orgSlug = process.env.TESTS_ORG;
 	if (!orgSlug) {
 		throw new Error(
@@ -56,8 +55,7 @@ export const createTestContext = async () => {
 	const stripeCli = createStripeCli({ org, env });
 	const features = await FeatureService.list({ db, orgId: org.id, env });
 
-	// Get org secret key for API calls
-	// Priority: 1. Environment variable (set by test runner), 2. Org's secret_keys field
+	// Org secret key, set by test runner.
 	const orgSecretKey = process.env.UNIT_TEST_AUTUMN_SECRET_KEY || "";
 	if (!orgSecretKey) {
 		throw new Error(
@@ -90,32 +88,13 @@ export const createTestContext = async () => {
 };
 
 /**
- * Lazy-read default export. The actual TestContext is created once by the
- * bun preload (`server/tests/setup-integration-tests.ts`) and stashed on
- * `globalThis.__autumnTestContext`. We expose a Proxy here so the lookup
- * happens on property ACCESS, not at module evaluation.
+ * Lazy default export. The real TestContext is built once by the preload
+ * (`setup-integration-tests.ts`) and stashed on `globalThis`. The Proxy
+ * defers the lookup until first property access, sidestepping the
+ * import-order race (preload imports this module before populating the
+ * stash) and the top-level-await TDZ from a prior implementation.
  *
- * Why this matters:
- *
- *  - The preload imports this module to call `createTestContext()`. That
- *    triggers this module's evaluation BEFORE the preload's body runs, so
- *    if we captured the stash at evaluation time it would be `undefined`
- *    forever — the preload would set `globalThis` after the const had
- *    already frozen to null.
- *
- *  - Previously this module did a top-level `await createTestContext()`
- *    here, which made the module async and put its default export in TDZ
- *    until the await resolved. With many test files concurrently loading
- *    in one process, importers could race ahead of the not-yet-finalized
- *    default export and throw `ReferenceError: Cannot access 'defaultCtx'
- *    before initialization`. The Proxy eliminates that window — the module
- *    evaluates synchronously and the lookup is deferred to first property
- *    access on the default export, by which time the preload has finished.
- *
- *  - For unit tests (which skip integration preload), property access
- *    throws a clear "preload did not run" message instead of the cryptic
- *    `Cannot read property X of null` of the previous implementation.
- *    Unit tests don't access the default export anyway.
+ * Unit tests that hit this throw a clear "preload did not run" error.
  */
 const lazyDefaultCtx = new Proxy({} as TestContext, {
 	get(_target, prop, _receiver) {

--- a/server/tests/utils/testInitUtils/createTestContext.ts
+++ b/server/tests/utils/testInitUtils/createTestContext.ts
@@ -89,16 +89,65 @@ export const createTestContext = async () => {
 	} satisfies TestContext;
 };
 
-// Only create test context if we're actually running tests
-const isTestEnvironment =
-	process.env.NODE_ENV === "test" ||
-	process.argv.some((arg) => arg.includes("test")) ||
-	process.argv[1]?.includes("/tests/");
+/**
+ * Lazy-read default export. The actual TestContext is created once by the
+ * bun preload (`server/tests/setup-integration-tests.ts`) and stashed on
+ * `globalThis.__autumnTestContext`. We expose a Proxy here so the lookup
+ * happens on property ACCESS, not at module evaluation.
+ *
+ * Why this matters:
+ *
+ *  - The preload imports this module to call `createTestContext()`. That
+ *    triggers this module's evaluation BEFORE the preload's body runs, so
+ *    if we captured the stash at evaluation time it would be `undefined`
+ *    forever — the preload would set `globalThis` after the const had
+ *    already frozen to null.
+ *
+ *  - Previously this module did a top-level `await createTestContext()`
+ *    here, which made the module async and put its default export in TDZ
+ *    until the await resolved. With many test files concurrently loading
+ *    in one process, importers could race ahead of the not-yet-finalized
+ *    default export and throw `ReferenceError: Cannot access 'defaultCtx'
+ *    before initialization`. The Proxy eliminates that window — the module
+ *    evaluates synchronously and the lookup is deferred to first property
+ *    access on the default export, by which time the preload has finished.
+ *
+ *  - For unit tests (which skip integration preload), property access
+ *    throws a clear "preload did not run" message instead of the cryptic
+ *    `Cannot read property X of null` of the previous implementation.
+ *    Unit tests don't access the default export anyway.
+ */
+const lazyDefaultCtx = new Proxy({} as TestContext, {
+	get(_target, prop, _receiver) {
+		const ctx = (globalThis as { __autumnTestContext?: TestContext | null })
+			.__autumnTestContext;
+		if (ctx == null) {
+			throw new Error(
+				`Default TestContext is not initialized. The integration test ` +
+					`preload (server/tests/setup-integration-tests.ts) did not ` +
+					`populate globalThis.__autumnTestContext before "${String(prop)}" ` +
+					`was accessed. This usually means a unit test is reaching for ` +
+					`the default ctx, or the preload was bypassed.`,
+			);
+		}
+		return Reflect.get(ctx, prop);
+	},
+	has(_target, prop) {
+		const ctx = (globalThis as { __autumnTestContext?: TestContext | null })
+			.__autumnTestContext;
+		return ctx != null && prop in ctx;
+	},
+	ownKeys(_target) {
+		const ctx = (globalThis as { __autumnTestContext?: TestContext | null })
+			.__autumnTestContext;
+		return ctx == null ? [] : Reflect.ownKeys(ctx);
+	},
+	getOwnPropertyDescriptor(_target, prop) {
+		const ctx = (globalThis as { __autumnTestContext?: TestContext | null })
+			.__autumnTestContext;
+		if (ctx == null) return undefined;
+		return Reflect.getOwnPropertyDescriptor(ctx, prop);
+	},
+});
 
-let testContext: TestContext | null = null;
-
-if (isTestEnvironment) {
-	testContext = await createTestContext();
-}
-
-export default testContext as TestContext;
+export default lazyDefaultCtx;

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -230,10 +230,7 @@ type ConfigFn = (config: ScenarioConfig) => ScenarioConfig;
 // HELPER FUNCTIONS
 // ═══════════════════════════════════════════════════════════════════
 
-/**
- * Generate entity definitions from count and featureId.
- * Creates entities with ids "ent-1", "ent-2", etc.
- */
+/** Builds entities with ids "ent-1", "ent-2", etc. */
 const generateEntities = (config: EntityConfig): GeneratedEntity[] => {
 	return Array.from({ length: config.count }, (_, i) => ({
 		id: `ent-${i + 1}`,
@@ -247,22 +244,10 @@ const generateEntities = (config: EntityConfig): GeneratedEntity[] => {
 // ═══════════════════════════════════════════════════════════════════
 
 /**
- * Configure customer options: test clock, payment method, customer data, and default product.
- * @param testClock - Enable Stripe test clock for time manipulation (default: true)
- * @param paymentMethod - Attach payment method: "success", "fail", or "authenticate"
- * @param data - Customer metadata (fingerprint, name, email, etc.)
- * @param withDefault - Attach the default product on creation (default: false)
- * @param defaultGroup - The product group to use for default product selection
- * @param skipWebhooks - Skip sending webhooks for this customer creation (default: undefined, uses server default)
- * @param send_email_receipts - Whether to send email receipts to the customer
- * @param name - Override customer name (pass null for no name, undefined to use default)
- * @param email - Override customer email (pass null for no email, undefined to use default)
+ * Configure customer options: test clock, payment method, data, default product.
+ * Pass `name: null` / `email: null` for a nameless / emailless customer.
  * @example s.customer({ paymentMethod: "success" })
- * @example s.customer({ paymentMethod: "success", data: { name: "Test" } })
  * @example s.customer({ withDefault: true, defaultGroup: "enterprise" })
- * @example s.customer({ withDefault: true, skipWebhooks: false }) // Enable webhooks for testing
- * @example s.customer({ paymentMethod: "success", send_email_receipts: true })
- * @example s.customer({ name: null, email: null }) // Customer with no name or email
  */
 const customer = ({
 	testClock = true,
@@ -304,14 +289,9 @@ const customer = ({
 };
 
 /**
- * Define products to create for this test scenario.
- * Products are prefixed with customerId for test isolation.
- * @param list - Array of ProductV2 objects
- * @param prefix - Optional custom prefix for product IDs (defaults to customerId or "shared")
- * @param customerIdsToDelete - Array of customer IDs to delete before creating products
+ * Products for this scenario. Auto-prefixed with customerId for isolation.
  * @example s.products({ list: [pro, free] })
- * @example s.products({ list: [freeDefault], prefix: "my-prefix" }) // custom prefix when no customerId
- * @example s.products({ list: [pro, free], customerIdsToDelete: [customerId] })
+ * @example s.products({ list: [freeDefault], prefix: "my-prefix" })
  */
 const products = ({
 	list,
@@ -331,13 +311,8 @@ const products = ({
 };
 
 /**
- * Define entities to create for this test scenario.
- * Entities are auto-generated with ids "ent-1", "ent-2", etc.
- * @param count - Number of entities to create
- * @param featureId - Feature ID for all entities (e.g., TestFeature.Users)
- * @param defaultGroup - Optional default_group passed via customer_data.internal_options
+ * Auto-generates entities with ids "ent-1", "ent-2", etc.
  * @example s.entities({ count: 2, featureId: TestFeature.Users })
- * @example s.entities({ count: 1, featureId: TestFeature.Users, defaultGroup: "my-customer" })
  */
 const entities = ({
 	count,
@@ -355,10 +330,7 @@ const entities = ({
 };
 
 /**
- * Define additional customers for this test scenario.
- * Useful for referral tests where you need a referrer and redeemer.
- * Other customers share the same test clock as the primary customer.
- * @param customers - Array of customer configurations
+ * Additional customers (e.g. referrer/redeemer). Share the primary's test clock.
  * @example s.otherCustomers([{ id: "redeemer", paymentMethod: "success" }])
  */
 const otherCustomers = (customers: OtherCustomerConfig[]): ConfigFn => {
@@ -366,11 +338,8 @@ const otherCustomers = (customers: OtherCustomerConfig[]): ConfigFn => {
 };
 
 /**
- * Define a referral program for this test scenario.
- * IDs are auto-suffixed with the product prefix for test isolation.
- * @param reward - The reward configuration
- * @param program - The referral program configuration
- * @example s.referralProgram({ reward: rewards.monthOff(), program: referralPrograms.onCheckoutReferrer({ ... }) })
+ * Referral program. IDs auto-suffixed with productPrefix for isolation.
+ * @example s.referralProgram({ reward: rewards.monthOff(), program: referralPrograms.onCheckoutReferrer({...}) })
  */
 const referralProgramSetup = ({
 	reward,
@@ -383,10 +352,7 @@ const referralProgramSetup = ({
 };
 
 /**
- * Define a reward/coupon for this test scenario.
- * Reward ID is auto-suffixed with the product prefix for test isolation.
- * @param reward - The reward configuration (from constructCoupon)
- * @param productId - The product ID to apply this reward to
+ * Reward/coupon. Reward ID auto-suffixed with productPrefix.
  * @example s.reward({ reward: constructCoupon({ id: "50-off", discountValue: 50, ... }), productId: "pro" })
  */
 const rewardSetup = ({
@@ -403,22 +369,10 @@ const rewardSetup = ({
 };
 
 /**
- * Attach a product to the customer or a specific entity.
- * Product ID is auto-prefixed with customerId.
- * Actions are executed in the order they appear in the actions array.
- * @param productId - The product ID (without prefix)
- * @param customerId - Optional: use this customer instead of primary (from otherCustomers)
- * @param entityIndex - Optional entity index (0-based) to attach to (omit for customer-level)
- * @param options - Optional feature options (e.g., prepaid quantity)
- * @param newBillingSubscription - Create a separate Stripe subscription for this product
- * @param timeout - Optional timeout in milliseconds for the attach request
- * @example s.attach({ productId: "pro" }) // customer-level
- * @example s.attach({ productId: "pro", customerId: "redeemer" }) // attach to other customer
- * @example s.attach({ productId: "pro", entityIndex: 0 }) // attach to first entity (ent-1)
- * @example s.attach({ productId: "free", entityIndex: 1 }) // attach to second entity (ent-2)
+ * Attach a product to the customer or an entity. Product ID auto-prefixed.
+ * @example s.attach({ productId: "pro" })
+ * @example s.attach({ productId: "pro", entityIndex: 0 })
  * @example s.attach({ productId: "pro", options: [{ feature_id: "messages", quantity: 100 }] })
- * @example s.attach({ productId: "addon", newBillingSubscription: true }) // separate subscription
- * @example s.attach({ productId: "pro", timeout: 5000 }) // with timeout
  */
 const attach = ({
 	productId,
@@ -455,12 +409,9 @@ const attach = ({
 };
 
 /**
- * Cancel a product subscription for the customer or a specific entity.
- * Actions are executed in the order they appear in the actions array.
- * @param productId - The product ID (without prefix)
- * @param entityIndex - Optional entity index (0-based) to cancel for (omit for customer-level)
- * @example s.cancel({ productId: "pro" }) // customer-level
- * @example s.cancel({ productId: "pro", entityIndex: 0 }) // cancel for first entity
+ * Cancel a product subscription for the customer or an entity.
+ * @example s.cancel({ productId: "pro" })
+ * @example s.cancel({ productId: "pro", entityIndex: 0 })
  */
 const cancel = ({
 	productId,
@@ -479,25 +430,10 @@ const cancel = ({
 };
 
 /**
- * Advance the Stripe test clock.
- * Actions are executed in the order they appear in the actions array.
- * Multiple advanceTestClock calls are executed sequentially, each starting from where the previous one ended.
- * @param days - Number of days to advance
- * @param weeks - Number of weeks to advance
- * @param hours - Number of hours to advance
- * @param months - Number of months to advance
- * @param toNextInvoice - Advance to next billing cycle + invoice finalization time
- * @param waitForSeconds - Wait for Stripe webhooks to process after advancing
- * @example s.advanceTestClock({ days: 15 }) // advance 15 days
- * @example s.advanceTestClock({ months: 1 }) // advance 1 month
- * @example s.advanceTestClock({ toNextInvoice: true }) // advance to next invoice
- * @example s.advanceTestClock({ days: 8, waitForSeconds: 30 }) // advance 8 days, wait 30s for webhooks
- * @example
- * // Interleaved actions:
- * s.attach({ productId: "pro" }),
- * s.advanceTestClock({ days: 7 }),
- * s.cancel({ productId: "pro" }),
- * s.advanceTestClock({ days: 3 }),
+ * Advance the Stripe test clock. Successive calls chain from the previous endpoint.
+ * @example s.advanceTestClock({ days: 15 })
+ * @example s.advanceTestClock({ toNextInvoice: true })
+ * @example s.advanceTestClock({ days: 8, waitForSeconds: 30 })
  */
 const advanceTestClock = ({
 	days,
@@ -532,11 +468,8 @@ const advanceTestClock = ({
 };
 
 /**
- * Attach or replace a payment method for the customer.
- * Useful for testing payment failures or 3DS authentication flows mid-scenario.
- * @param type - Payment method type: "success", "fail", or "authenticate"
- * @example s.attachPaymentMethod({ type: "authenticate" }) // attach 3DS-required card
- * @example s.attachPaymentMethod({ type: "fail" }) // attach card that will fail
+ * Attach/replace the customer's payment method. Useful for mid-scenario PM swaps.
+ * @example s.attachPaymentMethod({ type: "authenticate" })
  */
 const attachPaymentMethod = ({
 	type,
@@ -555,11 +488,7 @@ const attachPaymentMethod = ({
 	});
 };
 
-/**
- * Remove all payment methods from the customer.
- * Useful for testing "no payment method" scenarios.
- * @example s.removePaymentMethod()
- */
+/** Remove all of the customer's payment methods. */
 const removePaymentMethod = (): ConfigFn => {
 	return (config) => ({
 		...config,
@@ -573,14 +502,9 @@ const removePaymentMethod = (): ConfigFn => {
 };
 
 /**
- * Track usage for a feature on the customer or a specific entity.
- * @param featureId - The feature ID to track usage for
- * @param value - The usage value to track
- * @param entityIndex - Optional entity index (0-based) to track for (omit for customer-level)
- * @param timeout - Optional timeout in milliseconds to wait after tracking (for sync)
- * @example s.track({ featureId: TestFeature.Messages, value: 300 }) // customer-level
- * @example s.track({ featureId: TestFeature.Messages, value: 250, entityIndex: 0 }) // entity-level
- * @example s.track({ featureId: TestFeature.Messages, value: 300, timeout: 2000 }) // with timeout
+ * Track feature usage for the customer or an entity.
+ * @example s.track({ featureId: TestFeature.Messages, value: 300 })
+ * @example s.track({ featureId: TestFeature.Messages, value: 250, entityIndex: 0 })
  */
 const track = ({
 	featureId,
@@ -609,14 +533,9 @@ const track = ({
 };
 
 /**
- * Update a subscription (e.g., cancel end of cycle, add items).
- * @param productId - The product ID (without prefix)
- * @param entityIndex - Optional entity index (0-based) for entity-level subscription
- * @param cancelAction - Cancel action: "cancel_end_of_cycle", "cancel_immediately", or "uncancel"
- * @param items - Optional items to add/update on the subscription
- * @example s.updateSubscription({ productId: "pro", cancelAction: "cancel_end_of_cycle" }) // customer-level
- * @example s.updateSubscription({ productId: "pro", entityIndex: 0, cancelAction: "cancel_end_of_cycle" }) // entity-level
- * @example s.updateSubscription({ productId: "pro", items: [consumableItem] }) // add items
+ * Update a subscription (cancel end-of-cycle, add items, etc.).
+ * @example s.updateSubscription({ productId: "pro", cancelAction: "cancel_end_of_cycle" })
+ * @example s.updateSubscription({ productId: "pro", items: [consumableItem] })
  */
 const updateSubscription = ({
 	productId,
@@ -645,10 +564,8 @@ const updateSubscription = ({
 };
 
 /**
- * Advance the test clock to the next invoice cycle.
- * @param withPause - If true, advances in two steps (to month boundary, then to finalize)
- * @example s.advanceToNextInvoice()
- * @example s.advanceToNextInvoice({ withPause: true })
+ * Advance the test clock to the next invoice cycle. `withPause` advances in
+ * two steps (month boundary, then finalize).
  */
 const advanceToNextInvoice = ({
 	withPause,
@@ -668,12 +585,8 @@ const advanceToNextInvoice = ({
 };
 
 /**
- * Reset a feature's usage cycle to simulate end-of-cycle rollover creation.
- * Use this for FREE products (no Stripe subscription) to create rollovers.
- * For PAID products, use s.advanceToNextInvoice() instead.
- *
- * @param featureId - The feature ID to reset
- * @param timeout - Optional timeout in milliseconds to wait after reset (default: 2000)
+ * Reset a feature's usage cycle. Use for FREE products (no Stripe sub);
+ * use s.advanceToNextInvoice() for PAID products.
  * @example s.resetFeature({ featureId: TestFeature.Messages })
  */
 const resetFeature = ({
@@ -697,10 +610,7 @@ const resetFeature = ({
 };
 
 /**
- * Delete a customer before the test runs.
- * Uses API to clear cache. Silently ignores if customer doesn't exist.
- * @param customerId - Delete by customer ID
- * @param email - Delete all customers with this email
+ * Delete a customer before the test runs (silent if missing). Clears cache via API.
  * @example s.deleteCustomer({ customerId: "test-customer" })
  * @example s.deleteCustomer({ email: "test@example.com" })
  */
@@ -731,26 +641,11 @@ const deleteCustomer = (
 };
 
 /**
- * Attach a product using the NEW billing/attach V2 endpoint.
- * Product ID is auto-prefixed with customerId.
- *
- * NOTE: Add-on is defined at product level using `products.recurringAddOn()` or
- * `products.base({ isAddOn: true })`, NOT in the attach params.
- *
- * @param productId - The product ID (without prefix)
- * @param customerId - Optional: use this customer instead of primary (from otherCustomers)
- * @param entityIndex - Optional entity index (0-based) to attach to (omit for customer-level)
- * @param options - Optional feature options (e.g., prepaid quantity)
- * @param newBillingSubscription - Create a separate Stripe subscription for this product
- * @param planSchedule - Override plan timing: "immediate" or "end_of_cycle"
- * @param timeout - Optional timeout in milliseconds for the attach request
- * @param items - Custom product items (creates is_custom customer product)
- * @param subscriptionId - Optional custom subscription ID for this attachment
- * @example s.billing.attach({ productId: "pro" }) // customer-level
- * @example s.billing.attach({ productId: "pro", customerId: "redeemer" }) // attach to other customer
- * @example s.billing.attach({ productId: "pro", entityIndex: 0 }) // attach to first entity
- * @example s.billing.attach({ productId: "pro", planSchedule: "end_of_cycle" }) // scheduled upgrade
- * @example s.billing.attach({ productId: "pro", items: [items.monthlyMessages({ includedUsage: 750 })] }) // custom plan
+ * Attach a product via /v1/billing.attach (V2). Product ID auto-prefixed.
+ * Add-on lives on the product (`products.recurringAddOn()`), not here.
+ * @example s.billing.attach({ productId: "pro" })
+ * @example s.billing.attach({ productId: "pro", planSchedule: "end_of_cycle" })
+ * @example s.billing.attach({ productId: "pro", items: [items.monthlyMessages({ includedUsage: 750 })] })
  */
 const billingAttach = ({
 	productId,
@@ -805,13 +700,8 @@ const billingAttach = ({
 };
 
 /**
- * Multi-attach multiple plans to a customer or entity via /billing.multi_attach.
- * @param plans - Array of plans to attach, each with productId and optional featureQuantities/version
- * @param entityIndex - Optional entity index (0-based) to attach to (omit for customer-level)
- * @param freeTrial - Optional free trial config applied to all plans
- * @param timeout - Optional timeout in milliseconds
+ * Multi-attach via /billing.multi_attach.
  * @example s.billing.multiAttach({ plans: [{ productId: "pro" }, { productId: "addon" }] })
- * @example s.billing.multiAttach({ plans: [{ productId: "pro" }], entityIndex: 0 })
  */
 const billingMultiAttach = ({
 	plans,
@@ -841,20 +731,14 @@ const billingMultiAttach = ({
 	});
 };
 
-/**
- * Alias for billing multi-attach to keep the short, top-level scenario-builder API consistent.
- */
+/** Top-level alias for billing multi-attach. */
 const multiAttach = billingMultiAttach;
 
 // ═══════════════════════════════════════════════════════════════════
 // REFERRAL ACTIONS
 // ═══════════════════════════════════════════════════════════════════
 
-/**
- * Create a referral code for the primary customer.
- * Requires s.referralProgram() to be configured.
- * @example s.referral.createCode()
- */
+/** Create a referral code (requires s.referralProgram()). */
 const createReferralCode = (): ConfigFn => {
 	return (config) => ({
 		...config,
@@ -862,12 +746,7 @@ const createReferralCode = (): ConfigFn => {
 	});
 };
 
-/**
- * Redeem the created referral code for a customer.
- * Requires s.referral.createCode() to be called first.
- * @param customerId - The customer ID to redeem for (from otherCustomers)
- * @example s.referral.redeem({ customerId: "redeemer" })
- */
+/** Redeem the referral code for `customerId` (requires s.referral.createCode() first). */
 const redeemReferralCode = ({
 	customerId,
 }: {
@@ -882,12 +761,7 @@ const redeemReferralCode = ({
 	});
 };
 
-/**
- * Create and redeem a referral code in one action.
- * Creates code for primary customer, redeems for specified customer.
- * @param customerId - The customer ID to redeem for (from otherCustomers)
- * @example s.referral.createAndRedeem({ customerId: "redeemer" })
- */
+/** Create code on primary, redeem for `customerId` in one step. */
 const createAndRedeemReferralCode = ({
 	customerId,
 }: {
@@ -903,24 +777,18 @@ const createAndRedeemReferralCode = ({
 };
 
 /**
- * Provision a fresh platform sub-org for this scenario via the
- * `POST /platform/organizations` endpoint, optionally with config overrides
- * (e.g. `automatic_tax: true`) and Stripe Tax registrations on its connect
- * account. The returned ctx is overridden to point at the sub-org so all
- * subsequent scenario operations (customer/product setup, attach, assertions)
- * route there instead of the master test org. Useful for isolating tests
- * that mutate org-level config.
+ * Provision a fresh platform sub-org via `POST /platform/organizations` and
+ * rebind ctx to it for the rest of the scenario. Use to isolate tests that
+ * mutate org-level config.
  *
- * Sub-org lifecycle: NOT cleaned up automatically at test end. Sub-orgs
- * persist in the master org's `created_by` set across runs until `bun cm`
- * (which runs `clearMasterOrg`) explicitly deletes them. Each call here uses
- * a randomized slug by default so accumulating sub-orgs don't collide.
+ * Sub-orgs are NOT auto-cleaned; `bun cm` runs `clearMasterOrg` to delete
+ * them. Slugs are randomized by default to avoid collisions.
  *
- * @param slug - Optional sub-org slug; defaults to a randomized "tax-XXXXXX".
- * @param name - Optional org display name; defaults to the slug.
- * @param userEmail - Optional owner email; defaults to "platform-tests@autumn.test".
- * @param configOverrides - Partial OrgConfig merged into the sub-org's config jsonb after creation.
- * @param taxRegistrations - List of countries to register Stripe Tax on the sub-org's connect account.
+ * @param slug - Sub-org slug; defaults to randomized "tax-XXXXXX".
+ * @param name - Display name; defaults to slug.
+ * @param userEmail - Owner email; defaults to "platform-tests@autumn.test".
+ * @param configOverrides - Merged into the sub-org's config jsonb.
+ * @param taxRegistrations - Countries to register Stripe Tax for.
  *
  * @example s.platform.create({ configOverrides: { automatic_tax: true }, taxRegistrations: ["AU"] })
  */
@@ -931,23 +799,7 @@ const platformCreate = (cfg: PlatformCreateConfig = {}): ConfigFn => {
 	});
 };
 
-/**
- * Scenario configuration functions.
- * Import and use with initScenario to configure test setup.
- * @example
- * ```typescript
- * import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
- *
- * const { autumnV1, ctx } = await initScenario({
- *   customerId: "my-test",
- *   options: [
- *     s.customer({ paymentMethod: "success" }),
- *     s.products({ list: [pro, free] }),
- *     s.attach({ productId: "pro" }),
- *   ],
- * });
- * ```
- */
+/** Scenario configuration functions for use with `initScenario`. */
 export const s = {
 	customer,
 	otherCustomers,
@@ -1001,58 +853,25 @@ const defaultConfig: ScenarioConfig = {
 };
 
 /**
- * Initialize a complete test scenario with customer, products, entities, and attachments.
- * Uses functional composition for flexible configuration.
- * Actions are executed in the exact order they appear in the actions array.
- *
- * @param customerId - Unique identifier used as customer ID and product prefix. If not provided, customer creation is skipped.
- * @param setup - Configuration functions (customer, products, entities)
- * @param actions - Action functions (attach, cancel, advanceTestClock) - executed in order
- * @returns autumnV1, autumnV2, ctx, testClockId, customer, entities, advancedTo
+ * Build a test scenario from setup/actions config functions. Customer
+ * creation is skipped when `customerId` is omitted (useful for null-id tests).
+ * Actions execute in array order.
  *
  * @example
  * ```typescript
- * // Simple test
  * const { autumnV1, ctx } = await initScenario({
  *   customerId: "simple-test",
- *   setup: [
- *     s.customer({ paymentMethod: "success" }),
- *     s.products({ list: [free] }),
- *   ],
- *   actions: [
- *     s.attach({ productId: "base" }),
- *   ],
- * });
- *
- * // Products only (no customer) - useful for null ID tests
- * const { autumnV1 } = await initScenario({
- *   setup: [s.products({ list: [freeDefault] })],
- *   actions: [],
- * });
- *
- * // Interleaved actions - executed in order
- * const { autumnV1, ctx, advancedTo } = await initScenario({
- *   customerId: "interleaved-test",
- *   setup: [
- *     s.customer({ testClock: true, paymentMethod: "success" }),
- *     s.products({ list: [pro] }),
- *   ],
- *   actions: [
- *     s.attach({ productId: "pro" }),
- *     s.advanceTestClock({ days: 7 }),  // Advance 7 days
- *     s.cancel({ productId: "pro" }),
- *     s.advanceTestClock({ days: 3 }),  // Advance another 3 days (10 total)
- *   ],
+ *   setup: [s.customer({ paymentMethod: "success" }), s.products({ list: [free] })],
+ *   actions: [s.attach({ productId: "base" })],
  * });
  * ```
  */
-// Other customer result type
 type OtherCustomerResult = {
 	id: string;
 	customer: Awaited<ReturnType<typeof initCustomerV3>>["customer"];
 };
 
-// Overload: when customerId is provided, return type has customerId: string
+// customerId provided -> customerId: string in return.
 export async function initScenario(params: {
 	customerId: string;
 	setup: ConfigFn[];
@@ -1078,7 +897,7 @@ export async function initScenario(params: {
 	redemption: RewardRedemption | null;
 }>;
 
-// Overload: when customerId is not provided, return type has customerId: undefined
+// customerId omitted -> customerId: undefined in return.
 export async function initScenario(params: {
 	customerId?: undefined;
 	setup: ConfigFn[];
@@ -1104,7 +923,6 @@ export async function initScenario(params: {
 	redemption: RewardRedemption | null;
 }>;
 
-// Implementation
 export async function initScenario({
 	customerId,
 	setup,
@@ -1116,16 +934,11 @@ export async function initScenario({
 	actions: ConfigFn[];
 	ctx?: TestContext;
 }) {
-	// Use provided context or fall back to default. May be reassigned below
-	// if `s.platform.create(...)` was used (sub-org provisioning).
+	// Use override or default ctx; may be rebound below if s.platform.create.
 	let ctx = ctxOverride ?? defaultCtx;
-	// Build config from setup and actions
 	const config = [...setup, ...actions].reduce((c, fn) => fn(c), defaultConfig);
 
-	// Provision a platform sub-org and re-bind ctx if requested. This must run
-	// BEFORE customer/product setup so all scenario operations route to the
-	// sub-org's Stripe Connect account and DB scope. The master org's secret
-	// key (from the current ctx) is used to authenticate the platform call.
+	// Sub-org provisioning runs first so subsequent setup hits the sub-org.
 	if (config.platformConfig) {
 		const masterAutumn = new AutumnInt({ secretKey: ctx.orgSecretKey });
 
@@ -1195,11 +1008,10 @@ export async function initScenario({
 		}
 	}
 
-	// 1. Initialize products & delete previous customers (prefix = customerId for isolation)
-	// Priority: explicit productPrefix > customerId > "shared"
+	// 1. Products + previous-customer cleanup. Prefix priority:
+	// productPrefix > customerId > "shared".
 	const productPrefix = config.productPrefix ?? customerId ?? "shared";
 
-	// Collect all customer IDs to delete (primary + other customers)
 	const otherCustomerIds = config.otherCustomers.map((c) => c.id);
 	const allCustomerIds = config.customerIds ?? [
 		...(customerId ? [customerId] : []),
@@ -1215,19 +1027,15 @@ export async function initScenario({
 		});
 	}
 
-	// 1.5. Initialize referral program (if configured)
-	// Suffix IDs with productPrefix for isolation and mutate in place
+	// 1.5. Referral program. Suffix IDs with productPrefix for isolation.
 	if (config.referralProgram) {
 		const { reward, program } = config.referralProgram;
 
-		// Suffix reward ID
 		reward.id = `${reward.id}_${productPrefix}`;
 
-		// Suffix program ID and update internal_reward_id reference
 		program.id = `${program.id}_${productPrefix}`;
 		program.internal_reward_id = reward.id;
 
-		// Suffix product_ids to match prefixed products
 		if (program.product_ids && program.product_ids.length > 0) {
 			program.product_ids = program.product_ids.map(
 				(pid) => `${pid}_${productPrefix}`,
@@ -1244,14 +1052,11 @@ export async function initScenario({
 		});
 	}
 
-	// 1.6. Initialize standalone rewards (if configured)
+	// 1.6. Standalone rewards. Suffix IDs with productPrefix.
 	for (const rewardConfig of config.rewards) {
 		const { reward, productId } = rewardConfig;
 
-		// Suffix reward ID with productPrefix for isolation
 		reward.id = `${reward.id}_${productPrefix}`;
-
-		// Suffix productId to match prefixed products
 		const prefixedProductId = `${productId}_${productPrefix}`;
 
 		await createReward({
@@ -1276,8 +1081,8 @@ export async function initScenario({
 			customerData: config.customerData,
 			attachPm: config.attachPm,
 			withTestClock: config.testClock,
-			withDefault: config.withDefault ?? false, // RIP
-			// Default group matches the product prefix (customerId) used in initProductsV0
+			withDefault: config.withDefault ?? false,
+			// Default group matches the product prefix used in initProductsV0.
 			defaultGroup: config.defaultGroup ?? customerId,
 			skipWebhooks: config.skipWebhooks,
 			sendEmailReceipts: config.sendEmailReceipts,
@@ -1289,7 +1094,7 @@ export async function initScenario({
 		customer = result.customer;
 	}
 
-	// 2.5. Initialize other customers (share test clock with primary customer)
+	// 2.5. Other customers — share the primary's test clock.
 	const otherCustomersMap = new Map<string, OtherCustomerResult>();
 	for (const otherCusConfig of config.otherCustomers) {
 		const otherResult = await initCustomerV3({
@@ -1297,7 +1102,7 @@ export async function initScenario({
 			customerId: otherCusConfig.id,
 			customerData: otherCusConfig.data,
 			attachPm: otherCusConfig.paymentMethod,
-			withTestClock: false, // Don't create a new test clock
+			withTestClock: false,
 			...(testClockId ? { existingTestClockId: testClockId } : {}),
 			withDefault: false,
 			defaultGroup: productPrefix,
@@ -1339,7 +1144,7 @@ export async function initScenario({
 		secretKey: ctx.orgSecretKey,
 	});
 
-	// 4. Create entities if any (requires customerId)
+	// 4. Entities (requires customerId).
 	if (generatedEntities.length > 0) {
 		if (!customerId) {
 			throw new Error(
@@ -1362,14 +1167,14 @@ export async function initScenario({
 		await autumnV1.entities.create(customerId, entityDefs);
 	}
 
-	// 5. Execute actions in order (attach, cancel, advanceClock, referrals)
+	// 5. Run actions in order.
 	let advancedTo: number = Date.now();
 	let referralCode: ReferralCode | null = null;
 	let redemption: RewardRedemption | null = null;
 
 	for (const action of config.actions) {
 		if (action.type === "attach") {
-			// Resolve target customer: action.customerId override or primary customerId
+			// Override or fall back to primary customerId.
 			const targetCustomerId = action.customerId ?? customerId;
 			if (!targetCustomerId) {
 				throw new Error(
@@ -1378,7 +1183,6 @@ export async function initScenario({
 			}
 			const prefixedProductId = `${action.productId}_${productPrefix}`;
 
-			// Resolve entityIndex to entityId
 			let entityId: string | undefined;
 			if (action.entityIndex !== undefined) {
 				if (action.entityIndex >= generatedEntities.length) {
@@ -1407,7 +1211,6 @@ export async function initScenario({
 			}
 			const prefixedProductId = `${action.productId}_${productPrefix}`;
 
-			// Resolve entityIndex to entityId
 			let entityId: string | undefined;
 			if (action.entityIndex !== undefined) {
 				if (action.entityIndex >= generatedEntities.length) {
@@ -1486,7 +1289,6 @@ export async function initScenario({
 				);
 			}
 
-			// Resolve entityIndex to entityId
 			let entityId: string | undefined;
 			if (action.entityIndex !== undefined) {
 				if (action.entityIndex >= generatedEntities.length) {
@@ -1514,7 +1316,6 @@ export async function initScenario({
 			}
 			const prefixedProductId = `${action.productId}_${productPrefix}`;
 
-			// Resolve entityIndex to entityId
 			let entityId: string | undefined;
 			if (action.entityIndex !== undefined) {
 				if (action.entityIndex >= generatedEntities.length) {
@@ -1565,7 +1366,7 @@ export async function initScenario({
 				});
 			}
 		} else if (action.type === "billingAttach") {
-			// Resolve target customer: action.customerId override or primary customerId
+			// Override or fall back to primary customerId.
 			const targetCustomerId = action.customerId ?? customerId;
 			if (!targetCustomerId) {
 				throw new Error(
@@ -1574,7 +1375,6 @@ export async function initScenario({
 			}
 			const prefixedProductId = `${action.productId}_${productPrefix}`;
 
-			// Resolve entityIndex to entityId
 			let entityId: string | undefined;
 			if (action.entityIndex !== undefined) {
 				if (action.entityIndex >= generatedEntities.length) {
@@ -1608,7 +1408,6 @@ export async function initScenario({
 				);
 			}
 
-			// Resolve entityIndex to entityId
 			let entityId: string | undefined;
 			if (action.entityIndex !== undefined) {
 				if (action.entityIndex >= generatedEntities.length) {
@@ -1693,9 +1492,7 @@ export async function initScenario({
 				);
 			}
 
-			// Product group is always the productPrefix (customerId)
-			// All products in a test share the same group unless explicitly overridden
-			// The productId param is not used for group - it was a naming confusion
+			// Product group is always productPrefix; productId param is unused.
 			const productGroup = productPrefix;
 
 			await resetAndGetCusEnt({
@@ -1705,7 +1502,7 @@ export async function initScenario({
 				featureId: action.featureId,
 			});
 
-			// Wait for cache to clear (default 2000ms)
+			// Wait for cache to clear.
 			const waitTime = action.timeout ?? 2000;
 			await new Promise((resolve) => setTimeout(resolve, waitTime));
 		}

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -1,7 +1,9 @@
+import type { CustomerData } from "@autumn/shared";
 import {
 	ApiVersion,
 	type CreateReward,
 	type CreateRewardProgram,
+	type OrgConfig,
 	type PlanTiming,
 	type ProductItem,
 	type ProductV2,
@@ -9,8 +11,8 @@ import {
 	type RewardRedemption,
 } from "@autumn/shared";
 import { resetAndGetCusEnt } from "@tests/balances/track/rollovers/rolloverTestUtils.js";
-import type { CustomerData } from "@autumn/shared";
 import { addHours, addMonths } from "date-fns";
+import type Stripe from "stripe";
 import { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { removeAllPaymentMethods } from "@/external/stripe/customers/paymentMethods/operations/removeAllPaymentMethods.js";
 import { CusService } from "@/internal/customers/CusService.js";
@@ -20,6 +22,10 @@ import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js"
 import { hoursToFinalizeInvoice } from "../constants.js";
 import { createReferralProgram, createReward } from "../productUtils.js";
 import { advanceTestClock as advanceTestClockFn } from "../stripeUtils.js";
+import {
+	createSubOrgTestContext,
+	type TaxRegistrationCountry,
+} from "./createSubOrgTestContext.js";
 import defaultCtx, { type TestContext } from "./createTestContext.js";
 
 // ═══════════════════════════════════════════════════════════════════
@@ -187,6 +193,14 @@ type CleanupConfig = {
 	emailsToDelete: string[];
 };
 
+type PlatformCreateConfig = {
+	slug?: string;
+	name?: string;
+	userEmail?: string;
+	configOverrides?: Partial<OrgConfig>;
+	taxRegistrations?: TaxRegistrationCountry[];
+};
+
 type ScenarioConfig = {
 	testClock: boolean;
 	attachPm?: "success" | "fail" | "authenticate" | "alipay";
@@ -197,6 +211,7 @@ type ScenarioConfig = {
 	sendEmailReceipts?: boolean;
 	nameOverride?: string | null;
 	emailOverride?: string | null;
+	stripeCustomerOverrides?: Partial<Stripe.CustomerCreateParams>;
 	products: ProductV2[];
 	productPrefix?: string;
 	entityConfig?: EntityConfig;
@@ -206,6 +221,7 @@ type ScenarioConfig = {
 	otherCustomers: OtherCustomerConfig[];
 	referralProgram?: ReferralProgramConfig;
 	rewards: RewardConfig[];
+	platformConfig?: PlatformCreateConfig;
 };
 
 type ConfigFn = (config: ScenarioConfig) => ScenarioConfig;
@@ -258,6 +274,7 @@ const customer = ({
 	send_email_receipts,
 	name,
 	email,
+	stripeCustomerOverrides,
 }: {
 	testClock?: boolean;
 	paymentMethod?: "success" | "fail" | "authenticate" | "alipay";
@@ -268,6 +285,7 @@ const customer = ({
 	send_email_receipts?: boolean;
 	name?: string | null;
 	email?: string | null;
+	stripeCustomerOverrides?: Partial<Stripe.CustomerCreateParams>;
 }): ConfigFn => {
 	return (config) => ({
 		...config,
@@ -280,6 +298,8 @@ const customer = ({
 		sendEmailReceipts: send_email_receipts ?? config.sendEmailReceipts,
 		nameOverride: name,
 		emailOverride: email,
+		stripeCustomerOverrides:
+			stripeCustomerOverrides ?? config.stripeCustomerOverrides,
 	});
 };
 
@@ -883,6 +903,35 @@ const createAndRedeemReferralCode = ({
 };
 
 /**
+ * Provision a fresh platform sub-org for this scenario via the
+ * `POST /platform/organizations` endpoint, optionally with config overrides
+ * (e.g. `automatic_tax: true`) and Stripe Tax registrations on its connect
+ * account. The returned ctx is overridden to point at the sub-org so all
+ * subsequent scenario operations (customer/product setup, attach, assertions)
+ * route there instead of the master test org. Useful for isolating tests
+ * that mutate org-level config.
+ *
+ * Sub-org lifecycle: NOT cleaned up automatically at test end. Sub-orgs
+ * persist in the master org's `created_by` set across runs until `bun cm`
+ * (which runs `clearMasterOrg`) explicitly deletes them. Each call here uses
+ * a randomized slug by default so accumulating sub-orgs don't collide.
+ *
+ * @param slug - Optional sub-org slug; defaults to a randomized "tax-XXXXXX".
+ * @param name - Optional org display name; defaults to the slug.
+ * @param userEmail - Optional owner email; defaults to "platform-tests@autumn.test".
+ * @param configOverrides - Partial OrgConfig merged into the sub-org's config jsonb after creation.
+ * @param taxRegistrations - List of countries to register Stripe Tax on the sub-org's connect account.
+ *
+ * @example s.platform.create({ configOverrides: { automatic_tax: true }, taxRegistrations: ["AU"] })
+ */
+const platformCreate = (cfg: PlatformCreateConfig = {}): ConfigFn => {
+	return (config) => ({
+		...config,
+		platformConfig: cfg,
+	});
+};
+
+/**
  * Scenario configuration functions.
  * Import and use with initScenario to configure test setup.
  * @example
@@ -925,6 +974,9 @@ export const s = {
 		createCode: createReferralCode,
 		redeem: redeemReferralCode,
 		createAndRedeem: createAndRedeemReferralCode,
+	},
+	platform: {
+		create: platformCreate,
 	},
 } as const;
 
@@ -1064,10 +1116,51 @@ export async function initScenario({
 	actions: ConfigFn[];
 	ctx?: TestContext;
 }) {
-	// Use provided context or fall back to default
-	const ctx = ctxOverride ?? defaultCtx;
+	// Use provided context or fall back to default. May be reassigned below
+	// if `s.platform.create(...)` was used (sub-org provisioning).
+	let ctx = ctxOverride ?? defaultCtx;
 	// Build config from setup and actions
 	const config = [...setup, ...actions].reduce((c, fn) => fn(c), defaultConfig);
+
+	// Provision a platform sub-org and re-bind ctx if requested. This must run
+	// BEFORE customer/product setup so all scenario operations route to the
+	// sub-org's Stripe Connect account and DB scope. The master org's secret
+	// key (from the current ctx) is used to authenticate the platform call.
+	if (config.platformConfig) {
+		const masterAutumn = new AutumnInt({ secretKey: ctx.orgSecretKey });
+
+		const slug =
+			config.platformConfig.slug ??
+			`tax-${Math.random().toString(36).slice(2, 8)}`;
+		const userEmail =
+			config.platformConfig.userEmail ?? "platform-tests@autumn.test";
+		const name = config.platformConfig.name ?? slug;
+
+		const response = (await masterAutumn.post("/platform/organizations", {
+			user_email: userEmail,
+			name,
+			slug,
+			env: "test",
+		})) as {
+			test_secret_key: string;
+			live_secret_key?: string;
+			org_slug: string;
+		};
+
+		ctx = await createSubOrgTestContext({
+			subOrgSlug: response.org_slug,
+			testSecretKey: response.test_secret_key,
+			configOverrides: config.platformConfig.configOverrides,
+			taxRegistrations: config.platformConfig.taxRegistrations,
+		});
+
+		console.log(
+			"[TEST] Creating sub-org:",
+			slug,
+			" | Impersonate via: ",
+			`http://localhost:3000/impersonate-redirect?org_id=${ctx.org.id}`,
+		);
+	}
 
 	// Generate entities from config
 	const generatedEntities = config.entityConfig
@@ -1190,6 +1283,7 @@ export async function initScenario({
 			sendEmailReceipts: config.sendEmailReceipts,
 			nameOverride: config.nameOverride,
 			emailOverride: config.emailOverride,
+			stripeCustomerOverrides: config.stripeCustomerOverrides,
 		});
 		testClockId = result.testClockId;
 		customer = result.customer;

--- a/shared/api/billing/common/billingParamsBase/billingParamsBaseV1.ts
+++ b/shared/api/billing/common/billingParamsBase/billingParamsBaseV1.ts
@@ -36,6 +36,21 @@ export const BillingParamsBaseV1Schema = z.object({
 		description:
 			"Invoice mode creates a draft or open invoice and sends it to the customer, instead of charging their card immediately. This uses Stripe's send_invoice collection method.",
 	}),
+
+	// Legacy V0 invoice-mode aliases. Accepted on V1+ schemas for callers
+	// (and tests) that still pass the flat fields. `setupInvoiceModeContext`
+	// promotes these into `invoice_mode` when the structured field is absent.
+	invoice: z.boolean().optional().meta({
+		description:
+			"Deprecated: legacy alias for `invoice_mode.enabled`. Prefer `invoice_mode: { enabled: true }`.",
+	}),
+	enable_product_immediately: z.boolean().optional().meta({
+		description:
+			"Deprecated: legacy alias for `invoice_mode.enable_plan_immediately`.",
+	}),
+	finalize_invoice: z.boolean().optional().meta({
+		description: "Deprecated: legacy alias for `invoice_mode.finalize`.",
+	}),
 	proration_behavior: BillingBehaviorSchema.optional().meta({
 		description:
 			"How to handle proration when updating an existing subscription. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges.",

--- a/shared/api/billing/common/billingParamsBase/billingParamsBaseV1.ts
+++ b/shared/api/billing/common/billingParamsBase/billingParamsBaseV1.ts
@@ -37,9 +37,8 @@ export const BillingParamsBaseV1Schema = z.object({
 			"Invoice mode creates a draft or open invoice and sends it to the customer, instead of charging their card immediately. This uses Stripe's send_invoice collection method.",
 	}),
 
-	// Legacy V0 invoice-mode aliases. Accepted on V1+ schemas for callers
-	// (and tests) that still pass the flat fields. `setupInvoiceModeContext`
-	// promotes these into `invoice_mode` when the structured field is absent.
+	// Legacy V0 flat aliases for `invoice_mode`. Promoted by
+	// `setupInvoiceModeContext` when the structured field is absent.
 	invoice: z.boolean().optional().meta({
 		description:
 			"Deprecated: legacy alias for `invoice_mode.enabled`. Prefer `invoice_mode: { enabled: true }`.",

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -36,6 +36,11 @@ export const OrgConfigSchema = z.object({
 	dryrun_autotopups: z.boolean().default(false),
 
 	forward_customer_metadata: z.boolean().default(false),
+
+	// Stripe Tax / VAT — when true, Stripe writes (invoices, subscriptions,
+	// checkout sessions) pass `automatic_tax: { enabled: true }` so Stripe
+	// computes tax server-side. Customer must have a tax-resolvable address.
+	automatic_tax: z.boolean().default(false),
 });
 
 export type OrgConfig = z.infer<typeof OrgConfigSchema>;

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -37,9 +37,8 @@ export const OrgConfigSchema = z.object({
 
 	forward_customer_metadata: z.boolean().default(false),
 
-	// Stripe Tax / VAT — when true, Stripe writes (invoices, subscriptions,
-	// checkout sessions) pass `automatic_tax: { enabled: true }` so Stripe
-	// computes tax server-side. Customer must have a tax-resolvable address.
+	// When true, Stripe writes pass `automatic_tax: { enabled: true }`.
+	// Customer must have a tax-resolvable address.
 	automatic_tax: z.boolean().default(false),
 });
 

--- a/vite/src/App.tsx
+++ b/vite/src/App.tsx
@@ -89,6 +89,10 @@ export default function App() {
 						element={<EdgeConfigView />}
 					/>
 					<Route
+						path="/sandbox/impersonate-redirect"
+						element={<ImpersonateRedirect />}
+					/>
+					<Route
 						path="/impersonate-redirect"
 						element={<ImpersonateRedirect />}
 					/>

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -24,9 +24,16 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import { useEnv } from "@/utils/envUtils";
-import { getStripeInvoiceLink } from "@/utils/linkUtils";
+import { notNullish } from "@/utils/genUtils";
+import {
+	getStripeConnectViewAsLink,
+	getStripeInvoiceLink,
+} from "@/utils/linkUtils";
+import { useAdmin } from "@/views/admin/hooks/useAdmin";
+import { useMasterStripeAccount } from "@/views/admin/hooks/useMasterStripeAccount";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { CustomerInvoiceStatus } from "../table/customer-invoices/CustomerInvoiceStatus";
 import { RefundInvoiceDialog } from "./RefundInvoiceDialog";
@@ -45,6 +52,12 @@ type ProductGroup = {
 	lineItemGroups: LineItemGroup[];
 };
 
+type InvoiceDetailSheetProps = {
+	invoice?: Invoice;
+	lineItems?: InvoiceLineItem[];
+	taxedAmount?: number;
+};
+
 /** Resolve a feature_id slug to its display name */
 const resolveFeatureName = ({
 	featureId,
@@ -58,15 +71,25 @@ const resolveFeatureName = ({
 	return feature?.name ?? featureId;
 };
 
-export function InvoiceDetailSheet() {
+export function InvoiceDetailSheet({
+	invoice: invoiceProp,
+	lineItems: lineItemsProp,
+	taxedAmount: taxedAmountProp,
+}: InvoiceDetailSheetProps = {}) {
 	const sheetData = useSheetStore((s) => s.data);
-	const invoice = sheetData?.invoice as Invoice | undefined;
-	const lineItems = (sheetData?.lineItems as InvoiceLineItem[]) ?? [];
+	const invoice = invoiceProp ?? (sheetData?.invoice as Invoice | undefined);
+	const lineItems =
+		lineItemsProp ?? ((sheetData?.lineItems as InvoiceLineItem[]) || []);
+	const taxedAmount =
+		taxedAmountProp ?? (sheetData?.taxedAmount as number | undefined);
 
 	const { stripeAccount } = useOrgStripeQuery();
 	const { features } = useFeaturesQuery();
 	const { products } = useProductsQuery();
 	const env = useEnv();
+	const { isAdmin } = useAdmin();
+	const { masterStripeAccount } = useMasterStripeAccount();
+	const { data: sessionData } = useSession();
 	const [refundDialogOpen, setRefundDialogOpen] = useState(false);
 	const { customer } = useCusQuery();
 
@@ -143,6 +166,18 @@ export function InvoiceDetailSheet() {
 		isStripeCustomer &&
 		invoice.status === InvoiceStatus.Paid &&
 		!isFullyRefunded;
+	const stripeConnectViewAsInvoiceLink =
+		isAdmin &&
+		notNullish(sessionData?.session?.impersonatedBy) &&
+		masterStripeAccount?.id &&
+		stripeAccount?.id
+			? getStripeConnectViewAsLink({
+					masterAccountId: masterStripeAccount.id,
+					connectedAccountId: stripeAccount.id,
+					env,
+					path: `invoices/${invoice.stripe_id}`,
+				})
+			: null;
 
 	const formatAmount = (amount: number, currency: string) => {
 		const absAmount = Math.abs(amount);
@@ -172,6 +207,11 @@ export function InvoiceDetailSheet() {
 	};
 
 	const handleViewInvoice = () => {
+		if (stripeConnectViewAsInvoiceLink) {
+			window.open(stripeConnectViewAsInvoiceLink, "_blank");
+			return;
+		}
+
 		if (invoice.hosted_invoice_url) {
 			window.open(invoice.hosted_invoice_url, "_blank");
 		} else {
@@ -231,6 +271,14 @@ export function InvoiceDetailSheet() {
 			{/* Invoice Total */}
 			<SheetSection withSeparator={true}>
 				<div className="space-y-2">
+					{taxedAmount != null && taxedAmount > 0 && (
+						<div className="flex items-center justify-between">
+							<span className="text-sm text-t2">Tax</span>
+							<span className="text-sm tabular-nums text-t2">
+								{formatSignedAmount(taxedAmount, invoice.currency)}
+							</span>
+						</div>
+					)}
 					<div className="flex items-center justify-between">
 						<span className="text-sm font-medium text-foreground">Total</span>
 						<span className="text-sm font-semibold text-foreground tabular-nums">

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -58,7 +58,7 @@ type InvoiceDetailSheetProps = {
 	taxedAmount?: number;
 };
 
-/** Resolve a feature_id slug to its display name */
+/** Resolve feature_id to its display name. */
 const resolveFeatureName = ({
 	featureId,
 	features,
@@ -94,7 +94,7 @@ export function InvoiceDetailSheet({
 	const { customer } = useCusQuery();
 
 	const productGroups = useMemo(() => {
-		// Step 1: bucket line items by product_id
+		// Bucket line items by product_id, then group within each bucket.
 		const byProduct = new Map<string, InvoiceLineItem[]>();
 		for (const item of lineItems) {
 			const key = item.product_id ?? "__unknown__";
@@ -106,7 +106,6 @@ export function InvoiceDetailSheet({
 			}
 		}
 
-		// Step 2: within each product bucket, group into LineItemGroups
 		const result: ProductGroup[] = [];
 		for (const [productKey, items] of byProduct) {
 			const groups = new Map<string, LineItemGroup>();
@@ -420,11 +419,10 @@ function LineItemGroupRow({
 		},
 	];
 
-	// For multi-item groups (tiered), show grouped display
+	// Tiered groups: header + per-tier rows.
 	if (!isSingleItem) {
 		return (
 			<div className="flex flex-col py-1">
-				{/* Group header with label and total */}
 				<div className="flex items-start justify-between gap-2">
 					<div className="flex flex-col min-w-0 flex-1 gap-0.5">
 						<div className="flex items-center gap-1.5">
@@ -463,7 +461,6 @@ function LineItemGroupRow({
 		);
 	}
 
-	// Single item display
 	const isRefund = firstItem.direction === "refund";
 	const paidAmount = firstItem.amount_after_discounts ?? firstItem.amount;
 
@@ -495,7 +492,6 @@ function LineItemGroupRow({
 						{period && <span className="text-xs text-t4">{period}</span>}
 					</div>
 					<div className="flex flex-col items-end shrink-0">
-						{/* Show original amount with strikethrough if discounted */}
 						{hasDiscounts && paidAmount !== firstItem.amount && (
 							<span className="text-xs tabular-nums text-t4 line-through">
 								{isRefund ? "-" : ""}
@@ -514,7 +510,6 @@ function LineItemGroupRow({
 					</div>
 				</div>
 
-				{/* Discount details */}
 				{hasDiscounts && (
 					<div className="mt-1 flex flex-wrap gap-1.5">
 						{firstItem.discounts.map((discount) => (
@@ -579,7 +574,6 @@ function DiscountBadge({
 	currency: string;
 	formatAmount: (amount: number, currency: string) => string;
 }) {
-	// Show percent_off if defined, otherwise show formatted amount_off
 	const label = discount.percent_off
 		? `${discount.percent_off}% off`
 		: `${formatAmount(discount.amount_off, currency)} off`;

--- a/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
@@ -35,7 +35,7 @@ export function CustomerInvoicesTable() {
 		[customer?.invoices],
 	);
 
-	const { lineItemsByInvoiceId } = useInvoiceLineItemsQuery({
+	const { lineItemsByInvoiceId, taxInfo } = useInvoiceLineItemsQuery({
 		customerId: customer?.id || customer?.internal_id,
 		invoiceIds,
 		enabled: invoiceIds.length > 0,
@@ -43,11 +43,13 @@ export function CustomerInvoicesTable() {
 
 	const handleRowClick = (invoice: Invoice) => {
 		const lineItems = lineItemsByInvoiceId[invoice.id] ?? [];
+		const taxedAmount = taxInfo[invoice.id]?.taxed_amount;
 		setSheet({
 			type: "invoice-detail",
 			data: {
 				invoice,
 				lineItems,
+				taxedAmount,
 			},
 		});
 	};

--- a/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-invoices/CustomerInvoicesTable.tsx
@@ -29,7 +29,6 @@ export function CustomerInvoicesTable() {
 		[customer?.invoices, products],
 	);
 
-	// Fetch line items for all invoices
 	const invoiceIds = useMemo(
 		() => customer?.invoices?.map((inv: Invoice) => inv.id) ?? [],
 		[customer?.invoices],

--- a/vite/src/views/customers2/customer/CustomerActions.tsx
+++ b/vite/src/views/customers2/customer/CustomerActions.tsx
@@ -5,7 +5,6 @@ import {
 	ArrowsClockwiseIcon,
 	BracketsSquareIcon,
 	CaretDownIcon,
-	LinkIcon,
 	PencilSimpleIcon,
 	SubtractIcon,
 	TicketIcon,
@@ -28,11 +27,12 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useDropdownShortcut } from "@/hooks/useDropdownShortcut";
+import { useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import { CusService } from "@/services/customers/CusService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
-import { getBackendErr } from "@/utils/genUtils";
+import { getBackendErr, notNullish } from "@/utils/genUtils";
 import {
 	getRevenueCatCusLink,
 	getStripeConnectViewAsLink,
@@ -64,8 +64,22 @@ export function CustomerActions() {
 	const setSheet = useSheetStore((s) => s.setSheet);
 	const env = useEnv();
 	const axiosInstance = useAxiosInstance();
+	const { data: sessionData } = useSession();
 
 	const stripeCustomerId = customer?.processor?.id;
+	const stripeConnectViewAsCustomerLink =
+		isAdmin &&
+		notNullish(sessionData?.session?.impersonatedBy) &&
+		masterStripeAccount?.id &&
+		stripeAccount?.id &&
+		stripeCustomerId
+			? getStripeConnectViewAsLink({
+					masterAccountId: masterStripeAccount.id,
+					connectedAccountId: stripeAccount.id,
+					env,
+					path: `customers/${stripeCustomerId}`,
+				})
+			: null;
 
 	const hasContinuousUseFeatures = features?.some(
 		(feature: Feature) =>
@@ -187,11 +201,12 @@ export function CustomerActions() {
 							<DropdownMenuItem
 								onClick={() => {
 									window.open(
-										getStripeCusLink({
-											customerId: stripeCustomerId,
-											env,
-											accountId: stripeAccount?.id,
-										}),
+										stripeConnectViewAsCustomerLink ??
+											getStripeCusLink({
+												customerId: stripeCustomerId,
+												env,
+												accountId: stripeAccount?.id,
+											}),
 										"_blank",
 									);
 								}}
@@ -216,28 +231,6 @@ export function CustomerActions() {
 							Open in Admin Panel
 						</DropdownMenuItem>
 					)}
-					{isAdmin &&
-						masterStripeAccount?.id &&
-						stripeAccount?.id &&
-						customer?.processor?.type === ProcessorType.Stripe && (
-							<DropdownMenuItem
-								onClick={() => {
-									window.open(
-										getStripeConnectViewAsLink({
-											masterAccountId: masterStripeAccount.id,
-											connectedAccountId: stripeAccount.id,
-											env,
-											path: `customers/${stripeCustomerId}`,
-										}),
-										"_blank",
-									);
-								}}
-								className="flex gap-2"
-							>
-								<LinkIcon className="size-3.5" />
-								View in Stripe Connect
-							</DropdownMenuItem>
-						)}
 					{((customer?.processor?.id &&
 						customer.processor.type === ProcessorType.RevenueCat) ||
 						customer?.customer_products?.some(

--- a/vite/src/views/customers2/hooks/useInvoiceLineItemsQuery.ts
+++ b/vite/src/views/customers2/hooks/useInvoiceLineItemsQuery.ts
@@ -4,6 +4,13 @@ import { useMemo } from "react";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 
+type InvoiceTaxInfo = Record<string, { taxed_amount: number }>;
+
+type InvoiceLineItemsResponse = {
+	line_items: InvoiceLineItem[];
+	tax_info?: InvoiceTaxInfo;
+};
+
 export const useInvoiceLineItemsQuery = ({
 	customerId,
 	invoiceIds,
@@ -16,9 +23,9 @@ export const useInvoiceLineItemsQuery = ({
 	const axiosInstance = useAxiosInstance();
 	const buildKey = useQueryKeyFactory();
 
-	const fetcher = async (): Promise<InvoiceLineItem[]> => {
+	const fetcher = async (): Promise<InvoiceLineItemsResponse> => {
 		if (invoiceIds.length === 0 || !customerId) {
-			return [];
+			return { line_items: [] };
 		}
 
 		const { data } = await axiosInstance.post(
@@ -28,7 +35,7 @@ export const useInvoiceLineItemsQuery = ({
 			},
 		);
 
-		return data.line_items ?? [];
+		return data ?? { line_items: [] };
 	};
 
 	const { data, isLoading, error, refetch } = useQuery({
@@ -43,18 +50,23 @@ export const useInvoiceLineItemsQuery = ({
 	>(() => {
 		if (!data) return {};
 
-		return data.reduce<Record<string, InvoiceLineItem[]>>((acc, lineItem) => {
-			const invoiceId = lineItem.invoice_id;
-			if (!acc[invoiceId]) {
-				acc[invoiceId] = [];
-			}
-			acc[invoiceId].push(lineItem);
-			return acc;
-		}, {});
+		return data.line_items.reduce<Record<string, InvoiceLineItem[]>>(
+			(acc, lineItem) => {
+				const invoiceId = lineItem.invoice_id;
+				if (!invoiceId) return acc;
+				if (!acc[invoiceId]) {
+					acc[invoiceId] = [];
+				}
+				acc[invoiceId].push(lineItem);
+				return acc;
+			},
+			{},
+		);
 	}, [data]);
 
 	return {
-		lineItems: data ?? [],
+		lineItems: data?.line_items || [],
+		taxInfo: data?.tax_info ?? {},
 		lineItemsByInvoiceId,
 		isLoading,
 		error,


### PR DESCRIPTION
- **feat: 🎸 worlds best accountant vs worlds best swe who wins**
- **fix: 🐛 unit test bugs**

## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements Stripe automatic tax (`automatic_tax: { enabled: true }`) across all billing write paths — subscriptions, invoices, checkout sessions, and proration — controlled by a new `org.config.automatic_tax` flag. It correctly skips auto-tax on invoice-mode paths (which lack buyer-facing address collection UI), adds backward-compatible legacy alias handling for the invoice mode params, and includes an extensive integration test suite with per-country Stripe Tax jurisdiction registration.

- **[Improvements]** `automatic_tax` injected into `subscriptions.create`, `subscriptions.update`, `invoices.create`, and `checkout.sessions.create` across all attach/upgrade code paths, with consistent invoice-mode skip guards.
- **[Improvements]** `deletePlatformSubOrg` extracted into a reusable helper; test infrastructure refactored with `createSubOrgTestContext` and a Proxy-based default ctx to eliminate TDZ races in concurrent test loading.
- **[Bug fixes]** `handleGetInvoiceLineItems` fetches Stripe invoice tax totals and returns them as `tax_info` for display in `InvoiceDetailSheet`, but the new code path lacks a `stripe_id` null guard — invoices without a Stripe ID (e.g. $0 records) will crash the endpoint.
- **[API changes]** `BillingParamsBaseV1Schema` accepts legacy V0 invoice-mode aliases (`invoice`, `enable_product_immediately`, `finalize_invoice`) alongside the structured `invoice_mode` object.
</details>

<h3>Confidence Score: 3/5</h3>

Hold for the missing stripe_id null guard — the new automatic-tax branch in handleGetInvoiceLineItems can crash the invoice line-items endpoint for any org with automatic_tax enabled if any invoice lacks a stripe_id.

One P1 (missing stripe_id null guard causes unhandled Stripe SDK throw on a user-facing endpoint) and two P2s (sequential fetches with sleep, redundant auto_tax strip-and-re-add). The P1 is narrowed to orgs with automatic_tax enabled and invoices without a stripe_id, but those conditions are plausible and the blast radius is the entire endpoint response for that customer.

server/src/internal/customers/internalHandlers/handleGetInvoiceLineItems.ts — missing stripe_id null guard and sequential fetch pattern

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/internalHandlers/handleGetInvoiceLineItems.ts | New automatic-tax branch fetches Stripe invoices sequentially with an artificial sleep and no null guard on `stripe_id`, risking crashes and slowness on user-facing endpoint |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts | Injects `automatic_tax` into all sub.update paths with correct invoice-mode guard; redundant strip-and-re-add of the field built by the action builder adds unnecessary complexity |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts | Adds `automatic_tax` to subscription update action with correct invoice-mode guard; `automatic_tax` exclusion from the `hasNoUpdates` check is correct and well-commented |
| server/src/internal/customers/add-product/handleCreateCheckout.ts | Injects auto-tax params in two separate checkout param blocks; injection wins over user-supplied params by being applied last — intentional but worth verifying both branches are necessary |
| server/src/internal/orgs/deleteOrg/deletePlatformSubOrg.ts | Well-structured extraction of platform sub-org deletion logic into a reusable helper with `skipLiveCustomerCheck` flag for test cleanup |
| server/tests/utils/testInitUtils/createTestContext.ts | Replaces top-level-await pattern with a Proxy deferring `globalThis.__autumnTestContext` lookup to first property access — eliminates TDZ race in concurrent test loading |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[billing.attach / attach request] --> B{org.config.automatic_tax?}
    B -- No --> C[Stripe call without automatic_tax]
    B -- Yes --> D{invoiceMode / invoiceOnly?}
    D -- Yes --> C
    D -- No --> E[Stripe call with automatic_tax: enabled]

    E --> F1[subscriptions.create\ncreateStripeSub2]
    E --> F2[subscriptions.update\nexecuteStripeSubscriptionOperation]
    E --> F3[invoices.create\nhandleOneOffFunction / createInvoiceForBilling]
    E --> F4[checkout.sessions.create\nbuildStripeCheckoutSessionAction]
    F4 --> G[billing_address_collection: required\ncustomer_update: address auto\ntax_id_collection: enabled]

    H[createProrationInvoice] --> I{org.config.automatic_tax?}
    I -- Yes --> J[automatic_tax: enabled - always charge_automatically]
    I -- No --> K[no automatic_tax]

    L[handleGetInvoiceLineItems] --> M{org.config.automatic_tax?}
    M -- No --> N[return line_items only]
    M -- Yes --> O[fetch Stripe invoices sequentially with 20ms sleep]
    O --> P{anyAutomaticTax?}
    P -- No --> N
    P -- Yes --> Q[return line_items + tax_info]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/customers/internalHandlers/handleGetInvoiceLineItems.ts:40-52
**Missing null guard on `stripe_id`**

`stripe.invoices.retrieve(invoice.stripe_id)` will be called for every invoice in `autumnInvoices`. If any invoice has a null/undefined `stripe_id` (e.g. $0 invoices, invoices created before Stripe sync, or non-Stripe-backed records), the Stripe SDK will throw `"No such invoice: 'null'"` — crashing the entire endpoint for all callers, not just the offending invoice. The original code path never touched Stripe, so this regression is new.

```typescript
for (const invoice of autumnInvoices) {
    await new Promise((res) => setTimeout(res, 20));
+   if (!invoice.stripe_id) continue;
    stripeInvoices.push({
        autumnInvoiceId: invoice.id,
        stripeInvoice: await stripe.invoices.retrieve(invoice.stripe_id),
    });
}
```

### Issue 2 of 3
server/src/internal/customers/internalHandlers/handleGetInvoiceLineItems.ts:37-52
**Sequential Stripe fetches with artificial sleep**

For an org with `automatic_tax` enabled, every call to the invoice line-items endpoint now issues N serial Stripe `invoices.retrieve` calls with a 20 ms sleep between each. For a customer with 20 invoices that's 400 ms of sleep alone, plus the latency of 20 round-trip HTTP calls — turning a lightweight DB read into an O(N) blocking request in a user-facing path. `Promise.all` eliminates both the artificial delay and the serial latency:

```typescript
const stripeInvoices = await Promise.all(
    autumnInvoices
        .filter((inv) => !!inv.stripe_id)
        .map(async (invoice) => ({
            autumnInvoiceId: invoice.id,
            stripeInvoice: await stripe.invoices.retrieve(invoice.stripe_id),
        })),
);
```

Stripe's API rate limits are in the hundreds of requests per second and are per-account, so fetching 10–20 invoices in parallel is well within bounds for a typical customer view.

### Issue 3 of 3
server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts:99-117
**Redundant strip-and-re-add of `automatic_tax`**

`buildStripeSubscriptionUpdateAction` already guards the `automatic_tax` field behind `ctx.org.config.automatic_tax && !billingContext.invoiceMode`, so the value it places in `subscriptionAction.params` is always identical to what `wantsAutoTax` evaluates here. Destructuring it out and re-spreading it adds complexity without changing behaviour — any future divergence between the two sites would silently produce inconsistency. Consider owning `automatic_tax` solely in the builder or solely in the executor.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 unit test bugs"](https://github.com/useautumn/autumn/commit/a9f955fb48fa82f4fee210317ae99757854a963c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30342480)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->