### PR TITLE
Add per-org Redis migration routing

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -48,7 +48,7 @@
 				"cd \"/Users/johnyeocx/Autumn/autumn-cloud\" && exec infisical run --env=prod --recursive -- bun run \"/Users/johnyeocx/Autumn/autumn-cloud/ai/src/mcp/index.ts\""
 			],
 			"env": {
-				"AUTUMN_REPO_ROOT": "/Users/johnyeocx/Autumn"
+				"AUTUMN_CLOUD_ROOT": "/Users/johnyeocx/Autumn/autumn-cloud"
 			}
 		}
 	},

--- a/server/src/cron/productCron/runProductCron.ts
+++ b/server/src/cron/productCron/runProductCron.ts
@@ -4,6 +4,7 @@ import {
 	ms,
 	orgToFeaturesByOrgEnv,
 } from "@autumn/shared";
+import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import { batchInvalidateCachedFullSubjects } from "@/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects";
 import { customerProductRepo } from "@/internal/customers/cusProducts/repos";
 import { ProductService } from "@/internal/products/ProductService";
@@ -77,6 +78,11 @@ export const runProductCron = async ({
 						customers: customersToDelete,
 						featuresByOrgEnv,
 						redisV2: ctx.redisV2,
+						getRedisForCustomer: ({ customer }) =>
+							resolveCustomerRedisRouting({
+								org,
+								customerId: customer.customerId,
+							}).redis,
 					});
 					console.log(`Expired ${rows.length} customer products`);
 					continue;

--- a/server/src/cron/productCron/runProductCron.ts
+++ b/server/src/cron/productCron/runProductCron.ts
@@ -4,7 +4,7 @@ import {
 	ms,
 	orgToFeaturesByOrgEnv,
 } from "@autumn/shared";
-import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { getRedisTargetsForCustomer } from "@/external/redis/customerRedisRouting.js";
 import { batchInvalidateCachedFullSubjects } from "@/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects";
 import { customerProductRepo } from "@/internal/customers/cusProducts/repos";
 import { ProductService } from "@/internal/products/ProductService";
