### PR TITLE
Charlie/migration persistence

### DIFF
--- a/server/src/external/tinybird/initTinybird.ts
+++ b/server/src/external/tinybird/initTinybird.ts
@@ -42,6 +42,25 @@ const TinybirdEventSchema = z.object({
 	properties: z.string().nullable(),
 });
 
+/** Zod schema for migration_customer_events.datasource */
+const TinybirdMigrationCustomerEventSchema = z.object({
+	id: z.string(),
+	timestamp: z.string(),
+	orgId: z.string(),
+	env: z.string(),
+	migrationId: z.string(),
+	migrationRunId: z.string(),
+	eventType: z.string(),
+	dryRun: z.number(),
+	internalCustomerId: z.string().nullable(),
+	customerId: z.string().nullable(),
+	details: z.string().nullable(),
+});
+
+export type TinybirdMigrationCustomerEvent = z.infer<
+	typeof TinybirdMigrationCustomerEventSchema
+>;
+
 /** Pre-built pipe callers */
 export const tinybirdPipes = tinybirdClient
 	? {
@@ -60,6 +79,11 @@ export const tinybirdIngest = tinybirdClient
 			events: tinybirdClient.buildIngestEndpoint({
 				datasource: "events",
 				event: TinybirdEventSchema,
+				wait: true,
+			}),
+			migrationCustomerEvents: tinybirdClient.buildIngestEndpoint({
+				datasource: "migration_customer_events",
+				event: TinybirdMigrationCustomerEventSchema,
 				wait: true,
 			}),
 		}

