### PR TITLE
fix: use compound key in generateItemChanges to prevent Map collision on duplicate feature_ids

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "autumn",

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -200,7 +200,7 @@ export function generateItemChanges({
 				: formatItemValue(updated);
 
 			changes.push({
-				id: `item-added-${featureId}`,
+				id: `item-added-${itemKey}`,
 				type: "item",
 				label: getFeatureName(updated),
 				icon: "item",

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -120,24 +120,28 @@ export function generateItemChanges({
 
 	const changes: ItemEdit[] = [];
 
+	const getItemKey = (item: ProductItem): string =>
+		`${item.feature_id}:${item.usage_model ?? ""}`;
+
 	const originalFeatureMap = new Map(
 		originalItems
 			.filter((item) => item.feature_id)
-			.map((item) => [item.feature_id, item]),
+			.map((item) => [getItemKey(item), item]),
 	);
 	const updatedFeatureMap = new Map(
 		updatedItems
 			.filter((item) => item.feature_id)
-			.map((item) => [item.feature_id, item]),
+			.map((item) => [getItemKey(item), item]),
 	);
 
-	for (const [featureId, original] of originalFeatureMap) {
-		const updated = updatedFeatureMap.get(featureId);
+	for (const [itemKey, original] of originalFeatureMap) {
+		const updated = updatedFeatureMap.get(itemKey);
+		const featureId = original.feature_id;
 
 		if (!updated) {
 			const oldFormatted = formatItemValue(original);
 			changes.push({
-				id: `item-removed-${featureId}`,
+				id: `item-removed-${itemKey}`,
 				type: "item",
 				label: getFeatureName(original),
 				icon: "item",
@@ -160,7 +164,7 @@ export function generateItemChanges({
 				updatedItem: updated,
 			});
 			changes.push({
-				id: `item-modified-${featureId}`,
+				id: `item-modified-${itemKey}`,
 				type: "item",
 				label: getFeatureName(original),
 				icon: "item",
@@ -175,8 +179,9 @@ export function generateItemChanges({
 		}
 	}
 
-	for (const [featureId, updated] of updatedFeatureMap) {
-		if (!originalFeatureMap.has(featureId)) {
+	for (const [itemKey, updated] of updatedFeatureMap) {
+		if (!originalFeatureMap.has(itemKey)) {
+			const featureId = updated.feature_id;
 			const prepaidQuantity =
 				featureId && prepaidOptions ? prepaidOptions[featureId] : undefined;
 


### PR DESCRIPTION
## Summary
- Fixed a bug where price customizations made via the inline plan editor were not reflected in the subscription update preview section.
- The root cause was that `generateItemChanges` used `feature_id` alone as the Map key when comparing original vs updated items. Plans with multiple items sharing the same `feature_id` but different `usage_model` (e.g. prepaid and pay_per_use for the same feature) caused silent Map overwrites, hiding edits to all but the last item per `feature_id`.
- Changed the Map key to a compound `feature_id:usage_model` key so each distinct item is uniquely identified in the comparison.

## Test plan
- [ ] Open the subscription update sheet for a customer whose plan has items with duplicate `feature_id`s (e.g. both prepaid and pay-per-use variants of the same feature)
- [ ] Customize a price on one of the duplicate-`feature_id` items via the plan editor
- [ ] Verify the pricing preview section appears immediately (without needing to also change quantity)
- [ ] Verify that non-duplicate-`feature_id` item customizations still work as before

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing price customizations in the subscription update preview by preventing Map key collisions in `generateItemChanges`. Items are now keyed by `feature_id:usage_model`, and change IDs use the same compound key for add/remove/modify events.

- **Bug Fixes**
  - Added `getItemKey`; both original/updated maps and loops now use the compound key.
  - Updated change IDs for added/removed/modified items to use the compound key; preview now reflects edits to duplicate-`feature_id` items immediately.

<sup>Written for commit 963cd15f7541f3fe74741f877b3e2effeab4da9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Map-key collision in `generateItemChanges` where plans containing multiple items with the same `feature_id` (e.g. prepaid + pay-per-use variants) caused silent overwrites, preventing price customizations from appearing in the subscription update preview.

- **[Bug fixes]** Introduces a compound `feature_id:usage_model` key via `getItemKey` so each distinct item is uniquely tracked in both `originalFeatureMap` and `updatedFeatureMap`, and updates `item-removed` / `item-modified` IDs to use this key.
- **[Bug fixes]** The `item-added` branch of the loop still generates its change-record `id` using the bare `featureId` rather than `itemKey`, leaving a duplicate-ID gap when two newly-added items share a `feature_id` but differ in `usage_model`.
- **[Improvements]** `bun.lock` drops the `configVersion: 0` field, a no-op lockfile normalization.
</details>


<h3>Confidence Score: 3/5</h3>

Safe to merge for the specific bug being fixed, but a mirror of the same collision pattern remains in the item-added path.

The compound-key fix is applied consistently to the Map construction, the item-removed ID, and the item-modified ID, but the item-added branch still builds its record ID from the bare feature_id. Two newly-added items sharing a feature_id but differing in usage_model will collide on that ID, reproducing the original class of bug in an adjacent code path.

shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts — specifically the item-added push around line 202.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts | Compound key fix applied correctly to Map construction and item-removed/item-modified IDs, but item-added ID still uses the bare feature_id, leaving a duplicate-key gap for simultaneously-added items sharing a feature_id. |
| bun.lock | Lockfile change: removes the configVersion: 0 field — likely a bun version update artifact, no functional impact. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts`, line 202-207 ([link](https://github.com/useautumn/autumn/blob/129cfb1186e5eef2294b59c51b1bc9019ee93098/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts#L202-L207)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The `item-added` branch still uses `featureId` (just `feature_id`) as the ID suffix instead of the new compound `itemKey`. If two items with the same `feature_id` but different `usage_model` are both newly added in the same diff, they produce identical IDs (`item-added-featureX`), which is the same Map-collision pattern this PR set out to fix — and in a React list it would cause duplicate-key warnings or incorrect reconciliation.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
   Line: 202-207

   Comment:
   The `item-added` branch still uses `featureId` (just `feature_id`) as the ID suffix instead of the new compound `itemKey`. If two items with the same `feature_id` but different `usage_model` are both newly added in the same diff, they produce identical IDs (`item-added-featureX`), which is the same Map-collision pattern this PR set out to fix — and in a React list it would cause duplicate-key warnings or incorrect reconciliation.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts:202-207
The `item-added` branch still uses `featureId` (just `feature_id`) as the ID suffix instead of the new compound `itemKey`. If two items with the same `feature_id` but different `usage_model` are both newly added in the same diff, they produce identical IDs (`item-added-featureX`), which is the same Map-collision pattern this PR set out to fix — and in a React list it would cause duplicate-key warnings or incorrect reconciliation.

```suggestion
			changes.push({
				id: `item-added-${itemKey}`,
				type: "item",
				label: getFeatureName(updated),
				icon: "item",
				description: `${getFeatureName(updated)} added (${newValue})`,
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use compound key in generateItemCha..."](https://github.com/useautumn/autumn/commit/129cfb1186e5eef2294b59c51b1bc9019ee93098) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31348311)</sub>

<!-- /greptile_comment -->