### PR TITLE
fix: prepaid price v2

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -2,6 +2,7 @@ import {
 	type AutumnBillingPlan,
 	type BillingContext,
 	cusProductToProduct,
+	isPrepaidPrice,
 	nullish,
 } from "@autumn/shared";
 import { createStripePriceIFNotExist } from "@/external/stripe/createStripePrice/createStripePrice";
@@ -35,7 +36,7 @@ export const initStripeResourcesForBillingPlan = async ({
 			prices: product.prices.filter(
 				(price) =>
 					nullish(price.config.stripe_price_id) ||
-					("stripe_prepaid_price_v2_id" in price.config &&
+					(isPrepaidPrice(price) &&
 						nullish(price.config.stripe_prepaid_price_v2_id)),
 			),
 		}))


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Stripe resource initialization for prepaid v2 prices by using `isPrepaidPrice` to correctly filter which prices need creation. Ensures missing prepaid v2 Stripe prices are created and avoids touching non‑prepaid prices.

- **Bug Fixes**
  - Use `isPrepaidPrice` from `@autumn/shared` before checking `stripe_prepaid_price_v2_id`, preventing false positives and missed initializations.

<sup>Written for commit 1d2d24faf42e5e7aea6a6097e98189ee93a893ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes an incorrect filter condition when determining which existing product prices need Stripe resources initialized. The old `"stripe_prepaid_price_v2_id" in price.config` check was a property-existence test that could misfire on any usage-price config object, depending on how the object was serialized; the new `isPrepaidPrice(price)` call checks the billing type directly (`UsageInAdvance`), making the condition both semantically correct and more robust.

- **Bug fixes**: Replaces `"stripe_prepaid_price_v2_id" in price.config` with `isPrepaidPrice(price)` so only genuine prepaid (UsageInAdvance) prices trigger the v2 Stripe price creation path, rather than any usage-price config that happens to carry the field key.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the single-line change narrows an overly broad filter to one that correctly identifies prepaid prices by their billing type.

The change is minimal and targeted: it swaps a brittle runtime key-existence check (`"stripe_prepaid_price_v2_id" in price.config`) for the dedicated `isPrepaidPrice` utility, which has its own test coverage across the codebase. No logic outside this filter is affected, and the replacement is semantically correct.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Replaces a fragile `"stripe_prepaid_price_v2_id" in price.config` property-existence check with the semantic `isPrepaidPrice(price)` utility, correctly targeting only UsageInAdvance prices for the v2 prepaid price creation condition. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[existingProducts prices filter] --> B{nullish stripe_price_id?}
    B -- Yes --> C[Include price for Stripe init]
    B -- No --> D{isPrepaidPrice?}
    D -- No --> E[Exclude price]
    D -- Yes --> F{nullish stripe_prepaid_price_v2_id?}
    F -- Yes --> C
    F -- No --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prepaid price v2"](https://github.com/useautumn/autumn/commit/1d2d24faf42e5e7aea6a6097e98189ee93a893ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30820436)</sub>

<!-- /greptile_comment -->