### PR TITLE
feat: 🎸 expand billing cotnrols auto top up

### DIFF
--- a/server/src/internal/balances/autoTopUp/repos/findAutoTopupLimitsByCustomer.ts
+++ b/server/src/internal/balances/autoTopUp/repos/findAutoTopupLimitsByCustomer.ts
@@ -1,0 +1,26 @@
+import { autoTopupLimitStates } from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+/**
+ * Fetch all auto_topup_limit_states rows for a customer (across features).
+ * Used by the read-side expand path to surface runtime purchase tracking.
+ */
+export const findAutoTopupLimitsByCustomer = async ({
+	ctx,
+	internalCustomerId,
+}: {
+	ctx: AutumnContext;
+	internalCustomerId: string;
+}) => {
+	const { org, env, db } = ctx;
+
+	return await db.query.autoTopupLimits.findMany({
+		where: and(
+			eq(autoTopupLimitStates.org_id, org.id),
+			eq(autoTopupLimitStates.env, env),
+			eq(autoTopupLimitStates.internal_customer_id, internalCustomerId),
+		),
+	});
+};

--- a/server/src/internal/balances/autoTopUp/repos/index.ts
+++ b/server/src/internal/balances/autoTopUp/repos/index.ts
@@ -1,9 +1,11 @@
 import { findAutoTopupLimitByScope } from "./findAutoTopupLimitByScope";
+import { findAutoTopupLimitsByCustomer } from "./findAutoTopupLimitsByCustomer";
 import { insertAutoTopupLimit } from "./insertAutoTopupLimit";
 import { updateAutoTopupLimitById } from "./updateAutoTopupLimitById";
 
 export const autoTopupLimitRepo = {
 	findByScope: findAutoTopupLimitByScope,
+	findAllByCustomer: findAutoTopupLimitsByCustomer,
 	insert: insertAutoTopupLimit,
 	updateById: updateAutoTopupLimitById,
 } as const;

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomer.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomer.ts
@@ -48,9 +48,19 @@ export const getApiCustomer = async ({
 		fullCus: fullCustomer,
 	});
 