--- a/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
@@ -10,6 +10,7 @@ import {
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
+import { CusPriceService } from "@/internal/customers/cusProducts/cusPrices/CusPriceService";
 import { invoiceActions } from "@/internal/invoices/actions";
 import { EntitlementService } from "@/internal/products/entitlements/EntitlementService";
 import { FreeTrialService } from "@/internal/products/free-trials/FreeTrialService";
@@ -115,7 +116,15 @@ export const executeAutumnBillingPlan = async ({
 		updates: autumnBillingPlan.updateCustomerEntitlements,
 	});
 
-	// 5a. Auto top-up rebalance: apply pre-computed paydown + remainder deltas as
+	// 5a. Migration `delete_items`: drop specific cusEnts/cusPrices by id.
+	for (const id of autumnBillingPlan.deleteCustomerEntitlementIds ?? []) {
+		await CusEntService.delete({ db, id });
+	}
+	for (const id of autumnBillingPlan.deleteCustomerPriceIds ?? []) {
+		await CusPriceService.delete({ db, id });
+	}
+
+	// 5b. Auto top-up rebalance: apply pre-computed paydown + remainder deltas as
 	// atomic SQL `balance + delta` increments.
 	if (autumnBillingPlan.autoTopupRebalance) {
 		await executeAutoTopupRebalance({

--- a/server/src/internal/migrations/v2/operations/index.ts
+++ b/server/src/internal/migrations/v2/operations/index.ts
@@ -1,0 +1,2 @@
+export * from "./types/index.js";
+export * from "./upsertItems/index.js";

--- a/server/src/internal/migrations/v2/operations/types/index.ts
+++ b/server/src/internal/migrations/v2/operations/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./migrateCustomerBillingContext.js";
+export * from "./operationProcessor.js";

--- a/server/src/internal/migrations/v2/operations/types/migrateCustomerBillingContext.ts
+++ b/server/src/internal/migrations/v2/operations/types/migrateCustomerBillingContext.ts
@@ -1,0 +1,29 @@
+import type {
+	BillingContext,
+	CustomerOperations,
+	FullCusProduct,
+	Migration,
+} from "@autumn/shared";
+import type { PreparedState } from "@/internal/migrations/v2/prepare/types/index.js";
+
+/**
+ * Per-customer billing context for the migration runner. Extends the
+ * standard `BillingContext` with migration metadata + the evolving
+ * `projected_cusproducts` view (post-op snapshot of the customer's
+ * cusproducts, threaded through processors as the plan folds).
+ */
+export type MigrateCustomerBillingContext = BillingContext & {
+	migration: Migration;
+	scope_id: string;
+	prepared_state: PreparedState;
+	operations: CustomerOperations;
+
+	/**
+	 * Reflects what the customer's cusproducts will look like AFTER the
+	 * AutumnBillingPlan executes. Starts equal to
+	 * `fullCustomer.customer_products` and gets updated by each processor
+	 * so downstream ops (e.g. `update_plans` after `add_plans`) can
+	 * target newly-attached / not-yet-expired plans correctly.
+	 */
+	projected_cusproducts: FullCusProduct[];
+};

--- a/server/src/internal/migrations/v2/operations/types/operationProcessor.ts
+++ b/server/src/internal/migrations/v2/operations/types/operationProcessor.ts
@@ -1,0 +1,27 @@
+import type { AutumnBillingPlan } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { MigrateCustomerBillingContext } from "./migrateCustomerBillingContext.js";
+
+/**
+ * Output of one processor: the updated AutumnBillingPlan plus the
+ * (possibly-updated) MigrateCustomerBillingContext. Returning the
+ * context lets a processor evolve `projected_cusproducts` so later
+ * processors see the post-op view of the customer.
+ */
+export type ProcessOperationResult = {
+	plan: AutumnBillingPlan;
+	billingContext: MigrateCustomerBillingContext;
+};
+
+/**
+ * Shared contract for every per-op processor. Pure-ish: any DB reads
+ * are allowed (catalog lookups, prepared_state inspection); all writes
+ * must go through the returned `plan`, which the orchestrator executes
+ * later.
+ */
+export type OperationProcessor<Op> = (args: {
+	ctx: AutumnContext;
+	billingContext: MigrateCustomerBillingContext;
+	op: Op;
+	plan: AutumnBillingPlan;
+}) => Promise<ProcessOperationResult>;

--- a/server/src/internal/migrations/v2/operations/upsertItems/index.ts
+++ b/server/src/internal/migrations/v2/operations/upsertItems/index.ts
@@ -1,0 +1,1 @@
+export * from "./processUpsertItems.js";

--- a/server/src/internal/migrations/v2/operations/upsertItems/processUpsertItems.ts
+++ b/server/src/internal/migrations/v2/operations/upsertItems/processUpsertItems.ts
@@ -1,0 +1,47 @@
+import type {
+	AutumnBillingPlan,
+	CreatePlanItemParamsV1,
+	FullCusProduct,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { ProcessOperationResult } from "../types/index.js";
+import type { MigrateCustomerBillingContext } from "../types/migrateCustomerBillingContext.js";
+
+/**
+ * Process one `upsert_items[i]` against ONE matched cusproduct. Folds
+ * mutations onto `plan` and returns the updated plan + context.
+ *
+ * Idempotent: the deterministic customer_entitlement id used here is
+ * `cusent_<scope_id>_<cusProduct.id>_<entitlement_id>`, so re-runs on
+ * the same migration are a no-op (the executor's existence check
+ * skips the insert).
+ *
+ * NOTE: filled in by the user. This scaffold preserves typing + no-op
+ * semantics so the processor compiles end-to-end while the body lands.
+ */
+export const processUpsertItems = async ({
+	ctx,
+	billingContext,
+	cusProduct,
+	upsertItem,
+	plan,
+}: {
+	ctx: AutumnContext;
+	billingContext: MigrateCustomerBillingContext;
+	cusProduct: FullCusProduct;
+	upsertItem: CreatePlanItemParamsV1;
+	plan: AutumnBillingPlan;
+}): Promise<ProcessOperationResult> => {
+	void ctx;
+	void cusProduct;
+	void upsertItem;
+	// TODO: implement
+	// 1. Resolve prepared cusEnt id from
+	//    billingContext.prepared_state[`ensure_prices_and_entitlements:${upsertItem.feature_id}:${cusProduct.product_id}`]
+	//    matching cusProduct.internal_product_id.
+	// 2. Build deterministic customer_entitlement id
+	//    `cusent_${billingContext.scope_id}_${cusProduct.id}_<entitlement_id>`.
+	// 3. Push InsertCustomerEntitlement onto plan.insertCustomerEntitlements.
+	// 4. Phase 2: priced items → push to plan.customPrices using prepared price.
+	return { plan, billingContext };
+};

--- a/server/src/internal/migrations/v2/prepare/inferImplicitPrep.ts
+++ b/server/src/internal/migrations/v2/prepare/inferImplicitPrep.ts
@@ -29,7 +29,7 @@ export const inferPrepareModules = ({
 			typeof op.target.plan_id === "string" ? op.target.plan_id : undefined;
 		if (!planId) continue;
 
-		for (const item of op.add_items ?? []) {
+		for (const item of op.upsert_items ?? []) {
 			if (!item.feature_id) continue;
 			// Phase 1 constraint: entitlement-only items. Priced items will be
 			// handled by the same module in phase 2+.

--- a/server/src/internal/migrations/v2/run/events/getMigrationRunEventType.ts
+++ b/server/src/internal/migrations/v2/run/events/getMigrationRunEventType.ts
@@ -1,0 +1,15 @@
+import type { MigrationCustomerEventType } from "./migrationCustomerEventTypes.js";
+
+/** Returns the terminal event type for a migration run summary. */
+export const getMigrationRunEventType = ({
+	scopes,
+}: {
+	scopes: { succeeded: number; failed: number }[];
+}): MigrationCustomerEventType => {
+	const succeeded = scopes.reduce((sum, scope) => sum + scope.succeeded, 0);
+	const failed = scopes.reduce((sum, scope) => sum + scope.failed, 0);
+
+	if (failed === 0) return "migration_succeeded";
+	if (succeeded === 0) return "migration_failed";
+	return "migration_partially_failed";
+};

--- a/server/src/internal/migrations/v2/run/events/getScopeEventSummaries.ts
+++ b/server/src/internal/migrations/v2/run/events/getScopeEventSummaries.ts
@@ -1,0 +1,24 @@
+import type { RunMigrationScopeResult } from "../types/runMigrationResponse.js";
+import type { RunScopeKind } from "../types/runScope.js";
+
+export type MigrationScopeEventSummary = {
+	kind: RunScopeKind;
+	count: number;
+	processed: number;
+	succeeded: number;
+	failed: number;
+};
+
+/** Summarizes scope results for migration terminal events. */
+export const getScopeEventSummaries = ({
+	scopeResults,
+}: {
+	scopeResults: RunMigrationScopeResult[];
+}): MigrationScopeEventSummary[] =>
+	scopeResults.map(({ kind, count, summary }) => ({
+		kind,
+		count,
+		processed: summary.processed,
+		succeeded: summary.succeeded,
+		failed: summary.failed,
+	}));

--- a/server/src/internal/migrations/v2/run/events/index.ts
+++ b/server/src/internal/migrations/v2/run/events/index.ts
@@ -1,3 +1,4 @@
+export * from "./getMigrationRunEventType.js";
 export * from "./migrationCustomerEventTypes.js";
 export * from "./recordMigrationCustomerEvent.js";
 export * from "./sendMigrationCustomerEvents.js";

--- a/server/src/internal/migrations/v2/run/events/index.ts
+++ b/server/src/internal/migrations/v2/run/events/index.ts
@@ -1,0 +1,3 @@
+export * from "./migrationCustomerEventTypes.js";
+export * from "./recordMigrationCustomerEvent.js";
+export * from "./sendMigrationCustomerEvents.js";

--- a/server/src/internal/migrations/v2/run/events/index.ts
+++ b/server/src/internal/migrations/v2/run/events/index.ts
@@ -1,4 +1,7 @@
 export * from "./getMigrationRunEventType.js";
+export * from "./getScopeEventSummaries.js";
 export * from "./migrationCustomerEventTypes.js";
 export * from "./recordMigrationCustomerEvent.js";
+export * from "./recordMigrationFailedEvent.js";
+export * from "./recordMigrationTerminalEvent.js";
 export * from "./sendMigrationCustomerEvents.js";

--- a/server/src/internal/migrations/v2/run/events/mapMigrationCustomerEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/mapMigrationCustomerEvent.ts
@@ -1,0 +1,37 @@
+import * as crypto from "node:crypto";
+import type { TinybirdMigrationCustomerEvent } from "@/external/tinybird/initTinybird.js";
+import type {
+	MigrationCustomerEvent,
+	MigrationCustomerEventDetails,
+} from "./migrationCustomerEventTypes.js";
+
+const stringifyBigInt = (_key: string, value: unknown): unknown =>
+	typeof value === "bigint" ? value.toString() : value;
+
+const stringifyDetails = ({
+	details,
+}: {
+	details?: MigrationCustomerEventDetails;
+}): string | null => {
+	if (!details) return null;
+	return JSON.stringify(details, stringifyBigInt);
+};
+
+/** Converts a migration event into the Tinybird ingest payload. */
+export const mapMigrationCustomerEvent = ({
+	event,
+}: {
+	event: MigrationCustomerEvent;
+}): TinybirdMigrationCustomerEvent => ({
+	id: `mig_evt_${crypto.randomUUID()}`,
+	timestamp: event.timestamp ?? new Date().toISOString(),
+	orgId: event.orgId,
+	env: event.env,
+	migrationId: event.migrationId,
+	migrationRunId: event.migrationRunId,
+	eventType: event.eventType,
+	dryRun: event.dryRun ? 1 : 0,
+	internalCustomerId: event.internalCustomerId ?? null,
+	customerId: event.customerId ?? null,
+	details: stringifyDetails({ details: event.details }),
+});

--- a/server/src/internal/migrations/v2/run/events/migrationCustomerEventTypes.ts
+++ b/server/src/internal/migrations/v2/run/events/migrationCustomerEventTypes.ts
@@ -1,0 +1,27 @@
+export type MigrationCustomerEventType =
+	| "migration_started"
+	| "migration_completed"
+	| "migration_failed"
+	| "customer_started"
+	| "customer_succeeded"
+	| "customer_failed"
+	| "customers_failed"
+	| "customer_skipped";
+
+export type MigrationCustomerEventDetails = Record<string, unknown>;
+
+export type MigrationCustomerEventInput = {
+	eventType: MigrationCustomerEventType;
+	internalCustomerId?: string | null;
+	customerId?: string | null;
+	details?: MigrationCustomerEventDetails;
+};
+
+export type MigrationCustomerEvent = MigrationCustomerEventInput & {
+	orgId: string;
+	env: string;
+	migrationId: string;
+	migrationRunId: string;
+	dryRun: boolean;
+	timestamp?: string;
+};

--- a/server/src/internal/migrations/v2/run/events/migrationCustomerEventTypes.ts
+++ b/server/src/internal/migrations/v2/run/events/migrationCustomerEventTypes.ts
@@ -1,11 +1,11 @@
 export type MigrationCustomerEventType =
 	| "migration_started"
-	| "migration_completed"
+	| "migration_succeeded"
+	| "migration_partially_failed"
 	| "migration_failed"
 	| "customer_started"
 	| "customer_succeeded"
 	| "customer_failed"
-	| "customers_failed"
 	| "customer_skipped";
 
 export type MigrationCustomerEventDetails = Record<string, unknown>;

--- a/server/src/internal/migrations/v2/run/events/recordMigrationCustomerEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/recordMigrationCustomerEvent.ts
@@ -1,0 +1,41 @@
+import type { Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type {
+	MigrationCustomerEvent,
+	MigrationCustomerEventInput,
+} from "./migrationCustomerEventTypes.js";
+import { sendMigrationCustomerEventsToTinybird } from "./sendMigrationCustomerEvents.js";
+
+/** Enriches and records one migration lifecycle event. */
+export const recordMigrationCustomerEvent = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	eventType,
+	internalCustomerId,
+	customerId,
+	details,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+} & MigrationCustomerEventInput): Promise<void> => {
+	const event: MigrationCustomerEvent = {
+		eventType,
+		internalCustomerId,
+		customerId,
+		details,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		migrationId: migration.id,
+		migrationRunId,
+		dryRun,
+	};
+
+	await sendMigrationCustomerEventsToTinybird({
+		events: [event],
+		logger: ctx.logger,
+	});
+};

--- a/server/src/internal/migrations/v2/run/events/recordMigrationFailedEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/recordMigrationFailedEvent.ts
@@ -1,0 +1,36 @@
+import type { Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { RunMigrationScopeResult } from "../types/runMigrationResponse.js";
+import { getScopeEventSummaries } from "./getScopeEventSummaries.js";
+import { recordMigrationCustomerEvent } from "./recordMigrationCustomerEvent.js";
+
+/** Records a failed run with partial scope progress. */
+export const recordMigrationFailedEvent = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	error,
+	scopeResults,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+	error: unknown;
+	scopeResults: RunMigrationScopeResult[];
+}): Promise<void> => {
+	await recordMigrationCustomerEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun,
+		eventType: "migration_failed",
+		details: {
+			error: {
+				message: error instanceof Error ? error.message : String(error),
+			},
+			scopes: getScopeEventSummaries({ scopeResults }),
+		},
+	});
+};

--- a/server/src/internal/migrations/v2/run/events/recordMigrationTerminalEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/recordMigrationTerminalEvent.ts
@@ -1,0 +1,34 @@
+import type { Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { RunMigrationScopeResult } from "../types/runMigrationResponse.js";
+import { getMigrationRunEventType } from "./getMigrationRunEventType.js";
+import { getScopeEventSummaries } from "./getScopeEventSummaries.js";
+import { recordMigrationCustomerEvent } from "./recordMigrationCustomerEvent.js";
+
+/** Records the final run event after all scopes finish. */
+export const recordMigrationTerminalEvent = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	scopeResults,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+	scopeResults: RunMigrationScopeResult[];
+}): Promise<void> => {
+	const scopes = getScopeEventSummaries({ scopeResults });
+
+	await recordMigrationCustomerEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun,
+		eventType: getMigrationRunEventType({ scopes }),
+		details: {
+			scopes,
+		},
+	});
+};

--- a/server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts
+++ b/server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts
@@ -1,0 +1,66 @@
+import * as crypto from "node:crypto";
+import * as Sentry from "@sentry/bun";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import {
+	isTinybirdConfigured,
+	tinybirdIngest,
+} from "@/external/tinybird/initTinybird.js";
+import { mapMigrationCustomerEvent } from "./mapMigrationCustomerEvent.js";
+import type { MigrationCustomerEvent } from "./migrationCustomerEventTypes.js";
+
+/**
+ * Best-effort Tinybird ingest for migration audit events.
+ * Migration execution must not depend on analytics availability.
+ */
+export const sendMigrationCustomerEventsToTinybird = async ({
+	events,
+	logger,
+}: {
+	events: MigrationCustomerEvent[];
+	logger: Logger;
+}): Promise<void> => {
+	if (events.length === 0) return;
+
+	if (!isTinybirdConfigured() || !tinybirdIngest) {
+		logger.debug("Tinybird not configured, skipping migration event send");
+		return;
+	}
+
+	try {
+		const tinybirdEvents = events.map((event) =>
+			mapMigrationCustomerEvent({ event }),
+		);
+		const result = await tinybirdIngest.migrationCustomerEvents(tinybirdEvents);
+		logger.info(`Sent ${events.length} migration events to Tinybird`, {
+			data: {
+				eventCount: events.length,
+				successfulRows: result.successful_rows,
+				quarantinedRows: result.quarantined_rows,
+			},
+		});
+	} catch (error) {
+		const errorId = `TB_MIG_ERR_${crypto.randomBytes(8).toString("hex").toUpperCase()}`;
+		const errorMessage = error instanceof Error ? error.message : String(error);
+
+		logger.error(`[${errorId}] Failed to send migration events to Tinybird`, {
+			data: {
+				errorId,
+				eventCount: events.length,
+				error: errorMessage,
+			},
+		});
+
+		Sentry.captureException(error, {
+			tags: {
+				errorId,
+				service: "tinybird",
+				area: "migration_customer_events",
+			},
+			extra: {
+				data: {
+					eventCount: events.length,
+				},
+			},
+		});
+	}
+};

--- a/server/src/internal/migrations/v2/run/migrateCustomer/evaluateMigrateCustomerStripe.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/evaluateMigrateCustomerStripe.ts
@@ -1,0 +1,30 @@
+import type { AutumnBillingPlan, BillingPlan } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { MigrateCustomerBillingContext } from "@/internal/migrations/v2/operations/types/index.js";
+
+/**
+ * Build the StripeBillingPlan from a computed AutumnBillingPlan and
+ * enforce the no-charges guard:
+ *  - throw on `invoiceAction` / `invoiceItemsAction` / `refundAction`
+ *  - reject `subscriptionAction` params that would create proration
+ *    invoice items
+ *
+ * Skipped entirely when `mode === "no_changes"`.
+ *
+ * STUB: lands when the per-op processors emit Stripe-relevant
+ * mutations (priced upsert_items, expire_plans with end_of_cycle, etc.).
+ */
+export const evaluateMigrateCustomerStripe = async ({
+	ctx,
+	billingContext,
+	autumnBillingPlan,
+}: {
+	ctx: AutumnContext;
+	billingContext: MigrateCustomerBillingContext;
+	autumnBillingPlan: AutumnBillingPlan;
+}): Promise<BillingPlan> => {
+	void ctx;
+	void billingContext;
+	// TODO: call evaluateStripeBillingPlan + run no-charges guard.
+	return { autumn: autumnBillingPlan, stripe: {} };
+};

--- a/server/src/internal/migrations/v2/run/migrateCustomer/executeMigrateCustomerPlan.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/executeMigrateCustomerPlan.ts
@@ -1,0 +1,36 @@
+import type { BillingPlan } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan.js";
+import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan.js";
+import type { MigrateCustomerBillingContext } from "@/internal/migrations/v2/operations/types/index.js";
+
+export type MigrateCustomerExecuteMode = "no_changes" | "stripe";
+
+/**
+ * Routes execution based on resolved billing mode.
+ *  - `no_changes`: DB-only via `executeAutumnBillingPlan` (no Stripe)
+ *  - `stripe`: full path via `executeBillingPlan` (Stripe + DB)
+ *
+ * Mode resolution lives in `evaluateMigrateCustomerStripe`; this fn
+ * just dispatches.
+ */
+export const executeMigrateCustomerPlan = async ({
+	ctx,
+	billingContext,
+	billingPlan,
+	mode,
+}: {
+	ctx: AutumnContext;
+	billingContext: MigrateCustomerBillingContext;
+	billingPlan: BillingPlan;
+	mode: MigrateCustomerExecuteMode;
+}): Promise<void> => {
+	if (mode === "no_changes") {
+		await executeAutumnBillingPlan({
+			ctx,
+			autumnBillingPlan: billingPlan.autumn,
+		});
+		return;
+	}
+	await executeBillingPlan({ ctx, billingContext, billingPlan });
+};

--- a/server/src/internal/migrations/v2/run/migrateCustomer/index.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/index.ts
@@ -1,0 +1,5 @@
+export * from "./evaluateMigrateCustomerStripe.js";
+export * from "./executeMigrateCustomerPlan.js";
+export * from "./migrateCustomer.js";
+export * from "./processOperations.js";
+export * from "./setup/index.js";

--- a/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
@@ -1,0 +1,121 @@
+import type { BillingPlan, Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { PreparedState } from "@/internal/migrations/v2/prepare/types/index.js";
+import { evaluateMigrateCustomerStripe } from "./evaluateMigrateCustomerStripe.js";
+import {
+	executeMigrateCustomerPlan,
+	type MigrateCustomerExecuteMode,
+} from "./executeMigrateCustomerPlan.js";
+import { processOperations } from "./processOperations.js";
+import { setupBucketBillingContext } from "./setup/setupBucketBillingContext.js";
+import { setupCustomerLevel } from "./setup/setupCustomerLevel.js";
+
+export type MigrateCustomerParams = {
+	customer_id: string;
+	migration: Migration;
+	scope_id: string;
+	prepared_state: PreparedState;
+	preview?: boolean;
+};
+
+export type MigrateCustomerBucketResult = {
+	stripe_subscription_id: string | null;
+	billing_plan: BillingPlan;
+	matched_cusproducts: number;
+	applied: boolean;
+	mode: MigrateCustomerExecuteMode;
+};
+
+export type MigrateCustomerResult = {
+	customer_id: string;
+	internal_customer_id: string;
+	buckets: MigrateCustomerBucketResult[];
+};
+
+/**
+ * Top-level per-customer migration runner.
+ *
+ *   1. Customer-level setup once (FullCustomer + bucket ops by Stripe sub).
+ *   2. For each bucket, run a familiar one-sub-per-action pipeline:
+ *      setup → process → evaluate → execute.
+ *   3. Aggregate per-bucket results.
+ *
+ * `preview: true` short-circuits each bucket after evaluate — no DB or
+ * Stripe writes. Bucket plans are returned for inspection.
+ */
+export const migrateCustomer = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: MigrateCustomerParams;
+}): Promise<MigrateCustomerResult> => {
+	const customerLevel = await setupCustomerLevel({
+		ctx,
+		migration: params.migration,
+		scope_id: params.scope_id,
+		prepared_state: params.prepared_state,
+		customer_id: params.customer_id,
+	});
+
+	const bucketResults: MigrateCustomerBucketResult[] = [];
+
+	for (const bucket of customerLevel.buckets) {
+		const billingContext = await setupBucketBillingContext({
+			ctx,
+			customerLevel,
+			bucket,
+		});
+
+		const { plan: autumnPlan } = await processOperations({
+			ctx,
+			billingContext,
+			bucket,
+			plan: {
+				customerId: customerLevel.fullCustomer.internal_id,
+				insertCustomerProducts: [],
+			},
+		});
+
+		const billingPlan = await evaluateMigrateCustomerStripe({
+			ctx,
+			billingContext,
+			autumnBillingPlan: autumnPlan,
+		});
+
+		const mode: MigrateCustomerExecuteMode =
+			Object.keys(billingPlan.stripe).length === 0 ? "no_changes" : "stripe";
+
+		if (params.preview) {
+			bucketResults.push({
+				stripe_subscription_id: bucket.stripe_subscription_id,
+				billing_plan: billingPlan,
+				matched_cusproducts: bucket.matches.length,
+				applied: false,
+				mode,
+			});
+			continue;
+		}
+
+		await executeMigrateCustomerPlan({
+			ctx,
+			billingContext,
+			billingPlan,
+			mode,
+		});
+
+		bucketResults.push({
+			stripe_subscription_id: bucket.stripe_subscription_id,
+			billing_plan: billingPlan,
+			matched_cusproducts: bucket.matches.length,
+			applied: true,
+			mode,
+		});
+	}
+
+	return {
+		customer_id: params.customer_id,
+		internal_customer_id: customerLevel.fullCustomer.internal_id,
+		buckets: bucketResults,
+	};
+};

--- a/server/src/internal/migrations/v2/run/migrateCustomer/processOperations.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/processOperations.ts
@@ -1,0 +1,43 @@
+import type { AutumnBillingPlan } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type {
+	MigrateCustomerBillingContext,
+	ProcessOperationResult,
+} from "@/internal/migrations/v2/operations/types/index.js";
+import { processUpsertItems } from "@/internal/migrations/v2/operations/upsertItems/index.js";
+import type { SubscriptionBucket } from "./setup/types.js";
+
+/**
+ * Walk one subscription bucket's matches and fold each (op, cusProduct,
+ * upsertItem) tuple onto the running plan + context. Phase 1 only walks
+ * `update_plans` upsert_items; `delete_items` and future ops slot in
+ * here as their processors land.
+ */
+export const processOperations = async ({
+	ctx,
+	billingContext,
+	bucket,
+	plan,
+}: {
+	ctx: AutumnContext;
+	billingContext: MigrateCustomerBillingContext;
+	bucket: SubscriptionBucket;
+	plan: AutumnBillingPlan;
+}): Promise<ProcessOperationResult> => {
+	let state: ProcessOperationResult = { plan, billingContext };
+
+	for (const { op, cusProduct } of bucket.matches) {
+		for (const upsertItem of op.upsert_items ?? []) {
+			state = await processUpsertItems({
+				ctx,
+				billingContext: state.billingContext,
+				cusProduct,
+				upsertItem,
+				plan: state.plan,
+			});
+		}
+		// TODO: delete_items processor
+	}
+
+	return state;
+};

--- a/server/src/internal/migrations/v2/run/migrateCustomer/setup/bucketOpsBySubscription.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/setup/bucketOpsBySubscription.ts
@@ -1,0 +1,45 @@
+import type { CustomerOperations, FullCusProduct } from "@autumn/shared";
+import { matchCustomerProductsByTarget } from "@/internal/migrations/v2/run/perItem/matchPlanFilter.js";
+import type { OperationMatch, SubscriptionBucket } from "./types.js";
+
+/**
+ * Resolve every op's `target` against the customer's cusproducts and
+ * group the resulting (op, cusProduct) matches by the cusproduct's
+ * Stripe subscription id (first entry of `subscription_ids`, or `null`).
+ *
+ * Buckets are returned with non-null subs first, then the null bucket
+ * last — purely cosmetic for predictable execution order.
+ */
+export const bucketOpsBySubscription = ({
+	cusProducts,
+	operations,
+}: {
+	cusProducts: FullCusProduct[];
+	operations: CustomerOperations;
+}): SubscriptionBucket[] => {
+	const groups = new Map<string | null, OperationMatch[]>();
+
+	for (const op of operations.update_plans ?? []) {
+		const matched = matchCustomerProductsByTarget({
+			cusProducts,
+			target: op.target,
+		});
+		for (const cusProduct of matched) {
+			const subId = cusProduct.subscription_ids?.[0] ?? null;
+			const list = groups.get(subId) ?? [];
+			list.push({ op, cusProduct });
+			groups.set(subId, list);
+		}
+	}
+
+	const buckets: SubscriptionBucket[] = [];
+	for (const [subId, matches] of groups) {
+		if (subId !== null)
+			buckets.push({ stripe_subscription_id: subId, matches });
+	}
+	const nullMatches = groups.get(null);
+	if (nullMatches?.length)
+		buckets.push({ stripe_subscription_id: null, matches: nullMatches });
+
+	return buckets;
+};

--- a/server/src/internal/migrations/v2/run/migrateCustomer/setup/index.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/setup/index.ts
@@ -1,0 +1,4 @@
+export * from "./bucketOpsBySubscription.js";
+export * from "./setupBucketBillingContext.js";
+export * from "./setupCustomerLevel.js";
+export * from "./types.js";

--- a/server/src/internal/migrations/v2/run/migrateCustomer/setup/setupBucketBillingContext.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/setup/setupBucketBillingContext.ts
@@ -1,0 +1,73 @@
+import { LATEST_BILLING_VERSION } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { setupStripeBillingContext } from "@/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.js";
+import type { MigrateCustomerBillingContext } from "@/internal/migrations/v2/operations/types/migrateCustomerBillingContext.js";
+import type { CustomerLevelContext } from "./setupCustomerLevel.js";
+import type { SubscriptionBucket } from "./types.js";
+
+/**
+ * Per-bucket setup. Reuses the customer-level FullCustomer and fetches
+ * Stripe state for THIS bucket's subscription only (skipped entirely
+ * when `bucket.stripe_subscription_id === null` — the entitlement-only
+ * / DB-only path).
+ *
+ * Returns a `MigrateCustomerBillingContext` ready for `processOperations`
+ * → `evaluateMigrateCustomerStripe` → `executeMigrateCustomerPlan`.
+ */
+export const setupBucketBillingContext = async ({
+	ctx,
+	customerLevel,
+	bucket,
+}: {
+	ctx: AutumnContext;
+	customerLevel: CustomerLevelContext;
+	bucket: SubscriptionBucket;
+}): Promise<MigrateCustomerBillingContext> => {
+	const { fullCustomer, migration, scope_id, prepared_state } = customerLevel;
+
+	const skipStripe =
+		bucket.stripe_subscription_id === null ||
+		migration.no_billing_changes === true;
+
+	// Use the first matched cusproduct in the bucket as the target so
+	// `setupStripeBillingContext` fetches the right sub + schedule.
+	const targetCustomerProduct = bucket.matches[0]?.cusProduct;
+
+	const stripeBilling = skipStripe
+		? {
+				stripeCustomer: undefined,
+				stripeSubscription: undefined,
+				stripeSubscriptionSchedule: undefined,
+				stripeDiscounts: undefined,
+				paymentMethod: undefined,
+			}
+		: await setupStripeBillingContext({
+				ctx,
+				fullCustomer,
+				targetCustomerProduct,
+			});
+
+	return {
+		fullCustomer,
+		fullProducts: [],
+		featureQuantities: [],
+		currentEpochMs: Date.now(),
+		billingCycleAnchorMs: "now",
+		resetCycleAnchorMs: "now",
+		billingVersion: LATEST_BILLING_VERSION,
+		skipBillingChanges: migration.no_billing_changes === true,
+
+		stripeCustomer: stripeBilling.stripeCustomer,
+		stripeSubscription: stripeBilling.stripeSubscription,
+		stripeSubscriptionSchedule: stripeBilling.stripeSubscriptionSchedule,
+		stripeDiscounts: stripeBilling.stripeDiscounts,
+		paymentMethod: stripeBilling.paymentMethod,
+
+		// Migration-specific
+		migration,
+		scope_id,
+		prepared_state,
+		operations: migration.operations?.customer ?? {},
+		projected_cusproducts: fullCustomer.customer_products,
+	};
+};

--- a/server/src/internal/migrations/v2/run/migrateCustomer/setup/setupCustomerLevel.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/setup/setupCustomerLevel.ts
@@ -1,0 +1,48 @@
+import type { FullCustomer, Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { setupFullCustomerContext } from "@/internal/billing/v2/setup/setupFullCustomerContext.js";
+import type { PreparedState } from "@/internal/migrations/v2/prepare/types/index.js";
+import { bucketOpsBySubscription } from "./bucketOpsBySubscription.js";
+import type { SubscriptionBucket } from "./types.js";
+
+export type CustomerLevelContext = {
+	migration: Migration;
+	scope_id: string;
+	prepared_state: PreparedState;
+	fullCustomer: FullCustomer;
+	buckets: SubscriptionBucket[];
+};
+
+/**
+ * Customer-level setup. Runs ONCE per customer:
+ *   1. Fetch FullCustomer (with subs + entities).
+ *   2. Match every op's target → group matches by Stripe sub id.
+ *
+ * Per-bucket Stripe state is fetched later in `setupBucketBillingContext`
+ * so unused subs aren't paid for.
+ */
+export const setupCustomerLevel = async ({
+	ctx,
+	migration,
+	scope_id,
+	prepared_state,
+	customer_id,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	scope_id: string;
+	prepared_state: PreparedState;
+	customer_id: string;
+}): Promise<CustomerLevelContext> => {
+	const fullCustomer = await setupFullCustomerContext({
+		ctx,
+		params: { customer_id },
+	});
+
+	const buckets = bucketOpsBySubscription({
+		cusProducts: fullCustomer.customer_products,
+		operations: migration.operations?.customer ?? {},
+	});
+
+	return { migration, scope_id, prepared_state, fullCustomer, buckets };
+};

--- a/server/src/internal/migrations/v2/run/migrateCustomer/setup/types.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/setup/types.ts
@@ -1,0 +1,21 @@
+import type { FullCusProduct, UpdatePlanOp } from "@autumn/shared";
+
+/**
+ * One (op, cusProduct) pair after target matching. Each match becomes
+ * a unit of work for the per-op processors.
+ */
+export type OperationMatch = {
+	op: UpdatePlanOp;
+	cusProduct: FullCusProduct;
+};
+
+/**
+ * A group of operation-matches that share one Stripe subscription (or
+ * the null bucket — entitlement-only / no Stripe sub). Each bucket
+ * runs its own setup → process → evaluate → execute pipeline so the
+ * familiar one-sub-per-action billing v2 model holds.
+ */
+export type SubscriptionBucket = {
+	stripe_subscription_id: string | null;
+	matches: OperationMatch[];
+};

--- a/server/src/internal/migrations/v2/run/orchestrators/index.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/index.ts
@@ -1,2 +1,3 @@
 export * from "./iterateScope.js";
 export * from "./runPreparation.js";
+export * from "./runScopeIteration.js";

--- a/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
@@ -1,0 +1,78 @@
+import type { Migration, Operations } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { PreparedState } from "@/internal/migrations/v2/prepare/types/index.js";
+import { runFilter } from "../../filters/runFilter.js";
+import { recordMigrationCustomerEvent } from "../events/index.js";
+import { runCustomerMigration } from "../perItem/runCustomerMigration.js";
+import type { RunMigrationScopeResult } from "../types/runMigrationResponse.js";
+import type { RunScopeKind } from "../types/runScope.js";
+import { iterateScope } from "./iterateScope.js";
+
+/** Runs one filtered migration scope iteration. */
+export const runScopeIteration = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	kind,
+	scope_id,
+	operations,
+	prepared_state,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+	kind: RunScopeKind;
+	scope_id: string;
+	operations: Operations;
+	prepared_state: PreparedState;
+}): Promise<RunMigrationScopeResult> => {
+	const { count, iterate } = await runFilter({ ctx, migration, kind });
+	ctx.logger.info(`run-migration: iterating scope`, {
+		data: { kind, count, dryRun },
+	});
+
+	const summary = await iterateScope({
+		iterate,
+		perItem: async (item) => {
+			if (item.kind !== "customer")
+				throw new Error(
+					`runMigration: per-item handler missing for kind "${item.kind}"`,
+				);
+
+			return runCustomerMigration({
+				ctx,
+				migration,
+				migrationRunId,
+				dryRun,
+				scope_id,
+				operations,
+				prepared_state,
+				internalCustomerId: item.internal_id,
+			});
+		},
+	});
+
+	for (const result of summary.results) {
+		if (result.status !== "failed") continue;
+
+		await recordMigrationCustomerEvent({
+			ctx,
+			migration,
+			migrationRunId,
+			dryRun,
+			eventType: "customer_failed",
+			internalCustomerId: result.item.internal_id,
+			customerId: result.item.id,
+			details: {
+				kind,
+				error: {
+					message: result.error.message,
+				},
+			},
+		});
+	}
+
+	return { kind, count, summary };
+};

