### PR TITLE
fix: use compound key in generateItemChanges to prevent Map collision on duplicate feature_ids

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "autumn",

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -200,7 +200,7 @@ export function generateItemChanges({
 				: formatItemValue(updated);
 
 			changes.push({
-				id: `item-added-${featureId}`,
+				id: `item-added-${itemKey}`,
 				type: "item",
 				label: getFeatureName(updated),
 				icon: "item",

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -120,24 +120,28 @@ export function generateItemChanges({
 
 	const changes: ItemEdit[] = [];
 
+	const getItemKey = (item: ProductItem): string =>
+		`${item.feature_id}:${item.usage_model ?? ""}`;
+
 	const originalFeatureMap = new Map(
 		originalItems
 			.filter((item) => item.feature_id)
-			.map((item) => [item.feature_id, item]),
+			.map((item) => [getItemKey(item), item]),
 	);
 	const updatedFeatureMap = new Map(
 		updatedItems
 			.filter((item) => item.feature_id)
-			.map((item) => [item.feature_id, item]),
+			.map((item) => [getItemKey(item), item]),
 	);
 
-	for (const [featureId, original] of originalFeatureMap) {
-		const updated = updatedFeatureMap.get(featureId);
+	for (const [itemKey, original] of originalFeatureMap) {
+		const updated = updatedFeatureMap.get(itemKey);
+		const featureId = original.feature_id;
 
 		if (!updated) {
 			const oldFormatted = formatItemValue(original);
 			changes.push({
-				id: `item-removed-${featureId}`,
+				id: `item-removed-${itemKey}`,
 				type: "item",
 				label: getFeatureName(original),
 				icon: "item",
@@ -160,7 +164,7 @@ export function generateItemChanges({
 				updatedItem: updated,
 			});
 			changes.push({
-				id: `item-modified-${featureId}`,
+				id: `item-modified-${itemKey}`,
 				type: "item",
 				label: getFeatureName(original),
 				icon: "item",
@@ -175,8 +179,9 @@ export function generateItemChanges({
 		}
 	}
 
-	for (const [featureId, updated] of updatedFeatureMap) {
-		if (!originalFeatureMap.has(featureId)) {
+	for (const [itemKey, updated] of updatedFeatureMap) {
+		if (!originalFeatureMap.has(itemKey)) {
+			const featureId = updated.feature_id;
 			const prepaidQuantity =
 				featureId && prepaidOptions ? prepaidOptions[featureId] : undefined;
 


### PR DESCRIPTION
## Summary
Cherry-pick of #1516 onto `main`.

- Fixed a bug where price customizations made via the inline plan editor were not reflected in the subscription update preview section.
- `generateItemChanges` used `feature_id` alone as the Map key, causing silent overwrites when multiple items share the same `feature_id` but differ by `usage_model` (e.g. prepaid vs pay_per_use).
- Changed the Map key to a compound `feature_id:usage_model` key and aligned the added-item change ID to use the same compound key.

## Test plan
- [ ] Open the subscription update sheet for a customer whose plan has items with duplicate `feature_id`s (e.g. both prepaid and pay-per-use variants of the same feature)
- [ ] Customize a price on one of the duplicate-`feature_id` items via the plan editor
- [ ] Verify the pricing preview section appears immediately (without needing to also change quantity)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hidden item changes when a plan has duplicate `feature_id`s across different `usage_model`s, so price edits in the inline plan editor show up in the subscription update preview.

- Bug Fixes
  - Use compound key `feature_id:usage_model` for item Maps in `generateItemChanges` to prevent collisions.
  - Align change IDs to use the same compound key for removed/modified/added item changes.

<sup>Written for commit df0e46c04a03d36181c300cfc61af24cbfc4a06b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent Map-collision bug in `generateItemChanges` where items sharing the same `feature_id` but differing by `usage_model` (e.g. prepaid vs pay-per-use) caused later entries to overwrite earlier ones, hiding price customizations from the subscription update preview.

- **[Bug fixes]** Introduces `getItemKey(item)` returning `feature_id:usage_model` and uses it as the Map key in both `originalFeatureMap` and `updatedFeatureMap`, eliminating the collision when duplicate `feature_id`s exist with different `usage_model` values.
- **[Bug fixes]** Aligns all change IDs (`item-removed-`, `item-modified-`, `item-added-`) to use the same compound key, ensuring each entry remains uniquely addressable in the rendered diff UI.
- **[Improvements]** `featureId` is now extracted directly from the item inside each loop body rather than being inherited from the now-compound loop variable, keeping `prepaidOptions` lookups keyed correctly by `feature_id` alone.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is tightly scoped to a single utility function and directly addresses the described collision.

The compound-key approach correctly disambiguates items that share a feature_id but differ by usage_model. The featureId variable used for prepaidOptions lookup is still sourced from the item directly, so that path is unaffected. No other callers or data paths appear to depend on the old single-key behavior in a way that would break.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts | Core bug fix: Map key changed from feature_id alone to compound feature_id:usage_model to prevent silent overwrites when a plan has multiple items sharing the same feature_id but differing by usage_model (e.g. prepaid vs pay_per_use). |
| bun.lock | Lockfile: removes configVersion: 0 field — minor housekeeping, no functional impact. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[originalItems and updatedItems] --> B[filter items with feature_id]
    B --> C[getItemKey builds compound key from feature_id and usage_model]
    C --> D[originalFeatureMap keyed by compound key]
    C --> E[updatedFeatureMap keyed by compound key]

    D --> F{Loop originalFeatureMap}
    F -- no match in updated --> G[Push item-removed change]
    F -- item value changed --> H[Push item-modified change]
    F -- unchanged --> I[Skip]

    E --> J{Loop updatedFeatureMap}
    J -- not in original --> K[Push item-added change]
    J -- already exists --> I

    G --> L[changes output]
    H --> L
    K --> L
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use compound itemKey for added-item..."](https://github.com/useautumn/autumn/commit/df0e46c04a03d36181c300cfc61af24cbfc4a06b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31350896)</sub>

<!-- /greptile_comment -->