### PR TITLE
Fix dashboard org switcher listing limit

### DIFF
--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -17,6 +17,7 @@ import { replicaDbMiddleware } from "./honoMiddlewares/replicaDbMiddleware.js";
 import type { HonoEnv } from "./honoUtils/HonoEnv.js";
 import { handleHealthCheck } from "./honoUtils/handleHealthCheck.js";
 import { handleReadyCheck } from "./honoUtils/handleReadyCheck.js";
+import { handleListAuthOrganizations } from "./internal/auth/handleListAuthOrganizations.js";
 import { cliRouter } from "./internal/dev/cli/cliRouter.js";
 import { handleOAuthCallback } from "./internal/orgs/handlers/stripeHandlers/handleOAuthCallback.js";
 import { apiRouter } from "./routers/apiRouter.js";
@@ -72,6 +73,9 @@ export const createHonoApp = () => {
 	app.get("/.well-known/oauth-authorization-server/api/auth", (c) => {
 		return oauthProviderAuthServerMetadata(auth)(c.req.raw);
 	});
+
+	// Better Auth's joined Drizzle query defaults to 100 memberships.
+	app.get("/api/auth/organization/list", handleListAuthOrganizations);
 
 	app.on(["POST", "GET"], "/api/auth/*", (c) => {
 		return auth.handler(c.req.raw);

--- a/server/src/internal/auth/handleListAuthOrganizations.ts
+++ b/server/src/internal/auth/handleListAuthOrganizations.ts
@@ -1,0 +1,35 @@
+import { member, organizations } from "@autumn/shared";
+import { asc, eq } from "drizzle-orm";
+import type { Context } from "hono";
+import { db } from "@/db/initDrizzle.js";
+import { auth } from "@/utils/auth.js";
+
+export const handleListAuthOrganizations = async (c: Context) => {
+	const session = await auth.api.getSession({
+		headers: c.req.raw.headers,
+	});
+
+	if (!session?.user?.id) {
+		return c.json({ message: "Unauthorized" }, 401);
+	}
+
+	const orgs = await db
+		.select({
+			id: organizations.id,
+			name: organizations.name,
+			slug: organizations.slug,
+			logo: organizations.logo,
+			createdAt: organizations.createdAt,
+			metadata: organizations.metadata,
+		})
+		.from(member)
+		.innerJoin(organizations, eq(member.organizationId, organizations.id))
+		.where(eq(member.userId, session.user.id))
+		.orderBy(
+			asc(organizations.name),
+			asc(organizations.slug),
+			asc(organizations.id),
+		);
+
+	return c.json(orgs);
+};

--- a/server/src/internal/auth/handleListAuthOrganizations.ts
+++ b/server/src/internal/auth/handleListAuthOrganizations.ts
@@ -1,8 +1,10 @@
-import { member, organizations } from "@autumn/shared";
+import { ErrCode, member, organizations, RecaseError } from "@autumn/shared";
 import { asc, eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { db } from "@/db/initDrizzle.js";
 import { auth } from "@/utils/auth.js";
+
+const AUTH_ORGANIZATION_LIST_LIMIT = 1000;
 
 export const handleListAuthOrganizations = async (c: Context) => {
 	const session = await auth.api.getSession({
@@ -10,7 +12,11 @@ export const handleListAuthOrganizations = async (c: Context) => {
 	});
 
 	if (!session?.user?.id) {
-		return c.json({ message: "Unauthorized" }, 401);
+		throw new RecaseError({
+			message: "Unauthorized - no session found",
+			code: ErrCode.NoAuthHeader,
+			statusCode: 401,
+		});
 	}
 
 	const orgs = await db
@@ -29,7 +35,8 @@ export const handleListAuthOrganizations = async (c: Context) => {
 			asc(organizations.name),
 			asc(organizations.slug),
 			asc(organizations.id),
-		);
+		)
+		.limit(AUTH_ORGANIZATION_LIST_LIMIT);
 
 	return c.json(orgs);
 };

--- a/vite/src/views/main-sidebar/components/OrgDropdown.tsx
+++ b/vite/src/views/main-sidebar/components/OrgDropdown.tsx
@@ -147,11 +147,7 @@ export const OrgDropdown = () => {
 								<Settings size={14} />
 							</div>
 						</DropdownMenuItem>
-						<DropdownMenuItem
-							onClick={(e) => {
-								setDialogType("create");
-							}}
-						>
+						<DropdownMenuItem onClick={() => setDialogType("create")}>
 							<div className="flex justify-between w-full items-center gap-2 text-t2">
 								<span>Create Organization</span>
 								<Plus size={14} />
@@ -159,7 +155,7 @@ export const OrgDropdown = () => {
 						</DropdownMenuItem>
 						{!expanded && (
 							<DropdownMenuItem
-								onClick={(e) => {
+								onClick={() => {
 									setExpanded(true);
 									setDropdownOpen(false);
 								}}
@@ -213,7 +209,7 @@ export const OrgDropdown = () => {
 										Switch Organization
 									</DropdownMenuSubTrigger>
 									<DropdownMenuPortal>
-										<DropdownMenuSubContent className="w-48">
+										<DropdownMenuSubContent className="w-64 max-h-[min(28rem,calc(100vh-4rem))] overflow-y-auto">
 											{orgs.map((org) => (
 												<SwitchOrgItem
 													key={org.id}
@@ -271,15 +267,25 @@ export const useOrgSwitch = () => {
 				const search = window.location.search;
 				navigate(`/sandbox${pathname}${search}`);
 			}
-		} catch (error: any) {
-			toast.error(error.message);
+		} catch (error) {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Failed to switch organization",
+			);
 		} finally {
 			setLoading?.(false);
 		}
 	};
 };
 
-const SwitchOrgItem = ({ org, setDropdownOpen }: any) => {
+const SwitchOrgItem = ({
+	org,
+	setDropdownOpen,
+}: {
+	org: { id: string; name: string };
+	setDropdownOpen: (open: boolean) => void;
+}) => {
 	const [loading, setLoading] = useState(false);
 	const switchOrg = useOrgSwitch();
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the dashboard org switcher so it lists all organizations, not just the first 100. Adds a backend endpoint and UI tweaks to load and scroll big org lists.

- **Bug Fixes**
  - Added `GET /api/auth/organization/list` to return all user orgs via `member` → `organizations` join, ordered by name/slug/id and capped at 1000.
  - Registered the route in server init.
  - Widened the switcher submenu and added a viewport-aware max height with scroll.
  - Hardened org switch errors (fallback message) and added strict types for the menu item.

<sup>Written for commit ddb2080ee461bcd1d8589730df145dd0c7ee1e26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

