### PR TITLE
Fix member toolbar dropdown z-index in Dialog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -209,7 +209,7 @@
     },
     "packages/autumn-js": {
       "name": "autumn-js",
-      "version": "1.2.17",
+      "version": "1.2.10",
       "dependencies": {
         "query-string": "^9.2.2",
         "rou3": "^0.6.1",

--- a/bun.lock
+++ b/bun.lock
@@ -209,7 +209,7 @@
     },
     "packages/autumn-js": {
       "name": "autumn-js",
-      "version": "1.2.10",
+      "version": "1.2.17",
       "dependencies": {
         "query-string": "^9.2.2",
         "rou3": "^0.6.1",

--- a/vite/src/views/main-sidebar/org-dropdown/manage-org/MemberRowToolbar.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/manage-org/MemberRowToolbar.tsx
@@ -94,10 +94,10 @@ export const MemberRowToolbar = ({
 					size="icon"
 					iconOrientation="center"
 					icon={<EllipsisVertical />}
-					className="!h-5 !w-5 rounded-lg hover:bg-stone-50"
+					className="!h-5 !w-5 rounded-lg hover:bg-interactive-secondary-hover"
 				/>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end">
+			<DropdownMenuContent align="end" className="z-[200]">
 				<DropdownMenuItem
 					variant="destructive"
 					shimmer={deleteLoading}


### PR DESCRIPTION
## Summary
- Cherry-picked from `fix/manage-org-member-toolbar-dropdown` branch
- Fixes the member toolbar dropdown being hidden behind the Dialog overlay by adjusting z-index on the `MemberRowToolbar` component

## Test plan
- Open the manage org members dialog
- Verify the toolbar dropdown on each member row renders above the dialog backdrop

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the member row toolbar menu being hidden behind the Manage Members dialog by raising its z-index. Also updates the trigger hover color for consistency.

- **Bug Fixes**
  - Set `z-[200]` on `DropdownMenuContent` so the menu appears above the dialog backdrop.
  - Changed trigger hover to `hover:bg-interactive-secondary-hover`.

<sup>Written for commit 98f982e9f2b3a04286a496e05e82adee5fe70ab3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the member-row toolbar dropdown being obscured by the manage-org Dialog overlay by setting `z-[200]` on `DropdownMenuContent`, consistent with how `Select` and `Tooltip` already handle z-index above dialogs. Also swaps the hardcoded `hover:bg-stone-50` for the design-system token `hover:bg-interactive-secondary-hover`.

- **Bug fixes** — `DropdownMenuContent` in `MemberRowToolbar` was hidden behind the Dialog overlay (`z-[170]`) and content (`z-[180]`); the added `z-[200]` matches the pattern used by `Select` and `Tooltip` and resolves the layering issue.
- **Improvements** — Trigger button hover state migrated from hardcoded `stone-50` to the `interactive-secondary-hover` design token, keeping it consistent with the rest of the design system.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line, well-scoped fix with no impact outside MemberRowToolbar.

Both changes are minimal and correct. The z-[200] value mirrors the existing pattern in Select and Tooltip, sits above the Dialog content layer at z-[180], and the DropdownMenu component's cn() merge ensures the override is applied. The design-token swap is cosmetic and self-contained.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/main-sidebar/org-dropdown/manage-org/MemberRowToolbar.tsx | Adds z-[200] to DropdownMenuContent so it renders above the Dialog overlay (z-[170]) and content (z-[180]); also replaces hardcoded hover:bg-stone-50 with the design-token class hover:bg-interactive-secondary-hover. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Dialog Overlay\nz-[170]"] --> B["Dialog Content\nz-[180]"]
    B --> C["MemberRowToolbar\n(inside Dialog)"]
    C --> D["DropdownMenuTrigger\n(IconButton)"]
    D --> E["DropdownMenuPrimitive.Portal\n(renders at body level)"]
    E --> F["DropdownMenuContent\nz-[200] ← fix applied"]
    F --> G["DropdownMenuItem\n(Remove / delete action)"]

    style A fill:#ffd6d6
    style B fill:#ffc8a2
    style F fill:#c8f0c8
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Drop unrelated bun.lock change"](https://github.com/useautumn/autumn/commit/98f982e9f2b3a04286a496e05e82adee5fe70ab3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30816243)</sub>

<!-- /greptile_comment -->