### PR TITLE
feat: return balances field

### DIFF
--- a/server/src/internal/balances/check/runCheckWithTrackV2.ts
+++ b/server/src/internal/balances/check/runCheckWithTrackV2.ts
@@ -1,4 +1,5 @@
 import {
+	type ApiBalanceV1,
 	ApiVersion,
 	CheckResponseV3Schema,
 	ErrCode,
@@ -77,6 +78,7 @@ export const runCheckWithTrackV2 = async ({
 	};
 
 	let allowed = true;
+	let trackBalances: Record<string, ApiBalanceV1 | null> | undefined;
 
 	try {
 		const response = await runTrackV3({
@@ -86,8 +88,11 @@ export const runCheckWithTrackV2 = async ({
 			apiVersion: ApiVersion.V2_1,
 		});
 
-		checkData.apiBalance = response.balance ?? undefined;
-		checkData.evaluationApiBalance = response.balance ?? undefined;
+		const trackedBalance =
+			response.balance ?? response.balances?.[body.feature_id] ?? undefined;
+		checkData.apiBalance = trackedBalance ?? undefined;
+		checkData.evaluationApiBalance = trackedBalance ?? undefined;
+		trackBalances = response.balances;
 	} catch (error) {
 		if (error instanceof InsufficientBalanceError) {
 			allowed = false;
@@ -140,6 +145,7 @@ export const runCheckWithTrackV2 = async ({
 		entity_id: checkData.entityId,
 		required_balance: requiredBalance,
 		balance: checkData.apiBalance ?? null,
+		balances: trackBalances,
 		flag: checkData.apiFlag ?? null,
 	});
 };

--- a/server/src/internal/balances/track/deductUtils/calculateDeduction.ts
+++ b/server/src/internal/balances/track/deductUtils/calculateDeduction.ts
@@ -34,10 +34,7 @@ export const calculateDeduction = ({
 		const maxAddable =
 			maxBalance === undefined
 				? amountToAdd
-				: Math.max(
-						0,
-						new Decimal(maxBalance).sub(currentBalance).toNumber(),
-					);
+				: Math.max(0, new Decimal(maxBalance).sub(currentBalance).toNumber());
 		const added = Math.min(amountToAdd, maxAddable);
 
 		deducted = -added;
@@ -46,10 +43,7 @@ export const calculateDeduction = ({
 		const maxDeductible =
 			minBalance === undefined
 				? amountToDeduct
-				: Math.max(
-						0,
-						new Decimal(currentBalance).sub(minBalance).toNumber(),
-					);
+				: Math.max(0, new Decimal(currentBalance).sub(minBalance).toNumber());
 		deducted = Math.min(amountToDeduct, maxDeductible);
 		newBalance = new Decimal(currentBalance).sub(deducted).toNumber();
 	}

--- a/server/src/internal/balances/track/runQueuedTrack.ts
+++ b/server/src/internal/balances/track/runQueuedTrack.ts
@@ -1,4 +1,9 @@
-import { ErrCode, RecaseError, type ApiVersion, type TrackParams } from "@autumn/shared";
+import {
+	type ApiVersion,
+	ErrCode,
+	RecaseError,
+	type TrackParams,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getTrackFeatureDeductionsForBody } from "./utils/getFeatureDeductions.js";
 import { runTrackV3 } from "./v3/runTrackV3.js";

--- a/server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts
+++ b/server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts
@@ -1,10 +1,9 @@
 import {
 	type ApiBalanceV1,
-	type FullCustomer,
+	type ApiCustomerV5,
 	getRelevantFeatures,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getApiCustomerBase } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.js";
 import type { FeatureDeduction } from "../types/featureDeduction.js";
 
 /**
@@ -16,17 +15,15 @@ import type { FeatureDeduction } from "../types/featureDeduction.js";
  * the single balance is exposed via the legacy `balance` field by
  * deductionToTrackResponse).
  */
-export const deductionToBalancesResponse = async ({
+export const deductionToBalancesResponse = ({
 	ctx,
-	fullCus,
+	apiCustomer,
 	featureDeductions,
 }: {
 	ctx: AutumnContext;
-	fullCus: FullCustomer;
+	apiCustomer: ApiCustomerV5;
 	featureDeductions: FeatureDeduction[];
-}): Promise<Record<string, ApiBalanceV1 | null> | undefined> => {
-	const { apiCustomer } = await getApiCustomerBase({ ctx, fullCus });
-
+}): Record<string, ApiBalanceV1 | null> | undefined => {
 	const balances: Record<string, ApiBalanceV1 | null> = {};
 
 	for (const deduction of featureDeductions) {

--- a/server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts
+++ b/server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts
@@ -1,0 +1,45 @@
+import {
+	type ApiBalanceV1,
+	type FullCustomer,
+	getRelevantFeatures,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getApiCustomerBase } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.js";
+import type { FeatureDeduction } from "../types/featureDeduction.js";
+
+/**
+ * Builds the `balances` map for a track/check response: the tracked feature's
+ * balance plus every linked credit system's balance (via getRelevantFeatures).
+ * Entries are null when the customer has no balance for that feature.
+ *
+ * Returns undefined when fewer than two relevant balances exist (in that case
+ * the single balance is exposed via the legacy `balance` field by
+ * deductionToTrackResponse).
+ */
+export const deductionToBalancesResponse = async ({
+	ctx,
+	fullCus,
+	featureDeductions,
+}: {
+	ctx: AutumnContext;
+	fullCus: FullCustomer;
+	featureDeductions: FeatureDeduction[];
+}): Promise<Record<string, ApiBalanceV1 | null> | undefined> => {
+	const { apiCustomer } = await getApiCustomerBase({ ctx, fullCus });
+
+	const balances: Record<string, ApiBalanceV1 | null> = {};
+
+	for (const deduction of featureDeductions) {
+		const relevantFeatures = getRelevantFeatures({
+			features: ctx.features,
+			featureId: deduction.feature.id,
+		});
+
+		for (const feature of relevantFeatures) {
+			balances[feature.id] = apiCustomer.balances[feature.id] ?? null;
+		}
+	}
+
+	if (Object.keys(balances).length < 2) return undefined;
+	return balances;
+};

--- a/server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts
+++ b/server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts
@@ -12,10 +12,11 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getApiCustomerBase } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.js";
 import type { DeductionUpdate } from "../types/deductionUpdate.js";
 import type { FeatureDeduction } from "../types/featureDeduction.js";
+import { deductionToBalancesResponse } from "./deductionToBalancesResponse.js";
 
 type TrackBalanceResponse = {
 	balance: ApiBalanceV1 | null;
-	balances?: Record<string, ApiBalanceV1>;
+	balances?: Record<string, ApiBalanceV1 | null>;
 };
 
 /**
@@ -187,23 +188,21 @@ export const deductionToTrackResponse = async ({
 		}
 	}
 
-	// 5. Return appropriate response based on number of balances
+	// `balances` exposes the full record of related features (main + linked
+	// credit systems). `balance` keeps the legacy single-feature heuristic.
+	const balances = await deductionToBalancesResponse({
+		ctx,
+		fullCus,
+		featureDeductions,
+	});
+
 	if (Object.keys(finalBalances).length === 0) {
-		return {
-			balance: null,
-			balances: undefined,
-		};
+		return { balance: null, balances };
 	}
 
 	if (Object.keys(finalBalances).length === 1) {
-		return {
-			balance: Object.values(finalBalances)[0],
-			balances: undefined,
-		};
+		return { balance: Object.values(finalBalances)[0], balances };
 	}
 
-	return {
-		balance: null,
-		balances: finalBalances,
-	};
+	return { balance: null, balances };
 };

--- a/server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts
+++ b/server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts
@@ -190,9 +190,9 @@ export const deductionToTrackResponse = async ({
 
 	// `balances` exposes the full record of related features (main + linked
 	// credit systems). `balance` keeps the legacy single-feature heuristic.
-	const balances = await deductionToBalancesResponse({
+	const balances = deductionToBalancesResponse({
 		ctx,
-		fullCus,
+		apiCustomer,
 		featureDeductions,
 	});
 

--- a/server/src/internal/balances/utils/deductionV2/deductionToBalancesResponseV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/deductionToBalancesResponseV2.ts
@@ -1,0 +1,45 @@
+import {
+	type ApiBalanceV1,
+	type FullSubject,
+	getRelevantFeatures,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getApiSubject } from "@/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.js";
+import type { FeatureDeduction } from "../types/featureDeduction.js";
+
+/**
+ * V2 (FullSubject) variant of deductionToBalancesResponse — returns ALL
+ * balances related to the tracked features (main + linked credit systems),
+ * with null entries for features the customer has no entitlement to.
+ */
+export const deductionToBalancesResponseV2 = async ({
+	ctx,
+	fullSubject,
+	featureDeductions,
+}: {
+	ctx: AutumnContext;
+	fullSubject: FullSubject;
+	featureDeductions: FeatureDeduction[];
+}): Promise<Record<string, ApiBalanceV1 | null> | undefined> => {
+	const apiSubject = await getApiSubject({
+		ctx,
+		fullSubject,
+		includeAggregations: true,
+	});
+
+	const balances: Record<string, ApiBalanceV1 | null> = {};
+
+	for (const deduction of featureDeductions) {
+		const relevantFeatures = getRelevantFeatures({
+			features: ctx.features,
+			featureId: deduction.feature.id,
+		});
+
+		for (const feature of relevantFeatures) {
+			balances[feature.id] = apiSubject.balances?.[feature.id] ?? null;
+		}
+	}
+
+	if (Object.keys(balances).length < 2) return undefined;
+	return balances;
+};

--- a/server/src/internal/balances/utils/deductionV2/deductionToTrackResponseV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/deductionToTrackResponseV2.ts
@@ -12,10 +12,11 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getApiSubject } from "@/internal/customers/cusUtils/getApiCustomerV2/getApiSubject.js";
 import type { DeductionUpdate } from "../types/deductionUpdate.js";
 import type { FeatureDeduction } from "../types/featureDeduction.js";
+import { deductionToBalancesResponseV2 } from "./deductionToBalancesResponseV2.js";
 
 type TrackBalanceResponse = {
 	balance: ApiBalanceV1 | null;
-	balances?: Record<string, ApiBalanceV1>;
+	balances?: Record<string, ApiBalanceV1 | null>;
 };
 
 const computeActualDeductions = ({
@@ -176,22 +177,19 @@ export const deductionToTrackResponseV2 = async ({
 		}
 	}
 
+	const balances = await deductionToBalancesResponseV2({
+		ctx,
+		fullSubject,
+		featureDeductions,
+	});
+
 	if (Object.keys(finalBalances).length === 0) {
-		return {
-			balance: null,
-			balances: undefined,
-		};
+		return { balance: null, balances };
 	}
 
 	if (Object.keys(finalBalances).length === 1) {
-		return {
-			balance: Object.values(finalBalances)[0],
-			balances: undefined,
-		};
+		return { balance: Object.values(finalBalances)[0], balances };
 	}
 
-	return {
-		balance: null,
-		balances: finalBalances,
-	};
+	return { balance: null, balances };
 };

--- a/server/src/internal/balances/utils/deductionV2/index.ts
+++ b/server/src/internal/balances/utils/deductionV2/index.ts
@@ -1,5 +1,6 @@
 export { applyDeductionUpdateToFullSubject } from "./applyDeductionUpdateToFullSubject.js";
 export { applyRolloverUpdatesToFullSubject } from "./applyRolloverUpdatesToFullSubject.js";
+export { deductionToBalancesResponseV2 } from "./deductionToBalancesResponseV2.js";
 export { deductionToTrackResponseV2 } from "./deductionToTrackResponseV2.js";
 export { executePostgresDeductionV2 } from "./executePostgresDeductionV2.js";
 export { executeRedisDeductionV2 } from "./executeRedisDeductionV2.js";

--- a/server/tests/_groups/temp.ts
+++ b/server/tests/_groups/temp.ts
@@ -9,5 +9,7 @@ export const temp: TestGroup = {
 		// "integration/billing/stripe-webhooks/subscription-created",
 		"integration/billing/sync/to-sync-params",
 		// "integration/billing/restore",
+		"integration/balances/track/basic/track-credit-system-all-balances",
+		"integration/balances/check/check-send-event-credit-system",
 	],
 };

--- a/server/tests/integration/balances/check/check-send-event-credit-system.test.ts
+++ b/server/tests/integration/balances/check/check-send-event-credit-system.test.ts
@@ -38,8 +38,6 @@ test.concurrent(`${chalk.yellowBright("check-send-event-credit-system: returns b
 		send_event: true,
 	});
 
-	console.log("Check response:", JSON.stringify(checkRes, null, 2));
-
 	expect(checkRes.allowed).toBe(true);
 	// Backwards-compat single balance
 	expect(checkRes.balance).not.toBeNull();

--- a/server/tests/integration/balances/check/check-send-event-credit-system.test.ts
+++ b/server/tests/integration/balances/check/check-send-event-credit-system.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+
+import type { CheckResponseV3 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// Check + send_event on a feature linked to a credit system should:
+//  - keep `balance` populated with the tracked feature (backwards compat)
+//  - populate `balances` with both the feature and the credit system
+
+test.concurrent(`${chalk.yellowBright("check-send-event-credit-system: returns balance + balances for linked credit system")}`, async () => {
+	const action1Item = items.free({
+		featureId: TestFeature.Action1,
+		includedUsage: 100,
+	});
+	const creditsItem = items.free({
+		featureId: TestFeature.Credits,
+		includedUsage: 200,
+	});
+	const freeProd = products.base({
+		id: "free",
+		items: [action1Item, creditsItem],
+	});
+
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "check-send-event-credit-system",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	const checkRes = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		feature_id: TestFeature.Action1,
+		required_balance: 5,
+		send_event: true,
+	});
+
+	console.log("Check response:", JSON.stringify(checkRes, null, 2));
+
+	expect(checkRes.allowed).toBe(true);
+	// Backwards-compat single balance
+	expect(checkRes.balance).not.toBeNull();
+	expect(checkRes.balance?.feature_id).toBe(TestFeature.Action1);
+	// New balances field exposes both the feature and its credit system
+	expect(checkRes.balances).toBeDefined();
+	expect(Object.keys(checkRes.balances ?? {}).sort()).toEqual(
+		[TestFeature.Action1, TestFeature.Credits].sort(),
+	);
+	expect(checkRes.balances?.[TestFeature.Action1]).not.toBeNull();
+	expect(checkRes.balances?.[TestFeature.Credits]).not.toBeNull();
+});
+
+test.concurrent(`${chalk.yellowBright("check-send-event-no-credit-system: returns single balance and no balances field")}`, async () => {
+	const messagesItem = items.free({
+		featureId: TestFeature.Messages,
+		includedUsage: 100,
+	});
+	const freeProd = products.base({
+		id: "free",
+		items: [messagesItem],
+	});
+
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "check-send-event-no-credit-system",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	const checkRes = await autumnV2_2.check<CheckResponseV3>({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		required_balance: 1,
+		send_event: true,
+	});
+
+	expect(checkRes.allowed).toBe(true);
+	expect(checkRes.balance).not.toBeNull();
+	expect(checkRes.balance?.feature_id).toBe(TestFeature.Messages);
+	expect(checkRes.balances).toBeUndefined();
+});

--- a/server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts
@@ -1,0 +1,225 @@
+import { expect, test } from "bun:test";
+
+import type { TrackResponseV3 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════
+// Scenario A: track feature_id linked to 2 credit systems
+// Action1 → Credits, and we add an extra credit system entry that
+// references Action1 too. v2Features only ships Credits referencing
+// Action1; we use Action1 + Credits (1 main + 1 credit system) = 2
+// balances. To get 3 balances we'd need an extra credit system —
+// instead we cover the multi-credit-system case via Scenario B.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("track-all-balances-A: track feature_id linked to credit system returns both balances")}`, async () => {
+	const action1Item = items.free({
+		featureId: TestFeature.Action1,
+		includedUsage: 100,
+	});
+	const creditsItem = items.free({
+		featureId: TestFeature.Credits,
+		includedUsage: 200,
+	});
+	const freeProd = products.base({
+		id: "free",
+		items: [action1Item, creditsItem],
+	});
+
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "track-all-balances-a",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	const trackRes: TrackResponseV3 = await autumnV2_2.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Action1,
+		value: 10,
+	});
+
+	// `balance` keeps backwards-compat single-feature heuristic
+	expect(trackRes.balance).not.toBeNull();
+	expect(trackRes.balance?.feature_id).toBe(TestFeature.Action1);
+	// `balances` exposes the feature plus its linked credit system
+	expect(trackRes.balances).toBeDefined();
+	expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
+		[TestFeature.Action1, TestFeature.Credits].sort(),
+	);
+	expect(trackRes.balances?.[TestFeature.Action1]).not.toBeNull();
+	expect(trackRes.balances?.[TestFeature.Credits]).not.toBeNull();
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Scenario B: event_name → 2 features, each with 1 credit system
+// "action-event" matches Action1 (→ Credits) and Action3 (→ Credits2).
+// Expect 4 balances: Action1, Action3, Credits, Credits2.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("track-all-balances-B: event_name across two features returns four balances")}`, async () => {
+	const action1Item = items.free({
+		featureId: TestFeature.Action1,
+		includedUsage: 80,
+	});
+	const creditsItem = items.free({
+		featureId: TestFeature.Credits,
+		includedUsage: 150,
+	});
+	const action3Item = items.free({
+		featureId: TestFeature.Action3,
+		includedUsage: 60,
+	});
+	const credits2Item = items.free({
+		featureId: TestFeature.Credits2,
+		includedUsage: 100,
+	});
+	const freeProd = products.base({
+		id: "free",
+		items: [action1Item, creditsItem, action3Item, credits2Item],
+	});
+
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "track-all-balances-b",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	const trackRes: TrackResponseV3 = await autumnV2_2.track({
+		customer_id: customerId,
+		event_name: "action-event",
+		value: 5,
+	});
+
+	expect(trackRes.balance).toBeNull();
+	expect(trackRes.balances).toBeDefined();
+	expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
+		[
+			TestFeature.Action1,
+			TestFeature.Action3,
+			TestFeature.Credits,
+			TestFeature.Credits2,
+		].sort(),
+	);
+	for (const fid of [
+		TestFeature.Action1,
+		TestFeature.Action3,
+		TestFeature.Credits,
+		TestFeature.Credits2,
+	]) {
+		expect(trackRes.balances?.[fid]).not.toBeNull();
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Scenario C: feature_id with no linked credit systems
+// Messages has no credit system referencing it. Expect single balance.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("track-all-balances-C: feature_id with no credit systems returns single balance")}`, async () => {
+	const messagesItem = items.free({
+		featureId: TestFeature.Messages,
+		includedUsage: 100,
+	});
+	const freeProd = products.base({
+		id: "free",
+		items: [messagesItem],
+	});
+
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "track-all-balances-c",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	const trackRes: TrackResponseV3 = await autumnV2_2.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 7,
+	});
+
+	expect(trackRes.balance).not.toBeNull();
+	expect(trackRes.balance?.feature_id).toBe(TestFeature.Messages);
+	expect(trackRes.balances).toBeUndefined();
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Scenario D: tracking a credit system directly does NOT return its
+// metered features (no walking backwards).
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("track-all-balances-D: tracking credit system directly returns only that balance")}`, async () => {
+	const action1Item = items.free({
+		featureId: TestFeature.Action1,
+		includedUsage: 100,
+	});
+	const creditsItem = items.free({
+		featureId: TestFeature.Credits,
+		includedUsage: 200,
+	});
+	const freeProd = products.base({
+		id: "free",
+		items: [action1Item, creditsItem],
+	});
+
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "track-all-balances-d",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	const trackRes: TrackResponseV3 = await autumnV2_2.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Credits,
+		value: 5,
+	});
+
+	expect(trackRes.balance).not.toBeNull();
+	expect(trackRes.balance?.feature_id).toBe(TestFeature.Credits);
+	expect(trackRes.balances).toBeUndefined();
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Scenario E: relevant credit system feature exists in the org but
+// the customer has no entitlement to it. Response key is present
+// with value null.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(`${chalk.yellowBright("track-all-balances-E: missing entitlement on related feature returns null entry")}`, async () => {
+	const action1Item = items.free({
+		featureId: TestFeature.Action1,
+		includedUsage: 100,
+	});
+	const freeProd = products.base({
+		id: "free",
+		items: [action1Item],
+	});
+
+	const { customerId, autumnV2_2 } = await initScenario({
+		customerId: "track-all-balances-e",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	const trackRes: TrackResponseV3 = await autumnV2_2.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Action1,
+		value: 5,
+	});
+
+	console.log("Track response:", JSON.stringify(trackRes, null, 2));
+
+	// `balance` falls back to Action1 (Credits is not entitled)
+	expect(trackRes.balance).not.toBeNull();
+	expect(trackRes.balance?.feature_id).toBe(TestFeature.Action1);
+	// `balances` includes the null entry for the missing entitlement
+	expect(trackRes.balances).toBeDefined();
+	expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
+		[TestFeature.Action1, TestFeature.Credits].sort(),
+	);
+	expect(trackRes.balances?.[TestFeature.Action1]).not.toBeNull();
+	expect(trackRes.balances?.[TestFeature.Credits]).toBeNull();
+});

--- a/server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts
@@ -210,8 +210,6 @@ test.concurrent(`${chalk.yellowBright("track-all-balances-E: missing entitlement
 		value: 5,
 	});
 
-	console.log("Track response:", JSON.stringify(trackRes, null, 2));
-
 	// `balance` falls back to Action1 (Credits is not entitled)
 	expect(trackRes.balance).not.toBeNull();
 	expect(trackRes.balance?.feature_id).toBe(TestFeature.Action1);

--- a/server/tests/integration/balances/track/basic/track-credit-system.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-system.test.ts
@@ -190,6 +190,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system3: test deduction orde
 		current_balance: 100 - deduct1,
 		usage: deduct1,
 	});
+	expect(trackRes1.balances?.[TestFeature.Action1]).toBeDefined();
+	expect(trackRes1.balances?.[TestFeature.Credits]).toBeDefined();
 
 	await timeout(2000);
 	const customer1 = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
@@ -224,6 +226,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system3: test deduction orde
 		current_balance: 0,
 		usage: 100,
 	});
+	expect(trackRes2.balances?.[TestFeature.Action1]).toBeDefined();
+	expect(trackRes2.balances?.[TestFeature.Credits]).toBeDefined();
 
 	await timeout(2000);
 	const customer2 = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
@@ -256,6 +260,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system3: test deduction orde
 		feature_id: TestFeature.Credits,
 		current_balance: new Decimal(creditsBefore!).minus(creditCost3).toNumber(),
 	});
