### PR TITLE
Fix sync sheet showing nothing when detection matches zero plans

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts
+++ b/server/src/internal/billing/v2/actions/sync/syncProposalsV2.ts
@@ -2,6 +2,7 @@ import {
 	ErrCode,
 	type FullCusProduct,
 	RecaseError,
+	type SyncPhase,
 	type SyncProposalsV2Params,
 	type SyncProposalsV2Response,
 	type SyncProposalV2,
@@ -42,10 +43,17 @@ const buildProposal = async ({
 		subscription,
 	});
 
+	const detectedPhases = params.phases ?? [];
+
+	// Always include at least one phase so the UI can display the Stripe
+	// subscription items and let the user manually pick Autumn plans.
+	const fallbackPhase: SyncPhase = { starts_at: "now", plans: [] };
+	const phases = detectedPhases.length > 0 ? detectedPhases : [fallbackPhase];
+
 	return {
 		stripe_subscription_id: params.stripe_subscription_id,
 		stripe_schedule_id: params.stripe_schedule_id,
-		phases: params.phases ?? [],
+		phases,
 		stripe_subscription: subscription,
 		stripe_schedule: schedule,
 		already_linked_product_id: findAlreadyLinkedProductId({


### PR DESCRIPTION
## Summary
- When auto-detection matched zero Autumn plans for a Stripe subscription, the `phases` array was empty, causing the sync editor view to render nothing — no subscription items and no way to add plans.
- Adds a fallback `{ starts_at: "now", plans: [] }` phase so the UI always displays the Stripe subscription items and lets the user manually pick Autumn plans.

## Test plan
- Open sync sheet for a customer whose Stripe subscription doesn't match any Autumn products
- Verify "Subscription items" and "Autumn plans" sections render
- Verify "Add plan" button is available to manually pick plans
- Verify subscriptions that DO auto-match still work as before

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sync sheet showing nothing when auto-detection matches zero Autumn plans. Adds a default "now" phase so Stripe subscription items render and users can add plans.

- **Bug Fixes**
  - When no phases are detected, create a fallback `{ starts_at: "now", plans: [] }` so the editor always has at least one phase.
  - If phases are detected, use them unchanged to preserve existing behavior.

<sup>Written for commit 19cfd79d1158ab3f8ba3a4967684def824dc69b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

