### PR TITLE
feat: 🎸 show tax previews on taxable orgs

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -65,19 +65,9 @@ export async function attach({
 
 	logStripeBillingPlan({ ctx, stripeBillingPlan, billingContext });
 
-	// 3b. Build preview-only enrichments (read-only, never executed).
-	const previewBillingPlan = preview
-		? await computeAttachPreviewBillingPlan({
-				ctx,
-				billingContext,
-				autumnBillingPlan,
-			})
-		: undefined;
-
 	const billingPlan = {
 		autumn: autumnBillingPlan,
 		stripe: stripeBillingPlan,
-		preview: previewBillingPlan,
 	};
 
 	// 4. Errors (requires full billing plan)
@@ -89,9 +79,15 @@ export async function attach({
 	});
 
 	if (preview) {
+		const previewBillingPlan = await computeAttachPreviewBillingPlan({
+			ctx,
+			billingContext,
+			autumnBillingPlan,
+		});
+
 		return {
 			billingContext,
-			billingPlan,
+			billingPlan: { ...billingPlan, preview: previewBillingPlan },
 		};
 	}
 

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -14,6 +14,7 @@ import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBilling
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
 import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
+import { computeAttachPreviewBillingPlan } from "@/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan";
 import { hashJson } from "@/utils/hash/hashJson";
 import {
@@ -64,9 +65,19 @@ export async function attach({
 
 	logStripeBillingPlan({ ctx, stripeBillingPlan, billingContext });
 
+	// 3b. Build preview-only enrichments (read-only, never executed).
+	const previewBillingPlan = preview
+		? await computeAttachPreviewBillingPlan({
+				ctx,
+				billingContext,
+				autumnBillingPlan,
+			})
+		: undefined;
+
 	const billingPlan = {
 		autumn: autumnBillingPlan,
 		stripe: stripeBillingPlan,
+		preview: previewBillingPlan,
 	};
 
 	// 4. Errors (requires full billing plan)

--- a/server/src/internal/billing/v2/utils/billingPlan/billingPlanToAttachPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/billingPlanToAttachPreview.ts
@@ -42,5 +42,6 @@ export const billingPlanToAttachPreview = async ({
 		object: "attach_preview" as const,
 		redirect_to_checkout: willRedirectToCheckout,
 		checkout_type: checkoutType,
+		tax: billingPlan.preview?.tax,
 	} satisfies AttachPreviewResponse;
 };

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts
@@ -1,0 +1,36 @@
+import type {
+	AttachBillingContext,
+	AutumnBillingPlan,
+	PreviewBillingPlan,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeAttachTaxPreview } from "./tax/computeAttachTaxPreview";
+
+/**
+ * Build-stage orchestrator for preview-only enrichments on the attach flow.
+ *
+ * Invoked from `attach.ts` ONLY when `preview: true`. Calls each individual
+ * enrichment helper (currently just tax) and assembles the
+ * `PreviewBillingPlan` bag that lives at `billingPlan.preview`.
+ *
+ * New preview enrichments (per-line tax breakdown, alt-currency previews,
+ * next-cycle tax, etc.) slot in here as additional fields on
+ * `PreviewBillingPlan` + their own helper module under `preview/`.
+ */
+export const computeAttachPreviewBillingPlan = async ({
+	ctx,
+	billingContext,
+	autumnBillingPlan,
+}: {
+	ctx: AutumnContext;
+	billingContext: AttachBillingContext;
+	autumnBillingPlan: AutumnBillingPlan;
+}): Promise<PreviewBillingPlan> => {
+	const tax = await computeAttachTaxPreview({
+		ctx,
+		billingContext,
+		autumnBillingPlan,
+	});
+
+	return { tax };
+};

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
@@ -20,7 +20,9 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
  *
  * Skip-conditions (return undefined):
  *  - org has `automatic_tax: false`
- *  - flow is `stripe_checkout` (Checkout collects the address itself)
+ *  - flow is `stripe_checkout` or `autumn_checkout` (the buyer-facing form
+ *    may collect/update the address, so a pre-checkout tax preview risks
+ *    diverging from what Stripe charges at checkout)
  *  - no Stripe customer exists (we only support previewing against an
  *    existing Stripe customer; Stripe's location waterfall needs it)
  *  - nothing positive to charge immediately (no taxable subtotal)
@@ -39,20 +41,21 @@ export const computeAttachTaxPreview = async ({
 	autumnBillingPlan: AutumnBillingPlan;
 }): Promise<PreviewTax | undefined> => {
 	if (!ctx.org.config.automatic_tax) return undefined;
-	if (billingContext.checkoutMode === "stripe_checkout") return undefined;
+	if (
+		billingContext.checkoutMode === "stripe_checkout" ||
+		billingContext.checkoutMode === "autumn_checkout"
+	) {
+		return undefined;
+	}
 	if (!billingContext.stripeCustomer?.id) return undefined;
 
 	const allLineItems = autumnBillingPlan.lineItems ?? [];
 	if (allLineItems.length === 0) return undefined;
 
-	// Stripe Tax requires `line_items.amount` to be a positive integer, so
-	// only send lines that are immediately charged AND positive. Credit
-	// (negative) lines aren't taxable on the Stripe side anyway, so
-	// dropping them mirrors how the actual proration invoice would be
-	// taxed.
-	const taxableLines = allLineItems.filter(
-		(line) => line.chargeImmediately && line.amount > 0,
-	);
+	const taxableLines = allLineItems.filter((line) => {
+		const net = line.amountAfterDiscounts ?? line.amount;
+		return line.chargeImmediately && net > 0;
+	});
 	if (taxableLines.length === 0) return undefined;
 
 	const currency = orgToCurrency({ org: ctx.org });
@@ -63,7 +66,10 @@ export const computeAttachTaxPreview = async ({
 			currency,
 			customer: billingContext.stripeCustomer.id,
 			line_items: taxableLines.map((line, idx) => ({
-				amount: atmnToStripeAmount({ amount: line.amount, currency }),
+				amount: atmnToStripeAmount({
+					amount: line.amountAfterDiscounts ?? line.amount,
+					currency,
+				}),
 				reference: line.id || `li_${idx}`,
 				quantity: 1,
 			})),

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
@@ -20,12 +20,17 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
  *
  * Skip-conditions (return undefined):
  *  - org has `automatic_tax: false`
- *  - flow is `stripe_checkout` or `autumn_checkout` (the buyer-facing form
- *    may collect/update the address, so a pre-checkout tax preview risks
- *    diverging from what Stripe charges at checkout)
+ *  - flow is `stripe_checkout` (Stripe Checkout collects the address itself
+ *    and computes tax during the buyer-facing form, so any pre-checkout
+ *    preview here would diverge from what Stripe ultimately charges)
  *  - no Stripe customer exists (we only support previewing against an
  *    existing Stripe customer; Stripe's location waterfall needs it)
  *  - nothing positive to charge immediately (no taxable subtotal)
+ *
+ * Note: `autumn_checkout` is intentionally NOT skipped. It's a
+ * confirmation-only flow — no address or payment method collection — so
+ * the customer's existing Stripe address (and the resulting tax) is
+ * exactly what gets charged on confirmation.
  *
  * On Stripe error → returns `{ status: "incomplete", ...zeros }` so the
  * merchant sees an explicit "tax not computed" signal in the preview rather
@@ -41,12 +46,7 @@ export const computeAttachTaxPreview = async ({
 	autumnBillingPlan: AutumnBillingPlan;
 }): Promise<PreviewTax | undefined> => {
 	if (!ctx.org.config.automatic_tax) return undefined;
-	if (
-		billingContext.checkoutMode === "stripe_checkout" ||
-		billingContext.checkoutMode === "autumn_checkout"
-	) {
-		return undefined;
-	}
+	if (billingContext.checkoutMode === "stripe_checkout") return undefined;
 	if (!billingContext.stripeCustomer?.id) return undefined;
 
 	const allLineItems = autumnBillingPlan.lineItems ?? [];

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
@@ -1,0 +1,102 @@
+import type {
+	AttachBillingContext,
+	AutumnBillingPlan,
+	PreviewTax,
+} from "@autumn/shared";
+import {
+	atmnToStripeAmount,
+	orgToCurrency,
+	stripeToAtmnAmount,
+} from "@autumn/shared";
+import { createStripeCli } from "@/external/connect/createStripeCli";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+/**
+ * Build-stage helper that computes a tax preview for an attach via Stripe Tax.
+ *
+ * Read-only: calls `stripe.tax.calculations.create` (a non-mutating "what
+ * would tax be" lookup). Output is consumed by the formatter, not the
+ * executor — only ever populated when attach is invoked with `preview: true`.
+ *
+ * Skip-conditions (return undefined):
+ *  - org has `automatic_tax: false`
+ *  - flow is `stripe_checkout` (Checkout collects the address itself)
+ *  - no Stripe customer exists (we only support previewing against an
+ *    existing Stripe customer; Stripe's location waterfall needs it)
+ *  - nothing positive to charge immediately (no taxable subtotal)
+ *
+ * On Stripe error → returns `{ status: "incomplete", ...zeros }` so the
+ * merchant sees an explicit "tax not computed" signal in the preview rather
+ * than a silently missing field.
+ */
+export const computeAttachTaxPreview = async ({
+	ctx,
+	billingContext,
+	autumnBillingPlan,
+}: {
+	ctx: AutumnContext;
+	billingContext: AttachBillingContext;
+	autumnBillingPlan: AutumnBillingPlan;
+}): Promise<PreviewTax | undefined> => {
+	if (!ctx.org.config.automatic_tax) return undefined;
+	if (billingContext.checkoutMode === "stripe_checkout") return undefined;
+	if (!billingContext.stripeCustomer?.id) return undefined;
+
+	const allLineItems = autumnBillingPlan.lineItems ?? [];
+	if (allLineItems.length === 0) return undefined;
+
+	// Stripe Tax requires `line_items.amount` to be a positive integer, so
+	// only send lines that are immediately charged AND positive. Credit
+	// (negative) lines aren't taxable on the Stripe side anyway, so
+	// dropping them mirrors how the actual proration invoice would be
+	// taxed.
+	const taxableLines = allLineItems.filter(
+		(line) => line.chargeImmediately && line.amount > 0,
+	);
+	if (taxableLines.length === 0) return undefined;
+
+	const currency = orgToCurrency({ org: ctx.org });
+	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+
+	try {
+		const calc = await stripeCli.tax.calculations.create({
+			currency,
+			customer: billingContext.stripeCustomer.id,
+			line_items: taxableLines.map((line, idx) => ({
+				amount: atmnToStripeAmount({ amount: line.amount, currency }),
+				reference: line.id || `li_${idx}`,
+				quantity: 1,
+			})),
+		});
+
+		return {
+			total: stripeToAtmnAmount({
+				amount:
+					(calc.tax_amount_exclusive ?? 0) + (calc.tax_amount_inclusive ?? 0),
+				currency,
+			}),
+			amount_inclusive: stripeToAtmnAmount({
+				amount: calc.tax_amount_inclusive ?? 0,
+				currency,
+			}),
+			amount_exclusive: stripeToAtmnAmount({
+				amount: calc.tax_amount_exclusive ?? 0,
+				currency,
+			}),
+			currency,
+			status: "complete",
+		};
+	} catch (err) {
+		const errMsg = (err as { message?: string })?.message ?? String(err);
+		ctx.logger.warn(
+			`[computeAttachTaxPreview] Stripe Tax calculation failed; returning incomplete status: ${errMsg}`,
+		);
+		return {
+			total: 0,
+			amount_inclusive: 0,
+			amount_exclusive: 0,
+			currency,
+			status: "incomplete",
+		};
+	}
+};

--- a/server/tests/integration/billing/tax/automatic-tax-preview-attach-immediate.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-preview-attach-immediate.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration test for the new `tax` field on `previewAttach`.
+ *
+ * Architecture (per fetch–build–execute):
+ *   Symptom surfaces in: server/src/internal/billing/v2/utils/billingPlan/billingPlanToAttachPreview.ts
+ *     (formatter passes through `billingPlan.preview.tax` to the response)
+ *   Root cause lives in: server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
+ *     (build-stage helper that calls Stripe Tax)
+ *   Fix layer: upstream — preview enrichment is a build-stage output read by
+ *     the formatter; never reaches the executor.
+ *
+ * Three concurrent cases:
+ *  - auto_tax-on, AU customer with address, Pro→Premium upgrade preview →
+ *    `response.tax.status === "complete"`, total > 0
+ *  - auto_tax-off (default) → `response.tax === undefined`
+ *  - auto_tax-on, customer with no resolvable location →
+ *    `response.tax.status === "incomplete"`, totals all zero
+ */
+
+import { expect, test } from "bun:test";
+import type { AttachPreviewResponse } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+
+const auAddress = {
+	country: "AU",
+	line1: "1 Test St",
+	city: "Sydney",
+	postal_code: "2000",
+	state: "NSW",
+};
+
+async function flipAutoTaxOn(ctx: TestContext) {
+	const existingConfig = ctx.org.config;
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...existingConfig, automatic_tax: true },
+		},
+	});
+}
+
+test.concurrent(`${chalk.yellowBright(
+	"automatic-tax-preview-attach-immediate (auto_tax on, AU customer): preview returns tax.status=complete with positive total",
+)}`, async () => {
+	const customerId = "tax-preview-on-au";
+	const proProd = products.pro({ id: "pro", items: [] });
+	const premiumProd = products.premium({ id: "premium", items: [] });
+
+	const { ctx, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			s.platform.create({
+				configOverrides: { automatic_tax: true },
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+				stripeCustomerOverrides: { address: auAddress },
+			}),
+			s.products({ list: [proProd, premiumProd] }),
+		],
+		actions: [s.billing.attach({ productId: "pro" })],
+	});
+
+	const preview = (await autumnV2_2.billing.previewAttach({
+		customer_id: customerId,
+		plan_id: `premium_${customerId}`,
+	})) as AttachPreviewResponse;
+
+	expect(preview.tax).toBeDefined();
+	expect(preview.tax?.status).toBe("complete");
+	expect(preview.tax?.currency).toBe(preview.currency);
+	expect(preview.tax?.total).toBeGreaterThan(0);
+	expect(preview.tax?.amount_exclusive).toBeGreaterThan(0);
+	expect(preview.tax?.amount_inclusive).toBe(0);
+
+	// Sanity: the existing autumn-side total stays separate from the
+	// stripe-side tax breakdown. They're computing different things —
+	// the autumn `total` may include credits that Stripe doesn't tax.
+	expect(preview.total).toBeGreaterThan(0);
+	// Don't assert preview.total === preview.tax.total — divergence is
+	// expected and documented on the schema.
+}, 300_000);
+
+test.concurrent(`${chalk.yellowBright(
+	"automatic-tax-preview-attach-immediate (auto_tax off): preview omits the tax field entirely",
+)}`, async () => {
+	const customerId = "tax-preview-off";
+	const proProd = products.pro({ id: "pro", items: [] });
+	const premiumProd = products.premium({ id: "premium", items: [] });
+
+	const { autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			// No configOverrides — automatic_tax defaults to false.
+			s.platform.create({
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+				stripeCustomerOverrides: { address: auAddress },
+			}),
+			s.products({ list: [proProd, premiumProd] }),
+		],
+		actions: [s.billing.attach({ productId: "pro" })],
+	});
+
+	const preview = (await autumnV2_2.billing.previewAttach({
+		customer_id: customerId,
+		plan_id: `premium_${customerId}`,
+	})) as AttachPreviewResponse;
+
+	expect(preview.tax).toBeUndefined();
+}, 300_000);
+
+test.concurrent(`${chalk.yellowBright(
+	"automatic-tax-preview-attach-immediate (auto_tax on, no address): preview returns tax.status=incomplete with zeros",
+)}`, async () => {
+	const customerId = "tax-preview-on-no-addr";
+	const proProd = products.pro({ id: "pro", items: [] });
+	const premiumProd = products.premium({ id: "premium", items: [] });
+
+	const { ctx, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [
+			// Start with auto_tax OFF so initial Pro attach succeeds even
+			// without an address; flip on after to exercise the
+			// preview-with-no-address branch.
+			s.platform.create({
+				taxRegistrations: ["AU"],
+			}),
+			s.customer({
+				testClock: false,
+				paymentMethod: "success",
+				// NO stripeCustomerOverrides — no address.
+			}),
+			s.products({ list: [proProd, premiumProd] }),
+		],
+		actions: [s.billing.attach({ productId: "pro" })],
+	});
+
+	await flipAutoTaxOn(ctx);
+
+	const preview = (await autumnV2_2.billing.previewAttach({
+		customer_id: customerId,
+		plan_id: `premium_${customerId}`,
+	})) as AttachPreviewResponse;
+
+	expect(preview.tax).toBeDefined();
+	expect(preview.tax?.status).toBe("incomplete");
+	expect(preview.tax?.total).toBe(0);
+	expect(preview.tax?.amount_exclusive).toBe(0);
+	expect(preview.tax?.amount_inclusive).toBe(0);
+	expect(preview.tax?.currency).toBe(preview.currency);
+
+	console.log(`[preview-tax] incomplete: currency=${preview.tax?.currency}`);
+}, 300_000);

--- a/shared/api/billing/common/attachPreviewResponse.ts
+++ b/shared/api/billing/common/attachPreviewResponse.ts
@@ -1,5 +1,8 @@
 import { z } from "zod/v4";
-import { BillingPreviewResponseSchema } from "./billingPreviewResponse.js";
+import {
+	BillingPreviewResponseSchema,
+	PreviewTaxSchema,
+} from "./billingPreviewResponse.js";
 
 export const AttachPreviewResponseSchema = BillingPreviewResponseSchema.extend({
 	object: z.literal("attach_preview").meta({ internal: true }),
@@ -15,6 +18,11 @@ export const AttachPreviewResponseSchema = BillingPreviewResponseSchema.extend({
 			description:
 				"The type of checkout that will be used if the customer is redirected to a checkout page.",
 		}),
+
+	tax: PreviewTaxSchema.optional().meta({
+		description:
+			"Tax preview for the immediate charge, computed via Stripe Tax. Present only when the org has `automatic_tax` enabled, the customer exists in Stripe, there's a positive amount to charge immediately, and the flow is NOT a Stripe Checkout redirect (Stripe Checkout collects the address and computes tax during the buyer-facing form).",
+	}),
 	// redirect_type: z.enum(["stripe_checkout", "autumn_checkout", "none"]),
 });
 

--- a/shared/api/billing/common/billingPreviewResponse.ts
+++ b/shared/api/billing/common/billingPreviewResponse.ts
@@ -25,6 +25,31 @@ export const PreviewLineItemDiscountSchema = z.object({
 	reward_name: z.string().optional(),
 });
 
+export const PreviewTaxSchema = z.object({
+	total: z.number().meta({
+		description:
+			"Total tax amount in the response's major currency unit. Sum of inclusive + exclusive taxes computed by Stripe Tax across all positive line items. Negative (credit) lines are excluded from tax computation per Stripe's behavior.",
+	}),
+	amount_inclusive: z.number().meta({
+		description:
+			"Tax portion in major units that is INCLUDED in line item subtotals (when line items use `tax_behavior: inclusive`). Currently always 0 — autumn line items use exclusive tax behavior — but exposed for forward compatibility.",
+	}),
+	amount_exclusive: z.number().meta({
+		description:
+			"Tax portion in major units that will be ADDED ON TOP of line item subtotals.",
+	}),
+	currency: z.string().meta({
+		description:
+			"Three-letter ISO currency code (lowercase). Matches the response's top-level `currency`.",
+	}),
+	status: z.enum(["complete", "incomplete"]).meta({
+		description:
+			"Autumn-side status. 'complete' means Stripe Tax computed the calculation successfully (zero is a valid complete result, e.g. tax-free jurisdictions). 'incomplete' means we caught a Stripe error (typically because the customer's location couldn't be resolved); totals will be zero.",
+	}),
+});
+
+export type PreviewTax = z.infer<typeof PreviewTaxSchema>;
+
 export const ExtPreviewLineItemSchema = z.object({
 	display_name: z.string().meta({
 		description:

--- a/shared/models/billingModels/plan/billingPlan.ts
+++ b/shared/models/billingModels/plan/billingPlan.ts
@@ -15,11 +15,16 @@ import {
 	type DeferredAutumnBillingPlanData,
 	type DeferredSetupPaymentData,
 } from "./autumnBillingPlan";
+import {
+	type PreviewBillingPlan,
+	PreviewBillingPlanSchema,
+} from "./previewBillingPlan";
 
 export type {
 	AutumnBillingPlan,
 	DeferredAutumnBillingPlanData,
 	DeferredSetupPaymentData,
+	PreviewBillingPlan,
 	StripeBillingPlan,
 	StripeCheckoutSessionAction,
 	StripeInvoiceAction,
@@ -32,6 +37,7 @@ export type {
 export const BillingPlanSchema = z.object({
 	autumn: AutumnBillingPlanSchema,
 	stripe: StripeBillingPlanSchema,
+	preview: PreviewBillingPlanSchema.optional(),
 });
 
 export type BillingPlan = z.infer<typeof BillingPlanSchema>;

--- a/shared/models/billingModels/plan/index.ts
+++ b/shared/models/billingModels/plan/index.ts
@@ -1,3 +1,4 @@
 export * from "./autumnBillingPlan";
 export * from "./billingPlan";
 export * from "./billingResult";
+export * from "./previewBillingPlan";

--- a/shared/models/billingModels/plan/previewBillingPlan.ts
+++ b/shared/models/billingModels/plan/previewBillingPlan.ts
@@ -1,0 +1,16 @@
+import { PreviewTaxSchema } from "@api/billing/common/billingPreviewResponse";
+import { z } from "zod/v4";
+
+/**
+ * Preview-only enrichments populated when a build is requested in preview mode.
+ * Lives on `BillingPlan.preview` alongside `autumn` (autumn plan) and `stripe`
+ * (stripe action plan). Each field is computed by a dedicated build-stage
+ * helper in `server/src/internal/billing/v2/utils/billingPlan/preview/...`.
+ *
+ * Never populated outside the preview flow — execute paths never see this.
+ */
+export const PreviewBillingPlanSchema = z.object({
+	tax: PreviewTaxSchema.optional(),
+});
+
+export type PreviewBillingPlan = z.infer<typeof PreviewBillingPlanSchema>;

--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -1,9 +1,14 @@
-import type { Entity, FullCustomer } from "@autumn/shared";
+import {
+	type Entity,
+	formatAmount,
+	type FullCustomer,
+} from "@autumn/shared";
 import { PlusIcon } from "@phosphor-icons/react";
 import type { AxiosError } from "axios";
 import { format } from "date-fns";
+import { Decimal } from "decimal.js";
 import { AnimatePresence, motion } from "motion/react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
 	AttachAdvancedSection,
@@ -106,36 +111,71 @@ function ReviewPreviewBlock() {
 	if (showSkeleton) hasShownSkeleton.current = true;
 	const animateIn = hasShownSkeleton.current && !showSkeleton;
 
+	// Surface "tax couldn't be computed" once per resolved preview as a
+	// non-blocking warning. We don't render the Tax row in that case — see
+	// the totals section below.
+	const incompleteToastShownFor = useRef<string | null>(null);
+	useEffect(() => {
+		if (!previewData?.tax) return;
+		if (previewData.tax.status !== "incomplete") return;
+		// Dedupe per request: keyed by the customer + plan in scope so flips
+		// on the same form don't spam.
+		const key = `${formValues.customerId ?? ""}|${formValues.productId ?? ""}`;
+		if (incompleteToastShownFor.current === key) return;
+		incompleteToastShownFor.current = key;
+		toast.warning(
+			"While preparing a tax preview for this purchase, we were unable to determine the customer's location. Tax will not be shown in this preview, but Stripe will compute it on the actual charge.",
+		);
+	}, [previewData?.tax, formValues.customerId, formValues.productId]);
+
 	if (!hasProductSelected) return null;
 
 	const error = queryError
 		? getBackendErr(queryError as AxiosError, "Failed to load preview")
 		: undefined;
 
-	const totals: {
+	// Only "Next Cycle" lives in the LineItemsPreview totals array. The
+	// immediate "Tax" + "Total Due Now" rows are rendered in a bespoke
+	// section below to match the InvoiceDetailSheet pattern.
+	const previewTotals: {
 		label: string;
 		amount: number;
 		variant: "primary" | "secondary";
 		badge?: string;
 	}[] = [];
 
-	if (previewData) {
-		totals.push({
+	// Tax-aware totals. Only show the Tax row when status is "complete" AND
+	// total > 0 — incomplete is surfaced via toast above; zero tax means
+	// nothing taxable in this jurisdiction (no value in showing $0).
+	const showTaxRow =
+		previewData?.tax?.status === "complete" && previewData.tax.total > 0;
+	const taxAmount = showTaxRow ? (previewData?.tax?.total ?? 0) : 0;
+	const totalDueNow = previewData
+		? Math.max(previewData.total, 0) + taxAmount
+		: 0;
+
+	// When there's no Tax row to display, fall back to rendering "Total
+	// Due Now" via the LineItemsPreview totals array — same layout as
+	// before. Only render the bespoke Tax + Total section when we're
+	// actually showing a Tax row, so we don't add an extra empty
+	// SheetSection padding when tax is absent or hidden.
+	if (!showTaxRow && previewData) {
+		previewTotals.push({
 			label: "Total Due Now",
 			amount: Math.max(previewData.total, 0),
 			variant: "primary",
 		});
+	}
 
-		if (previewData.next_cycle) {
-			totals.push({
-				label: "Next Cycle",
-				amount: previewData.next_cycle.total,
-				variant: "secondary",
-				badge: previewData.next_cycle.starts_at
-					? format(new Date(previewData.next_cycle.starts_at), "MMM d, yyyy")
-					: undefined,
-			});
-		}
+	if (previewData?.next_cycle) {
+		previewTotals.push({
+			label: "Next Cycle",
+			amount: previewData.next_cycle.total,
+			variant: "secondary",
+			badge: previewData.next_cycle.starts_at
+				? format(new Date(previewData.next_cycle.starts_at), "MMM d, yyyy")
+				: undefined,
+		});
 	}
 
 	return (
@@ -163,13 +203,53 @@ function ReviewPreviewBlock() {
 							<PreviewErrorDisplay error={error} />
 						</SheetSection>
 					) : (
-						<LineItemsPreview
-							title="Pricing Preview"
-							lineItems={previewData?.line_items}
-							currency={previewData?.currency}
-							totals={totals}
-							filterZeroAmounts
-						/>
+						<>
+							<LineItemsPreview
+								title="Pricing Preview"
+								lineItems={previewData?.line_items}
+								currency={previewData?.currency}
+								totals={previewTotals}
+								filterZeroAmounts
+							/>
+							{showTaxRow && previewData && (
+								<SheetSection withSeparator={false}>
+									<div className="space-y-2">
+										<div className="flex items-center justify-between">
+											<span className="text-sm text-t2">Tax</span>
+											<span className="text-sm tabular-nums text-t2">
+												{formatAmount({
+													amount: new Decimal(taxAmount)
+														.toDecimalPlaces(2)
+														.toNumber(),
+													currency: previewData.currency,
+													minFractionDigits: 2,
+													amountFormatOptions: {
+														currencyDisplay: "narrowSymbol",
+													},
+												})}
+											</span>
+										</div>
+										<div className="flex items-center justify-between">
+											<span className="text-sm font-medium text-foreground">
+												Total Due Now
+											</span>
+											<span className="text-sm font-semibold text-foreground tabular-nums">
+												{formatAmount({
+													amount: new Decimal(totalDueNow)
+														.toDecimalPlaces(2)
+														.toNumber(),
+													currency: previewData.currency,
+													minFractionDigits: 2,
+													amountFormatOptions: {
+														currencyDisplay: "narrowSymbol",
+													},
+												})}
+											</span>
+										</div>
+									</div>
+								</SheetSection>
+							)}
+						</>
 					)}
 					<AttachFooterV3 />
 				</motion.div>


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a tax preview field (`tax`) to the `previewAttach` response for orgs with Stripe automatic tax enabled. When `preview: true` is passed to `attach()`, a new build-stage orchestrator (`computeAttachPreviewBillingPlan`) calls Stripe's read-only `tax.calculations.create` API to compute `amount_exclusive`, `amount_inclusive`, `total`, and `currency`, surfacing a `status: "complete" | "incomplete"` signal so callers can distinguish a successful calculation from a Stripe-side location error.

**Key changes:**
- [Improvements] New `PreviewBillingPlan` / `PreviewTax` shared types and Zod schemas slot cleanly alongside the existing `autumn`/`stripe` plan bags
- [API changes] `AttachPreviewResponse` gains an optional `tax` field, fully backward-compatible (absent when `automatic_tax` is off, checkout is `stripe_checkout`, no customer exists, or no immediately-charged positive lines)
- [Improvements] Three integration tests cover: tax-on with AU address (complete + positive total), tax-off (field omitted), tax-on with no address (incomplete + zeros)
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — only P2 findings; core logic, error handling, and schema changes are correct

No P0 or P1 issues found. The two P2 findings are: the autumn_checkout skip-condition gap (tax preview may use a stale address) and the Stripe Tax API call occurring before validation in handleAttachV2Errors. Both are correctness-adjacent but not breaking given the existing guards in computeAttachTaxPreview.

computeAttachTaxPreview.ts (autumn_checkout guard) and attach.ts (ordering of preview computation vs. error check)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts | New build-stage helper that calls Stripe Tax calculations (read-only) to produce a PreviewTax; well-guarded with early-returns and error fallback, but autumn_checkout is not skipped (see comment) |
| server/src/internal/billing/v2/actions/attach/attach.ts | Wires in computeAttachPreviewBillingPlan at step 3b; preview enrichment is computed before handleAttachV2Errors, causing an unnecessary Stripe API call on invalid attach requests |
| server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts | Orchestrator for preview-only enrichments; clean, extensible design that delegates to per-concern helpers under preview/ |
| shared/api/billing/common/billingPreviewResponse.ts | Adds PreviewTaxSchema and PreviewTax type with well-documented fields; schema fields are correctly typed and exported |
| shared/models/billingModels/plan/previewBillingPlan.ts | New PreviewBillingPlan schema that acts as the bag for all preview-only enrichments on BillingPlan; clean design |
| server/tests/integration/billing/tax/automatic-tax-preview-attach-immediate.test.ts | Integration tests cover three key scenarios (tax on with address, tax off, tax on without address); assertions are thorough and well-documented |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant attach.ts
    participant computeAttachPreviewBillingPlan
    participant computeAttachTaxPreview
    participant StripeTax as Stripe Tax API
    participant billingPlanToAttachPreview

    Client->>attach.ts: attach({ preview: true, ... })
    attach.ts->>attach.ts: setupAttachBillingContext()
    attach.ts->>attach.ts: computeAttachPlan() → autumnBillingPlan
    attach.ts->>attach.ts: evaluateStripeBillingPlan() → stripeBillingPlan
    attach.ts->>computeAttachPreviewBillingPlan: { ctx, billingContext, autumnBillingPlan }
    computeAttachPreviewBillingPlan->>computeAttachTaxPreview: { ctx, billingContext, autumnBillingPlan }
    Note over computeAttachTaxPreview: Guard checks: automatic_tax? stripeCustomer? checkoutMode ≠ stripe_checkout? taxable lines > 0?
    computeAttachTaxPreview->>StripeTax: tax.calculations.create({ currency, customer, line_items })
    StripeTax-->>computeAttachTaxPreview: { tax_amount_exclusive, tax_amount_inclusive }
    computeAttachTaxPreview-->>computeAttachPreviewBillingPlan: PreviewTax { total, amount_exclusive, amount_inclusive, currency, status }
    computeAttachPreviewBillingPlan-->>attach.ts: PreviewBillingPlan { tax }
    attach.ts->>attach.ts: handleAttachV2Errors()
    attach.ts-->>Client: { billingContext, billingPlan: { autumn, stripe, preview } }
    Client->>billingPlanToAttachPreview: billingPlan
    billingPlanToAttachPreview-->>Client: AttachPreviewResponse { ..., tax }
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts:42
**`autumn_checkout` not guarded — tax preview may be stale**

The early-return guards skip `stripe_checkout` because Stripe's hosted checkout collects the address. The same applies to `autumn_checkout`: the customer will be redirected to a form that may collect (or update) their address, meaning the tax preview computed here against their *current* Stripe address could diverge from the tax Stripe charges at checkout. If Autumn Checkout always preserves the pre-existing address, this is fine — but that assumption isn't documented and isn't enforced. Consider either guarding it the same way as `stripe_checkout`, or adding an explicit comment explaining why `autumn_checkout` is intentionally allowed through.

### Issue 2 of 2
server/src/internal/billing/v2/actions/attach/attach.ts:68-75
**Preview enrichment computed before validation**

`computeAttachPreviewBillingPlan` (which triggers a live Stripe Tax API call) is invoked at step 3b, before `handleAttachV2Errors` at step 4. If the attach fails validation — e.g. a missing price, an invalid product, or a payment-method error — the Stripe Tax call was wasted. Since the preview enrichment only needs the already-computed `autumnBillingPlan` and `billingContext`, it can safely be moved to just after the error check and just before the `if (preview) return` short-circuit, keeping the happy path identical while eliminating unnecessary external calls on error paths.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 show tax previews on taxable or..."](https://github.com/useautumn/autumn/commit/17e16f3490820ee19b19a76470bca1ab63b5819f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30379760)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->