### PR TITLE
Fix proration settings hidden during cross-entity free-to-paid attach

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleAttachV2Errors.ts
@@ -75,7 +75,6 @@ export const handleAttachV2Errors = async ({
 	// 10. Proration behavior errors (none restrictions)
 	handleProrationBehaviorErrors({
 		billingContext,
-		currentCustomerProduct: billingContext.currentCustomerProduct,
 		billingPlan,
 		params,
 	});

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -69,7 +69,6 @@ export const handleUpdateSubscriptionErrors = async ({
 	// 9. Proration behavior errors
 	handleProrationBehaviorErrors({
 		billingContext,
-		currentCustomerProduct: customerProduct,
 		billingPlan,
 		params,
 	});

--- a/server/src/internal/billing/v2/common/errors/handleBillingBehaviorErrors.ts
+++ b/server/src/internal/billing/v2/common/errors/handleBillingBehaviorErrors.ts
@@ -2,12 +2,9 @@ import type {
 	AttachParamsV1,
 	BillingContext,
 	BillingPlan,
-	FullCusProduct,
 } from "@autumn/shared";
 import {
-	cusProductToPrices,
 	ErrCode,
-	isFreeProduct,
 	RecaseError,
 	type UpdateSubscriptionV1Params,
 } from "@autumn/shared";
@@ -20,18 +17,15 @@ import {
 /**
  * Validates that proration_behavior: 'none' is not used
  * in scenarios where deferring charges is invalid:
- * 1. Free -> Paid transitions (must charge immediately)
- * 2. Trial -> Non-trial transitions (removing a trial)
- * 3. Any operation that would result in a charge
+ * 1. Trial -> Non-trial transitions (removing a trial)
+ * 2. Any operation that would result in a charge
  */
 export const handleProrationBehaviorErrors = ({
 	billingContext,
-	currentCustomerProduct,
 	billingPlan,
 	params,
 }: {
 	billingContext: BillingContext;
-	currentCustomerProduct?: FullCusProduct;
 	billingPlan: BillingPlan;
 	params: UpdateSubscriptionV1Params | AttachParamsV1;
 }) => {
@@ -41,30 +35,7 @@ export const handleProrationBehaviorErrors = ({
 	// When anchor reset + none is used, charges are expected (full new plan price)
 	if (billingContext.requestedBillingCycleAnchor === "now") return;
 
-	const { autumn: autumnBillingPlan } = billingPlan;
-
-	// Check 1: Free -> Paid transition
-	const newCustomerProduct = autumnBillingPlan.insertCustomerProducts?.[0];
-	if (newCustomerProduct && currentCustomerProduct) {
-		const currentPrices = cusProductToPrices({
-			cusProduct: currentCustomerProduct,
-		});
-		const newPrices = cusProductToPrices({ cusProduct: newCustomerProduct });
-
-		const currentIsFree = isFreeProduct({ prices: currentPrices });
-		const newIsFree = isFreeProduct({ prices: newPrices });
-
-		if (currentIsFree && !newIsFree) {
-			throw new RecaseError({
-				message:
-					"Cannot set proration_behavior to 'none' when upgrading from a free product to a paid product",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-	}
-
-	// Check 2: Trial -> Non-trial transition (removing trial)
+	// Trial -> Non-trial transition (removing trial)
 	const { isTrialing, willBeTrialing } = getTrialStateTransition({
 		billingContext,
 	});
@@ -78,7 +49,7 @@ export const handleProrationBehaviorErrors = ({
 		});
 	}
 
-	// Check 3: Block any operations that would result in a charge
+	// Block any operations that would result in a charge
 	const chargeResult = billingPlanWillCharge({ billingPlan });
 
 	if (chargeResult.willCharge) {

--- a/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
@@ -35,7 +35,7 @@ import { cn } from "@/lib/utils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import type { FormCustomLineItem } from "../attachFormSchema";
 import { useAttachFormContext } from "../context/AttachFormProvider";
-import { usePlanScheduleField } from "../hooks/usePlanScheduleField";
+import { useAttachBillingOptionsState } from "../hooks/useAttachBillingOptionsState";
 import { addDiscount } from "../utils/discountUtils";
 import { getAttachScheduledStartDate } from "../utils/buildAttachPreviewTotals";
 import { AttachDiscountRow } from "./AttachDiscountRow";
@@ -160,7 +160,7 @@ export function AttachAdvancedSection() {
 		handleScheduleChange,
 		handleBillingCycleChange,
 		handleProrationBehaviorChange,
-	} = usePlanScheduleField();
+	} = useAttachBillingOptionsState();
 
 	const isPaidRecurringProduct =
 		!!product &&

--- a/vite/src/components/forms/attach-v2/components/AttachFooter.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooter.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/v2/tooltips/Tooltip";
 import { cn } from "@/lib/utils";
 import { useAttachFormContext } from "../context/AttachFormProvider";
-import { usePlanScheduleField } from "../hooks/usePlanScheduleField";
+import { useAttachBillingOptionsState } from "../hooks/useAttachBillingOptionsState";
 import { AttachFooterSkeleton } from "./AttachPreviewSkeleton";
 
 export function AttachFooter() {
@@ -25,7 +25,7 @@ export function AttachFooter() {
 		formValues,
 	} = useAttachFormContext();
 
-	const { isEndOfCycleSelected } = usePlanScheduleField();
+	const { isEndOfCycleSelected } = useAttachBillingOptionsState();
 
 	const invoiceDisabledReason = isEndOfCycleSelected
 		? "Invoices are not available for end of cycle changes as there is no immediate charge to invoice"

--- a/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
@@ -9,7 +9,7 @@ import {
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { cn } from "@/lib/utils";
 import { useAttachFormContext } from "../context/AttachFormProvider";
-import { usePlanScheduleField } from "../hooks/usePlanScheduleField";
+import { useAttachBillingOptionsState } from "../hooks/useAttachBillingOptionsState";
 import { isFutureStartDate } from "../utils/buildAttachPreviewTotals";
 
 export function getConfirmLabel({
@@ -51,7 +51,7 @@ export function AttachFooterV3() {
 	const { setSheet } = useSheetStore();
 	const itemId = useSheetStore((s) => s.itemId);
 
-	const { isEndOfCycleSelected } = usePlanScheduleField();
+	const { isEndOfCycleSelected } = useAttachBillingOptionsState();
 
 	const previewData = previewQuery.data;
 	const hasFutureStartDate = isFutureStartDate(formValues.startDate);

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -1,4 +1,5 @@
 import type {
+	CusProduct,
 	Feature,
 	FrontendProduct,
 	FullCusProduct,
@@ -73,6 +74,7 @@ interface AttachFormContextValue {
 	previewPrepaidOptions: Record<string, number>;
 
 	isFreeToPaidTransition: boolean;
+	hasActiveSubscription: boolean;
 
 	previewQuery: UseAttachPreviewReturn;
 	previewDiff: UsePreviewDiffReturn;
@@ -262,6 +264,18 @@ export function AttachFormProvider({
 		return isFreeProduct({ prices: outgoingPrices });
 	}, [effectiveProduct, fullCustomer, entityId]);
 
+	const hasActiveSubscription =
+		((fullCustomer?.customer_products ?? []) as CusProduct[]).some(
+			(customerProduct) =>
+				(ACTIVE_STATUSES.includes(customerProduct.status) ||
+					customerProduct.status === CusProductStatus.Trialing) &&
+				customerProduct.subscription_ids &&
+				customerProduct.subscription_ids.length > 0,
+		);
+
+	const disableProration =
+		isFreeToPaidTransition && !hasActiveSubscription;
+
 	const { prepaidItems } = usePrepaidItems({ product: effectiveProduct });
 
 	const resolveCurrentItems = useCallback(
@@ -398,7 +412,7 @@ export function AttachFormProvider({
 		carryOverUsages,
 		carryOverUsageFeatureIds,
 		customLineItems,
-		isFreeToPaidTransition,
+		disableProration,
 	});
 
 	const previewQuery = useAttachPreview({
@@ -506,6 +520,7 @@ export function AttachFormProvider({
 			initialPrepaidOptions,
 			previewPrepaidOptions,
 			isFreeToPaidTransition,
+			hasActiveSubscription,
 			previewQuery,
 			previewDiff,
 			showPlanEditor,
@@ -533,6 +548,7 @@ export function AttachFormProvider({
 			numVersions,
 			previewPrepaidOptions,
 			isFreeToPaidTransition,
+			hasActiveSubscription,
 			previewQuery,
 			previewDiff,
 			showPlanEditor,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
@@ -18,25 +18,18 @@ import {
 } from "../utils/attachProrationBehaviorRules";
 
 /** Encapsulates planSchedule + prorationBehavior derived state and mutations. */
-export function usePlanScheduleField() {
-	const { form, formValues, previewQuery, isFreeToPaidTransition } =
-		useAttachFormContext();
+export function useAttachBillingOptionsState() {
+	const {
+		form,
+		formValues,
+		previewQuery,
+		isFreeToPaidTransition,
+		hasActiveSubscription,
+	} = useAttachFormContext();
 	const { planSchedule, prorationBehavior, newBillingSubscription, startDate } =
 		formValues;
 	const previewData = previewQuery.data;
 	const { customer } = useCusQuery();
-
-	const hasActiveSubscription = useMemo(
-		() =>
-			((customer?.customer_products ?? []) as CusProduct[]).some(
-				(cp) =>
-					(ACTIVE_STATUSES.includes(cp.status) ||
-						cp.status === CusProductStatus.Trialing) &&
-					cp.subscription_ids &&
-					cp.subscription_ids.length > 0,
-			),
-		[customer?.customer_products],
-	);
 
 	const hasActiveProductWithTrial = useMemo(
 		() =>
@@ -94,27 +87,30 @@ export function usePlanScheduleField() {
 		? "immediate"
 		: (planSchedule ?? defaultPlanSchedule);
 
-	const showProrationRow =
-		hasActiveSubscription &&
-		!hasActiveProductWithTrial &&
-		!isFreeToPaidTransition;
+	const hasSubscriptionToProrate =
+		hasActiveSubscription && !hasActiveProductWithTrial;
+	const showProrationRow = hasSubscriptionToProrate;
+
+	const freeToPaidWithNoExistingSubscription =
+		isFreeToPaidTransition && !hasActiveSubscription;
+
 	const showProrationBehavior =
 		showProrationRow && effectivePlanSchedule === "immediate";
 	const isNoChargesAllowed = isNoChargesAllowedForAttach({
 		newBillingSubscription,
-		blocksNextCycleOnly: isFreeToPaidTransition,
+		disableProration: freeToPaidWithNoExistingSubscription,
 	});
 	const normalizedProrationBehavior = normalizeAttachProrationBehavior({
 		prorationBehavior,
 		newBillingSubscription,
-		blocksNextCycleOnly: isFreeToPaidTransition,
+		disableProration: freeToPaidWithNoExistingSubscription,
 	});
 	const effectiveProrationBehavior =
 		normalizedProrationBehavior ??
 		(isNoChargesAllowed ? "none" : "prorate_immediately");
 	const noChargesDisabledReason = getNoChargesDisabledReason({
 		newBillingSubscription,
-		blocksNextCycleOnly: isFreeToPaidTransition,
+		disableProration: freeToPaidWithNoExistingSubscription,
 	});
 
 	const hasCustomSchedule =
@@ -173,7 +169,7 @@ export function usePlanScheduleField() {
 			normalizeAttachProrationBehavior({
 				prorationBehavior,
 				newBillingSubscription: createNewCycle,
-				blocksNextCycleOnly: isFreeToPaidTransition,
+				disableProration: freeToPaidWithNoExistingSubscription,
 			}),
 		);
 	};
@@ -184,7 +180,7 @@ export function usePlanScheduleField() {
 			normalizeAttachProrationBehavior({
 				prorationBehavior: value,
 				newBillingSubscription,
-				blocksNextCycleOnly: isFreeToPaidTransition,
+				disableProration: freeToPaidWithNoExistingSubscription,
 			}),
 		);
 	};

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -44,7 +44,7 @@ export interface BuildAttachRequestBodyParams {
 	carryOverUsages: boolean;
 	carryOverUsageFeatureIds: string[];
 	customLineItems: FormCustomLineItem[];
-	isFreeToPaidTransition: boolean;
+	disableProration: boolean;
 }
 
 /** Pure function to build the attach request body. Extracted for testability. */
@@ -74,7 +74,7 @@ export function buildAttachRequestBody({
 	carryOverUsages,
 	carryOverUsageFeatureIds = [],
 	customLineItems,
-	isFreeToPaidTransition,
+	disableProration,
 }: BuildAttachRequestBodyParams): AttachParamsV0 | null {
 	if (!customerId || !product) {
 		return null;
@@ -136,7 +136,7 @@ export function buildAttachRequestBody({
 	const normalizedProrationBehavior = normalizeAttachProrationBehavior({
 		prorationBehavior,
 		newBillingSubscription,
-		blocksNextCycleOnly: isFreeToPaidTransition,
+		disableProration,
 	});
 
 	if (normalizedProrationBehavior) {
@@ -218,7 +218,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 		carryOverUsages,
 		carryOverUsageFeatureIds,
 		customLineItems,
-		isFreeToPaidTransition,
+		disableProration,
 	} = params;
 
 	const requestBody = useMemo(
@@ -249,7 +249,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 				carryOverUsages,
 				carryOverUsageFeatureIds,
 				customLineItems,
-				isFreeToPaidTransition,
+				disableProration,
 			}),
 		[
 			customerId,
@@ -277,7 +277,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 			carryOverUsages,
 			carryOverUsageFeatureIds,
 			customLineItems,
-			isFreeToPaidTransition,
+			disableProration,
 		],
 	);
 

--- a/vite/src/components/forms/attach-v2/index.ts
+++ b/vite/src/components/forms/attach-v2/index.ts
@@ -21,7 +21,7 @@ export * from "./hooks/useAttachMutation";
 export * from "./hooks/useAttachPreview";
 export * from "./hooks/useAttachRequestBody";
 export * from "./hooks/useGrantFree";
-export * from "./hooks/usePlanScheduleField";
+export * from "./hooks/useAttachBillingOptionsState";
 export * from "./hooks/usePreviewDiff";
 
 // Utils

--- a/vite/src/components/forms/attach-v2/utils/attachProrationBehaviorRules.ts
+++ b/vite/src/components/forms/attach-v2/utils/attachProrationBehaviorRules.ts
@@ -7,29 +7,29 @@ const NO_CHARGES_FREE_TO_PAID_DISABLED_REASON =
 
 export function isNoChargesAllowedForAttach({
 	newBillingSubscription,
-	blocksNextCycleOnly = false,
+	disableProration = false,
 }: {
 	newBillingSubscription: boolean;
-	blocksNextCycleOnly?: boolean;
+	disableProration?: boolean;
 }) {
-	return !newBillingSubscription && !blocksNextCycleOnly;
+	return !newBillingSubscription && !disableProration;
 }
 
 export function normalizeAttachProrationBehavior({
 	prorationBehavior,
 	newBillingSubscription,
-	blocksNextCycleOnly = false,
+	disableProration = false,
 }: {
 	prorationBehavior: BillingBehavior | null;
 	newBillingSubscription: boolean;
-	blocksNextCycleOnly?: boolean;
+	disableProration?: boolean;
 }) {
 	if (prorationBehavior !== "none") {
 		return prorationBehavior;
 	}
 
 	if (
-		isNoChargesAllowedForAttach({ newBillingSubscription, blocksNextCycleOnly })
+		isNoChargesAllowedForAttach({ newBillingSubscription, disableProration })
 	) {
 		return prorationBehavior;
 	}
@@ -39,16 +39,16 @@ export function normalizeAttachProrationBehavior({
 
 export function getNoChargesDisabledReason({
 	newBillingSubscription,
-	blocksNextCycleOnly = false,
+	disableProration = false,
 }: {
 	newBillingSubscription: boolean;
-	blocksNextCycleOnly?: boolean;
+	disableProration?: boolean;
 }) {
 	if (newBillingSubscription) {
 		return NO_CHARGES_NEW_CYCLE_DISABLED_REASON;
 	}
 
-	if (blocksNextCycleOnly) {
+	if (disableProration) {
 		return NO_CHARGES_FREE_TO_PAID_DISABLED_REASON;
 	}
 

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -42,7 +42,7 @@ const baseParams: Omit<
 	carryOverUsages: false,
 	carryOverUsageFeatureIds: [],
 	customLineItems: [],
-	isFreeToPaidTransition: false,
+	disableProration: false,
 };
 
 describe("buildAttachRequestBody — billing_units handling", () => {


### PR DESCRIPTION
## Summary
- Fix proration toggle being hidden/disabled when attaching a paid product to an entity while another entity already has an active subscription (cross-entity free-to-paid)
- Remove redundant backend free-to-paid `proration_behavior:'none'` validation (the charge-detection check already covers this)
- Rename `blocksNextCycleOnly` to `disableProration` and `usePlanScheduleField` to `useAttachBillingOptionsState` for clarity
- Move `hasActiveSubscription` into `AttachFormProvider` context to avoid duplicating the computation

## Test plan
- [ ] Attach a paid product on entity 2 when entity 1 has an active subscription — proration toggle should be visible and enabled
- [ ] Attach a paid product when no subscription exists anywhere — proration toggle should remain hidden
- [ ] Verify `bun test` passes for `build-attach-request-body.test.ts`
- [ ] Verify no Stripe errors when attaching with proration behavior `none` in valid scenarios

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes proration options being hidden during cross-entity free‑to‑paid attach. The proration toggle now appears when the customer has any active subscription on another entity, and backend validation is simplified.

- **Bug Fixes**
  - Show the proration row when any active subscription exists, even for free‑to‑paid attaches on a different entity.
  - Compute `disableProration` as “free‑to‑paid AND no existing subscription” and use it in proration rules.
  - Remove the redundant backend block on `proration_behavior: 'none'` for free‑to‑paid; rely on trial‑removal and will‑charge checks.

- **Refactors**
  - Rename `blocksNextCycleOnly` → `disableProration` and `usePlanScheduleField` → `useAttachBillingOptionsState`.
  - Move `hasActiveSubscription` into `AttachFormProvider` to avoid duplicate computation.
  - Update request body builder, exports, and tests to use the new names.

<sup>Written for commit ff8c5492a16e781771bd91bb550e2c0ba8376c39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the proration toggle being hidden when attaching a paid product to an entity while a *different* entity already holds an active subscription (cross-entity free-to-paid). It also cleans up naming and removes a now-redundant backend validation.

- **Bug fixes**: Removes `!isFreeToPaidTransition` from `showProrationRow` in `useAttachBillingOptionsState` and introduces `freeToPaidWithNoExistingSubscription` to distinguish "truly no subscription anywhere" from "subscription on a different entity", so the proration row is correctly shown in cross-entity scenarios.
- **Improvements**: Moves `hasActiveSubscription` computation into `AttachFormProvider` context to avoid duplicating the lookup across consumers; renames `blocksNextCycleOnly` → `disableProration` and `usePlanScheduleField` → `useAttachBillingOptionsState` for clarity.
- **Bug fixes**: Removes the redundant backend free-to-paid `proration_behavior:'none'` check in `handleBillingBehaviorErrors` — the `billingPlanWillCharge` guard already rejects any request where charges would occur, making the explicit free-to-paid guard unnecessary.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core logic change is well-scoped and the bug fix is correct across all identified scenarios.

The cross-entity proration fix is sound: removing !isFreeToPaidTransition from showProrationRow while introducing freeToPaidWithNoExistingSubscription as a replacement guard correctly handles same-entity free-to-paid (proration disabled), cross-entity free-to-paid (proration enabled), and all-paid upgrade (proration enabled as before). The backend removal of the free-to-paid check is safe because billingPlanWillCharge already rejects any attach that would produce a charge with proration_behavior: none. The one thing worth tidying is hasActiveSubscription being computed inline in the provider body while the closely related isFreeToPaidTransition is wrapped in useMemo — inconsistency rather than a functional bug.

AttachFormProvider.tsx — hasActiveSubscription and disableProration are missing useMemo wrappers, unlike the adjacent isFreeToPaidTransition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx | Adds `hasActiveSubscription` and `disableProration` to provider context; `hasActiveSubscription` is computed inline without `useMemo`, inconsistent with the memoized `isFreeToPaidTransition` computed from the same data source. |
| vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts | Renamed from `usePlanScheduleField`; moves `hasActiveSubscription` out and removes its `useMemo` block; removes `!isFreeToPaidTransition` guard from `showProrationRow` to fix the cross-entity bug; introduces `freeToPaidWithNoExistingSubscription` local variable for clarity. |
| server/src/internal/billing/v2/common/errors/handleBillingBehaviorErrors.ts | Removes the free-to-paid proration:none validation check; the remaining `billingPlanWillCharge` guard already rejects such requests when charges would occur. |
| vite/src/components/forms/attach-v2/utils/attachProrationBehaviorRules.ts | Renames `blocksNextCycleOnly` to `disableProration` across all three utility functions for clarity; logic is unchanged. |
| vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts | Updates `baseParams` fixture to use renamed `disableProration` parameter; no test logic changes needed beyond the rename. |
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Parameter renamed from `isFreeToPaidTransition` to `disableProration` in `BuildAttachRequestBodyParams` and threaded through to `normalizeAttachProrationBehavior`; semantics are now more precisely scoped. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AttachFormProvider] -->|computes| B[isFreeToPaidTransition\nuseMemo - entity-scoped]
    A -->|computes| C[hasActiveSubscription\nany entity with subscription_ids]
    A -->|computes| D[disableProration\nisFreeToPaid AND no active sub]

    A -->|context| E[useAttachBillingOptionsState]
    E --> F{hasActiveSubscription?}
    F -- No --> G[showProrationRow = false\nproration hidden]
    F -- Yes --> H{hasActiveProductWithTrial?}
    H -- Yes --> G
    H -- No --> I[showProrationRow = true\nproration visible]

    E --> J{freeToPaidWithNoExistingSubscription?\nisFreeToPaid AND NOT hasActiveSub}
    J -- true --> K[disableProration = true\nproration:none forced / UI disabled]
    J -- false --> L[disableProration = false\nproration user-selectable]

    D -->|passed to| M[useAttachRequestBody\nbuildAttachRequestBody]
    M -->|normalizes| N[proration_behavior in API request]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx:267-277
`hasActiveSubscription` and `disableProration` are computed inline without `useMemo`, while `isFreeToPaidTransition` — which reads the same `fullCustomer` — is memoized. Both values are passed into the context object, which means they're recalculated on every provider render regardless of whether `customer_products` has changed.

```suggestion
	const hasActiveSubscription = useMemo(
		() =>
			((fullCustomer?.customer_products ?? []) as CusProduct[]).some(
				(customerProduct) =>
					(ACTIVE_STATUSES.includes(customerProduct.status) ||
						customerProduct.status === CusProductStatus.Trialing) &&
					customerProduct.subscription_ids &&
					customerProduct.subscription_ids.length > 0,
			),
		[fullCustomer?.customer_products],
	);

	const disableProration = useMemo(
		() => isFreeToPaidTransition && !hasActiveSubscription,
		[isFreeToPaidTransition, hasActiveSubscription],
	);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix proration settings hidden during cro..."](https://github.com/useautumn/autumn/commit/ff8c5492a16e781771bd91bb550e2c0ba8376c39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31195852)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->