### PR TITLE
Checkout session stage & auto top-up dashboard improvements

### DIFF
--- a/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
@@ -2,6 +2,7 @@ import { CusProductStatus, CustomerExpand, Scopes } from "@autumn/shared";
 import { getTestClockFrozenTimeMs } from "@/external/stripe/testClocks/utils/convertStripeTestClock";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { CusService } from "@/internal/customers/CusService";
+import { getCusAutoTopupPurchaseLimits } from "@/internal/customers/cusUtils/cusResponseUtils/getCusAutoTopupPurchaseLimits";
 
 /**
  * Internal route for get full customer object.
@@ -29,13 +30,24 @@ export const handleGetCustomer = createRoute({
 			],
 		});
 
-		const testClockFrozenTimeMs = await getTestClockFrozenTimeMs({
-			ctx,
-			stripeCustomerId: fullCus.processor?.id,
-		});
+		const [testClockFrozenTimeMs, autoTopupsWithLimits] = await Promise.all([
+			getTestClockFrozenTimeMs({
+				ctx,
+				stripeCustomerId: fullCus.processor?.id,
+			}),
+			getCusAutoTopupPurchaseLimits({
+				ctx,
+				internalCustomerId: fullCus.internal_id,
+				autoTopupsConfig: fullCus.auto_topups,
+				expand: [CustomerExpand.AutoTopupsPurchaseLimit],
+			}),
+		]);
 
 		return c.json({
-			customer: fullCus,
+			customer: {
+				...fullCus,
+				auto_topups: autoTopupsWithLimits ?? fullCus.auto_topups,
+			},
 			test_clock_frozen_time_ms: testClockFrozenTimeMs,
 		});
 	},

--- a/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
@@ -31,7 +31,7 @@ function getConfirmLabel({
 	);
 	if (isScheduled) return "Schedule Change";
 
-	if (previewData.redirect_to_checkout) return "Copy Checkout URL";
+	if (previewData.redirect_to_checkout) return "Generate Checkout URL";
 
 	if (previewData.total <= 0) return "Attach Plan";
 
@@ -94,7 +94,13 @@ export function AttachFooterV3() {
 				<Button
 					variant="primary"
 					className="w-full"
-					onClick={() => handleConfirm()}
+					onClick={() => {
+						if (previewData?.redirect_to_checkout) {
+							setSheet({ type: "attach-checkout-session", itemId });
+						} else {
+							handleConfirm();
+						}
+					}}
 					isLoading={isPending}
 				>
 					{confirmLabel}

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -93,6 +93,11 @@ interface AttachFormContextValue {
 		stripeId: string | undefined;
 		hostedInvoiceUrl: string | null | undefined;
 	}>;
+	handleCheckoutAttach: (params: {
+		enablePlanImmediately: boolean;
+	}) => Promise<{
+		paymentUrl: string | null | undefined;
+	}>;
 }
 
 const AttachFormReactContext = createContext<AttachFormContextValue | null>(
@@ -420,7 +425,12 @@ export function AttachFormProvider({
 		incomingItems: originalItems,
 	});
 
-	const { handleConfirm, handleInvoiceAttach, isPending } = useAttachMutation({
+	const {
+		handleConfirm,
+		handleInvoiceAttach,
+		handleCheckoutAttach,
+		isPending,
+	} = useAttachMutation({
 		customerId,
 		buildRequestBody,
 		onCheckoutRedirect,
@@ -504,6 +514,7 @@ export function AttachFormProvider({
 			isPending,
 			handleConfirm,
 			handleInvoiceAttach,
+			handleCheckoutAttach,
 		}),
 		[
 			customerId,
@@ -530,6 +541,7 @@ export function AttachFormProvider({
 			isPending,
 			handleConfirm,
 			handleInvoiceAttach,
+			handleCheckoutAttach,
 		],
 	);
 

--- a/vite/src/components/forms/attach-v2/hooks/useAttachMutation.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachMutation.ts
@@ -27,10 +27,12 @@ export function useAttachMutation({
 			useInvoice,
 			enableProductImmediately,
 			finalizeInvoice,
+			skipDefaultSuccess,
 		}: {
 			useInvoice?: boolean;
 			enableProductImmediately?: boolean;
 			finalizeInvoice?: boolean;
+			skipDefaultSuccess?: boolean;
 		}) => {
 			if (!customerId) {
 				throw new Error("Customer ID is required");
@@ -51,9 +53,18 @@ export function useAttachMutation({
 				requestBody,
 			);
 
-			return { data: response.data, useInvoice };
+			return { data: response.data, useInvoice, skipDefaultSuccess };
 		},
-		onSuccess: ({ data, useInvoice }) => {
+		onSuccess: ({ data, useInvoice, skipDefaultSuccess }) => {
+			if (skipDefaultSuccess) {
+				if (customerId) {
+					queryClient.invalidateQueries({
+						queryKey: ["customer", customerId],
+					});
+				}
+				return;
+			}
+
 			if (useInvoice) {
 				if (data?.invoice) {
 					toast.success("Invoice created successfully");
@@ -106,10 +117,24 @@ export function useAttachMutation({
 		};
 	};
 
+	const handleCheckoutAttach = async ({
+		enablePlanImmediately,
+	}: {
+		enablePlanImmediately: boolean;
+	}) => {
+		const result = await mutation.mutateAsync({
+			useInvoice: false,
+			enableProductImmediately: enablePlanImmediately,
+			skipDefaultSuccess: true,
+		});
+		return { paymentUrl: result.data?.payment_url };
+	};
+
 	return {
 		mutation,
 		handleConfirm,
 		handleInvoiceAttach,
+		handleCheckoutAttach,
 		isPending: mutation.isPending,
 	};
 }

--- a/vite/src/components/forms/shared/GenerateCheckoutStage.tsx
+++ b/vite/src/components/forms/shared/GenerateCheckoutStage.tsx
@@ -1,0 +1,226 @@
+import { ArrowLeft, CheckCircleIcon, LinkIcon } from "@phosphor-icons/react";
+import { format } from "date-fns";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/v2/buttons/Button";
+import { CopyButton } from "@/components/v2/buttons/CopyButton";
+import type { BillingLineItem } from "@/components/v2/LineItemsPreview";
+import { LineItemsPreview } from "@/components/v2/LineItemsPreview";
+import {
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { PlanActivationSection } from "./SendInvoiceStage";
+
+export interface GenerateCheckoutSubmitParams {
+	enablePlanImmediately: boolean;
+}
+
+export function GenerateCheckoutStage({
+	productName,
+	isPending,
+	onBack,
+	onSubmit,
+	lineItems,
+	currency,
+	totals,
+}: {
+	productName?: string;
+	isPending: boolean;
+	onBack: () => void;
+	onSubmit: (params: GenerateCheckoutSubmitParams) => Promise<{
+		paymentUrl: string | null | undefined;
+	}>;
+	lineItems?: BillingLineItem[];
+	currency?: string;
+	totals?: {
+		label: string;
+		amount: number;
+		variant?: "primary" | "secondary";
+		badge?: string;
+	}[];
+}) {
+	const [enableImmediately, setEnableImmediately] = useState(true);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [completedCheckoutUrl, setCompletedCheckoutUrl] = useState<
+		string | null
+	>(null);
+
+	const handleGenerate = async () => {
+		setIsSubmitting(true);
+		try {
+			const { paymentUrl } = await onSubmit({
+				enablePlanImmediately: enableImmediately,
+			});
+			if (paymentUrl) {
+				setCompletedCheckoutUrl(paymentUrl);
+				navigator.clipboard.writeText(paymentUrl);
+				toast.success("Checkout URL copied to clipboard");
+			}
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	if (completedCheckoutUrl) {
+		return (
+			<>
+				<SheetHeader
+					title="Checkout URL Generated"
+					description={
+						productName
+							? `Checkout session created for ${productName}`
+							: "Checkout session has been created"
+					}
+					noSeparator
+				/>
+
+				<SheetSection withSeparator={false}>
+					<div className="flex flex-col items-center gap-2 pt-4">
+						<div className="size-10 rounded-full bg-green-500/10 flex items-center justify-center">
+							<CheckCircleIcon
+								size={24}
+								weight="duotone"
+								className="text-green-500"
+							/>
+						</div>
+						<p className="text-sm text-t2 text-center">
+							The checkout URL has been generated and copied to your clipboard.
+						</p>
+					</div>
+				</SheetSection>
+
+				<SheetFooter className="flex flex-col grid-cols-1 mt-0">
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={() => window.open(completedCheckoutUrl, "_blank")}
+					>
+						Open checkout URL
+					</Button>
+					<CopyButton
+						text={completedCheckoutUrl}
+						innerClassName="text-xs text-t3 font-mono w-96"
+					/>
+				</SheetFooter>
+			</>
+		);
+	}
+
+	return (
+		<>
+			<SheetHeader
+				title="Generate Checkout"
+				description={
+					productName
+						? `Create a checkout session for ${productName}`
+						: "Configure checkout session"
+				}
+			>
+				<button
+					type="button"
+					onClick={onBack}
+					className="flex items-center gap-1 text-t3 text-sm cursor-pointer mt-2 hover:text-foreground transition-colors"
+				>
+					<ArrowLeft size={14} />
+					Back
+				</button>
+			</SheetHeader>
+
+			<PlanActivationSection
+				enableImmediately={enableImmediately}
+				setEnableImmediately={setEnableImmediately}
+			/>
+
+			<LineItemsPreview
+				title="Pricing Preview"
+				lineItems={lineItems}
+				currency={currency}
+				totals={totals}
+				filterZeroAmounts
+			/>
+
+			<SheetFooter className="flex flex-col grid-cols-1 mt-0">
+				<Button
+					variant="primary"
+					className="w-full"
+					onClick={handleGenerate}
+					isLoading={isSubmitting}
+					disabled={isPending}
+				>
+					<LinkIcon size={16} weight="bold" />
+					Generate Checkout URL
+				</Button>
+			</SheetFooter>
+		</>
+	);
+}
+
+export function GenerateCheckoutStageWithPreview({
+	productName,
+	previewQuery,
+	isPending,
+	onSubmit,
+	onBack,
+}: {
+	productName?: string;
+	previewQuery: {
+		data?:
+			| {
+					total: number;
+					next_cycle?: { total: number; starts_at?: number };
+					line_items: BillingLineItem[];
+					currency?: string;
+			  }
+			| null
+			| undefined;
+	};
+	isPending: boolean;
+	onSubmit: (params: GenerateCheckoutSubmitParams) => Promise<{
+		paymentUrl: string | null | undefined;
+	}>;
+	onBack: () => void;
+}) {
+	const previewData = previewQuery.data;
+
+	const totals = useMemo(() => {
+		const result: {
+			label: string;
+			amount: number;
+			variant: "primary" | "secondary";
+			badge?: string;
+		}[] = [];
+		if (!previewData) return result;
+
+		result.push({
+			label: "Total Due Now",
+			amount: Math.max(previewData.total, 0),
+			variant: "primary",
+		});
+
+		if (previewData.next_cycle) {
+			result.push({
+				label: "Next Cycle",
+				amount: previewData.next_cycle.total,
+				variant: "secondary",
+				badge: previewData.next_cycle.starts_at
+					? format(new Date(previewData.next_cycle.starts_at), "MMM d, yyyy")
+					: undefined,
+			});
+		}
+		return result;
+	}, [previewData]);
+
+	return (
+		<GenerateCheckoutStage
+			productName={productName}
+			isPending={isPending}
+			onBack={onBack}
+			onSubmit={onSubmit}
+			lineItems={previewData?.line_items}
+			currency={previewData?.currency}
+			totals={totals}
+		/>
+	);
+}

--- a/vite/src/components/forms/shared/GenerateCheckoutStage.tsx
+++ b/vite/src/components/forms/shared/GenerateCheckoutStage.tsx
@@ -53,11 +53,13 @@ export function GenerateCheckoutStage({
 			const { paymentUrl } = await onSubmit({
 				enablePlanImmediately: enableImmediately,
 			});
-			if (paymentUrl) {
-				setCompletedCheckoutUrl(paymentUrl);
-				navigator.clipboard.writeText(paymentUrl);
-				toast.success("Checkout URL copied to clipboard");
-			}
+		if (paymentUrl) {
+			setCompletedCheckoutUrl(paymentUrl);
+			navigator.clipboard.writeText(paymentUrl);
+			toast.success("Checkout URL copied to clipboard");
+		} else {
+			toast.error("No checkout URL was returned. Please try again.");
+		}
 		} finally {
 			setIsSubmitting(false);
 		}

--- a/vite/src/components/forms/shared/SendInvoiceStage.tsx
+++ b/vite/src/components/forms/shared/SendInvoiceStage.tsx
@@ -28,6 +28,58 @@ export interface SendInvoiceSubmitParams {
 	finalizeInvoice: boolean;
 }
 
+export function PlanActivationSection({
+	enableImmediately,
+	setEnableImmediately,
+	disabled,
+}: {
+	enableImmediately: boolean;
+	setEnableImmediately: (value: boolean) => void;
+	disabled?: boolean;
+}) {
+	return (
+		<SheetSection
+			title="Plan Activation"
+			withSeparator
+			className={disabled ? "opacity-50 pointer-events-none" : ""}
+		>
+			<div className="space-y-4">
+				<div className="flex w-full items-center gap-4">
+					<PanelButton
+						isSelected={enableImmediately}
+						onClick={() => setEnableImmediately(true)}
+						icon={<LightningIcon size={18} weight="duotone" />}
+					/>
+					<div className="flex-1">
+						<div className="text-body-highlight mb-1">
+							Enable plan immediately
+						</div>
+						<div className="text-body-secondary leading-tight">
+							Plan activates now, payment is collected separately.
+						</div>
+					</div>
+				</div>
+
+				<div className="flex w-full items-center gap-4">
+					<PanelButton
+						isSelected={!enableImmediately}
+						onClick={() => setEnableImmediately(false)}
+						icon={<HourglassIcon size={18} weight="duotone" />}
+					/>
+					<div className="flex-1">
+						<div className="text-body-highlight mb-1">
+							Enable plan after payment
+						</div>
+						<div className="text-body-secondary leading-tight">
+							Plan activates only after the customer completes payment.
+						</div>
+					</div>
+				</div>
+			</div>
+		</SheetSection>
+	);
+}
+
 export function SendInvoiceStage({
 	productName,
 	isPending,
@@ -65,9 +117,9 @@ export function SendInvoiceStage({
 	const [completedInvoiceUrl, setCompletedInvoiceUrl] = useState<string | null>(
 		null,
 	);
-	const [activeAction, setActiveAction] = useState<
-		"draft" | "finalize" | null
-	>(null);
+	const [activeAction, setActiveAction] = useState<"draft" | "finalize" | null>(
+		null,
+	);
 
 	const customerId = customer?.id ?? customer?.internal_id;
 
@@ -160,9 +212,9 @@ export function SendInvoiceStage({
 						View Stripe invoice
 					</Button>
 					<CopyButton
-							text={completedInvoiceUrl}
-							innerClassName="text-xs text-t3 font-mono w-96"
-						/>
+						text={completedInvoiceUrl}
+						innerClassName="text-xs text-t3 font-mono w-96"
+					/>
 				</SheetFooter>
 			</>
 		);
@@ -217,45 +269,11 @@ export function SendInvoiceStage({
 				</SheetSection>
 			)}
 
-			<SheetSection
-				title="Plan Activation"
-				withSeparator
-				className={needsEmail ? "opacity-50 pointer-events-none" : ""}
-			>
-				<div className="space-y-4">
-					<div className="flex w-full items-center gap-4">
-						<PanelButton
-							isSelected={enableImmediately}
-							onClick={() => setEnableImmediately(true)}
-							icon={<LightningIcon size={18} weight="duotone" />}
-						/>
-						<div className="flex-1">
-							<div className="text-body-highlight mb-1">
-								Enable plan immediately
-							</div>
-							<div className="text-body-secondary leading-tight">
-								Plan activates now, invoice is sent for payment.
-							</div>
-						</div>
-					</div>
-
-					<div className="flex w-full items-center gap-4">
-						<PanelButton
-							isSelected={!enableImmediately}
-							onClick={() => setEnableImmediately(false)}
-							icon={<HourglassIcon size={18} weight="duotone" />}
-						/>
-						<div className="flex-1">
-							<div className="text-body-highlight mb-1">
-								Enable plan after payment
-							</div>
-							<div className="text-body-secondary leading-tight">
-								Plan activates only after the customer pays the invoice.
-							</div>
-						</div>
-					</div>
-				</div>
-			</SheetSection>
+			<PlanActivationSection
+				enableImmediately={enableImmediately}
+				setEnableImmediately={setEnableImmediately}
+				disabled={needsEmail}
+			/>
 
 			<LineItemsPreview
 				title="Pricing Preview"

--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -12,6 +12,7 @@ export type SheetType =
 	| "attach-product"
 	| "attach-review"
 	| "attach-send-invoice"
+	| "attach-checkout-session"
 	| "subscription-detail"
 	| "subscription-update"
 	| "subscription-update-send-invoice"
@@ -108,7 +109,8 @@ export const useIsAttachingProduct = () =>
 		(s) =>
 			s.type === "attach-product" ||
 			s.type === "attach-review" ||
-			s.type === "attach-send-invoice",
+			s.type === "attach-send-invoice" ||
+			s.type === "attach-checkout-session",
 	);
 
 /**

--- a/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
+++ b/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
@@ -1,19 +1,14 @@
-import {
-	ACTIVE_STATUSES,
-	type AutoTopup,
-	cusEntsToBalance,
-	cusEntsToGrantedBalance,
-	cusEntsToPrepaidQuantity,
-	type DbOverageAllowed,
-	type DbSpendLimit,
-	type DbUsageAlert,
-	type Entity,
-	type Feature,
-	type FullCustomer,
-	fullCustomerToCustomerEntitlements,
-	nullish,
+import type {
+	AutoTopupResponse,
+	DbOverageAllowed,
+	DbSpendLimit,
+	DbUsageAlert,
+	Entity,
+	Feature,
+	FullCustomer,
 } from "@autumn/shared";
 import { GavelIcon, PlusIcon } from "@phosphor-icons/react";
+import { format } from "date-fns";
 import { type ReactNode, useMemo } from "react";
 import { Table } from "@/components/general/table";
 import { SectionTag } from "@/components/v2/badges/SectionTag";
@@ -91,11 +86,12 @@ const AutoTopupRow = ({
 	featureNameById,
 	onClick,
 }: {
-	autoTopup: AutoTopup;
+	autoTopup: AutoTopupResponse;
 	featureNameById: Map<string, string>;
 	onClick: () => void;
 }) => {
 	const purchaseLimit = autoTopup.purchase_limit;
+	const hasExpandedLimit = purchaseLimit && "count" in purchaseLimit;
 
 	return (
 		<button type="button" className={rowClassName} onClick={onClick}>
@@ -111,7 +107,14 @@ const AutoTopupRow = ({
 				<Pill>Qty: {autoTopup.quantity.toLocaleString()}</Pill>
 				{purchaseLimit && (
 					<Pill className="hidden lg:inline">
-						Limit: {purchaseLimit.limit}/{purchaseLimit.interval}
+						{hasExpandedLimit
+							? `${purchaseLimit.count}/${purchaseLimit.limit} per ${purchaseLimit.interval}`
+							: `Limit: ${purchaseLimit.limit} per ${purchaseLimit.interval}`}
+					</Pill>
+				)}
+				{hasExpandedLimit && purchaseLimit.next_reset_at && (
+					<Pill className="hidden xl:inline">
+						Resets {format(new Date(purchaseLimit.next_reset_at), "MMM d")}
 					</Pill>
 				)}
 			</div>
@@ -150,26 +153,15 @@ const SpendLimitRow = ({
 const UsageAlertRow = ({
 	usageAlert,
 	featureNameById,
-	featureBalance,
 	onClick,
 }: {
 	usageAlert: DbUsageAlert;
 	featureNameById: Map<string, string>;
-	featureBalance: {
-		remaining: number;
-		remainingPercentage: number | null;
-		usage: number;
-		usagePercentage: number | null;
-	} | null;
 	onClick: () => void;
 }) => {
 	const isPercentageType =
 		usageAlert.threshold_type === "usage_percentage" ||
 		usageAlert.threshold_type === "remaining_percentage";
-
-	const isUsageType =
-		usageAlert.threshold_type === "usage" ||
-		usageAlert.threshold_type === "usage_percentage";
 
 	const thresholdLabel = isPercentageType
 		? `${usageAlert.threshold}%`
@@ -181,28 +173,6 @@ const UsageAlertRow = ({
 		remaining: "absolute remaining",
 		remaining_percentage: "% remaining of allowance",
 	};
-
-	const statusPill = (() => {
-		if (!featureBalance) return null;
-
-		if (isUsageType) {
-			const percentage = featureBalance.usagePercentage;
-			return (
-				<Pill>
-					Usage: {featureBalance.usage.toLocaleString()}
-					{percentage !== null && ` (${Math.round(percentage)}%)`}
-				</Pill>
-			);
-		}
-
-		return (
-			<Pill>
-				Remaining: {featureBalance.remaining.toLocaleString()}
-				{featureBalance.remainingPercentage !== null &&
-					` (${Math.round(featureBalance.remainingPercentage)}%)`}
-			</Pill>
-		);
-	})();
 
 	return (
 		<button type="button" className={rowClassName} onClick={onClick}>
@@ -219,7 +189,6 @@ const UsageAlertRow = ({
 				</span>
 			)}
 			<div className="ml-auto flex items-center gap-1.5 shrink-0">
-				{statusPill}
 				<Pill>At: {thresholdLabel}</Pill>
 				<Pill className="hidden sm:inline">
 					{thresholdTypeLabel[usageAlert.threshold_type]}
@@ -283,72 +252,6 @@ export function CustomerBillingControlsSection() {
 	const overageAllowed = selectedEntity
 		? (selectedEntity.overage_allowed ?? [])
 		: (fullCustomer?.overage_allowed ?? []);
-
-	const balanceByFeatureId = useMemo(() => {
-		if (!fullCustomer)
-			return new Map<
-				string,
-				{
-					remaining: number;
-					remainingPercentage: number | null;
-					usage: number;
-					usagePercentage: number | null;
-				}
-			>();
-
-		const featureIds = [
-			...new Set(
-				usageAlerts
-					.map((alert) => alert.feature_id)
-					.filter((id): id is string => !!id),
-			),
-		];
-
-		const result = new Map<
-			string,
-			{
-				remaining: number;
-				remainingPercentage: number | null;
-				usage: number;
-				usagePercentage: number | null;
-			}
-		>();
-		for (const featureId of featureIds) {
-			const cusEnts = fullCustomerToCustomerEntitlements({
-				fullCustomer,
-				featureId,
-				entity: selectedEntity ?? undefined,
-				inStatuses: ACTIVE_STATUSES,
-			});
-
-			const grantedBalance = cusEntsToGrantedBalance({
-				cusEnts,
-				entityId: entityId ?? undefined,
-			});
-			const prepaid = cusEntsToPrepaidQuantity({
-				cusEnts,
-				sumAcrossEntities: nullish(entityId),
-			});
-			const totalAllowance = grantedBalance + prepaid;
-
-			const balance = cusEntsToBalance({
-				cusEnts,
-				entityId: entityId ?? undefined,
-			});
-
-			const usage = totalAllowance - balance;
-
-			result.set(featureId, {
-				remaining: balance,
-				remainingPercentage:
-					totalAllowance > 0 ? (balance / totalAllowance) * 100 : null,
-				usage,
-				usagePercentage:
-					totalAllowance > 0 ? (usage / totalAllowance) * 100 : null,
-			});
-		}
-		return result;
-	}, [fullCustomer, usageAlerts, selectedEntity, entityId]);
 
 	const hasAnyControls =
 		autoTopups.length > 0 ||
@@ -527,26 +430,19 @@ export function CustomerBillingControlsSection() {
 					{usageAlerts.length > 0 && (
 						<BillingControlsGroup title="Usage alerts" emptyText="" hasItems>
 							<div className="flex flex-col gap-1.5 rounded-lg">
-								{usageAlerts.map((usageAlert, index) => {
-									const featureBalance = usageAlert.feature_id
-										? balanceByFeatureId.get(usageAlert.feature_id) ??
-											null
-										: null;
-									return (
-										<UsageAlertRow
-											key={`usage-alert-${usageAlert.feature_id ?? "global"}-${usageAlert.name ?? index}`}
-											usageAlert={usageAlert}
-											featureNameById={featureNameById}
-											featureBalance={featureBalance}
-											onClick={() =>
-												setSheet({
-													type: "billing-usage-alert-edit",
-													data: { index, item: usageAlert },
-												})
-											}
-										/>
-									);
-								})}
+								{usageAlerts.map((usageAlert, index) => (
+									<UsageAlertRow
+										key={`usage-alert-${usageAlert.feature_id ?? "global"}-${usageAlert.name ?? index}`}
+										usageAlert={usageAlert}
+										featureNameById={featureNameById}
+										onClick={() =>
+											setSheet({
+												type: "billing-usage-alert-edit",
+												data: { index, item: usageAlert },
+											})
+										}
+									/>
+								))}
 							</div>
 						</BillingControlsGroup>
 					)}

--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -16,6 +16,7 @@ import {
 	useAttachFormContext,
 } from "@/components/forms/attach-v2";
 import { AttachFooterV3 } from "@/components/forms/attach-v2/components/AttachFooterV3";
+import { GenerateCheckoutStageWithPreview } from "@/components/forms/shared/GenerateCheckoutStage";
 import { SendInvoiceStageWithPreview } from "@/components/forms/shared/SendInvoiceStage";
 import { PreviewErrorDisplay } from "@/components/forms/update-subscription-v2/components/PreviewErrorDisplay";
 import {
@@ -438,6 +439,23 @@ function SendInvoiceContent() {
 	);
 }
 
+function CheckoutSessionContent() {
+	const { product, previewQuery, isPending, handleCheckoutAttach } =
+		useAttachFormContext();
+	const { setSheet } = useSheetStore();
+	const itemId = useSheetStore((s) => s.itemId);
+
+	return (
+		<GenerateCheckoutStageWithPreview
+			productName={product?.name}
+			previewQuery={previewQuery}
+			isPending={isPending}
+			onSubmit={handleCheckoutAttach}
+			onBack={() => setSheet({ type: "attach-review", itemId })}
+		/>
+	);
+}
+
 function SheetContent() {
 	const sheetType = useSheetStore((s) => s.type);
 	const {
@@ -447,16 +465,19 @@ function SheetContent() {
 		handlePlanEditorCancel,
 	} = useAttachFormContext();
 
+	const StageContent =
+		sheetType === "attach-send-invoice"
+			? SendInvoiceContent
+			: sheetType === "attach-checkout-session"
+				? CheckoutSessionContent
+				: sheetType === "attach-review"
+					? ReviewContent
+					: SelectContent;
+
 	return (
 		<LayoutGroup>
 			<div className="flex flex-col h-full overflow-y-auto">
-				{sheetType === "attach-send-invoice" ? (
-					<SendInvoiceContent />
-				) : sheetType === "attach-review" ? (
-					<ReviewContent />
-				) : (
-					<SelectContent />
-				)}
+				<StageContent />
 
 				{productWithFormItems && (
 					<InlinePlanEditor

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -1,5 +1,6 @@
 import {
 	type AutoTopup,
+	type AutoTopupResponse,
 	cusEntToCusPrice,
 	type Feature,
 	FeatureType,
@@ -12,6 +13,7 @@ import {
 	PurchaseLimitInterval,
 	type UsagePriceConfig,
 } from "@autumn/shared";
+import { format } from "date-fns";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import FieldLabel from "@/components/general/modal-components/FieldLabel";
@@ -65,8 +67,14 @@ export function BillingAutoTopupSheet() {
 	const axiosInstance = useAxiosInstance();
 
 	const isEdit = sheetType === "billing-auto-topup-edit";
-	const existingItem = sheetData?.item as AutoTopup | undefined;
+	const existingItem = sheetData?.item as AutoTopupResponse | undefined;
 	const existingIndex = sheetData?.index as number | undefined;
+
+	const expandedPurchaseLimit = useMemo(() => {
+		const limit = existingItem?.purchase_limit;
+		if (!limit || !("count" in limit)) return null;
+		return limit;
+	}, [existingItem]);
 
 	const [isSaving, setIsSaving] = useState(false);
 	const [featureId, setFeatureId] = useState(existingItem?.feature_id ?? "");
@@ -332,6 +340,26 @@ export function BillingAutoTopupSheet() {
 						/>
 						<FormLabel className="mb-0">Purchase limit</FormLabel>
 					</div>
+
+					{hasPurchaseLimit && expandedPurchaseLimit && (
+						<InfoBox variant="note"
+						classNames={{
+							infoBox: "my-3"
+						}}
+						>
+							{expandedPurchaseLimit.count} of{" "}
+							{expandedPurchaseLimit.limit ?? "∞"} top-ups used this window
+							{expandedPurchaseLimit.next_reset_at && (
+								<>
+									{" · Resets "}
+									{format(
+										new Date(expandedPurchaseLimit.next_reset_at),
+										"MMM d, yyyy",
+									)}
+								</>
+							)}
+						</InfoBox>
+					)}
 
 					{hasPurchaseLimit && (
 						<div className="flex flex-col gap-3">

--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -46,6 +46,7 @@ export function CustomerSheets() {
 			case "attach-product":
 			case "attach-review":
 			case "attach-send-invoice":
+			case "attach-checkout-session":
 				return <AttachProductSheet />;
 			// case "attach-product-v2":
 			// 	return <AttachProductSheetV3 />;


### PR DESCRIPTION
## Summary
- Add a checkout session stage to the AttachProduct sheet, allowing plan activation with a generated checkout link
- Expose auto top-up purchase limit count and next reset date on the customer billing controls dashboard, simplifying the UI

## Test plan
- [ ] Verify AttachProduct sheet shows the checkout stage flow correctly
- [ ] Confirm auto top-up section displays purchase limit count and next reset
- [ ] Test checkout link generation and copy functionality

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a checkout session stage to the Attach Product flow so users can generate a checkout URL and choose when the plan activates. Also surfaces auto top-up purchase limit usage and next reset dates in the billing dashboard.

- **New Features**
  - New "Generate Checkout" stage in Attach Product: choose activation timing, create a checkout session, auto-copy the URL, see a success state with an open link, and view a price preview; shows an error if no URL is returned.
  - When `redirect_to_checkout` is set, the footer routes to the new `attach-checkout-session` stage; added `handleCheckoutAttach` (returns `payment_url`) and `skipDefaultSuccess` in the mutation; registered `attach-checkout-session` in the sheet store.
  - Dashboard and edit sheet now show auto top-up usage (count/limit per interval) and the next reset date; server expands purchase limit state and includes it in the customer response.

- **Refactors**
  - Extracted `PlanActivationSection` for reuse in invoice and checkout; updated `SendInvoiceStage` to use it.
  - Simplified billing controls by removing usage alert balance/percentage pills.

<sup>Written for commit 4bd3257c3e9bd89fa915d942c47fb4dac3a2e18e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a checkout session stage to the `AttachProduct` sheet — including a new `GenerateCheckoutStage` component, `attach-checkout-session` sheet type, and a `handleCheckoutAttach` mutation path — and improves the auto top-up dashboard by surfacing purchase limit count and next reset date from a new server-side enrichment call (`getCusAutoTopupPurchaseLimits`). It also simplifies the billing controls UI by removing the in-client feature-balance calculation and usage-alert balance pills.

**Key changes:**
- [Improvements] Checkout session stage: generates a shareable checkout URL from the attach flow, with an activation-mode toggle reusing the extracted `PlanActivationSection` component.
- [Improvements] Auto top-up dashboard: the internal `handleGetCustomer` endpoint now enriches `auto_topups` with runtime `count` and `next_reset_at` from `auto_topup_limit_states`, displayed in both the controls table and the edit sheet.
- [Improvements] UI simplification: removed `balanceByFeatureId` memo and feature-balance pills from usage alert rows.
</details>

<h3>Confidence Score: 3/5</h3>

Mostly safe to merge after addressing the silent-failure case in GenerateCheckoutStage.

One P1 finding: when the API returns a success response but no payment_url, the user receives zero feedback — the spinner stops and nothing happens, leaving the sheet in a broken-looking state. This is on a new code path so it won't regress existing flows, but it will affect any user who hits that edge case in the checkout flow.

vite/src/components/forms/shared/GenerateCheckoutStage.tsx — missing else-branch for the falsy-paymentUrl case in handleGenerate.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/shared/GenerateCheckoutStage.tsx | New component for the checkout session generation flow; missing error feedback when paymentUrl is null/undefined and clipboard write is unawaited. |
| vite/src/components/forms/attach-v2/hooks/useAttachMutation.ts | Adds handleCheckoutAttach and skipDefaultSuccess flag to reuse the mutation for checkout URL generation without triggering the default toast/redirect flow. |
| server/src/internal/customers/internalHandlers/handleGetCustomer.ts | Parallelizes test-clock and auto-topup purchase-limit fetches, enriching the auto_topups field in the response with runtime count and reset info. |
| vite/src/views/customers2/components/CustomerBillingControlsSection.tsx | Removes the in-client balanceByFeatureId calculation and feature-balance pill from usage alert rows; adds purchase count and next-reset display to auto-topup rows. |
| vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx | Switches from AutoTopup to AutoTopupResponse and shows an info box with purchase count and next reset date when the expanded purchase limit is present. |
| vite/src/components/forms/shared/SendInvoiceStage.tsx | Extracts PlanActivationSection into a shared component reused by both the invoice and checkout stages; formatting-only cleanup of CopyButton indentation. |
| vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx | Footer now navigates to the attach-checkout-session sheet instead of directly calling handleConfirm when the product requires a checkout redirect. |
| vite/src/views/customers2/components/sheets/AttachProductSheet.tsx | Adds CheckoutSessionContent stage and refactors the SheetContent stage-switching logic to use a variable instead of nested ternaries. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant AttachFooterV3
    participant SheetStore
    participant CheckoutSessionContent
    participant GenerateCheckoutStage
    participant useAttachMutation
    participant API as /v1/billing.attach

    User->>AttachFooterV3: Click "Generate Checkout URL"
    AttachFooterV3->>SheetStore: setSheet({ type: "attach-checkout-session" })
    SheetStore-->>CheckoutSessionContent: renders
    CheckoutSessionContent-->>GenerateCheckoutStage: renders (with previewQuery data)

    User->>GenerateCheckoutStage: Click "Generate Checkout URL"
    GenerateCheckoutStage->>useAttachMutation: handleCheckoutAttach({ enablePlanImmediately })
    useAttachMutation->>API: POST /v1/billing.attach (skipDefaultSuccess=true)
    API-->>useAttachMutation: { payment_url }
    useAttachMutation-->>GenerateCheckoutStage: { paymentUrl }

    alt paymentUrl present
        GenerateCheckoutStage->>GenerateCheckoutStage: setCompletedCheckoutUrl(paymentUrl)
        GenerateCheckoutStage->>GenerateCheckoutStage: navigator.clipboard.writeText(paymentUrl)
        GenerateCheckoutStage-->>User: Show success state + Open checkout URL button
    else paymentUrl null/undefined
        GenerateCheckoutStage-->>User: No feedback shown (bug)
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/components/forms/shared/GenerateCheckoutStage.tsx:56-60
**Silent failure when `paymentUrl` is falsy**

If the API call succeeds but returns a null/undefined `payment_url`, the `if (paymentUrl)` branch is skipped entirely: `isSubmitting` resets, no checkout state is set, and no error or warning is shown to the user. The user sees the button stop spinning with no feedback, and the sheet appears stuck.

Add an `else` branch to surface this case:

```suggestion
		if (paymentUrl) {
			setCompletedCheckoutUrl(paymentUrl);
			navigator.clipboard.writeText(paymentUrl);
			toast.success("Checkout URL copied to clipboard");
		} else {
			toast.error("No checkout URL was returned. Please try again.");
		}
```

### Issue 2 of 2
vite/src/components/forms/shared/GenerateCheckoutStage.tsx:58-59
**Unawaited clipboard write gives misleading toast**

`navigator.clipboard.writeText` returns a Promise. If the user hasn't granted clipboard permission, the write fails silently while the `toast.success("Checkout URL copied to clipboard")` still fires, giving false feedback. Awaiting the call allows you to catch the rejection and show a more accurate message.

```suggestion
			await navigator.clipboard.writeText(paymentUrl).catch(() => {});
			toast.success("Checkout URL copied to clipboard");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Expose auto top-up purchase limit count ..."](https://github.com/useautumn/autumn/commit/312534999686716388c00d31297c59004a51095e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30486203)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->