### PR TITLE
fix: balances validation

### DIFF
--- a/server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts
+++ b/server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts
@@ -33,7 +33,7 @@ export const deductionToBalancesResponse = ({
 		});
 
 		for (const feature of relevantFeatures) {
-			balances[feature.id] = apiCustomer.balances[feature.id] ?? null;
+			balances[feature.id] = apiCustomer.balances[feature.id] ?? undefined;
 		}
 	}
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix balances validation by setting missing feature balances to undefined instead of null. This aligns the response with the expected schema and prevents validation errors.

<sup>Written for commit 6830fefe12c3ce35a2cc4949021e58aa95ba52fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a validation issue in the balances response by swapping the `null` fallback to `undefined` for missing feature balances — `undefined` values are omitted by `JSON.stringify`, preventing downstream schema validation failures.

- **[Bug fixes]** `deductionToBalancesResponse`: changes the nullish-coalescing fallback from `?? null` to `?? undefined` so that feature IDs absent from `apiCustomer.balances` are dropped from the JSON response instead of appearing as explicit `null` entries.
- **[Bug fixes]** The local variable type and function return type (`Record<string, ApiBalanceV1 | null>`) no longer match the actual runtime values, which can now include `undefined`; the `TrackBalanceResponse.balances` field in `deductionToTrackResponse.ts` inherits the same stale `| null` annotation.
</details>


<h3>Confidence Score: 3/5</h3>

The behavioral change is intentional and the JSON output is correct, but the type annotations in the changed file (and the consuming TrackBalanceResponse) still declare | null while the record now carries | undefined values at runtime.

The one-line fix correctly strips null entries from the JSON response. However, the declared type of the local balances variable and the function return type both still say Record<string, ApiBalanceV1 | null>, when they should say | undefined. TypeScript does not catch this silently because apiCustomer.balances is typed without noUncheckedIndexedAccess, leaving in-process consumers with a false type contract.

deductionToBalancesResponse.ts needs its type declarations updated; deductionToTrackResponse.ts (TrackBalanceResponse.balances) should be reviewed for the same | null annotation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts | Changed fallback from `null` to `undefined` for missing balances (fixing validation); local variable and return type still declare `| null` instead of `| undefined`, creating a silent type mismatch. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts`, line 26-27 ([link](https://github.com/useautumn/autumn/blob/6830fefe12c3ce35a2cc4949021e58aa95ba52fd/server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts#L26-L27)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The `balances` object is declared as `Record<string, ApiBalanceV1 | null>` and the function's return type mirrors that, but after this change the record values can now be `undefined` (when `apiCustomer.balances[feature.id]` is absent). TypeScript does not catch this at compile time (because `apiCustomer.balances` is typed as `Record<string, ApiBalanceV1>` without `noUncheckedIndexedAccess`), so consumers that read back from this record and branch on `| null` may get `undefined` unexpectedly. Update the local variable and return type to reflect the actual value domain.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts
   Line: 26-27

   Comment:
   The `balances` object is declared as `Record<string, ApiBalanceV1 | null>` and the function's return type mirrors that, but after this change the record values can now be `undefined` (when `apiCustomer.balances[feature.id]` is absent). TypeScript does not catch this at compile time (because `apiCustomer.balances` is typed as `Record<string, ApiBalanceV1>` without `noUncheckedIndexedAccess`), so consumers that read back from this record and branch on `| null` may get `undefined` unexpectedly. Update the local variable and return type to reflect the actual value domain.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts`, line 12 ([link](https://github.com/useautumn/autumn/blob/6830fefe12c3ce35a2cc4949021e58aa95ba52fd/server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts#L12)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The JSDoc comment still says entries are `null` for missing balances, but after this change they will be `undefined` (and therefore omitted from JSON). Update the comment to match the new behaviour.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts
   Line: 12

   Comment:
   The JSDoc comment still says entries are `null` for missing balances, but after this change they will be `undefined` (and therefore omitted from JSON). Update the comment to match the new behaviour.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts:26-27
The `balances` object is declared as `Record<string, ApiBalanceV1 | null>` and the function's return type mirrors that, but after this change the record values can now be `undefined` (when `apiCustomer.balances[feature.id]` is absent). TypeScript does not catch this at compile time (because `apiCustomer.balances` is typed as `Record<string, ApiBalanceV1>` without `noUncheckedIndexedAccess`), so consumers that read back from this record and branch on `| null` may get `undefined` unexpectedly. Update the local variable and return type to reflect the actual value domain.

```suggestion
}): Record<string, ApiBalanceV1 | undefined> | undefined => {
	const balances: Record<string, ApiBalanceV1 | undefined> = {};
```

### Issue 2 of 2
server/src/internal/balances/utils/deduction/deductionToBalancesResponse.ts:12
The JSDoc comment still says entries are `null` for missing balances, but after this change they will be `undefined` (and therefore omitted from JSON). Update the comment to match the new behaviour.

```suggestion
 * Entries are omitted (undefined) when the customer has no balance for that feature.
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: balances validation"](https://github.com/useautumn/autumn/commit/6830fefe12c3ce35a2cc4949021e58aa95ba52fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31047908)</sub>

<!-- /greptile_comment -->