### PR TITLE
feat/credit note preview

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
@@ -13,6 +13,7 @@ import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBilling
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
 import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
+import { computeAttachPreviewBillingPlan } from "@/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan";
 import {
 	type CreateAutumnCheckoutResult,
@@ -77,9 +78,14 @@ export async function updateSubscription({
 	});
 
 	if (preview) {
+		const previewBillingPlan = await computeAttachPreviewBillingPlan({
+			ctx,
+			billingContext,
+			autumnBillingPlan,
+		});
 		return {
 			billingContext,
-			billingPlan,
+			billingPlan: { ...billingPlan, preview: previewBillingPlan },
 			billingResult: undefined,
 		};
 	}

--- a/server/src/internal/billing/v2/utils/billingPlan/billingPlanToAttachPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/billingPlanToAttachPreview.ts
@@ -43,5 +43,6 @@ export const billingPlanToAttachPreview = async ({
 		redirect_to_checkout: willRedirectToCheckout,
 		checkout_type: checkoutType,
 		tax: billingPlan.preview?.tax,
+		invoice_credits: billingPlan.preview?.invoiceCredits,
 	} satisfies AttachPreviewResponse;
 };

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts
@@ -1,21 +1,27 @@
 import type {
-	AttachBillingContext,
 	AutumnBillingPlan,
+	BillingContext,
 	PreviewBillingPlan,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeAttachInvoiceCreditPreview } from "./invoiceCredits/computeAttachInvoiceCreditPreview";
 import { computeAttachTaxPreview } from "./tax/computeAttachTaxPreview";
 
 /**
- * Build-stage orchestrator for preview-only enrichments on the attach flow.
+ * Build-stage orchestrator for preview-only enrichments. Originally
+ * scoped to the attach flow (hence the name); now also drives previews
+ * for `updateSubscription` and `multiAttach`. The helpers it composes
+ * only read fields available on the parent `BillingContext`, so the
+ * widened parameter type is type-safe across all preview callers.
  *
- * Invoked from `attach.ts` ONLY when `preview: true`. Calls each individual
- * enrichment helper (currently just tax) and assembles the
- * `PreviewBillingPlan` bag that lives at `billingPlan.preview`.
+ * Rename to `computePreviewBillingPlan` is a follow-up.
  *
- * New preview enrichments (per-line tax breakdown, alt-currency previews,
- * next-cycle tax, etc.) slot in here as additional fields on
- * `PreviewBillingPlan` + their own helper module under `preview/`.
+ * Invoked from action handlers ONLY when `preview: true`. Calls each
+ * individual enrichment helper and assembles the `PreviewBillingPlan`
+ * bag that lives at `billingPlan.preview`. New preview enrichments
+ * (per-line tax breakdown, alt-currency previews, next-cycle tax, etc.)
+ * slot in here as additional fields on `PreviewBillingPlan` + their own
+ * helper module under `preview/`.
  */
 export const computeAttachPreviewBillingPlan = async ({
 	ctx,
@@ -23,14 +29,17 @@ export const computeAttachPreviewBillingPlan = async ({
 	autumnBillingPlan,
 }: {
 	ctx: AutumnContext;
-	billingContext: AttachBillingContext;
+	billingContext: BillingContext;
 	autumnBillingPlan: AutumnBillingPlan;
 }): Promise<PreviewBillingPlan> => {
-	const tax = await computeAttachTaxPreview({
-		ctx,
-		billingContext,
-		autumnBillingPlan,
-	});
+	// Tax involves a Stripe round-trip; invoice-credits is local. Run in
+	// parallel so the credits read doesn't add to the wall-clock latency.
+	const [tax, invoiceCredits] = await Promise.all([
+		computeAttachTaxPreview({ ctx, billingContext, autumnBillingPlan }),
+		Promise.resolve(
+			computeAttachInvoiceCreditPreview({ ctx, billingContext }),
+		),
+	]);
 
-	return { tax };
+	return { tax, invoiceCredits };
 };

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/invoiceCredits/computeAttachInvoiceCreditPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/invoiceCredits/computeAttachInvoiceCreditPreview.ts
@@ -1,0 +1,30 @@
+import type {
+	BillingContext,
+	PreviewInvoiceCredits,
+} from "@autumn/shared";
+import { orgToCurrency, stripeToAtmnAmount } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+/**
+ * Build-stage helper that surfaces the Stripe customer's credit balance on
+ * the attach preview so sales/dashboard users can see how much credit will
+ * offset the next invoice.
+ */
+export const computeAttachInvoiceCreditPreview = ({
+	ctx,
+	billingContext,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+}): PreviewInvoiceCredits | undefined => {
+	if (!billingContext.stripeCustomer) return undefined;
+
+	const stripeBalance = billingContext.stripeCustomer.balance ?? 0;
+	const currency = orgToCurrency({ org: ctx.org });
+
+	// Flip sign: Stripe stores credit as negative; we surface as positive.
+	return {
+		balance: stripeToAtmnAmount({ amount: -stripeBalance, currency }),
+		currency,
+	};
+};

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
@@ -1,6 +1,6 @@
 import type {
-	AttachBillingContext,
 	AutumnBillingPlan,
+	BillingContext,
 	PreviewTax,
 } from "@autumn/shared";
 import {
@@ -56,7 +56,7 @@ export const computeAttachTaxPreview = async ({
 	autumnBillingPlan,
 }: {
 	ctx: AutumnContext;
-	billingContext: AttachBillingContext;
+	billingContext: BillingContext;
 	autumnBillingPlan: AutumnBillingPlan;
 }): Promise<PreviewTax | undefined> => {
 	if (!ctx.org.config.automatic_tax) return undefined;

--- a/server/src/internal/billing/v2/utils/billingPlan/toUpdateSubscriptionPreview/billingPlanToUpdateSubscriptionPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toUpdateSubscriptionPreview/billingPlanToUpdateSubscriptionPreview.ts
@@ -28,5 +28,7 @@ export const billingPlanToUpdateSubscriptionPreview = async ({
 		intent: billingPlanToUpdateSubscriptionPreviewIntent({
 			billingContext,
 		}),
+		tax: billingPlan.preview?.tax,
+		invoice_credits: billingPlan.preview?.invoiceCredits,
 	} satisfies PreviewUpdateSubscriptionResponse;
 };

--- a/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
+++ b/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
@@ -1,10 +1,44 @@
 import type { BillingContext, BillingPlan } from "@autumn/shared";
 import { type BillingPreviewResponse, orgToCurrency } from "@autumn/shared";
+import { Decimal } from "decimal.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { billingPlanToImmediatePreview } from "./billingPlan/toImmediatePreview/billingPlanToImmediatePreview";
 import { billingPlanToNextCyclePreview } from "./billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview";
 import { billingPlanToChanges } from "./billingPlan/toPreviewChanges/billingPlanToChanges";
 import { logBillingPreview } from "./logs/logBillingPreview";
+
+/**
+ * Apply preview-layer adjustments (Stripe Tax, Stripe customer credit
+ * balance) to the immediate-period total. Mirrors what Stripe will actually
+ * invoice:
+ *  - Tax is added on top of the discounted subtotal.
+ *  - Customer credit is subtracted, capped at (subtotal + tax) so the total
+ *    never goes negative. Leftover credit rolls to the next invoice in
+ *    Stripe; we don't surface that here beyond the row tooltip on the FE.
+ *
+ * `next_cycle.total` is intentionally NOT adjusted — we don't compute
+ * next-cycle tax (would require a forward-dated Stripe Tax calculation),
+ * and the `subtotal`/`total` doc strings on `next_cycle` reflect that.
+ *
+ * If `billingPlan.preview` is undefined (non-attach flows that skip the
+ * enrichment step) the math is a no-op and `total` is unchanged.
+ */
+const applyPreviewAdjustmentsToTotal = ({
+	subtotal,
+	total,
+	billingPlan,
+}: {
+	subtotal: number;
+	total: number;
+	billingPlan: BillingPlan;
+}): number => {
+	const taxTotal = billingPlan.preview?.tax?.total ?? 0;
+	const creditBalance = billingPlan.preview?.invoiceCredits?.balance ?? 0;
+
+	const taxed = new Decimal(total).add(taxTotal);
+	const cappedCredit = Decimal.min(creditBalance, Decimal.max(taxed, 0));
+	return taxed.sub(cappedCredit).toDP(2).toNumber();
+};
 
 export const billingPlanToPreviewResponse = async ({
 	ctx,
@@ -20,8 +54,18 @@ export const billingPlanToPreviewResponse = async ({
 	const autumnBillingPlan = billingPlan.autumn;
 	const allLineItems = autumnBillingPlan.lineItems ?? [];
 
-	const { immediateLineItems, previewLineItems, subtotal, total } =
-		billingPlanToImmediatePreview({ billingPlan });
+	const {
+		immediateLineItems,
+		previewLineItems,
+		subtotal,
+		total: lineItemsTotal,
+	} = billingPlanToImmediatePreview({ billingPlan });
+
+	const total = applyPreviewAdjustmentsToTotal({
+		subtotal,
+		total: lineItemsTotal,
+		billingPlan,
+	});
 
 	const currency = orgToCurrency({ org: ctx.org });
 

--- a/server/tests/integration/billing/preview/preview-attach-invoice-credits.test.ts
+++ b/server/tests/integration/billing/preview/preview-attach-invoice-credits.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration test for the new `invoice_credits` field on `previewAttach`.
+ *
+ * Architecture (per fetch–build–execute):
+ *   Symptom surfaces in: server/src/internal/billing/v2/utils/billingPlan/billingPlanToAttachPreview.ts
+ *     (formatter passes through `billingPlan.preview.invoiceCredits` to the response)
+ *   Root cause lives in: server/src/internal/billing/v2/utils/billingPlan/preview/invoiceCredits/computeAttachInvoiceCreditPreview.ts
+ *     (build-stage helper that reads stripeCustomer.balance off the
+ *     billingContext)
+ *   Fix layer: same — preview enrichment is genuinely owned at this layer,
+ *     mirroring the existing tax helper. No upstream invariant lives higher.
+ *
+ * Contract: `invoice_credits` is ALWAYS present in the response when a
+ * Stripe customer is connected to this customer, regardless of balance
+ * value or checkout mode. The frontend decides whether to display the row.
+ *
+ * Sign convention under test: Stripe stores a customer credit as a NEGATIVE
+ * `balance`. The API surfaces it as a POSITIVE `balance` so the frontend
+ * can simply subtract it from the post-tax total.
+ *
+ * Cases:
+ *  - Stripe balance = -2000 ($20 credit), card-on-file flow → present, balance=20.
+ *  - Stripe balance = 0 → present, balance=0.
+ *  - Stripe balance = -2000, stripe_checkout flow → present, balance=20.
+ *    (Field still returned; FE just hides the row when redirecting to Checkout.)
+ */
+
+import { expect, test } from "bun:test";
+import type { AttachPreviewResponse } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("preview-attach-invoice-credits (Stripe credit on file): present, sign-flipped to positive, currency matches")}`,
+	async () => {
+		const customerId = "invoice-credits-on";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					// Stripe stores credit as a negative balance. -2000 = $20 credit.
+					stripeCustomerOverrides: { balance: -2000 },
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: `pro_${customerId}`,
+		})) as AttachPreviewResponse;
+
+		expect(preview.invoice_credits).toBeDefined();
+		// Sign-flipped: stripe -2000 → atmn +20 in major units.
+		expect(preview.invoice_credits?.balance).toBe(20);
+		expect(preview.invoice_credits?.currency).toBe(preview.currency);
+		// Total contract: subtotal stays pre-credit; total subtracts credit
+		// capped at subtotal+tax (no auto_tax here → tax=0). $20 plan,
+		// $20 credit on file → total = 0.
+		expect(preview.subtotal).toBe(20);
+		expect(preview.total).toBe(0);
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-attach-invoice-credits (zero balance): present, balance=0, currency matches")}`,
+	async () => {
+		const customerId = "invoice-credits-zero";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					// No balance override — Stripe defaults to 0.
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: `pro_${customerId}`,
+		})) as AttachPreviewResponse;
+
+		expect(preview.invoice_credits).toBeDefined();
+		expect(preview.invoice_credits?.balance).toBe(0);
+		expect(preview.invoice_credits?.currency).toBe(preview.currency);
+		// No credit, no tax → total === subtotal.
+		expect(preview.subtotal).toBe(20);
+		expect(preview.total).toBe(20);
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-attach-invoice-credits (stripe_checkout flow): still present, frontend chooses not to render the row")}`,
+	async () => {
+		const customerId = "invoice-credits-stripe-checkout";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					// NO paymentMethod — forces stripe_checkout flow on attach.
+					stripeCustomerOverrides: { balance: -2000 },
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: `pro_${customerId}`,
+		})) as AttachPreviewResponse;
+
+		expect(preview.checkout_type).toBe("stripe_checkout");
+		// Field is still returned — Stripe Checkout will apply the balance
+		// itself, so the FE hides the row to avoid confusing display. But
+		// the numeric `total` stays accurate per the API contract: $20
+		// plan minus $20 credit = $0.
+		expect(preview.invoice_credits).toBeDefined();
+		expect(preview.invoice_credits?.balance).toBe(20);
+		expect(preview.invoice_credits?.currency).toBe(preview.currency);
+		expect(preview.subtotal).toBe(20);
+		expect(preview.total).toBe(0);
+	},
+	300_000,
+);

--- a/server/tests/integration/billing/preview/preview-update-subscription-tax-and-credits.test.ts
+++ b/server/tests/integration/billing/preview/preview-update-subscription-tax-and-credits.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Integration tests for the new `tax` and `invoice_credits` fields on
+ * `previewUpdateSubscription`. Mirrors the attach preview suite — same
+ * helpers fire for both flows now via the shared
+ * `computeAttachPreviewBillingPlan` orchestrator.
+ *
+ * Architecture (per fetch–build–execute):
+ *   Symptom surfaces in: server/src/internal/billing/v2/utils/billingPlan/toUpdateSubscriptionPreview/billingPlanToUpdateSubscriptionPreview.ts
+ *   Root cause lives in: server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts
+ *     (orchestrator widened to BillingContext, runs for update-sub too)
+ *   Fix layer: same — preview enrichment is genuinely owned at this layer.
+ *
+ * NEW-FEATURE assertions: each case validates every new field, not just
+ * one. Locking the contract on first introduction.
+ *
+ * Two flow shapes (prepaid quantity vs. base-price custom plan) because
+ * platform.create sub-orgs (needed for AU tax registrations) don't carry
+ * the v2 TestFeature catalog. Credits cases use prepaid+Messages on the
+ * default org; tax cases use a feature-less monthly price item on a
+ * sub-org that has Stripe Tax registered for AU.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV3,
+	PreviewUpdateSubscriptionResponse,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const auAddress = {
+	country: "AU",
+	line1: "1 Test St",
+	city: "Sydney",
+	postal_code: "2000",
+	state: "NSW",
+};
+
+// Credits flow: prepaid Messages, default org.
+const billingUnits = 12;
+const pricePerUnit = 8;
+const baseUnits = 10;
+const targetUnits = 20;
+const expectedSubtotal = (targetUnits - baseUnits) * pricePerUnit; // $80
+
+const buildPrepaidProduct = () =>
+	products.base({
+		id: "prepaid",
+		items: [
+			items.prepaid({
+				featureId: TestFeature.Messages,
+				billingUnits,
+				price: pricePerUnit,
+			}),
+		],
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("preview-update-subscription-credits (Stripe credit on file): credits present, sign-flipped, total subtracts capped credit")}`,
+	async () => {
+		const customerId = "us-credits-on";
+		const product = buildPrepaidProduct();
+
+		const { ctx, autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [product] }),
+			],
+			actions: [
+				s.attach({
+					productId: product.id,
+					options: [
+						{
+							feature_id: TestFeature.Messages,
+							quantity: baseUnits * billingUnits,
+						},
+					],
+				}),
+			],
+		});
+
+		// Set credit balance AFTER initial attach so Stripe doesn't consume
+		// it on the first invoice. We want the credit on file at the moment
+		// the previewUpdate runs.
+		const customer =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		const stripeCustomerId = customer.stripe_id;
+		expect(stripeCustomerId).toBeDefined();
+		await ctx.stripeCli.customers.update(stripeCustomerId!, {
+			balance: -2000,
+		});
+
+		const preview = (await autumnV1.subscriptions.previewUpdate({
+			customer_id: customerId,
+			product_id: product.id,
+			options: [
+				{
+					feature_id: TestFeature.Messages,
+					quantity: targetUnits * billingUnits,
+				},
+			],
+		})) as PreviewUpdateSubscriptionResponse;
+
+		expect(preview.subtotal).toBe(expectedSubtotal);
+		expect(preview.invoice_credits).toBeDefined();
+		expect(preview.invoice_credits?.balance).toBe(20);
+		expect(preview.invoice_credits?.currency).toBe(preview.currency);
+		expect(preview.tax).toBeUndefined();
+		// Contract: total = subtotal + tax(0) - cappedCredit. Cap at
+		// (subtotal + tax) so the result never goes negative.
+		const expectedCappedCredit = Math.min(20, expectedSubtotal);
+		expect(preview.total).toBe(expectedSubtotal - expectedCappedCredit);
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-update-subscription-credits (zero balance): credits present with balance=0, total === subtotal")}`,
+	async () => {
+		const customerId = "us-credits-zero";
+		const product = buildPrepaidProduct();
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [product] }),
+			],
+			actions: [
+				s.attach({
+					productId: product.id,
+					options: [
+						{
+							feature_id: TestFeature.Messages,
+							quantity: baseUnits * billingUnits,
+						},
+					],
+				}),
+			],
+		});
+
+		const preview = (await autumnV1.subscriptions.previewUpdate({
+			customer_id: customerId,
+			product_id: product.id,
+			options: [
+				{
+					feature_id: TestFeature.Messages,
+					quantity: targetUnits * billingUnits,
+				},
+			],
+		})) as PreviewUpdateSubscriptionResponse;
+
+		expect(preview.subtotal).toBe(expectedSubtotal);
+		expect(preview.invoice_credits).toBeDefined();
+		expect(preview.invoice_credits?.balance).toBe(0);
+		expect(preview.invoice_credits?.currency).toBe(preview.currency);
+		expect(preview.tax).toBeUndefined();
+		expect(preview.total).toBe(expectedSubtotal);
+	},
+	300_000,
+);
+
+// Tax flow: pro plan ($20/mo) with custom-plan upgrade to $50/mo via
+// `items` override on previewUpdate. Sub-org with AU tax registration.
+// Default org doesn't have AU tax registered, so we need the sub-org.
+// Pro/premium fixtures with empty items don't need TestFeature catalog.
+test.concurrent(
+	`${chalk.yellowBright("preview-update-subscription-tax (auto_tax on, AU customer): tax.status=complete, total = subtotal + tax")}`,
+	async () => {
+		const customerId = "us-tax-on";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { automatic_tax: true },
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [s.billing.attach({ productId: "pro" })],
+		});
+
+		// Custom-plan update: bump base price from $20 → $50 to force a
+		// positive prorated immediate charge that Stripe Tax can compute on.
+		const preview = (await autumnV1.subscriptions.previewUpdate({
+			customer_id: customerId,
+			product_id: `pro_${customerId}`,
+			items: [items.monthlyPrice({ price: 50 })],
+		})) as PreviewUpdateSubscriptionResponse;
+
+		expect(preview.subtotal).toBeGreaterThan(0);
+		expect(preview.tax).toBeDefined();
+		expect(preview.tax?.status).toBe("complete");
+		expect(preview.tax?.currency).toBe(preview.currency);
+		expect(preview.tax?.total).toBeGreaterThan(0);
+		expect(preview.tax?.amount_exclusive).toBeGreaterThan(0);
+
+		expect(preview.invoice_credits?.balance ?? 0).toBe(0);
+		expect(preview.total).toBeCloseTo(
+			preview.subtotal + (preview.tax?.total ?? 0),
+			2,
+		);
+		expect(preview.total).toBeGreaterThan(preview.subtotal);
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-update-subscription-tax (auto_tax off): tax field omitted, total === subtotal (no credit)")}`,
+	async () => {
+		const customerId = "us-tax-off";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				// auto_tax defaults to false. Use a sub-org for parity with
+				// the auto_tax-on case (same code path through platform.create).
+				s.platform.create({ taxRegistrations: ["AU"] }),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+					stripeCustomerOverrides: { address: auAddress },
+				}),
+				s.products({ list: [proProd] }),
+			],
+			actions: [s.billing.attach({ productId: "pro" })],
+		});
+
+		const preview = (await autumnV1.subscriptions.previewUpdate({
+			customer_id: customerId,
+			product_id: `pro_${customerId}`,
+			items: [items.monthlyPrice({ price: 50 })],
+		})) as PreviewUpdateSubscriptionResponse;
+
+		expect(preview.subtotal).toBeGreaterThan(0);
+		expect(preview.tax).toBeUndefined();
+		expect(preview.invoice_credits?.balance ?? 0).toBe(0);
+		expect(preview.total).toBe(preview.subtotal);
+	},
+	300_000,
+);

