### PR TITLE
Stop Stripe resource creation during previews

### DIFF
--- a/server/src/external/stripe/createStripePrice/createStripePrice.ts
+++ b/server/src/external/stripe/createStripePrice/createStripePrice.ts
@@ -11,6 +11,7 @@ import { getBillingType } from "@server/internal/products/prices/priceUtils";
 import Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { createStripePrepaidPriceV2 } from "@/external/stripe/createStripePrice/createStripePrepaidPriceV2.js";
+import { assertNoPreviewStripeIdsOnProduct } from "@/external/stripe/previewStripeResourceIds.js";
 import { getStripePrice } from "@/external/stripe/prices/operations/getStripePrice.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { billingIntervalToStripe } from "../stripePriceUtils.js";
@@ -140,6 +141,7 @@ export const createStripePriceIFNotExist = async ({
 	// Fetch latest price data...
 
 	const { org, logger, db, env } = ctx;
+	assertNoPreviewStripeIdsOnProduct({ product });
 	const stripeCli = createStripeCli({ org, env });
 
 	const billingType = getBillingType(price.config!);

--- a/server/src/external/stripe/previewStripeResourceIds.ts
+++ b/server/src/external/stripe/previewStripeResourceIds.ts
@@ -1,0 +1,155 @@
+import {
+	type FullProduct,
+	InternalError,
+	isPrepaidPrice,
+	type Price,
+	ProcessorType,
+	type Product,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import { hashJson } from "@/utils/hash/hashJson";
+
+export const PREVIEW_STRIPE_PRICE_ID_PREFIX = "price_PREVIEW_";
+export const PREVIEW_STRIPE_PRODUCT_ID_PREFIX = "prod_PREVIEW_";
+
+const previewHash = ({ value }: { value: unknown }) =>
+	hashJson({ value }).slice(0, 24);
+
+export const isPreviewStripeId = ({ stripeId }: { stripeId?: string | null }) =>
+	stripeId?.startsWith(PREVIEW_STRIPE_PRICE_ID_PREFIX) === true ||
+	stripeId?.startsWith(PREVIEW_STRIPE_PRODUCT_ID_PREFIX) === true;
+
+export const assertNotPreviewStripeId = ({
+	stripeId,
+	fieldName,
+}: {
+	stripeId?: string | null;
+	fieldName: string;
+}) => {
+	if (!isPreviewStripeId({ stripeId })) return;
+
+	throw new InternalError({
+		message: `Refusing to persist preview Stripe id in ${fieldName}`,
+	});
+};
+
+export const previewStripeProductIdForProduct = ({
+	product,
+}: {
+	product: Product;
+}) =>
+	`${PREVIEW_STRIPE_PRODUCT_ID_PREFIX}${previewHash({
+		value: {
+			env: product.env,
+			internalProductId: product.internal_id,
+			productId: product.id,
+		},
+	})}`;
+
+const previewStripeProductIdForPrice = ({
+	price,
+	product,
+	internalEntityId,
+}: {
+	price: Price;
+	product: Product;
+	internalEntityId?: string;
+}) => {
+	const config = price.config as Partial<UsagePriceConfig>;
+	return `${PREVIEW_STRIPE_PRODUCT_ID_PREFIX}${previewHash({
+		value: {
+			env: product.env,
+			featureId: config.feature_id,
+			internalEntityId,
+			internalFeatureId: config.internal_feature_id,
+			internalProductId: product.internal_id,
+			productId: product.id,
+		},
+	})}`;
+};
+
+const previewStripePriceIdForPrice = ({
+	price,
+	product,
+	fieldName,
+}: {
+	price: Price;
+	product: Product;
+	fieldName: string;
+}) =>
+	`${PREVIEW_STRIPE_PRICE_ID_PREFIX}${previewHash({
+		value: {
+			config: price.config,
+			fieldName,
+			internalProductId: product.internal_id,
+		},
+	})}`;
+
+export const applyPreviewStripeResourcesToProduct = ({
+	product,
+	internalEntityId,
+}: {
+	product: FullProduct;
+	internalEntityId?: string;
+}) => {
+	const productProcessorId =
+		product.processor?.id ?? previewStripeProductIdForProduct({ product });
+
+	product.processor = {
+		id: productProcessorId,
+		type: ProcessorType.Stripe,
+	};
+
+	for (const price of product.prices) {
+		const config = price.config as Partial<UsagePriceConfig>;
+
+		config.stripe_price_id ??= previewStripePriceIdForPrice({
+			price,
+			product,
+			fieldName: "stripe_price_id",
+		});
+
+		if ("feature_id" in config && config.feature_id) {
+			config.stripe_product_id ??= previewStripeProductIdForPrice({
+				price,
+				product,
+				internalEntityId,
+			});
+		}
+
+		if (isPrepaidPrice(price)) {
+			config.stripe_prepaid_price_v2_id ??= previewStripePriceIdForPrice({
+				price,
+				product,
+				fieldName: "stripe_prepaid_price_v2_id",
+			});
+		}
+	}
+};
+
+export const assertNoPreviewStripeIdsOnProduct = ({
+	product,
+}: {
+	product: FullProduct;
+}) => {
+	assertNotPreviewStripeId({
+		stripeId: product.processor?.id,
+		fieldName: "product.processor.id",
+	});
+
+	for (const price of product.prices) {
+		const config = price.config as Partial<UsagePriceConfig>;
+		for (const fieldName of [
+			"stripe_price_id",
+			"stripe_product_id",
+			"stripe_empty_price_id",
+			"stripe_placeholder_price_id",
+			"stripe_prepaid_price_v2_id",
+		] as const) {
+			assertNotPreviewStripeId({
+				stripeId: config[fieldName],
+				fieldName: `price.config.${fieldName}`,
+			});
+		}
+	}
+};

--- a/server/src/external/stripe/previewStripeResourceIds.ts
+++ b/server/src/external/stripe/previewStripeResourceIds.ts
@@ -1,12 +1,22 @@
 import {
+	type AutumnBillingPlan,
+	type BillingContext,
+	cusProductToProduct,
+	type FullCusProduct,
 	type FullProduct,
+	findCustomerProductById,
 	InternalError,
 	isPrepaidPrice,
+	isUsagePrice,
 	type Price,
 	ProcessorType,
 	type Product,
 	type UsagePriceConfig,
 } from "@autumn/shared";
+import {
+	applyCustomerProductPatch,
+	getPatchCustomerProducts,
+} from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { hashJson } from "@/utils/hash/hashJson";
 
 export const PREVIEW_STRIPE_PRICE_ID_PREFIX = "price_PREVIEW_";
@@ -109,7 +119,7 @@ export const applyPreviewStripeResourcesToProduct = ({
 			fieldName: "stripe_price_id",
 		});
 
-		if ("feature_id" in config && config.feature_id) {
+		if (isUsagePrice({ price })) {
 			config.stripe_product_id ??= previewStripeProductIdForPrice({
 				price,
 				product,
@@ -124,6 +134,81 @@ export const applyPreviewStripeResourcesToProduct = ({
 				fieldName: "stripe_prepaid_price_v2_id",
 			});
 		}
+	}
+};
+
+const applyPreviewStripeResourcesToCustomerProduct = ({
+	customerProduct,
+	internalEntityId,
+}: {
+	customerProduct: FullCusProduct;
+	internalEntityId?: string;
+}) => {
+	const product = cusProductToProduct({ cusProduct: customerProduct });
+	applyPreviewStripeResourcesToProduct({ product, internalEntityId });
+	customerProduct.product.processor = product.processor ?? null;
+};
+
+/** Stamp preview Stripe IDs onto every customer product touched by a dry-run billing plan. */
+export const applyPreviewStripeResourcesToBillingPlan = ({
+	autumnBillingPlan,
+	billingContext,
+}: {
+	autumnBillingPlan: AutumnBillingPlan;
+	billingContext: BillingContext;
+}) => {
+	const { fullCustomer } = billingContext;
+	const internalEntityId = fullCustomer.entity?.internal_id;
+	const patchCustomerProducts = getPatchCustomerProducts({ autumnBillingPlan });
+	const patchedCustomerProductIds = new Set(
+		patchCustomerProducts.map(
+			(patchCustomerProduct) => patchCustomerProduct.customerProduct.id,
+		),
+	);
+
+	for (const customerProduct of autumnBillingPlan.insertCustomerProducts) {
+		applyPreviewStripeResourcesToCustomerProduct({
+			customerProduct,
+			internalEntityId,
+		});
+	}
+
+	for (const patchCustomerProduct of patchCustomerProducts) {
+		const matchingCustomerProduct =
+			findCustomerProductById({
+				fullCustomer,
+				customerProductId: patchCustomerProduct.customerProduct.id,
+			}) ?? patchCustomerProduct.customerProduct;
+		const patchedCustomerProduct = applyCustomerProductPatch({
+			customerProduct: matchingCustomerProduct,
+			patch: patchCustomerProduct,
+		});
+
+		applyPreviewStripeResourcesToCustomerProduct({
+			customerProduct: patchedCustomerProduct,
+			internalEntityId,
+		});
+
+		if (matchingCustomerProduct === patchCustomerProduct.customerProduct) {
+			continue;
+		}
+
+		applyPreviewStripeResourcesToCustomerProduct({
+			customerProduct: applyCustomerProductPatch({
+				customerProduct: patchCustomerProduct.customerProduct,
+				patch: patchCustomerProduct,
+			}),
+			internalEntityId,
+		});
+	}
+
+	for (const customerProduct of fullCustomer.customer_products) {
+		if (patchedCustomerProductIds.has(customerProduct.id)) continue;
+
+		applyPreviewStripeResourcesToCustomerProduct({
+			customerProduct,
+			internalEntityId,
+		});
 	}
 };
 

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -43,6 +43,7 @@ export async function attach({
 		params,
 		contextOverride,
 	});
+	billingContext.dryRunStripe = preview;
 
 	logAttachContext({ ctx, billingContext });
 

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -41,9 +41,9 @@ export async function attach({
 	const billingContext = await setupAttachBillingContext({
 		ctx,
 		params,
+		preview,
 		contextOverride,
 	});
-	billingContext.dryRunStripe = preview;
 
 	logAttachContext({ ctx, billingContext });
 

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -38,10 +38,12 @@ import { setupAttachTrialContext } from "./setupAttachTrialContext";
 export const setupAttachBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 	contextOverride = {},
 }: {
 	ctx: AutumnContext;
 	params: AttachParamsV1;
+	preview?: boolean;
 	contextOverride?: BillingContextOverride;
 }): Promise<AttachBillingContext> => {
 	const { fullCustomer: fullCustomerOverride } = contextOverride;
@@ -194,7 +196,8 @@ export const setupAttachBillingContext = async ({
 		});
 
 	const billingStartsAt =
-		params.starts_at ?? (planTiming === "end_of_cycle" ? endOfCycleMs : undefined);
+		params.starts_at ??
+		(planTiming === "end_of_cycle" ? endOfCycleMs : undefined);
 	const hasFutureStartDate = isFutureStartDate(
 		params.starts_at,
 		currentEpochMs,
@@ -277,6 +280,7 @@ export const setupAttachBillingContext = async ({
 		externalId: params.subscription_id,
 
 		skipBillingChanges,
+		dryRunStripe: preview,
 
 		anchorResetRefund: setupAnchorResetRefund({
 			billingCycleAnchor: params.billing_cycle_anchor,

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -106,9 +106,11 @@ const setupImmediateMultiProductTrialContext = async ({
 export const setupImmediateMultiProductBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
+	preview?: boolean;
 }): Promise<MultiAttachBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
 		ctx,
@@ -254,5 +256,6 @@ export const setupImmediateMultiProductBillingContext = async ({
 		successUrl:
 			params.success_url ?? orgToReturnUrl({ org: ctx.org, env: ctx.env }),
 		checkoutSessionParams: params.checkout_session_params,
+		dryRunStripe: preview,
 	};
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -27,8 +27,8 @@ export const previewCreateScheduleWithContext = async ({
 	const billingContext = await setupCreateScheduleBillingContext({
 		ctx,
 		params,
+		preview: true,
 	});
-	billingContext.dryRunStripe = true;
 
 	await handleCreateScheduleErrors({
 		db: ctx.db,

--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -28,6 +28,7 @@ export const previewCreateScheduleWithContext = async ({
 		ctx,
 		params,
 	});
+	billingContext.dryRunStripe = true;
 
 	await handleCreateScheduleErrors({
 		db: ctx.db,

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -70,9 +70,11 @@ const setupCreateScheduleCheckoutMode = ({
 export const setupCreateScheduleBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: CreateScheduleParamsV0;
+	preview?: boolean;
 }): Promise<CreateScheduleBillingContext> => {
 	const normalizedPhases = normalizeCreateSchedulePhases({
 		phases: params.phases,
@@ -99,6 +101,7 @@ export const setupCreateScheduleBillingContext = async ({
 	const billingContext = await setupImmediateMultiProductBillingContext({
 		ctx,
 		params: immediateParams,
+		preview,
 	});
 
 	validateCreateSchedulePhasePlans({

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -34,8 +34,8 @@ export async function multiAttach({
 	const billingContext = await setupMultiAttachBillingContext({
 		ctx,
 		params,
+		preview,
 	});
-	billingContext.dryRunStripe = preview;
 
 	// 2. Errors
 	await handleMultiAttachErrors({

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -35,6 +35,7 @@ export async function multiAttach({
 		ctx,
 		params,
 	});
+	billingContext.dryRunStripe = preview;
 
 	// 2. Errors
 	await handleMultiAttachErrors({

--- a/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
@@ -11,11 +11,14 @@ import { setupImmediateMultiProductBillingContext } from "../../common/immediate
 export const setupMultiAttachBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
+	preview?: boolean;
 }): Promise<MultiAttachBillingContext> =>
 	setupImmediateMultiProductBillingContext({
 		ctx,
 		params,
+		preview,
 	});

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -40,10 +40,12 @@ const FIELDS_WITH_BILLING_CHANGES = [
 export const setupUpdateSubscriptionBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 	contextOverride = {},
 }: {
 	ctx: AutumnContext;
 	params: UpdateSubscriptionV1Params;
+	preview?: boolean;
 	contextOverride?: UpdateSubscriptionBillingContextOverride;
 }): Promise<UpdateSubscriptionBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
@@ -207,6 +209,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		actionSource: "updateSubscription",
 
 		skipBillingChanges,
+		dryRunStripe: preview,
 
 		checkoutMode,
 

--- a/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
@@ -45,6 +45,7 @@ export async function updateSubscription({
 		params,
 		contextOverride,
 	});
+	billingContext.dryRunStripe = preview;
 
 	logUpdateSubscriptionContext({ ctx, billingContext });
 
@@ -96,12 +97,12 @@ export async function updateSubscription({
 	) {
 		const autumnCheckoutResult =
 			await createAutumnCheckout<UpdateSubscriptionBillingContext>({
-			ctx,
-			action: CheckoutAction.UpdateSubscription,
-			params,
-			billingContext,
-			billingPlan,
-		});
+				ctx,
+				action: CheckoutAction.UpdateSubscription,
+				params,
+				billingContext,
+				billingPlan,
+			});
 
 		return autumnCheckoutResult;
 	}

--- a/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
@@ -43,9 +43,9 @@ export async function updateSubscription({
 	const billingContext = await setupUpdateSubscriptionBillingContext({
 		ctx,
 		params,
+		preview,
 		contextOverride,
 	});
-	billingContext.dryRunStripe = preview;
 
 	logUpdateSubscriptionContext({ ctx, billingContext });
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -2,16 +2,33 @@ import {
 	type AutumnBillingPlan,
 	type BillingContext,
 	cusProductToProduct,
+	type FullCusProduct,
+	type FullProduct,
+	findCustomerProductById,
+	isFixedPrice,
 	isPrepaidPrice,
 	nullish,
+	type Price,
 } from "@autumn/shared";
 import { createStripePriceIFNotExist } from "@/external/stripe/createStripePrice/createStripePrice";
+import { applyPreviewStripeResourcesToProduct } from "@/external/stripe/previewStripeResourceIds";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import {
 	applyCustomerProductPatch,
 	getPatchCustomerProducts,
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { checkStripeProductExists } from "@/internal/products/productUtils";
+
+const shouldInitializeStripePrice = ({ price }: { price: Price }) => {
+	if (!isFixedPrice(price)) return true;
+
+	return (price.config.amount ?? 0) > 0;
+};
+
+const productNeedsPlanStripeProduct = ({ product }: { product: FullProduct }) =>
+	product.prices.some(
+		(price) => isFixedPrice(price) && shouldInitializeStripePrice({ price }),
+	);
 
 export const initStripeResourcesForBillingPlan = async ({
 	ctx,
@@ -26,22 +43,22 @@ export const initStripeResourcesForBillingPlan = async ({
 
 	const { fullCustomer } = billingContext;
 	const { insertCustomerProducts } = autumnBillingPlan;
+	const patchCustomerProducts = getPatchCustomerProducts({ autumnBillingPlan });
 
-	const newProducts = insertCustomerProducts.flatMap((cp) =>
-		cusProductToProduct({ cusProduct: cp }),
+	const newProducts = insertCustomerProducts.flatMap((customerProduct) =>
+		cusProductToProduct({ cusProduct: customerProduct }),
 	);
 
-	const patchProducts = getPatchCustomerProducts({ autumnBillingPlan }).map(
-		(patchCustomerProduct) =>
-			cusProductToProduct({
-				cusProduct: applyCustomerProductPatch({
-					customerProduct: patchCustomerProduct.customerProduct,
-					patch: patchCustomerProduct,
-				}),
+	const patchProducts = patchCustomerProducts.map((patchCustomerProduct) =>
+		cusProductToProduct({
+			cusProduct: applyCustomerProductPatch({
+				customerProduct: patchCustomerProduct.customerProduct,
+				patch: patchCustomerProduct,
 			}),
+		}),
 	);
 	const patchedCustomerProductIds = new Set(
-		getPatchCustomerProducts({ autumnBillingPlan }).map(
+		patchCustomerProducts.map(
 			(patchCustomerProduct) => patchCustomerProduct.customerProduct.id,
 		),
 	);
@@ -57,9 +74,10 @@ export const initStripeResourcesForBillingPlan = async ({
 			...product,
 			prices: product.prices.filter(
 				(price) =>
-					nullish(price.config.stripe_price_id) ||
-					(isPrepaidPrice(price) &&
-						nullish(price.config.stripe_prepaid_price_v2_id)),
+					shouldInitializeStripePrice({ price }) &&
+					(nullish(price.config.stripe_price_id) ||
+						(isPrepaidPrice(price) &&
+							nullish(price.config.stripe_prepaid_price_v2_id))),
 			),
 		}))
 		.filter(
@@ -67,10 +85,67 @@ export const initStripeResourcesForBillingPlan = async ({
 		);
 
 	const allProducts = [...newProducts, ...patchProducts, ...existingProducts];
+	const internalEntityId = fullCustomer.entity?.internal_id;
+
+	if (billingContext.dryRunStripe) {
+		const applyPreviewStripeResourcesToCustomerProduct = ({
+			customerProduct,
+		}: {
+			customerProduct: FullCusProduct;
+		}) => {
+			const product = cusProductToProduct({ cusProduct: customerProduct });
+			applyPreviewStripeResourcesToProduct({ product, internalEntityId });
+			customerProduct.product.processor = product.processor ?? null;
+		};
+
+		for (const customerProduct of insertCustomerProducts) {
+			applyPreviewStripeResourcesToCustomerProduct({
+				customerProduct,
+			});
+		}
+
+		for (const patchCustomerProduct of patchCustomerProducts) {
+			const matchingCustomerProduct =
+				findCustomerProductById({
+					fullCustomer,
+					customerProductId: patchCustomerProduct.customerProduct.id,
+				}) ?? patchCustomerProduct.customerProduct;
+			const patchedCustomerProduct = applyCustomerProductPatch({
+				customerProduct: matchingCustomerProduct,
+				patch: patchCustomerProduct,
+			});
+
+			applyPreviewStripeResourcesToCustomerProduct({
+				customerProduct: patchedCustomerProduct,
+			});
+
+			if (matchingCustomerProduct === patchCustomerProduct.customerProduct) {
+				continue;
+			}
+
+			applyPreviewStripeResourcesToCustomerProduct({
+				customerProduct: applyCustomerProductPatch({
+					customerProduct: patchCustomerProduct.customerProduct,
+					patch: patchCustomerProduct,
+				}),
+			});
+		}
+
+		for (const customerProduct of fullCustomer.customer_products) {
+			if (patchedCustomerProductIds.has(customerProduct.id)) continue;
+
+			applyPreviewStripeResourcesToCustomerProduct({
+				customerProduct,
+			});
+		}
+
+		return;
+	}
 
 	const batchProductUpdates = [];
 	for (const product of allProducts) {
 		if (product.processor?.id != null) continue;
+		if (!productNeedsPlanStripeProduct({ product })) continue;
 
 		batchProductUpdates.push(
 			checkStripeProductExists({
@@ -86,10 +161,10 @@ export const initStripeResourcesForBillingPlan = async ({
 
 	const batchPriceUpdates = [];
 
-	const internalEntityId = fullCustomer.entity?.internal_id;
-
 	for (const product of allProducts) {
 		for (const price of product.prices) {
+			if (!shouldInitializeStripePrice({ price })) continue;
+
 			batchPriceUpdates.push(
 				createStripePriceIFNotExist({
 					ctx,

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -2,16 +2,13 @@ import {
 	type AutumnBillingPlan,
 	type BillingContext,
 	cusProductToProduct,
-	type FullCusProduct,
-	type FullProduct,
-	findCustomerProductById,
 	isFixedPrice,
 	isPrepaidPrice,
 	nullish,
 	type Price,
 } from "@autumn/shared";
 import { createStripePriceIFNotExist } from "@/external/stripe/createStripePrice/createStripePrice";
-import { applyPreviewStripeResourcesToProduct } from "@/external/stripe/previewStripeResourceIds";
+import { applyPreviewStripeResourcesToBillingPlan } from "@/external/stripe/previewStripeResourceIds";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import {
 	applyCustomerProductPatch,
@@ -25,11 +22,6 @@ const shouldInitializeStripePrice = ({ price }: { price: Price }) => {
 	return (price.config.amount ?? 0) > 0;
 };
 
-const productNeedsPlanStripeProduct = ({ product }: { product: FullProduct }) =>
-	product.prices.some(
-		(price) => isFixedPrice(price) && shouldInitializeStripePrice({ price }),
-	);
-
 export const initStripeResourcesForBillingPlan = async ({
 	ctx,
 	autumnBillingPlan,
@@ -40,6 +32,14 @@ export const initStripeResourcesForBillingPlan = async ({
 	billingContext: BillingContext;
 }) => {
 	const { db, org, env, logger } = ctx;
+
+	if (billingContext.dryRunStripe) {
+		applyPreviewStripeResourcesToBillingPlan({
+			autumnBillingPlan,
+			billingContext,
+		});
+		return;
+	}
 
 	const { fullCustomer } = billingContext;
 	const { insertCustomerProducts } = autumnBillingPlan;
@@ -87,65 +87,17 @@ export const initStripeResourcesForBillingPlan = async ({
 	const allProducts = [...newProducts, ...patchProducts, ...existingProducts];
 	const internalEntityId = fullCustomer.entity?.internal_id;
 
-	if (billingContext.dryRunStripe) {
-		const applyPreviewStripeResourcesToCustomerProduct = ({
-			customerProduct,
-		}: {
-			customerProduct: FullCusProduct;
-		}) => {
-			const product = cusProductToProduct({ cusProduct: customerProduct });
-			applyPreviewStripeResourcesToProduct({ product, internalEntityId });
-			customerProduct.product.processor = product.processor ?? null;
-		};
-
-		for (const customerProduct of insertCustomerProducts) {
-			applyPreviewStripeResourcesToCustomerProduct({
-				customerProduct,
-			});
-		}
-
-		for (const patchCustomerProduct of patchCustomerProducts) {
-			const matchingCustomerProduct =
-				findCustomerProductById({
-					fullCustomer,
-					customerProductId: patchCustomerProduct.customerProduct.id,
-				}) ?? patchCustomerProduct.customerProduct;
-			const patchedCustomerProduct = applyCustomerProductPatch({
-				customerProduct: matchingCustomerProduct,
-				patch: patchCustomerProduct,
-			});
-
-			applyPreviewStripeResourcesToCustomerProduct({
-				customerProduct: patchedCustomerProduct,
-			});
-
-			if (matchingCustomerProduct === patchCustomerProduct.customerProduct) {
-				continue;
-			}
-
-			applyPreviewStripeResourcesToCustomerProduct({
-				customerProduct: applyCustomerProductPatch({
-					customerProduct: patchCustomerProduct.customerProduct,
-					patch: patchCustomerProduct,
-				}),
-			});
-		}
-
-		for (const customerProduct of fullCustomer.customer_products) {
-			if (patchedCustomerProductIds.has(customerProduct.id)) continue;
-
-			applyPreviewStripeResourcesToCustomerProduct({
-				customerProduct,
-			});
-		}
-
-		return;
-	}
-
 	const batchProductUpdates = [];
 	for (const product of allProducts) {
 		if (product.processor?.id != null) continue;
-		if (!productNeedsPlanStripeProduct({ product })) continue;
+		if (
+			!product.prices.some(
+				(price) =>
+					isFixedPrice(price) && shouldInitializeStripePrice({ price }),
+			)
+		) {
+			continue;
+		}
 
 		batchProductUpdates.push(
 			checkStripeProductExists({

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -3,6 +3,7 @@ import {
 	type BillingContext,
 	cusProductToProduct,
 	isFixedPrice,
+	isFreeProduct,
 	isPrepaidPrice,
 	nullish,
 	type Price,
@@ -90,14 +91,7 @@ export const initStripeResourcesForBillingPlan = async ({
 	const batchProductUpdates = [];
 	for (const product of allProducts) {
 		if (product.processor?.id != null) continue;
-		if (
-			!product.prices.some(
-				(price) =>
-					isFixedPrice(price) && shouldInitializeStripePrice({ price }),
-			)
-		) {
-			continue;
-		}
+		if (isFreeProduct({ prices: product.prices })) continue;
 
 		batchProductUpdates.push(
 			checkStripeProductExists({

--- a/server/src/internal/billing/v2/providers/stripe/utils/stripeItemSpec/cusPriceToStripeItemSpec/cusPriceToStripeItemSpec.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/stripeItemSpec/cusPriceToStripeItemSpec/cusPriceToStripeItemSpec.ts
@@ -1,6 +1,7 @@
 import {
 	type BillingContext,
 	cusPriceToCusEntWithCusProduct,
+	type FixedPriceConfig,
 	type FullCusProduct,
 	type FullCustomerPrice,
 	isAllocatedPrice,
@@ -38,6 +39,9 @@ export const cusPriceToStripeItemSpec = ({
 
 	// 1. Fixed / one-off price (no entitlement needed)
 	if (isFixedPrice(price)) {
+		const config = price.config as FixedPriceConfig;
+		if ((config.amount ?? 0) <= 0) return null;
+
 		spec = fixedPriceToStripeItemSpec({ cusPrice, cusProduct });
 	} else {
 		// Resolve cusEntWithCusProduct for usage-based prices

--- a/server/src/internal/products/productUtils.ts
+++ b/server/src/internal/products/productUtils.ts
@@ -23,6 +23,7 @@ import {
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
 import { createStripeCli } from "@server/external/connect/createStripeCli.js";
 import { createStripePriceIFNotExist } from "@server/external/stripe/createStripePrice/createStripePrice.js";
+import { assertNoPreviewStripeIdsOnProduct } from "@server/external/stripe/previewStripeResourceIds.js";
 import { getBillingType } from "@server/internal/products/prices/priceUtils.js";
 import RecaseError from "@server/utils/errorUtils.js";
 import { generateId, notNullish } from "@server/utils/genUtils.js";
@@ -244,6 +245,7 @@ export const checkStripeProductExists = async ({
 	logger: any;
 }) => {
 	let createNew = false;
+	assertNoPreviewStripeIdsOnProduct({ product });
 	const stripeCli = createStripeCli({
 		org,
 		env,

--- a/server/tests/unit/billing/init-stripe-resources-for-products.test.ts
+++ b/server/tests/unit/billing/init-stripe-resources-for-products.test.ts
@@ -3,15 +3,18 @@ import {
 	type AutumnBillingPlan,
 	type BillingContext,
 	BillingInterval,
+	BillWhen,
 	type FullCusProduct,
 	type FullCustomerPrice,
 	type Price,
 	PriceType,
+	type UsagePriceConfig,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
 const mockState = {
 	priceIds: [] as string[],
+	productCalls: 0,
 };
 
 mock.module("@/external/stripe/createStripePrice/createStripePrice", () => ({
@@ -21,12 +24,21 @@ mock.module("@/external/stripe/createStripePrice/createStripePrice", () => ({
 }));
 
 mock.module("@/internal/products/productUtils", () => ({
-	checkStripeProductExists: async () => undefined,
+	checkStripeProductExists: async () => {
+		mockState.productCalls++;
+	},
 }));
 
 import { initStripeResourcesForBillingPlan } from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts";
+import { customerProductToStripeItemSpecs } from "@/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerProductToStripeItemSpecs";
 
-const fixedPrice = ({ id }: { id: string }): Price => ({
+const fixedPrice = ({
+	id,
+	amount = 10,
+}: {
+	id: string;
+	amount?: number;
+}): Price => ({
 	id,
 	internal_product_id: "prod_internal",
 	org_id: "org_1",
@@ -37,12 +49,36 @@ const fixedPrice = ({ id }: { id: string }): Price => ({
 	proration_config: null,
 	config: {
 		type: PriceType.Fixed,
-		amount: 10,
+		amount,
 		interval: BillingInterval.Month,
 		stripe_price_id: null,
 		stripe_product_id: null,
 		feature_id: null,
 		internal_feature_id: null,
+	},
+});
+
+const prepaidPrice = ({ id }: { id: string }): Price => ({
+	id,
+	internal_product_id: "prod_internal",
+	org_id: "org_1",
+	created_at: 1,
+	tier_behavior: null,
+	is_custom: false,
+	entitlement_id: "ent_1",
+	proration_config: null,
+	config: {
+		type: PriceType.Usage,
+		bill_when: BillWhen.StartOfPeriod,
+		billing_units: 1,
+		internal_feature_id: "feature_internal",
+		feature_id: "messages",
+		usage_tiers: [{ amount: 10, to: -1 }],
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		stripe_price_id: null,
+		stripe_product_id: null,
+		stripe_prepaid_price_v2_id: null,
 	},
 });
 
@@ -109,6 +145,174 @@ const customerProduct = ({
 describe("initStripeResourcesForBillingPlan", () => {
 	beforeEach(() => {
 		mockState.priceIds = [];
+		mockState.productCalls = 0;
+	});
+
+	test("uses preview Stripe IDs without initializing Stripe resources during dry run", async () => {
+		const basePrice = fixedPrice({ id: "price_base" });
+		const messagesPrice = prepaidPrice({ id: "price_messages" });
+		const baseCustomerPrice = customerPrice({
+			id: "cus_price_base",
+			price: basePrice,
+		});
+		const messagesCustomerPrice = customerPrice({
+			id: "cus_price_messages",
+			price: messagesPrice,
+		});
+		const newCustomerProduct = customerProduct({
+			customerPrices: [baseCustomerPrice, messagesCustomerPrice],
+		});
+
+		await initStripeResourcesForBillingPlan({
+			ctx: {
+				db: {},
+				org: { id: "org_1" },
+				env: "sandbox",
+				logger: { debug: () => undefined },
+			} as unknown as AutumnContext,
+			billingContext: {
+				dryRunStripe: true,
+				fullCustomer: {
+					internal_id: "cus_internal",
+					customer_products: [],
+				},
+			} as unknown as BillingContext,
+			autumnBillingPlan: {
+				customerId: "cus_1",
+				insertCustomerProducts: [newCustomerProduct],
+			} as AutumnBillingPlan,
+		});
+
+		const messagesConfig = messagesPrice.config as UsagePriceConfig;
+
+		expect(mockState.productCalls).toBe(0);
+		expect(mockState.priceIds).toEqual([]);
+		expect(newCustomerProduct.product.processor?.id).toStartWith(
+			"prod_PREVIEW_",
+		);
+		expect(basePrice.config.stripe_price_id).toStartWith("price_PREVIEW_");
+		expect(messagesConfig.stripe_price_id).toStartWith("price_PREVIEW_");
+		expect(messagesConfig.stripe_product_id).toStartWith("prod_PREVIEW_");
+		expect(messagesConfig.stripe_prepaid_price_v2_id).toStartWith(
+			"price_PREVIEW_",
+		);
+	});
+
+	test("uses preview Stripe IDs for patched customer products during dry run", async () => {
+		const keptPrice = fixedPrice({ id: "price_kept" });
+		const insertedPrice = prepaidPrice({ id: "price_inserted" });
+		const originalCustomerProduct = customerProduct({
+			customerPrices: [
+				customerPrice({
+					id: "cus_price_kept",
+					price: keptPrice,
+				}),
+			],
+		});
+		const insertedCustomerPrice = customerPrice({
+			id: "cus_price_inserted",
+			price: insertedPrice,
+		});
+
+		await initStripeResourcesForBillingPlan({
+			ctx: {
+				db: {},
+				org: { id: "org_1" },
+				env: "sandbox",
+				logger: { debug: () => undefined },
+			} as unknown as AutumnContext,
+			billingContext: {
+				dryRunStripe: true,
+				fullCustomer: {
+					internal_id: "cus_internal",
+					customer_products: [originalCustomerProduct],
+				},
+			} as unknown as BillingContext,
+			autumnBillingPlan: {
+				customerId: "cus_1",
+				insertCustomerProducts: [],
+				patchCustomerProducts: [
+					{
+						customerProduct: originalCustomerProduct,
+						insertCustomerPrices: [insertedCustomerPrice],
+						insertCustomerEntitlements: [],
+						deleteCustomerPrices: [],
+						deleteCustomerEntitlements: [],
+					},
+				],
+			} as AutumnBillingPlan,
+		});
+
+		const insertedConfig = insertedPrice.config as UsagePriceConfig;
+
+		expect(mockState.productCalls).toBe(0);
+		expect(mockState.priceIds).toEqual([]);
+		expect(originalCustomerProduct.product.processor?.id).toStartWith(
+			"prod_PREVIEW_",
+		);
+		expect(keptPrice.config.stripe_price_id).toStartWith("price_PREVIEW_");
+		expect(insertedConfig.stripe_price_id).toStartWith("price_PREVIEW_");
+		expect(insertedConfig.stripe_product_id).toStartWith("prod_PREVIEW_");
+		expect(insertedConfig.stripe_prepaid_price_v2_id).toStartWith(
+			"price_PREVIEW_",
+		);
+	});
+
+	test("does not initialize Stripe resources for zero fixed prices", async () => {
+		const zeroPrice = fixedPrice({ id: "price_free", amount: 0 });
+		const freeCustomerProduct = customerProduct({
+			customerPrices: [
+				customerPrice({
+					id: "cus_price_free",
+					price: zeroPrice,
+				}),
+			],
+		});
+
+		await initStripeResourcesForBillingPlan({
+			ctx: {
+				db: {},
+				org: { id: "org_1" },
+				env: "sandbox",
+				logger: { debug: () => undefined },
+			} as unknown as AutumnContext,
+			billingContext: {
+				fullCustomer: {
+					internal_id: "cus_internal",
+					customer_products: [],
+				},
+			} as unknown as BillingContext,
+			autumnBillingPlan: {
+				customerId: "cus_1",
+				insertCustomerProducts: [freeCustomerProduct],
+			} as AutumnBillingPlan,
+		});
+
+		expect(mockState.productCalls).toBe(0);
+		expect(mockState.priceIds).toEqual([]);
+		expect(zeroPrice.config.stripe_price_id).toBeNull();
+	});
+
+	test("omits zero fixed prices from Stripe item specs", () => {
+		const zeroPrice = fixedPrice({ id: "price_free", amount: 0 });
+		const freeCustomerProduct = customerProduct({
+			customerPrices: [
+				customerPrice({
+					id: "cus_price_free",
+					price: zeroPrice,
+				}),
+			],
+		});
+
+		const stripeItemSpecs = customerProductToStripeItemSpecs({
+			ctx: {} as AutumnContext,
+			customerProduct: freeCustomerProduct,
+		});
+
+		expect(stripeItemSpecs).toEqual({
+			oneOffItems: [],
+			recurringItems: [],
+		});
 	});
 
 	test("does not initialize Stripe resources for prices removed by a patch", async () => {
@@ -138,7 +342,7 @@ describe("initStripeResourcesForBillingPlan", () => {
 					internal_id: "cus_internal",
 					customer_products: [originalCustomerProduct],
 				},
-			} as BillingContext,
+			} as unknown as BillingContext,
 			autumnBillingPlan: {
 				customerId: "cus_1",
 				insertCustomerProducts: [],

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -85,6 +85,7 @@ export interface BillingContext {
 	userMetadata?: Record<string, string>;
 
 	skipBillingChanges?: boolean;
+	dryRunStripe?: boolean;
 
 	checkoutMode?: CheckoutMode;
 


### PR DESCRIPTION
Previews now set dryRunStripe on billing contexts and assign deterministic preview Stripe product and price IDs inside initStripeResourcesForBillingPlan instead of calling Stripe. Real Stripe resource initialization rejects preview IDs, and zero fixed/base prices no longer create Stripe resources or subscription item specs.\n\nTests:\n- bun test tests/unit/billing/init-stripe-resources-for-products.test.ts\n- cd server && bun ts\n- bunx biome check <touched files>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop creating real Stripe resources during previews. Previews run in dry-run mode, use deterministic `prod_PREVIEW_*` and `price_PREVIEW_*` IDs, ignore zero-amount fixed prices, and skip Stripe product creation for free products.

- **New Features**
  - Added `dryRunStripe` to `BillingContext`; setup functions set it when `preview` is true.
  - Apply preview IDs via `applyPreviewStripeResourcesToBillingPlan` instead of calling Stripe.
  - Block preview IDs in real paths (`checkStripeProductExists`, `createStripePriceIFNotExist`).
  - Skip zero-amount fixed prices for Stripe creation and subscription item specs.
  - Skip Stripe product creation for free products using `isFreeProduct`.

- **Refactors**
  - Threaded `preview` through `setupAttachBillingContext`, `setupUpdateSubscriptionBillingContext`, `setupImmediateMultiProductBillingContext`, `setupMultiAttachBillingContext`, and `setupCreateScheduleBillingContext`.
  - Moved preview-ID stamping to `previewStripeResourceIds` and used `isUsagePrice` for checks.

<sup>Written for commit d8176d8ff166fd9459c0070297369de93dc31f7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