--- a/server/src/internal/migrations/v2/run/perItem/index.ts
+++ b/server/src/internal/migrations/v2/run/perItem/index.ts
@@ -1,4 +1,5 @@
 export * from "./applyAddItem.js";
 export * from "./matchPlanFilter.js";
 export * from "./matchStringMatcher.js";
+export * from "./runCustomerMigration.js";
 export * from "./runOpsForCustomer.js";

--- a/server/src/internal/migrations/v2/run/perItem/runCustomerMigration.ts
+++ b/server/src/internal/migrations/v2/run/perItem/runCustomerMigration.ts
@@ -1,0 +1,76 @@
+import type { Migration, Operations } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import type { PreparedState } from "@/internal/migrations/v2/prepare/types/index.js";
+import { recordMigrationCustomerEvent } from "../events/index.js";
+import {
+	type RunOpsForCustomerResult,
+	runOpsForCustomer,
+} from "./runOpsForCustomer.js";
+
+/** Runs one customer and records its lifecycle events. */
+export const runCustomerMigration = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	scope_id,
+	operations,
+	prepared_state,
+	internalCustomerId,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+	scope_id: string;
+	operations: Operations;
+	prepared_state: PreparedState;
+	internalCustomerId: string;
+}): Promise<RunOpsForCustomerResult> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: internalCustomerId,
+	});
+
+	await recordMigrationCustomerEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun,
+		eventType: "customer_started",
+		internalCustomerId: fullCustomer.internal_id,
+		customerId: fullCustomer.id,
+		details: { beforeCustomer: fullCustomer },
+	});
+
+	const result = await runOpsForCustomer({
+		ctx,
+		scopeId: scope_id,
+		fullCustomer,
+		operations,
+		preparedState: prepared_state,
+		dryRun,
+	});
+
+	const eventType =
+		result.matched_cusproducts === 0
+			? "customer_skipped"
+			: "customer_succeeded";
+
+	await recordMigrationCustomerEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun,
+		eventType,
+		internalCustomerId: fullCustomer.internal_id,
+		customerId: fullCustomer.id,
+		details: {
+			matchedCustomerProducts: result.matched_cusproducts,
+			upsertItems: result.upsert_items,
+		},
+	});
+
+	return result;
+};

