### PR TITLE
feat: 🎸 better git workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,8 @@ jobs:
             --push \
             --provenance=false \
             --sbom=false \
-            --cache-from type=registry,ref=${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG_BRANCH} \
-            --cache-to type=inline \
+            --cache-from type=registry,ref=${ECR_REGISTRY}/${ECR_REPOSITORY}:buildcache-${IMAGE_TAG_BRANCH} \
+            --cache-to type=registry,ref=${ECR_REGISTRY}/${ECR_REPOSITORY}:buildcache-${IMAGE_TAG_BRANCH},mode=max \
             --tag ${TAGS//,/ --tag } \
             -f docker/Dockerfile \
             .

--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -4,9 +4,15 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "shared/**"
+      - "server/**"
   push:
     branches:
       - main
+    paths:
+      - "shared/**"
+      - "server/**"
 
 jobs:
   validate-schema:

--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -4,34 +4,57 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "shared/**"
-      - "server/**"
   push:
     branches:
       - main
-    paths:
-      - "shared/**"
-      - "server/**"
 
 jobs:
-  validate-schema:
-    name: Validate Schema
+  changes:
+    name: Detect schema-relevant changes
     runs-on: ubuntu-latest
-
+    outputs:
+      schema: ${{ steps.filter.outputs.schema }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            schema:
+              - 'shared/**'
+              - 'server/**'
+              - 'scripts/migrations/**'
+              - '.github/workflows/validate-schema.yml'
+
+  validate-schema:
+    name: Validate Schema
+    needs: changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip (no schema-relevant changes)
+        if: needs.changes.outputs.schema != 'true'
+        run: echo "No schema-relevant changes detected; skipping validation."
+
+      - name: Checkout code
+        if: needs.changes.outputs.schema == 'true'
+        uses: actions/checkout@v4
+
       - name: Set up Bun
+        if: needs.changes.outputs.schema == 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.10
 
       - name: Install dependencies
+        if: needs.changes.outputs.schema == 'true'
         run: bun install
 
       - name: Validate schema
+        if: needs.changes.outputs.schema == 'true'
         env:
           DATABASE_URL: ${{ secrets.DATABASE_READ_ONLY_URL }}
           DB_MAX_CONNECTIONS: 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up CI by switching Docker builds to a branch-scoped registry cache and making schema validation conditional while still reporting a status. This reduces build times and avoids unnecessary or missing workflow runs.

- **Refactors**
  - Build: use registry cache `buildcache-${IMAGE_TAG_BRANCH}` for `--cache-from/--cache-to` with `mode=max` (replaces inline cache).
  - Validate schema: add a `changes` job using `dorny/paths-filter@v3`; run steps only when `shared/**`, `server/**`, `scripts/migrations/**`, or `.github/workflows/validate-schema.yml` change, otherwise short-circuit but report success.

<sup>Written for commit 542a0fa7e4eaf518a8e3634832be032f2a961a5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves two GitHub Actions workflows: the Docker build cache strategy is upgraded to use a dedicated registry-backed cache tag with `mode=max`, and the schema validation workflow is restricted to only fire when relevant source paths change.

- **Improvements** — `build.yml` switches from `type=inline` to `type=registry,mode=max` caching with a dedicated `buildcache-{branch}` ECR tag, properly separating cache storage from production image tags and caching all intermediate build layers for faster subsequent builds.
- **Improvements** — `validate-schema.yml` adds `paths` filters (`shared/**`, `server/**`) to both `pull_request` and `push` triggers, avoiding unnecessary schema validation runs when unrelated files change.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with one caveat: the path filter on validate-schema.yml can silently prevent PRs from merging if that check is required in branch protection.

The Docker cache change is a straightforward improvement with no downside. The path filter on validate-schema.yml is the only concern — if the workflow isn't triggered because a PR touches unrelated paths, GitHub never posts a status, and a required branch protection check would leave the PR permanently blocked. Whether this bites in practice depends on the branch protection configuration.

.github/workflows/validate-schema.yml — verify that `Validate Schema` is not configured as a required status check, or add a fallback always-passing job for non-matching paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yml | Switches Docker layer cache from inline to a dedicated registry-based cache tag with mode=max, which properly separates cache storage from production image tags and caches all intermediate layers. |
| .github/workflows/validate-schema.yml | Adds path filters to limit schema validation to runs touching shared/** or server/**; may block PRs to main if validate-schema is a required status check and the PR touches only other paths. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Push/PR
    participant BW as build.yml
    participant ECR as Amazon ECR
    participant VW as validate-schema.yml

    GH->>BW: push to main/staging/dev
    BW->>ECR: "pull buildcache-{branch} (cache-from)"
    ECR-->>BW: "cache layers (mode=max)"
    BW->>ECR: "docker buildx build & push {branch}-{sha}"
    BW->>ECR: "write buildcache-{branch} (cache-to, mode=max)"

    GH->>VW: PR/push to main
    alt "paths match shared/** or server/**"
        VW->>VW: run validate-schema.ts
    else paths do NOT match
        VW-->>GH: workflow not triggered (no status reported)
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/validate-schema.yml:4-15
**Path filters may block PRs to `main` if this is a required status check**

When a `pull_request` workflow is not triggered at all due to path filters (as opposed to being skipped via an `if:` condition), GitHub never reports any status for it. If `Validate Schema` is configured as a required status check on `main`, any PR that only touches files outside `shared/**` and `server/**` (e.g., `.github/**`, frontend-only changes) will be permanently stuck waiting for a check that will never run. The fix is to either mark this check as optional in branch protection, or add a second job that always runs and reports success when the path filter doesn't match.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 better git workflows"](https://github.com/useautumn/autumn/commit/2d11c6279554e2b3dec07f8c03709ef220de7c34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31343312)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->