### PR TITLE
dev

### DIFF
--- a/server/tests/integration/crud/customers/customer-processors.test.ts
+++ b/server/tests/integration/crud/customers/customer-processors.test.ts
@@ -12,9 +12,9 @@ import {
 } from "@autumn/shared";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
-import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { ProductService } from "@/internal/products/ProductService.js";
@@ -79,6 +79,7 @@ const seedCusProduct = async ({
 		customer_id: customerId,
 		internal_entity_id: null,
 		entity_id: null,
+		updated_at: Date.now(),
 		created_at: Date.now(),
 		status,
 		canceled: false,
@@ -270,7 +271,10 @@ test.concurrent(`${chalk.yellowBright("customer processors: active RevenueCat cu
 		actions: [],
 	});
 
-	const customer = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
 	// pro.id is mutated in place by addPrefixToProducts during initScenario,
 	// so it already carries the productPrefix suffix here.
 	const product = await ProductService.get({
@@ -329,7 +333,10 @@ test.concurrent(`${chalk.yellowBright("customer processors: expired-only Revenue
 		actions: [],
 	});
 
-	const customer = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
 	const product = await ProductService.get({
 		db: ctx.db,
 		id: pro.id, // mutated to include productPrefix by initScenario
@@ -412,9 +419,8 @@ test.concurrent(`${chalk.yellowBright("customer processors: anonymous customer w
 		source: "test:rc-anon-seed",
 	});
 
-	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(
-		internalCustomerId,
-	);
+	const cached =
+		await autumnV2_1.customers.get<ApiCustomerV5>(internalCustomerId);
 	expect(cached.processors?.revenuecat).toEqual({ id: null });
 	// id: null contract — must round-trip through ApiCustomerV5Schema cleanly.
 	// (Zod parse is exercised implicitly by the response builder; the explicit
@@ -458,7 +464,10 @@ test.concurrent(`${chalk.yellowBright("customer processors: multi-PSP customer s
 	});
 
 	// RevenueCat cusProduct seed
-	const customer = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
 	const product = await ProductService.get({
 		db: ctx.db,
 		id: pro.id, // mutated to include productPrefix by initScenario
@@ -524,7 +533,10 @@ test.concurrent(`${chalk.yellowBright("customer processors: unrelated update (na
 		},
 	});
 
-	const customer = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
 	const product = await ProductService.get({
 		db: ctx.db,
 		id: pro.id, // mutated to include productPrefix by initScenario
@@ -604,7 +616,10 @@ test.concurrent(`${chalk.yellowBright("customer processors: ApiCustomerV3 respon
 		},
 	});
 
-	const customer = await CusService.getFull({ ctx, idOrInternalId: customerId });
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
 	const product = await ProductService.get({
 		db: ctx.db,
 		id: pro.id, // mutated to include productPrefix by initScenario


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes type errors in customer processor integration tests by adding the missing updated_at timestamp to seeded customer-product records and cleaning up type imports. Aligns test fixtures with the current schema to prevent failures when fetching full customers and products.

<sup>Written for commit 32f46f6344ec530e0727f3e914f153cdc9e93d2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes minor housekeeping changes to the customer-processors integration test file: it adds the previously-absent `updated_at` field to the `seedCusProduct` fixture object (aligning it with the `CusProduct` schema that marks the field required-but-nullable), reformats several `CusService.getFull` call sites for readability, and reorders one import.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are confined to a single integration test file with no production code affected.

The only substantive change is adding `updated_at: Date.now()` to the test fixture's `CusProduct` object, which correctly matches the schema definition (`z.number().nullable()`). The remaining edits are pure formatting. No logic, schema, or API surface is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/integration/crud/customers/customer-processors.test.ts | Adds missing `updated_at` field to `seedCusProduct` test fixture, reformats several multi-arg `CusService.getFull` call sites, and moves the `TestContext` import to follow project ordering conventions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[seedCusProduct] -->|builds CusProduct object| B["CusProduct { id, ..., updated_at: Date.now(), created_at: Date.now(), ... }"]
    B -->|insert| C[customerProducts DB table]
    C -->|CusService.getFull| D[Full customer record]
    D -->|assertion checks| E[Test assertions]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: type errors"](https://github.com/useautumn/autumn/commit/32f46f6344ec530e0727f3e914f153cdc9e93d2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31205442)</sub>

<!-- /greptile_comment -->