### PR TITLE
Add GSAP entrance animation to logo wall

### DIFF
--- a/apps/website/components/logo-wall.tsx
+++ b/apps/website/components/logo-wall.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { getGsap } from "@/lib/lazyGsap";
 
 const LOGOS = [
 	{ id: 1, name: "Mintlify", src: "/images/logos/mintlify_logo.svg.svg", className: "scale-90 md:scale-70" },
@@ -10,45 +12,91 @@ const LOGOS = [
 	{ id: 5, name: "T3.chat", src: "/images/logos/T3_svg.svg", className: "scale-65 md:scale-55" },
 ];
 
-const NUM_MOBILE_COLS = 3;
-const NUM_DESKTOP_COLS = 5;
-
 export default function LogoWall() {
+	const sectionRef = useRef<HTMLElement | null>(null);
+
+	useEffect(() => {
+		const section = sectionRef.current;
+		if (!section) return;
+
+		let ctx: { revert: () => void } | null = null;
+		let cancelled = false;
+
+		if (window.innerWidth < 1024) return;
+
+		getGsap().then((gsap) => {
+			if (cancelled) return;
+			ctx = gsap.context(() => {
+				gsap.set(".logo-wall-title", {
+					opacity: 0,
+					y: 20,
+					scale: 0.97,
+					transformOrigin: "center bottom",
+				});
+				gsap.set(".logo-wall-item", {
+					opacity: 0,
+					y: 15,
+					scale: 0.96,
+				});
+
+				const tl = gsap.timeline({
+					defaults: { overwrite: "auto" },
+					delay: 0.35,
+				});
+
+				tl.to(".logo-wall-title, .logo-wall-item", {
+					opacity: 1,
+					y: 0,
+					scale: 1,
+					duration: 1.1,
+					ease: "power3.out",
+				});
+			}, section);
+		});
+
+		return () => {
+			cancelled = true;
+			ctx?.revert();
+		};
+	}, []);
+
 	return (
-		<section className="w-full bg-[#0F0F0F]"
-		style={{
-			backgroundImage:
-				"radial-gradient(circle, rgba(255,255,255,0.06) 1px, transparent 1px)",
-			backgroundSize: "14px 14px",
-		}}>
+		<section
+			ref={sectionRef}
+			className="w-full bg-[#0F0F0F]"
+			style={{
+				backgroundImage:
+					"radial-gradient(circle, rgba(255,255,255,0.06) 1px, transparent 1px)",
+				backgroundSize: "14px 14px",
+			}}
+		>
 			<div className="flex flex-col">
 				<div className="px-4 xl:px-22.75 pt-10.5 flex items-center justify-center">
-					<span className="font-sans text-[14px] font-light text-[#FFFFFF99] tracking-[-2%] leading-5">
-						Powering millions of customers for growing startups 
+					<span className="logo-wall-title lg:opacity-0 font-sans text-[14px] font-light text-[#FFFFFF99] tracking-[-2%] leading-5">
+						Powering millions of customers for growing startups
 					</span>
 				</div>
 
-				{/* Logo grid — 2 cols on mobile, 3 cols on desktop */}
-			<div className="flex-1 flex flex-wrap justify-center md:grid md:grid-cols-5 px-4 py-4 md:py-0">
-				{LOGOS.map((logo) => (
-					<div
-						key={logo.id}
-						className="flex items-center justify-center min-h-[50px] md:min-h-[100px] border-[#292929] w-1/3 md:w-auto"
-					>
-						{logo.src && (
-							<img
-								src={logo.src}
-								alt={logo.name}
-								className={cn(
-									"h-5 md:h-7 w-auto max-w-full object-contain",
-									logo.className
-								)}
-								loading="lazy"
-							/>
-						)}
-					</div>
-				))}
-			</div>
+				<div className="flex-1 flex flex-wrap justify-center md:grid md:grid-cols-5 px-4 py-4 md:py-0">
+					{LOGOS.map((logo) => (
+						<div
+							key={logo.id}
+							className="logo-wall-item lg:opacity-0 flex items-center justify-center min-h-[50px] md:min-h-[100px] border-[#292929] w-1/3 md:w-auto"
+						>
+							{logo.src && (
+								<img
+									src={logo.src}
+									alt={logo.name}
+									className={cn(
+										"h-5 md:h-7 w-auto max-w-full object-contain",
+										logo.className,
+									)}
+									loading="lazy"
+								/>
+							)}
+						</div>
+					))}
+				</div>
 			</div>
 		</section>
 	);


### PR DESCRIPTION
## Summary
Adds a GSAP entrance animation to the logo wall component so it slides up in sync with the hero's AutumnConfig reveal on desktop. On mobile (<1024px), GSAP is skipped and elements remain immediately visible — matching the hero's existing mobile behavior.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests where applicable
- [x] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Additional Context
- Uses the same `getGsap()` lazy loader and `gsap.context()` cleanup pattern as the hero
- Timeline delay of 0.35s aligns with the 4th hero-reveal element (the AutumnConfig container) so both animate together
- Title and logos slide up as a single group (no per-logo stagger) with `power3.out` easing
- `lg:opacity-0` classes ensure elements start hidden on desktop for GSAP to reveal, while staying visible on mobile

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a GSAP entrance animation to the `LogoWall` component that slides the title and logos up on desktop (≥1024px), using the same `getGsap()` lazy loader, `gsap.context()` scoping, and `cancelled`-flag cleanup pattern already established in the hero. Mobile visitors are unaffected — elements remain immediately visible via the absence of the `lg:opacity-0` class at smaller breakpoints.

**Key changes:**
- [Improvements] GSAP entrance animation (opacity + translate-Y + scale) added to `logo-wall.tsx`, scoped to `section` ref with proper async cleanup.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is purely additive and well-scoped, with one P2 design concern about scroll-awareness.

Only P2 findings — the fixed-delay animation fires regardless of viewport position, which means most users won't see it since the logo wall is typically below the fold. No logic errors, no regressions, no security issues.

apps/website/components/logo-wall.tsx — the animation timing / scroll-trigger concern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/components/logo-wall.tsx | Adds GSAP entrance animation scoped to desktop (≥1024px) following the hero's lazy-load and context-cleanup pattern; one P2 concern about the fixed-delay animation firing regardless of scroll position. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant LogoWall
    participant getGsap
    participant GSAP

    Browser->>LogoWall: mount (useEffect)
    LogoWall->>LogoWall: check window.innerWidth
    alt mobile (< 1024px)
        LogoWall-->>Browser: return early, elements stay visible
    else desktop (≥ 1024px)
        LogoWall->>getGsap: getGsap()
        getGsap-->>GSAP: dynamic import("gsap")
        GSAP-->>LogoWall: gsap instance
        LogoWall->>GSAP: gsap.context(fn, sectionRef)
        GSAP->>GSAP: gsap.set(".logo-wall-title", opacity:0, y:20)
        GSAP->>GSAP: gsap.set(".logo-wall-item", opacity:0, y:15)
        GSAP->>GSAP: timeline delay 0.35s
        GSAP->>Browser: animate opacity→1, y→0, scale→1 (1.1s)
    end
    Browser->>LogoWall: unmount (cleanup)
    LogoWall->>LogoWall: cancelled = true
    LogoWall->>GSAP: ctx.revert()
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/website/components/logo-wall.tsx:42-53
**Animation plays without scroll-awareness**

The timeline fires after a fixed 0.35 s delay on every page load, regardless of whether the logo wall is in the viewport. On most screen heights the logo wall is below the fold, so the animation completes before the user ever scrolls to it — the entrance effect is invisible to the majority of visitors. The hero uses the same pattern, but the hero is always at the top of the page so it is always visible at page load; the logo wall is not in the same position.

Consider scoping the animation to when the section enters the viewport (e.g. via `IntersectionObserver` or GSAP ScrollTrigger), or at minimum kick off the tween only once the element is near the viewport.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add GSAP entrance animation to logo wall..."](https://github.com/useautumn/autumn/commit/c31a28fbf7380f37bebf280d5a6f9770e5124277) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30344994)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->