@@ -77,11 +77,10 @@ export const runProductCron = async ({
 					await batchInvalidateCachedFullSubjects({
 						customers: customersToDelete,
 						featuresByOrgEnv,
-						getRedisForCustomer: ({ customer }) =>
-							resolveCustomerRedisRouting({
+						getRedisTargetsForCustomer: () =>
+							getRedisTargetsForCustomer({
 								org,
-								customerId: customer.customerId,
-							}).redis,
+							}),
 					});
 					console.log(`Expired ${rows.length} customer products`);
 					continue;

--- a/server/src/cron/productCron/runProductCron.ts
+++ b/server/src/cron/productCron/runProductCron.ts
@@ -77,7 +77,6 @@ export const runProductCron = async ({
 					await batchInvalidateCachedFullSubjects({
 						customers: customersToDelete,
 						featuresByOrgEnv,
-						redisV2: ctx.redisV2,
 						getRedisForCustomer: ({ customer }) =>
 							resolveCustomerRedisRouting({
 								org,

--- a/server/src/cron/resetCron/resetCustomerEntitlement.ts
+++ b/server/src/cron/resetCron/resetCustomerEntitlement.ts
@@ -8,7 +8,8 @@ import {
 import { UTCDate } from "@date-fns/utc";
 import { format } from "date-fns";
 import type { RepoContext } from "@/db/repoContext";
-import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
+import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import type { OrgWithRedisConfig } from "@/external/redis/orgRedisPool.js";
 import { invalidateCustomerEntitlementBalance } from "@/internal/customers/cache/fullSubject/actions/invalidate/invalidateCustomerEntitlementBalance.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
 import { getRelatedCusPrice } from "@/internal/customers/cusProducts/cusEnts/cusEntUtils.js";
@@ -26,15 +27,21 @@ const shortDurations = [EntInterval.Minute, EntInterval.Hour, EntInterval.Day];
 
 const resetCustomerEntitlementInDb = async ({
 	ctx,
+	org,
 	cusEnt,
 	updatedCusEnts,
 	persistFreeOverage = false,
 }: {
 	ctx: CronContext;
+	org: OrgWithRedisConfig;
 	cusEnt: ResetCusEnt;
 	updatedCusEnts: ResetCusEnt[];
 	persistFreeOverage?: boolean;
 }) => {
+	const redisRouting = resolveCustomerRedisRouting({
+		org,
+		customerId: cusEnt.customer_id ?? "",
+	});
 	const repoContext: RepoContext = {
 		db: ctx.db,
 		logger: ctx.logger,
@@ -43,7 +50,7 @@ const resetCustomerEntitlementInDb = async ({
 		},
 		env: cusEnt.customer.env,
 		customerId: cusEnt.customer_id ?? "",
-		redisV2: resolveRedisV2(),
+		redisV2: redisRouting.redis,
 	};
 
 	try {
@@ -186,17 +193,25 @@ const resetCustomerEntitlementInDb = async ({
 
 export const resetCustomerEntitlement = async ({
 	ctx,
+	org,
 	cusEnt,
 	updatedCusEnts,
 	persistFreeOverage = false,
 }: {
 	ctx: CronContext;
+	org?: OrgWithRedisConfig;
 	cusEnt: ResetCusEnt;
 	updatedCusEnts: ResetCusEnt[];
 	persistFreeOverage?: boolean;
 }) => {
+	const routingOrg = org ?? { id: cusEnt.customer.org_id, redis_config: null };
+	const redisRouting = resolveCustomerRedisRouting({
+		org: routingOrg,
+		customerId: cusEnt.customer_id ?? "",
+	});
 	const result = await resetCustomerEntitlementInDb({
 		ctx,
+		org: routingOrg,
 		cusEnt,
 		updatedCusEnts,
 		persistFreeOverage,
@@ -207,7 +222,7 @@ export const resetCustomerEntitlement = async ({
 		customerId: cusEnt.customer_id ?? "",
 		featureId: cusEnt.entitlement.feature.id,
 		customerEntitlementId: cusEnt.id,
-		redisV2: resolveRedisV2(),
+		redisV2: redisRouting.redis,
 	});
 	return result;
 };

--- a/server/src/cron/resetCron/runResetCron.ts
+++ b/server/src/cron/resetCron/runResetCron.ts
@@ -121,6 +121,7 @@ export const runResetCron = async ({ ctx }: { ctx: CronContext }) => {
 					batchResets.push(
 						resetCustomerEntitlement({
 							ctx,
+							org: orgWithFeatures.org,
 							cusEnt: cusEnt,
 							updatedCusEnts,
 							persistFreeOverage:

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -7,7 +7,6 @@ export {
 	type CustomerRedisRoutingInfo,
 	getCustomerBucket,
 	getCustomerRedisRoutingId,
-	getRedisUrlForCustomerFromOrg,
 	isRedisMigrationCacheStale,
 } from "./customerRedisRoutingInfo.js";
 
@@ -51,28 +50,37 @@ export const resolveCustomerRedisRouting = ({
 	};
 };
 
-export const assignCustomerRedisToCtx = ({
+export const getCtxWithCustomerRedis = <T extends AutumnContext>({
 	ctx,
 	customerId = ctx.customerId,
 }: {
-	ctx: AutumnContext;
+	ctx: T;
 	customerId?: string;
-}): CustomerRedisRoutingInfo => {
+}): { ctx: T; routingInfo: CustomerRedisRoutingInfo } => {
 	const routingInfo = resolveCustomerRedisRouting({
 		org: ctx.org,
 		customerId,
 	});
 
-	ctx.redisV2 = routingInfo.redis;
-	return routingInfo;
+	return {
+		ctx: {
+			...ctx,
+			redisV2: routingInfo.redis,
+		} as T,
+		routingInfo,
+	};
 };
 
-export const getRedisUrlForCustomer = ({
+export const getRedisTargetsForCustomer = ({
 	org,
-	customerId,
+	currentRedis,
 }: {
 	org: OrgWithRedisConfig;
-	customerId?: string;
-}): string | undefined => {
-	return getCustomerRedisRoutingInfo({ org, customerId }).redisUrl;
+	currentRedis?: Redis;
+}): Redis[] => {
+	const redisTargets = [currentRedis ?? resolveRedisV2()];
+	if (org.redis_config) {
+		redisTargets.push(resolveRedisV2(), getOrgRedis({ org }));
+	}
+	return [...new Set(redisTargets)];
 };

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -6,6 +6,7 @@ import { resolveRedisV2 } from "./resolveRedisV2.js";
 export {
 	type CustomerRedisRoutingInfo,
 	getCustomerBucket,
+	getCustomerRedisRoutingId,
 	getRedisUrlForCustomerFromOrg,
 	isRedisMigrationCacheStale,
 } from "./customerRedisRoutingInfo.js";

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -64,7 +64,22 @@ export const assignCustomerRedisToCtx = ({
 	});
 
 	ctx.redisV2 = routingInfo.redis;
+
 	return routingInfo;
+};
+
+export const overrideCtxRedisV2 = ({
+	ctx,
+	redisV2,
+}: {
+	ctx: AutumnContext;
+	redisV2: Redis;
+}): AutumnContext => {
+	if (ctx.redisV2 === redisV2) return ctx;
+
+	const injectedCtx = Object.create(ctx) as AutumnContext;
+	injectedCtx.redisV2 = redisV2;
+	return injectedCtx;
 };
 
 export const getRedisUrlForCustomer = ({

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -7,7 +7,6 @@ export {
 	type CustomerRedisRoutingInfo,
 	getCustomerBucket,
 	getCustomerRedisRoutingId,
-	getRedisUrlForCustomerFromOrg,
 	isRedisMigrationCacheStale,
 } from "./customerRedisRoutingInfo.js";
 
@@ -51,21 +50,25 @@ export const resolveCustomerRedisRouting = ({
 	};
 };
 
-export const assignCustomerRedisToCtx = ({
+export const getCtxWithCustomerRedis = <T extends AutumnContext>({
 	ctx,
 	customerId = ctx.customerId,
 }: {
-	ctx: AutumnContext;
+	ctx: T;
 	customerId?: string;
-}): CustomerRedisRoutingInfo => {
+}): { ctx: T; routingInfo: CustomerRedisRoutingInfo } => {
 	const routingInfo = resolveCustomerRedisRouting({
 		org: ctx.org,
 		customerId,
 	});
 
-	ctx.redisV2 = routingInfo.redis;
-
-	return routingInfo;
+	return {
+		ctx: {
+			...ctx,
+			redisV2: routingInfo.redis,
+		} as T,
+		routingInfo,
+	};
 };
 
 export const overrideCtxRedisV2 = ({
@@ -90,4 +93,18 @@ export const getRedisUrlForCustomer = ({
 	customerId?: string;
 }): string | undefined => {
 	return getCustomerRedisRoutingInfo({ org, customerId }).redisUrl;
+};
+
+export const getRedisTargetsForCustomer = ({
+	org,
+	currentRedis,
+}: {
+	org: OrgWithRedisConfig;
+	currentRedis?: Redis;
+}): Redis[] => {
+	const redisTargets = [currentRedis ?? resolveRedisV2()];
+	if (org.redis_config) {
+		redisTargets.push(resolveRedisV2(), getOrgRedis({ org }));
+	}
+	return [...new Set(redisTargets)];
 };

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -1,0 +1,77 @@
+import type { Redis } from "ioredis";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getOrgRedis, type OrgWithRedisConfig } from "./orgRedisPool.js";
+import { resolveRedisV2 } from "./resolveRedisV2.js";
+
+export {
+	type CustomerRedisRoutingInfo,
+	getCustomerBucket,
+	getRedisUrlForCustomerFromOrg,
+	isRedisMigrationCacheStale,
+} from "./customerRedisRoutingInfo.js";
+
+import {
+	type CustomerRedisRoutingInfo,
+	getCustomerRedisRoutingInfoForOrg,
+} from "./customerRedisRoutingInfo.js";
+
+export const getCustomerRedisRoutingInfo = ({
+	org,
+	customerId,
+}: {
+	org: OrgWithRedisConfig;
+	customerId?: string;
+}): CustomerRedisRoutingInfo => {
+	return getCustomerRedisRoutingInfoForOrg({
+		org,
+		customerId,
+	});
+};
+
+export const resolveCustomerRedisRouting = ({
+	org,
+	customerId,
+}: {
+	org: OrgWithRedisConfig;
+	customerId?: string;
+}): CustomerRedisRoutingInfo & { redis: Redis } => {
+	const routingInfo = getCustomerRedisRoutingInfo({ org, customerId });
+
+	if (routingInfo.usesDedicatedRedis) {
+		return {
+			...routingInfo,
+			redis: getOrgRedis({ org }),
+		};
+	}
+
+	return {
+		...routingInfo,
+		redis: resolveRedisV2(),
+	};
+};
+
+export const setCustomerRedisRouting = ({
+	ctx,
+	customerId = ctx.customerId,
+}: {
+	ctx: AutumnContext;
+	customerId?: string;
+}): CustomerRedisRoutingInfo => {
+	const routingInfo = resolveCustomerRedisRouting({
+		org: ctx.org,
+		customerId,
+	});
+
+	ctx.redisV2 = routingInfo.redis;
+	return routingInfo;
+};
+
+export const getRedisUrlForCustomer = ({
+	org,
+	customerId,
+}: {
+	org: OrgWithRedisConfig;
+	customerId?: string;
+}): string | undefined => {
+	return getCustomerRedisRoutingInfo({ org, customerId }).redisUrl;
+};

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -50,7 +50,7 @@ export const resolveCustomerRedisRouting = ({
 	};
 };
 
-export const setCustomerRedisRouting = ({
+export const assignCustomerRedisToCtx = ({
 	ctx,
 	customerId = ctx.customerId,
 }: {

--- a/server/src/external/redis/customerRedisRoutingInfo.ts
+++ b/server/src/external/redis/customerRedisRoutingInfo.ts
@@ -1,0 +1,70 @@
+import type { OrgRedisConfig } from "@autumn/shared";
+
+type OrgWithRedisConfig = {
+	id: string;
+	redis_config?: OrgRedisConfig | null;
+};
+
+export type CustomerRedisRoutingInfo = {
+	bucket?: number;
+	redisUrl?: string;
+	usesDedicatedRedis: boolean;
+};
+
+export const getCustomerBucket = (customerId: string): number =>
+	Number(BigInt(Bun.hash(customerId)) % 100n);
+
+export const getCustomerRedisRoutingInfoForOrg = ({
+	org,
+	customerId,
+}: {
+	org: OrgWithRedisConfig;
+	customerId?: string;
+}): CustomerRedisRoutingInfo => {
+	if (!org.redis_config || !customerId) {
+		return {
+			usesDedicatedRedis: false,
+		};
+	}
+
+	const bucket = getCustomerBucket(customerId);
+	const usesDedicatedRedis = bucket < org.redis_config.migrationPercent;
+
+	return {
+		bucket,
+		redisUrl: usesDedicatedRedis ? org.redis_config.url : undefined,
+		usesDedicatedRedis,
+	};
+};
+
+export const getRedisUrlForCustomerFromOrg = ({
+	org,
+	customerId,
+}: {
+	org: OrgWithRedisConfig;
+	customerId?: string;
+}): string | undefined =>
+	getCustomerRedisRoutingInfoForOrg({
+		org,
+		customerId,
+	}).redisUrl;
+
+export const isRedisMigrationCacheStale = ({
+	cachedAt,
+	customerId,
+	redisConfig,
+}: {
+	cachedAt?: number;
+	customerId?: string;
+	redisConfig?: OrgRedisConfig | null;
+}): boolean => {
+	if (!redisConfig?.migrationChangedAt) return false;
+	if (!customerId) return false;
+	if (cachedAt === undefined) return false;
+	if (cachedAt >= redisConfig.migrationChangedAt) return false;
+
+	const bucket = getCustomerBucket(customerId);
+	const wasOnDedicated = bucket < redisConfig.previousMigrationPercent;
+	const isOnDedicated = bucket < redisConfig.migrationPercent;
+	return wasOnDedicated !== isOnDedicated;
+};

--- a/server/src/external/redis/customerRedisRoutingInfo.ts
+++ b/server/src/external/redis/customerRedisRoutingInfo.ts
@@ -41,18 +41,6 @@ export const getCustomerRedisRoutingInfoForOrg = ({
 	};
 };
 
-export const getRedisUrlForCustomerFromOrg = ({
-	org,
-	customerId,
-}: {
-	org: OrgWithRedisConfig;
-	customerId?: string;
-}): string | undefined =>
-	getCustomerRedisRoutingInfoForOrg({
-		org,
-		customerId,
-	}).redisUrl;
-
 export const isRedisMigrationCacheStale = ({
 	cachedAt,
 	customerId,

--- a/server/src/external/redis/customerRedisRoutingInfo.ts
+++ b/server/src/external/redis/customerRedisRoutingInfo.ts
@@ -7,6 +7,13 @@ export type CustomerRedisRoutingInfo = {
 	usesDedicatedRedis: boolean;
 };
 
+// Mirrors full-subject cache identity: public ID first, internal ID fallback.
+export const getCustomerRedisRoutingId = ({
+	customer,
+}: {
+	customer: { id?: string | null; internal_id: string };
+}): string => customer.id ?? customer.internal_id;
+
 // Deterministic rollout bucket, not a cryptographic hash.
 export const getCustomerBucket = (customerId: string): number =>
 	Number(BigInt(Bun.hash(customerId)) % 100n);

--- a/server/src/external/redis/customerRedisRoutingInfo.ts
+++ b/server/src/external/redis/customerRedisRoutingInfo.ts
@@ -1,9 +1,5 @@
 import type { OrgRedisConfig } from "@autumn/shared";
-
-type OrgWithRedisConfig = {
-	id: string;
-	redis_config?: OrgRedisConfig | null;
-};
+import type { OrgWithRedisConfig } from "./orgRedisPool.js";
 
 export type CustomerRedisRoutingInfo = {
 	bucket?: number;
@@ -11,6 +7,7 @@ export type CustomerRedisRoutingInfo = {
 	usesDedicatedRedis: boolean;
 };
 
+// Deterministic rollout bucket, not a cryptographic hash.
 export const getCustomerBucket = (customerId: string): number =>
 	Number(BigInt(Bun.hash(customerId)) % 100n);
 

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -1,6 +1,7 @@
 import type { OrgRedisConfig } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { decryptData } from "@/utils/encryptUtils.js";
 import { createRedisConnection, currentRegion } from "./initRedis.js";
@@ -34,11 +35,11 @@ const createOrgRedisConnection = ({
 	});
 
 	instance.on("error", (error) => {
-		console.error(`[OrgRedis] org=${orgId}: ${error.message}`);
+		logger.error(`[OrgRedis] org=${orgId}: ${error.message}`);
 	});
 
 	instance.on("ready", () => {
-		console.log(`[OrgRedis] org=${orgId}: connected`);
+		logger.info(`[OrgRedis] org=${orgId}: connected`);
 	});
 
 	return instance;
@@ -57,10 +58,13 @@ export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
 	let connectionString: string;
 	try {
 		connectionString = decryptData(org.redis_config.connectionString);
-	} catch {
-		console.error(
+	} catch (error) {
+		logger.error(
 			`[OrgRedis] Failed to decrypt redis_config for org ${org.id}, falling back to shared Redis V2`,
 		);
+		if (error instanceof Error) {
+			logger.error(error);
+		}
 		return resolveRedisV2();
 	}
 
@@ -70,14 +74,6 @@ export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
 	});
 	pool.set(org.id, { instance, url: org.redis_config.url });
 	return instance;
-};
-
-export const getPooledOrgRedis = ({
-	orgId,
-}: {
-	orgId: string;
-}): Redis | null => {
-	return pool.get(orgId)?.instance ?? null;
 };
 
 export const removeOrgRedis = ({ orgId }: { orgId: string }): void => {
@@ -96,7 +92,7 @@ export const preWarmOrgRedisConnections = async ({
 
 	if (orgsWithRedis.length === 0) return;
 
-	console.log(
+	logger.info(
 		`[OrgRedis] Pre-warming connections for ${orgsWithRedis.length} orgs in ${currentRegion}...`,
 	);
 

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -1,0 +1,106 @@
+import type { OrgRedisConfig } from "@autumn/shared";
+import type { Redis } from "ioredis";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { decryptData } from "@/utils/encryptUtils.js";
+import { createRedisConnection, currentRegion } from "./initRedis.js";
+import { REDIS_V2_COMMAND_TIMEOUT_MS } from "./initUtils/redisV2Config.js";
+import { resolveRedisV2 } from "./resolveRedisV2.js";
+
+export type OrgWithRedisConfig = {
+	id: string;
+	redis_config?: OrgRedisConfig | null;
+};
+
+type PoolEntry = {
+	instance: Redis;
+	url: string;
+};
+
+const pool = new Map<string, PoolEntry>();
+
+const createOrgRedisConnection = ({
+	connectionString,
+	orgId,
+}: {
+	connectionString: string;
+	orgId: string;
+}): Redis => {
+	const instance = createRedisConnection({
+		cacheUrl: connectionString,
+		region: `org:${orgId}:v2:dragonfly`,
+		supportsUpstashShebang: false,
+		commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
+	});
+
+	instance.on("error", (error) => {
+		console.error(`[OrgRedis] org=${orgId}: ${error.message}`);
+	});
+
+	instance.on("ready", () => {
+		console.log(`[OrgRedis] org=${orgId}: connected`);
+	});
+
+	return instance;
+};
+
+export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
+	if (!org.redis_config) return resolveRedisV2();
+
+	const existing = pool.get(org.id);
+	if (existing) {
+		if (existing.url === org.redis_config.url) return existing.instance;
+		existing.instance.disconnect();
+		pool.delete(org.id);
+	}
+
+	let connectionString: string;
+	try {
+		connectionString = decryptData(org.redis_config.connectionString);
+	} catch {
+		console.error(
+			`[OrgRedis] Failed to decrypt redis_config for org ${org.id}, falling back to shared Redis V2`,
+		);
+		return resolveRedisV2();
+	}
+
+	const instance = createOrgRedisConnection({
+		connectionString,
+		orgId: org.id,
+	});
+	pool.set(org.id, { instance, url: org.redis_config.url });
+	return instance;
+};
+
+export const getPooledOrgRedis = ({
+	orgId,
+}: {
+	orgId: string;
+}): Redis | null => {
+	return pool.get(orgId)?.instance ?? null;
+};
+
+export const removeOrgRedis = ({ orgId }: { orgId: string }): void => {
+	const existing = pool.get(orgId);
+	if (!existing) return;
+	existing.instance.disconnect();
+	pool.delete(orgId);
+};
+
+export const preWarmOrgRedisConnections = async ({
+	db,
+}: {
+	db: DrizzleCli;
+}): Promise<void> => {
+	const orgsWithRedis = await OrgService.listWithRedisConfig({ db });
+
+	if (orgsWithRedis.length === 0) return;
+
+	console.log(
+		`[OrgRedis] Pre-warming connections for ${orgsWithRedis.length} orgs in ${currentRegion}...`,
+	);
+
+	for (const org of orgsWithRedis) {
+		getOrgRedis({ org });
+	}
+};

--- a/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
+++ b/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
@@ -1,0 +1,37 @@
+import type { Redis } from "ioredis";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getOrgRedis } from "../orgRedisPool.js";
+import { resolveRedisV2 } from "../resolveRedisV2.js";
+
+const dedupeRedisInstances = ({ candidates }: { candidates: Redis[] }) =>
+	candidates.filter(
+		(candidate, index) => candidates.indexOf(candidate) === index,
+	);
+
+export const getRedisV2LockReceiptCandidates = ({
+	ctx,
+}: {
+	ctx: AutumnContext;
+}): Redis[] => {
+	const candidates: Redis[] = [ctx.redisV2];
+
+	if (ctx.org.redis_config && ctx.org.redis_config.migrationPercent > 0) {
+		candidates.push(getOrgRedis({ org: ctx.org }), resolveRedisV2());
+	}
+
+	return dedupeRedisInstances({ candidates });
+};
+
+export const getRedisV2OrgCleanupCandidates = ({
+	ctx,
+}: {
+	ctx: AutumnContext;
+}): Redis[] => {
+	const candidates: Redis[] = [ctx.redisV2, resolveRedisV2()];
+
+	if (ctx.org.redis_config) {
+		candidates.push(getOrgRedis({ org: ctx.org }));
+	}
+
+	return dedupeRedisInstances({ candidates });
+};

--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -6,12 +6,13 @@ import {
 	ProcessorType,
 	RecaseError,
 } from "@shared/index";
+import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { CusService } from "@/internal/customers/CusService";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
-import { pricesOnlyOneOff } from "@/internal/products/prices/priceUtils.js";
 import { ProductService } from "@/internal/products/ProductService";
+import { pricesOnlyOneOff } from "@/internal/products/prices/priceUtils.js";
 import { getOrCreateCustomer } from "../../../internal/customers/cusUtils/getOrCreateCustomer";
 
 /**
@@ -102,6 +103,7 @@ export const resolveRevenuecatResources = async ({
 		orgId: ctx.org.id,
 		customerId: ctx.customerId,
 	});
+	setCustomerRedisRouting({ ctx, customerId: ctx.customerId });
 
 	return { product, customer, cusProducts };
 };

--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -6,7 +6,7 @@ import {
 	ProcessorType,
 	RecaseError,
 } from "@shared/index";
-import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
 import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { CusService } from "@/internal/customers/CusService";
@@ -103,7 +103,7 @@ export const resolveRevenuecatResources = async ({
 		orgId: ctx.org.id,
 		customerId: ctx.customerId,
 	});
-	setCustomerRedisRouting({ ctx, customerId: ctx.customerId });
+	assignCustomerRedisToCtx({ ctx, customerId: ctx.customerId });
 
 	return { product, customer, cusProducts };
 };

--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -6,7 +6,7 @@ import {
 	ProcessorType,
 	RecaseError,
 } from "@shared/index";
-import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
 import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { CusService } from "@/internal/customers/CusService";
@@ -31,6 +31,7 @@ export const resolveRevenuecatResources = async ({
 	customerId: string;
 	autoCreateCustomer?: boolean;
 }): Promise<{
+	ctx: RevenueCatWebhookContext;
 	product: FullProduct;
 	customer: FullCustomer;
 	cusProducts: FullCusProduct[];
@@ -103,7 +104,10 @@ export const resolveRevenuecatResources = async ({
 		orgId: ctx.org.id,
 		customerId: ctx.customerId,
 	});
-	assignCustomerRedisToCtx({ ctx, customerId: ctx.customerId });
+	const { ctx: routedCtx } = getCtxWithCustomerRedis({
+		ctx,
+		customerId: ctx.customerId,
+	});
 
-	return { product, customer, cusProducts };
+	return { ctx: routedCtx, product, customer, cusProducts };
 };

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
@@ -29,7 +29,12 @@ export const handleRenewal = async ({
 	const { db, org, env, logger, features } = ctx;
 	const { product_id, app_user_id } = event;
 
-	const { product, customer, cusProducts } = await resolveRevenuecatResources({
+	const {
+		ctx: customerCtx,
+		product,
+		customer,
+		cusProducts,
+	} = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id,
@@ -50,7 +55,7 @@ export const handleRenewal = async ({
 
 		// Send webhook for simple renewal (no state change)
 		await addProductsUpdatedWebhookTask({
-			ctx,
+			ctx: customerCtx,
 			internalCustomerId: curSameProduct.internal_customer_id,
 			org,
 			env,
@@ -68,7 +73,7 @@ export const handleRenewal = async ({
 			`Renewal for existing past due product ${product.id}, marking as active`,
 		);
 		await CusProductService.update({
-			ctx,
+			ctx: customerCtx,
 			cusProductId: curSameProduct.id,
 			updates: {
 				status: CusProductStatus.Active,
@@ -77,7 +82,7 @@ export const handleRenewal = async ({
 
 		// Send webhook for past_due → active recovery
 		await addProductsUpdatedWebhookTask({
-			ctx,
+			ctx: customerCtx,
 			internalCustomerId: curSameProduct.internal_customer_id,
 			org,
 			env,
@@ -111,7 +116,7 @@ export const handleRenewal = async ({
 
 		// Expire old cus_product
 		await CusProductService.update({
-			ctx,
+			ctx: customerCtx,
 			cusProductId: curMainProduct.id,
 			updates: {
 				status: CusProductStatus.Expired,
@@ -121,7 +126,7 @@ export const handleRenewal = async ({
 
 		// Send webhook for the expired product
 		await addProductsUpdatedWebhookTask({
-			ctx,
+			ctx: customerCtx,
 			internalCustomerId: curMainProduct.internal_customer_id,
 			org,
 			env,
@@ -134,7 +139,7 @@ export const handleRenewal = async ({
 	} else if (curSameProduct) {
 		// Reactivate the same product if it was expired/cancelled
 		await CusProductService.update({
-			ctx,
+			ctx: customerCtx,
 			cusProductId: curSameProduct.id,
 			updates: {
 				status: CusProductStatus.Active,
@@ -146,7 +151,7 @@ export const handleRenewal = async ({
 
 		// Send webhook for reactivation
 		await addProductsUpdatedWebhookTask({
-			ctx,
+			ctx: customerCtx,
 			internalCustomerId: curSameProduct.internal_customer_id,
 			org,
 			env,

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatBillingIssue.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatBillingIssue.ts
@@ -3,10 +3,8 @@ import { RecaseError } from "@shared/api/errors/base/RecaseError";
 import { ErrCode } from "@shared/enums/ErrCode";
 import { CusProductStatus } from "@shared/models/cusProductModels/cusProductEnums";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
-import {
-	ACTIVE_STATUSES,
-} from "@/internal/customers/cusProducts/CusProductService";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
+import { ACTIVE_STATUSES } from "@/internal/customers/cusProducts/CusProductService";
 import { getExistingCusProducts } from "@/internal/customers/cusProducts/cusProductUtils/getExistingCusProducts";
 import { resolveRevenuecatResources } from "../misc/resolveRevenuecatResources";
 
@@ -20,7 +18,12 @@ export const handleBillingIssue = async ({
 	const { logger } = ctx;
 	const { product_id, app_user_id } = event;
 
-	const { product, customer, cusProducts } = await resolveRevenuecatResources({
+	const {
+		ctx: customerCtx,
+		product,
+		customer,
+		cusProducts,
+	} = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id,
@@ -48,7 +51,7 @@ export const handleBillingIssue = async ({
 
 	if (ACTIVE_STATUSES.includes(curSameProduct.status)) {
 		await customerProductActions.markPastDue({
-			ctx,
+			ctx: customerCtx,
 			customerProduct: curSameProduct,
 			fullCustomer: customer,
 		});

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatCancellation.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatCancellation.ts
@@ -16,7 +16,12 @@ export const handleCancellation = async ({
 	const { product_id, original_app_user_id, app_user_id, expiration_at_ms } =
 		event;
 
-	const { product, customer, cusProducts } = await resolveRevenuecatResources({
+	const {
+		ctx: customerCtx,
+		product,
+		customer,
+		cusProducts,
+	} = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id ?? original_app_user_id,
@@ -36,7 +41,7 @@ export const handleCancellation = async ({
 	}
 
 	await customerProductActions.cancel({
-		ctx,
+		ctx: customerCtx,
 		customerProduct: curSameProduct,
 		fullCustomer: customer,
 		endedAt: expiration_at_ms,

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatExpiration.ts
@@ -15,7 +15,12 @@ export const handleExpiration = async ({
 	const { logger } = ctx;
 	const { product_id, original_app_user_id, app_user_id } = event;
 
-	const { product, customer, cusProducts } = await resolveRevenuecatResources({
+	const {
+		ctx: customerCtx,
+		product,
+		customer,
+		cusProducts,
+	} = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id ?? original_app_user_id,
@@ -35,7 +40,7 @@ export const handleExpiration = async ({
 	}
 
 	await customerProductActions.expireAndActivateDefault({
-		ctx,
+		ctx: customerCtx,
 		customerProduct: curSameProduct,
 		fullCustomer: customer,
 		updates: {

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatInitialPurchase.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatInitialPurchase.ts
@@ -29,7 +29,12 @@ export const handleInitialPurchase = async ({
 	const { db, org, env, logger, features } = ctx;
 	const { product_id, app_user_id } = event;
 
-	const { product, customer, cusProducts } = await resolveRevenuecatResources({
+	const {
+		ctx: customerCtx,
+		product,
+		customer,
+		cusProducts,
+	} = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id,
@@ -73,7 +78,7 @@ export const handleInitialPurchase = async ({
 
 		// Expire old cus_product
 		await CusProductService.update({
-			ctx,
+			ctx: customerCtx,
 			cusProductId: curMainProduct.id,
 			updates: {
 				status: CusProductStatus.Expired,

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatUncancellation.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatUncancellation.ts
@@ -14,7 +14,12 @@ export const handleUncancellation = async ({
 	const { logger } = ctx;
 	const { product_id, original_app_user_id, app_user_id } = event;
 
-	const { product, customer, cusProducts } = await resolveRevenuecatResources({
+	const {
+		ctx: customerCtx,
+		product,
+		customer,
+		cusProducts,
+	} = await resolveRevenuecatResources({
 		ctx,
 		revenuecatProductId: product_id,
 		customerId: app_user_id ?? original_app_user_id,
@@ -35,7 +40,7 @@ export const handleUncancellation = async ({
 	}
 
 	await customerProductActions.uncancel({
-		ctx,
+		ctx: customerCtx,
 		customerProduct: cusProduct,
 		fullCustomer: customer,
 	});

--- a/server/src/external/stripe/stripeCusUtils.ts
+++ b/server/src/external/stripe/stripeCusUtils.ts
@@ -10,7 +10,7 @@ import { StatusCodes } from "http-status-codes";
 import type { Stripe } from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
-import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
+import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import { createStripeCustomer } from "@/external/stripe/customers";
 import { CusService } from "@/internal/customers/CusService.js";
 
@@ -150,7 +150,10 @@ export const attachPmToCus = async ({
 			org,
 			env,
 			logger: logger,
-			redisV2: resolveRedisV2(),
+			redisV2: resolveCustomerRedisRouting({
+				org,
+				customerId: customer.id ?? customer.internal_id,
+			}).redis,
 		};
 
 		await CusService.update({

--- a/server/src/external/stripe/stripeCusUtils.ts
+++ b/server/src/external/stripe/stripeCusUtils.ts
@@ -10,7 +10,10 @@ import { StatusCodes } from "http-status-codes";
 import type { Stripe } from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
-import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import {
+	getCustomerRedisRoutingId,
+	resolveCustomerRedisRouting,
+} from "@/external/redis/customerRedisRouting.js";
 import { createStripeCustomer } from "@/external/stripe/customers";
 import { CusService } from "@/internal/customers/CusService.js";
 
@@ -152,7 +155,7 @@ export const attachPmToCus = async ({
 			logger: logger,
 			redisV2: resolveCustomerRedisRouting({
 				org,
-				customerId: customer.id ?? customer.internal_id,
+				customerId: getCustomerRedisRoutingId({ customer }),
 			}).redis,
 		};
 

--- a/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
@@ -1,5 +1,6 @@
 import { RELEVANT_STATUSES } from "@autumn/shared";
 import type { Context, Next } from "hono";
+import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { CusService } from "../../../internal/customers/CusService";
 import type {
@@ -68,6 +69,7 @@ export const stripeToAutumnCustomerMiddleware = async (
 			orgId: ctx.org.id,
 			customerId,
 		});
+		setCustomerRedisRouting({ ctx, customerId });
 	}
 
 	await next();

--- a/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
@@ -1,6 +1,6 @@
 import { RELEVANT_STATUSES } from "@autumn/shared";
 import type { Context, Next } from "hono";
-import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { CusService } from "../../../internal/customers/CusService";
 import type {
@@ -64,12 +64,18 @@ export const stripeToAutumnCustomerMiddleware = async (
 		ctx.fullCustomer?.id || ctx.fullCustomer?.internal_id || undefined;
 
 	if (customerId) {
-		ctx.customerId = customerId;
-		ctx.rolloutSnapshot = computeRolloutSnapshot({
-			orgId: ctx.org.id,
+		const { ctx: routedCtx } = getCtxWithCustomerRedis({
+			ctx: {
+				...ctx,
+				customerId,
+				rolloutSnapshot: computeRolloutSnapshot({
+					orgId: ctx.org.id,
+					customerId,
+				}),
+			},
 			customerId,
 		});
-		assignCustomerRedisToCtx({ ctx, customerId });
+		c.set("ctx", routedCtx);
 	}
 
 	await next();

--- a/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeToAutumnCustomerMiddleware.ts
@@ -1,6 +1,6 @@
 import { RELEVANT_STATUSES } from "@autumn/shared";
 import type { Context, Next } from "hono";
-import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { CusService } from "../../../internal/customers/CusService";
 import type {
@@ -69,7 +69,7 @@ export const stripeToAutumnCustomerMiddleware = async (
 			orgId: ctx.org.id,
 			customerId,
 		});
-		setCustomerRedisRouting({ ctx, customerId });
+		assignCustomerRedisToCtx({ ctx, customerId });
 	}
 
 	await next();

--- a/server/src/external/vercel/misc/vercelCustomerMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelCustomerMiddleware.ts
@@ -1,5 +1,5 @@
 import type { Context, Next } from "hono";
-import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -44,7 +44,7 @@ export const vercelCustomerMiddleware = async (
 			orgId: ctx.org.id,
 			customerId,
 		});
-		setCustomerRedisRouting({ ctx, customerId });
+		assignCustomerRedisToCtx({ ctx, customerId });
 	}
 
 	await next();

--- a/server/src/external/vercel/misc/vercelCustomerMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelCustomerMiddleware.ts
@@ -1,4 +1,5 @@
 import type { Context, Next } from "hono";
+import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -43,6 +44,7 @@ export const vercelCustomerMiddleware = async (
 			orgId: ctx.org.id,
 			customerId,
 		});
+		setCustomerRedisRouting({ ctx, customerId });
 	}
 
 	await next();

--- a/server/src/external/vercel/misc/vercelCustomerMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelCustomerMiddleware.ts
@@ -1,5 +1,5 @@
 import type { Context, Next } from "hono";
-import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -35,16 +35,26 @@ export const vercelCustomerMiddleware = async (
 		vercelInstallationId: integrationConfigurationId,
 	});
 
-	ctx.fullCustomer = customer ?? undefined;
-
 	const customerId = customer?.id || customer?.internal_id || undefined;
 	if (customerId) {
-		ctx.customerId = customerId;
-		ctx.rolloutSnapshot = computeRolloutSnapshot({
-			orgId: ctx.org.id,
+		const { ctx: routedCtx } = getCtxWithCustomerRedis({
+			ctx: {
+				...ctx,
+				fullCustomer: customer ?? undefined,
+				customerId,
+				rolloutSnapshot: computeRolloutSnapshot({
+					orgId: ctx.org.id,
+					customerId,
+				}),
+			},
 			customerId,
 		});
-		assignCustomerRedisToCtx({ ctx, customerId });
+		c.set("ctx", routedCtx);
+	} else {
+		c.set("ctx", {
+			...ctx,
+			fullCustomer: customer ?? undefined,
+		});
 	}
 
 	await next();

--- a/server/src/external/vercel/misc/vercelMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelMiddleware.ts
@@ -2,7 +2,7 @@ import { AppEnv, AuthType, type Organization } from "@autumn/shared";
 import chalk from "chalk";
 import type { Context, Next } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
-import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -13,43 +13,49 @@ export const vercelSeederMiddleware = async (
 	c: Context<HonoEnv>,
 	next: Next,
 ) => {
-	const { orgId, env } = c.req.param();
+	const { orgId, env: routeEnv } = c.req.param();
 	const ctx = c.get("ctx");
 
-	if (!ctx.org && orgId) {
-		ctx.org = await OrgService.get({ db: ctx.db, orgId });
-	}
+	const org =
+		!ctx.org && orgId ? await OrgService.get({ db: ctx.db, orgId }) : ctx.org;
+	const env = ctx.env !== routeEnv ? (routeEnv as AppEnv) : ctx.env;
 
-	if (ctx.env !== env) {
-		ctx.env = env as AppEnv;
-	}
+	const features =
+		!ctx.features && orgId
+			? await FeatureService.list({
+					db: ctx.db,
+					orgId,
+					env: env ?? AppEnv.Sandbox,
+				})
+			: ctx.features;
 
-	if (!ctx.features && orgId) {
-		ctx.features = await FeatureService.list({
-			db: ctx.db,
-			orgId,
-			env: ctx.env ?? AppEnv.Sandbox,
-		});
-	}
+	const nextCtx = {
+		...ctx,
+		org,
+		env,
+		features,
+		rolloutSnapshot: computeRolloutSnapshot({
+			orgId: org?.id,
+			customerId: ctx.customerId,
+		}),
+	};
 
-	ctx.rolloutSnapshot = computeRolloutSnapshot({
-		orgId: ctx.org?.id,
-		customerId: ctx.customerId,
-	});
-	if (ctx.org) {
-		assignCustomerRedisToCtx({ ctx });
-	}
+	const routedCtx = org
+		? getCtxWithCustomerRedis({ ctx: nextCtx }).ctx
+		: nextCtx;
 
-	ctx.logger = addAppContextToLogs({
-		logger: ctx.logger,
+	routedCtx.logger = addAppContextToLogs({
+		logger: routedCtx.logger,
 		appContext: {
-			org_id: ctx.org?.id,
-			org_slug: ctx.org?.slug,
-			env: ctx.env,
+			org_id: routedCtx.org?.id,
+			org_slug: routedCtx.org?.slug,
+			env: routedCtx.env,
 			auth_type: AuthType.Vercel,
-			api_version: ctx.apiVersion?.semver,
+			api_version: routedCtx.apiVersion?.semver,
 		},
 	});
+
+	c.set("ctx", routedCtx);
 
 	await next();
 };
@@ -61,7 +67,7 @@ export const logVercelWebhook = ({
 }: {
 	logger: Logger;
 	org: Organization;
-	event: any;
+	event: { type: string; id: string };
 }) => {
 	logger.info(
 		`${chalk.magenta("VERCEL").padEnd(18)} ${event.type.padEnd(30)} ${org.slug} | ${event.id}`,

--- a/server/src/external/vercel/misc/vercelMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelMiddleware.ts
@@ -2,6 +2,7 @@ import { AppEnv, AuthType, type Organization } from "@autumn/shared";
 import chalk from "chalk";
 import type { Context, Next } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -35,6 +36,9 @@ export const vercelSeederMiddleware = async (
 		orgId: ctx.org?.id,
 		customerId: ctx.customerId,
 	});
+	if (ctx.org) {
+		setCustomerRedisRouting({ ctx });
+	}
 
 	ctx.logger = addAppContextToLogs({
 		logger: ctx.logger,

--- a/server/src/external/vercel/misc/vercelMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelMiddleware.ts
@@ -2,7 +2,7 @@ import { AppEnv, AuthType, type Organization } from "@autumn/shared";
 import chalk from "chalk";
 import type { Context, Next } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
-import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -37,7 +37,7 @@ export const vercelSeederMiddleware = async (
 		customerId: ctx.customerId,
 	});
 	if (ctx.org) {
-		setCustomerRedisRouting({ ctx });
+		assignCustomerRedisToCtx({ ctx });
 	}
 
 	ctx.logger = addAppContextToLogs({

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -16,6 +16,26 @@ import { addRequestToLogs } from "@/utils/logging/addContextToLogs";
 import { resolveCustomerId } from "./utils/resolveCustomerId.js";
 import { resolveEntityId } from "./utils/resolveEntityId.js";
 
+const SENSITIVE_REQUEST_BODY_KEYS = new Set(["connectionString"]);
+const REDACTED_REQUEST_BODY_VALUE = "[REDACTED]";
+
+const redactSensitiveRequestBody = ({ body }: { body: unknown }): unknown => {
+	if (!body || typeof body !== "object") return body;
+
+	if (Array.isArray(body)) {
+		return body.map((item) => redactSensitiveRequestBody({ body: item }));
+	}
+
+	return Object.fromEntries(
+		Object.entries(body).map(([key, value]) => [
+			key,
+			SENSITIVE_REQUEST_BODY_KEYS.has(key)
+				? REDACTED_REQUEST_BODY_VALUE
+				: redactSensitiveRequestBody({ body: value }),
+		]),
+	);
+};
+
 /**
  * Base middleware that sets up the request context
  * Sets up: db, logger, id, timestamp
@@ -61,7 +81,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 			ip_address: c.req.header("x-forwarded-for"),
 			region: process.env.AWS_REGION,
 			query: c.req.query(),
-			body,
+			body: redactSensitiveRequestBody({ body }),
 
 			name: `${c.req.method} ${c.req.path}`,
 		},

--- a/server/src/honoMiddlewares/orgRedisMiddleware.ts
+++ b/server/src/honoMiddlewares/orgRedisMiddleware.ts
@@ -1,5 +1,5 @@
 import type { Context, Next } from "hono";
-import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 
 export const orgRedisMiddleware = async (
@@ -7,6 +7,6 @@ export const orgRedisMiddleware = async (
 	next: Next,
 ): Promise<void> => {
 	const ctx = c.get("ctx");
-	setCustomerRedisRouting({ ctx });
+	assignCustomerRedisToCtx({ ctx });
 	await next();
 };

--- a/server/src/honoMiddlewares/orgRedisMiddleware.ts
+++ b/server/src/honoMiddlewares/orgRedisMiddleware.ts
@@ -1,0 +1,12 @@
+import type { Context, Next } from "hono";
+import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+
+export const orgRedisMiddleware = async (
+	c: Context<HonoEnv>,
+	next: Next,
+): Promise<void> => {
+	const ctx = c.get("ctx");
+	setCustomerRedisRouting({ ctx });
+	await next();
+};

--- a/server/src/honoMiddlewares/orgRedisMiddleware.ts
+++ b/server/src/honoMiddlewares/orgRedisMiddleware.ts
@@ -1,5 +1,5 @@
 import type { Context, Next } from "hono";
-import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 
 export const orgRedisMiddleware = async (
@@ -7,6 +7,7 @@ export const orgRedisMiddleware = async (
 	next: Next,
 ): Promise<void> => {
 	const ctx = c.get("ctx");
-	assignCustomerRedisToCtx({ ctx });
+	const { ctx: routedCtx } = getCtxWithCustomerRedis({ ctx });
+	c.set("ctx", routedCtx);
 	await next();
 };

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -5,7 +5,7 @@ import cluster from "node:cluster";
 import http from "node:http";
 import os from "node:os";
 import { getRequestListener } from "@hono/node-server";
-import { client, clientCritical, clientReplica } from "./db/initDrizzle.js";
+import { client, clientCritical, clientReplica, db } from "./db/initDrizzle.js";
 import {
 	initPgHealthMonitor,
 	shutdownPgHealthMonitor,
@@ -38,6 +38,7 @@ import {
 	startRedisV2Monitor,
 	stopRedisV2Monitor,
 } from "./external/redis/initUtils/redisV2Availability.js";
+import { preWarmOrgRedisConnections } from "./external/redis/orgRedisPool.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
 import { checkEnvVars } from "./utils/initUtils.js";
@@ -58,6 +59,9 @@ const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 
 	void warmupRegionalRedis().catch((error) => {
 		logger.warn("[Redis] Warmup failed", { error });
+	});
+	void preWarmOrgRedisConnections({ db }).catch((error) => {
+		logger.warn("[OrgRedis] Warmup failed", { error });
 	});
 	await startAllEdgeConfigPolling({ logger });
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);

--- a/server/src/internal/balances/finalizeLock/runFinalizeLock.ts
+++ b/server/src/internal/balances/finalizeLock/runFinalizeLock.ts
@@ -48,6 +48,7 @@ const runFinalizeLockInner = async ({ ctx, params }: RunFinalizeLockArgs) => {
 			receipt: fetchedReceipt.receipt,
 			lockReceiptKey: fetchedReceipt.lockReceiptKey,
 			claimed: fetchedReceipt.claimed,
+			lockRedisInstance: fetchedReceipt.redisInstance,
 		});
 	}
 

--- a/server/src/internal/balances/finalizeLock/runFinalizeLockV2.ts
+++ b/server/src/internal/balances/finalizeLock/runFinalizeLockV2.ts
@@ -5,6 +5,7 @@ import {
 	RecaseError,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
+import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { cancelLockExpiry } from "@/internal/balances/utils/lock/cancelLockExpiry.js";
 import type { LockReceipt } from "@/internal/balances/utils/lock/fetchLockReceipt.js";
@@ -24,12 +25,14 @@ export const runFinalizeLockV2 = async ({
 	receipt,
 	lockReceiptKey,
 	claimed,
+	lockRedisInstance,
 }: {
 	ctx: AutumnContext;
 	params: FinalizeLockParamsV0;
 	receipt: LockReceipt;
 	lockReceiptKey: string;
 	claimed: boolean;
+	lockRedisInstance: Redis;
 }) => {
 	if (!claimed) {
 		throw new RecaseError({
@@ -45,6 +48,7 @@ export const runFinalizeLockV2 = async ({
 		params,
 		receipt,
 		lockReceiptKey,
+		redisInstance: lockRedisInstance,
 	});
 	const { redisInstance, finalValue, lockValue } = finalizeLockContext;
 

--- a/server/src/internal/balances/finalizeLock/runRedisFinalizeLockV2.ts
+++ b/server/src/internal/balances/finalizeLock/runRedisFinalizeLockV2.ts
@@ -15,7 +15,7 @@ export const runRedisFinalizeLockV2 = async ({
 	ctx: AutumnContext;
 	finalizeLockContext: FinalizeLockContextV2;
 }) => {
-	const { receipt, fullSubject, deduction, deductionOptions } =
+	const { receipt, fullSubject, deduction, deductionOptions, redisInstance } =
 		finalizeLockContext;
 
 	let redisResult: Awaited<ReturnType<typeof executeRedisDeductionV2>>;
@@ -27,6 +27,7 @@ export const runRedisFinalizeLockV2 = async ({
 			entityId: receipt.entity_id ?? undefined,
 			deductions: [deduction],
 			deductionOptions,
+			redisInstance,
 		});
 	} catch (error) {
 		if (error instanceof RedisDeductionError && error.shouldFallback()) {

--- a/server/src/internal/balances/utils/lock/fetchLockReceipt.ts
+++ b/server/src/internal/balances/utils/lock/fetchLockReceipt.ts
@@ -1,5 +1,6 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { redis } from "@/external/redis/initRedis.js";
+import { getRedisV2LockReceiptCandidates } from "@/external/redis/orgRedisUtils/orgRedisMigrationUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { fetchAndClaimLockReceiptV2 } from "@/internal/balances/utils/lockV2/fetchAndClaimLockReceiptV2.js";
 import type { MutationLogItem } from "@/internal/balances/utils/types/mutationLogItem.js";
@@ -39,6 +40,28 @@ const normalizeLockReceiptItems = ({
 	});
 };
 
+const fetchAndClaimLockReceiptV2FromCandidates = async ({
+	ctx,
+	lockId,
+}: {
+	ctx: AutumnContext;
+	lockId: string;
+}) => {
+	const candidates = getRedisV2LockReceiptCandidates({ ctx });
+
+	for (const redisInstance of candidates) {
+		const result = await fetchAndClaimLockReceiptV2({
+			ctx,
+			lockId,
+			redisInstance,
+		});
+
+		if (result.found) return result;
+	}
+
+	return { found: false as const };
+};
+
 export const fetchLockReceipt = async ({
 	ctx,
 	lockId,
@@ -46,7 +69,6 @@ export const fetchLockReceipt = async ({
 	ctx: AutumnContext;
 	lockId: string;
 }) => {
-	const { redisV2 } = ctx;
 	const hashedKey = Bun.hash(lockId).toString();
 	const lockReceiptKey = buildLockReceiptKey({
 		orgId: ctx.org.id,
@@ -56,6 +78,7 @@ export const fetchLockReceipt = async ({
 
 	// V2 half doubles as a fetch+claim (pipelined GET + SET NX on a marker key)
 	// so the dispatcher can route to runFinalizeLockV2 without a follow-up claim RT.
+	// During org Redis migrations, V2 checks both shared and dedicated Redis.
 	// V1 half stays a plain JSON.GET — V1 finalize still claims via Lua afterwards.
 	const [rawReceiptV1, v2Result] = await Promise.all([
 		tryRedisRead(
@@ -63,10 +86,9 @@ export const fetchLockReceipt = async ({
 				redis.call("JSON.GET", lockReceiptKey, "$") as Promise<string | null>,
 			redis,
 		),
-		fetchAndClaimLockReceiptV2({
+		fetchAndClaimLockReceiptV2FromCandidates({
 			ctx,
 			lockId,
-			redisInstance: redisV2,
 		}),
 	]);
 
@@ -76,6 +98,7 @@ export const fetchLockReceipt = async ({
 			lockReceiptKey: v2Result.lockReceiptKey,
 			source: "redis_v2" as const,
 			claimed: v2Result.claimed,
+			redisInstance: v2Result.redisInstance,
 		};
 	}
 

--- a/server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts
+++ b/server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts
@@ -1,6 +1,7 @@
 import type { Feature, FullSubject } from "@autumn/shared";
 import { type FinalizeLockParamsV0, findFeatureById } from "@autumn/shared";
 import type { Redis } from "ioredis";
+import { overrideCtxRedisV2 } from "@/external/redis/customerRedisRouting.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { LockReceipt } from "@/internal/balances/utils/lock/fetchLockReceipt.js";
 import {
@@ -30,14 +31,18 @@ export const buildFinalizeLockContextV2 = async ({
 	params,
 	receipt,
 	lockReceiptKey,
+	redisInstance,
 }: {
 	ctx: AutumnContext;
 	params: FinalizeLockParamsV0;
 	receipt: LockReceipt;
 	lockReceiptKey: string;
+	redisInstance: Redis;
 }): Promise<FinalizeLockContextV2> => {
+	const ctxWithRedisV2 = overrideCtxRedisV2({ ctx, redisV2: redisInstance });
+
 	const fullSubject = await getOrSetCachedFullSubject({
-		ctx,
+		ctx: ctxWithRedisV2,
 		customerId: receipt.customer_id,
 		entityId: receipt.entity_id ?? undefined,
 		source: "runFinalizeLockV2",
@@ -61,7 +66,7 @@ export const buildFinalizeLockContextV2 = async ({
 	return {
 		receipt,
 		lockReceiptKey,
-		redisInstance: ctx.redisV2,
+		redisInstance,
 		fullSubject,
 		feature,
 		lockValue,

--- a/server/src/internal/balances/utils/lockV2/fetchAndClaimLockReceiptV2.ts
+++ b/server/src/internal/balances/utils/lockV2/fetchAndClaimLockReceiptV2.ts
@@ -21,6 +21,7 @@ type FetchAndClaimResult =
 			claimed: boolean;
 			receipt: LockReceipt;
 			lockReceiptKey: string;
+			redisInstance: Redis;
 	  };
 
 const normalizeLockReceiptItems = ({
@@ -118,5 +119,6 @@ export const fetchAndClaimLockReceiptV2 = async ({
 		claimed: claimResult === "OK",
 		receipt,
 		lockReceiptKey,
+		redisInstance,
 	};
 };

--- a/server/src/internal/checkouts/middleware/checkoutMiddleware.ts
+++ b/server/src/internal/checkouts/middleware/checkoutMiddleware.ts
@@ -12,7 +12,7 @@ import {
 import type { Context, Next } from "hono";
 import { rateLimiter } from "hono-rate-limiter";
 import { StatusCodes } from "http-status-codes";
-import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv";
 import { checkoutActions } from "@/internal/checkouts/actions";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -130,10 +130,10 @@ export const checkoutMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 			customerId: validCheckout.customer_id,
 		}),
 	};
-	assignCustomerRedisToCtx({ ctx: nextCtx });
+	const { ctx: routedCtx } = getCtxWithCustomerRedis({ ctx: nextCtx });
 
 	// Set up context with org/env/features for handlers
-	c.set("ctx", nextCtx);
+	c.set("ctx", routedCtx);
 
 	// Attach checkout to context for handlers
 	c.set("checkout", validCheckout);

--- a/server/src/internal/checkouts/middleware/checkoutMiddleware.ts
+++ b/server/src/internal/checkouts/middleware/checkoutMiddleware.ts
@@ -12,7 +12,7 @@ import {
 import type { Context, Next } from "hono";
 import { rateLimiter } from "hono-rate-limiter";
 import { StatusCodes } from "http-status-codes";
-import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv";
 import { checkoutActions } from "@/internal/checkouts/actions";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -130,7 +130,7 @@ export const checkoutMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 			customerId: validCheckout.customer_id,
 		}),
 	};
-	setCustomerRedisRouting({ ctx: nextCtx });
+	assignCustomerRedisToCtx({ ctx: nextCtx });
 
 	// Set up context with org/env/features for handlers
 	c.set("ctx", nextCtx);

--- a/server/src/internal/checkouts/middleware/checkoutMiddleware.ts
+++ b/server/src/internal/checkouts/middleware/checkoutMiddleware.ts
@@ -12,6 +12,7 @@ import {
 import type { Context, Next } from "hono";
 import { rateLimiter } from "hono-rate-limiter";
 import { StatusCodes } from "http-status-codes";
+import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv";
 import { checkoutActions } from "@/internal/checkouts/actions";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -117,8 +118,7 @@ export const checkoutMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		});
 	}
 
-	// Set up context with org/env/features for handlers
-	c.set("ctx", {
+	const nextCtx = {
 		...ctx,
 		org: orgWithFeatures.org,
 		env,
@@ -129,7 +129,11 @@ export const checkoutMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 			orgId: orgWithFeatures.org.id,
 			customerId: validCheckout.customer_id,
 		}),
-	});
+	};
+	setCustomerRedisRouting({ ctx: nextCtx });
+
+	// Set up context with org/env/features for handlers
+	c.set("ctx", nextCtx);
 
 	// Attach checkout to context for handlers
 	c.set("checkout", validCheckout);

--- a/server/src/internal/customers/add-product/createFullCusProduct.ts
+++ b/server/src/internal/customers/add-product/createFullCusProduct.ts
@@ -21,7 +21,10 @@ import {
 } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { RepoContext } from "@/db/repoContext.js";
-import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import {
+	getCustomerRedisRoutingId,
+	resolveCustomerRedisRouting,
+} from "@/external/redis/customerRedisRouting.js";
 import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated.js";
 import { triggerVerifyCacheConsistency } from "@/internal/billing/v2/workflows/verifyCacheConsistency/triggerVerifyCacheConsistency.js";
 import { searchCusProducts } from "@/internal/customers/cusProducts/cusProductUtils.js";
@@ -365,7 +368,7 @@ export const createFullCusProduct = async ({
 		logger,
 		redisV2: resolveCustomerRedisRouting({
 			org,
-			customerId: customer.id ?? customer.internal_id,
+			customerId: getCustomerRedisRoutingId({ customer }),
 		}).redis,
 	};
 

--- a/server/src/internal/customers/add-product/createFullCusProduct.ts
+++ b/server/src/internal/customers/add-product/createFullCusProduct.ts
@@ -21,7 +21,7 @@ import {
 } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { RepoContext } from "@/db/repoContext.js";
-import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
+import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated.js";
 import { triggerVerifyCacheConsistency } from "@/internal/billing/v2/workflows/verifyCacheConsistency/triggerVerifyCacheConsistency.js";
 import { searchCusProducts } from "@/internal/customers/cusProducts/cusProductUtils.js";
@@ -363,7 +363,10 @@ export const createFullCusProduct = async ({
 		},
 		env: customer.env,
 		logger,
-		redisV2: resolveRedisV2(),
+		redisV2: resolveCustomerRedisRouting({
+			org,
+			customerId: customer.id ?? customer.internal_id,
+		}).redis,
 	};
 
 	if (

--- a/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
@@ -1,4 +1,5 @@
 import { type FullSubject, normalizedToFullSubject } from "@autumn/shared";
+import { isRedisMigrationCacheStale } from "@/external/redis/customerRedisRouting.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { lazyResetSubjectEntitlements } from "@/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
@@ -147,6 +148,28 @@ export const getCachedFullSubject = async ({
 			customerId,
 			entityId,
 			source: "stale-rollout",
+		});
+		return {
+			fullSubject: undefined,
+			subjectViewEpoch: currentSubjectViewEpoch,
+		};
+	}
+
+	if (
+		isRedisMigrationCacheStale({
+			cachedAt: cached._cachedAt,
+			customerId,
+			redisConfig: ctx.org.redis_config,
+		})
+	) {
+		logger.warn(
+			`[getCachedFullSubject] Stale Redis migration cache for ${customerId}${entityId ? `:${entityId}` : ""}, evicting`,
+		);
+		await invalidateCachedFullSubject({
+			ctx,
+			customerId,
+			entityId,
+			source: "stale-redis-migration",
 		});
 		return {
 			fullSubject: undefined,

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts
@@ -100,13 +100,11 @@ const batchInvalidateCachedFullSubjectsOnRedis = async ({
 export const batchInvalidateCachedFullSubjects = async ({
 	customers,
 	featuresByOrgEnv,
-	redisV2,
 	getRedisForCustomer,
 }: {
 	customers: BatchInvalidateCustomer[];
 	featuresByOrgEnv: FeaturesByOrgEnv;
-	redisV2: Redis;
-	getRedisForCustomer?: ({
+	getRedisForCustomer: ({
 		customer,
 	}: {
 		customer: BatchInvalidateCustomer;
@@ -115,15 +113,6 @@ export const batchInvalidateCachedFullSubjects = async ({
 	if (customers.length === 0) return 0;
 
 	const deleted = await batchDeleteCachedFullCustomers({ customers });
-
-	if (!getRedisForCustomer) {
-		await batchInvalidateCachedFullSubjectsOnRedis({
-			customers,
-			featuresByOrgEnv,
-			redisV2,
-		});
-		return deleted;
-	}
 
 	const customersByRedis = new Map<Redis, BatchInvalidateCustomer[]>();
 	for (const customer of customers) {

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts
@@ -19,7 +19,7 @@ type BatchInvalidateCustomer = {
 
 type FeaturesByOrgEnv = Record<string, Feature[]>;
 
-export const batchInvalidateCachedFullSubjects = async ({
+const batchInvalidateCachedFullSubjectsOnRedis = async ({
 	customers,
 	featuresByOrgEnv,
 	redisV2,
@@ -27,11 +27,8 @@ export const batchInvalidateCachedFullSubjects = async ({
 	customers: BatchInvalidateCustomer[];
 	featuresByOrgEnv: FeaturesByOrgEnv;
 	redisV2: Redis;
-}): Promise<number> => {
-	if (customers.length === 0) return 0;
-
-	const deleted = await batchDeleteCachedFullCustomers({ customers });
-	if (redisV2.status !== "ready") return deleted;
+}): Promise<void> => {
+	if (customers.length === 0 || redisV2.status !== "ready") return;
 
 	for (
 		let offset = 0;
@@ -98,6 +95,53 @@ export const batchInvalidateCachedFullSubjects = async ({
 
 		await tryRedisWrite(() => writePipeline.exec(), redisV2);
 	}
+};
+
+export const batchInvalidateCachedFullSubjects = async ({
+	customers,
+	featuresByOrgEnv,
+	redisV2,
+	getRedisForCustomer,
+}: {
+	customers: BatchInvalidateCustomer[];
+	featuresByOrgEnv: FeaturesByOrgEnv;
+	redisV2: Redis;
+	getRedisForCustomer?: ({
+		customer,
+	}: {
+		customer: BatchInvalidateCustomer;
+	}) => Redis;
+}): Promise<number> => {
+	if (customers.length === 0) return 0;
+
+	const deleted = await batchDeleteCachedFullCustomers({ customers });
+
+	if (!getRedisForCustomer) {
+		await batchInvalidateCachedFullSubjectsOnRedis({
+			customers,
+			featuresByOrgEnv,
+			redisV2,
+		});
+		return deleted;
+	}
+
+	const customersByRedis = new Map<Redis, BatchInvalidateCustomer[]>();
+	for (const customer of customers) {
+		const targetRedis = getRedisForCustomer({ customer });
+		const existing = customersByRedis.get(targetRedis) ?? [];
+		existing.push(customer);
+		customersByRedis.set(targetRedis, existing);
+	}
+
+	await Promise.all(
+		[...customersByRedis.entries()].map(([targetRedis, redisCustomers]) =>
+			batchInvalidateCachedFullSubjectsOnRedis({
+				customers: redisCustomers,
+				featuresByOrgEnv,
+				redisV2: targetRedis,
+			}),
+		),
+	);
 
 	return deleted;
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts
@@ -100,15 +100,15 @@ const batchInvalidateCachedFullSubjectsOnRedis = async ({
 export const batchInvalidateCachedFullSubjects = async ({
 	customers,
 	featuresByOrgEnv,
-	getRedisForCustomer,
+	getRedisTargetsForCustomer,
 }: {
 	customers: BatchInvalidateCustomer[];
 	featuresByOrgEnv: FeaturesByOrgEnv;
-	getRedisForCustomer: ({
+	getRedisTargetsForCustomer: ({
 		customer,
 	}: {
 		customer: BatchInvalidateCustomer;
-	}) => Redis;
+	}) => Redis[];
 }): Promise<number> => {
 	if (customers.length === 0) return 0;
 
@@ -116,10 +116,13 @@ export const batchInvalidateCachedFullSubjects = async ({
 
 	const customersByRedis = new Map<Redis, BatchInvalidateCustomer[]>();
 	for (const customer of customers) {
-		const targetRedis = getRedisForCustomer({ customer });
-		const existing = customersByRedis.get(targetRedis) ?? [];
-		existing.push(customer);
-		customersByRedis.set(targetRedis, existing);
+		for (const targetRedis of new Set(
+			getRedisTargetsForCustomer({ customer }),
+		)) {
+			const existing = customersByRedis.get(targetRedis) ?? [];
+			existing.push(customer);
+			customersByRedis.set(targetRedis, existing);
+		}
 	}
 
 	await Promise.all(

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
@@ -1,3 +1,5 @@
+import type { Redis } from "ioredis";
+import { getRedisTargetsForCustomer } from "@/external/redis/customerRedisRouting.js";
 import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
@@ -5,30 +7,29 @@ import { buildFullSubjectViewEpochKey } from "../../builders/buildFullSubjectVie
 import { FULL_SUBJECT_EPOCH_TTL_SECONDS } from "../../config/fullSubjectCacheConfig.js";
 import { invalidateSharedBalanceFields } from "./invalidateSharedBalanceFields.js";
 
-export const invalidateCachedFullSubject = async ({
+const invalidateCachedFullSubjectOnRedis = async ({
 	customerId,
 	entityId,
 	ctx,
 	source,
+	redisV2,
 }: {
 	customerId: string;
 	entityId?: string;
 	ctx: AutumnContext;
 	source?: string;
+	redisV2: Redis;
 }): Promise<void> => {
-	if (!customerId) return;
+	if (redisV2.status !== "ready") return;
 
 	await invalidateSharedBalanceFields({
 		ctx,
 		customerId,
+		redisV2,
 	});
 
-	const { org, env, logger, redisV2 } = ctx;
+	const { org, env, logger } = ctx;
 
-	// All four ops share the `{customerId}` hash tag so they land on the same
-	// Redis slot. Bundling them into a single pipeline collapses what used to
-	// be 3–4 sequential RTTs (UNLINK subject + optional UNLINK entity subject
-	// + INCR epoch + EXPIRE epoch) into one.
 	const customerSubjectKey = buildFullSubjectKey({
 		orgId: org.id,
 		env,
@@ -66,4 +67,33 @@ export const invalidateCachedFullSubject = async ({
 			`[invalidateCachedFullSubject] subject: ${subjectLabel}, source: ${source}`,
 		);
 	}
+};
+
+export const invalidateCachedFullSubject = async ({
+	customerId,
+	entityId,
+	ctx,
+	source,
+}: {
+	customerId: string;
+	entityId?: string;
+	ctx: AutumnContext;
+	source?: string;
+}): Promise<void> => {
+	if (!customerId) return;
+
+	await Promise.all(
+		getRedisTargetsForCustomer({
+			org: ctx.org,
+			currentRedis: ctx.redisV2,
+		}).map((redisV2) =>
+			invalidateCachedFullSubjectOnRedis({
+				customerId,
+				entityId,
+				ctx,
+				source,
+				redisV2,
+			}),
+		),
+	);
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubjectExact.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubjectExact.ts
@@ -1,6 +1,51 @@
+import type { Redis } from "ioredis";
+import { getRedisTargetsForCustomer } from "@/external/redis/customerRedisRouting.js";
+import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
+
+const invalidateCachedFullSubjectExactOnRedis = async ({
+	customerId,
+	entityId,
+	ctx,
+	source,
+	redisV2,
+}: {
+	customerId: string;
+	entityId?: string;
+	ctx: AutumnContext;
+	source?: string;
+	redisV2: Redis;
+}): Promise<void> => {
+	if (redisV2.status !== "ready") return;
+
+	const { org, env, logger } = ctx;
+
+	const subjectKey = buildFullSubjectKey({
+		orgId: org.id,
+		env,
+		customerId,
+		entityId,
+	});
+	const subjectLabel = entityId ? `${customerId}:${entityId}` : customerId;
+
+	const result = await tryRedisOp({
+		operation: () => redisV2.unlink(subjectKey),
+		source: "invalidateCachedFullSubjectExact",
+		redisInstance: redisV2,
+		onError: (error: unknown) => {
+			logger.error(
+				`[invalidateCachedFullSubjectExact] subject: ${subjectLabel}, source: ${source}, error: ${error}`,
+			);
+		},
+	});
+
+	if (result !== undefined) {
+		logger.info(
+			`[invalidateCachedFullSubjectExact] subject: ${subjectLabel}, source: ${source}`,
+		);
+	}
+};
 
 export const invalidateCachedFullSubjectExact = async ({
 	customerId,
@@ -13,28 +58,20 @@ export const invalidateCachedFullSubjectExact = async ({
 	ctx: AutumnContext;
 	source?: string;
 }): Promise<void> => {
-	const { org, env, logger, redisV2 } = ctx;
-	if (!customerId || redisV2.status !== "ready") return;
+	if (!customerId) return;
 
-	const subjectKey = buildFullSubjectKey({
-		orgId: org.id,
-		env,
-		customerId,
-		entityId,
-	});
-	const subjectLabel = entityId ? `${customerId}:${entityId}` : customerId;
-
-	try {
-		await tryRedisWrite(async () => {
-			await redisV2.unlink(subjectKey);
-		}, redisV2);
-
-		logger.info(
-			`[invalidateCachedFullSubject] subject: ${subjectLabel}, source: ${source}`,
-		);
-	} catch (error) {
-		logger.error(
-			`[invalidateCachedFullSubject] subject: ${subjectLabel}, source: ${source}, error: ${error}`,
-		);
-	}
+	await Promise.all(
+		getRedisTargetsForCustomer({
+			org: ctx.org,
+			currentRedis: ctx.redisV2,
+		}).map((redisV2) =>
+			invalidateCachedFullSubjectExactOnRedis({
+				customerId,
+				entityId,
+				ctx,
+				source,
+				redisV2,
+			}),
+		),
+	);
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -1,3 +1,4 @@
+import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
@@ -17,11 +18,13 @@ import type { CachedFullSubject } from "../../fullSubjectCacheModel.js";
 export const invalidateSharedBalanceFields = async ({
 	ctx,
 	customerId,
+	redisV2 = ctx.redisV2,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
+	redisV2?: Redis;
 }): Promise<void> => {
-	const { org, env, redisV2 } = ctx;
+	const { org, env } = ctx;
 	if (!customerId || redisV2.status !== "ready") return;
 
 	const subjectKey = buildFullSubjectKey({ orgId: org.id, env, customerId });
@@ -29,19 +32,21 @@ export const invalidateSharedBalanceFields = async ({
 	const cachedRaw = await tryRedisRead(() => redisV2.get(subjectKey), redisV2);
 	if (!cachedRaw) return;
 
-	await deleteFieldsFromManifest({ ctx, customerId, cachedRaw });
+	await deleteFieldsFromManifest({ ctx, customerId, cachedRaw, redisV2 });
 };
 
 async function deleteFieldsFromManifest({
 	ctx,
 	customerId,
 	cachedRaw,
+	redisV2,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	cachedRaw: string;
+	redisV2: Redis;
 }) {
-	const { org, env, logger, redisV2 } = ctx;
+	const { org, env, logger } = ctx;
 
 	let manifest: CachedFullSubject;
 	try {

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
@@ -1,5 +1,6 @@
 import type { FullSubject } from "@autumn/shared";
 import { normalizedToFullSubject } from "@autumn/shared";
+import { isRedisMigrationCacheStale } from "@/external/redis/customerRedisRouting.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { lazyResetSubjectEntitlements } from "@/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
@@ -179,6 +180,32 @@ export const getCachedPartialFullSubject = async ({
 		warnMessage: `[getCachedPartialFullSubject] Stale rollout cache for ${subjectLabel}, evicting`,
 	});
 	if (rolloutOk === undefined) {
+		return {
+			fullSubject: undefined,
+			subjectViewEpoch: currentSubjectViewEpoch,
+		};
+	}
+
+	const redisMigrationOk = await tryOrInvalidate({
+		ctx,
+		operation: () =>
+			isRedisMigrationCacheStale({
+				cachedAt: cached._cachedAt,
+				customerId,
+				redisConfig: ctx.org.redis_config,
+			})
+				? undefined
+				: true,
+		invalidate: () =>
+			invalidateCachedFullSubject({
+				ctx,
+				customerId,
+				entityId,
+				source: "partial-stale-redis-migration",
+			}),
+		warnMessage: `[getCachedPartialFullSubject] Stale Redis migration cache for ${subjectLabel}, evicting`,
+	});
+	if (redisMigrationOk === undefined) {
 		return {
 			fullSubject: undefined,
 			subjectViewEpoch: currentSubjectViewEpoch,

--- a/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.ts
@@ -31,8 +31,13 @@ export const getRolloverUpdates = ({
 		toUpdate: [],
 	};
 	const ent = cusEnt.entitlement;
-	const shouldRollover =
-		cusEnt.balance && cusEnt.balance > 0 && notNullish(ent.rollover);
+	const hasEntityBalanceToRollover =
+		notNullish(ent.entity_feature_id) &&
+		Object.values(cusEnt.entities ?? {}).some((entity) => entity.balance > 0);
+	const hasBalanceToRollover = notNullish(ent.entity_feature_id)
+		? hasEntityBalanceToRollover
+		: cusEnt.balance != null && cusEnt.balance > 0;
+	const shouldRollover = hasBalanceToRollover && notNullish(ent.rollover);
 
 	if (!shouldRollover) return update;
 
@@ -176,21 +181,6 @@ export function performMaximumClearing({
 		return { toDelete, toUpdate };
 	}
 
-	const allEntityIds = new Set<string>();
-	rows.forEach((row) => {
-		if (row.entities && Array.isArray(row.entities)) {
-			row.entities.forEach((entity: any) => {
-				if (entity.id) {
-					allEntityIds.add(entity.id);
-				}
-			});
-		}
-	});
-
-	const entityTotals = new Map<string, number>();
-	allEntityIds.forEach((id) => {
-		entityTotals.set(id, 0);
-	});
 	const entityIdToTotal: Record<string, number> = {};
 	rows.forEach((row) => {
 		for (const entityId in row.entities) {

--- a/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts
+++ b/server/src/internal/customers/cusUtils/fullCustomerCacheUtils/getCachedFullCustomer.ts
@@ -8,6 +8,7 @@ import {
 import { Decimal } from "decimal.js";
 import type { Redis } from "ioredis";
 import { getDbHealth, PgHealth } from "@/db/pgHealthMonitor.js";
+import { isRedisMigrationCacheStale } from "@/external/redis/customerRedisRouting.js";
 import { redis } from "@/external/redis/initRedis.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { isSnapshotCacheStale } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -167,6 +168,25 @@ export const getCachedFullCustomer = async ({
 			ctx,
 			customerId,
 			source: "stale-rollout",
+			skipGuard: true,
+		});
+		return undefined;
+	}
+
+	if (
+		isRedisMigrationCacheStale({
+			cachedAt,
+			customerId,
+			redisConfig: ctx.org.redis_config,
+		})
+	) {
+		ctx.logger.warn(
+			`[getCachedFullCustomer] Stale Redis migration cache for ${customerId}, evicting`,
+		);
+		await deleteCachedFullCustomer({
+			ctx,
+			customerId,
+			source: "stale-redis-migration",
 			skipGuard: true,
 		});
 		return undefined;

--- a/server/src/internal/customers/handlers/handleClearCustomerCache.ts
+++ b/server/src/internal/customers/handlers/handleClearCustomerCache.ts
@@ -1,5 +1,6 @@
 import { orgToFeaturesByOrgEnv, Scopes } from "@autumn/shared";
 import { z } from "zod/v4";
+import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import { createRoute } from "../../../honoMiddlewares/routeHandler";
 import { batchInvalidateCachedFullSubjects } from "../cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects";
 import { deleteCachedFullCustomer } from "../cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
@@ -37,7 +38,11 @@ export const handleClearCustomerCache = createRoute({
 			await batchInvalidateCachedFullSubjects({
 				customers: customersToDelete,
 				featuresByOrgEnv,
-				redisV2: ctx.redisV2,
+				getRedisForCustomer: ({ customer }) =>
+					resolveCustomerRedisRouting({
+						org: ctx.org,
+						customerId: customer.customerId,
+					}).redis,
 			});
 		}
 

--- a/server/src/internal/customers/handlers/handleClearCustomerCache.ts
+++ b/server/src/internal/customers/handlers/handleClearCustomerCache.ts
@@ -1,6 +1,6 @@
 import { orgToFeaturesByOrgEnv, Scopes } from "@autumn/shared";
 import { z } from "zod/v4";
-import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { getRedisTargetsForCustomer } from "@/external/redis/customerRedisRouting.js";
 import { createRoute } from "../../../honoMiddlewares/routeHandler";
 import { batchInvalidateCachedFullSubjects } from "../cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects";
 import { deleteCachedFullCustomer } from "../cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
@@ -38,11 +38,10 @@ export const handleClearCustomerCache = createRoute({
 			await batchInvalidateCachedFullSubjects({
 				customers: customersToDelete,
 				featuresByOrgEnv,
-				getRedisForCustomer: ({ customer }) =>
-					resolveCustomerRedisRouting({
+				getRedisTargetsForCustomer: () =>
+					getRedisTargetsForCustomer({
 						org: ctx.org,
-						customerId: customer.customerId,
-					}).redis,
+					}),
 			});
 		}
 

--- a/server/src/internal/features/featureActions/runClearCreditSystemCacheTask.ts
+++ b/server/src/internal/features/featureActions/runClearCreditSystemCacheTask.ts
@@ -8,6 +8,7 @@ import {
 } from "@autumn/shared";
 import { and, asc, count, eq, gt, inArray } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import { batchInvalidateCachedFullSubjects } from "@/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
@@ -166,6 +167,11 @@ export const runClearCreditSystemCacheTask = async ({
 				customers: customersToDelete,
 				featuresByOrgEnv,
 				redisV2: resolveRedisV2(),
+				getRedisForCustomer: ({ customer }) =>
+					resolveCustomerRedisRouting({
+						org: orgWithFeatures.org,
+						customerId: customer.customerId,
+					}).redis,
 			});
 			totalDeleted += deleted;
 		}

--- a/server/src/internal/features/featureActions/runClearCreditSystemCacheTask.ts
+++ b/server/src/internal/features/featureActions/runClearCreditSystemCacheTask.ts
@@ -9,7 +9,6 @@ import {
 import { and, asc, count, eq, gt, inArray } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
-import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import { batchInvalidateCachedFullSubjects } from "@/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import type { Logger } from "../../../external/logtail/logtailUtils";
@@ -166,7 +165,6 @@ export const runClearCreditSystemCacheTask = async ({
 			const deleted = await batchInvalidateCachedFullSubjects({
 				customers: customersToDelete,
 				featuresByOrgEnv,
-				redisV2: resolveRedisV2(),
 				getRedisForCustomer: ({ customer }) =>
 					resolveCustomerRedisRouting({
 						org: orgWithFeatures.org,

--- a/server/src/internal/features/featureActions/runClearCreditSystemCacheTask.ts
+++ b/server/src/internal/features/featureActions/runClearCreditSystemCacheTask.ts
@@ -8,7 +8,7 @@ import {
 } from "@autumn/shared";
 import { and, asc, count, eq, gt, inArray } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
-import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { getRedisTargetsForCustomer } from "@/external/redis/customerRedisRouting.js";
 import { batchInvalidateCachedFullSubjects } from "@/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import type { Logger } from "../../../external/logtail/logtailUtils";
@@ -165,11 +165,10 @@ export const runClearCreditSystemCacheTask = async ({
 			const deleted = await batchInvalidateCachedFullSubjects({
 				customers: customersToDelete,
 				featuresByOrgEnv,
-				getRedisForCustomer: ({ customer }) =>
-					resolveCustomerRedisRouting({
+				getRedisTargetsForCustomer: () =>
+					getRedisTargetsForCustomer({
 						org: orgWithFeatures.org,
-						customerId: customer.customerId,
-					}).redis,
+					}),
 			});
 			totalDeleted += deleted;
 		}

--- a/server/src/internal/migrations/migrationSteps/migrateCustomer.ts
+++ b/server/src/internal/migrations/migrationSteps/migrateCustomer.ts
@@ -5,7 +5,7 @@ import {
 	type MigrationJob,
 	ProcessorType,
 } from "@autumn/shared";
-import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { billingActions } from "@/internal/billing/v2/actions/index.js";
 import { CusService } from "@/internal/customers/CusService.js";
@@ -40,11 +40,14 @@ export const migrateCustomer = async ({
 		customerId,
 		logger: customerLogger,
 	};
-	assignCustomerRedisToCtx({ ctx: customerCtx, customerId });
+	const { ctx: routedCustomerCtx } = getCtxWithCustomerRedis({
+		ctx: customerCtx,
+		customerId,
+	});
 
 	try {
 		const fullCus = await CusService.getFull({
-			ctx: customerCtx,
+			ctx: routedCustomerCtx,
 			idOrInternalId: customerId,
 			withEntities: true,
 			inStatuses: ACTIVE_STATUSES,
@@ -64,7 +67,7 @@ export const migrateCustomer = async ({
 			const cusProduct = filteredCusProducts[i];
 			if (cusProduct.processor?.type === ProcessorType.RevenueCat) {
 				await migrateRevenueCatCustomer({
-					ctx: customerCtx,
+					ctx: routedCustomerCtx,
 					fullCus,
 					cusProduct,
 					toProduct,
@@ -72,7 +75,7 @@ export const migrateCustomer = async ({
 				});
 			} else {
 				await billingActions.migrate({
-					ctx: customerCtx,
+					ctx: routedCustomerCtx,
 					fullCustomer: fullCus,
 					currentCustomerProduct: cusProduct,
 					newProduct: toProduct,
@@ -101,7 +104,7 @@ export const migrateCustomer = async ({
 
 			await deleteCachedFullCustomer({
 				customerId: fullCus.id ?? "",
-				ctx: customerCtx,
+				ctx: routedCustomerCtx,
 			});
 		}
 

--- a/server/src/internal/migrations/migrationSteps/migrateCustomer.ts
+++ b/server/src/internal/migrations/migrationSteps/migrateCustomer.ts
@@ -5,6 +5,7 @@ import {
 	type MigrationJob,
 	ProcessorType,
 } from "@autumn/shared";
+import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { billingActions } from "@/internal/billing/v2/actions/index.js";
 import { CusService } from "@/internal/customers/CusService.js";
@@ -34,7 +35,12 @@ export const migrateCustomer = async ({
 		customerId,
 	});
 
-	const customerCtx: AutumnContext = { ...ctx, logger: customerLogger };
+	const customerCtx: AutumnContext = {
+		...ctx,
+		customerId,
+		logger: customerLogger,
+	};
+	setCustomerRedisRouting({ ctx: customerCtx, customerId });
 
 	try {
 		const fullCus = await CusService.getFull({
@@ -95,7 +101,7 @@ export const migrateCustomer = async ({
 
 			await deleteCachedFullCustomer({
 				customerId: fullCus.id ?? "",
-				ctx,
+				ctx: customerCtx,
 			});
 		}
 

--- a/server/src/internal/migrations/migrationSteps/migrateCustomer.ts
+++ b/server/src/internal/migrations/migrationSteps/migrateCustomer.ts
@@ -5,7 +5,7 @@ import {
 	type MigrationJob,
 	ProcessorType,
 } from "@autumn/shared";
-import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { billingActions } from "@/internal/billing/v2/actions/index.js";
 import { CusService } from "@/internal/customers/CusService.js";
@@ -40,7 +40,7 @@ export const migrateCustomer = async ({
 		customerId,
 		logger: customerLogger,
 	};
-	setCustomerRedisRouting({ ctx: customerCtx, customerId });
+	assignCustomerRedisToCtx({ ctx: customerCtx, customerId });
 
 	try {
 		const fullCus = await CusService.getFull({

--- a/server/src/internal/orgs/OrgService.ts
+++ b/server/src/internal/orgs/OrgService.ts
@@ -469,6 +469,15 @@ export class OrgService {
 		await clearOrgCache({ db, orgId });
 	}
 
+	static async listWithRedisConfig({ db }: { db: DrizzleCli }) {
+		const result = await db.query.organizations.findMany({
+			where: isNotNull(organizations.redis_config),
+			columns: { id: true, redis_config: true },
+		});
+
+		return result;
+	}
+
 	static async listPreviewOrgsForDeletion({ db }: { db: DrizzleCli }) {
 		const PREVIEW_ORG_PATTERN = "preview|%";
 		// 1. Find all preview orgs with no memberships

--- a/server/src/internal/orgs/handlers/handleRedisConfig.ts
+++ b/server/src/internal/orgs/handlers/handleRedisConfig.ts
@@ -1,0 +1,139 @@
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
+import { z } from "zod/v4";
+import { getOrgRedis, removeOrgRedis } from "@/external/redis/orgRedisPool.js";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { encryptData } from "@/utils/encryptUtils.js";
+import { OrgService } from "../OrgService.js";
+
+export const handleUpsertRedisConfig = createRoute({
+	scopes: [Scopes.Organisation.Write],
+	body: z.object({
+		connectionString: z.string().min(1),
+	}),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, org, logger } = ctx;
+		const { connectionString: rawConnectionString } = c.req.valid("json");
+		const connectionString = rawConnectionString.trim();
+
+		if (!connectionString) {
+			throw new RecaseError({
+				message: "Connection string is required",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		if (org.redis_config) {
+			throw new RecaseError({
+				message:
+					"Redis config already exists. Remove it before creating a new one.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		let redisUrl: URL;
+		try {
+			redisUrl = new URL(connectionString);
+		} catch {
+			throw new RecaseError({
+				message: "Invalid connection string: could not parse URL",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		const now = Date.now();
+		const updatedOrg = await OrgService.update({
+			db,
+			orgId: org.id,
+			updates: {
+				redis_config: {
+					connectionString: encryptData(connectionString),
+					url: redisUrl.host,
+					migrationPercent: 0,
+					previousMigrationPercent: 0,
+					migrationChangedAt: now,
+				},
+			},
+		});
+
+		if (updatedOrg) {
+			getOrgRedis({ org: updatedOrg });
+			logger.info(
+				`[handleUpsertRedisConfig] org=${org.id}: redis_config created, url=${redisUrl.host}`,
+			);
+		}
+
+		return c.json({ success: true });
+	},
+});
+
+export const handleUpdateRedisMigration = createRoute({
+	scopes: [Scopes.Organisation.Write],
+	body: z.object({
+		migrationPercent: z.number().int().min(0).max(100),
+	}),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, org, logger } = ctx;
+		const { migrationPercent } = c.req.valid("json");
+
+		if (!org.redis_config) {
+			throw new RecaseError({
+				message: "No Redis config set on this org",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await OrgService.update({
+			db,
+			orgId: org.id,
+			updates: {
+				redis_config: {
+					...org.redis_config,
+					previousMigrationPercent: org.redis_config.migrationPercent,
+					migrationPercent,
+					migrationChangedAt: Date.now(),
+				},
+			},
+		});
+
+		logger.info(
+			`[handleUpdateRedisMigration] org=${org.id}: ${org.redis_config.migrationPercent}% -> ${migrationPercent}%`,
+		);
+
+		return c.json({ success: true });
+	},
+});
+
+export const handleDeleteRedisConfig = createRoute({
+	scopes: [Scopes.Organisation.Write],
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, org, logger } = ctx;
+
+		if (org.redis_config && org.redis_config.migrationPercent > 0) {
+			throw new RecaseError({
+				message: `Cannot remove Redis config while migrationPercent is ${org.redis_config.migrationPercent}%. Set it to 0 first.`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await OrgService.update({
+			db,
+			orgId: org.id,
+			updates: { redis_config: null },
+		});
+		removeOrgRedis({ orgId: org.id });
+
+		logger.info(
+			`[handleDeleteRedisConfig] org=${org.id}: redis_config removed`,
+		);
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/orgs/handlers/handleRedisConfig.ts
+++ b/server/src/internal/orgs/handlers/handleRedisConfig.ts
@@ -5,6 +5,8 @@ import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { encryptData } from "@/utils/encryptUtils.js";
 import { OrgService } from "../OrgService.js";
 
+const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
+
 export const handleUpsertRedisConfig = createRoute({
 	scopes: [Scopes.Organisation.Write],
 	body: z.object({
@@ -43,6 +45,13 @@ export const handleUpsertRedisConfig = createRoute({
 				statusCode: 400,
 			});
 		}
+		if (!REDIS_PROTOCOLS.has(redisUrl.protocol)) {
+			throw new RecaseError({
+				message: "Invalid connection string: expected redis:// or rediss://",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
 
 		const now = Date.now();
 		const updatedOrg = await OrgService.update({
@@ -62,7 +71,7 @@ export const handleUpsertRedisConfig = createRoute({
 		if (updatedOrg) {
 			getOrgRedis({ org: updatedOrg });
 			logger.info(
-				`[handleUpsertRedisConfig] org=${org.id}: redis_config created, url=${redisUrl.host}`,
+				`[handleUpsertRedisConfig] org=${org.id}: redis_config created, url=${redisUrl.host}, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
 			);
 		}
 
@@ -123,6 +132,8 @@ export const handleDeleteRedisConfig = createRoute({
 			});
 		}
 
+		// Intended for use after migrationPercent has settled at 0; in-flight
+		// requests may still hold the old org config for a short window.
 		await OrgService.update({
 			db,
 			orgId: org.id,

--- a/server/src/internal/orgs/handlers/handleRedisConfig.ts
+++ b/server/src/internal/orgs/handlers/handleRedisConfig.ts
@@ -4,6 +4,7 @@ import { getOrgRedis, removeOrgRedis } from "@/external/redis/orgRedisPool.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { encryptData } from "@/utils/encryptUtils.js";
 import { OrgService } from "../OrgService.js";
+import { clearOrgCache } from "../orgUtils/clearOrgCache.js";
 
 const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
 
@@ -70,6 +71,7 @@ export const handleUpsertRedisConfig = createRoute({
 
 		if (updatedOrg) {
 			getOrgRedis({ org: updatedOrg });
+			await clearOrgCache({ db, orgId: org.id, env: ctx.env, logger });
 			logger.info(
 				`[handleUpsertRedisConfig] org=${org.id}: redis_config created, url=${redisUrl.host}, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
 			);
@@ -109,6 +111,7 @@ export const handleUpdateRedisMigration = createRoute({
 				},
 			},
 		});
+		await clearOrgCache({ db, orgId: org.id, env: ctx.env, logger });
 
 		logger.info(
 			`[handleUpdateRedisMigration] org=${org.id}: ${org.redis_config.migrationPercent}% -> ${migrationPercent}%`,
@@ -139,6 +142,7 @@ export const handleDeleteRedisConfig = createRoute({
 			orgId: org.id,
 			updates: { redis_config: null },
 		});
+		await clearOrgCache({ db, orgId: org.id, env: ctx.env, logger });
 		removeOrgRedis({ orgId: org.id });
 
 		logger.info(

--- a/server/src/internal/orgs/orgRouter.ts
+++ b/server/src/internal/orgs/orgRouter.ts
@@ -7,6 +7,11 @@ import { handleDeleteOrg } from "./handlers/crudHandlers/handleDeleteOrg.js";
 import { handleGetOrg } from "./handlers/crudHandlers/handleGetOrg.js";
 import { handleGetOrgFlags } from "./handlers/handleGetOrgFlags.js";
 import { handleGetUploadUrl } from "./handlers/handleGetUploadUrl.js";
+import {
+	handleDeleteRedisConfig,
+	handleUpdateRedisMigration,
+	handleUpsertRedisConfig,
+} from "./handlers/handleRedisConfig.js";
 import { handleResetDefaultAccount } from "./handlers/handleResetDefaultAccount.js";
 import {
 	handleGetRevenueCatConfig,
@@ -51,6 +56,10 @@ honoOrgRouter.delete("/stripe", ...handleDeleteStripe);
 honoOrgRouter.post("/stripe", ...handleConnectStripe);
 honoOrgRouter.get("/stripe/oauth_url", ...handleGetOAuthUrl);
 honoOrgRouter.post("/reset_default_account", ...handleResetDefaultAccount);
+
+honoOrgRouter.patch("/redis", ...handleUpsertRedisConfig);
+honoOrgRouter.delete("/redis", ...handleDeleteRedisConfig);
+honoOrgRouter.patch("/redis/migration", ...handleUpdateRedisMigration);
 
 honoOrgRouter.patch("/vercel", ...handleUpsertVercelConfig);
 honoOrgRouter.get("/vercel_sink", ...handleGetVercelSink);

--- a/server/src/internal/orgs/orgUtils.ts
+++ b/server/src/internal/orgs/orgUtils.ts
@@ -265,6 +265,12 @@ export const createOrgResponse = ({
 		live_pkey: org.live_pkey,
 		onboarded: org.onboarded ?? true,
 		deployed: org.deployed ?? true,
+		redis_config: org.redis_config
+			? {
+					url: org.redis_config.url,
+					migrationPercent: org.redis_config.migrationPercent,
+				}
+			: null,
 	};
 };
 

--- a/server/src/internal/orgs/orgUtils.ts
+++ b/server/src/internal/orgs/orgUtils.ts
@@ -267,7 +267,7 @@ export const createOrgResponse = ({
 		deployed: org.deployed ?? true,
 		redis_config: org.redis_config
 			? {
-					url: org.redis_config.url,
+					host: org.redis_config.url,
 					migrationPercent: org.redis_config.migrationPercent,
 				}
 			: null,

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -2,7 +2,7 @@ import { type AppEnv, AuthType, createdAtToVersion } from "@autumn/shared";
 import { addAppContextToLogs } from "@/utils/logging/addContextToLogs.js";
 import type { DrizzleCli } from "../db/initDrizzle.js";
 import type { Logger } from "../external/logtail/logtailUtils.js";
-import { setCustomerRedisRouting } from "../external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "../external/redis/customerRedisRouting.js";
 import { resolveRedisV2 } from "../external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "../honoUtils/HonoEnv.js";
 import { computeRolloutSnapshot } from "../internal/misc/rollouts/rolloutUtils.js";
@@ -87,7 +87,7 @@ export const createWorkerContext = async ({
 		extraLogs: {},
 		rolloutSnapshot,
 	};
-	setCustomerRedisRouting({ ctx, customerId });
+	assignCustomerRedisToCtx({ ctx, customerId });
 
 	return ctx;
 };

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -2,6 +2,7 @@ import { type AppEnv, AuthType, createdAtToVersion } from "@autumn/shared";
 import { addAppContextToLogs } from "@/utils/logging/addContextToLogs.js";
 import type { DrizzleCli } from "../db/initDrizzle.js";
 import type { Logger } from "../external/logtail/logtailUtils.js";
+import { setCustomerRedisRouting } from "../external/redis/customerRedisRouting.js";
 import { resolveRedisV2 } from "../external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "../honoUtils/HonoEnv.js";
 import { computeRolloutSnapshot } from "../internal/misc/rollouts/rolloutUtils.js";
@@ -86,6 +87,7 @@ export const createWorkerContext = async ({
 		extraLogs: {},
 		rolloutSnapshot,
 	};
+	setCustomerRedisRouting({ ctx, customerId });
 
 	return ctx;
 };

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -2,7 +2,7 @@ import { type AppEnv, AuthType, createdAtToVersion } from "@autumn/shared";
 import { addAppContextToLogs } from "@/utils/logging/addContextToLogs.js";
 import type { DrizzleCli } from "../db/initDrizzle.js";
 import type { Logger } from "../external/logtail/logtailUtils.js";
-import { assignCustomerRedisToCtx } from "../external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "../external/redis/customerRedisRouting.js";
 import { resolveRedisV2 } from "../external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "../honoUtils/HonoEnv.js";
 import { computeRolloutSnapshot } from "../internal/misc/rollouts/rolloutUtils.js";
@@ -87,7 +87,5 @@ export const createWorkerContext = async ({
 		extraLogs: {},
 		rolloutSnapshot,
 	};
-	assignCustomerRedisToCtx({ ctx, customerId });
-
-	return ctx;
+	return getCtxWithCustomerRedis({ ctx, customerId }).ctx;
 };

--- a/server/src/queue/initSqs.ts
+++ b/server/src/queue/initSqs.ts
@@ -22,12 +22,15 @@ export const extractLocalEndpoint = ({
 	}
 };
 
-const getSqsClientConfig = () => {
-	const queueUrl = process.env.SQS_QUEUE_URL_V2;
-	const endpoint = extractLocalEndpoint({ queueUrl });
+const getSqsClientConfig = ({ queueUrl }: { queueUrl?: string } = {}) => {
+	const resolvedQueueUrl = queueUrl ?? process.env.SQS_QUEUE_URL_V2;
+	const endpoint = extractLocalEndpoint({ queueUrl: resolvedQueueUrl });
+	const region =
+		extractRegionFromQueueUrl({ queueUrl: resolvedQueueUrl }) ||
+		DEFAULT_AWS_REGION;
+
 	return {
-		region:
-			extractRegionFromQueueUrl({ queueUrl }) || DEFAULT_AWS_REGION,
+		region,
 		...(endpoint ? { endpoint } : {}),
 		credentials: {
 			accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
@@ -36,19 +39,57 @@ const getSqsClientConfig = () => {
 	};
 };
 
+const getSqsClientCacheKey = ({ queueUrl }: { queueUrl?: string } = {}) => {
+	const resolvedQueueUrl = queueUrl ?? process.env.SQS_QUEUE_URL_V2;
+	const endpoint = extractLocalEndpoint({ queueUrl: resolvedQueueUrl });
+	const region =
+		extractRegionFromQueueUrl({ queueUrl: resolvedQueueUrl }) ||
+		DEFAULT_AWS_REGION;
+
+	return `${region}:${endpoint ?? "aws"}`;
+};
+
+const sqsClientsByCacheKey = new Map<string, SQSClient>();
+
 let sqsClient = new SQSClient(getSqsClientConfig());
+sqsClientsByCacheKey.set(getSqsClientCacheKey(), sqsClient);
 
 export const sqs = sqsClient;
 
 /** Recreates the SQS client with fresh connections */
-export const recreateSqsClient = (): SQSClient => {
+export const recreateSqsClient = ({
+	queueUrl,
+}: {
+	queueUrl?: string;
+} = {}): SQSClient => {
 	console.log(`[SQS] Recreating SQS client (stale connection suspected)`);
-	sqsClient.destroy();
-	sqsClient = new SQSClient(getSqsClientConfig());
-	return sqsClient;
+	const cacheKey = getSqsClientCacheKey({ queueUrl });
+	const existingClient = sqsClientsByCacheKey.get(cacheKey);
+	existingClient?.destroy();
+
+	const nextClient = new SQSClient(getSqsClientConfig({ queueUrl }));
+	sqsClientsByCacheKey.set(cacheKey, nextClient);
+
+	if (!queueUrl || queueUrl === process.env.SQS_QUEUE_URL_V2) {
+		sqsClient = nextClient;
+	}
+
+	return nextClient;
 };
 
 /** Get the current SQS client (use this instead of direct sqs export for refreshable access) */
-export const getSqsClient = (): SQSClient => sqsClient;
+export const getSqsClient = ({
+	queueUrl,
+}: {
+	queueUrl?: string;
+} = {}): SQSClient => {
+	const cacheKey = getSqsClientCacheKey({ queueUrl });
+	const existingClient = sqsClientsByCacheKey.get(cacheKey);
+	if (existingClient) return existingClient;
+
+	const nextClient = new SQSClient(getSqsClientConfig({ queueUrl }));
+	sqsClientsByCacheKey.set(cacheKey, nextClient);
+	return nextClient;
+};
 
 export const QUEUE_URL = process.env.SQS_QUEUE_URL_V2 || "";

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -471,8 +471,8 @@ export const initWorkers = async ({
 				db,
 				queueUrl,
 				isFifo: queueUrl.endsWith(".fifo"),
-				getSqsClientFn: getSqsClient,
-				recreateSqsClientFn: recreateSqsClient,
+				getSqsClientFn: () => getSqsClient({ queueUrl }),
+				recreateSqsClientFn: () => recreateSqsClient({ queueUrl }),
 				shouldPoll: () =>
 					isJobQueueEnabled({ queue: queueId }) &&
 					isActiveSlot({ serviceName: "workers" }),

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -124,7 +124,7 @@ export const addTaskToQueue = async <T extends keyof Payloads>({
 	const resolvedQueueUrl = queueUrl || process.env.SQS_QUEUE_URL_V2;
 
 	if (resolvedQueueUrl) {
-		const sqsClient = getSqsClient();
+		const sqsClient = getSqsClient({ queueUrl: resolvedQueueUrl });
 
 		// SQS implementation
 		const isFifoQueue = resolvedQueueUrl.endsWith(".fifo");

--- a/server/src/routers/apiRouter.ts
+++ b/server/src/routers/apiRouter.ts
@@ -9,6 +9,7 @@ import { criticalDbMiddleware } from "../honoMiddlewares/criticalDbMiddleware.js
 import { customerBlockMiddleware } from "../honoMiddlewares/customerBlockMiddleware.js";
 import { idempotencyMiddleware } from "../honoMiddlewares/idempotencyMiddleware.js";
 import { orgConfigMiddleware } from "../honoMiddlewares/orgConfigMiddleware.js";
+import { orgRedisMiddleware } from "../honoMiddlewares/orgRedisMiddleware.js";
 import { queryMiddleware } from "../honoMiddlewares/queryMiddleware.js";
 import { rateLimitMiddleware } from "../honoMiddlewares/rateLimitMiddleware.js";
 import { refreshCacheMiddleware } from "../honoMiddlewares/refreshCacheMiddleware.js";
@@ -48,6 +49,7 @@ apiRouter.use("*", secretKeyMiddleware);
 apiRouter.use("*", requestBlockMiddleware);
 apiRouter.use("*", orgConfigMiddleware);
 apiRouter.use("*", rolloutMiddleware);
+apiRouter.use("*", orgRedisMiddleware);
 apiRouter.use("*", apiVersionMiddleware);
 apiRouter.use("*", traceEnrichMiddleware);
 apiRouter.use("*", refreshCacheMiddleware);

--- a/server/src/utils/workerUtils/createAutumnContext.ts
+++ b/server/src/utils/workerUtils/createAutumnContext.ts
@@ -8,7 +8,7 @@ import {
 
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
-import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -72,6 +72,5 @@ export const createWorkerAutumnContext = async ({
 		extraLogs: {},
 		rolloutSnapshot,
 	} satisfies AutumnContext;
-	assignCustomerRedisToCtx({ ctx });
-	return ctx;
+	return getCtxWithCustomerRedis({ ctx }).ctx;
 };

--- a/server/src/utils/workerUtils/createAutumnContext.ts
+++ b/server/src/utils/workerUtils/createAutumnContext.ts
@@ -8,7 +8,7 @@ import {
 
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
-import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
+import { assignCustomerRedisToCtx } from "@/external/redis/customerRedisRouting.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -72,6 +72,6 @@ export const createWorkerAutumnContext = async ({
 		extraLogs: {},
 		rolloutSnapshot,
 	} satisfies AutumnContext;
-	setCustomerRedisRouting({ ctx });
+	assignCustomerRedisToCtx({ ctx });
 	return ctx;
 };

--- a/server/src/utils/workerUtils/createAutumnContext.ts
+++ b/server/src/utils/workerUtils/createAutumnContext.ts
@@ -8,6 +8,7 @@ import {
 
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { setCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
@@ -50,7 +51,7 @@ export const createWorkerAutumnContext = async ({
 
 	const rolloutSnapshot = computeRolloutSnapshot({ orgId: org.id });
 
-	return {
+	const ctx = {
 		org,
 		env,
 		features,
@@ -71,4 +72,6 @@ export const createWorkerAutumnContext = async ({
 		extraLogs: {},
 		rolloutSnapshot,
 	} satisfies AutumnContext;
+	setCustomerRedisRouting({ ctx });
+	return ctx;
 };

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -100,7 +100,35 @@ if (cluster.isPrimary) {
 	startMemoryMonitor("worker", 60_000);
 	await startAllEdgeConfigPolling({ logger });
 
-	process.once("exit", stopAllEdgeConfigPolling);
+	const { db } = await import("./db/initDrizzle.js");
+	const { primeRedisMonitor } = await import(
+		"./external/redis/initUtils/redisAvailability.js"
+	);
+	const {
+		primeRedisV2Monitor,
+		startRedisV2Monitor,
+		stopRedisV2Monitor,
+	} = await import("./external/redis/initUtils/redisV2Availability.js");
+	const { startRedisMonitor, stopRedisMonitor } = await import(
+		"./external/redis/initRedis.js"
+	);
+	const { preWarmOrgRedisConnections } = await import(
+		"./external/redis/orgRedisPool.js"
+	);
+
+	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);
+	startRedisMonitor();
+	startRedisV2Monitor();
+
+	void preWarmOrgRedisConnections({ db }).catch((error) => {
+		logger.warn("[OrgRedis] Warmup failed", { error });
+	});
+
+	process.once("exit", () => {
+		stopAllEdgeConfigPolling();
+		stopRedisMonitor();
+		stopRedisV2Monitor();
+	});
 
 	const { initWorkers } = await import("./queue/initWorkers.js");
 	await initWorkers({ startupStartedAt, queueImplementation });

--- a/server/tests/balances/track/rollovers/rolloverTestUtils.ts
+++ b/server/tests/balances/track/rollovers/rolloverTestUtils.ts
@@ -2,7 +2,9 @@ import type { Customer } from "@autumn/shared";
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
 import { clearCusEntsFromCache } from "@/cron/resetCron/clearCusEntsFromCache";
 import { resetCustomerEntitlement } from "@/cron/resetCron/resetCustomerEntitlement.js";
-import { invalidateCustomerEntitlementBalance } from "@/internal/customers/cache/fullSubject/actions/invalidate/invalidateCustomerEntitlementBalance";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
+import { waitForRedisReady } from "@/external/redis/initRedis.js";
+import { invalidateCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
 import { cusProductToCusEnt } from "@/internal/customers/cusProducts/cusProductUtils/convertCusProduct.js";
 import { getMainCusProduct } from "@/internal/customers/cusProducts/cusProductUtils.js";
@@ -40,21 +42,27 @@ export const resetAndGetCusEnt = async ({
 		customer,
 	};
 
-	const updatedCusEnt = await resetCustomerEntitlement({
+	const { ctx: routedCtx } = getCtxWithCustomerRedis({
 		ctx,
+		customerId: customer.id ?? "",
+	});
+	await waitForRedisReady(routedCtx.redisV2, "customer-redis", 5000).catch(
+		() => undefined,
+	);
+
+	const updatedCusEnt = await resetCustomerEntitlement({
+		ctx: routedCtx,
+		org: ctx.org,
 		cusEnt: resetCusEnt,
 		updatedCusEnts: [],
 		persistFreeOverage,
 	});
 
 	if (!skipCacheDeletion) {
-		await invalidateCustomerEntitlementBalance({
-			orgId: customer.org_id,
-			env: customer.env,
+		await invalidateCachedFullSubject({
+			ctx: routedCtx,
 			customerId: customer.id ?? "",
-			featureId,
-			customerEntitlementId: resetCusEnt.id,
-			redisV2: ctx.redisV2,
+			source: "resetAndGetCusEnt",
 		});
 
 		await clearCusEntsFromCache({

--- a/server/tests/integration/balances/lock/check-with-lock-expiry.test.ts
+++ b/server/tests/integration/balances/lock/check-with-lock-expiry.test.ts
@@ -201,10 +201,13 @@ test.concurrent(`${chalk.yellowBright("check-lock-expiry-4: no expires_at sets T
 		lock: { enabled: true, lock_id: customerId },
 	});
 
-	const { lockReceiptKey, source } = await fetchLockReceipt({ ctx, lockId: customerId });
-	const redisInstance = source === "redis_v2" ? ctx.redisV2 : redis;
+	const fetchedReceipt = await fetchLockReceipt({ ctx, lockId: customerId });
+	const redisInstance =
+		fetchedReceipt.source === "redis_v2" ? fetchedReceipt.redisInstance : redis;
 
-	const expireAt = await redisInstance.expiretime(lockReceiptKey);
+	const expireAt = await redisInstance.expiretime(
+		fetchedReceipt.lockReceiptKey,
+	);
 	const expectedTtl = beforeCheck + 24 * 60 * 60;
 
 	// TTL should be within 5s of now + 1 day
@@ -238,10 +241,13 @@ test.concurrent(`${chalk.yellowBright("check-lock-expiry-5: expires_at set, TTL 
 		lock: { enabled: true, lock_id: customerId, expires_at: expiresAt },
 	});
 
-	const { lockReceiptKey, source } = await fetchLockReceipt({ ctx, lockId: customerId });
-	const redisInstance = source === "redis_v2" ? ctx.redisV2 : redis;
+	const fetchedReceipt = await fetchLockReceipt({ ctx, lockId: customerId });
+	const redisInstance =
+		fetchedReceipt.source === "redis_v2" ? fetchedReceipt.redisInstance : redis;
 
-	const expireAt = await redisInstance.expiretime(lockReceiptKey);
+	const expireAt = await redisInstance.expiretime(
+		fetchedReceipt.lockReceiptKey,
+	);
 	const expectedTtl = Math.ceil(expiresAt / 1000) + 60 * 60;
 
 	// TTL should be within 5s of expires_at + 1 hour

--- a/server/tests/integration/balances/lock/entities/check-lock-per-entity.test.ts
+++ b/server/tests/integration/balances/lock/entities/check-lock-per-entity.test.ts
@@ -3,6 +3,7 @@ import type { ApiCustomerV5 } from "@autumn/shared";
 import { expectCustomerEventsCorrect } from "@tests/integration/balances/utils/events/expectCustomerEventsCorrect.js";
 import { deleteLock } from "@tests/integration/balances/utils/lockUtils/deleteLock.js";
 import { expectLockReceiptDeleted } from "@tests/integration/balances/utils/lockUtils/expectLockReceiptDeleted.js";
+import { warmEntityCaches } from "@tests/integration/balances/utils/warmEntityCaches";
 import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -63,6 +64,7 @@ test.concurrent(`${chalk.yellowBright("lock-entity EP-2: entity-level lock=30 co
 	});
 
 	await deleteLock({ ctx, lockId: lockKey });
+	await warmEntityCaches({ autumn: autumnV2_1, customerId, entities });
 
 	// Lock at entity level (ent-1)
 	await autumnV2_1.check({
@@ -139,6 +141,7 @@ test.concurrent(`${chalk.yellowBright("lock-entity EP-3: entity-level lock=30 co
 	});
 
 	await deleteLock({ ctx, lockId: lockKey });
+	await warmEntityCaches({ autumn: autumnV2_1, customerId, entities });
 
 	await autumnV2_1.check({
 		customer_id: customerId,
@@ -310,6 +313,7 @@ test.concurrent(`${chalk.yellowBright("lock-entity EP-5: entity-level across loc
 	});
 
 	await deleteLock({ ctx, lockId: lockKey });
+	await warmEntityCaches({ autumn: autumnV2_1, customerId, entities });
 
 	// Customer-level lock (no entity_id)
 	await autumnV2_1.check({
@@ -392,6 +396,7 @@ test.concurrent(`${chalk.yellowBright("lock-entity EP-6: customer-level lock=120
 	});
 
 	await deleteLock({ ctx, lockId: lockKey });
+	await warmEntityCaches({ autumn: autumnV2_1, customerId, entities });
 
 	await autumnV2_1.check({
 		customer_id: customerId,
@@ -477,6 +482,7 @@ test.concurrent(`${chalk.yellowBright("lock-entity EP-7: ent-1 lock held while c
 	});
 
 	await deleteLock({ ctx, lockId: lockKey });
+	await warmEntityCaches({ autumn: autumnV2_1, customerId, entities });
 
 	// Lock ent-1 (deducts 30 from ent-1 bucket)
 	await autumnV2_1.check({
@@ -568,6 +574,8 @@ test.concurrent(`${chalk.yellowBright("lock-entity EP-8: two concurrent entity l
 		deleteLock({ ctx, lockId: lockKeyB }),
 	]);
 
+	await warmEntityCaches({ autumn: autumnV2_1, customerId, entities });
+
 	// Fire both locks concurrently
 	await Promise.all([
 		autumnV2_1.check({
@@ -600,15 +608,6 @@ test.concurrent(`${chalk.yellowBright("lock-entity EP-8: two concurrent entity l
 		}),
 	]);
 
-	// Lock A confirm: delta=15-30=-15 → restore 15 to ent-1 (→35)
-	// Lock B confirm: delta=25-20=+5 → deduct 5 more from ent-2 (→25)
-	const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-	expectBalanceCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		remaining: 160,
-	});
-
 	const ent1 = await autumnV2_1.entities.get<ApiCustomerV5>(
 		customerId,
 		entities[0].id,
@@ -617,6 +616,15 @@ test.concurrent(`${chalk.yellowBright("lock-entity EP-8: two concurrent entity l
 		customer: ent1,
 		featureId: TestFeature.Messages,
 		remaining: 135,
+	});
+
+	// Lock A confirm: delta=15-30=-15 → restore 15 to ent-1 (→35)
+	// Lock B confirm: delta=25-20=+5 → deduct 5 more from ent-2 (→25)
+	const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expectBalanceCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		remaining: 160,
 	});
 
 	const ent2 = await autumnV2_1.entities.get<ApiCustomerV5>(

--- a/server/tests/integration/balances/reset/persist-free-overage-on.test.ts
+++ b/server/tests/integration/balances/reset/persist-free-overage-on.test.ts
@@ -3,7 +3,6 @@ import {
 	type ApiCustomer,
 	type ApiCustomerV3,
 	customerEntitlements,
-	type OrgConfig,
 } from "@autumn/shared";
 import { resetAndGetCusEnt } from "@tests/balances/track/rollovers/rolloverTestUtils.js";
 import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
@@ -20,7 +19,6 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { eq } from "drizzle-orm";
 import { db } from "@/db/initDrizzle.js";
-import { OrgService } from "@/internal/orgs/OrgService.js";
 
 const setBalanceInDb = async ({
 	cusEntId,
@@ -35,33 +33,14 @@ const setBalanceInDb = async ({
 		.where(eq(customerEntitlements.id, cusEntId));
 };
 
-const enablePersistFreeOverage = async ({
-	orgId,
-	orgConfig,
-}: {
-	orgId: string;
-	orgConfig: OrgConfig;
-}) => {
-	await OrgService.update({
-		db,
-		orgId,
-		updates: { config: { ...orgConfig, persist_free_overage: true } },
+const persistFreeOverageOrg = ({ slug }: { slug: string }) =>
+	s.platform.create({
+		userEmail: `persist-overage-${slug}-${Math.random()
+			.toString(36)
+			.slice(2, 8)}@autumn.test`,
+		configOverrides: { persist_free_overage: true },
+		setupDefaultFeatures: true,
 	});
-};
-
-const disablePersistFreeOverage = async ({
-	orgId,
-	orgConfig,
-}: {
-	orgId: string;
-	orgConfig: OrgConfig;
-}) => {
-	await OrgService.update({
-		db,
-		orgId,
-		updates: { config: { ...orgConfig, persist_free_overage: false } },
-	});
-};
 
 // ─────────────────────────────────────────────────────────────────
 // 1. Lazy reset (DB path)
@@ -73,41 +52,33 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (DB): lazy reset deduc
 
 	const { customerId, autumnV2, ctx } = await initScenario({
 		customerId: "persist-ovg-on-db",
-		setup: [s.customer({ testClock: false }), s.products({ list: [free] })],
+		setup: [
+			persistFreeOverageOrg({ slug: "db" }),
+			s.customer({ testClock: false }),
+			s.products({ list: [free] }),
+		],
 		actions: [s.attach({ productId: free.id })],
 	});
 
-	await enablePersistFreeOverage({
-		orgId: ctx.org.id,
-		orgConfig: ctx.org.config,
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt).toBeDefined();
+
+	await setBalanceInDb({ cusEntId: cusEnt!.id, balance: -100 });
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
 	});
 
-	try {
-		const cusEnt = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-		expect(cusEnt).toBeDefined();
-
-		await setBalanceInDb({ cusEntId: cusEnt!.id, balance: -100 });
-		await expireCusEntForReset({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-
-		const after = await autumnV2.customers.get<ApiCustomer>(customerId, {
-			skip_cache: "true",
-		});
-		expect(after.balances[TestFeature.Messages].current_balance).toBe(0);
-		expect(after.balances[TestFeature.Messages].usage).toBe(100);
-	} finally {
-		await disablePersistFreeOverage({
-			orgId: ctx.org.id,
-			orgConfig: ctx.org.config,
-		});
-	}
+	const after = await autumnV2.customers.get<ApiCustomer>(customerId, {
+		skip_cache: "true",
+	});
+	expect(after.balances[TestFeature.Messages].current_balance).toBe(0);
+	expect(after.balances[TestFeature.Messages].usage).toBe(100);
 });
 
 // ─────────────────────────────────────────────────────────────────
@@ -120,59 +91,51 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (cache): lazy reset de
 
 	const { customerId, autumnV2, ctx } = await initScenario({
 		customerId: "persist-ovg-on-cache",
-		setup: [s.customer({ testClock: false }), s.products({ list: [free] })],
+		setup: [
+			persistFreeOverageOrg({ slug: "cache" }),
+			s.customer({ testClock: false }),
+			s.products({ list: [free] }),
+		],
 		actions: [s.attach({ productId: free.id })],
 	});
 
-	await enablePersistFreeOverage({
+	await autumnV2.customers.get<ApiCustomer>(customerId);
+
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt).toBeDefined();
+
+	await setBalanceInDb({ cusEntId: cusEnt!.id, balance: -50 });
+	await setCachedCusEntField({
 		orgId: ctx.org.id,
-		orgConfig: ctx.org.config,
+		env: ctx.env,
+		customerId,
+		cusEntId: cusEnt!.id,
+		field: "balance",
+		value: -50,
+	});
+	await setCachedSubjectBalanceField({
+		ctx,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		customerId,
+		featureId: TestFeature.Messages,
+		customerEntitlementId: cusEnt!.id,
+		field: "balance",
+		value: -50,
+	});
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
 	});
 
-	try {
-		await autumnV2.customers.get<ApiCustomer>(customerId);
-
-		const cusEnt = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-		expect(cusEnt).toBeDefined();
-
-		await setBalanceInDb({ cusEntId: cusEnt!.id, balance: -50 });
-		await setCachedCusEntField({
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId,
-			cusEntId: cusEnt!.id,
-			field: "balance",
-			value: -50,
-		});
-		await setCachedSubjectBalanceField({
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId,
-			featureId: TestFeature.Messages,
-			customerEntitlementId: cusEnt!.id,
-			field: "balance",
-			value: -50,
-			redisV2: ctx.redisV2,
-		});
-		await expireCusEntForReset({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-
-		const after = await autumnV2.customers.get<ApiCustomer>(customerId);
-		expect(after.balances[TestFeature.Messages].current_balance).toBe(50);
-		expect(after.balances[TestFeature.Messages].usage).toBe(50);
-	} finally {
-		await disablePersistFreeOverage({
-			orgId: ctx.org.id,
-			orgConfig: ctx.org.config,
-		});
-	}
+	const after = await autumnV2.customers.get<ApiCustomer>(customerId);
+	expect(after.balances[TestFeature.Messages].current_balance).toBe(50);
+	expect(after.balances[TestFeature.Messages].usage).toBe(50);
 });
 
 // ─────────────────────────────────────────────────────────────────
@@ -185,7 +148,11 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (cron): cron reset ded
 
 	const { customerId, ctx, customer } = await initScenario({
 		customerId: "persist-ovg-on-cron",
-		setup: [s.customer({ testClock: false }), s.products({ list: [free] })],
+		setup: [
+			persistFreeOverageOrg({ slug: "cron" }),
+			s.customer({ testClock: false }),
+			s.products({ list: [free] }),
+		],
 		actions: [s.attach({ productId: free.id })],
 	});
 
@@ -219,41 +186,33 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (no overage): positive
 
 	const { customerId, autumnV2, ctx } = await initScenario({
 		customerId: "persist-ovg-on-positive",
-		setup: [s.customer({ testClock: false }), s.products({ list: [free] })],
+		setup: [
+			persistFreeOverageOrg({ slug: "positive" }),
+			s.customer({ testClock: false }),
+			s.products({ list: [free] }),
+		],
 		actions: [s.attach({ productId: free.id })],
 	});
 
-	await enablePersistFreeOverage({
-		orgId: ctx.org.id,
-		orgConfig: ctx.org.config,
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEnt).toBeDefined();
+
+	await setBalanceInDb({ cusEntId: cusEnt!.id, balance: 50 });
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
 	});
 
-	try {
-		const cusEnt = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-		expect(cusEnt).toBeDefined();
-
-		await setBalanceInDb({ cusEntId: cusEnt!.id, balance: 50 });
-		await expireCusEntForReset({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-
-		const after = await autumnV2.customers.get<ApiCustomer>(customerId, {
-			skip_cache: "true",
-		});
-		expect(after.balances[TestFeature.Messages].current_balance).toBe(100);
-		expect(after.balances[TestFeature.Messages].usage).toBe(0);
-	} finally {
-		await disablePersistFreeOverage({
-			orgId: ctx.org.id,
-			orgConfig: ctx.org.config,
-		});
-	}
+	const after = await autumnV2.customers.get<ApiCustomer>(customerId, {
+		skip_cache: "true",
+	});
+	expect(after.balances[TestFeature.Messages].current_balance).toBe(100);
+	expect(after.balances[TestFeature.Messages].usage).toBe(0);
 });
 
 // ─────────────────────────────────────────────────────────────────
@@ -270,6 +229,7 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (per-entity): each ent
 	const { customerId, ctx } = await initScenario({
 		customerId: "persist-ovg-on-entity",
 		setup: [
+			persistFreeOverageOrg({ slug: "entity" }),
 			s.customer({ testClock: false }),
 			s.products({ list: [free] }),
 			s.entities({ count: 2, featureId: TestFeature.Users }),
@@ -277,56 +237,43 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (per-entity): each ent
 		actions: [s.attach({ productId: free.id })],
 	});
 
-	await enablePersistFreeOverage({
-		orgId: ctx.org.id,
-		orgConfig: ctx.org.config,
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
 	});
-	ctx.org.config = { ...ctx.org.config, persist_free_overage: true };
+	expect(cusEnt).toBeDefined();
+	expect(cusEnt!.entities).toBeDefined();
 
-	try {
-		const cusEnt = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-		expect(cusEnt).toBeDefined();
-		expect(cusEnt!.entities).toBeDefined();
+	const entities = { ...cusEnt!.entities! };
+	const entityIds = Object.keys(entities);
+	expect(entityIds.length).toBe(2);
 
-		const entities = { ...cusEnt!.entities! };
-		const entityIds = Object.keys(entities);
-		expect(entityIds.length).toBe(2);
+	entities[entityIds[0]].balance = -50;
+	entities[entityIds[0]].adjustment = 0;
+	entities[entityIds[1]].balance = 30;
+	entities[entityIds[1]].adjustment = 0;
 
-		entities[entityIds[0]].balance = -50;
-		entities[entityIds[0]].adjustment = 0;
-		entities[entityIds[1]].balance = 30;
-		entities[entityIds[1]].adjustment = 0;
+	await db
+		.update(customerEntitlements)
+		.set({ entities })
+		.where(eq(customerEntitlements.id, cusEnt!.id));
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
 
-		await db
-			.update(customerEntitlements)
-			.set({ entities })
-			.where(eq(customerEntitlements.id, cusEnt!.id));
-		await expireCusEntForReset({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
+	const cusEntAfter = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEntAfter).toBeDefined();
+	expect(cusEntAfter!.entities).toBeDefined();
 
-		const cusEntAfter = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-		expect(cusEntAfter).toBeDefined();
-		expect(cusEntAfter!.entities).toBeDefined();
-
-		expect(cusEntAfter!.entities![entityIds[0]].balance).toBe(50);
-		expect(cusEntAfter!.entities![entityIds[1]].balance).toBe(100);
-	} finally {
-		await disablePersistFreeOverage({
-			orgId: ctx.org.id,
-			orgConfig: ctx.org.config,
-		});
-	}
+	expect(cusEntAfter!.entities![entityIds[0]].balance).toBe(50);
+	expect(cusEntAfter!.entities![entityIds[1]].balance).toBe(100);
 });
 
 // ─────────────────────────────────────────────────────────────────
@@ -343,6 +290,7 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (per-entity mixed): di
 	const { customerId, ctx } = await initScenario({
 		customerId: "persist-ovg-on-ent-mix",
 		setup: [
+			persistFreeOverageOrg({ slug: "entity-mixed" }),
 			s.customer({ testClock: false }),
 			s.products({ list: [free] }),
 			s.entities({ count: 2, featureId: TestFeature.Users }),
@@ -350,56 +298,43 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (per-entity mixed): di
 		actions: [s.attach({ productId: free.id })],
 	});
 
-	await enablePersistFreeOverage({
-		orgId: ctx.org.id,
-		orgConfig: ctx.org.config,
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
 	});
-	ctx.org.config = { ...ctx.org.config, persist_free_overage: true };
+	expect(cusEnt).toBeDefined();
+	expect(cusEnt!.entities).toBeDefined();
 
-	try {
-		const cusEnt = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-		expect(cusEnt).toBeDefined();
-		expect(cusEnt!.entities).toBeDefined();
+	const entities = { ...cusEnt!.entities! };
+	const entityIds = Object.keys(entities);
+	expect(entityIds.length).toBe(2);
 
-		const entities = { ...cusEnt!.entities! };
-		const entityIds = Object.keys(entities);
-		expect(entityIds.length).toBe(2);
+	entities[entityIds[0]].balance = -30;
+	entities[entityIds[0]].adjustment = 0;
+	entities[entityIds[1]].balance = -200;
+	entities[entityIds[1]].adjustment = 0;
 
-		entities[entityIds[0]].balance = -30;
-		entities[entityIds[0]].adjustment = 0;
-		entities[entityIds[1]].balance = -200;
-		entities[entityIds[1]].adjustment = 0;
+	await db
+		.update(customerEntitlements)
+		.set({ entities })
+		.where(eq(customerEntitlements.id, cusEnt!.id));
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
 
-		await db
-			.update(customerEntitlements)
-			.set({ entities })
-			.where(eq(customerEntitlements.id, cusEnt!.id));
-		await expireCusEntForReset({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
+	const cusEntAfter = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+	expect(cusEntAfter).toBeDefined();
+	expect(cusEntAfter!.entities).toBeDefined();
 
-		const cusEntAfter = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.Messages,
-		});
-		expect(cusEntAfter).toBeDefined();
-		expect(cusEntAfter!.entities).toBeDefined();
-
-		expect(cusEntAfter!.entities![entityIds[0]].balance).toBe(70);
-		expect(cusEntAfter!.entities![entityIds[1]].balance).toBe(-100);
-	} finally {
-		await disablePersistFreeOverage({
-			orgId: ctx.org.id,
-			orgConfig: ctx.org.config,
-		});
-	}
+	expect(cusEntAfter!.entities![entityIds[0]].balance).toBe(70);
+	expect(cusEntAfter!.entities![entityIds[1]].balance).toBe(-100);
 });
 
 // ─────────────────────────────────────────────────────────────────
@@ -418,6 +353,7 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (prepaid): invoice res
 	const { customerId, autumnV1, ctx, testClockId } = await initScenario({
 		customerId: "persist-ovg-on-prepaid",
 		setup: [
+			persistFreeOverageOrg({ slug: "prepaid" }),
 			s.customer({ paymentMethod: "success" }),
 			s.products({ list: [pro] }),
 		],
@@ -430,38 +366,24 @@ test.concurrent(`${chalk.yellowBright("persist overage ON (prepaid): invoice res
 		],
 	});
 
-	// Enable flag BEFORE advancing, so the webhook handler sees it in DB
-	await enablePersistFreeOverage({
-		orgId: ctx.org.id,
-		orgConfig: ctx.org.config,
+	// After attach: prepaid balance = 200 (quantity=200, billingUnits=100, so 2*100=200), lifetime = 50
+	// Total messages balance = 200 + 50 = 250
+	// After track 300: deducted 300 from messages
+	// The prepaid cusEnt's balance should be negative (overage)
+	// On advance, handlePrepaidPrices resets prepaid with persistFreeOverage
+	await advanceToNextInvoice({
+		stripeCli: ctx.stripeCli,
+		testClockId: testClockId!,
+		withPause: true,
 	});
 
-	try {
-		// After attach: prepaid balance = 200 (quantity=200, billingUnits=100, so 2*100=200), lifetime = 50
-		// Total messages balance = 200 + 50 = 250
-		// After track 300: deducted 300 from messages
-		// The prepaid cusEnt's balance should be negative (overage)
-		// On advance, handlePrepaidPrices resets prepaid with persistFreeOverage
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 
-		await advanceToNextInvoice({
-			stripeCli: ctx.stripeCli,
-			testClockId: testClockId!,
-			withPause: true,
-		});
-
-		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
-
-		// Lifetime messages (50) should be untouched by the prepaid reset
-		// Prepaid: was 200, used 300 -> overage of some amount on the prepaid cusEnt
-		// After reset with persist_free_overage: new prepaid balance = 200 - overage
-		// The exact split depends on deduction order, so just verify the feature exists
-		// and the balance is less than the full 250 (200 prepaid + 50 lifetime)
-		expect(customer.features[TestFeature.Messages]).toBeDefined();
-		expect(customer.features[TestFeature.Messages].balance).toBeLessThan(250);
-	} finally {
-		await disablePersistFreeOverage({
-			orgId: ctx.org.id,
-			orgConfig: ctx.org.config,
-		});
-	}
+	// Lifetime messages (50) should be untouched by the prepaid reset
+	// Prepaid: was 200, used 300 -> overage of some amount on the prepaid cusEnt
+	// After reset with persist_free_overage: new prepaid balance = 200 - overage
+	// The exact split depends on deduction order, so just verify the feature exists
+	// and the balance is less than the full 250 (200 prepaid + 50 lifetime)
+	expect(customer.features[TestFeature.Messages]).toBeDefined();
+	expect(customer.features[TestFeature.Messages].balance).toBeLessThan(250);
 });

--- a/server/tests/integration/balances/utils/lockUtils/deleteLock.ts
+++ b/server/tests/integration/balances/utils/lockUtils/deleteLock.ts
@@ -1,5 +1,6 @@
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { redis } from "@/external/redis/initRedis.js";
+import { getRedisV2OrgCleanupCandidates } from "@/external/redis/orgRedisUtils/orgRedisMigrationUtils.js";
 import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
 import { buildClaimMarkerKey } from "@/internal/balances/utils/lockV2/buildClaimMarkerKey.js";
 
@@ -20,6 +21,8 @@ export const deleteLock = async ({
 
 	await Promise.all([
 		redis.del(redisReceiptKey),
-		ctx.redisV2.del(redisReceiptKey, claimMarkerKey),
+		...getRedisV2OrgCleanupCandidates({ ctx }).map((redisInstance) =>
+			redisInstance.del(redisReceiptKey, claimMarkerKey),
+		),
 	]);
 };

--- a/server/tests/integration/balances/utils/lockUtils/expectLockReceiptDeleted.ts
+++ b/server/tests/integration/balances/utils/lockUtils/expectLockReceiptDeleted.ts
@@ -1,6 +1,7 @@
 import { expect } from "bun:test";
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { redis } from "@/external/redis/initRedis.js";
+import { getRedisV2OrgCleanupCandidates } from "@/external/redis/orgRedisUtils/orgRedisMigrationUtils.js";
 import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
 
 /** Asserts that the lock receipt for the given ID no longer exists in Redis. */
@@ -20,4 +21,13 @@ export const expectLockReceiptDeleted = async ({
 
 	const receipt = await redis.call("JSON.GET", redisReceiptKey, "$");
 	expect(receipt).toBeNull();
+
+	const v2ReceiptCounts = await Promise.all(
+		getRedisV2OrgCleanupCandidates({ ctx }).map((redisInstance) =>
+			redisInstance.exists(redisReceiptKey),
+		),
+	);
+	for (const receiptCount of v2ReceiptCounts) {
+		expect(receiptCount).toBe(0);
+	}
 };

--- a/server/tests/unit/balances/lock/fetchLockReceipt.test.ts
+++ b/server/tests/unit/balances/lock/fetchLockReceipt.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Redis } from "ioredis";
+
+const sharedRedis = { name: "shared" } as unknown as Redis;
+const dedicatedRedis = { name: "dedicated" } as unknown as Redis;
+
+const mockState = {
+	jsonGetResult: null as string | null,
+	v2ResultsByRedis: new Map<object, { found: boolean }>(),
+	v2Calls: [] as object[],
+};
+
+mock.module("@/external/redis/initRedis.js", () => ({
+	redis: {
+		call: async () => mockState.jsonGetResult,
+	},
+}));
+
+mock.module("@/external/redis/orgRedisPool.js", () => ({
+	getOrgRedis: () => dedicatedRedis,
+}));
+
+mock.module("@/external/redis/resolveRedisV2.js", () => ({
+	resolveRedisV2: () => sharedRedis,
+}));
+
+mock.module("@/utils/cacheUtils/cacheUtils.js", () => ({
+	tryRedisRead: async (operation: () => Promise<unknown>) => operation(),
+}));
+
+mock.module(
+	"@/internal/balances/utils/lockV2/fetchAndClaimLockReceiptV2.js",
+	() => ({
+		fetchAndClaimLockReceiptV2: async ({
+			redisInstance,
+		}: {
+			redisInstance: object;
+		}) => {
+			mockState.v2Calls.push(redisInstance);
+			const result = mockState.v2ResultsByRedis.get(redisInstance);
+
+			if (!result?.found) return { found: false };
+
+			return {
+				found: true,
+				claimed: true,
+				lockReceiptKey: "lock:receipt",
+				redisInstance,
+				receipt: {
+					customer_id: "customer_123",
+					feature_id: "messages",
+					items: [],
+				},
+			};
+		},
+	}),
+);
+
+import { fetchLockReceipt } from "@/internal/balances/utils/lock/fetchLockReceipt.js";
+
+const makeContext = ({ migrationPercent }: { migrationPercent: number }) =>
+	({
+		org: {
+			id: "org_123",
+			redis_config: {
+				connectionString: "encrypted",
+				url: "dragonfly.internal:6379",
+				migrationPercent,
+				previousMigrationPercent: 0,
+				migrationChangedAt: 1,
+			},
+		},
+		env: "sandbox",
+		redisV2: sharedRedis,
+	}) as never;
+
+beforeEach(() => {
+	mockState.jsonGetResult = null;
+	mockState.v2ResultsByRedis.clear();
+	mockState.v2Calls = [];
+});
+
+describe("fetchLockReceipt", () => {
+	test("checks dedicated Redis during an org Redis migration and returns the source instance", async () => {
+		mockState.v2ResultsByRedis.set(sharedRedis, { found: false });
+		mockState.v2ResultsByRedis.set(dedicatedRedis, { found: true });
+
+		const result = await fetchLockReceipt({
+			ctx: makeContext({ migrationPercent: 50 }),
+			lockId: "lock_123",
+		});
+
+		expect(result.source).toBe("redis_v2");
+		if (result.source !== "redis_v2")
+			throw new Error("Expected Redis V2 receipt");
+		expect(result.redisInstance).toBe(dedicatedRedis);
+		expect(mockState.v2Calls).toEqual([sharedRedis, dedicatedRedis]);
+	});
+
+	test("does not check dedicated Redis when the org migration is complete", async () => {
+		mockState.v2ResultsByRedis.set(sharedRedis, { found: true });
+
+		const result = await fetchLockReceipt({
+			ctx: makeContext({ migrationPercent: 100 }),
+			lockId: "lock_123",
+		});
+
+		expect(result.source).toBe("redis_v2");
+		if (result.source !== "redis_v2")
+			throw new Error("Expected Redis V2 receipt");
+		expect(result.redisInstance).toBe(sharedRedis);
+		expect(mockState.v2Calls).toEqual([sharedRedis]);
+	});
+});

--- a/server/tests/unit/redis/batch-invalidate-full-subjects.test.ts
+++ b/server/tests/unit/redis/batch-invalidate-full-subjects.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AppEnv } from "@autumn/shared";
+import type { Redis } from "ioredis";
+
+const mockState = {
+	deletedCount: 0,
+};
+
+mock.module(
+	"@/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.js",
+	() => ({
+		batchDeleteCachedFullCustomers: async ({
+			customers,
+		}: {
+			customers: unknown[];
+		}) => {
+			mockState.deletedCount = customers.length;
+			return customers.length;
+		},
+	}),
+);
+
+mock.module("@/utils/cacheUtils/cacheUtils.js", () => ({
+	tryRedisRead: async <T>(operation: () => Promise<T>) => operation(),
+	tryRedisWrite: async <T>(operation: () => Promise<T>) => operation(),
+}));
+
+import { batchInvalidateCachedFullSubjects } from "@/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.js";
+
+type RedisCalls = {
+	readKeys: string[];
+	writeOps: string[];
+};
+
+const createFakeRedis = (): { redis: Redis; calls: RedisCalls } => {
+	const calls: RedisCalls = {
+		readKeys: [],
+		writeOps: [],
+	};
+	let pipelineCount = 0;
+
+	const redis = {
+		status: "ready",
+		pipeline: () => {
+			const isReadPipeline = pipelineCount % 2 === 0;
+			pipelineCount++;
+
+			const readKeys: string[] = [];
+			const writeOps: string[] = [];
+			const pipeline = {
+				get: (key: string) => {
+					readKeys.push(key);
+					return pipeline;
+				},
+				unlink: (key: string) => {
+					writeOps.push(`unlink:${key}`);
+					return pipeline;
+				},
+				incr: (key: string) => {
+					writeOps.push(`incr:${key}`);
+					return pipeline;
+				},
+				expire: (key: string, ttlSeconds: number) => {
+					writeOps.push(`expire:${key}:${ttlSeconds}`);
+					return pipeline;
+				},
+				exec: async () => {
+					if (isReadPipeline) {
+						calls.readKeys.push(...readKeys);
+						return readKeys.map(() => [
+							null,
+							JSON.stringify({ meteredFeatures: ["feature_metered"] }),
+						]);
+					}
+
+					calls.writeOps.push(...writeOps);
+					return [];
+				},
+			};
+
+			return pipeline;
+		},
+	} as unknown as Redis;
+
+	return { redis, calls };
+};
+
+describe("batchInvalidateCachedFullSubjects", () => {
+	beforeEach(() => {
+		mockState.deletedCount = 0;
+	});
+
+	test("fans out invalidation to the Redis instance for each customer", async () => {
+		const primary = createFakeRedis();
+		const dedicated = createFakeRedis();
+		const customers = [
+			{
+				orgId: "org_test",
+				env: "sandbox" as AppEnv,
+				customerId: "cus_primary",
+			},
+			{
+				orgId: "org_test",
+				env: "sandbox" as AppEnv,
+				customerId: "cus_dedicated",
+			},
+		];
+
+		const deleted = await batchInvalidateCachedFullSubjects({
+			customers,
+			featuresByOrgEnv: {},
+			getRedisForCustomer: ({ customer }) =>
+				customer.customerId === "cus_dedicated"
+					? dedicated.redis
+					: primary.redis,
+		});
+
+		expect(deleted).toBe(2);
+		expect(mockState.deletedCount).toBe(2);
+
+		expect(primary.calls.readKeys).toHaveLength(1);
+		expect(primary.calls.readKeys[0]).toContain("cus_primary");
+		expect(primary.calls.readKeys[0]).not.toContain("cus_dedicated");
+
+		expect(dedicated.calls.readKeys).toHaveLength(1);
+		expect(dedicated.calls.readKeys[0]).toContain("cus_dedicated");
+		expect(dedicated.calls.readKeys[0]).not.toContain("cus_primary");
+
+		expect(
+			primary.calls.writeOps.some((op) => op.includes("cus_primary")),
+		).toBe(true);
+		expect(
+			dedicated.calls.writeOps.some((op) => op.includes("cus_dedicated")),
+		).toBe(true);
+	});
+});

--- a/server/tests/unit/redis/batch-invalidate-full-subjects.test.ts
+++ b/server/tests/unit/redis/batch-invalidate-full-subjects.test.ts
@@ -109,10 +109,11 @@ describe("batchInvalidateCachedFullSubjects", () => {
 		const deleted = await batchInvalidateCachedFullSubjects({
 			customers,
 			featuresByOrgEnv: {},
-			getRedisForCustomer: ({ customer }) =>
+			getRedisTargetsForCustomer: ({ customer }) => [
 				customer.customerId === "cus_dedicated"
 					? dedicated.redis
 					: primary.redis,
+			],
 		});
 
 		expect(deleted).toBe(2);
@@ -131,6 +132,28 @@ describe("batchInvalidateCachedFullSubjects", () => {
 		).toBe(true);
 		expect(
 			dedicated.calls.writeOps.some((op) => op.includes("cus_dedicated")),
+		).toBe(true);
+	});
+
+	test("dedupes duplicate Redis targets for the same customer", async () => {
+		const primary = createFakeRedis();
+		const customers = [
+			{
+				orgId: "org_test",
+				env: "sandbox" as AppEnv,
+				customerId: "cus_primary",
+			},
+		];
+
+		await batchInvalidateCachedFullSubjects({
+			customers,
+			featuresByOrgEnv: {},
+			getRedisTargetsForCustomer: () => [primary.redis, primary.redis],
+		});
+
+		expect(primary.calls.readKeys).toHaveLength(1);
+		expect(
+			primary.calls.writeOps.some((op) => op.includes("cus_primary")),
 		).toBe(true);
 	});
 });

--- a/server/tests/unit/redis/customer-redis-routing.test.ts
+++ b/server/tests/unit/redis/customer-redis-routing.test.ts
@@ -4,7 +4,6 @@ import {
 	getCustomerBucket,
 	getCustomerRedisRoutingId,
 	getCustomerRedisRoutingInfoForOrg,
-	getRedisUrlForCustomerFromOrg,
 } from "@/external/redis/customerRedisRoutingInfo.js";
 
 const makeRedisConfig = (
@@ -93,9 +92,9 @@ describe("customer Redis routing", () => {
 		});
 
 		expect(
-			getRedisUrlForCustomerFromOrg({
+			getCustomerRedisRoutingInfoForOrg({
 				org,
-			}),
+			}).redisUrl,
 		).toBeUndefined();
 	});
 
@@ -105,10 +104,10 @@ describe("customer Redis routing", () => {
 		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
 
 		expect(
-			getRedisUrlForCustomerFromOrg({
+			getCustomerRedisRoutingInfoForOrg({
 				org,
 				customerId,
-			}),
+			}).redisUrl,
 		).toBe(config.url);
 		expect(
 			getCustomerRedisRoutingInfoForOrg({
@@ -128,10 +127,10 @@ describe("customer Redis routing", () => {
 		const customerId = findCustomerInBucketRange({ min: 50, max: 100 });
 
 		expect(
-			getRedisUrlForCustomerFromOrg({
+			getCustomerRedisRoutingInfoForOrg({
 				org,
 				customerId,
-			}),
+			}).redisUrl,
 		).toBeUndefined();
 		expect(
 			getCustomerRedisRoutingInfoForOrg({

--- a/server/tests/unit/redis/customer-redis-routing.test.ts
+++ b/server/tests/unit/redis/customer-redis-routing.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import type { Organization, OrgRedisConfig } from "@autumn/shared";
+import {
+	getCustomerBucket,
+	getCustomerRedisRoutingInfoForOrg,
+	getRedisUrlForCustomerFromOrg,
+} from "@/external/redis/customerRedisRoutingInfo.js";
+
+const makeRedisConfig = (
+	overrides: Partial<OrgRedisConfig> = {},
+): OrgRedisConfig => ({
+	connectionString: "encrypted",
+	url: "dragonfly.internal:6379",
+	migrationPercent: 50,
+	previousMigrationPercent: 0,
+	migrationChangedAt: 1000,
+	...overrides,
+});
+
+const makeOrg = ({
+	redisConfig = makeRedisConfig(),
+}: {
+	redisConfig?: OrgRedisConfig | null;
+}) =>
+	({
+		id: "org_test",
+		redis_config: redisConfig,
+	}) as Organization;
+
+const findCustomerInBucketRange = ({
+	min,
+	max,
+}: {
+	min: number;
+	max: number;
+}): string => {
+	for (let index = 0; index < 10_000; index++) {
+		const customerId = `cus_routing_${index}`;
+		const bucket = getCustomerBucket(customerId);
+		if (bucket >= min && bucket < max) return customerId;
+	}
+	throw new Error(`No customer found in bucket range [${min}, ${max})`);
+};
+
+describe("customer Redis routing", () => {
+	test("assigns a deterministic bucket from 0 to 99", () => {
+		const bucket = getCustomerBucket("cus_abc123");
+
+		expect(bucket).toBe(getCustomerBucket("cus_abc123"));
+		expect(bucket).toBeGreaterThanOrEqual(0);
+		expect(bucket).toBeLessThan(100);
+	});
+
+	test("uses shared Redis when the org has no redis_config", () => {
+		const org = makeOrg({ redisConfig: null });
+
+		expect(
+			getCustomerRedisRoutingInfoForOrg({
+				org,
+				customerId: "cus_1",
+			}),
+		).toEqual({
+			usesDedicatedRedis: false,
+		});
+	});
+
+	test("uses shared Redis when customerId is missing", () => {
+		const org = makeOrg({
+			redisConfig: makeRedisConfig({ migrationPercent: 100 }),
+		});
+
+		expect(
+			getRedisUrlForCustomerFromOrg({
+				org,
+			}),
+		).toBeUndefined();
+	});
+
+	test("routes buckets below migrationPercent to dedicated Dragonfly", () => {
+		const config = makeRedisConfig({ migrationPercent: 50 });
+		const org = makeOrg({ redisConfig: config });
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+
+		expect(
+			getRedisUrlForCustomerFromOrg({
+				org,
+				customerId,
+			}),
+		).toBe(config.url);
+		expect(
+			getCustomerRedisRoutingInfoForOrg({
+				org,
+				customerId,
+			}),
+		).toMatchObject({
+			redisUrl: config.url,
+			usesDedicatedRedis: true,
+		});
+	});
+
+	test("keeps buckets at or above migrationPercent on shared Redis", () => {
+		const org = makeOrg({
+			redisConfig: makeRedisConfig({ migrationPercent: 50 }),
+		});
+		const customerId = findCustomerInBucketRange({ min: 50, max: 100 });
+
+		expect(
+			getRedisUrlForCustomerFromOrg({
+				org,
+				customerId,
+			}),
+		).toBeUndefined();
+		expect(
+			getCustomerRedisRoutingInfoForOrg({
+				org,
+				customerId,
+			}),
+		).toMatchObject({
+			usesDedicatedRedis: false,
+		});
+	});
+});

--- a/server/tests/unit/redis/customer-redis-routing.test.ts
+++ b/server/tests/unit/redis/customer-redis-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { Organization, OrgRedisConfig } from "@autumn/shared";
 import {
 	getCustomerBucket,
+	getCustomerRedisRoutingId,
 	getCustomerRedisRoutingInfoForOrg,
 	getRedisUrlForCustomerFromOrg,
 } from "@/external/redis/customerRedisRoutingInfo.js";
@@ -43,6 +44,28 @@ const findCustomerInBucketRange = ({
 };
 
 describe("customer Redis routing", () => {
+	test("uses the public customer ID as the routing ID when present", () => {
+		expect(
+			getCustomerRedisRoutingId({
+				customer: {
+					id: "cus_public",
+					internal_id: "cus_internal",
+				},
+			}),
+		).toBe("cus_public");
+	});
+
+	test("falls back to internal ID for customers without a public ID", () => {
+		expect(
+			getCustomerRedisRoutingId({
+				customer: {
+					id: null,
+					internal_id: "cus_internal",
+				},
+			}),
+		).toBe("cus_internal");
+	});
+
 	test("assigns a deterministic bucket from 0 to 99", () => {
 		const bucket = getCustomerBucket("cus_abc123");
 

--- a/server/tests/unit/redis/migration-staleness.test.ts
+++ b/server/tests/unit/redis/migration-staleness.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import type { OrgRedisConfig } from "@autumn/shared";
+import {
+	getCustomerBucket,
+	isRedisMigrationCacheStale,
+} from "@/external/redis/customerRedisRoutingInfo.js";
+
+const makeConfig = (
+	overrides: Partial<OrgRedisConfig> = {},
+): OrgRedisConfig => ({
+	connectionString: "encrypted",
+	url: "dragonfly.internal:6379",
+	migrationPercent: 50,
+	previousMigrationPercent: 0,
+	migrationChangedAt: 1000,
+	...overrides,
+});
+
+const findCustomerInBucketRange = ({
+	min,
+	max,
+}: {
+	min: number;
+	max: number;
+}): string => {
+	for (let index = 0; index < 10_000; index++) {
+		const customerId = `cus_stale_${index}`;
+		const bucket = getCustomerBucket(customerId);
+		if (bucket >= min && bucket < max) return customerId;
+	}
+	throw new Error(`No customer found in bucket range [${min}, ${max})`);
+};
+
+describe("isRedisMigrationCacheStale", () => {
+	test("marks cache stale when a forward migration moves the customer to dedicated Redis", () => {
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+
+		expect(
+			isRedisMigrationCacheStale({
+				cachedAt: 500,
+				customerId,
+				redisConfig: makeConfig({
+					migrationPercent: 50,
+					previousMigrationPercent: 0,
+					migrationChangedAt: 1000,
+				}),
+			}),
+		).toBe(true);
+	});
+
+	test("keeps cache fresh when a forward migration does not move the customer", () => {
+		const customerId = findCustomerInBucketRange({ min: 50, max: 100 });
+
+		expect(
+			isRedisMigrationCacheStale({
+				cachedAt: 500,
+				customerId,
+				redisConfig: makeConfig({
+					migrationPercent: 50,
+					previousMigrationPercent: 0,
+					migrationChangedAt: 1000,
+				}),
+			}),
+		).toBe(false);
+	});
+
+	test("marks cache stale when rollback moves the customer back to shared Redis", () => {
+		const customerId = findCustomerInBucketRange({ min: 20, max: 50 });
+
+		expect(
+			isRedisMigrationCacheStale({
+				cachedAt: 1500,
+				customerId,
+				redisConfig: makeConfig({
+					migrationPercent: 20,
+					previousMigrationPercent: 50,
+					migrationChangedAt: 2000,
+				}),
+			}),
+		).toBe(true);
+	});
+
+	test("keeps cache fresh when it was written after the migration changed", () => {
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+
+		expect(
+			isRedisMigrationCacheStale({
+				cachedAt: 1000,
+				customerId,
+				redisConfig: makeConfig({
+					migrationPercent: 50,
+					previousMigrationPercent: 0,
+					migrationChangedAt: 1000,
+				}),
+			}),
+		).toBe(false);
+	});
+
+	test("keeps legacy entries without cachedAt fresh", () => {
+		expect(
+			isRedisMigrationCacheStale({
+				cachedAt: undefined,
+				customerId: "cus_legacy",
+				redisConfig: makeConfig(),
+			}),
+		).toBe(false);
+	});
+
+	test("keeps cache fresh without a redis config or customer ID", () => {
+		expect(
+			isRedisMigrationCacheStale({
+				cachedAt: 500,
+				customerId: "cus_1",
+				redisConfig: null,
+			}),
+		).toBe(false);
+		expect(
+			isRedisMigrationCacheStale({
+				cachedAt: 500,
+				customerId: undefined,
+				redisConfig: makeConfig(),
+			}),
+		).toBe(false);
+	});
+});

--- a/server/tests/utils/cusProductUtils/resetTestUtils.ts
+++ b/server/tests/utils/cusProductUtils/resetTestUtils.ts
@@ -7,10 +7,25 @@ import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntit
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { eq } from "drizzle-orm";
 import type { Redis } from "ioredis";
-import { redis } from "@/external/redis/initRedis.js";
+import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
+import { redis, waitForRedisReady } from "@/external/redis/initRedis.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { buildSharedFullSubjectBalanceKey } from "@/internal/customers/cache/fullSubject/builders/buildSharedFullSubjectBalanceKey.js";
 import { buildFullCustomerCacheKey } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/fullCustomerCacheConfig.js";
+
+const getRoutedRedisForCustomer = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+}): Promise<Redis> => {
+	const { ctx: routedCtx } = getCtxWithCustomerRedis({ ctx, customerId });
+	await waitForRedisReady(routedCtx.redisV2, "customer-redis", 5000).catch(
+		() => undefined,
+	);
+	return routedCtx.redisV2;
+};
 
 /**
  * Update next_reset_at for a specific cusEnt in the Redis FullCustomer cache.
@@ -70,6 +85,7 @@ export const setCachedCusEntField = async ({
 
 /** Patch next_reset_at on a SubjectBalance in the V2 shared balance hash. */
 export const setCachedSubjectBalanceField = async ({
+	ctx,
 	orgId,
 	env,
 	customerId,
@@ -79,6 +95,7 @@ export const setCachedSubjectBalanceField = async ({
 	value,
 	redisV2,
 }: {
+	ctx?: TestContext;
 	orgId: string;
 	env: string;
 	customerId: string;
@@ -86,8 +103,15 @@ export const setCachedSubjectBalanceField = async ({
 	customerEntitlementId: string;
 	field: string;
 	value: number | string | null;
-	redisV2: Redis;
+	redisV2?: Redis;
 }): Promise<void> => {
+	const targetRedisV2 =
+		redisV2 ??
+		(ctx ? await getRoutedRedisForCustomer({ ctx, customerId }) : null);
+	if (!targetRedisV2) {
+		throw new Error("setCachedSubjectBalanceField requires redisV2 or ctx");
+	}
+
 	const balanceKey = buildSharedFullSubjectBalanceKey({
 		orgId,
 		env,
@@ -95,12 +119,12 @@ export const setCachedSubjectBalanceField = async ({
 		featureId,
 	});
 
-	const raw = await redisV2.hget(balanceKey, customerEntitlementId);
+	const raw = await targetRedisV2.hget(balanceKey, customerEntitlementId);
 	if (!raw) return;
 
 	const subjectBalance = JSON.parse(raw);
 	subjectBalance[field] = value;
-	await redisV2.hset(
+	await targetRedisV2.hset(
 		balanceKey,
 		customerEntitlementId,
 		JSON.stringify(subjectBalance),
@@ -136,6 +160,7 @@ export const expireCusEntForReset = async ({
 	}
 
 	const pastTime = pastTimeMs ?? Date.now() - 1000;
+	const routedRedisV2 = await getRoutedRedisForCustomer({ ctx, customerId });
 
 	// Update Postgres
 	await ctx.db
@@ -162,7 +187,7 @@ export const expireCusEntForReset = async ({
 		customerEntitlementId: cusEnt.id,
 		field: "next_reset_at",
 		value: pastTime,
-		redisV2: ctx.redisV2,
+		redisV2: routedRedisV2,
 	});
 
 	return cusEnt;
@@ -200,6 +225,7 @@ export const expireAllCusEntsForReset = async ({
 	}
 
 	const pastTime = pastTimeMs ?? Date.now() - 1000;
+	const routedRedisV2 = await getRoutedRedisForCustomer({ ctx, customerId });
 
 	for (const cusEnt of cusEnts) {
 		await ctx.db
@@ -224,7 +250,7 @@ export const expireAllCusEntsForReset = async ({
 			customerEntitlementId: cusEnt.id,
 			field: "next_reset_at",
 			value: pastTime,
-			redisV2: ctx.redisV2,
+			redisV2: routedRedisV2,
 		});
 	}
 

--- a/server/tests/utils/testInitUtils/createSubOrgTestContext.ts
+++ b/server/tests/utils/testInitUtils/createSubOrgTestContext.ts
@@ -5,6 +5,7 @@ import {
 	LATEST_VERSION,
 	type OrgConfig,
 } from "@autumn/shared";
+import { getFeatures } from "@tests/setup/v2Features.js";
 import { initDrizzle } from "@/db/initDrizzle.js";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
@@ -29,11 +30,13 @@ export const createSubOrgTestContext = async ({
 	testSecretKey,
 	configOverrides,
 	taxRegistrations,
+	setupDefaultFeatures,
 }: {
 	subOrgSlug: string;
 	testSecretKey: string;
 	configOverrides?: Partial<OrgConfig>;
 	taxRegistrations?: TaxRegistrationCountry[];
+	setupDefaultFeatures?: boolean;
 }): Promise<TestContext> => {
 	const { db } = initDrizzle();
 
@@ -188,6 +191,14 @@ export const createSubOrgTestContext = async ({
 				);
 			}
 		}
+	}
+
+	if (setupDefaultFeatures) {
+		await FeatureService.insert({
+			db,
+			data: Object.values(getFeatures({ orgId: subOrg.id })),
+			logger,
+		});
 	}
 
 	// 5. Sub-org features.

--- a/server/tests/utils/testInitUtils/createTestContext.ts
+++ b/server/tests/utils/testInitUtils/createTestContext.ts
@@ -111,6 +111,19 @@ const lazyDefaultCtx = new Proxy({} as TestContext, {
 		}
 		return Reflect.get(ctx, prop);
 	},
+	set(_target, prop, value, _receiver) {
+		const ctx = (globalThis as { __autumnTestContext?: TestContext | null })
+			.__autumnTestContext;
+		if (ctx == null) {
+			throw new Error(
+				`Default TestContext is not initialized. The integration test ` +
+					`preload (server/tests/setup-integration-tests.ts) did not ` +
+					`populate globalThis.__autumnTestContext before "${String(prop)}" ` +
+					`was assigned.`,
+			);
+		}
+		return Reflect.set(ctx, prop, value);
+	},
 	has(_target, prop) {
 		const ctx = (globalThis as { __autumnTestContext?: TestContext | null })
 			.__autumnTestContext;
@@ -125,7 +138,15 @@ const lazyDefaultCtx = new Proxy({} as TestContext, {
 		const ctx = (globalThis as { __autumnTestContext?: TestContext | null })
 			.__autumnTestContext;
 		if (ctx == null) return undefined;
-		return Reflect.getOwnPropertyDescriptor(ctx, prop);
+		const descriptor = Reflect.getOwnPropertyDescriptor(ctx, prop);
+		if (!descriptor) return undefined;
+
+		return {
+			configurable: true,
+			enumerable: descriptor.enumerable,
+			writable: true,
+			value: Reflect.get(ctx, prop),
+		};
 	},
 });
 

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -199,6 +199,7 @@ type PlatformCreateConfig = {
 	userEmail?: string;
 	configOverrides?: Partial<OrgConfig>;
 	taxRegistrations?: TaxRegistrationCountry[];
+	setupDefaultFeatures?: boolean;
 };
 
 type ScenarioConfig = {
@@ -789,6 +790,7 @@ const createAndRedeemReferralCode = ({
  * @param userEmail - Owner email; defaults to "platform-tests@autumn.test".
  * @param configOverrides - Merged into the sub-org's config jsonb.
  * @param taxRegistrations - Countries to register Stripe Tax for.
+ * @param setupDefaultFeatures - Inserts standard test features on the sub-org.
  *
  * @example s.platform.create({ configOverrides: { automatic_tax: true }, taxRegistrations: ["AU"] })
  */
@@ -965,6 +967,7 @@ export async function initScenario({
 			testSecretKey: response.test_secret_key,
 			configOverrides: config.platformConfig.configOverrides,
 			taxRegistrations: config.platformConfig.taxRegistrations,
+			setupDefaultFeatures: config.platformConfig.setupDefaultFeatures,
 		});
 
 		console.log(

--- a/shared/models/orgModels/frontendOrg.ts
+++ b/shared/models/orgModels/frontendOrg.ts
@@ -24,6 +24,12 @@ export const FrontendOrgSchema = z.object({
 	through_master: z.boolean(),
 	onboarded: z.boolean(),
 	deployed: z.boolean(),
+	redis_config: z
+		.object({
+			url: z.string(),
+			migrationPercent: z.number(),
+		})
+		.nullable(),
 	processor_configs: z.object({
 		vercel: z.object({
 			connected: z.boolean(),

--- a/shared/models/orgModels/frontendOrg.ts
+++ b/shared/models/orgModels/frontendOrg.ts
@@ -26,7 +26,7 @@ export const FrontendOrgSchema = z.object({
 	deployed: z.boolean(),
 	redis_config: z
 		.object({
-			url: z.string(),
+			host: z.string(),
 			migrationPercent: z.number(),
 		})
 		.nullable(),

--- a/shared/models/orgModels/orgTable.ts
+++ b/shared/models/orgModels/orgTable.ts
@@ -41,6 +41,19 @@ export type StripeConnectConfig = {
 	master_org_id?: string;
 };
 
+export type OrgRedisConfig = {
+	/** AES-256-CBC encrypted full Redis connection string via encryptData() */
+	connectionString: string;
+	/** Plain domain/host only, used for pool URL-change detection */
+	url: string;
+	/** Percentage of customers routed to the dedicated Redis (0-100) */
+	migrationPercent: number;
+	/** The migrationPercent before the last change, used for staleness detection */
+	previousMigrationPercent: number;
+	/** Epoch ms when migrationPercent was last changed */
+	migrationChangedAt: number;
+};
+
 export const organizations = pgTable(
 	"organizations",
 	{
@@ -86,6 +99,8 @@ export const organizations = pgTable(
 		created_by: text("created_by"),
 		onboarded: boolean("onboarded").default(false),
 		deployed: boolean("deployed").default(false),
+
+		redis_config: jsonb("redis_config").$type<OrgRedisConfig>(),
 	},
 	(table) => [
 		index("idx_organizations_name_trgm")

--- a/vite/src/hooks/common/useAppQueryStates.tsx
+++ b/vite/src/hooks/common/useAppQueryStates.tsx
@@ -6,6 +6,9 @@ import { useNavigate, useSearchParams } from "react-router";
 type SecondaryTabType =
 	| "api_keys"
 	| "stripe"
+	| "vercel"
+	| "revenuecat"
+	| "redis"
 	| "products"
 	| "rewards"
 	| "features"

--- a/vite/src/views/developer/DevView.tsx
+++ b/vite/src/views/developer/DevView.tsx
@@ -6,9 +6,11 @@ import { useTheme } from "@/contexts/ThemeProvider";
 import { useAppQueryStates } from "@/hooks/common/useAppQueryStates";
 import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
 import { useDevQuery } from "@/hooks/queries/useDevQuery";
+import { useAdmin } from "../admin/hooks/useAdmin";
 import LoadingScreen from "../general/LoadingScreen";
 import { OnboardingGuide } from "../onboarding4/OnboardingGuide";
 import { ApiKeysPage } from "./api-keys/ApiKeysPage";
+import { ConfigureRedis } from "./configure-redis/ConfigureRedis";
 import { ConfigureRevenueCat } from "./configure-revenuecat/ConfigureRevenueCat";
 import { ConfigureStripe } from "./configure-stripe/ConfigureStripe";
 import { ConfigureVercel } from "./configure-vercel/ConfigureVercel";
@@ -17,6 +19,7 @@ import { PublishableKeySection } from "./publishable-key";
 export default function DevScreen() {
 	const { apiKeys, svixDashboardUrl, isLoading, error } = useDevQuery();
 	const { queryStates } = useAppQueryStates({ defaultTab: "api_keys" });
+	const { isAdmin } = useAdmin();
 
 	const tab = queryStates.tab;
 	const { pkey, webhooks, vercel, revenuecat } = useAutumnFlags();
@@ -42,6 +45,8 @@ export default function DevScreen() {
 			{tab === "vercel" && vercel && <ConfigureVercel />}
 
 			{tab === "revenuecat" && revenuecat && <ConfigureRevenueCat />}
+
+			{tab === "redis" && isAdmin && <ConfigureRedis />}
 		</div>
 	);
 }

--- a/vite/src/views/developer/configure-redis/ConfigureRedis.tsx
+++ b/vite/src/views/developer/configure-redis/ConfigureRedis.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/v2/cards/Card";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import { useOrg } from "@/hooks/common/useOrg";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+const CONFIRM_REMOVE_TEXT = "remove";
+
+const getToastErrorMessage = ({
+	error,
+	fallback,
+}: {
+	error: unknown;
+	fallback: string;
+}) => {
+	if (!error || typeof error !== "object" || !("response" in error)) {
+		return fallback;
+	}
+
+	const response = error.response as
+		| { data?: { message?: string } }
+		| undefined;
+	return response?.data?.message ?? fallback;
+};
+
+export const ConfigureRedis = () => {
+	const { org, mutate } = useOrg();
+	const axiosInstance = useAxiosInstance();
+
+	const [connectionString, setConnectionString] = useState("");
+	const [saving, setSaving] = useState(false);
+	const [removing, setRemoving] = useState(false);
+	const [updatingMigration, setUpdatingMigration] = useState(false);
+
+	const [showConnectDialog, setShowConnectDialog] = useState(false);
+	const [showRemoveDialog, setShowRemoveDialog] = useState(false);
+	const [showMigrationDialog, setShowMigrationDialog] = useState(false);
+	const [removeConfirmText, setRemoveConfirmText] = useState("");
+	const [newMigrationPercent, setNewMigrationPercent] = useState("");
+
+	const redisConfig = org?.redis_config;
+	const isConfigured = !!redisConfig;
+
+	useEffect(() => {
+		if (!showRemoveDialog) setRemoveConfirmText("");
+	}, [showRemoveDialog]);
+
+	useEffect(() => {
+		if (showMigrationDialog) {
+			setNewMigrationPercent(String(redisConfig?.migrationPercent ?? 0));
+		}
+	}, [showMigrationDialog, redisConfig?.migrationPercent]);
+
+	const handleConnect = async () => {
+		if (!connectionString.trim()) return;
+
+		setSaving(true);
+		try {
+			await axiosInstance.patch("/v1/organization/redis", {
+				connectionString,
+			});
+			await mutate();
+			setConnectionString("");
+			setShowConnectDialog(false);
+			toast.success("Redis connection created");
+		} catch (error) {
+			toast.error(
+				getToastErrorMessage({
+					error,
+					fallback: "Failed to create Redis connection",
+				}),
+			);
+		}
+		setSaving(false);
+	};
+
+	const handleUpdateMigration = async () => {
+		const percent = Number(newMigrationPercent);
+		if (
+			Number.isNaN(percent) ||
+			!Number.isInteger(percent) ||
+			percent < 0 ||
+			percent > 100
+		) {
+			toast.error("Migration percent must be a whole number between 0 and 100");
+			return;
+		}
+
+		setUpdatingMigration(true);
+		try {
+			await axiosInstance.patch("/v1/organization/redis/migration", {
+				migrationPercent: percent,
+			});
+			await mutate();
+			setShowMigrationDialog(false);
+			toast.success(`Migration updated to ${percent}%`);
+		} catch (error) {
+			toast.error(
+				getToastErrorMessage({
+					error,
+					fallback: "Failed to update migration",
+				}),
+			);
+		}
+		setUpdatingMigration(false);
+	};
+
+	const handleRemove = async () => {
+		if (removeConfirmText !== CONFIRM_REMOVE_TEXT) return;
+
+		setRemoving(true);
+		try {
+			await axiosInstance.delete("/v1/organization/redis");
+			await mutate();
+			setShowRemoveDialog(false);
+			toast.success("Redis connection removed");
+		} catch (error) {
+			toast.error(
+				getToastErrorMessage({
+					error,
+					fallback: "Failed to remove Redis connection",
+				}),
+			);
+		}
+		setRemoving(false);
+	};
+
+	return (
+		<>
+			<Card>
+				<CardHeader>
+					<CardTitle>Redis</CardTitle>
+					<CardDescription>
+						Connect a dedicated Redis instance for this org. Customer cache and
+						balance operations route by migration percentage.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="flex flex-col gap-4">
+					{isConfigured ? (
+						<div className="flex flex-col gap-4">
+							<div className="flex flex-col gap-1">
+								<FormLabel>Connected Instance</FormLabel>
+								<Input
+									value={redisConfig.url}
+									readOnly
+									className="font-mono text-xs"
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<FormLabel>Migration Percentage</FormLabel>
+								<div className="flex items-center gap-2">
+									<Input
+										value={`${redisConfig.migrationPercent}%`}
+										readOnly
+										className="w-24 font-mono text-xs"
+									/>
+									<span className="text-t3 text-xs">
+										of customers on dedicated Redis
+									</span>
+								</div>
+							</div>
+							<div className="flex gap-2">
+								<Button
+									variant="secondary"
+									onClick={() => setShowMigrationDialog(true)}
+								>
+									Update Migration %
+								</Button>
+								<Button
+									variant="destructive"
+									onClick={() => setShowRemoveDialog(true)}
+									disabled={redisConfig.migrationPercent > 0}
+								>
+									Remove
+								</Button>
+							</div>
+							{redisConfig.migrationPercent > 0 && (
+								<p className="text-t3 text-xs">
+									Set migration to 0% before removing the Redis connection.
+								</p>
+							)}
+						</div>
+					) : (
+						<div className="flex flex-col gap-4">
+							<div className="flex flex-col gap-1">
+								<FormLabel>Connection String</FormLabel>
+								<Input
+									placeholder="rediss://default:password@host:6379"
+									value={connectionString}
+									onChange={(event) => setConnectionString(event.target.value)}
+									className="font-mono text-xs"
+								/>
+							</div>
+							<div>
+								<Button
+									onClick={() => setShowConnectDialog(true)}
+									disabled={!connectionString.trim()}
+								>
+									Connect Redis
+								</Button>
+							</div>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+
+			<Dialog open={showConnectDialog} onOpenChange={setShowConnectDialog}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Connect Redis</DialogTitle>
+						<DialogDescription>
+							Migration starts at 0%. No customers will be routed until the
+							migration percentage is increased.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="secondary"
+							onClick={() => setShowConnectDialog(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							onClick={handleConnect}
+							isLoading={saving}
+							disabled={!connectionString.trim()}
+						>
+							Connect
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={showMigrationDialog} onOpenChange={setShowMigrationDialog}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Update Migration Percentage</DialogTitle>
+						<DialogDescription>
+							Customers are assigned deterministically by customer ID.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="flex flex-col gap-1">
+						<FormLabel>
+							Current: {redisConfig?.migrationPercent ?? 0}% / New:
+						</FormLabel>
+						<div className="flex items-center gap-2">
+							<Input
+								type="number"
+								min={0}
+								max={100}
+								value={newMigrationPercent}
+								onChange={(event) => setNewMigrationPercent(event.target.value)}
+								className="w-24 font-mono text-xs"
+							/>
+							<span className="text-t3 text-sm">%</span>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="secondary"
+							onClick={() => setShowMigrationDialog(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							onClick={handleUpdateMigration}
+							isLoading={updatingMigration}
+						>
+							Update
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={showRemoveDialog} onOpenChange={setShowRemoveDialog}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Remove Redis Connection</DialogTitle>
+						<DialogDescription>
+							This org will revert to the shared Redis instance. Type{" "}
+							<span className="font-bold">"{CONFIRM_REMOVE_TEXT}"</span> to
+							confirm.
+						</DialogDescription>
+					</DialogHeader>
+					<Input
+						placeholder={`Type "${CONFIRM_REMOVE_TEXT}" to confirm`}
+						value={removeConfirmText}
+						onChange={(event) => setRemoveConfirmText(event.target.value)}
+						variant="destructive"
+					/>
+					<DialogFooter>
+						<Button
+							variant="secondary"
+							onClick={() => setShowRemoveDialog(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={handleRemove}
+							isLoading={removing}
+							disabled={removeConfirmText !== CONFIRM_REMOVE_TEXT}
+						>
+							Remove
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+};

--- a/vite/src/views/developer/configure-redis/ConfigureRedis.tsx
+++ b/vite/src/views/developer/configure-redis/ConfigureRedis.tsx
@@ -156,9 +156,9 @@ export const ConfigureRedis = () => {
 					{isConfigured ? (
 						<div className="flex flex-col gap-4">
 							<div className="flex flex-col gap-1">
-								<FormLabel>Connected Instance</FormLabel>
+								<FormLabel>Connected Host</FormLabel>
 								<Input
-									value={redisConfig.url}
+									value={redisConfig.host}
 									readOnly
 									className="font-mono text-xs"
 								/>

--- a/vite/src/views/main-sidebar/MainSidebar.tsx
+++ b/vite/src/views/main-sidebar/MainSidebar.tsx
@@ -4,6 +4,7 @@ import {
 	ChartBarIcon,
 	CoinVerticalIcon,
 	CubeIcon,
+	DatabaseIcon,
 	LegoIcon,
 	OptionIcon,
 	TerminalWindowIcon,
@@ -20,6 +21,7 @@ import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 import { useScopes } from "@/hooks/useScopes";
 import { cn } from "@/lib/utils";
 import { useEnv } from "@/utils/envUtils";
+import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { CollapsibleNavGroup } from "./CollapsibleNavGroup";
 import { OrgDropdown } from "./components/OrgDropdown";
 import { EnvDropdown } from "./EnvDropdown";
@@ -30,12 +32,14 @@ import { SidebarRail } from "./SidebarRail";
 
 const buildDevSubTabs = ({
 	flags,
+	isAdmin,
 }: {
 	flags: {
 		webhooks: boolean;
 		vercel: boolean;
 		revenuecat: boolean;
 	};
+	isAdmin: boolean;
 }) => {
 	return [
 		{
@@ -76,6 +80,15 @@ const buildDevSubTabs = ({
 					},
 				]
 			: []),
+		...(isAdmin
+			? [
+					{
+						title: "Redis",
+						value: "redis",
+						icon: <DatabaseIcon size={16} weight="fill" />,
+					},
+				]
+			: []),
 	];
 };
 
@@ -88,6 +101,7 @@ export const MainSidebar = ({
 
 	const flags = useAutumnFlags();
 	const { has } = useScopes();
+	const { isAdmin } = useAdmin();
 	const canSeeDev = has("apiKeys:read");
 
 	const [storedExpanded, setExpanded] = useLocalStorage<boolean>(
@@ -194,7 +208,7 @@ export const MainSidebar = ({
 								env={env}
 								isOpen={devGroupOpen}
 								onToggle={() => setDevGroupOpen((prev) => !prev)}
-								subTabs={buildDevSubTabs({ flags })}
+								subTabs={buildDevSubTabs({ flags, isAdmin })}
 							/>
 						)}
 					</div>


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑org Redis migration routing with per‑customer bucketing, cross‑Redis cache invalidation, and cache staleness eviction while defaulting to shared Redis. Also fixes entity‑scoped rollover resets, routes lock receipts across both Redis instances, and redacts `connectionString` in request logs.

- **New Features**
  - Per-customer routing: deterministic buckets via `getCustomerRedisRoutingId`; changing `migrationPercent` auto‑evicts stale caches.
  - Fan‑out invalidation: batch/single invalidations target shared and/or dedicated Redis via `getRedisTargetsForCustomer`.
  - Org Redis pool: encrypted connection strings, URL change detection, pre‑warm on startup/workers, fallback to shared on decrypt failure.
  - Lock flows: fetch/claim and cleanup search both Redis instances; finalize uses the receipt’s Redis instance.
  - Routing coverage: `orgRedisMiddleware` and `getCtxWithCustomerRedis` applied across Stripe/RevenueCat/Vercel middlewares, checkouts, workers, crons, and migrations.
  - APIs & UI: `PATCH /v1/organization/redis`, `PATCH /v1/organization/redis/migration`, `DELETE /v1/organization/redis`; Dev → Redis (admins) to manage; org API returns `redis_config` with `host` and `migrationPercent`.

- **Migration**
  - No action needed: existing orgs stay on shared Redis.
  - To migrate: connect via UI/API (starts at 0%), raise `migrationPercent` gradually; rollback by lowering; delete config only after setting to 0%.

<sup>Written for commit 25f20c30c935eb41a8ce9b98f6b418fcaacf1a64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

