### PR TITLE
chore: handle cancel with future starts_at

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelPlan.ts
@@ -1,7 +1,11 @@
 import {
 	type AutumnBillingPlan,
+	CusProductStatus,
 	cp,
 	type FullCusProduct,
+	findMainActiveCustomerProductByGroup,
+	isCustomerProductCanceling,
+	isFutureStartDate,
 	type UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -39,6 +43,68 @@ const computeScheduledAddOnsToDelete = ({
 	});
 };
 
+const shouldDeleteCustomerProductBeforeBillingStarts = ({
+	customerProduct,
+	currentEpochMs,
+}: {
+	customerProduct: FullCusProduct;
+	currentEpochMs: number;
+}): boolean => {
+	if (customerProduct.status === CusProductStatus.Scheduled) return true;
+
+	const hasStripeSchedule = (customerProduct.scheduled_ids?.length ?? 0) > 0;
+	const hasStripeSubscription =
+		(customerProduct.subscription_ids?.length ?? 0) > 0;
+
+	return (
+		hasStripeSchedule &&
+		!hasStripeSubscription &&
+		isFutureStartDate(customerProduct.starts_at, currentEpochMs)
+	);
+};
+
+const computeScheduledCancelPlan = ({
+	billingContext,
+	plan,
+}: {
+	billingContext: UpdateSubscriptionBillingContext;
+	plan: AutumnBillingPlan;
+}): AutumnBillingPlan => {
+	const { customerProduct, fullCustomer } = billingContext;
+
+	const activeCustomerProduct = findMainActiveCustomerProductByGroup({
+		fullCus: fullCustomer,
+		productGroup: customerProduct.product.group,
+		internalEntityId: customerProduct.internal_entity_id ?? undefined,
+	});
+
+	const scheduledCancelPlan: AutumnBillingPlan = {
+		...plan,
+		updateCustomerProduct: undefined,
+		deleteCustomerProduct: customerProduct,
+	};
+
+	if (
+		!activeCustomerProduct ||
+		activeCustomerProduct.id === customerProduct.id ||
+		!isCustomerProductCanceling(activeCustomerProduct)
+	) {
+		return scheduledCancelPlan;
+	}
+
+	return {
+		...scheduledCancelPlan,
+		updateCustomerProduct: {
+			customerProduct: activeCustomerProduct,
+			updates: {
+				canceled: false,
+				canceled_at: null,
+				ended_at: null,
+			},
+		},
+	};
+};
+
 /**
  * Computes and applies the cancel plan for a subscription.
  *
@@ -59,6 +125,18 @@ export const computeCancelPlan = ({
 
 	if (billingContext.cancelAction === "uncancel") {
 		return applyUncancelToPlan({
+			billingContext,
+			plan,
+		});
+	}
+
+	if (
+		shouldDeleteCustomerProductBeforeBillingStarts({
+			customerProduct: billingContext.customerProduct,
+			currentEpochMs: billingContext.currentEpochMs,
+		})
+	) {
+		return computeScheduledCancelPlan({
 			billingContext,
 			plan,
 		});

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleCurrentCustomerProductErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleCurrentCustomerProductErrors.ts
@@ -12,7 +12,10 @@ export const handleCurrentCustomerProductErrors = ({
 }) => {
 	const { customerProduct } = billingContext;
 
-	if (isCustomerProductScheduled(customerProduct)) {
+	if (
+		isCustomerProductScheduled(customerProduct) &&
+		!billingContext.cancelAction
+	) {
 		throw new RecaseError({
 			message: `Cannot update subscription for '${customerProduct.product.name}' because it is scheduled and not yet active`,
 		});

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors.ts
@@ -80,5 +80,5 @@ export const handleUpdateSubscriptionErrors = async ({
 	handleUpdateCheckoutErrors({ billingContext });
 
 	// 12. Stripe billing plan errors (validate Stripe resources)
-	handleStripeBillingPlanErrors({ billingContext });
+	handleStripeBillingPlanErrors({ billingContext, billingPlan });
 };

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionScheduleAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionScheduleAction.ts
@@ -91,12 +91,40 @@ const getScheduleScenario = ({
 	return "multi_phase";
 };
 
+const buildNoPhasesAction = ({
+	hasSubscription,
+	scheduleId,
+}: {
+	hasSubscription: boolean;
+	scheduleId: string | undefined;
+}): StripeSubscriptionScheduleResult => {
+	if (!scheduleId) return {};
+
+	if (hasSubscription) {
+		return {
+			scheduleAction: {
+				type: "release",
+				stripeSubscriptionScheduleId: scheduleId,
+			},
+			subscriptionCancelAt: null,
+		};
+	}
+
+	return {
+		scheduleAction: {
+			type: "cancel",
+			stripeSubscriptionScheduleId: scheduleId,
+		},
+	};
+};
+
 /**
  * Builds the appropriate action for each scenario.
  */
 const buildActionForScenario = ({
 	scenario,
 	hasSchedule,
+	hasSubscription,
 	scheduleId,
 	scheduledPhases,
 	cancelAtSeconds,
@@ -105,6 +133,7 @@ const buildActionForScenario = ({
 }: {
 	scenario: ScheduleScenario;
 	hasSchedule: boolean;
+	hasSubscription: boolean;
 	scheduleId: string | undefined;
 	scheduledPhases: Stripe.SubscriptionScheduleUpdateParams.Phase[];
 	cancelAtSeconds: number | undefined;
@@ -113,7 +142,10 @@ const buildActionForScenario = ({
 }): StripeSubscriptionScheduleResult => {
 	switch (scenario) {
 		case "no_phases":
-			return {};
+			return buildNoPhasesAction({
+				hasSubscription,
+				scheduleId,
+			});
 
 		case "single_indefinite":
 			// Product continues indefinitely: release schedule if exists, clear any cancel_at
@@ -285,6 +317,7 @@ export const buildStripeSubscriptionScheduleAction = ({
 	return buildActionForScenario({
 		scenario,
 		hasSchedule: !!stripeSubscriptionSchedule,
+		hasSubscription: !!stripeSubscription,
 		scheduleId: stripeSubscriptionSchedule?.id,
 		scheduledPhases,
 		cancelAtSeconds,

--- a/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
+++ b/server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts
@@ -1,5 +1,8 @@
+import type {
+	BillingPlan,
+	UpdateSubscriptionBillingContext,
+} from "@autumn/shared";
 import { ErrCode, InternalError } from "@autumn/shared";
-import type { UpdateSubscriptionBillingContext } from "@autumn/shared";
 
 /**
  * Validates Stripe-specific billing context requirements before executing billing plan.
@@ -7,22 +10,24 @@ import type { UpdateSubscriptionBillingContext } from "@autumn/shared";
  */
 export const handleStripeBillingPlanErrors = ({
 	billingContext,
+	billingPlan,
 }: {
 	billingContext: UpdateSubscriptionBillingContext;
+	billingPlan: BillingPlan;
 }) => {
-	// If there's an existing subscription schedule, validate it has current_phase.start_date
-	// This is required for schedule updates (Stripe requires anchoring phases to the current phase start)
+	const { stripeSubscriptionSchedule } = billingContext;
+	const { subscriptionScheduleAction } = billingPlan.stripe;
 
-	if (billingContext.stripeSubscriptionSchedule) {
-		const currentPhaseStart =
-			billingContext.stripeSubscriptionSchedule.current_phase?.start_date;
+	if (subscriptionScheduleAction?.type !== "update") return;
+	if (!stripeSubscriptionSchedule?.subscription) return;
 
-		if (!currentPhaseStart) {
-			throw new InternalError({
-				message:
-					"Cannot update subscription schedule: missing current phase start_date",
-				code: ErrCode.InternalError,
-			});
-		}
+	const currentPhaseStart =
+		stripeSubscriptionSchedule.current_phase?.start_date;
+	if (!currentPhaseStart) {
+		throw new InternalError({
+			message:
+				"Cannot update subscription schedule: missing current phase start_date",
+			code: ErrCode.InternalError,
+		});
 	}
 };

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction.ts
@@ -257,5 +257,14 @@ export const executeStripeSubscriptionScheduleAction = async ({
 				subscriptionScheduleAction.stripeSubscriptionScheduleId,
 			);
 			return null;
+
+		case "cancel":
+			ctx.logger.debug(
+				`[executeStripeSubscriptionScheduleAction] Canceling schedule: ${subscriptionScheduleAction.stripeSubscriptionScheduleId}`,
+			);
+			await stripeCli.subscriptionSchedules.cancel(
+				subscriptionScheduleAction.stripeSubscriptionScheduleId,
+			);
+			return null;
 	}
 };

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/logSubscriptionScheduleAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/logSubscriptionScheduleAction.ts
@@ -1,7 +1,9 @@
+import type {
+	BillingContext,
+	StripeSubscriptionScheduleAction,
+} from "@autumn/shared";
 import { formatSecondsToDate } from "@autumn/shared";
 import type { AutumnContext } from "@server/honoUtils/HonoEnv";
-import type { BillingContext } from "@autumn/shared";
-import type { StripeSubscriptionScheduleAction } from "@autumn/shared";
 import type Stripe from "stripe";
 import { billingContextFormatPriceByStripePriceId } from "@/internal/billing/v2/utils/billingContextPriceLookup";
 
@@ -45,7 +47,10 @@ export const logSubscriptionScheduleAction = ({
 	billingContext: BillingContext;
 	subscriptionScheduleAction: StripeSubscriptionScheduleAction;
 }): void => {
-	if (subscriptionScheduleAction.type === "release") {
+	if (
+		subscriptionScheduleAction.type === "release" ||
+		subscriptionScheduleAction.type === "cancel"
+	) {
 		ctx.logger.debug(
 			`[logSubscriptionScheduleAction] Action type: ${subscriptionScheduleAction.type}`,
 		);

--- a/server/tests/integration/billing/attach/params/start-date/starts-at-scheduling.test.ts
+++ b/server/tests/integration/billing/attach/params/start-date/starts-at-scheduling.test.ts
@@ -101,6 +101,116 @@ test.concurrent(`${chalk.yellowBright("starts_at: future attach creates schedule
 	await expectCustomerInvoiceCorrect({ customerId, count: 0 });
 });
 
+test.concurrent(`${chalk.yellowBright("starts_at: scheduled subscription can be canceled by customer_product_id")}`, async () => {
+	const customerId = "attach-start-date-cancel-scheduled";
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const { autumnV1, autumnV2_2, ctx, advancedTo } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [],
+	});
+
+	const startDate = addDays(advancedTo, 1).getTime();
+	await autumnV2_2.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		plan_id: pro.id,
+		starts_at: startDate,
+	});
+
+	const scheduledCustomerProduct = await getCustomerProduct({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+	const scheduleId = scheduledCustomerProduct.scheduled_ids?.[0];
+	if (!scheduleId)
+		throw new Error("Expected scheduled product to have schedule");
+
+	const preview = await autumnV1.subscriptions.previewUpdate({
+		customer_id: customerId,
+		customer_product_id: scheduledCustomerProduct.id,
+		cancel_action: "cancel_immediately",
+	});
+	expect(preview.total).toBe(0);
+
+	await autumnV1.subscriptions.update({
+		customer_id: customerId,
+		customer_product_id: scheduledCustomerProduct.id,
+		cancel_action: "cancel_immediately",
+	});
+
+	const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+	await expectCustomerProducts({
+		customer,
+		notPresent: [pro.id],
+	});
+
+	const stripeSchedule =
+		await ctx.stripeCli.subscriptionSchedules.retrieve(scheduleId);
+	expect(stripeSchedule.status).toBe("canceled");
+	await expectCustomerInvoiceCorrect({ customerId, count: 0 });
+});
+
+test.concurrent(`${chalk.yellowBright("starts_at: immediate-access future subscription cancels by deleting schedule")}`, async () => {
+	const customerId = "attach-start-date-cancel-immediate-access-v2";
+	const pro = products.pro({
+		id: "pro-immediate-access-cancel",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const { autumnV1, autumnV2_2, ctx, advancedTo } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [],
+	});
+
+	const startDate = addDays(advancedTo, 1).getTime();
+	await autumnV2_2.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		plan_id: pro.id,
+		starts_at: startDate,
+		enable_plan_immediately: true,
+	});
+
+	const customerProduct = await getCustomerProduct({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+	const scheduleId = customerProduct.scheduled_ids?.[0];
+	if (!scheduleId)
+		throw new Error("Expected immediate-access product to have schedule");
+	expect(customerProduct.status).toBe(CusProductStatus.Active);
+	expect(customerProduct.subscription_ids ?? []).toEqual([]);
+
+	await autumnV1.subscriptions.update({
+		customer_id: customerId,
+		customer_product_id: customerProduct.id,
+		cancel_action: "cancel_end_of_cycle",
+	});
+
+	const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+	await expectCustomerProducts({
+		customer,
+		notPresent: [pro.id],
+	});
+
+	const stripeSchedule =
+		await ctx.stripeCli.subscriptionSchedules.retrieve(scheduleId);
+	expect(stripeSchedule.status).toBe("canceled");
+	await expectCustomerInvoiceCorrect({ customerId, count: 0 });
+});
+
 test.concurrent(`${chalk.yellowBright("starts_at: future attach without payment method creates invoice schedule")}`, async () => {
 	const customerId = "attach-start-date-future-invoice";
 	const pro = products.pro({

--- a/server/tests/integration/billing/update-subscription/errors/cancel-errors.test.ts
+++ b/server/tests/integration/billing/update-subscription/errors/cancel-errors.test.ts
@@ -5,12 +5,14 @@
  */
 
 import { expect, test } from "bun:test";
-import { type ApiCustomerV3, ErrCode, FreeTrialDuration } from "@autumn/shared";
+import { type ApiCustomerV3, FreeTrialDuration } from "@autumn/shared";
 import {
+	expectCustomerProducts,
 	expectProductCanceling,
 	expectProductNotPresent,
 	expectProductScheduled,
 } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectSubToBeCorrect } from "@tests/merged/mergeUtils/expectSubCorrect";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
@@ -18,20 +20,21 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// TEST 1: Cannot cancel a scheduled product
+// TEST 1: Cancel a scheduled product
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
  * Scenario:
  * - User is on Premium ($50/mo)
  * - User downgrades to Pro ($20/mo) → Premium is canceling, Pro is scheduled
- * - User tries to cancel Pro (the scheduled product)
+ * - User cancels Pro (the scheduled product)
  *
  * Expected Result:
- * - Should return an error - cannot cancel a scheduled product
+ * - Pro scheduled attachment is removed
+ * - Premium is uncanceled and remains active
  */
-test.concurrent(`${chalk.yellowBright("error: cannot cancel scheduled product")}`, async () => {
-	const customerId = "err-cancel-scheduled";
+test.concurrent(`${chalk.yellowBright("cancel: scheduled product removes pending schedule")}`, async () => {
+	const customerId = "cancel-scheduled-product";
 
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
 
@@ -46,7 +49,7 @@ test.concurrent(`${chalk.yellowBright("error: cannot cancel scheduled product")}
 		items: [messagesItem, premiumPriceItem],
 	});
 
-	const { autumnV1 } = await initScenario({
+	const { autumnV1, ctx } = await initScenario({
 		customerId,
 		setup: [
 			s.customer({ paymentMethod: "success" }),
@@ -70,16 +73,24 @@ test.concurrent(`${chalk.yellowBright("error: cannot cancel scheduled product")}
 		productId: pro.id,
 	});
 
-	// Try to cancel the scheduled product - should fail
-	await expectAutumnError({
-		errCode: ErrCode.InvalidRequest,
-		func: async () => {
-			await autumnV1.subscriptions.update({
-				customer_id: customerId,
-				product_id: pro.id,
-				cancel_action: "cancel_immediately",
-			});
-		},
+	await autumnV1.subscriptions.update({
+		customer_id: customerId,
+		product_id: pro.id,
+		cancel_action: "cancel_immediately",
+	});
+
+	const customerAfterCancel =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectCustomerProducts({
+		customer: customerAfterCancel,
+		active: [premium.id],
+		notPresent: [pro.id],
+	});
+	await expectSubToBeCorrect({
+		db: ctx.db,
+		customerId,
+		org: ctx.org,
+		env: ctx.env,
 	});
 });
 

--- a/shared/models/billingModels/stripe/stripeSubscriptionScheduleAction.ts
+++ b/shared/models/billingModels/stripe/stripeSubscriptionScheduleAction.ts
@@ -17,6 +17,10 @@ export const StripeSubscriptionScheduleActionSchema = z.discriminatedUnion(
 			type: z.literal("release"),
 			stripeSubscriptionScheduleId: z.string(),
 		}),
+		z.object({
+			type: z.literal("cancel"),
+			stripeSubscriptionScheduleId: z.string(),
+		}),
 	],
 );
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables canceling subscriptions scheduled with a future starts_at (including immediate-access attachments) by deleting the pending schedule and removing the customer product. Also restores the previously canceling active product when the scheduled replacement is canceled.

- **New Features**
  - Added early-cancel path in `computeCancelPlan` to delete scheduled customer products before billing starts and skip normal EOC flow.
  - Restores the active product in the same group if it was set to cancel due to a downgrade when the scheduled product is canceled.
  - Stripe: introduced `cancel` schedule action and execution; for “no_phases” scenarios the builder now cancels the schedule if there’s no subscription, or releases it if there is.
  - Error handling: allow operations on scheduled products when a `cancel_action` is present; only require `current_phase.start_date` when the schedule is being updated.
  - Added integration tests for canceling scheduled products via `customer_product_id` and for immediate-access future attachments; improved schedule action logging.

<sup>Written for commit c7d9c7746f456f22b6563516c3070ac66da87aff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the cancel subscription flow to correctly handle products with a future `starts_at` date — both purely `Scheduled` products and "immediate-access" products that have a Stripe subscription schedule but no active subscription yet.

- **[Bug fixes]** `computeCancelPlan` now short-circuits to `computeScheduledCancelPlan` for not-yet-billed products, deleting the customer product and optionally uncanceling the previously-active product.
- **[Improvements]** A new `cancel` action type is added to `StripeSubscriptionScheduleAction`, and `buildNoPhasesAction` now cancels the Stripe schedule (instead of no-op) when no subscription is attached.
- **[Improvements]** `handleStripeBillingPlanErrors` is tightened to only enforce `current_phase.start_date` when actually performing a schedule `update` that has an attached subscription, preventing false-positive errors on cancel/release paths.
</details>


<h3>Confidence Score: 4/5</h3>

The core cancel-scheduled flow is well-structured and the two new integration tests verify the happy paths end-to-end; two edge cases in adjacent logic are worth a second look before merging.

The new cancel path for future-start products is clearly reasoned and tested. Two secondary changes introduce mild concerns: the no_phases branch now releases an existing schedule and clears cancel_at where it previously did nothing, and the handleCurrentCustomerProductErrors guard now permits uncancel on scheduled products routing through applyUncancelToPlan on a product that has never been billed.

buildStripeSubscriptionScheduleAction.ts (new buildNoPhasesAction behaviour) and handleCurrentCustomerProductErrors.ts (uncancel guard) deserve an extra read before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelPlan.ts | Adds shouldDeleteCustomerProductBeforeBillingStarts and computeScheduledCancelPlan; logic is sound but the Scheduled-status early-return bypasses the future-date check, which could misroute zombie scheduled products. |
| server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionScheduleAction.ts | Adds buildNoPhasesAction; the new release+clear-cancel_at path for no_phases+hasSubscription+hasSchedule is a subtle behaviour change from the previous no-op. |
| server/src/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors.ts | Guard narrowed to only validate current_phase.start_date when action type is update and the schedule has a subscription — correctly avoids false errors on cancel/release paths. |
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionScheduleAction.ts | Adds the cancel case to the switch statement; straightforward and consistent with the existing release case. |
| server/src/internal/billing/v2/actions/updateSubscription/errors/handleCurrentCustomerProductErrors.ts | Loosens the scheduled-product guard to allow cancel actions; also inadvertently allows uncancel on scheduled products, which then routes to applyUncancelToPlan. |
| shared/models/billingModels/stripe/stripeSubscriptionScheduleAction.ts | Adds cancel discriminant to the Zod schema; clean and complete. |
| server/tests/integration/billing/attach/params/start-date/starts-at-scheduling.test.ts | Two new integration tests covering scheduled-subscription cancellation and immediate-access future-subscription cancellation; both verify Stripe schedule status and invoice count. |
| server/tests/integration/billing/update-subscription/errors/cancel-errors.test.ts | Converts the previous error test to a positive assertion that the scheduled product is removed and the active product is uncanceled. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/billing/v2/actions/updateSubscription/errors/handleCurrentCustomerProductErrors.ts`, line 15-22 ([link](https://github.com/useautumn/autumn/blob/c7d9c7746f456f22b6563516c3070ac66da87aff/server/src/internal/billing/v2/actions/updateSubscription/errors/handleCurrentCustomerProductErrors.ts#L15-L22)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Uncancel allowed on scheduled products**

   The guard now passes for any `cancelAction`, including `"uncancel"`. In `computeCancelPlan` the `"uncancel"` branch fires *before* `shouldDeleteCustomerProductBeforeBillingStarts`, so `applyUncancelToPlan` would be called on a product that is still `Scheduled` and has never been billed. The resulting plan would try to clear `canceled_at`/`ended_at` on a product that never had those fields set, which is benign but unexpected. If `uncancel` on a scheduled product should remain unsupported, tighten the condition to `!billingContext.cancelAction || billingContext.cancelAction === "uncancel"`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/actions/updateSubscription/errors/handleCurrentCustomerProductErrors.ts
   Line: 15-22

   Comment:
   **Uncancel allowed on scheduled products**

   The guard now passes for any `cancelAction`, including `"uncancel"`. In `computeCancelPlan` the `"uncancel"` branch fires *before* `shouldDeleteCustomerProductBeforeBillingStarts`, so `applyUncancelToPlan` would be called on a product that is still `Scheduled` and has never been billed. The resulting plan would try to clear `canceled_at`/`ended_at` on a product that never had those fields set, which is benign but unexpected. If `uncancel` on a scheduled product should remain unsupported, tighten the condition to `!billingContext.cancelAction || billingContext.cancelAction === "uncancel"`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/actions/updateSubscription/errors/handleCurrentCustomerProductErrors.ts:15-22
**Uncancel allowed on scheduled products**

The guard now passes for any `cancelAction`, including `"uncancel"`. In `computeCancelPlan` the `"uncancel"` branch fires *before* `shouldDeleteCustomerProductBeforeBillingStarts`, so `applyUncancelToPlan` would be called on a product that is still `Scheduled` and has never been billed. The resulting plan would try to clear `canceled_at`/`ended_at` on a product that never had those fields set, which is benign but unexpected. If `uncancel` on a scheduled product should remain unsupported, tighten the condition to `!billingContext.cancelAction || billingContext.cancelAction === "uncancel"`.

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionScheduleAction.ts:94-119
**no_phases + subscription + existing schedule now releases instead of no-op**

Before this PR the `no_phases` case returned `{}` regardless of whether a schedule existed. Now, when a schedule is present *and* there is an active subscription, the function releases the schedule and clears `subscriptionCancelAt`. This is a broader change than the cancel-scheduled flow this PR targets and will affect any code path that reaches `no_phases` while a subscription-attached schedule exists. Releasing the schedule is likely correct, but the `subscriptionCancelAt: null` side-effect — clearing a previously-set `cancel_at` — could unintentionally reinstate a subscription that was already scheduled to cancel via `cancel_at` rather than a schedule phase.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: handle cancel with future starts\_..."](https://github.com/useautumn/autumn/commit/c7d9c7746f456f22b6563516c3070ac66da87aff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31305342)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->