--- a/server/src/internal/migrations/v2/run/perItem/runOpsForCustomer.ts
+++ b/server/src/internal/migrations/v2/run/perItem/runOpsForCustomer.ts
@@ -1,6 +1,5 @@
-import type { Operations } from "@autumn/shared";
+import type { FullCustomer, Operations } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { CusService } from "@/internal/customers/CusService.js";
 import type { PreparedState } from "@/internal/migrations/v2/prepare/types/index.js";
 import { type ApplyAddItemResult, applyAddItem } from "./applyAddItem.js";
 import { matchCustomerProductsByTarget } from "./matchPlanFilter.js";
@@ -18,24 +17,19 @@ export type RunOpsForCustomerResult = {
  */
 export const runOpsForCustomer = async ({
 	ctx,
-	scope_id,
-	internal_customer_id,
+	scopeId,
+	fullCustomer,
 	operations,
-	prepared_state,
-	dry_run,
+	preparedState,
+	dryRun,
 }: {
 	ctx: AutumnContext;
-	scope_id: string;
-	internal_customer_id: string;
+	scopeId: string;
+	fullCustomer: FullCustomer;
 	operations: Operations;
-	prepared_state: PreparedState;
-	dry_run: boolean;
+	preparedState: PreparedState;
+	dryRun: boolean;
 }): Promise<RunOpsForCustomerResult> => {
-	const fullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: internal_customer_id,
-	});
-
 	const updatePlans = operations.customer?.update_plans ?? [];
 	let matched = 0;
 	const upsertItemResults: ApplyAddItemResult[] = [];