+	expect(trackRes3.balances?.[TestFeature.Action1]).toBeDefined();
+	expect(trackRes3.balances?.[TestFeature.Credits]).toBeDefined();
 
 	await timeout(2000);
 	const customer3 = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
@@ -337,8 +343,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system4: test deduction with
 
 	expect(trackRes1.balances?.[TestFeature.Action1]).toBeDefined();
 	expect(trackRes1.balances?.[TestFeature.Action3]).toBeDefined();
-	expect(trackRes1.balances?.[TestFeature.Credits]).toBeUndefined();
-	expect(trackRes1.balances?.[TestFeature.Credits2]).toBeUndefined();
+	expect(trackRes1.balances?.[TestFeature.Credits]).toBeDefined();
+	expect(trackRes1.balances?.[TestFeature.Credits2]).toBeDefined();
 
 	const customer1 = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 	expect(customer1.features[TestFeature.Action1]).toMatchObject({
@@ -381,8 +387,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system4: test deduction with
 
 	expect(trackRes2.balances?.[TestFeature.Action1]).toBeDefined();
 	expect(trackRes2.balances?.[TestFeature.Action3]).toBeDefined();
-	expect(trackRes2.balances?.[TestFeature.Credits]).toBeUndefined();
-	expect(trackRes2.balances?.[TestFeature.Credits2]).toBeUndefined();
+	expect(trackRes2.balances?.[TestFeature.Credits]).toBeDefined();
+	expect(trackRes2.balances?.[TestFeature.Credits2]).toBeDefined();
 
 	const customer2 = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 	expect(customer2.features[TestFeature.Action1]).toMatchObject({
@@ -431,8 +437,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system4: test deduction with
 		value: deduct3,
 	});
 
-	expect(trackRes3.balances?.[TestFeature.Action1]).toBeUndefined();
-	expect(trackRes3.balances?.[TestFeature.Action3]).toBeUndefined();
+	expect(trackRes3.balances?.[TestFeature.Action1]).toBeDefined();
+	expect(trackRes3.balances?.[TestFeature.Action3]).toBeDefined();
 	expect(trackRes3.balances?.[TestFeature.Credits]).toBeDefined();
 	expect(trackRes3.balances?.[TestFeature.Credits2]).toBeDefined();
 
@@ -531,6 +537,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system5: test deduction orde
 		current_balance: 100 - deduct1,
 		usage: deduct1,
 	});
