### PR TITLE
Add admin UI to manage per-org Redis routing across orgs

### DIFF
--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -5,6 +5,12 @@ import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSourc
 import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsConfig";
 import { handleGetAdminJobQueueConfig } from "./handleGetAdminJobQueueConfig";
 import { handleGetAdminOrgLimitsConfig } from "./handleGetAdminOrgLimitsConfig";
+import {
+	handleDeleteAdminOrgRedisConfig,
+	handleGetAdminOrgRedisConfig,
+	handleUpdateAdminOrgRedisMigration,
+	handleUpsertAdminOrgRedisConfig,
+} from "./handleAdminOrgRedisConfig";
 import { handleGetAdminOrgRequestBlock } from "./handleGetAdminOrgRequestBlock";
 import { handleGetAdminRequestBlockConfig } from "./handleGetAdminRequestBlockConfig";
 import { handleGetAdminRedisV2CacheConfig } from "./handleGetAdminRedisV2CacheConfig";
@@ -42,6 +48,19 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/orgs/:org_id/request-block",
 	...handleUpsertAdminOrgRequestBlock,
+);
+honoAdminRouter.get("/orgs/:org_id/redis", ...handleGetAdminOrgRedisConfig);
+honoAdminRouter.patch(
+	"/orgs/:org_id/redis",
+	...handleUpsertAdminOrgRedisConfig,
+);
+honoAdminRouter.patch(
+	"/orgs/:org_id/redis/migration",
+	...handleUpdateAdminOrgRedisMigration,
+);
+honoAdminRouter.delete(
+	"/orgs/:org_id/redis",
+	...handleDeleteAdminOrgRedisConfig,
 );
 honoAdminRouter.get(
 	"/request-block-config",

--- a/server/src/internal/admin/handleAdminOrgRedisConfig.ts
+++ b/server/src/internal/admin/handleAdminOrgRedisConfig.ts
@@ -1,0 +1,209 @@
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
+import { z } from "zod/v4";
+import { getOrgRedis, removeOrgRedis } from "@/external/redis/orgRedisPool.js";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
+import { encryptData } from "@/utils/encryptUtils.js";
+
+const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
+
+const orgIdParam = z.object({ org_id: z.string().min(1) });
+
+const loadTargetOrg = async ({ db, orgId }: { db: any; orgId: string }) => {
+	const org = await OrgService.get({ db, orgId });
+	if (!org) {
+		throw new RecaseError({
+			message: `Org not found: ${orgId}`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 404,
+		});
+	}
+	return org;
+};
+
+/**
+ * GET /admin/orgs/:org_id/redis
+ * Returns the org's redis_config in frontend-safe shape (host + percent only).
+ */
+export const handleGetAdminOrgRedisConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	params: orgIdParam,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { org_id: orgId } = c.req.valid("param");
+		const org = await loadTargetOrg({ db: ctx.db, orgId });
+
+		return c.json({
+			org_id: org.id,
+			org_slug: org.slug,
+			redis_config: org.redis_config
+				? {
+						host: org.redis_config.url,
+						migrationPercent: org.redis_config.migrationPercent,
+						previousMigrationPercent: org.redis_config.previousMigrationPercent,
+						migrationChangedAt: org.redis_config.migrationChangedAt,
+					}
+				: null,
+		});
+	},
+});
+
+/**
+ * PATCH /admin/orgs/:org_id/redis  body: { connectionString }
+ * Initial-create the redis_config for the target org. Encrypts connection
+ * string, stores host separately, sets migrationPercent: 0.
+ */
+export const handleUpsertAdminOrgRedisConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	params: orgIdParam,
+	body: z.object({ connectionString: z.string().min(1) }),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, logger } = ctx;
+		const { org_id: orgId } = c.req.valid("param");
+		const { connectionString: rawConnectionString } = c.req.valid("json");
+		const connectionString = rawConnectionString.trim();
+
+		const org = await loadTargetOrg({ db, orgId });
+
+		if (org.redis_config) {
+			throw new RecaseError({
+				message:
+					"Redis config already exists for this org. Remove it before creating a new one.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		let redisUrl: URL;
+		try {
+			redisUrl = new URL(connectionString);
+		} catch {
+			throw new RecaseError({
+				message: "Invalid connection string: could not parse URL",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		if (!REDIS_PROTOCOLS.has(redisUrl.protocol)) {
+			throw new RecaseError({
+				message: "Invalid connection string: expected redis:// or rediss://",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		const now = Date.now();
+		const updatedOrg = await OrgService.update({
+			db,
+			orgId: org.id,
+			updates: {
+				redis_config: {
+					connectionString: encryptData(connectionString),
+					url: redisUrl.host,
+					migrationPercent: 0,
+					previousMigrationPercent: 0,
+					migrationChangedAt: now,
+				},
+			},
+		});
+
+		if (updatedOrg) {
+			getOrgRedis({ org: updatedOrg });
+			await clearOrgCache({ db, orgId: org.id, env: ctx.env, logger });
+			logger.info(
+				`[admin/handleUpsertAdminOrgRedisConfig] org=${org.id}: redis_config created, url=${redisUrl.host}, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
+			);
+		}
+
+		return c.json({ success: true });
+	},
+});
+
+/**
+ * PATCH /admin/orgs/:org_id/redis/migration  body: { migrationPercent }
+ * Update the migrationPercent field. Stores previous value + timestamp so
+ * the staleness primitive (isRedisMigrationCacheStale) can evict entries
+ * whose bucket crossed the threshold.
+ */
+export const handleUpdateAdminOrgRedisMigration = createRoute({
+	scopes: [Scopes.Superuser],
+	params: orgIdParam,
+	body: z.object({ migrationPercent: z.number().int().min(0).max(100) }),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, logger } = ctx;
+		const { org_id: orgId } = c.req.valid("param");
+		const { migrationPercent } = c.req.valid("json");
+
+		const org = await loadTargetOrg({ db, orgId });
+
+		if (!org.redis_config) {
+			throw new RecaseError({
+				message: "No Redis config set on this org. Connect one first.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await OrgService.update({
+			db,
+			orgId: org.id,
+			updates: {
+				redis_config: {
+					...org.redis_config,
+					previousMigrationPercent: org.redis_config.migrationPercent,
+					migrationPercent,
+					migrationChangedAt: Date.now(),
+				},
+			},
+		});
+		await clearOrgCache({ db, orgId: org.id, env: ctx.env, logger });
+
+		logger.info(
+			`[admin/handleUpdateAdminOrgRedisMigration] org=${org.id}: ${org.redis_config.migrationPercent}% -> ${migrationPercent}%, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
+		);
+
+		return c.json({ success: true });
+	},
+});
+
+/**
+ * DELETE /admin/orgs/:org_id/redis
+ * Removes the redis_config entirely. Refuses while migrationPercent > 0
+ * to prevent yanking the rug from under in-flight customers.
+ */
+export const handleDeleteAdminOrgRedisConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	params: orgIdParam,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, logger } = ctx;
+		const { org_id: orgId } = c.req.valid("param");
+
+		const org = await loadTargetOrg({ db, orgId });
+
+		if (org.redis_config && org.redis_config.migrationPercent > 0) {
+			throw new RecaseError({
+				message: `Cannot remove Redis config while migrationPercent is ${org.redis_config.migrationPercent}%. Set it to 0 first.`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await OrgService.update({
+			db,
+			orgId: org.id,
+			updates: { redis_config: null },
+		});
+		await clearOrgCache({ db, orgId: org.id, env: ctx.env, logger });
+		removeOrgRedis({ orgId: org.id });
+
+		logger.info(
+			`[admin/handleDeleteAdminOrgRedisConfig] org=${org.id}: redis_config removed, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
+		);
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/admin/handleAdminOrgRedisConfig.ts
+++ b/server/src/internal/admin/handleAdminOrgRedisConfig.ts
@@ -31,7 +31,7 @@ export const handleGetAdminOrgRedisConfig = createRoute({
 	params: orgIdParam,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const { org_id: orgId } = c.req.valid("param");
+		const { org_id: orgId } = c.req.param();
 		const org = await loadTargetOrg({ db: ctx.db, orgId });
 
 		return c.json({
@@ -61,7 +61,7 @@ export const handleUpsertAdminOrgRedisConfig = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, logger } = ctx;
-		const { org_id: orgId } = c.req.valid("param");
+		const { org_id: orgId } = c.req.param();
 		const { connectionString: rawConnectionString } = c.req.valid("json");
 		const connectionString = rawConnectionString.trim();
 
@@ -134,7 +134,7 @@ export const handleUpdateAdminOrgRedisMigration = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, logger } = ctx;
-		const { org_id: orgId } = c.req.valid("param");
+		const { org_id: orgId } = c.req.param();
 		const { migrationPercent } = c.req.valid("json");
 
 		const org = await loadTargetOrg({ db, orgId });
@@ -180,7 +180,7 @@ export const handleDeleteAdminOrgRedisConfig = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, logger } = ctx;
-		const { org_id: orgId } = c.req.valid("param");
+		const { org_id: orgId } = c.req.param();
 
 		const org = await loadTargetOrg({ db, orgId });
 

--- a/server/src/internal/admin/handleAdminOrgRedisConfig.ts
+++ b/server/src/internal/admin/handleAdminOrgRedisConfig.ts
@@ -10,18 +10,6 @@ const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
 
 const orgIdParam = z.object({ org_id: z.string().min(1) });
 
-const loadTargetOrg = async ({ db, orgId }: { db: any; orgId: string }) => {
-	const org = await OrgService.get({ db, orgId });
-	if (!org) {
-		throw new RecaseError({
-			message: `Org not found: ${orgId}`,
-			code: ErrCode.InvalidRequest,
-			statusCode: 404,
-		});
-	}
-	return org;
-};
-
 /**
  * GET /admin/orgs/:org_id/redis
  * Returns the org's redis_config in frontend-safe shape (host + percent only).
@@ -32,7 +20,7 @@ export const handleGetAdminOrgRedisConfig = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { org_id: orgId } = c.req.param();
-		const org = await loadTargetOrg({ db: ctx.db, orgId });
+		const org = await OrgService.get({ db: ctx.db, orgId });
 
 		return c.json({
 			org_id: org.id,
@@ -65,7 +53,7 @@ export const handleUpsertAdminOrgRedisConfig = createRoute({
 		const { connectionString: rawConnectionString } = c.req.valid("json");
 		const connectionString = rawConnectionString.trim();
 
-		const org = await loadTargetOrg({ db, orgId });
+		const org = await OrgService.get({ db, orgId });
 
 		if (org.redis_config) {
 			throw new RecaseError({
@@ -137,7 +125,7 @@ export const handleUpdateAdminOrgRedisMigration = createRoute({
 		const { org_id: orgId } = c.req.param();
 		const { migrationPercent } = c.req.valid("json");
 
-		const org = await loadTargetOrg({ db, orgId });
+		const org = await OrgService.get({ db, orgId });
 
 		if (!org.redis_config) {
 			throw new RecaseError({
@@ -182,7 +170,7 @@ export const handleDeleteAdminOrgRedisConfig = createRoute({
 		const { db, logger } = ctx;
 		const { org_id: orgId } = c.req.param();
 
-		const org = await loadTargetOrg({ db, orgId });
+		const org = await OrgService.get({ db, orgId });
 
 		if (org.redis_config && org.redis_config.migrationPercent > 0) {
 			throw new RecaseError({

--- a/server/src/internal/admin/handleListAdminOrgs.ts
+++ b/server/src/internal/admin/handleListAdminOrgs.ts
@@ -98,17 +98,28 @@ export const handleListAdminOrgs = createRoute({
 			.where(inArray(member.organizationId, orgIds));
 
 		return c.json({
-			rows: orgs.slice(0, 20).map((org) => ({
-				...org,
-				users: memberships
-					.filter((membership) => membership.member.organizationId === org.id)
-					.map((membership) => membership.user),
-				requestBlockSummary: {
-					blockAll: requestBlockConfig.orgs[org.id]?.blockAll ?? false,
-					ruleCount:
-						requestBlockConfig.orgs[org.id]?.blockedEndpoints.length ?? 0,
-				},
-			})),
+			rows: orgs.slice(0, 20).map((org) => {
+				const { redis_config: rawRedisConfig, ...rest } = org;
+				return {
+					...rest,
+					// Redact encrypted connection string from admin list — UI only
+					// needs host + percent for the table column.
+					redis_config: rawRedisConfig
+						? {
+								url: rawRedisConfig.url,
+								migrationPercent: rawRedisConfig.migrationPercent,
+							}
+						: null,
+					users: memberships
+						.filter((membership) => membership.member.organizationId === org.id)
+						.map((membership) => membership.user),
+					requestBlockSummary: {
+						blockAll: requestBlockConfig.orgs[org.id]?.blockAll ?? false,
+						ruleCount:
+							requestBlockConfig.orgs[org.id]?.blockedEndpoints.length ?? 0,
+					},
+				};
+			}),
 			hasNextPage: orgs.length > 20,
 		});
 	},

--- a/vite/src/views/admin/AdminOrgColumns.tsx
+++ b/vite/src/views/admin/AdminOrgColumns.tsx
@@ -153,10 +153,10 @@ export const createAdminOrgColumns = ({
 			const users = row.original.users;
 			const firstNonAdminUser = users.find((user) => user.role !== "admin");
 
-			if (!firstNonAdminUser) {
-				return null;
-			}
-
+			// Org-level admin actions (Block, Redis) must remain reachable even when
+			// the org has only admin users — gating them on `firstNonAdminUser`
+			// would silently hide them. Only `ImpersonateButton` requires a
+			// non-admin user to target.
 			return (
 				<div onClick={(e) => e.stopPropagation()} className="flex gap-2">
 					<Button
@@ -173,7 +173,9 @@ export const createAdminOrgColumns = ({
 					>
 						Redis
 					</Button>
-					<ImpersonateButton userId={firstNonAdminUser.id} />
+					{firstNonAdminUser && (
+						<ImpersonateButton userId={firstNonAdminUser.id} />
+					)}
 				</div>
 			);
 		},

--- a/vite/src/views/admin/AdminOrgColumns.tsx
+++ b/vite/src/views/admin/AdminOrgColumns.tsx
@@ -16,12 +16,18 @@ export type AdminOrg = {
 		blockAll: boolean;
 		ruleCount: number;
 	};
+	redis_config: {
+		url: string;
+		migrationPercent: number;
+	} | null;
 };
 
 export const createAdminOrgColumns = ({
 	onManageRequestBlocks,
+	onManageRedis,
 }: {
 	onManageRequestBlocks: (org: AdminOrg) => void;
+	onManageRedis: (org: AdminOrg) => void;
 }): ColumnDef<AdminOrg, unknown>[] => [
 	{
 		id: "id",
@@ -111,6 +117,34 @@ export const createAdminOrgColumns = ({
 		},
 	},
 	{
+		id: "redisConfig",
+		header: "Redis",
+		accessorKey: "redis_config",
+		cell: ({ row }: { row: Row<AdminOrg> }) => {
+			const cfg = row.original.redis_config;
+			if (!cfg) return <Badge variant="muted">Shared V2</Badge>;
+			if (cfg.migrationPercent === 0) {
+				return (
+					<Badge className="bg-amber-50 text-amber-700 border-amber-200">
+						Configured (0%)
+					</Badge>
+				);
+			}
+			if (cfg.migrationPercent === 100) {
+				return (
+					<Badge className="bg-emerald-50 text-emerald-700 border-emerald-200">
+						100% routed
+					</Badge>
+				);
+			}
+			return (
+				<Badge className="bg-blue-50 text-blue-700 border-blue-200">
+					{cfg.migrationPercent}% routed
+				</Badge>
+			);
+		},
+	},
+	{
 		id: "impersonate",
 		header: "Actions",
 		enableSorting: false,
@@ -131,6 +165,13 @@ export const createAdminOrgColumns = ({
 						onClick={() => onManageRequestBlocks(row.original)}
 					>
 						Block
+					</Button>
+					<Button
+						variant="secondary"
+						size="sm"
+						onClick={() => onManageRedis(row.original)}
+					>
+						Redis
 					</Button>
 					<ImpersonateButton userId={firstNonAdminUser.id} />
 				</div>

--- a/vite/src/views/admin/AdminOrgTable.tsx
+++ b/vite/src/views/admin/AdminOrgTable.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/v2/buttons/Button";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { type AdminOrg, createAdminOrgColumns } from "./AdminOrgColumns";
+import { OrgRedisConfigDialog } from "./components/OrgRedisConfigDialog";
 import { RequestBlockDialog } from "./components/RequestBlockDialog";
 import { useAdminTable } from "./hooks/useAdminTable";
 
@@ -15,6 +16,7 @@ export const AdminOrgTable = () => {
 	const [before, setBefore] = useState<string | undefined>(undefined);
 	const [page, setPage] = useState(1);
 	const [selectedOrg, setSelectedOrg] = useState<AdminOrg | null>(null);
+	const [redisOrg, setRedisOrg] = useState<AdminOrg | null>(null);
 
 	const params = new URLSearchParams();
 	if (search) params.append("search", search);
@@ -65,6 +67,7 @@ export const AdminOrgTable = () => {
 		() =>
 			createAdminOrgColumns({
 				onManageRequestBlocks: (org) => setSelectedOrg(org),
+				onManageRedis: (org) => setRedisOrg(org),
 			}),
 		[],
 	);
@@ -87,6 +90,19 @@ export const AdminOrgTable = () => {
 				}}
 				orgId={selectedOrg?.id}
 				orgName={selectedOrg?.name}
+				onSaved={async () => {
+					await refetch();
+				}}
+			/>
+			<OrgRedisConfigDialog
+				open={Boolean(redisOrg)}
+				onOpenChange={(open) => {
+					if (!open) {
+						setRedisOrg(null);
+					}
+				}}
+				orgId={redisOrg?.id}
+				orgName={redisOrg?.name}
 				onSaved={async () => {
 					await refetch();
 				}}

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -63,10 +63,13 @@ export function OrgRedisConfigDialog({
 			enabled: open && !!orgId,
 		});
 
-	// Surface load failures as a toast (parity with previous behavior).
+	// Surface load failures as a toast — only when there's no data to fall
+	// back on. After a successful mutation triggers a refetch, transient GET
+	// failures shouldn't surface as "Failed to load" since the dialog can
+	// keep displaying the previous data.
 	useEffect(() => {
-		if (isError) toast.error("Failed to load Redis config");
-	}, [isError]);
+		if (isError && !data) toast.error("Failed to load Redis config");
+	}, [isError, data]);
 
 	// Sync the editable migration input from server data when it loads or
 	// changes (e.g. after a successful update).
@@ -78,12 +81,22 @@ export function OrgRedisConfigDialog({
 		}
 	}, [data]);
 
-	// Reset transient inputs when (re)opening for a different org.
+	// Reset transient inputs when (re)opening — including same-org reopens.
+	// React Query's structural sharing means cached `data` may be returned
+	// with the same reference on reopen, so the `[data]` effect above won't
+	// fire. Without resetting `migrationInput` here, a previously typed but
+	// unsaved value would persist into the next session and the admin could
+	// silently apply a stale edit.
 	useEffect(() => {
 		if (open && orgId) {
 			setConnectionString("");
 			setRemoveConfirm("");
+			setMigrationInput(
+				data?.redis_config ? String(data.redis_config.migrationPercent) : "",
+			);
 		}
+		// `data` deliberately excluded — refetches shouldn't clobber edits.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [open, orgId]);
 
 	// Best-effort post-mutation refetch + parent notification. Failures here

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/v2/buttons/Button";
@@ -41,8 +42,6 @@ export function OrgRedisConfigDialog({
 	onSaved: () => void | Promise<void>;
 }) {
 	const axiosInstance = useAxiosInstance();
-	const [loading, setLoading] = useState(false);
-	const [data, setData] = useState<AdminOrgRedisConfigResponse | null>(null);
 
 	const [connectionString, setConnectionString] = useState("");
 	const [migrationInput, setMigrationInput] = useState("");
@@ -52,56 +51,50 @@ export function OrgRedisConfigDialog({
 	const [updatingMigration, setUpdatingMigration] = useState(false);
 	const [removing, setRemoving] = useState(false);
 
-	useEffect(() => {
-		if (!open || !orgId) return;
-
-		let cancelled = false;
-		setLoading(true);
-		setConnectionString("");
-		setRemoveConfirm("");
-
-		axiosInstance
-			.get<AdminOrgRedisConfigResponse>(`/admin/orgs/${orgId}/redis`)
-			.then(({ data }) => {
-				if (cancelled) return;
-				setData(data);
-				setMigrationInput(
-					data.redis_config ? String(data.redis_config.migrationPercent) : "0",
+	const { data, isLoading, isError, refetch } =
+		useQuery<AdminOrgRedisConfigResponse>({
+			queryKey: ["admin-org-redis", orgId],
+			queryFn: async () => {
+				const { data } = await axiosInstance.get<AdminOrgRedisConfigResponse>(
+					`/admin/orgs/${orgId}/redis`,
 				);
-			})
-			.catch((error) => {
-				if (cancelled) return;
-				toast.error(getBackendErr(error, "Failed to load Redis config"));
-			})
-			.finally(() => {
-				if (!cancelled) setLoading(false);
-			});
+				return data;
+			},
+			enabled: open && !!orgId,
+		});
 
-		return () => {
-			cancelled = true;
-		};
-	}, [open, orgId, axiosInstance]);
+	// Surface load failures as a toast (parity with previous behavior).
+	useEffect(() => {
+		if (isError) toast.error("Failed to load Redis config");
+	}, [isError]);
 
-	const refresh = async () => {
-		if (!orgId) return;
-		const { data } = await axiosInstance.get<AdminOrgRedisConfigResponse>(
-			`/admin/orgs/${orgId}/redis`,
-		);
-		setData(data);
-		setMigrationInput(
-			data.redis_config ? String(data.redis_config.migrationPercent) : "0",
-		);
-	};
+	// Sync the editable migration input from server data when it loads or
+	// changes (e.g. after a successful update).
+	useEffect(() => {
+		if (data) {
+			setMigrationInput(
+				data.redis_config ? String(data.redis_config.migrationPercent) : "0",
+			);
+		}
+	}, [data]);
+
+	// Reset transient inputs when (re)opening for a different org.
+	useEffect(() => {
+		if (open && orgId) {
+			setConnectionString("");
+			setRemoveConfirm("");
+		}
+	}, [open, orgId]);
 
 	// Best-effort post-mutation refetch + parent notification. Failures here
-	// must not surface as errors because the mutation itself has already
-	// persisted — a transient GET failure should not be reported as
-	// "Failed to connect/update/remove". Each step is also independent so a
-	// failure in `refresh()` (local dialog state) doesn't skip `onSaved()`
-	// (parent table refetch), and vice versa.
+	// must not surface as errors because the mutation has already persisted —
+	// a transient GET failure should not be reported as
+	// "Failed to connect/update/remove". Each step is independent so a failure
+	// in `refetch()` (local dialog state) doesn't skip `onSaved()` (parent
+	// table refetch), and vice versa.
 	const refreshAfterMutation = async () => {
 		try {
-			await refresh();
+			await refetch();
 		} catch {
 			// non-fatal: dialog will display stale state until reopened
 		}
@@ -188,7 +181,7 @@ export function OrgRedisConfigDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				{loading ? (
+				{isLoading ? (
 					<div className="py-8 text-center text-t3 text-sm">Loading…</div>
 				) : cfg ? (
 					<div className="flex flex-col gap-4">

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -93,6 +93,19 @@ export function OrgRedisConfigDialog({
 		);
 	};
 
+	// Best-effort post-mutation refetch + parent notification. Failures here
+	// must not surface as errors because the mutation itself has already
+	// persisted — a transient GET failure should not be reported as
+	// "Failed to connect/update/remove".
+	const refreshAfterMutation = async () => {
+		try {
+			await refresh();
+			await onSaved();
+		} catch {
+			// intentionally swallowed — see comment above
+		}
+	};
+
 	const handleConnect = async () => {
 		if (!orgId || !connectionString.trim()) return;
 		setSaving(true);
@@ -100,10 +113,9 @@ export function OrgRedisConfigDialog({
 			await axiosInstance.patch(`/admin/orgs/${orgId}/redis`, {
 				connectionString: connectionString.trim(),
 			});
-			await refresh();
-			await onSaved();
 			setConnectionString("");
 			toast.success("Redis connected");
+			await refreshAfterMutation();
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to connect Redis"));
 		} finally {
@@ -113,7 +125,12 @@ export function OrgRedisConfigDialog({
 
 	const handleUpdateMigration = async () => {
 		if (!orgId) return;
-		const percent = Number(migrationInput);
+		const normalizedInput = migrationInput.trim();
+		if (normalizedInput === "") {
+			toast.error("Migration percent must be an integer between 0 and 100");
+			return;
+		}
+		const percent = Number(normalizedInput);
 		if (
 			Number.isNaN(percent) ||
 			!Number.isInteger(percent) ||
@@ -128,9 +145,8 @@ export function OrgRedisConfigDialog({
 			await axiosInstance.patch(`/admin/orgs/${orgId}/redis/migration`, {
 				migrationPercent: percent,
 			});
-			await refresh();
-			await onSaved();
 			toast.success(`Migration updated to ${percent}%`);
+			await refreshAfterMutation();
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to update migration"));
 		} finally {
@@ -143,10 +159,9 @@ export function OrgRedisConfigDialog({
 		setRemoving(true);
 		try {
 			await axiosInstance.delete(`/admin/orgs/${orgId}/redis`);
-			await refresh();
-			await onSaved();
 			setRemoveConfirm("");
 			toast.success("Redis config removed");
+			await refreshAfterMutation();
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to remove Redis config"));
 		} finally {

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+
+const CONFIRM_REMOVE_TEXT = "remove";
+
+type AdminOrgRedisConfigResponse = {
+	org_id: string;
+	org_slug: string;
+	redis_config: {
+		host: string;
+		migrationPercent: number;
+		previousMigrationPercent: number;
+		migrationChangedAt: number;
+	} | null;
+};
+
+export function OrgRedisConfigDialog({
+	open,
+	onOpenChange,
+	orgId,
+	orgName,
+	onSaved,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	orgId?: string;
+	orgName?: string;
+	onSaved: () => void | Promise<void>;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const [loading, setLoading] = useState(false);
+	const [data, setData] = useState<AdminOrgRedisConfigResponse | null>(null);
+
+	const [connectionString, setConnectionString] = useState("");
+	const [migrationInput, setMigrationInput] = useState("");
+	const [removeConfirm, setRemoveConfirm] = useState("");
+
+	const [saving, setSaving] = useState(false);
+	const [updatingMigration, setUpdatingMigration] = useState(false);
+	const [removing, setRemoving] = useState(false);
+
+	useEffect(() => {
+		if (!open || !orgId) return;
+
+		let cancelled = false;
+		setLoading(true);
+		setConnectionString("");
+		setRemoveConfirm("");
+
+		axiosInstance
+			.get<AdminOrgRedisConfigResponse>(`/admin/orgs/${orgId}/redis`)
+			.then(({ data }) => {
+				if (cancelled) return;
+				setData(data);
+				setMigrationInput(
+					data.redis_config ? String(data.redis_config.migrationPercent) : "0",
+				);
+			})
+			.catch((error) => {
+				if (cancelled) return;
+				toast.error(getBackendErr(error, "Failed to load Redis config"));
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [open, orgId, axiosInstance]);
+
+	const refresh = async () => {
+		if (!orgId) return;
+		const { data } = await axiosInstance.get<AdminOrgRedisConfigResponse>(
+			`/admin/orgs/${orgId}/redis`,
+		);
+		setData(data);
+		setMigrationInput(
+			data.redis_config ? String(data.redis_config.migrationPercent) : "0",
+		);
+	};
+
+	const handleConnect = async () => {
+		if (!orgId || !connectionString.trim()) return;
+		setSaving(true);
+		try {
+			await axiosInstance.patch(`/admin/orgs/${orgId}/redis`, {
+				connectionString: connectionString.trim(),
+			});
+			await refresh();
+			await onSaved();
+			setConnectionString("");
+			toast.success("Redis connected");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to connect Redis"));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const handleUpdateMigration = async () => {
+		if (!orgId) return;
+		const percent = Number(migrationInput);
+		if (
+			Number.isNaN(percent) ||
+			!Number.isInteger(percent) ||
+			percent < 0 ||
+			percent > 100
+		) {
+			toast.error("Migration percent must be an integer between 0 and 100");
+			return;
+		}
+		setUpdatingMigration(true);
+		try {
+			await axiosInstance.patch(`/admin/orgs/${orgId}/redis/migration`, {
+				migrationPercent: percent,
+			});
+			await refresh();
+			await onSaved();
+			toast.success(`Migration updated to ${percent}%`);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to update migration"));
+		} finally {
+			setUpdatingMigration(false);
+		}
+	};
+
+	const handleRemove = async () => {
+		if (!orgId || removeConfirm !== CONFIRM_REMOVE_TEXT) return;
+		setRemoving(true);
+		try {
+			await axiosInstance.delete(`/admin/orgs/${orgId}/redis`);
+			await refresh();
+			await onSaved();
+			setRemoveConfirm("");
+			toast.success("Redis config removed");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to remove Redis config"));
+		} finally {
+			setRemoving(false);
+		}
+	};
+
+	const cfg = data?.redis_config ?? null;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Redis routing — {orgName ?? orgId}</DialogTitle>
+					<DialogDescription>
+						Configure a dedicated Redis instance for this org. Customer cache
+						and balance ops route by migration percentage.
+					</DialogDescription>
+				</DialogHeader>
+
+				{loading ? (
+					<div className="py-8 text-center text-t3 text-sm">Loading…</div>
+				) : cfg ? (
+					<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-1">
+							<FormLabel>Connected host</FormLabel>
+							<Input value={cfg.host} readOnly className="font-mono text-xs" />
+						</div>
+
+						<div className="flex flex-col gap-1">
+							<FormLabel>Migration percentage</FormLabel>
+							<div className="flex items-center gap-2">
+								<Input
+									type="number"
+									min={0}
+									max={100}
+									value={migrationInput}
+									onChange={(e) => setMigrationInput(e.target.value)}
+									className="w-24 font-mono text-xs"
+								/>
+								<span className="text-t3 text-xs">
+									% of customers routed to this Redis
+								</span>
+								<Button
+									onClick={handleUpdateMigration}
+									disabled={
+										updatingMigration ||
+										Number(migrationInput) === cfg.migrationPercent
+									}
+									size="sm"
+								>
+									{updatingMigration ? "Updating…" : "Update"}
+								</Button>
+							</div>
+							{cfg.previousMigrationPercent !== cfg.migrationPercent && (
+								<span className="text-t4 text-[11px]">
+									Previous: {cfg.previousMigrationPercent}% — changed{" "}
+									{new Date(cfg.migrationChangedAt).toLocaleString()}
+								</span>
+							)}
+						</div>
+
+						<div className="flex flex-col gap-2 border-t border-stroke pt-4">
+							<FormLabel>Remove Redis config</FormLabel>
+							<span className="text-t4 text-xs">
+								{cfg.migrationPercent > 0
+									? `Set migrationPercent to 0 first (currently ${cfg.migrationPercent}%).`
+									: `Type "${CONFIRM_REMOVE_TEXT}" to confirm removal.`}
+							</span>
+							<div className="flex items-center gap-2">
+								<Input
+									value={removeConfirm}
+									onChange={(e) => setRemoveConfirm(e.target.value)}
+									placeholder={CONFIRM_REMOVE_TEXT}
+									disabled={cfg.migrationPercent > 0}
+									className="text-xs"
+								/>
+								<Button
+									variant="destructive"
+									size="sm"
+									onClick={handleRemove}
+									disabled={
+										removing ||
+										cfg.migrationPercent > 0 ||
+										removeConfirm !== CONFIRM_REMOVE_TEXT
+									}
+								>
+									{removing ? "Removing…" : "Remove"}
+								</Button>
+							</div>
+						</div>
+					</div>
+				) : (
+					<div className="flex flex-col gap-3">
+						<FormLabel>Redis connection string</FormLabel>
+						<Input
+							value={connectionString}
+							onChange={(e) => setConnectionString(e.target.value)}
+							placeholder="rediss://default:password@host:port"
+							className="font-mono text-xs"
+						/>
+						<span className="text-t4 text-[11px]">
+							Stored encrypted (AES-256-CBC). Frontend never sees the connection
+							string after save — only the host. Migration starts at 0% (no
+							traffic routed) until you bump it.
+						</span>
+						<Button
+							onClick={handleConnect}
+							disabled={saving || !connectionString.trim()}
+						>
+							{saving ? "Connecting…" : "Connect Redis"}
+						</Button>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button variant="secondary" onClick={() => onOpenChange(false)}>
+						Close
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -96,13 +96,19 @@ export function OrgRedisConfigDialog({
 	// Best-effort post-mutation refetch + parent notification. Failures here
 	// must not surface as errors because the mutation itself has already
 	// persisted — a transient GET failure should not be reported as
-	// "Failed to connect/update/remove".
+	// "Failed to connect/update/remove". Each step is also independent so a
+	// failure in `refresh()` (local dialog state) doesn't skip `onSaved()`
+	// (parent table refetch), and vice versa.
 	const refreshAfterMutation = async () => {
 		try {
 			await refresh();
+		} catch {
+			// non-fatal: dialog will display stale state until reopened
+		}
+		try {
 			await onSaved();
 		} catch {
-			// intentionally swallowed — see comment above
+			// non-fatal: parent table will refetch on its next render cycle
 		}
 	};
 

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { z } from "zod";
 import { Button } from "@/components/v2/buttons/Button";
 import {
 	Dialog,
@@ -16,6 +17,13 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 
 const CONFIRM_REMOVE_TEXT = "remove";
+
+const migrationPercentSchema = z
+	.string()
+	.trim()
+	.regex(/^\d+$/)
+	.transform(Number)
+	.pipe(z.number().int().min(0).max(100));
 
 type AdminOrgRedisConfigResponse = {
 	org_id: string;
@@ -44,7 +52,13 @@ export function OrgRedisConfigDialog({
 	const axiosInstance = useAxiosInstance();
 
 	const [connectionString, setConnectionString] = useState("");
-	const [migrationInput, setMigrationInput] = useState("");
+	// `null` = "show the current server value". A string means the admin has
+	// typed something; that draft takes precedence until a successful update
+	// or a dialog reopen clears it. Deriving `migrationInput` during render
+	// (below) lets us avoid a useEffect that watches `data` to sync state.
+	const [migrationInputDraft, setMigrationInputDraft] = useState<string | null>(
+		null,
+	);
 	const [removeConfirm, setRemoveConfirm] = useState("");
 
 	const [saving, setSaving] = useState(false);
@@ -63,6 +77,10 @@ export function OrgRedisConfigDialog({
 			enabled: open && !!orgId,
 		});
 
+	const cfg = data?.redis_config ?? null;
+	const migrationInput =
+		migrationInputDraft ?? (cfg ? String(cfg.migrationPercent) : "");
+
 	// Surface load failures as a toast — only when there's no data to fall
 	// back on. After a successful mutation triggers a refetch, transient GET
 	// failures shouldn't surface as "Failed to load" since the dialog can
@@ -71,32 +89,16 @@ export function OrgRedisConfigDialog({
 		if (isError && !data) toast.error("Failed to load Redis config");
 	}, [isError, data]);
 
-	// Sync the editable migration input from server data when it loads or
-	// changes (e.g. after a successful update).
-	useEffect(() => {
-		if (data) {
-			setMigrationInput(
-				data.redis_config ? String(data.redis_config.migrationPercent) : "0",
-			);
-		}
-	}, [data]);
-
-	// Reset transient inputs when (re)opening — including same-org reopens.
-	// React Query's structural sharing means cached `data` may be returned
-	// with the same reference on reopen, so the `[data]` effect above won't
-	// fire. Without resetting `migrationInput` here, a previously typed but
-	// unsaved value would persist into the next session and the admin could
-	// silently apply a stale edit.
+	// Reset transient inputs whenever the dialog opens (or switches org).
+	// `migrationInputDraft = null` falls back to the server value during
+	// render, so a previously typed but unsaved value can't carry over into
+	// the next session.
 	useEffect(() => {
 		if (open && orgId) {
 			setConnectionString("");
 			setRemoveConfirm("");
-			setMigrationInput(
-				data?.redis_config ? String(data.redis_config.migrationPercent) : "",
-			);
+			setMigrationInputDraft(null);
 		}
-		// `data` deliberately excluded — refetches shouldn't clobber edits.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [open, orgId]);
 
 	// Best-effort post-mutation refetch + parent notification. Failures here
@@ -137,27 +139,20 @@ export function OrgRedisConfigDialog({
 
 	const handleUpdateMigration = async () => {
 		if (!orgId) return;
-		const normalizedInput = migrationInput.trim();
-		if (normalizedInput === "") {
+		const parsed = migrationPercentSchema.safeParse(migrationInput);
+		if (!parsed.success) {
 			toast.error("Migration percent must be an integer between 0 and 100");
 			return;
 		}
-		const percent = Number(normalizedInput);
-		if (
-			Number.isNaN(percent) ||
-			!Number.isInteger(percent) ||
-			percent < 0 ||
-			percent > 100
-		) {
-			toast.error("Migration percent must be an integer between 0 and 100");
-			return;
-		}
+		const percent = parsed.data;
 		setUpdatingMigration(true);
 		try {
 			await axiosInstance.patch(`/admin/orgs/${orgId}/redis/migration`, {
 				migrationPercent: percent,
 			});
 			toast.success(`Migration updated to ${percent}%`);
+			// Drop the draft so the input re-derives from the new server value.
+			setMigrationInputDraft(null);
 			await refreshAfterMutation();
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to update migration"));
@@ -180,8 +175,6 @@ export function OrgRedisConfigDialog({
 			setRemoving(false);
 		}
 	};
-
-	const cfg = data?.redis_config ?? null;
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -211,7 +204,7 @@ export function OrgRedisConfigDialog({
 									min={0}
 									max={100}
 									value={migrationInput}
-									onChange={(e) => setMigrationInput(e.target.value)}
+									onChange={(e) => setMigrationInputDraft(e.target.value)}
 									className="w-24 font-mono text-xs"
 								/>
 								<span className="text-t3 text-xs">

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { z } from "zod";
+import { z } from "zod/v4";
 import { Button } from "@/components/v2/buttons/Button";
 import {
 	Dialog,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an admin UI and backend endpoints to manage per‑org Redis routing with a migration percentage. Superusers can connect a dedicated Redis, ramp traffic, and safely remove the config, with status and actions in the org table.

- **New Features**
  - Server: Admin routes to get/create/update migration/delete per‑org Redis config; encrypts connection string and stores host for UI; clears org cache and warms/removes pool on changes.
  - Safety: Validates `redis://`/`rediss://`, prevents duplicate create, blocks delete unless `migrationPercent` is 0; tracks previous percent and change time for staleness.
  - UI: Org table adds a Redis column with badges (Shared V2/0%/partial/100%) and a Redis action; dialog to connect, edit 0–100 with previous/time context, and remove with typed confirmation; list API returns host + percent only.

- **Bug Fixes**
  - Keep Redis and Block actions visible for admin‑only orgs; only Impersonate needs a non‑admin user.
  - Migration input: empty is invalid, and the field resets on reopen to avoid carrying over unsaved edits.
  - Post‑mutation refresh: isolate dialog refetch from parent table refetch and only show a load‑failure toast when the initial load fails, avoiding misleading “Failed to …” toasts after successful changes; standardized imports to `zod/v4`.

<sup>Written for commit da5934868550b85311b81301b2a91b4c476fcde8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

