### PR TITLE
chore: add event persistence to migrations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -360,6 +360,7 @@
         "@react-email/components": "^0.0.42",
         "@sentry/bun": "catalog:",
         "@supabase/supabase-js": "^2.46.2",
+        "@tinybirdco/sdk": "^0.0.69",
         "@types/qs": "^6.14.0",
         "@types/semver": "^7.7.1",
         "@typescript/native-preview": "^7.0.0-dev.20251114.1",
@@ -2180,6 +2181,8 @@
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.14.0", "", {}, "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q=="],
+
+    "@tinybirdco/sdk": ["@tinybirdco/sdk@0.0.69", "", { "dependencies": { "@clack/prompts": "^1.0.0", "chokidar": "^4.0.0", "commander": "^12.0.0", "dotenv": "^16.0.0", "esbuild": "^0.24.0", "picocolors": "^1.1.1", "zod": "^3.25.0" }, "bin": { "tinybird": "bin/tinybird.js" } }, "sha512-ScwHmj/bIjjxc7skTv+lRES8x0OnCQ8s8CHhS8kVjL5R1A0nrLsoCamBbFQUe0R1RL5Cm+ylWkTTCLyvCqkjnw=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
@@ -6605,6 +6608,10 @@
 
     "@tailwindcss/vite/tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
 
+    "@tinybirdco/sdk/@clack/prompts": ["@clack/prompts@1.3.0", "", { "dependencies": { "@clack/core": "1.3.0", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw=="],
+
+    "@tinybirdco/sdk/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
     "@trigger.dev/core/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@trigger.dev/core/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.203.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ=="],
@@ -8236,6 +8243,8 @@
     "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ=="],
 
     "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw=="],
+
+    "@tinybirdco/sdk/@clack/prompts/@clack/core": ["@clack/core@1.3.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA=="],
 
     "@trigger.dev/core/@opentelemetry/api-logs/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -77,6 +77,7 @@
 		"@react-email/components": "^0.0.42",
 		"@sentry/bun": "catalog:",
 		"@supabase/supabase-js": "^2.46.2",
+		"@tinybirdco/sdk": "^0.0.69",
 		"@types/qs": "^6.14.0",
 		"@types/semver": "^7.7.1",
 		"@typescript/native-preview": "^7.0.0-dev.20251114.1",

--- a/server/src/external/tinybird/initTinybird.ts
+++ b/server/src/external/tinybird/initTinybird.ts
@@ -5,22 +5,16 @@ import { createAggregateSimplePipe } from "./pipes/aggregateSimplePipe.js";
 import { createEstimatedMrrPipe } from "./pipes/estimatedMrrPipe.js";
 import { createListEventNamesPipe } from "./pipes/listEventNamesPipe.js";
 import { createListEventsPaginatedPipe } from "./pipes/listEventsPaginatedPipe.js";
+import { tinybirdConfig } from "./tinybirdUtils.js";
 import { z } from "./tinybirdZod.js";
 
-const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
-
 /** Tinybird REST API client singleton. Null if not configured. */
-const tinybirdClient: Tinybird | null =
-	TINYBIRD_API_URL && TINYBIRD_TOKEN
-		? new Tinybird({
-				baseUrl: TINYBIRD_API_URL,
-				token: TINYBIRD_TOKEN,
-			})
-		: null;
+const tinybirdClient: Tinybird | null = tinybirdConfig
+	? new Tinybird(tinybirdConfig)
+	: null;
 
-if (tinybirdClient) {
-	console.log(`[Tinybird] Configured with URL: ${TINYBIRD_API_URL}`);
+if (tinybirdConfig) {
+	console.log(`[Tinybird] Configured with URL: ${tinybirdConfig.baseUrl}`);
 }
 
 /** Zod schema for TinybirdEvent (matches events.datasource) */
@@ -81,11 +75,6 @@ export const getTinybirdIngest = () => {
 	return tinybirdIngest;
 };
 
-/** Check if Tinybird is configured */
-export const isTinybirdConfigured = (): boolean => {
-	return tinybirdClient !== null;
-};
-
 // Re-export types
 export type {
 	AggregateGroupablePipeParams,
@@ -101,3 +90,4 @@ export type {
 	ListEventsPaginatedPipeParams,
 	ListEventsPaginatedPipeRow,
 } from "./pipes/index.js";
+export { isTinybirdConfigured } from "./tinybirdUtils.js";

--- a/server/src/external/tinybird/initTinybird.ts
+++ b/server/src/external/tinybird/initTinybird.ts
@@ -90,4 +90,3 @@ export type {
 	ListEventsPaginatedPipeParams,
 	ListEventsPaginatedPipeRow,
 } from "./pipes/index.js";
-export { isTinybirdConfigured } from "./tinybirdUtils.js";

--- a/server/src/external/tinybird/migrationCustomerEventsTinybird.ts
+++ b/server/src/external/tinybird/migrationCustomerEventsTinybird.ts
@@ -1,0 +1,30 @@
+import { TinybirdClient } from "@tinybirdco/sdk";
+
+const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
+
+export type TinybirdMigrationCustomerEvent = {
+	id: string;
+	timestamp: string;
+	org_id: string;
+	env: string;
+	migration_id: string;
+	migration_run_id: string;
+	event_type: string;
+	dry_run: number;
+	internal_customer_id: string | null;
+	customer_id: string | null;
+	details: string | null;
+};
+
+export const migrationCustomerEventsTinybird =
+	TINYBIRD_API_URL && TINYBIRD_TOKEN
+		? new TinybirdClient({
+				baseUrl: TINYBIRD_API_URL,
+				token: TINYBIRD_TOKEN,
+				devMode: false,
+			})
+		: null;
+
+export const isMigrationCustomerEventsTinybirdConfigured = (): boolean =>
+	migrationCustomerEventsTinybird !== null;

--- a/server/src/external/tinybird/migrationCustomerEventsTinybird.ts
+++ b/server/src/external/tinybird/migrationCustomerEventsTinybird.ts
@@ -1,7 +1,8 @@
 import { TinybirdClient } from "@tinybirdco/sdk";
+import { tinybirdConfig } from "./tinybirdUtils.js";
 
-const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
+export const MIGRATION_CUSTOMER_EVENTS_DATASOURCE =
+	"migration_customer_events" as const;
 
 export type TinybirdMigrationCustomerEvent = {
 	id: string;
@@ -11,20 +12,15 @@ export type TinybirdMigrationCustomerEvent = {
 	migration_id: string;
 	migration_run_id: string;
 	event_type: string;
-	dry_run: number;
+	dry_run: 0 | 1;
 	internal_customer_id: string | null;
 	customer_id: string | null;
 	details: string | null;
 };
 
-export const migrationCustomerEventsTinybird =
-	TINYBIRD_API_URL && TINYBIRD_TOKEN
-		? new TinybirdClient({
-				baseUrl: TINYBIRD_API_URL,
-				token: TINYBIRD_TOKEN,
-				devMode: false,
-			})
-		: null;
-
-export const isMigrationCustomerEventsTinybirdConfigured = (): boolean =>
-	migrationCustomerEventsTinybird !== null;
+export const migrationCustomerEventsTinybirdClient = tinybirdConfig
+	? new TinybirdClient({
+			...tinybirdConfig,
+			devMode: false,
+		})
+	: null;

--- a/server/src/external/tinybird/sendEvents/sendEvents.ts
+++ b/server/src/external/tinybird/sendEvents/sendEvents.ts
@@ -2,7 +2,8 @@ import * as crypto from "node:crypto";
 import type { EventInsert } from "@autumn/shared";
 import * as Sentry from "@sentry/bun";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
-import { isTinybirdConfigured, tinybirdIngest } from "../initTinybird.js";
+import { tinybirdIngest } from "../initTinybird.js";
+import { isTinybirdConfigured } from "../tinybirdUtils.js";
 import { mapToTinybirdEvent } from "./mapEvent.js";
 
 /** Generate a unique error ID for tracking */

--- a/server/src/external/tinybird/tinybirdUtils.ts
+++ b/server/src/external/tinybird/tinybirdUtils.ts
@@ -1,9 +1,28 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 
+const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
+
+export type TinybirdConfig = {
+	baseUrl: string;
+	token: string;
+};
+
+export const tinybirdConfig: TinybirdConfig | null =
+	TINYBIRD_API_URL && TINYBIRD_TOKEN
+		? {
+				baseUrl: TINYBIRD_API_URL,
+				token: TINYBIRD_TOKEN,
+			}
+		: null;
+
+/** Check if Tinybird is configured. */
+export const isTinybirdConfigured = (): boolean => tinybirdConfig !== null;
+
 /** Throws SERVICE_UNAVAILABLE if Tinybird is not configured. */
 export const assertTinybirdAvailable = () => {
-	if (!process.env.TINYBIRD_TOKEN) {
+	if (!isTinybirdConfigured()) {
 		throw new RecaseError({
 			message: "Tinybird is not configured, cannot fetch analytics",
 			code: ErrCode.TinybirdDisabled,

--- a/server/src/internal/migrations/v2/run/events/getMigrationRunEventType.ts
+++ b/server/src/internal/migrations/v2/run/events/getMigrationRunEventType.ts
@@ -1,0 +1,15 @@
+import type { MigrationCustomerEventType } from "./migrationCustomerEventTypes.js";
+
+/** Returns the terminal event type for a migration run summary. */
+export const getMigrationRunEventType = ({
+	scopes,
+}: {
+	scopes: { succeeded: number; failed: number }[];
+}): MigrationCustomerEventType => {
+	const succeeded = scopes.reduce((sum, scope) => sum + scope.succeeded, 0);
+	const failed = scopes.reduce((sum, scope) => sum + scope.failed, 0);
+
+	if (failed === 0) return "migration_succeeded";
+	if (succeeded === 0) return "migration_failed";
+	return "migration_partially_failed";
+};

--- a/server/src/internal/migrations/v2/run/events/getScopeEventSummaries.ts
+++ b/server/src/internal/migrations/v2/run/events/getScopeEventSummaries.ts
@@ -1,0 +1,24 @@
+import type { RunMigrationScopeResult } from "../types/runMigrationResponse.js";
+import type { RunScopeKind } from "../types/runScope.js";
+
+export type MigrationScopeEventSummary = {
+	kind: RunScopeKind;
+	count: number;
+	processed: number;
+	succeeded: number;
+	failed: number;
+};
+
+/** Summarizes scope results for migration terminal events. */
+export const getScopeEventSummaries = ({
+	scopeResults,
+}: {
+	scopeResults: RunMigrationScopeResult[];
+}): MigrationScopeEventSummary[] =>
+	scopeResults.map(({ kind, count, summary }) => ({
+		kind,
+		count,
+		processed: summary.processed,
+		succeeded: summary.succeeded,
+		failed: summary.failed,
+	}));

--- a/server/src/internal/migrations/v2/run/events/index.ts
+++ b/server/src/internal/migrations/v2/run/events/index.ts
@@ -1,0 +1,7 @@
+export * from "./getMigrationRunEventType.js";
+export * from "./getScopeEventSummaries.js";
+export * from "./migrationCustomerEventTypes.js";
+export * from "./recordMigrationCustomerEvent.js";
+export * from "./recordMigrationFailedEvent.js";
+export * from "./recordMigrationTerminalEvent.js";
+export * from "./sendMigrationCustomerEvents.js";

--- a/server/src/internal/migrations/v2/run/events/mapMigrationCustomerEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/mapMigrationCustomerEvent.ts
@@ -1,0 +1,37 @@
+import * as crypto from "node:crypto";
+import type { TinybirdMigrationCustomerEvent } from "@/external/tinybird/migrationCustomerEventsTinybird.js";
+import type {
+	MigrationCustomerEvent,
+	MigrationCustomerEventDetails,
+} from "./migrationCustomerEventTypes.js";
+
+const stringifyBigInt = (_key: string, value: unknown): unknown =>
+	typeof value === "bigint" ? value.toString() : value;
+
+const stringifyDetails = ({
+	details,
+}: {
+	details?: MigrationCustomerEventDetails;
+}): string | null => {
+	if (!details) return null;
+	return JSON.stringify(details, stringifyBigInt);
+};
+
+/** Converts a migration event into the Tinybird ingest payload. */
+export const mapMigrationCustomerEvent = ({
+	event,
+}: {
+	event: MigrationCustomerEvent;
+}): TinybirdMigrationCustomerEvent => ({
+	id: `mig_evt_${crypto.randomUUID()}`,
+	timestamp: event.timestamp ?? new Date().toISOString(),
+	org_id: event.orgId,
+	env: event.env,
+	migration_id: event.migrationId,
+	migration_run_id: event.migrationRunId,
+	event_type: event.eventType,
+	dry_run: event.dryRun ? 1 : 0,
+	internal_customer_id: event.internalCustomerId ?? null,
+	customer_id: event.customerId ?? null,
+	details: stringifyDetails({ details: event.details }),
+});

--- a/server/src/internal/migrations/v2/run/events/migrationCustomerEventTypes.ts
+++ b/server/src/internal/migrations/v2/run/events/migrationCustomerEventTypes.ts
@@ -1,0 +1,27 @@
+export type MigrationCustomerEventType =
+	| "migration_started"
+	| "migration_succeeded"
+	| "migration_partially_failed"
+	| "migration_failed"
+	| "customer_started"
+	| "customer_succeeded"
+	| "customer_failed"
+	| "customer_skipped";
+
+export type MigrationCustomerEventDetails = Record<string, unknown>;
+
+export type MigrationCustomerEventInput = {
+	eventType: MigrationCustomerEventType;
+	internalCustomerId?: string | null;
+	customerId?: string | null;
+	details?: MigrationCustomerEventDetails;
+};
+
+export type MigrationCustomerEvent = MigrationCustomerEventInput & {
+	orgId: string;
+	env: string;
+	migrationId: string;
+	migrationRunId: string;
+	dryRun: boolean;
+	timestamp?: string;
+};

--- a/server/src/internal/migrations/v2/run/events/recordMigrationCustomerEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/recordMigrationCustomerEvent.ts
@@ -6,6 +6,13 @@ import type {
 } from "./migrationCustomerEventTypes.js";
 import { sendMigrationCustomerEventsToTinybird } from "./sendMigrationCustomerEvents.js";
 
+type RecordMigrationCustomerEventParams = MigrationCustomerEventInput & {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+};
+
 /** Enriches and records one migration lifecycle event. */
 export const recordMigrationCustomerEvent = async ({
 	ctx,
@@ -16,12 +23,7 @@ export const recordMigrationCustomerEvent = async ({
 	internalCustomerId,
 	customerId,
 	details,
-}: {
-	ctx: AutumnContext;
-	migration: Migration;
-	migrationRunId: string;
-	dryRun: boolean;
-} & MigrationCustomerEventInput): Promise<void> => {
+}: RecordMigrationCustomerEventParams): Promise<void> => {
 	const event: MigrationCustomerEvent = {
 		eventType,
 		internalCustomerId,

--- a/server/src/internal/migrations/v2/run/events/recordMigrationCustomerEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/recordMigrationCustomerEvent.ts
@@ -1,0 +1,41 @@
+import type { Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type {
+	MigrationCustomerEvent,
+	MigrationCustomerEventInput,
+} from "./migrationCustomerEventTypes.js";
+import { sendMigrationCustomerEventsToTinybird } from "./sendMigrationCustomerEvents.js";
+
+/** Enriches and records one migration lifecycle event. */
+export const recordMigrationCustomerEvent = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	eventType,
+	internalCustomerId,
+	customerId,
+	details,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+} & MigrationCustomerEventInput): Promise<void> => {
+	const event: MigrationCustomerEvent = {
+		eventType,
+		internalCustomerId,
+		customerId,
+		details,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		migrationId: migration.id,
+		migrationRunId,
+		dryRun,
+	};
+
+	await sendMigrationCustomerEventsToTinybird({
+		events: [event],
+		logger: ctx.logger,
+	});
+};

--- a/server/src/internal/migrations/v2/run/events/recordMigrationFailedEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/recordMigrationFailedEvent.ts
@@ -1,0 +1,36 @@
+import type { Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { RunMigrationScopeResult } from "../types/runMigrationResponse.js";
+import { getScopeEventSummaries } from "./getScopeEventSummaries.js";
+import { recordMigrationCustomerEvent } from "./recordMigrationCustomerEvent.js";
+
+/** Records a failed run with partial scope progress. */
+export const recordMigrationFailedEvent = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	error,
+	scopeResults,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+	error: unknown;
+	scopeResults: RunMigrationScopeResult[];
+}): Promise<void> => {
+	await recordMigrationCustomerEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun,
+		eventType: "migration_failed",
+		details: {
+			error: {
+				message: error instanceof Error ? error.message : String(error),
+			},
+			scopes: getScopeEventSummaries({ scopeResults }),
+		},
+	});
+};

--- a/server/src/internal/migrations/v2/run/events/recordMigrationTerminalEvent.ts
+++ b/server/src/internal/migrations/v2/run/events/recordMigrationTerminalEvent.ts
@@ -1,0 +1,34 @@
+import type { Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { RunMigrationScopeResult } from "../types/runMigrationResponse.js";
+import { getMigrationRunEventType } from "./getMigrationRunEventType.js";
+import { getScopeEventSummaries } from "./getScopeEventSummaries.js";
+import { recordMigrationCustomerEvent } from "./recordMigrationCustomerEvent.js";
+
+/** Records the final run event after all scopes finish. */
+export const recordMigrationTerminalEvent = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	scopeResults,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+	scopeResults: RunMigrationScopeResult[];
+}): Promise<void> => {
+	const scopes = getScopeEventSummaries({ scopeResults });
+
+	await recordMigrationCustomerEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun,
+		eventType: getMigrationRunEventType({ scopes }),
+		details: {
+			scopes,
+		},
+	});
+};

--- a/server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts
+++ b/server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts
@@ -1,0 +1,76 @@
+import * as crypto from "node:crypto";
+import * as Sentry from "@sentry/bun";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import {
+	isMigrationCustomerEventsTinybirdConfigured,
+	migrationCustomerEventsTinybird,
+} from "@/external/tinybird/migrationCustomerEventsTinybird.js";
+import { mapMigrationCustomerEvent } from "./mapMigrationCustomerEvent.js";
+import type { MigrationCustomerEvent } from "./migrationCustomerEventTypes.js";
+
+/**
+ * Best-effort Tinybird ingest for migration audit events.
+ * Migration execution must not depend on analytics availability.
+ */
+export const sendMigrationCustomerEventsToTinybird = async ({
+	events,
+	logger,
+}: {
+	events: MigrationCustomerEvent[];
+	logger: Logger;
+}): Promise<void> => {
+	if (events.length === 0) return;
+
+	if (
+		!isMigrationCustomerEventsTinybirdConfigured() ||
+		!migrationCustomerEventsTinybird
+	) {
+		logger.debug("Tinybird not configured, skipping migration event send");
+		return;
+	}
+
+	try {
+		const tinybirdEvents = events.map((event) =>
+			mapMigrationCustomerEvent({ event }),
+		);
+		const result = await migrationCustomerEventsTinybird.ingestBatch(
+			"migration_customer_events",
+			tinybirdEvents,
+			{
+				wait: true,
+				maxRetries: 10,
+			},
+		);
+		logger.info(`Sent ${events.length} migration events to Tinybird`, {
+			data: {
+				eventCount: events.length,
+				successfulRows: result.successful_rows,
+				quarantinedRows: result.quarantined_rows,
+			},
+		});
+	} catch (error) {
+		const errorId = `TB_MIG_ERR_${crypto.randomBytes(8).toString("hex").toUpperCase()}`;
+		const errorMessage = error instanceof Error ? error.message : String(error);
+
+		logger.error(`[${errorId}] Failed to send migration events to Tinybird`, {
+			data: {
+				errorId,
+				eventCount: events.length,
+				error: errorMessage,
+			},
+		});
+
+		Sentry.captureException(error, {
+			tags: {
+				errorId,
+				service: "tinybird",
+				area: "migration_customer_events",
+			},
+			extra: {
+				data: {
+					eventCount: events.length,
+				},
+			},
+		});
+	}
+};

--- a/server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts
+++ b/server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts
@@ -2,8 +2,8 @@ import * as crypto from "node:crypto";
 import * as Sentry from "@sentry/bun";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import {
-	isMigrationCustomerEventsTinybirdConfigured,
-	migrationCustomerEventsTinybird,
+	MIGRATION_CUSTOMER_EVENTS_DATASOURCE,
+	migrationCustomerEventsTinybirdClient,
 } from "@/external/tinybird/migrationCustomerEventsTinybird.js";
 import { mapMigrationCustomerEvent } from "./mapMigrationCustomerEvent.js";
 import type { MigrationCustomerEvent } from "./migrationCustomerEventTypes.js";
@@ -21,10 +21,7 @@ export const sendMigrationCustomerEventsToTinybird = async ({
 }): Promise<void> => {
 	if (events.length === 0) return;
 
-	if (
-		!isMigrationCustomerEventsTinybirdConfigured() ||
-		!migrationCustomerEventsTinybird
-	) {
+	if (!migrationCustomerEventsTinybirdClient) {
 		logger.debug("Tinybird not configured, skipping migration event send");
 		return;
 	}
@@ -33,8 +30,8 @@ export const sendMigrationCustomerEventsToTinybird = async ({
 		const tinybirdEvents = events.map((event) =>
 			mapMigrationCustomerEvent({ event }),
 		);
-		const result = await migrationCustomerEventsTinybird.ingestBatch(
-			"migration_customer_events",
+		const result = await migrationCustomerEventsTinybirdClient.ingestBatch(
+			MIGRATION_CUSTOMER_EVENTS_DATASOURCE,
 			tinybirdEvents,
 			{
 				wait: true,

--- a/server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts
+++ b/server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts
@@ -8,6 +8,8 @@ import {
 import { mapMigrationCustomerEvent } from "./mapMigrationCustomerEvent.js";
 import type { MigrationCustomerEvent } from "./migrationCustomerEventTypes.js";
 
+const TINYBIRD_MIGRATION_EVENT_MAX_RETRIES = 2;
+
 /**
  * Best-effort Tinybird ingest for migration audit events.
  * Migration execution must not depend on analytics availability.
@@ -34,8 +36,8 @@ export const sendMigrationCustomerEventsToTinybird = async ({
 			MIGRATION_CUSTOMER_EVENTS_DATASOURCE,
 			tinybirdEvents,
 			{
-				wait: true,
-				maxRetries: 10,
+				wait: false,
+				maxRetries: TINYBIRD_MIGRATION_EVENT_MAX_RETRIES,
 			},
 		);
 		logger.info(`Sent ${events.length} migration events to Tinybird`, {

--- a/server/src/internal/migrations/v2/run/migrateCustomer/logs/logMigrateCustomerResult.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/logs/logMigrateCustomerResult.ts
@@ -16,7 +16,7 @@ const getMigrationCustomerExtras = ({
 }): Record<string, unknown> => {
 	const extras = ctx.extraLogs.migrationCustomer;
 	return extras && typeof extras === "object" && !Array.isArray(extras)
-		? extras
+		? (extras as Record<string, unknown>)
 		: {};
 };
 

--- a/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts
@@ -1,5 +1,7 @@
 import type { Migration } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { MigrateCustomerContext } from "@/internal/migrations/v2/operations/types/index.js";
+import { recordMigrationCustomerEvent } from "../events/index.js";
 import { evaluateMigrateCustomerStripe } from "./evaluateMigrateCustomerStripe.js";
 import { executeMigrateCustomerPlan } from "./executeMigrateCustomerPlan.js";
 import {
@@ -22,11 +24,13 @@ export const migrateCustomer = async ({
 	ctx,
 	customerId,
 	migration,
+	migrationRunId,
 	preview = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	migration: Migration;
+	migrationRunId: string;
 	preview?: boolean;
 }) => {
 	const migrationCtx = createMigrateCustomerRunContext({
@@ -35,15 +39,31 @@ export const migrateCustomer = async ({
 		migration,
 		preview,
 	});
+	let context: MigrateCustomerContext | undefined;
 
 	try {
-		const context = await setupMigrateCustomerContext({
+		context = await setupMigrateCustomerContext({
 			ctx: migrationCtx,
 			migration,
 			customerId,
 		});
 
-		const { plan: autumnPlan, billingContexts } = await processOperations({
+		await recordMigrationCustomerEvent({
+			ctx,
+			migration,
+			migrationRunId,
+			dryRun: preview,
+			eventType: "customer_started",
+			internalCustomerId: context.fullCustomer.internal_id,
+			customerId: context.fullCustomer.id,
+			details: { beforeCustomer: context.fullCustomer },
+		});
+
+		const {
+			plan: autumnPlan,
+			billingContexts,
+			matchedCustomerProducts,
+		} = await processOperations({
 			ctx: migrationCtx,
 			context,
 			plan: {
@@ -74,6 +94,22 @@ export const migrateCustomer = async ({
 			},
 		});
 
+		await recordMigrationCustomerEvent({
+			ctx,
+			migration,
+			migrationRunId,
+			dryRun: preview,
+			eventType:
+				matchedCustomerProducts === 0
+					? "customer_skipped"
+					: "customer_succeeded",
+			internalCustomerId: context.fullCustomer.internal_id,
+			customerId: context.fullCustomer.id,
+			details: {
+				matchedCustomerProducts,
+			},
+		});
+
 		return;
 	} catch (error) {
 		logMigrateCustomerResult({
@@ -83,6 +119,22 @@ export const migrateCustomer = async ({
 				error,
 			},
 		});
+
+		await recordMigrationCustomerEvent({
+			ctx,
+			migration,
+			migrationRunId,
+			dryRun: preview,
+			eventType: "customer_failed",
+			internalCustomerId: context?.fullCustomer.internal_id ?? customerId,
+			customerId: context?.fullCustomer.id,
+			details: {
+				error: {
+					message: error instanceof Error ? error.message : String(error),
+				},
+			},
+		});
+
 		throw error;
 	}
 };

--- a/server/src/internal/migrations/v2/run/orchestrators/index.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/index.ts
@@ -1,2 +1,3 @@
 export * from "./iterateScope.js";
 export * from "./runPreparation.js";
+export * from "./runScopeIteration.js";

--- a/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
@@ -1,0 +1,47 @@
+import type { Migration } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { runFilter } from "../../filters/runFilter.js";
+import { migrateCustomer } from "../migrateCustomer/index.js";
+import type { RunMigrationScopeResult } from "../types/runMigrationResponse.js";
+import type { RunScopeKind } from "../types/runScope.js";
+import { iterateScope } from "./iterateScope.js";
+
+/** Runs one filtered migration scope iteration. */
+export const runScopeIteration = async ({
+	ctx,
+	migration,
+	migrationRunId,
+	dryRun,
+	kind,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	migrationRunId: string;
+	dryRun: boolean;
+	kind: RunScopeKind;
+}): Promise<RunMigrationScopeResult> => {
+	const { count, iterate } = await runFilter({ ctx, migration, kind });
+	ctx.logger.info(`run-migration: iterating scope`, {
+		data: { kind, count, dryRun },
+	});
+
+	const summary = await iterateScope({
+		iterate,
+		perItem: async (item) => {
+			if (item.kind !== "customer")
+				throw new Error(
+					`runMigration: per-item handler missing for kind "${item.kind}"`,
+				);
+
+			return migrateCustomer({
+				ctx,
+				customerId: item.internal_id,
+				migration,
+				migrationRunId,
+				preview: dryRun,
+			});
+		},
+	});
+
+	return { kind, count, summary };
+};

--- a/server/src/internal/migrations/v2/run/runMigration.ts
+++ b/server/src/internal/migrations/v2/run/runMigration.ts
@@ -1,24 +1,76 @@
 import type { Migration } from "@autumn/shared";
 import type { AutumnContext } from "../../../../honoUtils/HonoEnv.js";
-import { runFilter } from "../filters/runFilter.js";
-import { migrateCustomer } from "./migrateCustomer/index.js";
-import { iterateScope, runPreparation } from "./orchestrators/index.js";
+import {
+	recordMigrationCustomerEvent,
+	recordMigrationFailedEvent,
+	recordMigrationTerminalEvent,
+} from "./events/index.js";
+import { runPreparation, runScopeIteration } from "./orchestrators/index.js";
+import { getRunScopes } from "./types/index.js";
 import type {
 	RunMigrationResponse,
 	RunMigrationScopeResult,
 } from "./types/runMigrationResponse.js";
-import type { RunScopeKind } from "./types/runScope.js";
 
 /** Top-level migration run: prepare → per-scope filter+iterate → per-item ops. */
 export const runMigration = async ({
 	ctx,
 	migration,
 	dry_run,
+	migrationRunId,
 }: {
 	ctx: AutumnContext;
 	migration: Migration;
 	dry_run: boolean;
+	migrationRunId: string;
 }): Promise<RunMigrationResponse> => {
+	const scopeResults: RunMigrationScopeResult[] = [];
+
+	try {
+		return await executeMigrationRun({
+			ctx,
+			migration,
+			dry_run,
+			migrationRunId,
+			scopeResults,
+		});
+	} catch (error) {
+		await recordMigrationFailedEvent({
+			ctx,
+			migration,
+			migrationRunId,
+			dryRun: dry_run,
+			error,
+			scopeResults,
+		});
+		throw error;
+	}
+};
+
+const executeMigrationRun = async ({
+	ctx,
+	migration,
+	dry_run,
+	migrationRunId,
+	scopeResults,
+}: {
+	ctx: AutumnContext;
+	migration: Migration;
+	dry_run: boolean;
+	migrationRunId: string;
+	scopeResults: RunMigrationScopeResult[];
+}): Promise<RunMigrationResponse> => {
+	await recordMigrationCustomerEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun: dry_run,
+		eventType: "migration_started",
+		details: {
+			migrationInternalId: migration.internal_id,
+		},
+	});
+
 	const { response: prepareResponse, prepared_state } = await runPreparation({
 		ctx,
 		migration,
@@ -26,36 +78,24 @@ export const runMigration = async ({
 	});
 	const preparedMigration = { ...migration, prepared_state };
 
-	const scopeResults: RunMigrationScopeResult[] = [];
-
-	for (const kind of scopesForRun(preparedMigration)) {
-		const { count, iterate } = await runFilter({
+	for (const kind of getRunScopes({ migration: preparedMigration })) {
+		const scopeResult = await runScopeIteration({
 			ctx,
 			migration: preparedMigration,
+			migrationRunId,
+			dryRun: dry_run,
 			kind,
 		});
-		ctx.logger.info(`run-migration: iterating scope`, {
-			data: { kind, count, dry_run },
-		});
-
-		const summary = await iterateScope({
-			iterate,
-			perItem: async (item) => {
-				if (item.kind !== "customer")
-					throw new Error(
-						`runMigration: per-item handler missing for kind "${item.kind}"`,
-					);
-				return migrateCustomer({
-					ctx,
-					customerId: item.internal_id,
-					migration: preparedMigration,
-					preview: dry_run,
-				});
-			},
-		});
-
-		scopeResults.push({ kind, count, summary });
+		scopeResults.push(scopeResult);
 	}
+
+	await recordMigrationTerminalEvent({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun: dry_run,
+		scopeResults,
+	});
 
 	return {
 		migration_id: migration.id,
@@ -63,12 +103,4 @@ export const runMigration = async ({
 		prepare_warnings: prepareResponse.warnings,
 		scopes: scopeResults,
 	};
-};
-
-/** Active scopes = top-level keys present in `migration.operations`. */
-const scopesForRun = (migration: Migration): RunScopeKind[] => {
-	const scopes: RunScopeKind[] = [];
-	if (migration.operations?.customer) scopes.push("customer");
-	// future: if (migration.operations?.plan) scopes.push("plan");
-	return scopes;
 };

--- a/server/src/internal/migrations/v2/run/types/getRunScopes.ts
+++ b/server/src/internal/migrations/v2/run/types/getRunScopes.ts
@@ -1,0 +1,14 @@
+import type { Migration } from "@autumn/shared";
+import type { RunScopeKind } from "./runScope.js";
+
+/** Returns active run scopes from top-level migration operations. */
+export const getRunScopes = ({
+	migration,
+}: {
+	migration: Migration;
+}): RunScopeKind[] => {
+	const scopes: RunScopeKind[] = [];
+	if (migration.operations?.customer) scopes.push("customer");
+	// future: if (migration.operations?.plan) scopes.push("plan");
+	return scopes;
+};

--- a/server/src/internal/migrations/v2/run/types/index.ts
+++ b/server/src/internal/migrations/v2/run/types/index.ts
@@ -1,2 +1,3 @@
+export * from "./getRunScopes.js";
 export * from "./runMigrationResponse.js";
 export * from "./runScope.js";

--- a/server/src/trigger/migrations/runMigrationTask.ts
+++ b/server/src/trigger/migrations/runMigrationTask.ts
@@ -33,7 +33,12 @@ export const runMigrationTask = task({
 
 		const migration = await migrationRepo.find({ ctx, id: migrationId });
 
-		const result = await runMigration({ ctx, migration, dry_run: dryRun });
+		const result = await runMigration({
+			ctx,
+			migration,
+			dry_run: dryRun,
+			migrationRunId: triggerCtx.run.id,
+		});
 
 		logger.info("run-migration: done", {
 			data: {

--- a/server/tests/integration/billing/migrations-v2/utils/runUpdatePlanMigration.ts
+++ b/server/tests/integration/billing/migrations-v2/utils/runUpdatePlanMigration.ts
@@ -28,7 +28,7 @@ const waitForMigrationResult = async ({
 	timeoutMs,
 	pollIntervalMs,
 }: {
-	waitFor: () => Promise<void>;
+	waitFor: () => Promise<unknown>;
 	timeoutMs: number;
 	pollIntervalMs: number;
 }) => {
@@ -71,7 +71,7 @@ export const runUpdatePlanMigration = async ({
 	filter: MigrationFilter;
 	operations: Operations;
 	runOnServer?: boolean;
-	waitFor?: () => Promise<void>;
+	waitFor?: () => Promise<unknown>;
 	timeoutMs?: number;
 	pollIntervalMs?: number;
 }) => {
@@ -108,6 +108,7 @@ export const runUpdatePlanMigration = async ({
 		ctx,
 		customerId,
 		migration: preparedMigration,
+		migrationRunId: `${migrationId}-local-run`,
 	});
 
 	return preparedMigration;

--- a/server/tinybird/datasources/migration_customer_events.datasource
+++ b/server/tinybird/datasources/migration_customer_events.datasource
@@ -1,0 +1,19 @@
+DESCRIPTION >
+    Per-customer lifecycle events for migrations v2. Append-only audit stream.
+
+SCHEMA >
+    `id` String `json:$.id`,
+    `timestamp` DateTime64(6) `json:$.timestamp`,
+    `org_id` String `json:$.org_id`,
+    `env` LowCardinality(String) `json:$.env`,
+    `migration_id` String `json:$.migration_id`,
+    `migration_run_id` String `json:$.migration_run_id`,
+    `event_type` LowCardinality(String) `json:$.event_type`,
+    `dry_run` UInt8 `json:$.dry_run`,
+    `internal_customer_id` Nullable(String) `json:$.internal_customer_id`,
+    `customer_id` Nullable(String) `json:$.customer_id`,
+    `details` Nullable(String) `json:$.details`
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
+ENGINE_SORTING_KEY "org_id, env, migration_run_id, internal_customer_id, timestamp"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Tinybird-backed event persistence for migrations v2, recording run and per-customer lifecycle events and sending them asynchronously to Tinybird without blocking migrations. Wires events into `runMigration`/`migrateCustomer` and adds `@tinybirdco/sdk`.

- **New Features**
  - Emit lifecycle events: `migration_started`, terminal (`migration_succeeded`/`migration_partially_failed`/`migration_failed`), and per-customer (`customer_started`/`customer_succeeded`/`customer_failed`/`customer_skipped`).
  - Include scope summaries, errors, and matched product counts in event details; normalize BigInts to strings.
  - Best‑effort send to Tinybird `migration_customer_events` (wait: false, maxRetries: 2); logs outcomes, captures failures in Sentry; no-op if not configured.
  - Thread `migration_run_id` from the task run; extracted helpers for scope summaries and terminal event type; factored out `runScopeIteration` and `getRunScopes`.

- **Migration**
  - Set `TINYBIRD_API_URL` and `TINYBIRD_TOKEN` for the server.
  - Create/deploy the Tinybird datasource at `server/tinybird/datasources/migration_customer_events.datasource`.
  - Install `@tinybirdco/sdk`. If env vars are not set, migration behavior is unchanged (events are skipped).

<sup>Written for commit 73b857b7c7f8516a122752481d71309dff65644d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a full event-persistence layer to the v2 migration system, recording per-customer lifecycle events (`customer_started`, `customer_succeeded`, `customer_skipped`, `customer_failed`) and run-level terminal events (`migration_started`, `migration_succeeded`, `migration_partially_failed`, `migration_failed`) to a new Tinybird datasource. Event sends are best-effort and errors are swallowed, so analytics failures can never block a migration.

- **[Improvements]** New `events/` module encapsulates all Tinybird ingest logic with Sentry error capture and a clean degraded-mode path when `TINYBIRD_API_URL`/`TINYBIRD_TOKEN` are absent.
- **[Improvements]** `runMigration` is split into an outer error-boundary function and `executeMigrationRun`; scope iteration is extracted into `runScopeIteration`, and `scopesForRun` is promoted to `getRunScopes` in the types module.
- **[Improvements]** New `migration_customer_events` Tinybird datasource with a sorting key tuned for per-run and per-customer timeline queries.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge. Event recording is fully fire-and-forget from the migration's perspective — all Tinybird errors are caught and reported to Sentry without affecting migration outcome.

The migration execution path is not at risk: `sendMigrationCustomerEventsToTinybird` wraps every ingest in a try/catch that swallows errors, so no analytics failure can break a migration. The main concerns are operational: `wait: true` with `maxRetries: 10` means each per-customer event call (two per customer) will block for potentially many seconds if Tinybird is degraded, and serialising `fullCustomer` into the `details` column ships PII to an analytics store without explicit scrubbing.

Review `sendMigrationCustomerEvents.ts` for the retry/wait configuration, and the `details: { beforeCustomer: context.fullCustomer }` line in `migrateCustomer.ts` for PII exposure before enabling in production environments with strict data residency requirements.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/migrations/v2/run/runMigration.ts | Refactored into `runMigration` (outer error boundary) + `executeMigrationRun` (inner); adds `migrationRunId` param, fires `migration_started`, terminal, and `migration_failed` events at run level. |
| server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts | Adds per-customer event recording: `customer_started` (with full customer snapshot), `customer_succeeded`/`customer_skipped` on success, and `customer_failed` in the catch. PII concern around serialising `fullCustomer` to Tinybird. |
| server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts | New best-effort Tinybird ingest with Sentry error capture; errors are swallowed correctly, but `wait: true` + `maxRetries: 10` may add latency within the per-customer migration loop. |
| server/src/external/tinybird/migrationCustomerEventsTinybird.ts | Module-level singleton `TinybirdClient`; gracefully degrades to `null` when env vars are absent. |
| server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts | New orchestrator that wraps `runFilter` + `iterateScope` + `migrateCustomer`; correctly threads `migrationRunId` down to `migrateCustomer`. |
| server/tinybird/datasources/migration_customer_events.datasource | New Tinybird datasource schema; sorting key tuned for per-run and per-customer timeline queries. |
| server/src/internal/migrations/v2/run/events/mapMigrationCustomerEvent.ts | Maps domain events to Tinybird payload; correctly handles `bigint` serialisation and optional fields. |
| server/tests/integration/billing/migrations-v2/utils/runUpdatePlanMigration.ts | Threaded `migrationRunId` into the local test path; `waitFor` return type relaxed to `Promise<unknown>`. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TriggerTask as runMigrationTask
    participant RM as runMigration
    participant EMR as executeMigrationRun
    participant RSI as runScopeIteration
    participant MC as migrateCustomer
    participant EVT as sendMigrationCustomerEventsToTinybird
    participant TB as Tinybird

    TriggerTask->>RM: runMigration(migrationRunId)
    RM->>EMR: executeMigrationRun(scopeResults[])
    EMR->>EVT: migration_started
    EVT->>TB: "ingestBatch (wait, maxRetries=10)"
    loop for each scope kind
        EMR->>RSI: runScopeIteration(kind, migrationRunId)
        RSI->>RSI: runFilter to iterate customers
        loop for each customer
            RSI->>MC: migrateCustomer(customerId, migrationRunId)
            MC->>EVT: customer_started
            EVT->>TB: ingestBatch
            MC->>MC: processOperations + evaluate + execute
            alt success
                MC->>EVT: customer_succeeded / customer_skipped
                EVT->>TB: ingestBatch
            else error
                MC->>EVT: customer_failed
                EVT->>TB: ingestBatch
                MC-->>RSI: throw caught by iterateScope continue
            end
        end
        RSI-->>EMR: RunMigrationScopeResult
    end
    EMR->>EVT: recordMigrationTerminalEvent
    EVT->>TB: ingestBatch
    EMR-->>RM: RunMigrationResponse
    alt executeMigrationRun threw
        RM->>EVT: recordMigrationFailedEvent
        EVT->>TB: ingestBatch
        RM-->>TriggerTask: throw
    else success
        RM-->>TriggerTask: RunMigrationResponse
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/package.json`, line 50 ([link](https://github.com/useautumn/autumn/blob/f09a8a5c2857bcb66bacd99707edcf0677c95959/server/package.json#L50)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`@tinybirdco/sdk` is a CLI-centric package with heavy server-side overhead**

   The lockfile shows `@tinybirdco/sdk@0.0.69` carries CLI-only dependencies — `esbuild`, `chokidar`, `commander`, and `@clack/prompts` — that are unused when the package is consumed as a library. Only the `TinybirdClient` class and `ingestBatch` are needed here. Consider whether a lighter HTTP-based alternative (e.g. `@tinybirdco/datasources` or a plain `fetch` wrapper against the Tinybird Events API) would reduce the dependency surface.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/package.json
   Line: 50

   Comment:
   **`@tinybirdco/sdk` is a CLI-centric package with heavy server-side overhead**

   The lockfile shows `@tinybirdco/sdk@0.0.69` carries CLI-only dependencies — `esbuild`, `chokidar`, `commander`, and `@clack/prompts` — that are unused when the package is consumed as a library. Only the `TinybirdClient` class and `ingestBatch` are needed here. Consider whether a lighter HTTP-based alternative (e.g. `@tinybirdco/datasources` or a plain `fetch` wrapper against the Tinybird Events API) would reduce the dependency surface.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/migrations/v2/run/events/sendMigrationCustomerEvents.ts:40-43
**`wait: true` + `maxRetries: 10` blocks the migration hot path**

`sendMigrationCustomerEventsToTinybird` is awaited synchronously inside both the success and error branches of `migrateCustomer`. With `wait: true` and 10 retries, a degraded or unavailable Tinybird will add substantial per-customer latency — two awaits per customer — even though the call is declared "best-effort." For a migration over thousands of customers this will compound badly. Consider reducing `maxRetries` to 2–3, or queuing the send outside the per-customer critical path (e.g. fire-and-forget with `void`).

### Issue 2 of 3
server/src/internal/migrations/v2/run/migrateCustomer/migrateCustomer.ts:59
**`fullCustomer` serialised to Tinybird may include PII**

`details: { beforeCustomer: context.fullCustomer }` serialises the complete customer object to the `details` column. `fullCustomer` likely contains emails, billing addresses, and other personal data. Tinybird is an analytics store with different retention/compliance expectations than your primary database. Consider stripping sensitive fields before ingesting (e.g. only capture `id`, `internal_id`, and non-personal plan/product info).

### Issue 3 of 3
server/package.json:50
**`@tinybirdco/sdk` is a CLI-centric package with heavy server-side overhead**

The lockfile shows `@tinybirdco/sdk@0.0.69` carries CLI-only dependencies — `esbuild`, `chokidar`, `commander`, and `@clack/prompts` — that are unused when the package is consumed as a library. Only the `TinybirdClient` class and `ingestBatch` are needed here. Consider whether a lighter HTTP-based alternative (e.g. `@tinybirdco/datasources` or a plain `fetch` wrapper against the Tinybird Events API) would reduce the dependency surface.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add event persistence to migratio..."](https://github.com/useautumn/autumn/commit/f09a8a5c2857bcb66bacd99707edcf0677c95959) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31308282)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->