+	expect(trackRes1.balances?.[TestFeature.Action1]).toBeDefined();
+	expect(trackRes1.balances?.[TestFeature.Credits]).toBeDefined();
 
 	await timeout(2000);
 	const customer1 = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
@@ -570,6 +578,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system5: test deduction orde
 		current_balance: 0,
 		usage: 100,
 	});
+	expect(trackRes2.balances?.[TestFeature.Action1]).toBeDefined();
+	expect(trackRes2.balances?.[TestFeature.Credits]).toBeDefined();
 
 	await timeout(2000);
 	const customer2 = await autumnV1.customers.get<ApiCustomerV3>(customerId, {
@@ -607,6 +617,8 @@ test.concurrent(`${chalk.yellowBright("track-credit-system5: test deduction orde
 		feature_id: TestFeature.Credits,
 		current_balance: new Decimal(creditsBefore!).minus(creditCost3).toNumber(),
 	});
+	expect(trackRes3.balances?.[TestFeature.Action1]).toBeDefined();
+	expect(trackRes3.balances?.[TestFeature.Credits]).toBeDefined();
 
 	await timeout(2000);
 	const customer3 = await autumnV1.customers.get<ApiCustomerV3>(customerId, {

--- a/server/tests/integration/balances/track/basic/track-event-name.test.ts
+++ b/server/tests/integration/balances/track/basic/track-event-name.test.ts
@@ -49,6 +49,8 @@ test.concurrent(`${chalk.yellowBright("track-event-name1: track with event_name 
 	expect(trackRes.balance?.feature_id).toBe(TestFeature.Action1);
 	expect(trackRes.balance?.current_balance).toBe(expectedBalance);
 	expect(trackRes.balance?.usage).toBe(deductValue);
+	expect(trackRes.balances?.[TestFeature.Action1]).toBeDefined();
+	expect(trackRes.balances?.[TestFeature.Credits]).toBeNull();
 
 	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 	expect(customer.features[TestFeature.Action1]).toMatchObject({

--- a/shared/api/balances/check/changes/V2.0_CheckChange.ts
+++ b/shared/api/balances/check/changes/V2.0_CheckChange.ts
@@ -1,4 +1,4 @@
-import { flagV0ToBalanceV0 } from "@api/models.js";
+import { type ApiBalance, flagV0ToBalanceV0 } from "@api/models.js";
 import { ApiVersion } from "@api/versionUtils/ApiVersion.js";
 import {
 	AffectedResource,
@@ -32,6 +32,16 @@ export const V2_0_CheckChange = defineVersionChange({
 	}: {
 		input: z.infer<typeof CheckResponseV3Schema>;
 	}): z.infer<typeof CheckResponseV2Schema> => {
+		let transformedBalances: Record<string, ApiBalance | null> | undefined;
+		if (input.balances) {
+			transformedBalances = {};
+			for (const [featureId, balance] of Object.entries(input.balances)) {
+				transformedBalances[featureId] = balance
+					? balanceV1ToV0({ input: balance })
+					: null;
+			}
+		}
+
 		return {
 			...input,
 			balance: input.balance
@@ -39,6 +49,7 @@ export const V2_0_CheckChange = defineVersionChange({
 				: input.flag
 					? flagV0ToBalanceV0({ input: input.flag })
 					: null,
+			balances: transformedBalances,
 		};
 	},
 });

--- a/shared/api/balances/check/checkFeaturePreview.ts
+++ b/shared/api/balances/check/checkFeaturePreview.ts
@@ -8,7 +8,8 @@ export const CheckFeaturePreviewSchema = z.object({
 			"The reason access was denied. 'usage_limit' means the customer exceeded their balance, 'feature_flag' means the feature is not included in their plan.",
 	}),
 	title: z.string().meta({
-		description: "A title suitable for displaying in a paywall or upgrade modal.",
+		description:
+			"A title suitable for displaying in a paywall or upgrade modal.",
 	}),
 	message: z.string().meta({
 		description: "A message explaining why access was denied.",

--- a/shared/api/balances/check/checkResponseV2.ts
+++ b/shared/api/balances/check/checkResponseV2.ts
@@ -9,6 +9,7 @@ export const CheckResponseV2Schema = z.object({
 	required_balance: z.number().optional(),
 
 	balance: ApiBalanceSchema.nullable(),
+	balances: z.record(z.string(), ApiBalanceSchema.nullable()).optional(),
 
 	preview: CheckFeaturePreviewSchema.optional(),
 });

--- a/shared/api/balances/check/checkResponseV3.ts
+++ b/shared/api/balances/check/checkResponseV3.ts
@@ -27,6 +27,13 @@ export const CheckResponseV3Schema = z.object({
 		description:
 			"The customer's balance for this feature. Null if the customer has no balance for this feature.",
 	}),
+	balances: z
+		.record(z.string(), ApiBalanceV1Schema.nullable())
+		.optional()
+		.meta({
+			description:
+				"Map of feature_id to balance for the checked feature and any related features (e.g. linked credit systems). ",
+		}),
 	flag: ApiFlagV0Schema.nullable().meta({
 		description: "The flag associated with this check, if any.",
 	}),

--- a/shared/api/balances/track/changes/V1.2_TrackChange.ts
+++ b/shared/api/balances/track/changes/V1.2_TrackChange.ts
@@ -55,10 +55,12 @@ export const V1_2_TrackChange = defineVersionChange({
 		if (input.balance?.feature_id) {
 			feature_id = input.balance.feature_id;
 		} else if (input.balances) {
-			// Get first feature_id from balances record
-			const balanceKeys = Object.keys(input.balances);
-			if (balanceKeys.length > 0) {
-				feature_id = input.balances[balanceKeys[0]]?.feature_id;
+			// Pick first non-null entry's feature_id
+			for (const balance of Object.values(input.balances)) {
+				if (balance?.feature_id) {
+					feature_id = balance.feature_id;
+					break;
+				}
 			}
 		}
 

--- a/shared/api/balances/track/changes/V2.0_TrackChange.ts
+++ b/shared/api/balances/track/changes/V2.0_TrackChange.ts
@@ -38,12 +38,14 @@ export const V2_0_TrackChange = defineVersionChange({
 			? balanceV1ToV0({ input: input.balance })
 			: null;
 
-		// Transform balances record
-		let transformedBalances: Record<string, ApiBalance> | undefined;
+		// Transform balances record (preserve null entries)
+		let transformedBalances: Record<string, ApiBalance | null> | undefined;
 		if (input.balances) {
 			transformedBalances = {};
 			for (const [featureId, balance] of Object.entries(input.balances)) {
-				transformedBalances[featureId] = balanceV1ToV0({ input: balance });
+				transformedBalances[featureId] = balance
+					? balanceV1ToV0({ input: balance })
+					: null;
 			}
 		}
 

--- a/shared/api/balances/track/trackResponseV2.ts
+++ b/shared/api/balances/track/trackResponseV2.ts
@@ -20,7 +20,7 @@ export const TrackResponseV2Schema = z.object({
 
 	value: z.number(),
 	balance: ApiBalanceSchema.nullable(),
-	balances: z.record(z.string(), ApiBalanceSchema).optional(),
+	balances: z.record(z.string(), ApiBalanceSchema.nullable()).optional(),
 
 	// feature_id: z.string().optional().meta({
 	// 	description: "The ID of the feature (if provided)",

--- a/shared/api/balances/track/trackResponseV3.ts
+++ b/shared/api/balances/track/trackResponseV3.ts
@@ -10,10 +10,12 @@ export const TrackResponseV3Schema = z.object({
 		description: "The ID of the customer whose usage was tracked.",
 	}),
 	entity_id: z.string().optional().meta({
-		description: "The ID of the entity, if entity-scoped tracking was performed.",
+		description:
+			"The ID of the entity, if entity-scoped tracking was performed.",
 	}),
 	event_name: z.string().optional().meta({
-		description: "The event name that was tracked, if event_name was used instead of feature_id.",
+		description:
+			"The event name that was tracked, if event_name was used instead of feature_id.",
 	}),
 
 	value: z.number().meta({
@@ -23,10 +25,13 @@ export const TrackResponseV3Schema = z.object({
 		description:
 			"The updated balance for the tracked feature. Null if tracking by event_name that affects multiple features.",
 	}),
-	balances: z.record(z.string(), ApiBalanceV1Schema).optional().meta({
-		description:
-			"Map of feature_id to updated balance when tracking by event_name affects multiple features.",
-	}),
+	balances: z
+		.record(z.string(), ApiBalanceV1Schema.nullable())
+		.optional()
+		.meta({
+			description:
+				"Map of feature_id to updated balance for the tracked feature and any related features (e.g. linked credit systems). Value is null when the customer has no balance for that feature.",
+		}),
 });
 
 export type TrackResponseV3 = z.infer<typeof TrackResponseV3Schema>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new balances field to track and check responses so clients can see the tracked feature’s balance plus any linked credit systems, while keeping the legacy balance field for backward compatibility. Also optimizes the v1 track path by reusing the already-fetched customer to avoid a duplicate read.

- **New Features**
  - `track` now includes `balances?: Record<feature_id, ApiBalance | null>` for the tracked feature and related credit systems; entries are `null` when not entitled. Omitted when only one balance is relevant. `balance` remains for single-feature cases.
  - `check` with `send_event` forwards `balances` from the internal track call and sets `balance` from `response.balance` or `response.balances[feature_id]`.
  - Schemas updated: `TrackResponseV3`, `TrackResponseV2`, `CheckResponseV3`, `CheckResponseV2`. Transforms preserve `null` entries and pick the first non-null feature when needed.
  - New helpers `deductionToBalancesResponse` and `deductionToBalancesResponseV2` populate related balances; v1 now reuses the pre-fetched `apiCustomer` to avoid an extra fetch. Integrated into track/check flow. Added integration tests covering linked credit systems, multi-feature events, missing entitlements, direct credit-system tracking, and check+send_event.

- **Migration**
  - No breaking changes. Existing clients can keep using `balance`.
  - To show related balances, read `balances` when present; treat `null` as “no entitlement.”
  - For `check`, prefer `balance` for the tracked feature; fall back to `balances[feature_id]` if needed.

<sup>Written for commit 48947f6ee9f82a231e5ff7ae8a2818fd26b043a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the track and check API responses with a new `balances` field — a map of `feature_id → ApiBalance | null` covering the tracked feature and all linked credit systems, replacing the previous behaviour where only a single `balance` was returned. Version-down transforms (`V2.0_TrackChange`, `V2.0_CheckChange`) are updated to propagate the new field to older API versions, and null entries are now preserved throughout the pipeline.

- **[API changes]** `TrackResponseV3` and `CheckResponseV3` gain an optional `balances` record; `balances` values are now `ApiBalanceV1 | null` (previously non-nullable) across V2 and V3 schemas, and version-down transforms handle null entries correctly.
- **[Improvements]** `deductionToBalancesResponse` / `deductionToBalancesResponseV2` (new helpers) collect all relevant feature balances after a deduction, returning `undefined` when only one balance exists so the legacy `balance` field continues to carry it.
- **[Improvements]** `runCheckWithTrackV2` falls back to `response.balances?.[body.feature_id]` when `response.balance` is null (multi-feature case), keeping backward-compatible balance population for check responses.
</details>


<h3>Confidence Score: 3/5</h3>

Safe to merge conceptually, but every track and check+send_event call now pays for an extra round-trip to fetch the API customer/subject that was already fetched in the same call stack.

The new `balances` helpers each call `getApiCustomerBase` / `getApiSubject` internally, while their callers have already fetched the same object moments before. Every production track event now makes two full customer-state fetches, which could meaningfully impact latency on the hot track path.

`deductionToTrackResponse.ts` and `deductionToTrackResponseV2.ts` are the key files — both now trigger a redundant fetch inside the newly extracted helpers.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts | Delegates `balances` computation to the new helper, but causes `getApiCustomerBase` to be called twice per track operation. |
| server/src/internal/balances/utils/deductionV2/deductionToTrackResponseV2.ts | Same dual-fetch pattern as V1 — `getApiSubject` is called twice per track via `deductionToBalancesResponseV2`. |
| server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts | New helper that builds the `balances` map from `getRelevantFeatures`; logic correct but `getApiCustomerBase` call is redundant given callers already fetch the same object. |
| server/src/internal/balances/utils/deductionV2/deductionToBalancesResponseV2.ts | V2 variant of the balances helper; same redundant `getApiSubject` call issue as V1. |
| server/src/internal/balances/check/runCheckWithTrackV2.ts | Correctly propagates `balances` from track response into check response; fallback to `response.balances?.[body.feature_id]` handles multi-feature tracking cleanly. |
| server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts | Comprehensive new test covering 5 scenarios; has a debug `console.log` left in Scenario E. |
| server/tests/integration/balances/check/check-send-event-credit-system.test.ts | New test verifying `balances` populated on check+send_event; debug `console.log` left in. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Track/CheckAPI
    participant deductionToTrackResponse
    participant getApiCustomerBase
    participant deductionToBalancesResponse

    Client->>Track/CheckAPI: track(feature_id, value)
    Track/CheckAPI->>deductionToTrackResponse: featureDeductions, updates
    deductionToTrackResponse->>getApiCustomerBase: fetch apiCustomer (1st call)
    getApiCustomerBase-->>deductionToTrackResponse: apiCustomer
    Note over deductionToTrackResponse: builds finalBalances (legacy single balance)
    deductionToTrackResponse->>deductionToBalancesResponse: featureDeductions
    deductionToBalancesResponse->>getApiCustomerBase: fetch apiCustomer (2nd call)
    getApiCustomerBase-->>deductionToBalancesResponse: apiCustomer
    deductionToBalancesResponse-->>deductionToTrackResponse: balances map
    deductionToTrackResponse-->>Track/CheckAPI: {balance, balances}
    Track/CheckAPI-->>Client: TrackResponseV3 / CheckResponseV3
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts`, line 153-207 ([link](https://github.com/useautumn/autumn/blob/c907ca329f59bc394da7f6d175292395b91c834c/server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts#L153-L207)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Duplicate `getApiCustomerBase` call on every track**

   `deductionToTrackResponse` already calls `getApiCustomerBase` at line 168 to build `finalBalances`, and then delegates to `deductionToBalancesResponse` (line 193) which calls `getApiCustomerBase` a second time inside that helper. Every track operation now pays for two full API-customer fetches even though both callers use the exact same customer snapshot. The fix is to pass the already-fetched `apiCustomer` into `deductionToBalancesResponse` rather than having it re-fetch it, or to inline the relevant logic. The same pattern exists in `deductionToTrackResponseV2` / `deductionToBalancesResponseV2` (`getApiSubject` is called twice).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts
   Line: 153-207

   Comment:
   **Duplicate `getApiCustomerBase` call on every track**

   `deductionToTrackResponse` already calls `getApiCustomerBase` at line 168 to build `finalBalances`, and then delegates to `deductionToBalancesResponse` (line 193) which calls `getApiCustomerBase` a second time inside that helper. Every track operation now pays for two full API-customer fetches even though both callers use the exact same customer snapshot. The fix is to pass the already-fetched `apiCustomer` into `deductionToBalancesResponse` rather than having it re-fetch it, or to inline the relevant logic. The same pattern exists in `deductionToTrackResponseV2` / `deductionToBalancesResponseV2` (`getApiSubject` is called twice).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/tests/_groups/temp.ts`, line 1-9 ([link](https://github.com/useautumn/autumn/blob/c907ca329f59bc394da7f6d175292395b91c834c/server/tests/_groups/temp.ts#L1-L9)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **New integration tests left in `temp.ts`**

   `temp.ts` appears to be a scratch/temporary test runner. The two newly added test paths (`track-credit-system-all-balances` and `check-send-event-credit-system`) should be moved to the appropriate permanent test group rather than staying in `temp`, otherwise they may not run consistently as part of the standard CI suite after development is complete.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/tests/_groups/temp.ts
   Line: 1-9

   Comment:
   **New integration tests left in `temp.ts`**

   `temp.ts` appears to be a scratch/temporary test runner. The two newly added test paths (`track-credit-system-all-balances` and `check-send-event-credit-system`) should be moved to the appropriate permanent test group rather than staying in `temp`, otherwise they may not run consistently as part of the standard CI suite after development is complete.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/internal/balances/utils/deduction/deductionToTrackResponse.ts:153-207
**Duplicate `getApiCustomerBase` call on every track**

`deductionToTrackResponse` already calls `getApiCustomerBase` at line 168 to build `finalBalances`, and then delegates to `deductionToBalancesResponse` (line 193) which calls `getApiCustomerBase` a second time inside that helper. Every track operation now pays for two full API-customer fetches even though both callers use the exact same customer snapshot. The fix is to pass the already-fetched `apiCustomer` into `deductionToBalancesResponse` rather than having it re-fetch it, or to inline the relevant logic. The same pattern exists in `deductionToTrackResponseV2` / `deductionToBalancesResponseV2` (`getApiSubject` is called twice).

### Issue 2 of 4
server/tests/integration/balances/check/check-send-event-credit-system.test.ts:41-43
Debug `console.log` left in the test — will emit JSON on every CI run, which adds noise to test output.

```suggestion
	expect(checkRes.allowed).toBe(true);
```

### Issue 3 of 4
server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts:213-215
Debug `console.log` left in the test — produces JSON output on every CI run for Scenario E.

```suggestion
	// `balance` falls back to Action1 (Credits is not entitled)
```

### Issue 4 of 4
server/tests/_groups/temp.ts:1-9
**New integration tests left in `temp.ts`**

`temp.ts` appears to be a scratch/temporary test runner. The two newly added test paths (`track-credit-system-all-balances` and `check-send-event-credit-system`) should be moved to the appropriate permanent test group rather than staying in `temp`, otherwise they may not run consistently as part of the standard CI suite after development is complete.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: return balances in track"](https://github.com/useautumn/autumn/commit/c907ca329f59bc394da7f6d175292395b91c834c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30980516)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->