### PR TITLE
fix: sync schedules

### DIFF
--- a/packages/stripe-sync/src/syncableResources.ts
+++ b/packages/stripe-sync/src/syncableResources.ts
@@ -1,5 +1,6 @@
 export const SYNCABLE_EVENT_PREFIXES = [
 	"customer.subscription.",
+	"subscription_schedule.",
 	"payment_intent.",
 	"invoice.",
 	"customer.",

--- a/server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts
@@ -1,5 +1,8 @@
+import { SpanStatusCode, context, trace } from "@opentelemetry/api";
 import type { Context, Next } from "hono";
 import type { StripeWebhookHonoEnv } from "./stripeWebhookContext";
+
+const tracer = trace.getTracer("autumn-stripe-webhook");
 
 const getWaitUntil = (c: Context<StripeWebhookHonoEnv>) => {
 	try {
@@ -14,20 +17,34 @@ export const stripeWebhookEarlyAckMiddleware = async (
 	next: Next,
 ) => {
 	const ctx = c.get("ctx");
+
+	// Start a span that survives past the early-ack response. Parented to the
+	// still-active root HTTP span; ended in finally(...) when deferred work
+	// completes so traceEnrichMiddleware + child spans land on a live span.
+	const deferredSpan = tracer.startSpan("stripe.webhook.deferred");
+	const ctxWithSpan = trace.setSpan(context.active(), deferredSpan);
+
 	const runWebhook = () =>
-		Promise.resolve()
-			.then(next)
-			.catch((error) => {
-				ctx.logger.error(`Stripe webhook background processing failed: ${error}`, {
-					error,
-				});
-			});
+		context.with(ctxWithSpan, () =>
+			Promise.resolve()
+				.then(next)
+				.catch((error) => {
+					deferredSpan.recordException(error);
+					deferredSpan.setStatus({ code: SpanStatusCode.ERROR });
+					ctx.logger.error(
+						`Stripe webhook background processing failed: ${error}`,
+						{ error },
+					);
+				})
+				.finally(() => deferredSpan.end()),
+		);
 
 	const waitUntil = getWaitUntil(c);
 	if (waitUntil) {
 		try {
 			waitUntil(runWebhook());
 		} catch (error) {
+			deferredSpan.end();
 			ctx.logger.error(`Stripe webhook waitUntil failed: ${error}`, { error });
 		}
 	} else {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sync Stripe subscription schedules and fix missing tracing for early-acknowledged webhook background work to improve reliability and visibility.

- **Bug Fixes**
  - Added `subscription_schedule.` to `SYNCABLE_EVENT_PREFIXES` so schedule events are synced.
  - In `stripeWebhookEarlyAckMiddleware`, start a deferred span with `@opentelemetry/api`, propagate context to background work, record exceptions, set error status, and always end the span; keep error logging and handle `waitUntil` safely.

<sup>Written for commit 6135fc9b41f6fce15fe6d265591be8474602b06d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes sync for Stripe subscription schedules by adding `subscription_schedule.` to `SYNCABLE_EVENT_PREFIXES`, and improves observability in the early-ack webhook middleware by adding an OpenTelemetry deferred span that lives through background processing.

**Key changes:**
- [Bug fixes] Added `subscription_schedule.` prefix to `SYNCABLE_EVENT_PREFIXES` so schedule-related Stripe events are synced correctly.
- [Improvements] Added a deferred OTel span in `stripeWebhookEarlyAckMiddleware` so tracing correctly captures asynchronous webhook processing after the early 200 response.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; only a P2 observation about span timing in an uncommon error path.

The core fix is a one-line addition with no risk. The tracing change is well-structured; the only concern is a span being ended prematurely when `waitUntil` itself throws, which is an edge case and already produces a silent no-op on the second `end()` call.

server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts — minor span lifecycle concern in the `waitUntil` error catch block.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/stripe-sync/src/syncableResources.ts | Adds `subscription_schedule.` to the list of syncable Stripe event prefixes, enabling schedule-related webhook events to be synced — the core bugfix of this PR. |
| server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts | Adds an OpenTelemetry deferred span that persists through background webhook processing; span is correctly ended in `.finally()` and on most error paths, but the `waitUntil`-throw catch path ends the span prematurely before deferred work completes. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Middleware as stripeWebhookEarlyAckMiddleware
    participant OTel as OpenTelemetry
    participant Next as Webhook Handler

    Stripe->>Middleware: POST /webhook
    Middleware->>OTel: startSpan("stripe.webhook.deferred")
    Middleware->>Middleware: runWebhook = context.with(ctxWithSpan, ...)
    alt waitUntil available (Cloudflare Workers)
        Middleware->>Middleware: waitUntil(runWebhook())
        Note over Middleware: deferred work runs in background
        Middleware-->>Stripe: 200 { received: true }
        Middleware->>Next: next() (background)
        Next-->>OTel: child spans recorded
        Middleware->>OTel: deferredSpan.end() (via .finally)
    else Node.js / setImmediate
        Middleware->>Middleware: setImmediate(() => runWebhook())
        Middleware-->>Stripe: 200 { received: true }
        Middleware->>Next: next() (deferred)
        Next-->>OTel: child spans recorded
        Middleware->>OTel: deferredSpan.end() (via .finally)
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts`, line 43-49 ([link](https://github.com/useautumn/autumn/blob/6135fc9b41f6fce15fe6d265591be8474602b06d/server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts#L43-L49)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Premature span end in `waitUntil` error path**

   When `waitUntil(runWebhook())` throws, `runWebhook()` has already been called (it's evaluated as the argument before `waitUntil` is invoked), so the deferred promise chain is already running. The catch block calls `deferredSpan.end()` synchronously, which ends the span before the webhook work completes. The `.finally(() => deferredSpan.end())` inside `runWebhook` will later call `end()` again (a silent no-op in the OTel SDK), but the span duration will not reflect the actual webhook processing time in this error case. Consider removing `deferredSpan.end()` from the catch block here since the `.finally()` inside `runWebhook` already guarantees cleanup.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts
   Line: 43-49

   Comment:
   **Premature span end in `waitUntil` error path**

   When `waitUntil(runWebhook())` throws, `runWebhook()` has already been called (it's evaluated as the argument before `waitUntil` is invoked), so the deferred promise chain is already running. The catch block calls `deferredSpan.end()` synchronously, which ends the span before the webhook work completes. The `.finally(() => deferredSpan.end())` inside `runWebhook` will later call `end()` again (a silent no-op in the OTel SDK), but the span duration will not reflect the actual webhook processing time in this error case. Consider removing `deferredSpan.end()` from the catch block here since the `.finally()` inside `runWebhook` already guarantees cleanup.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/external/stripe/webhookMiddlewares/stripeWebhookEarlyAckMiddleware.ts:43-49
**Premature span end in `waitUntil` error path**

When `waitUntil(runWebhook())` throws, `runWebhook()` has already been called (it's evaluated as the argument before `waitUntil` is invoked), so the deferred promise chain is already running. The catch block calls `deferredSpan.end()` synchronously, which ends the span before the webhook work completes. The `.finally(() => deferredSpan.end())` inside `runWebhook` will later call `end()` again (a silent no-op in the OTel SDK), but the span duration will not reflect the actual webhook processing time in this error case. Consider removing `deferredSpan.end()` from the catch block here since the `.finally()` inside `runWebhook` already guarantees cleanup.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: sync schedules and webhook otel"](https://github.com/useautumn/autumn/commit/6135fc9b41f6fce15fe6d265591be8474602b06d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30702707)</sub>

<!-- /greptile_comment -->