@@ -51,11 +45,11 @@ export const runOpsForCustomer = async ({
 			for (const addItem of op.upsert_items ?? []) {
 				const result = await applyAddItem({
 					ctx,
-					scope_id,
+					scope_id: scopeId,
 					cusProduct,
 					addItem,
-					prepared_state,
-					dry_run,
+					prepared_state: preparedState,
+					dry_run: dryRun,
 				});
 				upsertItemResults.push(result);
 			}
@@ -63,7 +57,7 @@ export const runOpsForCustomer = async ({
 	}
 
 	return {
-		internal_customer_id,
+		internal_customer_id: fullCustomer.internal_id,
 		matched_cusproducts: matched,
 		upsert_items: upsertItemResults,
 	};

--- a/server/src/internal/migrations/v2/run/perItem/runOpsForCustomer.ts
+++ b/server/src/internal/migrations/v2/run/perItem/runOpsForCustomer.ts
@@ -8,13 +8,13 @@ import { matchCustomerProductsByTarget } from "./matchPlanFilter.js";
 export type RunOpsForCustomerResult = {
 	internal_customer_id: string;
 	matched_cusproducts: number;
-	add_items: ApplyAddItemResult[];
+	upsert_items: ApplyAddItemResult[];
 };
 
 /**
  * Walk a customer's matching cusproducts × the migration's update_plans
- * × add_items. Phase 1 only — delete_items + priced add_items will be
- * routed in here as their handlers ship.
+ * × upsert_items. Phase 1 only — delete_items + priced upsert_items
+ * will be routed in here as their handlers ship.
  */
 export const runOpsForCustomer = async ({
 	ctx,
@@ -38,7 +38,7 @@ export const runOpsForCustomer = async ({
 
 	const updatePlans = operations.customer?.update_plans ?? [];
 	let matched = 0;
-	const addItemResults: ApplyAddItemResult[] = [];
+	const upsertItemResults: ApplyAddItemResult[] = [];
 
 	for (const op of updatePlans) {
 		const cps = matchCustomerProductsByTarget({
@@ -48,7 +48,7 @@ export const runOpsForCustomer = async ({
 		matched += cps.length;
 
 		for (const cusProduct of cps) {
-			for (const addItem of op.add_items ?? []) {
+			for (const addItem of op.upsert_items ?? []) {
 				const result = await applyAddItem({
 					ctx,
 					scope_id,
@@ -57,7 +57,7 @@ export const runOpsForCustomer = async ({
 					prepared_state,
 					dry_run,
 				});
-				addItemResults.push(result);
+				upsertItemResults.push(result);
 			}
 		}
 	}
@@ -65,6 +65,6 @@ export const runOpsForCustomer = async ({
 	return {
 		internal_customer_id,
 		matched_cusproducts: matched,
-		add_items: addItemResults,
+		upsert_items: upsertItemResults,
 	};
 };

--- a/server/src/internal/migrations/v2/run/runMigration.ts
+++ b/server/src/internal/migrations/v2/run/runMigration.ts
@@ -1,6 +1,8 @@
 import type { Migration, Operations } from "@autumn/shared";
+import { CusService } from "@/internal/customers/CusService.js";
 import type { AutumnContext } from "../../../../honoUtils/HonoEnv.js";
 import { runFilter } from "../filters/runFilter.js";
+import { recordMigrationCustomerEvent } from "./events/index.js";
 import { iterateScope, runPreparation } from "./orchestrators/index.js";
 import { runOpsForCustomer } from "./perItem/runOpsForCustomer.js";
 import type {
@@ -14,16 +16,30 @@ export const runMigration = async ({
 	ctx,
 	migration,
 	dry_run,
+	migrationRunId,
 }: {
 	ctx: AutumnContext;
 	migration: Migration;
 	dry_run: boolean;
+	migrationRunId: string;
 }): Promise<RunMigrationResponse> => {
-	const { response: prepareResponse, prepared_state } = await runPreparation({
+	await recordMigrationCustomerEvent({
 		ctx,
 		migration,
-		dry_run,
+		migrationRunId,
+		dryRun: dry_run,
+		eventType: "migration_started",
+		details: {
+			migrationInternalId: migration.internal_id,
+		},
 	});
+
+	const { response: prepareResponse, prepared_state: preparedState } =
+		await runPreparation({
+			ctx,
+			migration,
+			dry_run,
+		});
 
 	const scope_id = `mig_${migration.internal_id}`;
 	const operations: Operations = migration.operations ?? {};
@@ -43,19 +59,93 @@ export const runMigration = async ({
 					throw new Error(
 						`runMigration: per-item handler missing for kind "${item.kind}"`,
 					);
-				return runOpsForCustomer({
+
+				const fullCustomer = await CusService.getFull({
 					ctx,
-					scope_id,
-					internal_customer_id: item.internal_id,
-					operations,
-					prepared_state,
-					dry_run,
+					idOrInternalId: item.internal_id,
 				});
+
+				await recordMigrationCustomerEvent({
+					ctx,
+					migration,
+					migrationRunId,
+					dryRun: dry_run,
+					eventType: "customer_started",
+					internalCustomerId: fullCustomer.internal_id,
+					customerId: fullCustomer.id,
+					details: { beforeCustomer: fullCustomer },
+				});
+
+				const result = await runOpsForCustomer({
+					ctx,
+					scopeId: scope_id,
+					fullCustomer,
+					operations,
+					preparedState,
+					dryRun: dry_run,
+				});
+
+				await recordMigrationCustomerEvent({
+					ctx,
+					migration,
+					migrationRunId,
+					dryRun: dry_run,
+					eventType:
+						result.matched_cusproducts === 0
+							? "customer_skipped"
+							: "customer_succeeded",
+					internalCustomerId: fullCustomer.internal_id,
+					customerId: fullCustomer.id,
+					details: {
+						matchedCustomerProducts: result.matched_cusproducts,
+						upsertItems: result.upsert_items,
+					},
+				});
+
+				return result;
 			},
 		});
 
+		const failedResults = summary.results.filter(
+			(result) => result.status === "failed",
+		);
+		if (failedResults.length > 0) {
+			await recordMigrationCustomerEvent({
+				ctx,
+				migration,
+				migrationRunId,
+				dryRun: dry_run,
+				eventType: "customers_failed",
+				details: {
+					kind,
+					errors: failedResults.map((result) => ({
+						internalCustomerId: result.item.internal_id,
+						customerId: result.item.id,
+						message: result.error.message,
+					})),
+				},
+			});
+		}
+
 		scopeResults.push({ kind, count, summary });
 	}
+
+	await recordMigrationCustomerEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun: dry_run,
+		eventType: "migration_completed",
+		details: {
+			scopes: scopeResults.map(({ kind, count, summary }) => ({
+				kind,
+				count,
+				processed: summary.processed,
+				succeeded: summary.succeeded,
+				failed: summary.failed,
+			})),
+		},
+	});
 
 	return {
 		migration_id: migration.id,

--- a/server/src/internal/migrations/v2/run/runMigration.ts
+++ b/server/src/internal/migrations/v2/run/runMigration.ts
@@ -1,18 +1,16 @@
 import type { Migration, Operations } from "@autumn/shared";
-import { CusService } from "@/internal/customers/CusService.js";
 import type { AutumnContext } from "../../../../honoUtils/HonoEnv.js";
-import { runFilter } from "../filters/runFilter.js";
 import {
-	getMigrationRunEventType,
 	recordMigrationCustomerEvent,
+	recordMigrationFailedEvent,
+	recordMigrationTerminalEvent,
 } from "./events/index.js";
-import { iterateScope, runPreparation } from "./orchestrators/index.js";
-import { runOpsForCustomer } from "./perItem/runOpsForCustomer.js";
+import { runPreparation, runScopeIteration } from "./orchestrators/index.js";
+import { getRunScopes } from "./types/index.js";
 import type {
 	RunMigrationResponse,
 	RunMigrationScopeResult,
 } from "./types/runMigrationResponse.js";
-import type { RunScopeKind } from "./types/runScope.js";
 
 /** Top-level migration run: prepare → per-scope filter+iterate → per-item ops. */
 export const runMigration = async ({
@@ -26,6 +24,42 @@ export const runMigration = async ({
 	dry_run: boolean;
 	migrationRunId: string;
 }): Promise<RunMigrationResponse> => {
+	const scopeResults: RunMigrationScopeResult[] = [];
+
+	try {
+		return await executeMigrationRun({
+			ctx,
+			migration,
+			dry_run,
+			migrationRunId,
+			scopeResults,
+		});
+	} catch (error) {
+		await recordMigrationFailedEvent({
+			ctx,
+			migration,
+			migrationRunId,
+			dryRun: dry_run,
+			error,
+			scopeResults,
+		});
+		throw error;
+	}
+};
+
+const executeMigrationRun = async ({
+	ctx,
+	migration,
+	dry_run,
+	migrationRunId,
+	scopeResults,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	dry_run: boolean;
+	migrationRunId: string;
+	scopeResults: RunMigrationScopeResult[];
+}): Promise<RunMigrationResponse> => {
 	await recordMigrationCustomerEvent({
 		ctx,
 		migration,
@@ -37,119 +71,36 @@ export const runMigration = async ({
 		},
 	});
 
-	const { response: prepareResponse, prepared_state: preparedState } =
-		await runPreparation({
-			ctx,
-			migration,
-			dry_run,
-		});
+	const { response: prepareResponse, prepared_state } = await runPreparation({
+		ctx,
+		migration,
+		dry_run,
+	});
 
 	const scope_id = `mig_${migration.internal_id}`;
 	const operations: Operations = migration.operations ?? {};
 
-	const scopeResults: RunMigrationScopeResult[] = [];
-
-	for (const kind of scopesForRun(migration)) {
-		const { count, iterate } = await runFilter({ ctx, migration, kind });
-		ctx.logger.info(`run-migration: iterating scope`, {
-			data: { kind, count, dry_run },
+	for (const kind of getRunScopes({ migration })) {
+		const scopeResult = await runScopeIteration({
+			ctx,
+			migration,
+			migrationRunId,
+			dryRun: dry_run,
+			kind,
+			scope_id,
+			operations,
+			prepared_state,
 		});
 
-		const summary = await iterateScope({
-			iterate,
-			perItem: async (item) => {
-				if (item.kind !== "customer")
-					throw new Error(
-						`runMigration: per-item handler missing for kind "${item.kind}"`,
-					);
-
-				const fullCustomer = await CusService.getFull({
-					ctx,
-					idOrInternalId: item.internal_id,
-				});
-
-				await recordMigrationCustomerEvent({
-					ctx,
-					migration,
-					migrationRunId,
-					dryRun: dry_run,
-					eventType: "customer_started",
-					internalCustomerId: fullCustomer.internal_id,
-					customerId: fullCustomer.id,
-					details: { beforeCustomer: fullCustomer },
-				});
-
-				const result = await runOpsForCustomer({
-					ctx,
-					scopeId: scope_id,
-					fullCustomer,
-					operations,
-					preparedState,
-					dryRun: dry_run,
-				});
-
-				await recordMigrationCustomerEvent({
-					ctx,
-					migration,
-					migrationRunId,
-					dryRun: dry_run,
-					eventType:
-						result.matched_cusproducts === 0
-							? "customer_skipped"
-							: "customer_succeeded",
-					internalCustomerId: fullCustomer.internal_id,
-					customerId: fullCustomer.id,
-					details: {
-						matchedCustomerProducts: result.matched_cusproducts,
-						upsertItems: result.upsert_items,
-					},
-				});
-
-				return result;
-			},
-		});
-
-		const failedResults = summary.results.filter(
-			(result) => result.status === "failed",
-		);
-		for (const result of failedResults) {
-			await recordMigrationCustomerEvent({
-				ctx,
-				migration,
-				migrationRunId,
-				dryRun: dry_run,
-				eventType: "customer_failed",
-				internalCustomerId: result.item.internal_id,
-				customerId: result.item.id,
-				details: {
-					kind,
-					error: {
-						message: result.error.message,
-					},
-				},
-			});
-		}
-
-		scopeResults.push({ kind, count, summary });
+		scopeResults.push(scopeResult);
 	}
 
-	const scopes = scopeResults.map(({ kind, count, summary }) => ({
-		kind,
-		count,
-		processed: summary.processed,
-		succeeded: summary.succeeded,
-		failed: summary.failed,
-	}));
-
-	await recordMigrationCustomerEvent({
+	await recordMigrationTerminalEvent({
 		ctx,
 		migration,
 		migrationRunId,
 		dryRun: dry_run,
-		eventType: getMigrationRunEventType({ scopes }),
-		details: {
-			scopes,
-		},
+		scopeResults,
 	});
 
 	return {
@@ -158,12 +109,4 @@ export const runMigration = async ({
 		prepare_warnings: prepareResponse.warnings,
 		scopes: scopeResults,
 	};
-};
-
-/** Active scopes = top-level keys present in `migration.operations`. */
-const scopesForRun = (migration: Migration): RunScopeKind[] => {
-	const scopes: RunScopeKind[] = [];
-	if (migration.operations?.customer) scopes.push("customer");
-	// future: if (migration.operations?.plan) scopes.push("plan");
-	return scopes;
 };

--- a/server/src/internal/migrations/v2/run/runMigration.ts
+++ b/server/src/internal/migrations/v2/run/runMigration.ts
@@ -2,7 +2,10 @@ import type { Migration, Operations } from "@autumn/shared";
 import { CusService } from "@/internal/customers/CusService.js";
 import type { AutumnContext } from "../../../../honoUtils/HonoEnv.js";
 import { runFilter } from "../filters/runFilter.js";
-import { recordMigrationCustomerEvent } from "./events/index.js";
+import {
+	getMigrationRunEventType,
+	recordMigrationCustomerEvent,
+} from "./events/index.js";
 import { iterateScope, runPreparation } from "./orchestrators/index.js";
 import { runOpsForCustomer } from "./perItem/runOpsForCustomer.js";
 import type {
@@ -109,20 +112,20 @@ export const runMigration = async ({
 		const failedResults = summary.results.filter(
 			(result) => result.status === "failed",
 		);
-		if (failedResults.length > 0) {
+		for (const result of failedResults) {
 			await recordMigrationCustomerEvent({
 				ctx,
 				migration,
 				migrationRunId,
 				dryRun: dry_run,
-				eventType: "customers_failed",
+				eventType: "customer_failed",
+				internalCustomerId: result.item.internal_id,
+				customerId: result.item.id,
 				details: {
 					kind,
-					errors: failedResults.map((result) => ({
-						internalCustomerId: result.item.internal_id,
-						customerId: result.item.id,
+					error: {
 						message: result.error.message,
-					})),
+					},
 				},
 			});
 		}
@@ -130,20 +133,22 @@ export const runMigration = async ({
 		scopeResults.push({ kind, count, summary });
 	}
 
+	const scopes = scopeResults.map(({ kind, count, summary }) => ({
+		kind,
+		count,
+		processed: summary.processed,
+		succeeded: summary.succeeded,
+		failed: summary.failed,
+	}));
+
 	await recordMigrationCustomerEvent({
 		ctx,
 		migration,
 		migrationRunId,
 		dryRun: dry_run,
-		eventType: "migration_completed",
+		eventType: getMigrationRunEventType({ scopes }),
 		details: {
-			scopes: scopeResults.map(({ kind, count, summary }) => ({
-				kind,
-				count,
-				processed: summary.processed,
-				succeeded: summary.succeeded,
-				failed: summary.failed,
-			})),
+			scopes,
 		},
 	});
 

--- a/server/src/internal/migrations/v2/run/types/getRunScopes.ts
+++ b/server/src/internal/migrations/v2/run/types/getRunScopes.ts
@@ -1,0 +1,14 @@
+import type { Migration } from "@autumn/shared";
+import type { RunScopeKind } from "./runScope.js";
+
+/** Returns active run scopes from top-level migration operations. */
+export const getRunScopes = ({
+	migration,
+}: {
+	migration: Migration;
+}): RunScopeKind[] => {
+	const scopes: RunScopeKind[] = [];
+	if (migration.operations?.customer) scopes.push("customer");
+	// future: if (migration.operations?.plan) scopes.push("plan");
+	return scopes;
+};

--- a/server/src/internal/migrations/v2/run/types/index.ts
+++ b/server/src/internal/migrations/v2/run/types/index.ts
@@ -1,2 +1,3 @@
+export * from "./getRunScopes.js";
 export * from "./runMigrationResponse.js";
 export * from "./runScope.js";

--- a/server/src/trigger/migrations/runMigrationTask.ts
+++ b/server/src/trigger/migrations/runMigrationTask.ts
@@ -33,7 +33,12 @@ export const runMigrationTask = task({
 
 		const migration = await migrationRepo.find({ ctx, id: migrationId });
 
-		const result = await runMigration({ ctx, migration, dry_run: dryRun });
+		const result = await runMigration({
+			ctx,
+			migration,
+			dry_run: dryRun,
+			migrationRunId: triggerCtx.run.id,
+		});
 
 		logger.info("run-migration: done", {
 			data: {

--- a/server/tests/integration/billing/migrations-v2/migrations-add-items.test.ts
+++ b/server/tests/integration/billing/migrations-v2/migrations-add-items.test.ts
@@ -52,7 +52,7 @@ test.concurrent(`${chalk.yellowBright("migrations-v2 add-items: triggers run for
 				update_plans: [
 					{
 						target: { plan_id: free.id },
-						add_items: [{ feature_id: TestFeature.Dashboard }],
+						upsert_items: [{ feature_id: TestFeature.Dashboard }],
 					},
 				],
 			},

--- a/server/tinybird/datasources/migration_customer_events.datasource
+++ b/server/tinybird/datasources/migration_customer_events.datasource
@@ -1,0 +1,19 @@
+DESCRIPTION >
+    Per-customer lifecycle events for migrations v2. Append-only audit stream.
+
+SCHEMA >
+    `id` String `json:$.id`,
+    `timestamp` DateTime64(6) `json:$.timestamp`,
+    `org_id` String `json:$.orgId`,
+    `env` LowCardinality(String) `json:$.env`,
+    `migration_id` String `json:$.migrationId`,
+    `migration_run_id` String `json:$.migrationRunId`,
+    `event_type` LowCardinality(String) `json:$.eventType`,
+    `dry_run` UInt8 `json:$.dryRun`,
+    `internal_customer_id` Nullable(String) `json:$.internalCustomerId`,
+    `customer_id` Nullable(String) `json:$.customerId`,
+    `details` Nullable(String) `json:$.details`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
+ENGINE_SORTING_KEY "org_id, env, migration_run_id, internal_customer_id, timestamp"

--- a/shared/api/migrations/operations/customer/customerOperations.ts
+++ b/shared/api/migrations/operations/customer/customerOperations.ts
@@ -2,9 +2,12 @@ import { z } from "zod/v4";
 import { UpdatePlanOpSchema } from "./updatePlan/index.js";
 
 /**
- * Operations applied to a matched customer's resources. Phase 1 ships
- * only `update_plans`. `add_plans` / `remove_plans` slots reserved for
- * phase 2+.
+ * Operations applied to each matched customer.
+ *
+ * Phase 1 ships only `update_plans`. Slots reserved for phase 2+:
+ * `remove_plans`, `add_plans` — when added, the orchestrator will
+ * process them in the order remove → add → update so update_plans
+ * can target plans the prior phases just attached.
  */
 export const CustomerOperationsSchema = z
 	.object({

--- a/shared/api/migrations/operations/customer/updatePlan/updatePlanOp.ts
+++ b/shared/api/migrations/operations/customer/updatePlan/updatePlanOp.ts
@@ -7,30 +7,28 @@ import { PlanItemFilterSchema } from "../../../filters/planItemFilter.js";
  * Patch a customer's matching plan instances in place. Mirrors the patch
  * fields of CustomizePlanV1.
  *
- * Phase 1 fields: `target`, `add_items`, `delete_items`. Slots reserved
- * for phase 2+: `cancel_at`, `price`, `free_trial`, `update_items`,
- * `replace_items`.
+ * - `upsert_items` is idempotent: existing items matched on `feature_id`
+ *   are kept (or updated); missing ones are inserted. Uses the
+ *   `CreatePlanItemParamsV1` shape.
+ * - `delete_items` uses `PlanItemFilter` to match items and remove them.
  *
- * - `add_items`  uses `CreatePlanItemParamsV1` (the create-plan-item
- *   shape). Phase 1 expects entitlement-only items; priced items defer
- *   to phase 2 auto-prep, enforced by handler-side validation.
- * - `delete_items` uses `PlanItemFilter` to match items on each target
- *   plan and remove them.
+ * Slots reserved for phase 2+: `cancel_at`, `price`, `free_trial`,
+ * `update_items`, `replace_items`.
  */
 export const UpdatePlanOpSchema = z
 	.object({
 		target: PlanFilterSchema,
-		add_items: z.array(CreatePlanItemParamsV1Schema).optional(),
+		upsert_items: z.array(CreatePlanItemParamsV1Schema).optional(),
 		delete_items: z.array(PlanItemFilterSchema).optional(),
 	})
 	.check((ctx) => {
-		const hasAdds = (ctx.value.add_items?.length ?? 0) > 0;
+		const hasUpserts = (ctx.value.upsert_items?.length ?? 0) > 0;
 		const hasDeletes = (ctx.value.delete_items?.length ?? 0) > 0;
-		if (!hasAdds && !hasDeletes) {
+		if (!hasUpserts && !hasDeletes) {
 			ctx.issues.push({
 				code: "custom",
 				message:
-					"update_plans op requires non-empty add_items or delete_items",
+					"update_plans op requires non-empty upsert_items or delete_items",
 				input: ctx.value,
 			});
 		}

--- a/shared/models/billingModels/plan/autumnBillingPlan.ts
+++ b/shared/models/billingModels/plan/autumnBillingPlan.ts
@@ -71,6 +71,12 @@ export const AutumnBillingPlanSchema = z.object({
 	deleteCustomerProduct: FullCusProductSchema.optional(), // Scheduled product to delete (e.g., when updating while canceling)
 	deleteCustomerProducts: z.array(FullCusProductSchema).optional(),
 
+	// Used by migration `delete_items` to drop specific cusEnts/cusPrices
+	// without rebuilding the cusproduct. Honored by executeAutumnBillingPlan
+	// after insert/update phases.
+	deleteCustomerEntitlementIds: z.array(z.string()).optional(),
+	deleteCustomerPriceIds: z.array(z.string()).optional(),
+
 	customPrices: z.array(PriceSchema).optional(), // Custom prices to insert
 	customEntitlements: z.array(EntitlementSchema).optional(), // Custom entitlements to insert
 	customFreeTrial: FreeTrialSchema.optional(), // Custom free trial to insert

--- a/shared/models/migrationV2Models/migrationTable.ts
+++ b/shared/models/migrationV2Models/migrationTable.ts
@@ -1,4 +1,5 @@
 import {
+	boolean,
 	foreignKey,
 	jsonb,
 	numeric,
@@ -40,6 +41,11 @@ export const migrations = pgTable(
 		// Snapshot of the last successful prepare-run output, keyed by
 		// module key. See shared/api/migrations/prepare/preparedStateTypes.ts.
 		prepared_state: jsonb().$type<LoosePreparedState>(),
+
+		// `null` (default) → infer from compute output.
+		// `true` → force DB-only path; throw if any Stripe-relevant mutation slips in.
+		// `false` → force Stripe path even when inference would say DB-only.
+		no_billing_changes: boolean(),
 
 		created_at: numeric({ mode: "number" }).notNull(),
 		updated_at: numeric({ mode: "number" }),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds persistence for migration lifecycle events by streaming per-customer and run-level events to Tinybird for audits and debugging.

- **New Features**
  - Tinybird ingest for `migration_customer_events` with a new datasource and Zod schema.
  - Emits `migration_started`, per-customer `customer_started`/`customer_succeeded`/`customer_skipped`/`customer_failed`, and terminal run events (`migration_succeeded`/`migration_partially_failed`/`migration_failed`) with scope summaries and errors.
  - Best-effort send with logging and `@sentry/bun`; migration execution never blocks on analytics.
  - `runMigrationTask` passes `migrationRunId` to tie events to a specific run.

- **Refactors**
  - Split `runMigration` into `runScopeIteration`, `runCustomerMigration`, and `getRunScopes`; records per-item failures as events.
  - `runOpsForCustomer` now accepts `fullCustomer`, `preparedState`, `scopeId`, and `dryRun` (removes internal `CusService` fetch).

<sup>Written for commit 84d5bddaae058719b6203f223d4b43de4f2862a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

