### PR TITLE
fix: member toolbar dropdown visibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -209,7 +209,7 @@
     },
     "packages/autumn-js": {
       "name": "autumn-js",
-      "version": "1.2.17",
+      "version": "1.2.10",
       "dependencies": {
         "query-string": "^9.2.2",
         "rou3": "^0.6.1",

--- a/bun.lock
+++ b/bun.lock
@@ -209,7 +209,7 @@
     },
     "packages/autumn-js": {
       "name": "autumn-js",
-      "version": "1.2.10",
+      "version": "1.2.17",
       "dependencies": {
         "query-string": "^9.2.2",
         "rou3": "^0.6.1",

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/MemberRowToolbar.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/MemberRowToolbar.tsx
@@ -94,10 +94,10 @@ export const MemberRowToolbar = ({
 					size="icon"
 					iconOrientation="center"
 					icon={<EllipsisVertical />}
-					className="!h-5 !w-5 rounded-lg hover:bg-stone-50"
+					className="!h-5 !w-5 rounded-lg hover:bg-interactive-secondary-hover"
 				/>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end">
+			<DropdownMenuContent align="end" className="z-[200]">
 				<DropdownMenuItem
 					variant="destructive"
 					shimmer={deleteLoading}


### PR DESCRIPTION
The v2 `DropdownMenuContent` defaults to `z-[101]`, which renders behind `DialogContent` at `z-[180]`, making the ellipsis menu appear unresponsive.

- Added `z-[200]` to `DropdownMenuContent` so it renders above the parent Dialog, matching the pattern used by v2 Select/Tooltip/FeatureSelector.
- Updated hover color from `hover:bg-stone-50` to `hover:bg-interactive-secondary-hover` for design consistency.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/2b09dd80-ca1c-42b4-98af-ad10625d7cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-024" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/2b09dd80-ca1c-42b4-98af-ad10625d7cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-024&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-024"><img alt="SCO-024" src="https://capy.ai/api/badge/thread.svg?label=SCO-024"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the member toolbar dropdown rendering behind the Manage Org dialog so the ellipsis menu opens correctly. Also updates the hover color to match design tokens.

- **Bug Fixes**
  - Set dropdown `z-[200]` so it renders above dialog content (`z-[180]`).
  - Changed hover color to `hover:bg-interactive-secondary-hover` (was `hover:bg-stone-50`).

<sup>Written for commit c712ad222a0232f0048ac60b2a7e2db2ef9774ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the ellipsis dropdown in the member management toolbar being hidden behind the parent `DialogContent` by applying `z-[200]` to `DropdownMenuContent`, and updates the trigger button's hover color to the design-system token `interactive-secondary-hover`.

- **[Bug fixes]** `DropdownMenuContent` in `MemberRowToolbar` now receives `z-[200]`, overriding the component default of `z-[101]` so it renders above `DialogContent` at `z-[180]`.
- **[Improvements]** Trigger button hover color changed from `hover:bg-stone-50` to `hover:bg-interactive-secondary-hover` for design consistency with the rest of the v2 component set.
- **[Improvements]** `autumn-js` bumped from `1.2.10` to `1.2.17` in `bun.lock` (unrelated to the stated fix; verify intentionality).
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a targeted z-index override that directly fixes the reported visibility bug, consistent with the pattern used throughout other v2 components.

The fix is correct and well-scoped, but the root cause (DropdownMenuContent defaulting to z-[101]) remains in the base component, leaving other dropdowns rendered inside dialogs vulnerable to the same invisible-menu issue. The unrelated autumn-js bump also deserves a quick confirmation before merging.

vite/src/components/v2/dropdowns/DropdownMenu.tsx — the default z-index on DropdownMenuContent is still z-[101], which could affect other usages inside dialogs.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/main-sidebar/org-dropdown/manage-org/MemberRowToolbar.tsx | Adds z-[200] to DropdownMenuContent to render above DialogContent (z-[180]), and updates hover color to use the design-system token. Both changes are correct and consistent with other v2 components. |
| bun.lock | Bumps autumn-js from 1.2.10 to 1.2.17 — an unrelated dependency update not mentioned in the PR description. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Dialog["DialogContent\nz-[180]"]
    Trigger["EllipsisVertical IconButton\nhover:bg-interactive-secondary-hover"]
    Before["DropdownMenuContent (before)\nz-[101] — hidden behind Dialog"]
    After["DropdownMenuContent (after)\nz-[200] — renders above Dialog"]

    Dialog --> Trigger
    Trigger -->|"click (before)"| Before
    Trigger -->|"click (after)"| After

    style Before fill:#f87171,color:#fff
    style After fill:#4ade80,color:#fff
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `vite/src/components/v2/dropdowns/DropdownMenu.tsx`, line 174 ([link](https://github.com/useautumn/autumn/blob/c712ad222a0232f0048ac60b2a7e2db2ef9774ef/vite/src/components/v2/dropdowns/DropdownMenu.tsx#L174)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Root cause still lives in the base component**

   `DropdownMenuContent` defaults to `z-[101]`, so every other dropdown rendered inside a `DialogContent` (`z-[180]`) will exhibit the same invisible-menu bug — not just `MemberRowToolbar`. Every other overlay component in this codebase (`Select`, `Tooltip`, `Popover`, `FeatureSelector`) already uses `z-[200]`. Updating the default here would fix all current and future call sites at once without requiring per-instance overrides.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/components/v2/dropdowns/DropdownMenu.tsx
   Line: 174

   Comment:
   **Root cause still lives in the base component**

   `DropdownMenuContent` defaults to `z-[101]`, so every other dropdown rendered inside a `DialogContent` (`z-[180]`) will exhibit the same invisible-menu bug — not just `MemberRowToolbar`. Every other overlay component in this codebase (`Select`, `Tooltip`, `Popover`, `FeatureSelector`) already uses `z-[200]`. Updating the default here would fix all current and future call sites at once without requiring per-instance overrides.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `bun.lock`, line 212 ([link](https://github.com/useautumn/autumn/blob/c712ad222a0232f0048ac60b2a7e2db2ef9774ef/bun.lock#L212)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unrelated `autumn-js` version bump**

   `autumn-js` is bumped from `1.2.10` to `1.2.17` (7 patch/minor versions), but this isn't mentioned in the PR description or linked to the z-index fix. Please confirm whether this bump is intentional and, if so, add a note about what it changes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: bun.lock
   Line: 212

   Comment:
   **Unrelated `autumn-js` version bump**

   `autumn-js` is bumped from `1.2.10` to `1.2.17` (7 patch/minor versions), but this isn't mentioned in the PR description or linked to the z-index fix. Please confirm whether this bump is intentional and, if so, add a note about what it changes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/components/v2/dropdowns/DropdownMenu.tsx:174
**Root cause still lives in the base component**

`DropdownMenuContent` defaults to `z-[101]`, so every other dropdown rendered inside a `DialogContent` (`z-[180]`) will exhibit the same invisible-menu bug — not just `MemberRowToolbar`. Every other overlay component in this codebase (`Select`, `Tooltip`, `Popover`, `FeatureSelector`) already uses `z-[200]`. Updating the default here would fix all current and future call sites at once without requiring per-instance overrides.

### Issue 2 of 2
bun.lock:212
**Unrelated `autumn-js` version bump**

`autumn-js` is bumped from `1.2.10` to `1.2.17` (7 patch/minor versions), but this isn't mentioned in the PR description or linked to the z-index fix. Please confirm whether this bump is intentional and, if so, add a note about what it changes.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Drop unrelated bun.lock change"](https://github.com/useautumn/autumn/commit/c712ad222a0232f0048ac60b2a7e2db2ef9774ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30809713)</sub>

<!-- /greptile_comment -->