+	const { billing_controls_override, ...standardExpand } = apiCustomerExpand;
+
 	const apiCustomer: ApiCustomerV5 = {
 		...cleanedBaseCustomer,
-		...apiCustomerExpand,
+		...standardExpand,
+		...(billing_controls_override
+			? {
+					billing_controls: {
+						...cleanedBaseCustomer.billing_controls,
+						auto_topups: billing_controls_override.auto_topups,
+					},
+				}
+			: {}),
 	};
 
 	// Apply version transformations based on API version

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpand.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpand.ts
@@ -1,6 +1,5 @@
 import {
 	ApiBaseEntitySchema,
-	type ApiCusExpand,
 	CustomerExpand,
 	type FullCusProduct,
 	type FullCustomer,
@@ -8,10 +7,12 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "../../CusService.js";
+import { getCusAutoTopupPurchaseLimits } from "../cusResponseUtils/getCusAutoTopupPurchaseLimits.js";
 import { getCusPaymentMethodRes } from "../cusResponseUtils/getCusPaymentMethodRes.js";
 import { getCusReferrals } from "../cusResponseUtils/getCusReferrals.js";
 import { getCusRewards } from "../cusResponseUtils/getCusRewards.js";
 import { getCusTrialsUsed } from "../cusResponseUtils/getCusTrialsUsed.js";
+import type { ApiCustomerExpandResult } from "./getApiCustomerExpandV2.js";
 
 export const getApiCustomerExpand = async ({
 	ctx,
@@ -21,7 +22,7 @@ export const getApiCustomerExpand = async ({
 	ctx: AutumnContext;
 	customerId?: string;
 	fullCus?: FullCustomer;
-}): Promise<ApiCusExpand> => {
+}): Promise<ApiCustomerExpandResult> => {
 	const { org, env, db, expand } = ctx;
 
 	// Filter out synthetic nested expand paths handled within sub-builders.
@@ -56,33 +57,40 @@ export const getApiCustomerExpand = async ({
 
 	const cusExpand = expand as CustomerExpand[];
 
-	const [rewards, referrals, paymentMethod, trialsUsed] = await Promise.all([
-		getCusRewards({
-			org,
-			env,
-			fullCus,
-			subIds: fullCus.customer_products.flatMap(
-				(cp: FullCusProduct) => cp.subscription_ids || [],
-			),
-			expand: cusExpand,
-		}),
-		getCusReferrals({
-			db,
-			fullCus,
-			expand: cusExpand,
-		}),
-		getCusPaymentMethodRes({
-			org,
-			env,
-			fullCus,
-			expand: cusExpand,
-		}),
-		getCusTrialsUsed({
-			ctx,
-			fullCus,
-			expand: cusExpand,
-		}),
-	]);
+	const [rewards, referrals, paymentMethod, trialsUsed, autoTopupsWithLimits] =
+		await Promise.all([
+			getCusRewards({
+				org,
+				env,
+				fullCus,
+				subIds: fullCus.customer_products.flatMap(
+					(cp: FullCusProduct) => cp.subscription_ids || [],
+				),
+				expand: cusExpand,
+			}),
+			getCusReferrals({
+				db,
+				fullCus,
+				expand: cusExpand,
+			}),
+			getCusPaymentMethodRes({
+				org,
+				env,
+				fullCus,
+				expand: cusExpand,
+			}),
+			getCusTrialsUsed({
+				ctx,
+				fullCus,
+				expand: cusExpand,
+			}),
+			getCusAutoTopupPurchaseLimits({
+				ctx,
+				internalCustomerId: fullCus.internal_id,
+				autoTopupsConfig: fullCus.auto_topups,
+				expand: cusExpand,
+			}),
+		]);
 
 	return {
 		trials_used: trialsUsed ?? undefined,
@@ -91,6 +99,9 @@ export const getApiCustomerExpand = async ({
 		// upcoming_invoice: upcomingInvoice,
 		referrals: referrals ?? undefined,
 		payment_method: paymentMethod ?? undefined,
+		billing_controls_override: autoTopupsWithLimits
+			? { auto_topups: autoTopupsWithLimits }
+			: undefined,
 	};
 };
 

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpandV2.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpandV2.ts
@@ -1,6 +1,7 @@
 import {
 	ApiBaseEntitySchema,
 	type ApiCusExpand,
+	type AutoTopupResponse,
 	CustomerExpand,
 	type FullCusProduct,
 	type FullSubject,
@@ -9,10 +10,22 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
+import { getCusAutoTopupPurchaseLimits } from "../cusResponseUtils/getCusAutoTopupPurchaseLimits.js";
 import { getCusPaymentMethodRes } from "../cusResponseUtils/getCusPaymentMethodRes.js";
 import { getCusReferrals } from "../cusResponseUtils/getCusReferrals.js";
 import { getCusRewards } from "../cusResponseUtils/getCusRewards.js";
 import { getCusTrialsUsed } from "../cusResponseUtils/getCusTrialsUsed.js";
+
+/**
+ * Result of expand resolution. In addition to the standard `ApiCusExpand`
+ * fields, this carries an optional override for `billing_controls.auto_topups`
+ * which the caller merges into the base customer's `billing_controls` block.
+ */
+export type ApiCustomerExpandResult = ApiCusExpand & {
+	billing_controls_override?: {
+		auto_topups: AutoTopupResponse[];
+	};
+};
 
 /**
  * Build expand fields directly from a FullSubject — no extra FullCustomer fetch.
@@ -24,7 +37,7 @@ export const getApiCustomerExpandV2 = async ({
 }: {
 	ctx: AutumnContext;
 	fullSubject: FullSubject;
-}): Promise<ApiCusExpand> => {
+}): Promise<ApiCustomerExpandResult> => {
 	const { expand } = ctx;
 
 	const filteredExpand = filterExpand({
@@ -63,33 +76,45 @@ export const getApiCustomerExpandV2 = async ({
 		);
 	};
 
-	const [entities, rewards, referrals, paymentMethod, trialsUsed] =
-		await Promise.all([
-			getApiEntities(),
-			getCusRewards({
-				org: ctx.org,
-				env: ctx.env,
-				fullCus,
-				subIds,
-				expand: cusExpand,
-			}),
-			getCusReferrals({
-				db: ctx.db,
-				fullCus,
-				expand: cusExpand,
-			}),
-			getCusPaymentMethodRes({
-				org: ctx.org,
-				env: ctx.env,
-				fullCus,
-				expand: cusExpand,
-			}),
-			getCusTrialsUsed({
-				ctx,
-				fullCus,
-				expand: cusExpand,
-			}),
-		]);
+	const [
+		entities,
+		rewards,
+		referrals,
+		paymentMethod,
+		trialsUsed,
+		autoTopupsWithLimits,
+	] = await Promise.all([
+		getApiEntities(),
+		getCusRewards({
+			org: ctx.org,
+			env: ctx.env,
+			fullCus,
+			subIds,
+			expand: cusExpand,
+		}),
+		getCusReferrals({
+			db: ctx.db,
+			fullCus,
+			expand: cusExpand,
+		}),
+		getCusPaymentMethodRes({
+			org: ctx.org,
+			env: ctx.env,
+			fullCus,
+			expand: cusExpand,
+		}),
+		getCusTrialsUsed({
+			ctx,
+			fullCus,
+			expand: cusExpand,
+		}),
+		getCusAutoTopupPurchaseLimits({
+			ctx,
+			internalCustomerId: fullCus.internal_id,
+			autoTopupsConfig: fullCus.auto_topups,
+			expand: cusExpand,
+		}),
+	]);
 
 	return {
 		trials_used: trialsUsed ?? undefined,
@@ -97,5 +122,8 @@ export const getApiCustomerExpandV2 = async ({
 		rewards: rewards ?? undefined,
 		referrals: referrals ?? undefined,
 		payment_method: paymentMethod ?? undefined,
+		billing_controls_override: autoTopupsWithLimits
+			? { auto_topups: autoTopupsWithLimits }
+			: undefined,
 	};
 };

--- a/server/src/internal/customers/cusUtils/cusResponseUtils/getCusAutoTopupPurchaseLimits.ts
+++ b/server/src/internal/customers/cusUtils/cusResponseUtils/getCusAutoTopupPurchaseLimits.ts
@@ -1,0 +1,75 @@
+import {
+	type AutoTopup,
+	type AutoTopupResponse,
+	CustomerExpand,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { autoTopupLimitRepo } from "@/internal/balances/autoTopUp/repos";
+
+/**
+ * When `expand=billing_controls.auto_topups.purchase_limit` is requested,
+ * return a replacement `auto_topups` array where each entry's `purchase_limit`
+ * is augmented with runtime tracking (`count`, `next_reset_at`) from the
+ * `auto_topup_limit_states` table.
+ *
+ * Behavior:
+ *   - Returns `undefined` when the expand path is not requested.
+ *   - Returns `undefined` when there are no configured auto_topups.
+ *   - For each configured auto_topup with a matching DB row, the `purchase_limit`
+ *     object is rebuilt with `count` + `next_reset_at` from the row. If the
+ *     config had no `purchase_limit`, `interval` / `interval_count` / `limit`
+ *     are returned as `null`.
+ *   - For configured auto_topups WITHOUT a matching DB row (no top-up has
+ *     ever fired), the entry is passed through unchanged from config.
+ *
+ * Per design: no live window normalization — raw DB values are surfaced as-is.
+ */
+export const getCusAutoTopupPurchaseLimits = async ({
+	ctx,
+	internalCustomerId,
+	autoTopupsConfig,
+	expand,
+}: {
+	ctx: AutumnContext;
+	internalCustomerId: string;
+	autoTopupsConfig: AutoTopup[] | null | undefined;
+	expand: CustomerExpand[];
+}): Promise<AutoTopupResponse[] | undefined> => {
+	if (!expand.includes(CustomerExpand.AutoTopupsPurchaseLimit)) {
+		return undefined;
+	}
+
+	if (!autoTopupsConfig || autoTopupsConfig.length === 0) {
+		return undefined;
+	}
+
+	const rows = await autoTopupLimitRepo.findAllByCustomer({
+		ctx,
+		internalCustomerId,
+	});
+
+	const rowsByFeatureId = new Map(
+		rows.map((row) => [row.feature_id, row] as const),
+	);
+
+	return autoTopupsConfig.map((config): AutoTopupResponse => {
+		const row = rowsByFeatureId.get(config.feature_id);
+		if (!row) {
+			// No runtime row yet — pass config through unchanged.
+			return config;
+		}
+
+		const configuredLimit = config.purchase_limit;
+
+		return {
+			...config,
+			purchase_limit: {
+				interval: configuredLimit?.interval ?? null,
+				interval_count: configuredLimit?.interval_count ?? null,
+				limit: configuredLimit?.limit ?? null,
+				count: row.purchase_count,
+				next_reset_at: row.purchase_window_ends_at,
+			},
+		};
+	});
+};

--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerV2.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiCustomerV2.ts
@@ -41,9 +41,19 @@ export const getApiCustomerV2 = async ({
 		fullSubject,
 	});
 
+	const { billing_controls_override, ...standardExpand } = apiCustomerExpand;
+
 	const apiCustomer: ApiCustomerV5 = {
 		...cleanedBaseCustomer,
-		...apiCustomerExpand,
+		...standardExpand,
+		...(billing_controls_override
+			? {
+					billing_controls: {
+						...cleanedBaseCustomer.billing_controls,
+						auto_topups: billing_controls_override.auto_topups,
+					},
+				}
+			: {}),
 	};
 
 	return applyResponseVersionChanges<ApiCustomerV5>({

--- a/server/tests/integration/crud/customers/customer-billing-controls.test.ts
+++ b/server/tests/integration/crud/customers/customer-billing-controls.test.ts
@@ -1,10 +1,21 @@
 import { expect, test } from "bun:test";
-import type { ApiCustomerV5, CustomerBillingControls } from "@autumn/shared";
+import {
+	type ApiCustomerV5,
+	type CustomerBillingControls,
+	CustomerExpand,
+	PurchaseLimitInterval,
+} from "@autumn/shared";
+import { makeAutoTopupConfig } from "@tests/integration/balances/auto-topup/utils/makeAutoTopupConfig";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService.js";
+
+const AUTO_TOPUP_WAIT_MS = 20000;
 
 const spendLimitControls: CustomerBillingControls = {
 	spend_limits: [
@@ -471,4 +482,169 @@ test.concurrent(`${chalk.yellowBright("customer billing controls: clearing overa
 	expect(uncached.billing_controls?.spend_limits).toEqual(
 		spendLimitControls.spend_limits,
 	);
+});
+
+test.concurrent(`${chalk.yellowBright("customer billing controls: auto_topups.purchase_limit expand surfaces runtime tracking")}`, async () => {
+	/**
+	 * Exercises the new `expand=billing_controls.auto_topups.purchase_limit`
+	 * path through three branches:
+	 *
+	 *   Phase A — purchase_limit configured, no DB row yet
+	 *             → expand is a passthrough (no count / next_reset_at)
+	 *   Phase B — purchase_limit configured, top-up has fired
+	 *             → expand surfaces count + next_reset_at; non-expanded fetch
+	 *               must NOT include them; uncached path matches cached
+	 *   Phase C — purchase_limit removed from config, prior row persists
+	 *             → expand returns null for interval/interval_count/limit but
+	 *               continues to surface count + next_reset_at from the row
+	 *
+	 * Phase C asserts `count: 1` (carried over from Phase B's top-up).
+	 * Removing `purchase_limit` from config does not delete the row, but
+	 * `recordAutoTopupAttempt` only increments `purchase_count` when
+	 * `purchaseLimit` is configured — so subsequent top-ups don't advance the
+	 * counter. The runtime field reflects this honestly: an attempt without a
+	 * configured limit is, definitionally, not "consumed against a quota."
+	 */
+	const customerId = "customer-billing-controls-12";
+	const oneOffProd = products.oneOffAddOn({
+		id: "topup-expand",
+		items: [
+			items.oneOffMessages({
+				includedUsage: 0,
+				billingUnits: 100,
+				price: 10,
+			}),
+		],
+	});
+
+	const { autumnV2_1, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [oneOffProd] }),
+		],
+		actions: [
+			s.attach({
+				productId: oneOffProd.id,
+				options: [{ feature_id: TestFeature.Messages, quantity: 300 }],
+			}),
+		],
+	});
+
+	// ── Phase A: purchase_limit configured, no DB row yet → expand is a
+	// passthrough of the static config shape.
+	await autumnV2_2.customers.update(customerId, {
+		billing_controls: makeAutoTopupConfig({
+			threshold: 50,
+			quantity: 100,
+			purchaseLimit: { interval: PurchaseLimitInterval.Month, limit: 5 },
+		}),
+	});
+
+	const phaseA = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+		expand: [CustomerExpand.AutoTopupsPurchaseLimit],
+	});
+	const phaseAPurchaseLimit =
+		phaseA.billing_controls?.auto_topups?.[0]?.purchase_limit;
+	expect(phaseAPurchaseLimit).toEqual({
+		interval: PurchaseLimitInterval.Month,
+		interval_count: 1,
+		limit: 5,
+	});
+	expect(phaseAPurchaseLimit).not.toHaveProperty("count");
+	expect(phaseAPurchaseLimit).not.toHaveProperty("next_reset_at");
+
+	// ── Phase B: track usage to fire one auto top-up, then assert expand
+	// returns the runtime count + window end.
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 260,
+	});
+	await timeout(AUTO_TOPUP_WAIT_MS);
+
+	const phaseBExpanded = await autumnV2_1.customers.get<ApiCustomerV5>(
+		customerId,
+		{ expand: [CustomerExpand.AutoTopupsPurchaseLimit] },
+	);
+	const phaseBPurchaseLimit = phaseBExpanded.billing_controls?.auto_topups?.[0]
+		?.purchase_limit as
+		| {
+				interval: PurchaseLimitInterval | null;
+				interval_count: number | null;
+				limit: number | null;
+				count: number;
+				next_reset_at: number;
+		  }
+		| undefined;
+	expect(phaseBPurchaseLimit).toMatchObject({
+		interval: PurchaseLimitInterval.Month,
+		interval_count: 1,
+		limit: 5,
+		count: 1,
+	});
+	expect(typeof phaseBPurchaseLimit?.next_reset_at).toBe("number");
+	expect(phaseBPurchaseLimit?.next_reset_at).toBeGreaterThan(Date.now());
+
+	// Without the expand the runtime fields must not leak in, even though the
+	// DB row now exists.
+	const phaseBPlain = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	const phaseBPlainPurchaseLimit =
+		phaseBPlain.billing_controls?.auto_topups?.[0]?.purchase_limit;
+	expect(phaseBPlainPurchaseLimit).toEqual({
+		interval: PurchaseLimitInterval.Month,
+		interval_count: 1,
+		limit: 5,
+	});
+	expect(phaseBPlainPurchaseLimit).not.toHaveProperty("count");
+	expect(phaseBPlainPurchaseLimit).not.toHaveProperty("next_reset_at");
+
+	// skip_cache parity — uncached read should match the cached expanded read.
+	const phaseBUncached = await autumnV2_1.customers.get<ApiCustomerV5>(
+		customerId,
+		{
+			expand: [CustomerExpand.AutoTopupsPurchaseLimit],
+			skip_cache: "true",
+		},
+	);
+	expect(
+		phaseBUncached.billing_controls?.auto_topups?.[0]?.purchase_limit,
+	).toEqual(phaseBPurchaseLimit);
+
+	// ── Phase C: drop purchase_limit from config; the existing DB row keeps
+	// tracking. Expand should report null config fields plus the cumulative
+	// runtime count.
+	await autumnV2_2.customers.update(customerId, {
+		billing_controls: makeAutoTopupConfig({ threshold: 50, quantity: 100 }),
+	});
+	await autumnV2_2.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 100,
+	});
+	await timeout(AUTO_TOPUP_WAIT_MS);
+
+	const phaseC = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+		expand: [CustomerExpand.AutoTopupsPurchaseLimit],
+	});
+	const phaseCPurchaseLimit = phaseC.billing_controls?.auto_topups?.[0]
+		?.purchase_limit as
+		| {
+				interval: PurchaseLimitInterval | null;
+				interval_count: number | null;
+				limit: number | null;
+				count: number;
+				next_reset_at: number;
+		  }
+		| undefined;
+	expect(phaseCPurchaseLimit).toMatchObject({
+		interval: null,
+		interval_count: null,
+		limit: null,
+		// count stays at 1 — see header comment: Phase C's top-up fires but
+		// does not increment purchase_count because no purchase_limit is
+		// configured.
+		count: 1,
+	});
+	expect(typeof phaseCPurchaseLimit?.next_reset_at).toBe("number");
 });

--- a/shared/api/customers/baseApiCustomer.ts
+++ b/shared/api/customers/baseApiCustomer.ts
@@ -1,4 +1,4 @@
-import { CustomerBillingControlsSchema } from "@models/cusModels/billingControls/customerBillingControls";
+import { CustomerBillingControlsResponseSchema } from "@models/cusModels/billingControls/customerBillingControls";
 import { AppEnv } from "@models/genModels/genEnums";
 import { z } from "zod/v4";
 
@@ -34,7 +34,7 @@ export const BaseApiCustomerSchema = z.object({
 	send_email_receipts: z.boolean().meta({
 		description: "Whether to send email receipts to the customer.",
 	}),
-	billing_controls: CustomerBillingControlsSchema.meta({
+	billing_controls: CustomerBillingControlsResponseSchema.meta({
 		description: "Billing controls for the customer (auto top-ups, etc.)",
 	}),
 });

--- a/shared/api/customers/components/customerExpand/customerExpand.ts
+++ b/shared/api/customers/components/customerExpand/customerExpand.ts
@@ -12,6 +12,7 @@ export enum CustomerExpand {
 	PurchasesPlan = "purchases.plan",
 	BalancesFeature = "balances.feature",
 	FlagsFeature = "flags.feature",
+	AutoTopupsPurchaseLimit = "billing_controls.auto_topups.purchase_limit",
 }
 
 export const CustomerExpandEnum = z.enum(CustomerExpand).meta({

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -47,8 +47,81 @@ export const AutoTopupSchema = z.object({
 	}),
 });
 
+/**
+ * Expanded purchase_limit shape that augments the static config with runtime
+ * tracking state from `auto_topup_limit_states`. Only emitted on responses
+ * when expand=billing_controls.auto_topups.purchase_limit is requested.
+ *
+ * When no `purchase_limit` is configured for the auto_topup, the original
+ * config fields (interval, interval_count, limit) are returned as null and
+ * only `count` / `next_reset_at` reflect runtime state.
+ */
+export const ExpandedPurchaseLimitSchema = z.object({
+	interval: PurchaseLimitIntervalEnum.nullable().meta({
+		description:
+			"The time interval for the purchase limit window. Null when no purchase limit is configured.",
+	}),
+	interval_count: z.number().min(1).nullable().meta({
+		description:
+			"Number of intervals in the purchase limit window. Null when no purchase limit is configured.",
+	}),
+	limit: z.number().min(1).nullable().meta({
+		description:
+			"Maximum number of auto top-ups allowed within the interval. Null when no purchase limit is configured.",
+	}),
+	count: z.number().meta({
+		description:
+			"Number of auto top-ups already consumed in the current window.",
+	}),
+	next_reset_at: z.number().meta({
+		description:
+			"Unix ms timestamp when the current purchase window ends and the count resets.",
+	}),
+});
+
+/**
+ * Response-only variant of AutoTopupSchema. The `purchase_limit` field can be
+ * either the static config shape (default) or the expanded runtime shape (when
+ * the corresponding expand path is requested). Input/params schemas remain
+ * strict — see `CustomerBillingControlsParamsSchema`.
+ */
+export const AutoTopupResponseSchema = AutoTopupSchema.extend({
+	purchase_limit: z
+		.union([AutoTopupPurchaseLimitSchema, ExpandedPurchaseLimitSchema])
+		.optional()
+		.meta({
+			description:
+				"Optional rate limit to cap how often auto top-ups occur. Includes runtime state when expanded via billing_controls.auto_topups.purchase_limit.",
+		}),
+});
+
 export const CustomerBillingControlsSchema = z.object({
 	auto_topups: z.array(AutoTopupSchema).optional().meta({
+		description: "List of auto top-up configurations per feature.",
+	}),
+	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
+		description: "List of overage spend limits per feature.",
+	}),
+	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
+		description: "List of usage alert configurations per feature.",
+	}),
+	overage_allowed: z.array(DbOverageAllowedSchema).optional().meta({
+		description:
+			"List of overage allowed controls per feature. When enabled, usage can exceed balance.",
+	}),
+});
+
+/**
+ * Response-only variant of CustomerBillingControlsSchema that uses
+ * `AutoTopupResponseSchema` for `auto_topups` so the `purchase_limit` field
+ * may be either the static config shape or the expanded runtime shape (when
+ * expand=billing_controls.auto_topups.purchase_limit is requested).
+ *
+ * Input/params validation continues to use `CustomerBillingControlsSchema` /
+ * `CustomerBillingControlsParamsSchema`, which remain strict.
+ */
+export const CustomerBillingControlsResponseSchema = z.object({
+	auto_topups: z.array(AutoTopupResponseSchema).optional().meta({
 		description: "List of auto top-up configurations per feature.",
 	}),
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
@@ -110,9 +183,14 @@ export const CustomerBillingControlsParamsSchema =
 export type AutoTopupPurchaseLimit = z.infer<
 	typeof AutoTopupPurchaseLimitSchema
 >;
+export type ExpandedPurchaseLimit = z.infer<typeof ExpandedPurchaseLimitSchema>;
 export type AutoTopup = z.infer<typeof AutoTopupSchema>;
+export type AutoTopupResponse = z.infer<typeof AutoTopupResponseSchema>;
 export type CustomerBillingControls = z.infer<
 	typeof CustomerBillingControlsSchema
+>;
+export type CustomerBillingControlsResponse = z.infer<
+	typeof CustomerBillingControlsResponseSchema
 >;
 
 export type CustomerBillingControlsParams = z.input<


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `expand=billing_controls.auto_topups.purchase_limit` expand path to the customer API that surfaces runtime purchase tracking state (`count`, `next_reset_at`) alongside the static auto-topup config. A new `auto_topup_limit_states` DB query fetches rows per customer, and the result is merged into `billing_controls.auto_topups` only when the expand path is requested, leaving non-expanded responses unchanged.

**Key changes:**
- [Improvements] New `findAutoTopupLimitsByCustomer` repo function and `getCusAutoTopupPurchaseLimits` helper that augments static auto-topup configs with runtime window tracking.
- [API changes] New `CustomerExpand.AutoTopupsPurchaseLimit` enum value and response-only schemas (`ExpandedPurchaseLimitSchema`, `AutoTopupResponseSchema`, `CustomerBillingControlsResponseSchema`) to represent the expanded shape.
- [Improvements] Both `getApiCustomerExpand` and `getApiCustomerExpandV2` now run the new DB fetch in parallel with existing expand queries, merging via a `billing_controls_override` side-channel to avoid colliding with the base customer spread.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only finding is a union ordering footgun in the response schema that does not affect current runtime behavior.

All findings are P2. The z.union ordering in AutoTopupResponseSchema could silently strip count/next_reset_at if the schema is used for parsing in the future, but today responses are returned via c.json() without Zod-parsing on the output path, so there is no present runtime defect.

shared/models/cusModels/billingControls/customerBillingControls.ts — union member ordering in AutoTopupResponseSchema.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/repos/findAutoTopupLimitsByCustomer.ts | New repo function fetching all auto_topup_limit_states rows per customer; mirrors the existing findAutoTopupLimitByScope pattern correctly. |
| server/src/internal/customers/cusUtils/cusResponseUtils/getCusAutoTopupPurchaseLimits.ts | New helper that fetches DB rows and augments auto_topup config with runtime tracking; expand guard, empty-config guard, and per-feature mapping are all correct. |
| server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpand.ts | Adds getCusAutoTopupPurchaseLimits to the parallel Promise.all and threads result through billing_controls_override; parallel fetch and merge logic look correct. |
| server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpandV2.ts | V2 expand path mirrors the same billing_controls_override pattern; ApiCustomerExpandResult type is defined and used correctly. |
| shared/models/cusModels/billingControls/customerBillingControls.ts | Introduces ExpandedPurchaseLimitSchema, AutoTopupResponseSchema, and CustomerBillingControlsResponseSchema; union ordering in AutoTopupResponseSchema may silently strip runtime fields if the schema is used for parsing. |
| shared/api/customers/components/customerExpand/customerExpand.ts | Adds AutoTopupsPurchaseLimit expand enum value; straightforward additive change. |
| server/tests/integration/crud/customers/customer-billing-controls.test.ts | Adds comprehensive three-phase integration test covering passthrough, runtime tracking, and config-removed cases; assertions are thorough. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as API Handler
    participant GetExpand as getApiCustomerExpand(V2)
    participant GetLimits as getCusAutoTopupPurchaseLimits
    participant Repo as autoTopupLimitRepo
    participant DB as auto_topup_limit_states

    Client->>Handler: GET /customers/:id?expand=billing_controls.auto_topups.purchase_limit
    Handler->>GetExpand: getApiCustomerExpand({ ctx, fullCus })
    GetExpand->>GetLimits: getCusAutoTopupPurchaseLimits({ ctx, internalCustomerId, autoTopupsConfig, expand })
    alt expand NOT requested
        GetLimits-->>GetExpand: undefined
    else expand requested and configs exist
        GetLimits->>Repo: findAllByCustomer({ ctx, internalCustomerId })
        Repo->>DB: SELECT WHERE org_id + env + internal_customer_id
        DB-->>Repo: AutoTopupLimitState[]
        Repo-->>GetLimits: rows
        GetLimits-->>GetExpand: AutoTopupResponse[] (config + runtime count/next_reset_at)
    end
    GetExpand-->>Handler: { ...expandFields, billing_controls_override? }
    Handler->>Handler: merge billing_controls_override into base billing_controls
    Handler-->>Client: ApiCustomerV5 with billing_controls.auto_topups runtime state
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
shared/models/cusModels/billingControls/customerBillingControls.ts:89-95
**`z.union` ordering silently strips runtime tracking fields**

Zod tries each union member in order and strips unknown fields from object schemas. Since `AutoTopupPurchaseLimitSchema` is tried first and succeeds for any expanded response (Zod ignores the extra `count`/`next_reset_at` fields it doesn't know about), `ExpandedPurchaseLimitSchema` is never reached. If this schema is ever used to parse or serialize an already-expanded response, the runtime tracking fields will be silently dropped. Swapping the order so the more-specific (richer) schema is tried first would prevent this silent data loss.

```suggestion
export const AutoTopupResponseSchema = AutoTopupSchema.extend({
	purchase_limit: z
		.union([ExpandedPurchaseLimitSchema, AutoTopupPurchaseLimitSchema])
		.optional()
		.meta({
			description:
				"Optional rate limit to cap how often auto top-ups occur. Includes runtime state when expanded via billing_controls.auto_topups.purchase_limit.",
		}),
});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 expand billing cotnrols auto to..."](https://github.com/useautumn/autumn/commit/1a4d4b185401caee6899c073c8b9ccb9a6ae1f39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30376151)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->