--- a/server/tests/integration/billing/tax/automatic-tax-preview-attach-immediate.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-preview-attach-immediate.test.ts
@@ -80,12 +80,15 @@ test.concurrent(`${chalk.yellowBright(
 	expect(preview.tax?.amount_exclusive).toBeGreaterThan(0);
 	expect(preview.tax?.amount_inclusive).toBe(0);
 
-	// Sanity: the existing autumn-side total stays separate from the
-	// stripe-side tax breakdown. They're computing different things —
-	// the autumn `total` may include credits that Stripe doesn't tax.
-	expect(preview.total).toBeGreaterThan(0);
-	// Don't assert preview.total === preview.tax.total — divergence is
-	// expected and documented on the schema.
+	// New contract: `total` includes tax and the (capped) credit balance.
+	// `subtotal` stays pre-tax, pre-credit. Customer here has no credit on
+	// file, so credit term is 0 and total = subtotal + tax.
+	expect(preview.invoice_credits?.balance ?? 0).toBe(0);
+	expect(preview.total).toBeCloseTo(
+		preview.subtotal + (preview.tax?.total ?? 0),
+		2,
+	);
+	expect(preview.total).toBeGreaterThan(preview.subtotal);
 }, 300_000);
 
 test.concurrent(`${chalk.yellowBright(

--- a/shared/api/billing/common/attachPreviewResponse.ts
+++ b/shared/api/billing/common/attachPreviewResponse.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import {
 	BillingPreviewResponseSchema,
+	PreviewInvoiceCreditsSchema,
 	PreviewTaxSchema,
 } from "./billingPreviewResponse.js";
 
@@ -22,6 +23,10 @@ export const AttachPreviewResponseSchema = BillingPreviewResponseSchema.extend({
 	tax: PreviewTaxSchema.optional().meta({
 		description:
 			"Tax preview for the immediate charge. Contact us to enable the tax flag on your organisation. Shows only with flag enabled, a Stripe customer exists and has a location.",
+	}),
+
+	invoice_credits: PreviewInvoiceCreditsSchema.optional().meta({
+		description: "Stripe customer invoice credits preview.",
 	}),
 	// redirect_type: z.enum(["stripe_checkout", "autumn_checkout", "none"]),
 });

--- a/shared/api/billing/common/billingPreviewResponse.ts
+++ b/shared/api/billing/common/billingPreviewResponse.ts
@@ -46,6 +46,18 @@ export const PreviewTaxSchema = z.object({
 
 export type PreviewTax = z.infer<typeof PreviewTaxSchema>;
 
+export const PreviewInvoiceCreditsSchema = z.object({
+	balance: z.number().meta({
+		description:
+			"Stripe customer credit balance available, expressed as a positive number in major currency units.",
+	}),
+	currency: z.string().meta({
+		description: "Three-letter currency code.",
+	}),
+});
+
+export type PreviewInvoiceCredits = z.infer<typeof PreviewInvoiceCreditsSchema>;
+
 export const ExtPreviewLineItemSchema = z.object({
 	display_name: z.string().meta({
 		description:
@@ -56,11 +68,12 @@ export const ExtPreviewLineItemSchema = z.object({
 		.string()
 		.meta({ description: "A detailed description of the line item." }),
 	subtotal: z.number().meta({
-		description: "The amount in cents before discounts for this line item.",
+		description:
+			"The amount in cents before discounts and tax for this line item.",
 	}),
 	total: z.number().meta({
 		description:
-			"The final amount in cents after discounts for this line item.",
+			"The final amount in cents after discounts and tax for this line item.",
 	}),
 	discounts: z.array(PreviewLineItemDiscountSchema).default([]).meta({
 		description: "List of discounts applied to this line item.",
@@ -110,12 +123,12 @@ export const ExtBillingPreviewResponseSchema = z.object({
 	}),
 	subtotal: z.number().meta({
 		description:
-			"The total amount in cents before discounts for the current billing period.",
+			"The total amount in cents before discounts and tax for the current billing period.",
 	}),
 
 	total: z.number().meta({
 		description:
-			"The final amount in cents after discounts for the current billing period.",
+			"The final amount in cents after discounts and tax for the current billing period.",
 	}),
 
 	currency: z.string().meta({
@@ -130,11 +143,11 @@ export const ExtBillingPreviewResponseSchema = z.object({
 			}),
 			subtotal: z.number().meta({
 				description:
-					"The total amount in cents before discounts for the next cycle.",
+					"The total amount in cents before discounts and tax for the next cycle.",
 			}),
 			total: z.number().meta({
 				description:
-					"The final amount in cents after discounts for the next cycle.",
+					"The final amount in cents after discounts and tax for the next cycle.",
 			}),
 			line_items: z.array(PreviewLineItemSchema).meta({
 				description: "List of line items for the next billing cycle.",

--- a/shared/api/billing/updateSubscription/previewUpdateSubscriptionResponse.ts
+++ b/shared/api/billing/updateSubscription/previewUpdateSubscriptionResponse.ts
@@ -2,6 +2,8 @@ import { z } from "zod/v4";
 import {
 	BillingPreviewResponseSchema,
 	ExtBillingPreviewResponseSchema,
+	PreviewInvoiceCreditsSchema,
+	PreviewTaxSchema,
 } from "../common/billingPreviewResponse";
 
 export enum UpdateSubscriptionPreviewIntent {
@@ -16,12 +18,21 @@ export enum UpdateSubscriptionPreviewIntent {
 export const ExtPreviewUpdateSubscriptionResponseSchema =
 	ExtBillingPreviewResponseSchema.extend({
 		intent: z.enum(UpdateSubscriptionPreviewIntent),
+		tax: PreviewTaxSchema.optional().meta({
+			description:
+				"Tax preview for the immediate charge. Contact us to enable the tax flag on your organisation. Shows only with flag enabled, a Stripe customer exists and has a location.",
+		}),
+		invoice_credits: PreviewInvoiceCreditsSchema.optional().meta({
+			description: "Stripe customer invoice credits preview.",
+		}),
 	});
 
 export const PreviewUpdateSubscriptionResponseSchema =
 	BillingPreviewResponseSchema.extend({
 		object: z.literal("update_subscription_preview").meta({ internal: true }),
 		intent: z.enum(UpdateSubscriptionPreviewIntent),
+		tax: PreviewTaxSchema.optional(),
+		invoice_credits: PreviewInvoiceCreditsSchema.optional(),
 	});
 
 export type ExtPreviewUpdateSubscriptionResponse = z.infer<

--- a/shared/models/billingModels/plan/previewBillingPlan.ts
+++ b/shared/models/billingModels/plan/previewBillingPlan.ts
@@ -1,4 +1,7 @@
-import { PreviewTaxSchema } from "@api/billing/common/billingPreviewResponse";
+import {
+	PreviewInvoiceCreditsSchema,
+	PreviewTaxSchema,
+} from "@api/billing/common/billingPreviewResponse";
 import { z } from "zod/v4";
 
 /**
@@ -11,6 +14,7 @@ import { z } from "zod/v4";
  */
 export const PreviewBillingPlanSchema = z.object({
 	tax: PreviewTaxSchema.optional(),
+	invoiceCredits: PreviewInvoiceCreditsSchema.optional(),
 });
 
 export type PreviewBillingPlan = z.infer<typeof PreviewBillingPlanSchema>;

--- a/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionPreviewSection.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/UpdateSubscriptionPreviewSection.tsx
@@ -3,6 +3,7 @@ import type { AxiosError } from "axios";
 import { format } from "date-fns";
 import { getPreviewCreditAmount } from "@/components/forms/shared/previewCreditUtils";
 import { LineItemsPreview } from "@/components/v2/LineItemsPreview";
+import { PreviewTotalsBlock } from "@/components/v2/preview-totals/PreviewTotalsBlock";
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { getBackendErr } from "@/utils/genUtils";
 import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
@@ -30,25 +31,16 @@ export function UpdateSubscriptionPreviewSection() {
 			})
 		: null;
 
-	const totals = [];
-
-	if (previewData) {
-		totals.push({
-			label: "Total Due Now",
-			amount: Math.max(previewData.total, 0),
-			variant: "primary" as const,
+	const secondaryTotals = [];
+	if (previewData?.next_cycle) {
+		secondaryTotals.push({
+			label: "Next Cycle",
+			amount: previewData.next_cycle.total,
+			variant: "secondary" as const,
+			badge: previewData.next_cycle.starts_at
+				? format(new Date(previewData.next_cycle.starts_at), "MMM d, yyyy")
+				: undefined,
 		});
-
-		if (previewData.next_cycle) {
-			totals.push({
-				label: "Next Cycle",
-				amount: previewData.next_cycle.total,
-				variant: "secondary" as const,
-				badge: previewData.next_cycle.starts_at
-					? format(new Date(previewData.next_cycle.starts_at), "MMM d, yyyy")
-					: undefined,
-			});
-		}
 	}
 
 	if (!hasChanges) return null;
@@ -79,9 +71,14 @@ export function UpdateSubscriptionPreviewSection() {
 				isLoading={isLoading}
 				lineItems={previewData?.line_items}
 				currency={previewData?.currency}
-				totals={totals}
+				totals={secondaryTotals}
 				filterZeroAmounts
 			/>
+			{previewData && (
+				<SheetSection withSeparator={false}>
+					<PreviewTotalsBlock previewData={previewData} />
+				</SheetSection>
+			)}
 		</>
 	);
 }

--- a/vite/src/components/v2/preview-totals/PreviewTotalsBlock.tsx
+++ b/vite/src/components/v2/preview-totals/PreviewTotalsBlock.tsx
@@ -47,7 +47,12 @@ export function PreviewTotalsBlock({
 		!willRedirectToStripeCheckout && creditBalance > 0
 			? Math.min(creditBalance, subtotalBeforeCredit)
 			: 0;
-	const showCreditRow = creditApplied > 0;
+	// Hide the row entirely when there's no credit on file. We also hide
+	// when redirecting to Stripe Checkout (Stripe applies the balance in
+	// their hosted form — showing it here would diverge) or when nothing
+	// would actually be applied (e.g. $0 plan with credit).
+	const showCreditRow =
+		creditBalance > 0 && !willRedirectToStripeCheckout && creditApplied > 0;
 	const creditRollover = creditBalance - creditApplied;
 
 	const { currency } = previewData;
@@ -94,7 +99,7 @@ export function PreviewTotalsBlock({
 				</div>
 			)}
 
-			<div className="flex items-center justify-between border-t border-border/60 pt-2 mt-1">
+			<div className="flex items-center justify-between border-t border-border pt-2 mt-1">
 				<span className="text-sm font-semibold text-foreground">
 					Total Due Now
 				</span>

--- a/vite/src/components/v2/preview-totals/PreviewTotalsBlock.tsx
+++ b/vite/src/components/v2/preview-totals/PreviewTotalsBlock.tsx
@@ -1,0 +1,107 @@
+import { formatAmount } from "@autumn/shared";
+import { Decimal } from "decimal.js";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/v2/tooltips/Tooltip";
+
+type PreviewTotalsBlockPreviewData = {
+	currency: string;
+	subtotal: number;
+	total: number;
+	tax?: {
+		total: number;
+		status: "complete" | "incomplete";
+	};
+	invoice_credits?: {
+		balance: number;
+	};
+	checkout_type?: "stripe_checkout" | "autumn_checkout" | null;
+};
+
+const fmt = (amount: number, currency: string) =>
+	formatAmount({
+		amount: new Decimal(amount).toDecimalPlaces(2).toNumber(),
+		currency,
+		minFractionDigits: 2,
+		amountFormatOptions: { currencyDisplay: "narrowSymbol" },
+	});
+
+export function PreviewTotalsBlock({
+	previewData,
+}: {
+	previewData: PreviewTotalsBlockPreviewData;
+}) {
+	const showTaxRow =
+		previewData.tax?.status === "complete" && previewData.tax.total > 0;
+	const taxAmount = showTaxRow ? (previewData.tax?.total ?? 0) : 0;
+
+	const creditBalance = previewData.invoice_credits?.balance ?? 0;
+	const willRedirectToStripeCheckout =
+		previewData.checkout_type === "stripe_checkout";
+	const subtotalBeforeCredit = Math.max(previewData.subtotal, 0) + taxAmount;
+	// FE-side cap, purely for the row's displayed amount and rollover
+	// tooltip. The authoritative numeric total comes from the server.
+	const creditApplied =
+		!willRedirectToStripeCheckout && creditBalance > 0
+			? Math.min(creditBalance, subtotalBeforeCredit)
+			: 0;
+	const showCreditRow = creditApplied > 0;
+	const creditRollover = creditBalance - creditApplied;
+
+	const { currency } = previewData;
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center justify-between">
+				<span className="text-sm font-medium text-t2">Subtotal</span>
+				<span className="text-sm font-medium tabular-nums text-t2">
+					{fmt(previewData.subtotal, currency)}
+				</span>
+			</div>
+
+			{showTaxRow && (
+				<div className="flex items-center justify-between">
+					<span className="text-sm text-t2">Tax</span>
+					<span className="text-sm tabular-nums text-t2">
+						{fmt(taxAmount, currency)}
+					</span>
+				</div>
+			)}
+
+			{showCreditRow && (
+				<div className="flex items-center justify-between">
+					{creditRollover > 0 ? (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span className="text-sm text-t2 underline decoration-dotted decoration-t3/40 underline-offset-4 cursor-help">
+									Invoice Credits
+								</span>
+							</TooltipTrigger>
+							<TooltipContent side="top">
+								{fmt(creditBalance, currency)} total credit on file.{" "}
+								{fmt(creditRollover, currency)} will roll over to the next
+								invoice.
+							</TooltipContent>
+						</Tooltip>
+					) : (
+						<span className="text-sm text-t2">Invoice Credits</span>
+					)}
+					<span className="text-sm tabular-nums text-t2">
+						-{fmt(creditApplied, currency)}
+					</span>
+				</div>
+			)}
+
+			<div className="flex items-center justify-between border-t border-border/60 pt-2 mt-1">
+				<span className="text-sm font-semibold text-foreground">
+					Total Due Now
+				</span>
+				<span className="text-sm font-semibold text-foreground tabular-nums">
+					{fmt(previewData.total, currency)}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -1,7 +1,6 @@
-import { type Entity, type FullCustomer, formatAmount } from "@autumn/shared";
+import type { Entity, FullCustomer } from "@autumn/shared";
 import { PlusIcon } from "@phosphor-icons/react";
 import type { AxiosError } from "axios";
-import { Decimal } from "decimal.js";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -27,6 +26,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/v2/buttons/Button";
 import { InlinePlanEditor } from "@/components/v2/inline-custom-plan-editor/InlinePlanEditor";
 import { LineItemsPreview } from "@/components/v2/LineItemsPreview";
+import { PreviewTotalsBlock } from "@/components/v2/preview-totals/PreviewTotalsBlock";
 import {
 	LayoutGroup,
 	SheetFooter,
@@ -131,20 +131,11 @@ function ReviewPreviewBlock() {
 		? getBackendErr(queryError as AxiosError, "Failed to load preview")
 		: undefined;
 
-	// Tax-aware totals. Only show the Tax row when status is "complete" AND
-	// total > 0 — incomplete is surfaced via toast above; zero tax means
-	// nothing taxable in this jurisdiction (no value in showing $0).
-	const showTaxRow =
-		previewData?.tax?.status === "complete" && previewData.tax.total > 0;
-	const taxAmount = showTaxRow ? (previewData?.tax?.total ?? 0) : 0;
-	const totalDueNow = previewData
-		? Math.max(previewData.total, 0) + taxAmount
-		: 0;
 	const previewTotals = buildAttachPreviewTotals({
 		previewData,
 		startDate: formValues.startDate,
 	});
-	const lineItemTotals = showTaxRow
+	const lineItemTotals = previewData
 		? previewTotals.filter((total) => total.variant !== "primary")
 		: previewTotals;
 
@@ -181,42 +172,9 @@ function ReviewPreviewBlock() {
 								totals={lineItemTotals}
 								filterZeroAmounts
 							/>
-							{showTaxRow && previewData && (
+							{previewData && (
 								<SheetSection withSeparator={false}>
-									<div className="space-y-2">
-										<div className="flex items-center justify-between">
-											<span className="text-sm text-t2">Tax</span>
-											<span className="text-sm tabular-nums text-t2">
-												{formatAmount({
-													amount: new Decimal(taxAmount)
-														.toDecimalPlaces(2)
-														.toNumber(),
-													currency: previewData.currency,
-													minFractionDigits: 2,
-													amountFormatOptions: {
-														currencyDisplay: "narrowSymbol",
-													},
-												})}
-											</span>
-										</div>
-										<div className="flex items-center justify-between">
-											<span className="text-sm font-medium text-foreground">
-												Total Due Now
-											</span>
-											<span className="text-sm font-semibold text-foreground tabular-nums">
-												{formatAmount({
-													amount: new Decimal(totalDueNow)
-														.toDecimalPlaces(2)
-														.toNumber(),
-													currency: previewData.currency,
-													minFractionDigits: 2,
-													amountFormatOptions: {
-														currencyDisplay: "narrowSymbol",
-													},
-												})}
-											</span>
-										</div>
-									</div>
+									<PreviewTotalsBlock previewData={previewData} />
 								</SheetSection>
 							)}
 						</>

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
@@ -224,6 +224,33 @@ export const createCustomerListColumns = (): ColumnDef<
 ];
 
 /**
+ * Creates the product version column. Shows the active (non-expired,
+ * non-scheduled) product's version, prefixed with "v", in light grey.
+ */
+export const createProductVersionColumn = (): ColumnDef<
+	CustomerWithProducts,
+	unknown
+> => ({
+	id: "product_version",
+	header: "Version",
+	size: 80,
+	enableSorting: false,
+	cell: ({ row }: { row: Row<CustomerWithProducts> }) => {
+		const customer = row.original;
+		const activeProduct = customer.customer_products?.find(
+			(cusProduct) =>
+				(cusProduct as FullCusProduct).status !== CusProductStatus.Expired &&
+				(cusProduct as FullCusProduct).status !== CusProductStatus.Scheduled,
+		) as FullCusProduct | undefined;
+
+		const version = activeProduct?.product?.version;
+		if (version == null) return null;
+
+		return <span className="text-t6">v{version}</span>;
+	},
+});
+
+/**
  * Creates a usage column for a specific metered feature
  */
 export const createUsageColumn = ({

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -8,8 +8,10 @@ import { EmptyState } from "@/components/v2/empty-states/EmptyState";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useColumnVisibility } from "@/hooks/useColumnVisibility";
 import { useEnv } from "@/utils/envUtils";
+import { getVersionCounts } from "@/utils/productUtils";
 import { pushPage } from "@/utils/genUtils";
 import { useCustomerFilters } from "@/views/customers/hooks/useCustomerFilters";
 import { FULL_CUSTOMERS_QUERY_KEY } from "@/views/customers/hooks/useFullCusSearchQuery";
@@ -39,6 +41,13 @@ export function CustomerListTable({
 		env === AppEnv.Sandbox ? "calc(100vh - 174px)" : "calc(100vh - 134px)";
 
 	const { features } = useFeaturesQuery();
+	const { products } = useProductsQuery();
+	const showProductVersions = useMemo(() => {
+		const versionCounts = getVersionCounts(products);
+		return Object.values(versionCounts).some(
+			(v) => typeof v === "number" && v > 1,
+		);
+	}, [products]);
 	const { queryStates } = useCustomerFilters();
 	const buildKey = useQueryKeyFactory();
 
@@ -103,7 +112,11 @@ export function CustomerListTable({
 
 	// Create columns including dynamic usage columns from metered features
 	const { columns, defaultVisibleColumnIds, columnGroups } =
-		useCustomerListColumns({ features, storageKey: columnStorageKey });
+		useCustomerListColumns({
+			features,
+			storageKey: columnStorageKey,
+			showProductVersions,
+		});
 
 	const {
 		columnVisibility,

--- a/vite/src/views/customers2/hooks/useCustomerListColumns.ts
+++ b/vite/src/views/customers2/hooks/useCustomerListColumns.ts
@@ -7,15 +7,18 @@ import {
 import {
 	BASE_COLUMN_IDS,
 	createCustomerListColumns,
+	createProductVersionColumn,
 	createUsageColumn,
 } from "../components/table/customer-list/CustomerListColumns";
 
 export function useCustomerListColumns({
 	features,
 	storageKey,
+	showProductVersions,
 }: {
 	features: Feature[];
 	storageKey: string;
+	showProductVersions?: boolean;
 }) {
 	return useMemo(() => {
 		const baseColumns = createCustomerListColumns();
@@ -55,20 +58,37 @@ export function useCustomerListColumns({
 			});
 		}
 
+		// Optionally insert a Product Version column right after the Products
+		// column when the org has any product with more than one version.
+		// Hidden by default; togglable via the Display dropdown.
+		let columnsWithVersion = baseColumns;
+		if (showProductVersions) {
+			const productsIndex = baseColumns.findIndex(
+				(col) => col.id === "customer_products",
+			);
+			const insertAt =
+				productsIndex !== -1 ? productsIndex + 1 : baseColumns.length;
+			columnsWithVersion = [
+				...baseColumns.slice(0, insertAt),
+				createProductVersionColumn(),
+				...baseColumns.slice(insertAt),
+			];
+		}
+
 		// Insert usage columns before created_at (so created_at and actions stay at the end)
-		const createdAtIndex = baseColumns.findIndex(
+		const createdAtIndex = columnsWithVersion.findIndex(
 			(col) => col.id === "created_at",
 		);
 
-		let allColumns: typeof baseColumns;
+		let allColumns: typeof columnsWithVersion;
 		if (createdAtIndex !== -1 && usageColumns.length > 0) {
 			allColumns = [
-				...baseColumns.slice(0, createdAtIndex),
+				...columnsWithVersion.slice(0, createdAtIndex),
 				...usageColumns,
-				...baseColumns.slice(createdAtIndex),
+				...columnsWithVersion.slice(createdAtIndex),
 			];
 		} else {
-			allColumns = [...baseColumns, ...usageColumns];
+			allColumns = [...columnsWithVersion, ...usageColumns];
 		}
 
 		return {
@@ -76,5 +96,5 @@ export function useCustomerListColumns({
 			defaultVisibleColumnIds: BASE_COLUMN_IDS,
 			columnGroups,
 		};
-	}, [features, storageKey]);
+	}, [features, storageKey, showProductVersions]);
 }


### PR DESCRIPTION
- **feat: 🎸 credit notes in preview**
- **feat: 🎸 add tests and stuff**

## Summary
<!-- Provide a short summary of your changes and the motivation behind them. -->

## Related Issues
<!-- List any related issues, e.g. Fixes #123 or Closes #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
- [ ] I have read the [CONTRIBUTING.md](https://github.com/useautumn/autumn/blob/staging/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of this project
- [ ] I have added tests where applicable
- [ ] I have tested my changes locally
- [ ] I have linked relevant issues
- [ ] I have added screenshots for UI changes (if applicable)

## Screenshots (if applicable)
<!-- Add before/after screenshots or GIFs here -->

## Additional Context
<!-- Add any other context or information about the PR here --> 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Stripe customer invoice credits to billing previews and include both tax and credits in the “Total Due Now” for attach and update subscription flows. Adds a compact totals UI and full integration tests.

- New Features
  - Server
    - Added invoice credits to preview enrichment and responses: `invoice_credits` now returned for attach and update previews.
    - Generalized preview orchestrator to `BillingContext` and run tax and credits in parallel.
    - Immediate total now includes tax and subtracts capped credits; `next_cycle.total` remains pre-tax.
    - Updated shared schemas: introduced `PreviewInvoiceCredits`, clarified subtotal/total docs as “before/after discounts and tax”.
  - UI
    - Added `PreviewTotalsBlock` showing Subtotal, Tax (when complete), Invoice Credits (with rollover tooltip), and Total Due Now.
    - Integrated totals block into attach and update-subscription previews; secondary totals remain in the line items component.
    - Customer list: optional “Version” column to show active product version (hidden by default).
  - Tests
    - New integration tests for attach and update preview covering credits (sign flip, cap) and tax; updated tax-preview assertions to reflect new total calculation.

<sup>Written for commit 984737277e7b2df6783b642c60bafd4e8b83d14d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR surfaces Stripe customer credit balance (`invoice_credits`) and automatic tax in the attach and update-subscription preview responses, and replaces duplicated inline totals UI with a shared `PreviewTotalsBlock` component. Integration tests cover sign-flipping, zero-balance, stripe-checkout, and tax-on/off scenarios for both preview flows.

- **[Improvements, API changes]** `computeAttachPreviewBillingPlan` is widened to accept `BillingContext` (from `AttachBillingContext`), enabling the same tax+credits enrichment to run for both `attach` and `updateSubscription` preview paths; `invoice_credits` is added to both `AttachPreviewResponse` and `PreviewUpdateSubscriptionResponse` schemas.
- **[Improvements]** `applyPreviewAdjustmentsToTotal` in `billingPlanToPreviewResponse.ts` now folds tax and (capped) credit balance into the server-side `total`, replacing the previous double-count where the old `AttachProductSheet` was adding `taxAmount` to an already-tax-inclusive total.
- **[Improvements]** A conditional product-version column (`createProductVersionColumn`) is inserted in the customer list table when any product in the org has more than one version, hidden by default and togglable via the Display dropdown.
</details>

<h3>Confidence Score: 3/5</h3>

The core credit-display logic has an unhandled edge case that can silently produce incorrect totals and a misleading UI for customers with debit Stripe balances.

The sign-flip in `computeAttachInvoiceCreditPreview` only accounts for the common case where Stripe balance is negative (credit). When a customer carries a positive Stripe balance (debit), `-stripeBalance` is negative, `applyPreviewAdjustmentsToTotal` treats it as a negative credit and inflates the displayed total beyond the line-item sum, while `PreviewTotalsBlock` hides the credit row entirely — leaving users with a higher total and no explanation. This affects all three preview surfaces touched by the PR.

server/src/internal/billing/v2/utils/billingPlan/preview/invoiceCredits/computeAttachInvoiceCreditPreview.ts — the balance sign-flip needs a clamp to zero to exclude debit balances

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/billingPlan/preview/invoiceCredits/computeAttachInvoiceCreditPreview.ts | New helper that reads stripeCustomer.balance and flips the sign; does not guard against positive (debit) Stripe balances, which would produce a negative invoice_credits.balance, violating the documented schema contract and creating a silent UI mismatch. |
| server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts | New applyPreviewAdjustmentsToTotal correctly caps credit at max(taxed,0) so the total never goes negative in the credit case; inherits the negative-balance problem from the helper above. |
| server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts | Widened BillingContext param and parallelised tax+credits helpers; unnecessary Promise.resolve wrapper around the sync credits call is harmless but noisy. |
| vite/src/components/v2/preview-totals/PreviewTotalsBlock.tsx | New shared component renders subtotal/tax/credits/total rows; assumes invoice_credits.balance is always non-negative — if a negative value arrives (debit Stripe balance), the credit row is silently hidden while the total is already inflated server-side. |
| shared/api/billing/common/billingPreviewResponse.ts | Adds PreviewInvoiceCreditsSchema with balance documented as 'expressed as a positive number' — contract can be violated when Stripe customer has a positive (debit) balance. |
| server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts | Correctly calls computeAttachPreviewBillingPlan in the preview branch and merges the result onto billingPlan.preview before returning. |
| vite/src/views/customers2/components/sheets/AttachProductSheet.tsx | Replaces inline tax+total rendering with PreviewTotalsBlock; removes the previous double-tax bug where taxAmount was added to an already-tax-inclusive server total. |
| vite/src/views/customers2/hooks/useCustomerListColumns.ts | Conditionally inserts a product_version column after customer_products when any product has multiple versions; column is hidden by default as intended. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant attach/updateSub as attach / updateSubscription
    participant computePreview as computeAttachPreviewBillingPlan
    participant taxHelper as computeAttachTaxPreview
    participant creditsHelper as computeAttachInvoiceCreditPreview
    participant toPreviewResp as billingPlanToPreviewResponse
    participant formatter as billingPlanToAttachPreview / billingPlanToUpdateSubscriptionPreview

    Client->>attach/updateSub: preview: true
    attach/updateSub->>computePreview: {ctx, billingContext, autumnBillingPlan}
    par parallel
        computePreview->>taxHelper: Stripe Tax round-trip
        taxHelper-->>computePreview: PreviewTax | undefined
    and
        computePreview->>creditsHelper: read stripeCustomer.balance
        creditsHelper-->>computePreview: PreviewInvoiceCredits | undefined
    end
    computePreview-->>attach/updateSub: PreviewBillingPlan {tax, invoiceCredits}
    attach/updateSub->>toPreviewResp: billingPlan with preview attached
    toPreviewResp->>toPreviewResp: applyPreviewAdjustmentsToTotal(subtotal, lineItemsTotal, billingPlan)
    Note right of toPreviewResp: total = lineItemsTotal + tax - cappedCredit
    toPreviewResp-->>formatter: BillingPreviewResponse (adjusted total)
    formatter-->>Client: {subtotal, total, tax, invoice_credits, ...}
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/utils/billingPlan/preview/invoiceCredits/computeAttachInvoiceCreditPreview.ts:25-29
When `stripeCustomer.balance` is positive (a debit balance — money the customer owes Stripe), `-stripeBalance` is negative, and `stripeToAtmnAmount` faithfully returns a negative major-unit value. That negative value then flows into `applyPreviewAdjustmentsToTotal` where `cappedCredit = Decimal.min(negative, max(taxed, 0))` equals the negative number, so `taxed - cappedCredit` ends up *larger* than the line-item total. The UI's `PreviewTotalsBlock` hides the credit row when `creditBalance <= 0`, so the inflated total appears with no explanation. The schema docs also state the balance is "expressed as a positive number", which this violates. Clamping to zero before returning keeps the math a no-op for debit balances and preserves the documented contract.

```suggestion
	// Flip sign: Stripe stores credit as negative; we surface as positive.
	// Clamp to zero: positive Stripe balances are debits, not credits — we
	// don't surface them here (they are not "invoice credits").
	const balance = stripeToAtmnAmount({ amount: -stripeBalance, currency });
	return {
		balance: Math.max(balance, 0),
		currency,
	};
```

### Issue 2 of 2
server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts:37-42
`computeAttachInvoiceCreditPreview` is synchronous — it returns `PreviewInvoiceCredits | undefined` directly, not a `Promise`. Wrapping it in `Promise.resolve(...)` is harmless but misleading; it implies the function might be async and adds noise when reading the `Promise.all` pair alongside the genuinely async `computeAttachTaxPreview`.

```suggestion
	const [tax, invoiceCredits] = await Promise.all([
		computeAttachTaxPreview({ ctx, billingContext, autumnBillingPlan }),
		computeAttachInvoiceCreditPreview({ ctx, billingContext }),
	]);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 add tests and stuff"](https://github.com/useautumn/autumn/commit/984737277e7b2df6783b642c60bafd4e8b83d14d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30885100)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->