### PR TITLE
cherry/vercel fixes to dev

### DIFF
--- a/server/src/external/stripe/priceToStripeItem/priceToUsageInAdvance.ts
+++ b/server/src/external/stripe/priceToStripeItem/priceToUsageInAdvance.ts
@@ -37,6 +37,8 @@ export const priceToOneOffAndTiered = ({
 	} else if (nullish(optionsQuantity) && isCheckout) {
 		// 2. If quantity is nullish and is checkout, default to 1
 		finalQuantity = 1;
+	} else if (nullish(optionsQuantity) || optionsQuantity === 0) {
+		return null;
 	}
 
 	const overage = new Decimal(finalQuantity ?? 0)
@@ -106,6 +108,8 @@ export const priceToUsageInAdvance = ({
 	} else if (nullish(optionsQuantity) && isCheckout) {
 		// 2. If quantity is nullish and is checkout, default to 1
 		finalQuantity = 1;
+	} else if (nullish(optionsQuantity) || optionsQuantity === 0) {
+		return null;
 	}
 
 	const adjustableQuantity =

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts
@@ -3,7 +3,6 @@ import { storeRenewalLineItems } from "@/external/stripe/webhookHandlers/common"
 import { invoiceActions } from "@/internal/invoices/actions";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext";
 import { setupInvoiceFinalizedContext } from "./setupInvoiceFinalizedContext";
-import { processVercelInvoice } from "./tasks/processVercelInvoice";
 
 /**
  * Handles invoice.finalized webhook.
@@ -24,11 +23,6 @@ export const handleStripeInvoiceFinalized = async ({
 		ctx.logger.debug("[invoice.finalized] Skipping - context not found");
 		return;
 	}
-
-	const stripeInvoice = eventContext.stripeInvoice;
-	const stripeSubscription = eventContext.stripeSubscription;
-
-	await processVercelInvoice({ ctx, stripeInvoice, stripeSubscription });
 
 	ctx.logger.info(
 		`[invoice.finalized] Processing for invoice ${eventContext.stripeInvoice.id}`,

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts
@@ -1,4 +1,7 @@
 import type Stripe from "stripe";
+import { getStripeInvoice } from "@/external/stripe/invoices/operations/getStripeInvoice";
+import { stripeInvoiceToStripeSubscriptionId } from "@/external/stripe/invoices/utils/convertStripeInvoice";
+import { getExpandedStripeSubscription } from "@/external/stripe/subscriptions";
 import { storeRenewalLineItems } from "@/external/stripe/webhookHandlers/common";
 import { invoiceActions } from "@/internal/invoices/actions";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext";
@@ -18,6 +21,24 @@ export const handleStripeInvoiceFinalized = async ({
 	ctx: StripeWebhookContext;
 	event: Stripe.InvoiceFinalizedEvent;
 }) => {
+	const stripeInvoice = await getStripeInvoice({
+		stripeClient: ctx.stripeCli,
+		invoiceId: event.data.object.id!,
+		expand: ["discounts.source.coupon", "total_discount_amounts"],
+	});
+
+	const stripeSubscriptionId =
+		stripeInvoiceToStripeSubscriptionId(stripeInvoice);
+
+	const stripeSubscription = stripeSubscriptionId
+		? await getExpandedStripeSubscription({
+				ctx,
+				subscriptionId: stripeSubscriptionId,
+			})
+		: null;
+
+	await processVercelInvoice({ ctx, stripeInvoice, stripeSubscription });
+
 	const eventContext = await setupInvoiceFinalizedContext({ ctx, event });
 
 	if (!eventContext) {
@@ -28,9 +49,6 @@ export const handleStripeInvoiceFinalized = async ({
 	ctx.logger.info(
 		`[invoice.finalized] Processing for invoice ${eventContext.stripeInvoice.id}`,
 	);
-
-	// 1. Handle Vercel custom payment method invoices
-	await processVercelInvoice({ ctx, eventContext });
 
 	// 2. Upsert Autumn invoice record
 	const autumnInvoice = await invoiceActions.updateFromStripe({

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/handleStripeInvoiceFinalized.ts
@@ -1,7 +1,4 @@
 import type Stripe from "stripe";
-import { getStripeInvoice } from "@/external/stripe/invoices/operations/getStripeInvoice";
-import { stripeInvoiceToStripeSubscriptionId } from "@/external/stripe/invoices/utils/convertStripeInvoice";
-import { getExpandedStripeSubscription } from "@/external/stripe/subscriptions";
 import { storeRenewalLineItems } from "@/external/stripe/webhookHandlers/common";
 import { invoiceActions } from "@/internal/invoices/actions";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext";
@@ -21,30 +18,17 @@ export const handleStripeInvoiceFinalized = async ({
 	ctx: StripeWebhookContext;
 	event: Stripe.InvoiceFinalizedEvent;
 }) => {
-	const stripeInvoice = await getStripeInvoice({
-		stripeClient: ctx.stripeCli,
-		invoiceId: event.data.object.id!,
-		expand: ["discounts.source.coupon", "total_discount_amounts"],
-	});
-
-	const stripeSubscriptionId =
-		stripeInvoiceToStripeSubscriptionId(stripeInvoice);
-
-	const stripeSubscription = stripeSubscriptionId
-		? await getExpandedStripeSubscription({
-				ctx,
-				subscriptionId: stripeSubscriptionId,
-			})
-		: null;
-
-	await processVercelInvoice({ ctx, stripeInvoice, stripeSubscription });
-
 	const eventContext = await setupInvoiceFinalizedContext({ ctx, event });
 
 	if (!eventContext) {
 		ctx.logger.debug("[invoice.finalized] Skipping - context not found");
 		return;
 	}
+
+	const stripeInvoice = eventContext.stripeInvoice;
+	const stripeSubscription = eventContext.stripeSubscription;
+
+	await processVercelInvoice({ ctx, stripeInvoice, stripeSubscription });
 
 	ctx.logger.info(
 		`[invoice.finalized] Processing for invoice ${eventContext.stripeInvoice.id}`,

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/setupInvoiceFinalizedContext.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/setupInvoiceFinalizedContext.ts
@@ -11,7 +11,6 @@ import {
 import { stripeInvoiceToStripeSubscriptionId } from "@/external/stripe/invoices/utils/convertStripeInvoice";
 import { getExpandedStripeSubscription } from "@/external/stripe/subscriptions";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
-import { FeatureService } from "@/internal/features/FeatureService";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext";
 
 export interface InvoiceFinalizedContext {
@@ -22,7 +21,6 @@ export interface InvoiceFinalizedContext {
 	stripeSubscriptionId: string;
 	fullCustomer: FullCustomer;
 	customerProducts: FullCusProduct[];
-	features: Awaited<ReturnType<typeof FeatureService.list>>;
 }
 
 export const setupInvoiceFinalizedContext = async ({
@@ -32,7 +30,7 @@ export const setupInvoiceFinalizedContext = async ({
 	ctx: StripeWebhookContext;
 	event: Stripe.InvoiceFinalizedEvent;
 }): Promise<InvoiceFinalizedContext | null> => {
-	const { stripeCli, fullCustomer, db, org, env, logger } = ctx;
+	const { stripeCli, fullCustomer, logger } = ctx;
 
 	// 1. Get expanded invoice
 	const stripeInvoice = await getStripeInvoice({
@@ -86,19 +84,11 @@ export const setupInvoiceFinalizedContext = async ({
 	// 6. Update fullCustomer.customer_products with fresh data
 	fullCustomer.customer_products = customerProducts;
 
-	// 7. Get features for Vercel invoice processing
-	const features = await FeatureService.list({
-		db,
-		orgId: org.id,
-		env,
-	});
-
 	return {
 		stripeInvoice,
 		stripeSubscription,
 		stripeSubscriptionId,
 		fullCustomer,
 		customerProducts,
-		features,
 	};
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/setupInvoiceFinalizedContext.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/setupInvoiceFinalizedContext.ts
@@ -12,6 +12,7 @@ import { stripeInvoiceToStripeSubscriptionId } from "@/external/stripe/invoices/
 import { getExpandedStripeSubscription } from "@/external/stripe/subscriptions";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext";
+import { processVercelInvoice } from "./tasks/processVercelInvoice";
 
 export interface InvoiceFinalizedContext {
 	stripeInvoice: ExpandedStripeInvoice<
@@ -22,6 +23,20 @@ export interface InvoiceFinalizedContext {
 	fullCustomer: FullCustomer;
 	customerProducts: FullCusProduct[];
 }
+
+const isVercelInvoice = ({
+	stripeInvoice,
+	stripeSubscription,
+}: {
+	stripeInvoice: Stripe.Invoice;
+	stripeSubscription: Stripe.Subscription | null;
+}): boolean => {
+	const invoiceMeta = stripeInvoice.metadata as Record<string, string> | null;
+	return Boolean(
+		stripeSubscription?.metadata?.vercel_installation_id ||
+			invoiceMeta?.vercel_installation_id,
+	);
+};
 
 export const setupInvoiceFinalizedContext = async ({
 	ctx,
@@ -60,7 +75,13 @@ export const setupInvoiceFinalizedContext = async ({
 		subscriptionId: stripeSubscriptionId,
 	});
 
-	// 5. Get customer products by subscription ID
+	// 5. Vercel custom-PM invoices submit out-of-band BEFORE the cus_product
+	// gate — the cus_product is created downstream by marketplace.invoice.paid.
+	if (isVercelInvoice({ stripeInvoice, stripeSubscription })) {
+		await processVercelInvoice({ ctx, stripeInvoice, stripeSubscription });
+	}
+
+	// 6. Get customer products by subscription ID
 	const currentCustomerProducts = fullCustomer.customer_products.filter((cp) =>
 		isCustomerProductOnStripeSubscription({
 			customerProduct: cp,
@@ -81,7 +102,7 @@ export const setupInvoiceFinalizedContext = async ({
 		return null;
 	}
 
-	// 6. Update fullCustomer.customer_products with fresh data
+	// 7. Update fullCustomer.customer_products with fresh data
 	fullCustomer.customer_products = customerProducts;
 
 	return {

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/tasks/processVercelInvoice.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/tasks/processVercelInvoice.ts
@@ -1,11 +1,13 @@
+import type Stripe from "stripe";
+import type { ExpandedStripeInvoice } from "@/external/stripe/invoices/operations/getStripeInvoice";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import {
 	submitBillingDataToVercel,
 	submitInvoiceToVercel,
 } from "@/external/vercel/misc/vercelInvoicing";
 import { logVercelWebhook } from "@/external/vercel/misc/vercelMiddleware";
+import { FeatureService } from "@/internal/features/FeatureService";
 import { ProductService } from "@/internal/products/ProductService";
-import type { InvoiceFinalizedContext } from "../setupInvoiceFinalizedContext";
 
 /**
  * Handles Vercel custom payment method invoices.
@@ -13,38 +15,46 @@ import type { InvoiceFinalizedContext } from "../setupInvoiceFinalizedContext";
  */
 export const processVercelInvoice = async ({
 	ctx,
-	eventContext,
+	stripeInvoice,
+	stripeSubscription,
 }: {
 	ctx: StripeWebhookContext;
-	eventContext: InvoiceFinalizedContext;
+	stripeInvoice: ExpandedStripeInvoice<
+		["discounts.source.coupon", "total_discount_amounts"]
+	>;
+	stripeSubscription: Stripe.Subscription | null;
 }): Promise<void> => {
-	const { stripeCli, org, logger, fullCustomer } = ctx;
-	const { stripeInvoice, stripeSubscription, features } = eventContext;
+	const { stripeCli, org, env, db, logger, fullCustomer } = ctx;
 
-	// Skip zero-amount invoices
 	if (stripeInvoice.amount_due <= 0) {
 		return;
 	}
 
-	// Check for Vercel metadata
+	const invoiceMetadata = stripeInvoice.metadata as Record<
+		string,
+		string
+	> | null;
+
 	const vercelInstallationId =
-		stripeSubscription.metadata?.vercel_installation_id;
+		stripeSubscription?.metadata?.vercel_installation_id ??
+		invoiceMetadata?.vercel_installation_id;
 	const vercelBillingPlanId =
-		stripeSubscription.metadata?.vercel_billing_plan_id;
+		stripeSubscription?.metadata?.vercel_billing_plan_id ??
+		invoiceMetadata?.vercel_billing_plan_id;
 
 	if (!vercelInstallationId || !vercelBillingPlanId) {
 		return;
 	}
 
-	// Check for default payment method
-	if (!stripeSubscription.default_payment_method) {
+	const pmId =
+		(stripeSubscription?.default_payment_method as string | undefined) ??
+		fullCustomer?.processors?.vercel?.custom_payment_method_id;
+
+	if (!pmId) {
 		return;
 	}
 
-	// Verify it's a Vercel custom payment method
-	const paymentMethod = await stripeCli.paymentMethods.retrieve(
-		stripeSubscription.default_payment_method as string,
-	);
+	const paymentMethod = await stripeCli.paymentMethods.retrieve(pmId);
 
 	if (paymentMethod.type !== "custom" || !fullCustomer) {
 		return;
@@ -62,9 +72,9 @@ export const processVercelInvoice = async ({
 
 	// Get product for Vercel billing
 	const product = await ProductService.getFull({
-		db: ctx.db,
+		db,
 		orgId: org.id,
-		env: ctx.env,
+		env,
 		idOrInternalId: vercelBillingPlanId,
 	});
 
@@ -75,8 +85,13 @@ export const processVercelInvoice = async ({
 		return;
 	}
 
+	const features = await FeatureService.list({
+		db,
+		orgId: org.id,
+		env,
+	});
+
 	try {
-		// Submit billing data to Vercel (detailed usage breakdown)
 		await submitBillingDataToVercel({
 			installationId: vercelInstallationId,
 			invoice: stripeInvoice,
@@ -84,7 +99,6 @@ export const processVercelInvoice = async ({
 			product,
 		});
 
-		// Submit invoice to Vercel
 		await submitInvoiceToVercel({
 			installationId: vercelInstallationId,
 			invoice: stripeInvoice,
@@ -93,13 +107,6 @@ export const processVercelInvoice = async ({
 			org,
 			features,
 		});
-
-		// Note: Do NOT report payment to Stripe here - we've only submitted the invoice to Vercel
-		// Vercel will process payment asynchronously and send marketplace.invoice.paid webhook
-		// handleMarketplaceInvoicePaid will then:
-		//   1. Create cus_product (user gets access)
-		//   2. Report payment as "guaranteed" to Stripe
-		//   3. Attach payment record to invoice (marks it as paid)
 	} catch (error) {
 		logger.error("Failed to process Vercel invoice", {
 			data: {

--- a/server/src/external/vercel/handlers/handleListBillingPlans.ts
+++ b/server/src/external/vercel/handlers/handleListBillingPlans.ts
@@ -1,4 +1,17 @@
-import { AppEnv, type FullProduct, formatAmount, getProductItemDisplay, isFixedPrice, isPrepaidPrice, isPriceItem, mapToProductV2, type Organization, productV2ToBasePrice, type UsagePriceConfig, Scopes } from "@autumn/shared";
+import {
+	AppEnv,
+	type FullProduct,
+	formatAmount,
+	getProductItemDisplay,
+	isFixedPrice,
+	isPrepaidPrice,
+	isPriceItem,
+	mapToProductV2,
+	type Organization,
+	productV2ToBasePrice,
+	Scopes,
+	type UsagePriceConfig,
+} from "@autumn/shared";
 import { z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { parseVercelPrepaidQuantities } from "@/external/vercel/misc/vercelInvoicing.js";
@@ -122,6 +135,27 @@ export function productToBillingPlan({
 	return bp;
 }
 
+const getVercelPlanFilterReason = ({ product }: { product: FullProduct }) => {
+	if (
+		product.prices.some(
+			(price) => !isFixedPrice(price) && !isPrepaidPrice(price),
+		)
+	) {
+		return "Has usage prices";
+	}
+
+	if (product.is_add_on) return "Is add-on";
+	if (isOneOff(product.prices) && !isFreeProduct(product.prices)) {
+		return "Is paid one-off";
+	}
+	if (product.archived) return "Is archived";
+	if (product.entitlements.length === 0 && !product.is_default) {
+		return "Has no entitlements and is not default";
+	}
+
+	return null;
+};
+
 const listVercelPlansForOrg = async ({
 	db,
 	org,
@@ -150,25 +184,30 @@ const listVercelPlansForOrg = async ({
 	});
 
 	sortProductsByPrice({ products });
-
+	console.log(
+		"Products before filtering",
+		products.map((p) => p.name),
+	);
 	// 1. Get rid of products that have usage prices
 	// 2. Get rid of products that are archived
 	// 3. Get rid of products that are one off, only if they are not free
-	const filteredProducts = products
-		.filter(
-			(p) =>
-				// If the product has any prices that are not fixed or prepaid, filter it out
-				!p.prices.some(
-					(price) => !isFixedPrice(price) && !isPrepaidPrice(price),
-				),
-		)
-		.filter(
-			(p) =>
-				!p.is_add_on &&
-				(!isOneOff(p.prices) || isFreeProduct(p.prices)) &&
-				!p.archived &&
-				(p.entitlements.length > 0 || p.is_default),
-		);
+	const filteredProducts = products.filter(
+		(product) => !getVercelPlanFilterReason({ product }),
+	);
+
+	console.log(
+		"Products after filtering",
+		filteredProducts.map((p) => p.name),
+	);
+	console.log(
+		"For each product, here is the reason it was filtered out",
+		products
+			.map((product) => ({
+				name: product.name,
+				reason: getVercelPlanFilterReason({ product }),
+			}))
+			.filter(({ reason }) => reason),
+	);
 
 	return [
 		...filteredProducts.map((product) =>
@@ -195,7 +234,7 @@ const listVercelPlansForOrg = async ({
 	] satisfies VercelBillingPlan[];
 };
 
-export const handleListBillingPlansPerInstall = createRoute({
+export const handleVercelListBillingPlans = createRoute({
 	scopes: [Scopes.Public],
 	query: z.object({
 		metadata: z.string().optional(),
@@ -265,6 +304,8 @@ export const handleListBillingPlansPerInstall = createRoute({
 				customer?.customer_products?.length === 0 ||
 				customer?.customer_products?.every((p) => !p?.product?.is_default),
 		});
+
+		console.log("plans", plans);
 
 		return c.json({ plans });
 	},

--- a/server/src/external/vercel/handlers/handleUpdateBillingPlan.ts
+++ b/server/src/external/vercel/handlers/handleUpdateBillingPlan.ts
@@ -66,7 +66,9 @@ export const handleUpdateVercelBillingPlan = createRoute({
 			}
 
 			const existingSubscription = stripeCustomer.subscriptions?.data.find(
-				(s) => s.metadata.vercel_installation_id === integrationConfigurationId,
+				(s) =>
+					s.metadata.vercel_installation_id === integrationConfigurationId &&
+					s.status === "active",
 			);
 
 			if (!existingSubscription && billingPlanId === "cancel_plan") {

--- a/server/src/external/vercel/handlers/marketplace/handleMarketplaceInvoicePaid.ts
+++ b/server/src/external/vercel/handlers/marketplace/handleMarketplaceInvoicePaid.ts
@@ -1,4 +1,5 @@
 import { AttachScenario, type FeatureOptions } from "@autumn/shared";
+import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { sendUsageAndReset } from "@/external/stripe/webhookHandlers/handleInvoiceCreated/handleInvoiceCreated.js";
 import { parseVercelPrepaidQuantities } from "@/external/vercel/misc/vercelInvoicing.js";
@@ -10,6 +11,15 @@ import { CusProductService } from "@/internal/customers/cusProducts/CusProductSe
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { attachToInsertParams } from "@/internal/products/productUtils.js";
+
+const getInvoiceSubscriptionId = (invoice: Stripe.Invoice): string | null => {
+	const line = invoice.lines.data.find(
+		(l) =>
+			l.parent?.subscription_item_details?.subscription !== null &&
+			l.parent?.subscription_item_details?.subscription !== undefined,
+	);
+	return (line?.parent?.subscription_item_details?.subscription as string) ?? null;
+};
 
 export const handleMarketplaceInvoicePaid = async ({
 	ctx,
@@ -30,168 +40,187 @@ export const handleMarketplaceInvoicePaid = async ({
 
 	const stripeCli = createStripeCli({ org, env });
 
-	// 1. Get the invoice
 	const invoice = await stripeCli.invoices.retrieve(externalInvoiceId, {
 		expand: ["subscription"],
 	});
 
-	// 2. Check if already paid
 	if (invoice.status === "paid") {
 		logger.info("Invoice already marked as paid, skipping");
 		return;
 	}
 
-	// 3. Get subscription and payment method
-	const subscription = await stripeCli.subscriptions.retrieve(
-		invoice.lines.data.find(
-			(l) =>
-				l.parent?.subscription_item_details?.subscription !== null &&
-				l.parent?.subscription_item_details?.subscription !== undefined,
-		)?.parent?.subscription_item_details?.subscription as string,
-	);
+	const subscriptionId = getInvoiceSubscriptionId(invoice);
 
-	const customPaymentMethod = await stripeCli.paymentMethods.retrieve(
-		subscription.default_payment_method as string,
-	);
+	let customPaymentMethod: Stripe.PaymentMethod | null = null;
 
-	try {
+	if (subscriptionId) {
+		const subscription =
+			await stripeCli.subscriptions.retrieve(subscriptionId);
+
+		customPaymentMethod = await stripeCli.paymentMethods.retrieve(
+			subscription.default_payment_method as string,
+		);
+
+		try {
+			const partialCustomer = await CusService.getByStripeId({
+				ctx,
+				stripeId: invoice.customer as string,
+			});
+
+			if (!partialCustomer) {
+				throw new Error("Customer not found");
+			}
+
+			const customer = await CusService.getFull({
+				ctx,
+				idOrInternalId: partialCustomer.internal_id,
+			});
+
+			if (!customer) {
+				throw new Error("Customer not found");
+			}
+
+			const vercelBillingPlanId = subscription.metadata?.vercel_billing_plan_id;
+			if (!vercelBillingPlanId) {
+				logger.error("No vercel_billing_plan_id in subscription metadata");
+				throw new Error("Missing vercel_billing_plan_id");
+			}
+
+			const product = await ProductService.getFull({
+				db,
+				orgId: org.id,
+				env,
+				idOrInternalId: vercelBillingPlanId,
+			});
+
+			if (!product) {
+				throw new Error("Product not found");
+			}
+
+			const existingCusProducts = await CusProductService.getByStripeSubId({
+				db,
+				stripeSubId: subscription.id,
+				orgId: org.id,
+				env,
+			});
+
+			const isRenewal = existingCusProducts.length > 0;
+
+			let optionsList: FeatureOptions[] = [];
+			const vercelResourceId = subscription.metadata?.vercel_resource_id;
+
+			if (vercelResourceId?.startsWith("vre_")) {
+				try {
+					const resource = await VercelResourceService.getById({
+						db,
+						resourceId: vercelResourceId,
+						orgId: org.id,
+						env,
+					});
+
+					if (
+						resource?.metadata &&
+						Object.keys(resource.metadata).length > 0
+					) {
+						optionsList = parseVercelPrepaidQuantities({
+							metadata: resource.metadata,
+							product,
+							prices: product.prices,
+						});
+					}
+
+					await VercelResourceService.update({
+						db,
+						resourceId: vercelResourceId,
+						installationId,
+						orgId: org.id,
+						env,
+						updates: { status: "ready" },
+					});
+				} catch (error) {
+					logger.warn(`Could not fetch or parse resource metadata ${error}`, {
+						data: { resourceId: vercelResourceId },
+					});
+				}
+			}
+
+			if (isRenewal) {
+				const activeProduct = existingCusProducts[0];
+
+				await sendUsageAndReset({
+					ctx,
+					activeProduct,
+					invoice,
+					submitUsage: false,
+					resetBalance: true,
+				});
+			} else {
+				await createFullCusProduct({
+					db,
+					attachParams: attachToInsertParams(
+						{
+							customer,
+							products: [product],
+							prices: product.prices,
+							entitlements: product.entitlements,
+							entities: customer.entities || [],
+							org,
+							stripeCli,
+							now: Date.now(),
+							paymentMethod: null,
+							freeTrial: null,
+							optionsList,
+							cusProducts: customer.customer_products || [],
+							replaceables: [],
+							features: await FeatureService.list({
+								db,
+								orgId: org.id,
+								env,
+							}),
+						},
+						product,
+					),
+					subscriptionIds: [subscription.id],
+					scenario: AttachScenario.New,
+					logger,
+				});
+			}
+		} catch (error: any) {
+			logger.error("❌ Failed to create customer product", {
+				error: error.message,
+			});
+		}
+	} else {
 		const partialCustomer = await CusService.getByStripeId({
 			ctx,
 			stripeId: invoice.customer as string,
 		});
 
-		if (!partialCustomer) {
-			throw new Error("Customer not found");
-		}
+		const customPmId =
+			partialCustomer?.processors?.vercel?.custom_payment_method_id;
 
-		const customer = await CusService.getFull({
-			ctx,
-			idOrInternalId: partialCustomer.internal_id,
-		});
-
-		if (!customer) {
-			throw new Error("Customer not found");
-		}
-
-		const vercelBillingPlanId = subscription.metadata?.vercel_billing_plan_id;
-		if (!vercelBillingPlanId) {
-			logger.error("No vercel_billing_plan_id in subscription metadata");
-			throw new Error("Missing vercel_billing_plan_id");
-		}
-
-		const product = await ProductService.getFull({
-			db,
-			orgId: org.id,
-			env,
-			idOrInternalId: vercelBillingPlanId,
-		});
-
-		if (!product) {
-			throw new Error("Product not found");
-		}
-
-		// Check if this is a renewal (cus_product already exists for this subscription)
-		const existingCusProducts = await CusProductService.getByStripeSubId({
-			db,
-			stripeSubId: subscription.id,
-			orgId: org.id,
-			env,
-		});
-
-		const isRenewal = existingCusProducts.length > 0;
-
-		// Fetch Vercel resource by ID from subscription metadata
-		let optionsList: FeatureOptions[] = [];
-		const vercelResourceId = subscription.metadata?.vercel_resource_id;
-
-		if (vercelResourceId?.startsWith("vre_")) {
-			try {
-				const resource = await VercelResourceService.getById({
-					db,
-					resourceId: vercelResourceId,
-					orgId: org.id,
-					env,
-				});
-
-				if (resource?.metadata && Object.keys(resource.metadata).length > 0) {
-					optionsList = parseVercelPrepaidQuantities({
-						metadata: resource.metadata,
-						product,
-						prices: product.prices,
-					});
-				}
-
-				await VercelResourceService.update({
-					db,
-					resourceId: vercelResourceId,
-					installationId,
-					orgId: org.id,
-					env,
-					updates: {
-						status: "ready",
-					},
-				});
-			} catch (error) {
-				logger.warn(`Could not fetch or parse resource metadata ${error}`, {
+		if (!customPmId) {
+			logger.error(
+				"[handleMarketplaceInvoicePaid] No subscription on invoice and no Vercel custom PM on customer; cannot report payment",
+				{
 					data: {
-						resourceId: vercelResourceId,
+						externalInvoiceId,
+						stripeCustomerId: invoice.customer,
 					},
-				});
-				// Continue with empty optionsList
-			}
+				},
+			);
+			throw new Error(
+				"Cannot resolve payment method for non-subscription Vercel invoice",
+			);
 		}
 
-		if (isRenewal) {
-			const activeProduct = existingCusProducts[0];
-
-			await sendUsageAndReset({
-				ctx,
-				activeProduct,
-				invoice,
-				submitUsage: false, // Usage already submitted in invoice.created
-				resetBalance: true, // Payment confirmed - now safe to reset balance
-			});
-		} else {
-			// New subscription - create cus_product
-			await createFullCusProduct({
-				db,
-				attachParams: attachToInsertParams(
-					{
-						customer,
-						products: [product],
-						prices: product.prices,
-						entitlements: product.entitlements,
-						entities: customer.entities || [],
-						org,
-						stripeCli,
-						now: Date.now(),
-						paymentMethod: null,
-						freeTrial: null,
-						optionsList,
-						cusProducts: customer.customer_products || [],
-						replaceables: [],
-						features: await FeatureService.list({
-							db,
-							orgId: org.id,
-							env,
-						}),
-					},
-					product,
-				),
-				subscriptionIds: [subscription.id],
-				scenario: AttachScenario.New,
-				logger,
-			});
-		}
-	} catch (error: any) {
-		logger.error("❌ Failed to create customer product", {
-			error: error.message,
-		});
-		// Continue anyway - we still need to report payment
+		customPaymentMethod = await stripeCli.paymentMethods.retrieve(customPmId);
 	}
 
-	// 5. Report successful payment to Stripe via Payment Records API
-	// This marks the payment as "guaranteed" and allows Stripe to mark the invoice as paid
+	if (!customPaymentMethod) {
+		throw new Error("Failed to resolve custom payment method");
+	}
+
 	const paymentRecord = await stripeCli.paymentRecords.reportPayment({
 		amount_requested: {
 			value: invoice.amount_due,
@@ -217,13 +246,11 @@ export const handleMarketplaceInvoicePaid = async ({
 		},
 	});
 
-	// 6. Attach payment record to invoice
 	try {
 		await stripeCli.invoices.attachPayment(externalInvoiceId, {
 			payment_record: paymentRecord.id,
 		});
 	} catch (error: any) {
-		// Might already be attached from handleInvoicePaymentAttemptRequired
 		if (error.code === "resource_already_exists") {
 			logger.info("Payment record already attached to invoice");
 		} else {

--- a/server/src/external/vercel/handlers/resources/handleGetResource.ts
+++ b/server/src/external/vercel/handlers/resources/handleGetResource.ts
@@ -1,7 +1,14 @@
-import { Scopes } from "@autumn/shared";
-import type { AppEnv } from "@autumn/shared";
+import {
+	type AppEnv,
+	cusProductToProduct,
+	type FullCusProduct,
+	mapToProductV2,
+	productV2ToBasePrice,
+	Scopes,
+} from "@autumn/shared";
 import { VercelResourceService } from "@/external/vercel/services/VercelResourceService.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { productToBillingPlan } from "../handleListBillingPlans.js";
 
 /**
  * GET /v1/installations/{integrationConfigurationId}/resources/{resourceId}
@@ -12,7 +19,8 @@ export const handleGetResource = createRoute({
 	handler: async (c) => {
 		const { orgId, env, integrationConfigurationId, resourceId } =
 			c.req.param();
-		const { db } = c.get("ctx");
+		const ctx = c.get("ctx");
+		const { db, org, fullCustomer: customer } = ctx;
 
 		const resource = await VercelResourceService.getByIdAndInstallation({
 			db,
@@ -22,12 +30,36 @@ export const handleGetResource = createRoute({
 			env: env as AppEnv,
 		});
 
+		const getPlanAmount = (cusProduct: FullCusProduct) => {
+			const product = cusProductToProduct({ cusProduct });
+			const productV2 = mapToProductV2({ product });
+			const basePrice = productV2ToBasePrice({ product: productV2 });
+			return basePrice?.price ?? 0;
+		};
+
+		const nonAddonProducts = (customer?.customer_products || []).filter(
+			(cp) => !cp.product.is_add_on,
+		);
+
+		const customerProduct =
+			nonAddonProducts.sort((a, b) => getPlanAmount(b) - getPlanAmount(a))[0] ??
+			customer?.customer_products?.[0];
+
+		const billingPlan =
+			customerProduct !== undefined
+				? productToBillingPlan({
+						product: cusProductToProduct({ cusProduct: customerProduct }),
+						orgCurrency: org?.default_currency ?? "usd",
+					})
+				: undefined;
+
 		return c.json({
 			id: resource.id,
 			productId: resource.org_id,
 			name: resource.name,
 			metadata: resource.metadata,
 			status: resource.status,
+			...(billingPlan ? { billingPlan } : {}),
 		});
 	},
 });

--- a/server/src/external/vercel/handlers/resources/handleUpdateResource.ts
+++ b/server/src/external/vercel/handlers/resources/handleUpdateResource.ts
@@ -38,22 +38,30 @@ export const handleUpdateResource = createRoute({
 	handler: async (c) => {
 		const { orgId, env, integrationConfigurationId, resourceId } =
 			c.req.param();
-		const { db } = c.get("ctx");
+		const ctx = c.get("ctx");
+		const { db, fullCustomer: customer } = ctx;
 		const body = c.req.valid("json");
 
 		// Block metadata updates - metadata is set during resource creation and cannot be modified
 		if (body.metadata !== undefined) {
-			throw new RecaseError({
-				message:
-					"Metadata cannot be updated after resource creation. Prepaid quantities are fixed at subscription creation time.",
-				code: "metadata_update_not_allowed",
-				statusCode: StatusCodes.BAD_REQUEST,
-			});
+			const hasCurrentPlan = !!customer?.customer_products?.some(
+				(cp) => !cp?.product?.is_default,
+			);
+
+			if (!hasCurrentPlan) {
+				throw new RecaseError({
+					message:
+						"Metadata cannot be updated before a plan exists. Prepaid quantities are fixed at subscription creation time.",
+					code: "metadata_update_not_allowed",
+					statusCode: StatusCodes.BAD_REQUEST,
+				});
+			}
 		}
 
 		const updates: Record<string, any> = {};
 		if (body.name) updates.name = body.name;
 		if (body.status) updates.status = body.status;
+		if (body.metadata !== undefined) updates.metadata = body.metadata;
 
 		console.log(`Vercel, updating resource: `, body);
 

--- a/server/src/external/vercel/misc/vercelInvoicing.ts
+++ b/server/src/external/vercel/misc/vercelInvoicing.ts
@@ -53,8 +53,11 @@ export const submitBillingDataToVercel = async ({
 	});
 
 	const firstLineItem = invoice.lines.data[0];
-	const periodStart = firstLineItem?.period?.start || invoice.period_start;
-	const periodEnd = firstLineItem?.period?.end || invoice.period_end;
+	const rawPeriodStart = firstLineItem?.period?.start || invoice.period_start;
+	const rawPeriodEnd = firstLineItem?.period?.end || invoice.period_end;
+	const periodStart = rawPeriodStart;
+	const periodEnd =
+		rawPeriodEnd > rawPeriodStart ? rawPeriodEnd : rawPeriodStart + 1;
 
 	// Map invoice line items to Vercel billing format
 	const billingItems = invoice.lines.data
@@ -128,8 +131,11 @@ export const submitInvoiceToVercel = async ({
 
 	// Get the actual billing period from line items (invoice period_start/end can be the same on creation)
 	const firstLineItem = invoice.lines.data[0];
-	const periodStart = firstLineItem?.period?.start || invoice.period_start;
-	const periodEnd = firstLineItem?.period?.end || invoice.period_end;
+	const rawPeriodStart = firstLineItem?.period?.start || invoice.period_start;
+	const rawPeriodEnd = firstLineItem?.period?.end || invoice.period_end;
+	const periodStart = rawPeriodStart;
+	const periodEnd =
+		rawPeriodEnd > rawPeriodStart ? rawPeriodEnd : rawPeriodStart + 1;
 
 	// Calculate total amount from invoice (includes subscription + usage charges)
 	const totalAmount = invoice.amount_due / 100;

--- a/server/src/external/vercel/vercelWebhookRouter.ts
+++ b/server/src/external/vercel/vercelWebhookRouter.ts
@@ -5,7 +5,7 @@ import { analyticsMiddleware } from "@/honoMiddlewares/analyticsMiddleware.js";
 import { traceEnrichMiddleware } from "@/honoMiddlewares/traceMiddleware.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { sendCustomSvixEvent } from "../svix/svixHelpers.js";
-import { handleListBillingPlansPerInstall } from "./handlers/handleListBillingPlans.js";
+import { handleVercelListBillingPlans } from "./handlers/handleListBillingPlans.js";
 import { handleUpdateVercelBillingPlan } from "./handlers/handleUpdateBillingPlan.js";
 import { handleDeleteInstallation } from "./handlers/installations/handleDeleteInstallation.js";
 import { handleGetInstallation } from "./handlers/installations/handleGetInstallation.js";
@@ -48,7 +48,7 @@ vercelWebhookRouter.use(
 vercelWebhookRouter.get(
 	"/:orgId/:env/v1/products/:productId/plans",
 	vercelOidcAuthMiddleware,
-	...handleListBillingPlansPerInstall,
+	...handleVercelListBillingPlans,
 );
 
 // --- Installation sub-router ---
@@ -68,7 +68,7 @@ installationsRouter.use(
 );
 
 // Plans
-installationsRouter.get("/plans", ...handleListBillingPlansPerInstall);
+installationsRouter.get("/plans", ...handleVercelListBillingPlans);
 
 // Installation CRUD
 installationsRouter.get("/", ...handleGetInstallation);
@@ -79,6 +79,10 @@ installationsRouter.delete("/", ...handleDeleteInstallation);
 // Resources
 installationsRouter.post("/resources", ...handleCreateResource);
 installationsRouter.get("/resources/:resourceId", ...handleGetResource);
+installationsRouter.get(
+	"/resources/:resourceId/plans",
+	...handleVercelListBillingPlans,
+);
 installationsRouter.patch("/resources/:resourceId", ...handleUpdateResource);
 installationsRouter.delete("/resources/:resourceId", ...handleDeleteResource);
 installationsRouter.post(
@@ -157,10 +161,13 @@ vercelWebhookRouter.post(
 			}
 		} catch (error: any) {
 			logger.error("Failed to process Vercel marketplace webhook", {
-				error,
 				eventType,
+				errorName: error?.name,
+				errorMessage: error?.message,
+				errorStack: error?.stack,
+				errorString: String(error),
 			});
-			return c.json({ error: error.message }, 500);
+			return c.json({ error: error?.message ?? String(error) }, 500);
 		}
 	},
 );

--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -90,8 +90,9 @@ export const autoTopup = async ({
 
 		const isInvoiceMode = Boolean(autoTopupContext.invoiceMode);
 		const invoiceStatus = billingResult.stripe?.stripeInvoice?.status;
+		const isCustomPm = autoTopupContext.paymentMethod?.type === "custom";
 
-		if (!isInvoiceMode && invoiceStatus !== "paid") {
+		if (!isInvoiceMode && !isCustomPm && invoiceStatus !== "paid") {
 			await voidStripeInvoiceIfOpen({
 				ctx,
 				stripeInvoice: billingResult.stripe?.stripeInvoice,
@@ -100,7 +101,10 @@ export const autoTopup = async ({
 			return;
 		}
 
-		// Manually update cached options here since we're not refreshing cache.
+		if (isCustomPm) {
+			return;
+		}
+
 		const customerProductUpdate = autumnBillingPlan.updateCustomerProduct;
 		if (customerProductUpdate?.updates.options) {
 			const customerProductId = customerProductUpdate.customerProduct.id;

--- a/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
@@ -18,6 +18,7 @@ import { handleProrationBehaviorErrors } from "@/internal/billing/v2/common/erro
 import { handleCustomLineItemsErrors } from "@/internal/billing/v2/common/errors/handleCustomLineItemsErrors";
 import { handleExternalPSPErrors } from "@/internal/billing/v2/common/errors/handleExternalPSPErrors";
 import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/handleSubscriptionIdErrors";
+import { handleCustomPaymentMethodErrorsV2 } from "@/internal/customers/attach/attachUtils/handleAttachErrors";
 
 /** Validates attach v2 request before executing the billing plan. */
 export const handleAttachV2Errors = async ({
@@ -33,12 +34,15 @@ export const handleAttachV2Errors = async ({
 }) => {
 	const { autumn: autumnBillingPlan } = billingPlan;
 
-	// 1. External PSP errors (RevenueCat)
+	// 1.1. External PSP errors (RevenueCat)
 	handleExternalPSPErrors({
 		customerProducts: billingContext.fullCustomer.customer_products,
 		attachProduct: billingContext.attachProduct,
 		action: "attach",
 	});
+
+	// 1.2. Custom Payment Method errors (Vercel)
+	handleCustomPaymentMethodErrorsV2({ billingContext });
 
 	// 2. Current customer product errors (same product)
 	handleCurrentCustomerProductErrors({ billingContext });

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeInvoiceAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeInvoiceAction.ts
@@ -59,9 +59,10 @@ export const executeStripeInvoiceAction = async ({
 			billingPlan,
 			billingContext,
 			stripeInvoice: invoice,
-			expiresAt: deferredInvoiceMode
-				? Date.now() + ms.days(10)
-				: Date.now() + ms.minutes(10),
+			expiresAt:
+				deferredInvoiceMode || billingContext.paymentMethod?.type === "custom"
+					? Date.now() + ms.days(10)
+					: Date.now() + ms.minutes(10),
 			resumeAfter: StripeBillingStage.InvoiceAction,
 		});
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -69,11 +69,23 @@ export const createInvoiceForBilling = async ({
 		? "send_invoice"
 		: "charge_automatically";
 
+	const vercelInstallationId =
+		billingContext.paymentMethod?.type === "custom"
+			? billingContext.fullCustomer?.processors?.vercel?.installation_id
+			: undefined;
+
 	const invoiceMetadata = mergeStripeMetadata({
 		userMetadata: billingContext.userMetadata,
 		autumnMetadata: {
 			autumn_billing_update: "true",
 			autumn_invoice_mode: billingContext.invoiceMode ? "true" : "false",
+			...(vercelInstallationId
+				? {
+						vercel_installation_id: vercelInstallationId,
+						vercel_billing_plan_id:
+							billingContext.fullProducts?.[0]?.id ?? "",
+					}
+				: {}),
 		},
 	});
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts
@@ -47,7 +47,18 @@ export const payStripeInvoice = async ({
 		});
 	}
 
-	// 3. Attempt payment
+	if (paymentMethod.type === "custom") {
+		return {
+			paid: false,
+			invoice,
+			requiredAction: {
+				code: "payment_method_required",
+				reason: "Custom payment method requires out-of-band payment",
+			},
+		};
+	}
+
+	// 4. Attempt payment
 	const { data: paidInvoice, error } = await tryCatch(
 		stripeCli.invoices.pay(invoice.id, {
 			payment_method: paymentMethod.id,

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts
@@ -2,6 +2,7 @@ import {
 	type AttachBodyV0,
 	AttachBranch,
 	type AttachConfig,
+	type BillingContext,
 	BillingType,
 	ErrCode,
 	RecaseError,
@@ -149,6 +150,29 @@ export const handleCustomPaymentMethodErrors = ({
 				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
 		});
 	} else if (attachParams.customer.processors?.vercel?.installation_id) {
+		throw new RecaseError({
+			message:
+				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
+		});
+	}
+};
+
+export const handleCustomPaymentMethodErrorsV2 = ({
+	billingContext,
+}: {
+	billingContext: BillingContext;
+}) => {
+	const { paymentMethod } = billingContext;
+	if (
+		paymentMethod?.type === "custom" &&
+		billingContext.fullCustomer.processors?.vercel?.custom_payment_method_id ===
+			paymentMethod?.custom?.type
+	) {
+		throw new RecaseError({
+			message:
+				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",
+		});
+	} else if (billingContext.fullCustomer.processors?.vercel?.installation_id) {
 		throw new RecaseError({
 			message:
 				"This customer is billed outside of Stripe, please use the origin platform to manage their billing.",


### PR DESCRIPTION
- **fix: 🐛 filter stripe sub by active**
- **feat: 🎸 make auto top ups work w vercel**
- **fix: 🐛 prepaid prices defaulting to 0 in vercel marketpalce**
- **fix: 🐛 a bunch of random vercel bugs**
- **fix: 🐛 grace for vercel**
- **feat: 🎸 don't double fetch**
- **fix: 🐛 bug**

## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Vercel marketplace billing flow and custom payment method support. Adds auto top-ups for Vercel customers and fixes prepaid quantity, plan filtering, and invoice period issues.

- New Features
  - End-to-end Vercel custom payment method: set invoice metadata, skip Stripe pay, and mark payment via marketplace events; auto top-ups now work with custom PMs.
  - Process Vercel invoices during invoice.finalized setup (no double submit).
  - Resource API returns the customer’s current billingPlan; PATCH allows metadata once a plan exists.
  - Unified plans endpoint exposed for products and resources.

- Bug Fixes
  - Prevent prepaid prices defaulting to 0 by ignoring null/0 quantities unless checkout.
  - Only consider active Stripe subscriptions when updating or cancelling Vercel plans.
  - Ensure Vercel billing periods are valid (periodEnd > periodStart).
  - Harden marketplace.invoice.paid: handle invoices without a subscription, create/renew cus_products, and reliably attach payment records; improved error logs.
  - Block direct Stripe attach for Vercel-managed customers and extend invoice action expiry (10 days) to give the marketplace time to pay.

<sup>Written for commit 3de47826debd0c7ad12d3285ef1d4b50b545315b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR backports a set of Vercel Marketplace integration fixes and features from another branch to `dev`, covering invoice processing, auto top-up, prepaid pricing, subscription filtering, and resource management.

- **[Bug fixes]** Filter Stripe subscriptions by `status === \"active\"` when resolving existing Vercel subscriptions; fix period-end guard in Vercel invoicing to prevent `periodStart === periodEnd` rejections; refactor `processVercelInvoice` to fall back to invoice metadata and customer-processor PM when no subscription line item exists.
- **[Bug fixes]** Add early-return guard in `priceToOneOffAndTiered` / `priceToUsageInAdvance` for zero/null quantities (though the `optionsQuantity === 0` branch is unreachable as written — see inline comment); guard auto top-up against custom payment methods so out-of-band Vercel payments are not voided.
- **[Improvements]** Propagate Vercel installation/plan metadata onto Stripe invoices for auto top-up flows; extend deferred invoice expiry to custom-PM invoices; add `handleCustomPaymentMethodErrorsV2` to the attach v2 validation chain; enrich `GET /resources/:resourceId` with the customer's current billing plan.
</details>

<h3>Confidence Score: 3/5</h3>

The Vercel invoicing and webhook routing changes are sound, but two defects in the changed billing path need fixing before this is production-ready.

The zero-quantity early-return in `priceToUsageInAdvance` is unreachable as written, so zero-prepaid line items will continue to be sent to Stripe — the stated fix has no effect at runtime. In `handleMarketplaceInvoicePaid`, the subscription's `default_payment_method` is now cast and retrieved outside the inner try/catch; a subscription with no default PM will throw an unhandled error and return 500 to Vercel's webhook. Both issues sit on billing paths that run for every Vercel invoice cycle.

`priceToUsageInAdvance.ts` (unreachable zero-quantity guard) and `handleMarketplaceInvoicePaid.ts` (unguarded null cast on `default_payment_method`) warrant the most attention. Debug `console.log` calls in `handleListBillingPlans.ts` and `handleUpdateResource.ts` should also be cleaned up before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/priceToStripeItem/priceToUsageInAdvance.ts | Adds early-return guards for zero/nullish quantities, but the `optionsQuantity === 0` branch is unreachable — the first `if (notNullish)` always captures `0` before the new else-if fires. |
| server/src/external/vercel/handlers/handleListBillingPlans.ts | Refactors product filtering into `getVercelPlanFilterReason`, renames export to `handleVercelListBillingPlans`; leaves three debug `console.log` calls on the hot path. |
| server/src/external/vercel/handlers/marketplace/handleMarketplaceInvoicePaid.ts | Splits subscription-based vs. custom-PM invoice paths; PM retrieval is now outside the inner try/catch and will hard-fail if `default_payment_method` is null. |
| server/src/external/stripe/webhookHandlers/handleStripeInvoiceFinalized/tasks/processVercelInvoice.ts | Refactored to accept raw `stripeInvoice`/`stripeSubscription` instead of `eventContext`; falls back to invoice metadata and customer processor PM when subscription is absent. |
| server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts | Adds `handleCustomPaymentMethodErrorsV2`; the first branch condition compares incompatible types (PM ID vs custom type string) and is always false — dead code copied from the V1 function. |
| server/src/external/vercel/handlers/resources/handleGetResource.ts | Enriches the GET resource response with the customer's current billing plan by sorting non-add-on products by price and converting to `VercelBillingPlan`. |
| server/src/external/vercel/handlers/resources/handleUpdateResource.ts | Relaxes the metadata-update block to only reject updates when no plan exists; adds metadata to `updates` object; leaves a debug `console.log` with the full request body. |
| server/src/internal/balances/autoTopUp/autoTopup.ts | Skips invoice-void and cache-update logic for custom payment methods (Vercel), since payment is confirmed out-of-band. |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/payStripeInvoice.ts | Returns early with a `payment_method_required` action for custom payment methods instead of attempting a Stripe charge — correct for Vercel out-of-band billing. |
| server/src/external/vercel/handlers/handleUpdateBillingPlan.ts | Adds `status === "active"` filter when searching for an existing subscription, preventing cancelled/inactive subscriptions from blocking plan updates. |
| server/src/external/vercel/misc/vercelInvoicing.ts | Prevents invalid Vercel billing payloads where `period_end === period_start` by bumping end by 1 second when they are equal. |
| server/src/external/vercel/vercelWebhookRouter.ts | Updates import alias to `handleVercelListBillingPlans`, adds a new `/resources/:resourceId/plans` route, and improves error serialization in the webhook error handler. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant V as Vercel
    participant AH as Autumn (invoice.finalized handler)
    participant SI as setupInvoiceFinalizedContext
    participant PVI as processVercelInvoice
    participant S as Stripe
    participant MIP as handleMarketplaceInvoicePaid

    V->>S: Customer subscribes (Vercel custom PM)
    S->>AH: invoice.finalized webhook
    AH->>SI: setupInvoiceFinalizedContext()
    SI->>SI: isVercelInvoice? (check subscription OR invoice metadata)
    alt Is Vercel invoice
        SI->>PVI: processVercelInvoice(stripeInvoice, stripeSubscription)
        PVI->>PVI: Resolve vercelInstallationId / billingPlanId
        PVI->>PVI: Resolve PM (subscription default_pm OR customer.processors.vercel.custom_pm)
        PVI->>S: paymentMethods.retrieve(pmId)
        PVI->>V: submitBillingDataToVercel()
        PVI->>V: submitInvoiceToVercel()
    end
    SI-->>AH: InvoiceFinalizedContext (no features field)
    V->>MIP: marketplace.invoice.paid webhook
    alt Has subscription line item
        MIP->>S: subscriptions.retrieve(subscriptionId)
        MIP->>S: paymentMethods.retrieve(default_pm)
        MIP->>MIP: createFullCusProduct (new) OR sendUsageAndReset (renewal)
    else No subscription (custom PM only)
        MIP->>MIP: Read PM from customer.processors.vercel.custom_payment_method_id
    end
    MIP->>S: paymentRecords.reportPayment()
    MIP->>S: invoices.attachPayment()
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
server/src/external/stripe/priceToStripeItem/priceToUsageInAdvance.ts:39-40
**Zero-quantity guard is unreachable in both `priceToOneOffAndTiered` and `priceToUsageInAdvance`**

The new `else if (nullish(optionsQuantity) || optionsQuantity === 0)` branch can never fire for the `optionsQuantity === 0` case because the first `if (notNullish(optionsQuantity))` already captures `0` (zero is not `null`/`undefined`) and sets `finalQuantity = 0`. Execution never reaches the third branch when quantity is zero, so the function continues and generates a zero-amount Stripe line item — exactly the bug it was meant to fix. Only the `nullish` half of the `||` is reachable in this position.

The guard for `optionsQuantity === 0` should be moved inside the first branch (e.g., `if (notNullish(optionsQuantity) && optionsQuantity !== 0)`), or checked before the else-if chain entirely. The same problem exists in `priceToUsageInAdvance` at line ~110.

### Issue 2 of 5
server/src/external/vercel/handlers/marketplace/handleMarketplaceInvoicePaid.ts:60-62
**Unsafe cast of `default_payment_method` without null guard**

`subscription.default_payment_method as string` is evaluated outside the inner `try/catch`. If the Stripe subscription has no default payment method set (returns `null`), `stripeCli.paymentMethods.retrieve(null as string)` will throw a Stripe API error that propagates all the way up, causing the entire `handleMarketplaceInvoicePaid` function to return a 500 to Vercel instead of gracefully skipping. A null check here (or falling through to the `else` branch that reads the PM from `processors.vercel.custom_payment_method_id`) would prevent this hard failure.

### Issue 3 of 5
server/src/external/vercel/handlers/handleListBillingPlans.ts:187-210
**Debug `console.log` statements left in production path**

Three `console.log` calls — "Products before filtering", "Products after filtering", and "For each product, here is the reason it was filtered out" — are on the hot path for every `GET /plans` request. A fourth one (`console.log("plans", plans)`) is at line ~378. These will write potentially large objects (full product arrays) to stdout on every call and should be removed or replaced with structured logger calls before merging.

### Issue 4 of 5
server/src/external/vercel/handlers/resources/handleUpdateResource.ts:61
**Debug `console.log` with full request body in production**

`console.log('Vercel, updating resource: ', body)` prints the entire PATCH body — including user-supplied `metadata` — on every resource update request. This should be removed or converted to a structured logger call.

### Issue 5 of 5
server/src/internal/customers/attach/attachUtils/handleAttachErrors.ts:166-176
**First condition in `handleCustomPaymentMethodErrorsV2` is dead code**

The guard `billingContext.fullCustomer.processors?.vercel?.custom_payment_method_id === paymentMethod?.custom?.type` compares a Stripe payment-method ID (e.g. `"pm_abc123"`) against the custom type string (e.g. `"vercel"`). These two strings will never be equal, so the `if` branch is unreachable. The `else if` then fires for every customer that has a Vercel `installation_id`, throwing the same error unconditionally. The first arm can be removed to make the intent clear. (The original `handleCustomPaymentMethodErrors` has the same pattern, so this was likely copied verbatim.)

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 bug"](https://github.com/useautumn/autumn/commit/3de47826debd0c7ad12d3285ef1d4b50b545315b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30857802)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->