### PR TITLE
fix: 🐛 bug

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts
@@ -3,7 +3,6 @@ import { storeRenewalLineItems } from "@/external/stripe/webhookHandlers/common"
 import { invoiceActions } from "@/internal/invoices/actions";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext";
 import { setupInvoiceFinalizedContext } from "./setupInvoiceFinalizedContext";
-import { processVercelInvoice } from "./tasks/processVercelInvoice";
 
 /**
  * Handles invoice.finalized webhook.
@@ -24,11 +23,6 @@ export const handleStripeInvoiceFinalized = async ({
 		ctx.logger.debug("[invoice.finalized] Skipping - context not found");
 		return;
 	}
-
-	const stripeInvoice = eventContext.stripeInvoice;
-	const stripeSubscription = eventContext.stripeSubscription;
-
-	await processVercelInvoice({ ctx, stripeInvoice, stripeSubscription });
 
 	ctx.logger.info(
 		`[invoice.finalized] Processing for invoice ${eventContext.stripeInvoice.id}`,

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/setupInvoiceFinalizedContext.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/setupInvoiceFinalizedContext.ts
@@ -12,6 +12,7 @@ import { stripeInvoiceToStripeSubscriptionId } from "@/external/stripe/invoices/
 import { getExpandedStripeSubscription } from "@/external/stripe/subscriptions";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext";
+import { processVercelInvoice } from "./tasks/processVercelInvoice";
 
 export interface InvoiceFinalizedContext {
 	stripeInvoice: ExpandedStripeInvoice<
@@ -22,6 +23,20 @@ export interface InvoiceFinalizedContext {
 	fullCustomer: FullCustomer;
 	customerProducts: FullCusProduct[];
 }
+
+const isVercelInvoice = ({
+	stripeInvoice,
+	stripeSubscription,
+}: {
+	stripeInvoice: Stripe.Invoice;
+	stripeSubscription: Stripe.Subscription | null;
+}): boolean => {
+	const invoiceMeta = stripeInvoice.metadata as Record<string, string> | null;
+	return Boolean(
+		stripeSubscription?.metadata?.vercel_installation_id ||
+			invoiceMeta?.vercel_installation_id,
+	);
+};
 
 export const setupInvoiceFinalizedContext = async ({
 	ctx,
@@ -60,7 +75,13 @@ export const setupInvoiceFinalizedContext = async ({
 		subscriptionId: stripeSubscriptionId,
 	});
 
-	// 5. Get customer products by subscription ID
+	// 5. Vercel custom-PM invoices submit out-of-band BEFORE the cus_product
+	// gate — the cus_product is created downstream by marketplace.invoice.paid.
+	if (isVercelInvoice({ stripeInvoice, stripeSubscription })) {
+		await processVercelInvoice({ ctx, stripeInvoice, stripeSubscription });
+	}
+
+	// 6. Get customer products by subscription ID
 	const currentCustomerProducts = fullCustomer.customer_products.filter((cp) =>
 		isCustomerProductOnStripeSubscription({
 			customerProduct: cp,
@@ -81,7 +102,7 @@ export const setupInvoiceFinalizedContext = async ({
 		return null;
 	}
 
-	// 6. Update fullCustomer.customer_products with fresh data
+	// 7. Update fullCustomer.customer_products with fresh data
 	fullCustomer.customer_products = customerProducts;
 
 	return {

--- a/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
@@ -17,6 +17,7 @@ import { handleProrationBehaviorErrors } from "@/internal/billing/v2/common/erro
 import { handleCustomLineItemsErrors } from "@/internal/billing/v2/common/errors/handleCustomLineItemsErrors";
 import { handleExternalPSPErrors } from "@/internal/billing/v2/common/errors/handleExternalPSPErrors";
 import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/handleSubscriptionIdErrors";
+import { handleCustomPaymentMethodErrorsV2 } from "@/internal/customers/attach/attachUtils/handleAttachErrors";
 
 /** Validates attach v2 request before executing the billing plan. */
 export const handleAttachV2Errors = async ({
@@ -32,12 +33,15 @@ export const handleAttachV2Errors = async ({
 }) => {
 	const { autumn: autumnBillingPlan } = billingPlan;
 
-	// 1. External PSP errors (RevenueCat)
+	// 1.1. External PSP errors (RevenueCat)
 	handleExternalPSPErrors({
 		customerProducts: billingContext.fullCustomer.customer_products,
 		attachProduct: billingContext.attachProduct,
 		action: "attach",
 	});
+
+	// 1.2. Custom Payment Method errors (Vercel)
+	handleCustomPaymentMethodErrorsV2({ billingContext });
 
 	// 2. Current customer product errors (same product)
 	handleCurrentCustomerProductErrors({ billingContext });

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
@@ -2,6 +2,7 @@ import {
 	type AttachBodyV0,
 	AttachBranch,
 	type AttachConfig,
+	type BillingContext,
 	BillingType,
 	ErrCode,
 	RecaseError,
@@ -149,6 +150,29 @@ export const handleCustomPaymentMethodErrors = ({
 				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
 		});
 	} else if (attachParams.customer.processors?.vercel?.installation_id) {
+		throw new RecaseError({
+			message:
+				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
+		});
+	}
+};
+
+export const handleCustomPaymentMethodErrorsV2 = ({
+	billingContext,
+}: {
+	billingContext: BillingContext;
+}) => {
+	const { paymentMethod } = billingContext;
+	if (
+		paymentMethod?.type === "custom" &&
+		billingContext.fullCustomer.processors?.vercel?.custom_payment_method_id ===
+			paymentMethod?.custom?.type
+	) {
+		throw new RecaseError({
+			message:
+				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
+		});
+	} else if (billingContext.fullCustomer.processors?.vercel?.installation_id) {
 		throw new RecaseError({
 			message:
 				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Vercel invoice handling by processing Vercel invoices during invoice.finalized context setup, before any `cus_product` filtering. Also add an attach v2 guard to block Stripe actions for Vercel-billed customers with a clear error.

- **Bug Fixes**
  - Move `processVercelInvoice` into `setupInvoiceFinalizedContext` behind an `isVercelInvoice` check; remove the call from `handleStripeInvoiceFinalized`.
  - Run Vercel processing before loading customer products to avoid dropping invoices that arrive before a `cus_product` exists.
  - Add `handleCustomPaymentMethodErrorsV2` and invoke it in `handleAttachV2Errors` to prevent attaching in Stripe when the customer has a Vercel custom payment method or installation.

<sup>Written for commit 8646823d846e04c55f21cb2b34149bd4aba2a133. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Two related Vercel billing bugs are fixed: (1) `processVercelInvoice` was being called unconditionally for every finalized invoice; it is now guarded by `isVercelInvoice` and moved inside `setupInvoiceFinalizedContext` so that new Vercel customers (who have no `cus_product` yet) have their invoice submitted to the Vercel marketplace before the customer-products null-return gate. (2) V2 attach now mirrors V1 by calling `handleCustomPaymentMethodErrorsV2` to block Vercel-integrated customers from going through Autumn's Stripe-based attach flow.

- **Bug fixes** — `processVercelInvoice` is now gated with `isVercelInvoice` and runs before the `customerProducts.length === 0` early return, fixing the case where brand-new Vercel customers never had their invoice submitted to the marketplace.
- **Bug fixes** — `handleCustomPaymentMethodErrorsV2` added to V2 attach validation (`handleAttachV2Errors`), mirroring the existing V1 guard that routes Vercel customers back to the origin platform.
- **Improvements** — `isVercelInvoice` helper centralises the Vercel-invoice detection logic by checking both subscription and invoice metadata.
</details>

<h3>Confidence Score: 4/5</h3>

The core webhook and attach-guard changes are correct and well-scoped; the one observation is a minor missing error code on the new V2 guard.

The processVercelInvoice relocation now fires before the customer-products null-return gate, which is exactly what new Vercel customers need, and the isVercelInvoice guard prevents running Vercel invoice logic on every finalized invoice. The new handleCustomPaymentMethodErrorsV2 faithfully mirrors V1. The only note is that the else-if branch RecaseError is missing code and statusCode, meaning API consumers see an ambiguous error rather than a clear 400 for a well-understood rejection path.

handleAttachErrors.ts — the new handleCustomPaymentMethodErrorsV2 else-if branch throws without a code or statusCode, and unconditionally blocks any customer with a vercel.installation_id regardless of whether the product being attached has any billable prices.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/setupInvoiceFinalizedContext.ts | Moves processVercelInvoice into context setup with an isVercelInvoice guard, so new Vercel customers (no cus_products yet) get their invoices submitted to the marketplace before the null-return guard. Logic is sound, and processVercelInvoice has its own try/catch so it won't break the context pipeline. |
| server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts | Removes the unconditional processVercelInvoice call that ran for every finalized invoice; now delegation happens inside setupInvoiceFinalizedContext with a guard. Change is straightforward. |
| server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts | Adds handleCustomPaymentMethodErrorsV2 mirroring V1 logic for BillingContext. The else-if unconditionally blocks any customer with a vercel.installation_id, which is intentional (matches V1). Missing ErrCode/statusCode in RecaseError, also matching V1. |
| server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts | Adds handleCustomPaymentMethodErrorsV2 call at step 1.2; mirrors the existing PSP guard pattern cleanly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Stripe Webhook
    participant H as handleStripeInvoiceFinalized
    participant C as setupInvoiceFinalizedContext
    participant V as processVercelInvoice
    participant A as Autumn Invoice Ops

    S->>H: invoice.finalized event
    H->>C: setupInvoiceFinalizedContext()
    C->>C: getStripeInvoice + getExpandedSubscription
    
    alt isVercelInvoice (new guard)
        C->>V: processVercelInvoice()
        Note over V: Submits to Vercel marketplace
        V-->>C: done (errors caught internally)
    end

    alt customerProducts.length === 0
        C-->>H: null (early return)
        Note over H: Return - skips Autumn ops
        Note over H,C: NEW: Vercel invoices for new customers now reach Vercel BEFORE this null return
    else customerProducts exist
        C-->>H: InvoiceFinalizedContext
        H->>A: invoiceActions.updateFromStripe()
        H->>A: storeRenewalLineItems()
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts:175-180
The `else if` branch unconditionally throws for any customer with a `vercel.installation_id`, even when `paymentMethod` is `undefined` (e.g., attaching a free/zero-cost product). If a Vercel-integrated customer ever needs to claim a genuinely free product through the Autumn API, this guard will silently block them with a "billed outside of Stripe" message that is confusing in the free-product context. The same pattern exists in V1, so the risk is inherited rather than new — but V2 may reach more call sites. Consider gating the `else if` on the product actually having billable prices, or at minimum add a `code`/`statusCode` to the thrown error so callers can distinguish it.

```suggestion
	} else if (billingContext.fullCustomer.processors?.vercel?.installation_id) {
		throw new RecaseError({
			message:
				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
			code: ErrCode.InvalidRequest,
			statusCode: StatusCodes.BAD_REQUEST,
		});
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 bug"](https://github.com/useautumn/autumn/commit/8646823d846e04c55f21cb2b34149bd4aba2a133) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30856302)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->