### PR TITLE
Reuse Stripe resources for repeated plan items

### DIFF
--- a/server/src/external/stripe/previewStripeResourceIds.ts
+++ b/server/src/external/stripe/previewStripeResourceIds.ts
@@ -7,7 +7,10 @@ import {
 	findCustomerProductById,
 	InternalError,
 	isPrepaidPrice,
+	isPreviewStripeId,
 	isUsagePrice,
+	PREVIEW_STRIPE_PRICE_ID_PREFIX,
+	PREVIEW_STRIPE_PRODUCT_ID_PREFIX,
 	type Price,
 	ProcessorType,
 	type Product,
@@ -19,15 +22,8 @@ import {
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { hashJson } from "@/utils/hash/hashJson";
 
-export const PREVIEW_STRIPE_PRICE_ID_PREFIX = "price_PREVIEW_";
-export const PREVIEW_STRIPE_PRODUCT_ID_PREFIX = "prod_PREVIEW_";
-
 const previewHash = ({ value }: { value: unknown }) =>
 	hashJson({ value }).slice(0, 24);
-
-export const isPreviewStripeId = ({ stripeId }: { stripeId?: string | null }) =>
-	stripeId?.startsWith(PREVIEW_STRIPE_PRICE_ID_PREFIX) === true ||
-	stripeId?.startsWith(PREVIEW_STRIPE_PRODUCT_ID_PREFIX) === true;
 
 export const assertNotPreviewStripeId = ({
 	stripeId,

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -1,7 +1,9 @@
 import {
 	type AutumnBillingPlan,
 	type BillingContext,
+	copyStripeResourcesToMatchingPrice,
 	cusProductToProduct,
+	type FullProduct,
 	isFixedPrice,
 	isFreeProduct,
 	isPrepaidPrice,
@@ -15,12 +17,43 @@ import {
 	applyCustomerProductPatch,
 	getPatchCustomerProducts,
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
+import { PriceService } from "@/internal/products/prices/PriceService";
 import { checkStripeProductExists } from "@/internal/products/productUtils";
 
 const shouldInitializeStripePrice = ({ price }: { price: Price }) => {
 	if (!isFixedPrice(price)) return true;
 
 	return (price.config.amount ?? 0) > 0;
+};
+
+const applyStripeReuseWithinProduct = async ({
+	db,
+	product,
+}: {
+	db: AutumnContext["db"];
+	product: FullProduct;
+}) => {
+	for (const targetPrice of product.prices) {
+		const candidatePrices = product.prices.filter(
+			(price) => price.id !== targetPrice.id,
+		);
+		if (candidatePrices.length === 0) continue;
+
+		const { copiedFields } = copyStripeResourcesToMatchingPrice({
+			targetPrice,
+			candidatePrices,
+			targetEntitlements: product.entitlements,
+			candidateEntitlements: product.entitlements,
+		});
+
+		if (copiedFields.length === 0) continue;
+
+		await PriceService.update({
+			db,
+			id: targetPrice.id,
+			update: { config: targetPrice.config },
+		});
+	}
 };
 
 export const initStripeResourcesForBillingPlan = async ({
@@ -87,6 +120,12 @@ export const initStripeResourcesForBillingPlan = async ({
 
 	const allProducts = [...newProducts, ...patchProducts, ...existingProducts];
 	const internalEntityId = fullCustomer.entity?.internal_id;
+
+	await Promise.all(
+		allProducts.map((product) =>
+			applyStripeReuseWithinProduct({ db, product }),
+		),
+	);
 
 	const batchProductUpdates = [];
 	for (const product of allProducts) {

--- a/server/src/internal/products/handlers/handleVersionProduct.ts
+++ b/server/src/internal/products/handlers/handleVersionProduct.ts
@@ -98,7 +98,7 @@ export const handleVersionProductV2 = async ({
 		newItems: newProductV2.items,
 		features,
 		product: newProduct,
-		logger: console,
+		logger: ctx.logger,
 		isCustom: false,
 		newVersion: true,
 	});

--- a/server/src/internal/products/product-items/productItemUtils/handleNewProductItems.ts
+++ b/server/src/internal/products/product-items/productItemUtils/handleNewProductItems.ts
@@ -1,5 +1,6 @@
 import {
 	type AppEnv,
+	copyStripeResourcesToMatchingPrice,
 	type Entitlement,
 	type Feature,
 	isFeatureItem,
@@ -10,6 +11,7 @@ import {
 	type ProductItem,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
+import type { Logger } from "@server/external/logtail/logtailUtils.js";
 import { FeatureService } from "@server/internal/features/FeatureService.js";
 import { EntitlementService } from "@server/internal/products/entitlements/EntitlementService.js";
 import { PriceService } from "@server/internal/products/prices/PriceService.js";
@@ -76,7 +78,7 @@ const updateDbPricesAndEnts = async ({
 			ids: deletedEntIds,
 		});
 	} else {
-		const updateOrDelete: any = [];
+		const updateOrDelete: Promise<unknown>[] = [];
 		for (const ent of deletedEnts) {
 			const hasCustomPrice = customPrices.some(
 				(price) => price.entitlement_id === ent.id,
@@ -106,8 +108,7 @@ const updateDbPricesAndEnts = async ({
 	}
 };
 
-const handleCustomProductItems = async ({
-	db,
+const handleCustomProductItems = ({
 	newPrices,
 	newEnts,
 	updatedPrices,
@@ -116,7 +117,6 @@ const handleCustomProductItems = async ({
 	sameEnts,
 	features,
 }: {
-	db: DrizzleCli;
 	newPrices: Price[];
 	newEnts: Entitlement[];
 	updatedPrices: Price[];
@@ -124,17 +124,36 @@ const handleCustomProductItems = async ({
 	samePrices: Price[];
 	sameEnts: Entitlement[];
 	features: Feature[];
+}) => ({
+	prices: [...newPrices, ...updatedPrices, ...samePrices],
+	entitlements: [...newEnts, ...updatedEnts, ...sameEnts].map((ent) => ({
+		...ent,
+		feature: features.find((f) => f.id === ent.feature_id),
+	})),
+	customPrices: [...newPrices, ...updatedPrices],
+	customEnts: [...newEnts, ...updatedEnts],
+	features,
+});
+
+const carryForwardStripeResources = ({
+	targetPrices,
+	targetEntitlements,
+	candidatePrices,
+	candidateEntitlements,
+}: {
+	targetPrices: Price[];
+	targetEntitlements: Entitlement[];
+	candidatePrices: Price[];
+	candidateEntitlements: Entitlement[];
 }) => {
-	return {
-		prices: [...newPrices, ...updatedPrices, ...samePrices],
-		entitlements: [...newEnts, ...updatedEnts, ...sameEnts].map((ent) => ({
-			...ent,
-			feature: features.find((f) => f.id === ent.feature_id),
-		})),
-		customPrices: [...newPrices, ...updatedPrices],
-		customEnts: [...newEnts, ...updatedEnts],
-		features,
-	};
+	for (const targetPrice of targetPrices) {
+		copyStripeResourcesToMatchingPrice({
+			targetPrice,
+			candidatePrices,
+			targetEntitlements,
+			candidateEntitlements,
+		});
+	}
 };
 
 export const handleNewProductItems = async ({
@@ -155,7 +174,7 @@ export const handleNewProductItems = async ({
 	newItems: ProductItem[];
 	features: Feature[];
 	product: Product;
-	logger: any;
+	logger: Logger;
 	isCustom: boolean;
 	newVersion?: boolean;
 	saveToDb?: boolean;
@@ -249,6 +268,13 @@ export const handleNewProductItems = async ({
 		}
 	}
 
+	carryForwardStripeResources({
+		targetPrices: [...newPrices, ...updatedPrices],
+		targetEntitlements: [...newEnts, ...updatedEnts, ...sameEnts],
+		candidatePrices: curPrices,
+		candidateEntitlements: curEnts,
+	});
+
 	const printLogs = false;
 	if (printLogs) {
 		logPrices({ prices: newPrices, prefix: "New prices" });
@@ -272,7 +298,6 @@ export const handleNewProductItems = async ({
 
 	if ((isCustom || newVersion) && saveToDb) {
 		return handleCustomProductItems({
-			db,
 			newPrices,
 			newEnts,
 			updatedPrices,

--- a/server/tests/unit/shared/copyStripeResourcesToMatchingPrice.test.ts
+++ b/server/tests/unit/shared/copyStripeResourcesToMatchingPrice.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	copyStripeResourcesToMatchingPrice,
+	EntInterval,
+	type Entitlement,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+
+const orgId = "org_copy";
+const internalProductId = "prod_internal_copy";
+const now = 1_800_000_000_000;
+
+const baseConfig: UsagePriceConfig = {
+	type: PriceType.Usage,
+	bill_when: BillWhen.EndOfPeriod,
+	billing_units: 1,
+	should_prorate: false,
+	internal_feature_id: "feat_internal_ai_credits",
+	feature_id: "ai_credits",
+	usage_tiers: [{ amount: 0.1, to: TierInfinite }],
+	interval: BillingInterval.Month,
+	interval_count: 1,
+	stripe_product_id: "prod_ai_credits",
+	stripe_price_id: "price_ai_credits",
+	stripe_meter_id: "meter_ai_credits",
+	stripe_event_name: "ai_credits_used",
+};
+
+const candidate = (overrides: Partial<Price> = {}): Price => ({
+	id: "pr_existing",
+	org_id: orgId,
+	created_at: now,
+	internal_product_id: internalProductId,
+	is_custom: false,
+	config: { ...baseConfig },
+	entitlement_id: "ent_existing",
+	proration_config: null,
+	tier_behavior: null,
+	...overrides,
+});
+
+const target = (overrides: Partial<Price> = {}): Price => ({
+	id: "pr_new",
+	org_id: orgId,
+	created_at: now,
+	internal_product_id: internalProductId,
+	is_custom: false,
+	config: {
+		...baseConfig,
+		stripe_product_id: undefined,
+		stripe_price_id: undefined,
+		stripe_meter_id: undefined,
+		stripe_event_name: undefined,
+	} as UsagePriceConfig,
+	entitlement_id: "ent_new",
+	proration_config: null,
+	tier_behavior: null,
+	...overrides,
+});
+
+const entitlement = (overrides: Partial<Entitlement> = {}): Entitlement => ({
+	id: "ent_existing",
+	org_id: orgId,
+	created_at: now,
+	is_custom: false,
+	internal_product_id: internalProductId,
+	internal_feature_id: baseConfig.internal_feature_id!,
+	feature_id: baseConfig.feature_id!,
+	allowance: 100,
+	allowance_type: AllowanceType.Fixed,
+	interval: EntInterval.Month,
+	interval_count: 1,
+	carry_from_previous: false,
+	entity_feature_id: undefined,
+	usage_limit: null,
+	rollover: null,
+	...overrides,
+});
+
+describe("copyStripeResourcesToMatchingPrice", () => {
+	test("prefers a full match over a stripeProductOnly match", () => {
+		const fullCandidate = candidate({ id: "pr_full" });
+		const productOnlyCandidate = candidate({
+			id: "pr_cheaper",
+			config: {
+				...baseConfig,
+				usage_tiers: [{ amount: 0.05, to: TierInfinite }],
+				stripe_product_id: "prod_other_credits",
+				stripe_price_id: "price_other_credits",
+			},
+			entitlement_id: "ent_existing_cheaper",
+		});
+		const newPrice = target();
+
+		const result = copyStripeResourcesToMatchingPrice({
+			targetPrice: newPrice,
+			candidatePrices: [productOnlyCandidate, fullCandidate],
+			targetEntitlements: [entitlement({ id: "ent_new" })],
+			candidateEntitlements: [
+				entitlement(),
+				entitlement({
+					id: "ent_existing_cheaper",
+					allowance: 200,
+				}),
+			],
+		});
+
+		const config = newPrice.config as UsagePriceConfig;
+		expect(result.copiedFields).toContain("stripe_product_id");
+		expect(config.stripe_product_id).toBe("prod_ai_credits");
+		expect(config.stripe_price_id).toBe("price_ai_credits");
+		expect(config.stripe_meter_id).toBe("meter_ai_credits");
+		expect(config.stripe_event_name).toBe("ai_credits_used");
+	});
+
+	test("copies only stripe_product_id from a stripeProductOnly match", () => {
+		const productOnlyCandidate = candidate({
+			id: "pr_cheaper",
+			config: {
+				...baseConfig,
+				usage_tiers: [{ amount: 0.05, to: TierInfinite }],
+				stripe_product_id: "prod_other_credits",
+				stripe_price_id: "price_other_credits",
+				stripe_meter_id: "meter_other_credits",
+			},
+		});
+		const newPrice = target();
+
+		const result = copyStripeResourcesToMatchingPrice({
+			targetPrice: newPrice,
+			candidatePrices: [productOnlyCandidate],
+			targetEntitlements: [entitlement({ id: "ent_new" })],
+			candidateEntitlements: [entitlement()],
+		});
+
+		const config = newPrice.config as UsagePriceConfig;
+		expect(result.copiedFields).toEqual(["stripe_product_id"]);
+		expect(config.stripe_product_id).toBe("prod_other_credits");
+		expect(config.stripe_price_id).toBeUndefined();
+		expect(config.stripe_meter_id).toBeUndefined();
+	});
+
+	test("returns no copied fields when nothing matches", () => {
+		const unrelatedCandidate = candidate({
+			id: "pr_unrelated",
+			config: {
+				...baseConfig,
+				feature_id: "other_feature",
+				internal_feature_id: "feat_internal_other",
+			},
+		});
+
+		const newPrice = target();
+		const result = copyStripeResourcesToMatchingPrice({
+			targetPrice: newPrice,
+			candidatePrices: [unrelatedCandidate],
+			targetEntitlements: [entitlement({ id: "ent_new" })],
+			candidateEntitlements: [entitlement()],
+		});
+
+		const config = newPrice.config as UsagePriceConfig;
+		expect(result.copiedFields).toEqual([]);
+		expect(config.stripe_product_id).toBeUndefined();
+	});
+});

--- a/server/tests/unit/shared/getPriceStripeReuseLevel.test.ts
+++ b/server/tests/unit/shared/getPriceStripeReuseLevel.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	EntInterval,
+	type Entitlement,
+	type FixedPriceConfig,
+	getPriceStripeReuseLevel,
+	PREVIEW_STRIPE_PRICE_ID_PREFIX,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+
+const orgId = "org_match";
+const internalProductId = "prod_internal_match";
+const now = 1_800_000_000_000;
+
+const usageConfig: UsagePriceConfig = {
+	type: PriceType.Usage,
+	bill_when: BillWhen.EndOfPeriod,
+	billing_units: 1,
+	should_prorate: false,
+	internal_feature_id: "feat_internal_ai_credits",
+	feature_id: "ai_credits",
+	usage_tiers: [{ amount: 0.1, to: TierInfinite }],
+	interval: BillingInterval.Month,
+	interval_count: 1,
+	stripe_product_id: "prod_ai_credits",
+	stripe_price_id: "price_ai_credits",
+	stripe_meter_id: "meter_ai_credits",
+	stripe_event_name: "ai_credits_used",
+};
+
+const usagePrice = (overrides: Partial<Price> = {}): Price => ({
+	id: "pr_ai_credits",
+	org_id: orgId,
+	created_at: now,
+	internal_product_id: internalProductId,
+	is_custom: false,
+	config: { ...usageConfig },
+	entitlement_id: "ent_ai_credits",
+	proration_config: null,
+	tier_behavior: null,
+	...overrides,
+});
+
+const entitlement = (overrides: Partial<Entitlement> = {}): Entitlement => ({
+	id: "ent_ai_credits",
+	org_id: orgId,
+	created_at: now,
+	is_custom: false,
+	internal_product_id: internalProductId,
+	internal_feature_id: usageConfig.internal_feature_id!,
+	feature_id: usageConfig.feature_id!,
+	allowance: 100,
+	allowance_type: AllowanceType.Fixed,
+	interval: EntInterval.Month,
+	interval_count: 1,
+	carry_from_previous: false,
+	entity_feature_id: undefined,
+	usage_limit: null,
+	rollover: null,
+	...overrides,
+});
+
+describe("getPriceStripeReuseLevel", () => {
+	test("returns full when configs and paired entitlements match", () => {
+		const level = getPriceStripeReuseLevel({
+			newPrice: usagePrice({ id: "pr_new" }),
+			candidatePrice: usagePrice(),
+			newEntitlements: [entitlement()],
+			candidateEntitlements: [entitlement()],
+		});
+
+		expect(level).toBe("full");
+	});
+
+	test("returns stripeProductOnly when config differs but feature scope matches", () => {
+		const cheaper = usagePrice({
+			id: "pr_cheaper",
+			config: {
+				...usageConfig,
+				usage_tiers: [{ amount: 0.05, to: TierInfinite }],
+			},
+		});
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: cheaper,
+			candidatePrice: usagePrice(),
+			newEntitlements: [entitlement()],
+			candidateEntitlements: [entitlement()],
+		});
+
+		expect(level).toBe("stripeProductOnly");
+	});
+
+	test("returns none when entity scope differs", () => {
+		const level = getPriceStripeReuseLevel({
+			newPrice: usagePrice({
+				id: "pr_new",
+				entitlement_id: "ent_per_seat",
+			}),
+			candidatePrice: usagePrice(),
+			newEntitlements: [
+				entitlement({ id: "ent_per_seat", entity_feature_id: "seat" }),
+			],
+			candidateEntitlements: [entitlement()],
+		});
+
+		expect(level).toBe("none");
+	});
+
+	test("returns none when candidate has preview-only Stripe IDs", () => {
+		const previewCandidate = usagePrice({
+			config: {
+				...usageConfig,
+				stripe_product_id: `${PREVIEW_STRIPE_PRICE_ID_PREFIX}ai_credits`,
+			},
+		});
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: usagePrice({ id: "pr_new" }),
+			candidatePrice: previewCandidate,
+			newEntitlements: [entitlement()],
+			candidateEntitlements: [entitlement()],
+		});
+
+		expect(level).toBe("none");
+	});
+
+	test("returns full for matching fixed prices regardless of paired entitlements", () => {
+		const fixed: Price = {
+			id: "pr_base",
+			org_id: orgId,
+			created_at: now,
+			internal_product_id: internalProductId,
+			is_custom: false,
+			config: {
+				type: PriceType.Fixed,
+				amount: 500,
+				interval: BillingInterval.Month,
+				interval_count: 1,
+				stripe_product_id: null,
+				feature_id: null,
+				internal_feature_id: null,
+				stripe_price_id: "price_fixed",
+			} satisfies FixedPriceConfig,
+			proration_config: null,
+		};
+		const fixedTarget: Price = {
+			...fixed,
+			id: "pr_base_new",
+			config: {
+				...(fixed.config as FixedPriceConfig),
+				stripe_price_id: null,
+			},
+		};
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: fixedTarget,
+			candidatePrice: fixed,
+			newEntitlements: [],
+			candidateEntitlements: [],
+		});
+
+		expect(level).toBe("full");
+	});
+});

--- a/server/tests/unit/shared/getPriceStripeReuseLevel.test.ts
+++ b/server/tests/unit/shared/getPriceStripeReuseLevel.test.ts
@@ -132,6 +132,41 @@ describe("getPriceStripeReuseLevel", () => {
 		expect(level).toBe("none");
 	});
 
+	test("returns full when both usage prices share configs and lack paired entitlements", () => {
+		const orphan = usagePrice({ id: "pr_orphan", entitlement_id: null });
+		const orphanNew = usagePrice({ id: "pr_orphan_new", entitlement_id: null });
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: orphanNew,
+			candidatePrice: orphan,
+			newEntitlements: [],
+			candidateEntitlements: [],
+		});
+
+		expect(level).toBe("full");
+	});
+
+	test("returns stripeProductOnly when both usage prices lack entitlements but configs differ", () => {
+		const cheaper = usagePrice({
+			id: "pr_orphan_cheaper",
+			entitlement_id: null,
+			config: {
+				...usageConfig,
+				usage_tiers: [{ amount: 0.05, to: TierInfinite }],
+			},
+		});
+		const original = usagePrice({ id: "pr_orphan", entitlement_id: null });
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: cheaper,
+			candidatePrice: original,
+			newEntitlements: [],
+			candidateEntitlements: [],
+		});
+
+		expect(level).toBe("stripeProductOnly");
+	});
+
 	test("returns full for matching fixed prices regardless of paired entitlements", () => {
 		const fixed: Price = {
 			id: "pr_base",

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -25,13 +25,12 @@ export * from "./cusProductUtils/index";
 // Cus utils
 export * from "./cusUtils/index";
 export * from "./expandUtils";
-
+export * from "./featureUtils";
 // Feature utils
 export * from "./featureUtils/apiFeatureToDbFeature";
 export * from "./featureUtils/convertFeatureUtils";
 export * from "./featureUtils/findFeatureUtils";
 export * from "./featureUtils/index";
-export * from "./featureUtils";
 
 // INTERVAL UTILS
 export * from "./intervalUtils/addBillingInterval";
@@ -48,17 +47,24 @@ export * from "./productUtils/entUtils/index";
 export * from "./productUtils/freeTrialUtils";
 export * from "./productUtils/index";
 export * from "./productUtils/isProductUpgrade";
-export * from "./productUtils/priceUtils/index";
 export * from "./productUtils/priceUtils";
+export * from "./productUtils/priceUtils/index";
+// Price match utils
+export * from "./productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice";
+export * from "./productUtils/priceUtils/match/getPriceStripeReuseLevel";
 export * from "./productV2Utils/mapToProductV2";
 export * from "./productV2Utils/productItemUtils/classifyItemUtils";
 export * from "./productV2Utils/productItemUtils/getItemType";
-export * from "./productV2Utils/productItemUtils/matchPlanItem";
-export * from "./productV2Utils/productItemUtils/sortPlanItems";
 // Item utils
 export * from "./productV2Utils/productItemUtils/mapToItem";
+export * from "./productV2Utils/productItemUtils/matchPlanItem";
 export * from "./productV2Utils/productItemUtils/productItemUtils";
+export * from "./productV2Utils/productItemUtils/sortPlanItems";
 export * from "./productV2Utils/productV2ToFrontendProduct";
 export * from "./productV2Utils/productV2ToV1";
 export * from "./productV3Utils/productItemUtils/productV3ItemUtils";
+
+// Stripe resource utils
+export * from "./stripeUtils/classifyStripeResource/isPreviewStripeId";
+
 export * from "./utils";

--- a/shared/utils/productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice.ts
+++ b/shared/utils/productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice.ts
@@ -1,0 +1,106 @@
+import { type Entitlement, nullish, type Price } from "@autumn/shared";
+import { getPriceStripeReuseLevel } from "./getPriceStripeReuseLevel.js";
+
+const stripeResourceFields = [
+	"stripe_product_id",
+	"stripe_price_id",
+	"stripe_empty_price_id",
+	"stripe_placeholder_price_id",
+	"stripe_prepaid_price_v2_id",
+	"stripe_meter_id",
+	"stripe_event_name",
+] as const;
+
+export type StripeResourceField = (typeof stripeResourceFields)[number];
+
+type StripeResourceConfig = Partial<Record<StripeResourceField, string | null>>;
+
+const copyField = ({
+	fromConfig,
+	toConfig,
+	field,
+}: {
+	fromConfig: StripeResourceConfig;
+	toConfig: StripeResourceConfig;
+	field: StripeResourceField;
+}) => {
+	if (!nullish(toConfig[field])) return false;
+	if (nullish(fromConfig[field])) return false;
+
+	toConfig[field] = fromConfig[field];
+	return true;
+};
+
+/**
+ * Copy Stripe resource IDs (and `stripe_event_name`) from the best-matching
+ * candidate price onto `targetPrice.config`, in place. Returns the fields that
+ * were copied.
+ *
+ * Two-pass search: a "full" match (identical config + paired entitlement) is
+ * preferred over a "stripeProductOnly" match (same feature/entity scope). For
+ * "full" matches every Stripe resource field is copied; for "stripeProductOnly"
+ * only `stripe_product_id` is copied so a fresh price is later minted under the
+ * existing per-feature Stripe product.
+ */
+export const copyStripeResourcesToMatchingPrice = ({
+	targetPrice,
+	candidatePrices,
+	targetEntitlements,
+	candidateEntitlements,
+}: {
+	targetPrice: Price;
+	candidatePrices: Price[];
+	targetEntitlements: Entitlement[];
+	candidateEntitlements: Entitlement[];
+}): { copiedFields: StripeResourceField[] } => {
+	const levels = candidatePrices.map((candidatePrice) => ({
+		candidatePrice,
+		level: getPriceStripeReuseLevel({
+			newPrice: targetPrice,
+			candidatePrice,
+			newEntitlements: targetEntitlements,
+			candidateEntitlements,
+		}),
+	}));
+
+	const fullMatch = levels.find((entry) => entry.level === "full");
+	const productOnlyMatch =
+		fullMatch ?? levels.find((entry) => entry.level === "stripeProductOnly");
+
+	const productSource = productOnlyMatch?.candidatePrice;
+	const fullSource = fullMatch?.candidatePrice;
+
+	const targetConfig = targetPrice.config as StripeResourceConfig;
+	const copiedFields: StripeResourceField[] = [];
+
+	if (productSource) {
+		const fromConfig = productSource.config as StripeResourceConfig;
+		if (
+			copyField({
+				fromConfig,
+				toConfig: targetConfig,
+				field: "stripe_product_id",
+			})
+		) {
+			copiedFields.push("stripe_product_id");
+		}
+	}
+
+	if (fullSource) {
+		const fromConfig = fullSource.config as StripeResourceConfig;
+		for (const field of stripeResourceFields) {
+			if (field === "stripe_product_id") continue;
+			if (
+				copyField({
+					fromConfig,
+					toConfig: targetConfig,
+					field,
+				})
+			) {
+				copiedFields.push(field);
+			}
+		}
+	}
+
+	return { copiedFields };
+};

--- a/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
+++ b/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
@@ -1,0 +1,107 @@
+import {
+	type Entitlement,
+	entsAreSame,
+	isPreviewStripeId,
+	type Price,
+	PriceType,
+	pricesAreSame,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+
+export type PriceStripeReuseLevel = "full" | "stripeProductOnly" | "none";
+
+const stripeResourceFields = [
+	"stripe_product_id",
+	"stripe_price_id",
+	"stripe_empty_price_id",
+	"stripe_placeholder_price_id",
+	"stripe_prepaid_price_v2_id",
+	"stripe_meter_id",
+	"stripe_event_name",
+] as const;
+
+const priceHasPreviewStripeId = ({ price }: { price: Price }) => {
+	const config = price.config as Partial<
+		Record<(typeof stripeResourceFields)[number], string | null>
+	>;
+	return stripeResourceFields.some((field) =>
+		isPreviewStripeId({ stripeId: config[field] }),
+	);
+};
+
+const findPairedEntitlement = ({
+	price,
+	entitlements,
+}: {
+	price: Price;
+	entitlements: Entitlement[];
+}) =>
+	price.entitlement_id
+		? entitlements.find(
+				(entitlement) => entitlement.id === price.entitlement_id,
+			)
+		: undefined;
+
+/**
+ * Classify how much of the Stripe resource set on `candidatePrice` can be
+ * carried forward onto `newPrice` when the two represent the same logical
+ * Autumn price across a plan-update or version transition.
+ *
+ * - "full"               — config + paired entitlement are identical; reuse all stripe_*_id + stripe_event_name fields.
+ * - "stripeProductOnly"  — same (feature_id, entity_feature_id) usage scope; reuse just stripe_product_id so a new price is created under the existing plan-feature Stripe product.
+ * - "none"               — no reuse, or candidate is preview-only.
+ */
+export const getPriceStripeReuseLevel = ({
+	newPrice,
+	candidatePrice,
+	newEntitlements,
+	candidateEntitlements,
+}: {
+	newPrice: Price;
+	candidatePrice: Price;
+	newEntitlements: Entitlement[];
+	candidateEntitlements: Entitlement[];
+}): PriceStripeReuseLevel => {
+	if (priceHasPreviewStripeId({ price: candidatePrice })) return "none";
+	if (newPrice.config?.type !== candidatePrice.config?.type) return "none";
+
+	if (pricesAreSame(candidatePrice, newPrice, false)) {
+		if (newPrice.config?.type !== PriceType.Usage) return "full";
+
+		const newEnt = findPairedEntitlement({
+			price: newPrice,
+			entitlements: newEntitlements,
+		});
+		const candidateEnt = findPairedEntitlement({
+			price: candidatePrice,
+			entitlements: candidateEntitlements,
+		});
+
+		if (!newEnt || !candidateEnt) return "none";
+		if (entsAreSame(candidateEnt, newEnt)) return "full";
+	}
+
+	if (newPrice.config?.type !== PriceType.Usage) return "none";
+
+	const newUsageConfig = newPrice.config as UsagePriceConfig;
+	const candidateUsageConfig = candidatePrice.config as UsagePriceConfig;
+	if (newUsageConfig.feature_id !== candidateUsageConfig.feature_id) {
+		return "none";
+	}
+
+	const newEnt = findPairedEntitlement({
+		price: newPrice,
+		entitlements: newEntitlements,
+	});
+	const candidateEnt = findPairedEntitlement({
+		price: candidatePrice,
+		entitlements: candidateEntitlements,
+	});
+
+	if (!newEnt || !candidateEnt) return "none";
+	if (newEnt.entity_feature_id !== candidateEnt.entity_feature_id) {
+		return "none";
+	}
+
+	return "stripeProductOnly";
+};

--- a/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
+++ b/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
@@ -1,10 +1,12 @@
 import {
 	type Entitlement,
+	type EntitlementWithFeature,
 	entsAreSame,
 	isPreviewStripeId,
 	type Price,
 	PriceType,
 	pricesAreSame,
+	priceToEnt,
 	type UsagePriceConfig,
 } from "@autumn/shared";
 
@@ -35,20 +37,11 @@ const findPairedEntitlement = ({
 }: {
 	price: Price;
 	entitlements: Entitlement[];
-<<<<<<< Updated upstream
-}) =>
-	price.entitlement_id
-		? entitlements.find(
-				(entitlement) => entitlement.id === price.entitlement_id,
-			)
-		: undefined;
-=======
 }): Entitlement | undefined =>
 	priceToEnt({
 		price,
 		entitlements: entitlements as EntitlementWithFeature[],
 	});
->>>>>>> Stashed changes
 
 /**
  * Classify how much of the Stripe resource set on `candidatePrice` can be

--- a/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
+++ b/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
@@ -77,6 +77,8 @@ export const getPriceStripeReuseLevel = ({
 			entitlements: candidateEntitlements,
 		});
 
+		// Both null = same (null) entity scope; both have ents = compare them.
+		if (!newEnt && !candidateEnt) return "full";
 		if (!newEnt || !candidateEnt) return "none";
 		if (entsAreSame(candidateEnt, newEnt)) return "full";
 	}
@@ -98,6 +100,7 @@ export const getPriceStripeReuseLevel = ({
 		entitlements: candidateEntitlements,
 	});
 
+	if (!newEnt && !candidateEnt) return "stripeProductOnly";
 	if (!newEnt || !candidateEnt) return "none";
 	if (newEnt.entity_feature_id !== candidateEnt.entity_feature_id) {
 		return "none";

--- a/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
+++ b/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
@@ -35,12 +35,20 @@ const findPairedEntitlement = ({
 }: {
 	price: Price;
 	entitlements: Entitlement[];
+<<<<<<< Updated upstream
 }) =>
 	price.entitlement_id
 		? entitlements.find(
 				(entitlement) => entitlement.id === price.entitlement_id,
 			)
 		: undefined;
+=======
+}): Entitlement | undefined =>
+	priceToEnt({
+		price,
+		entitlements: entitlements as EntitlementWithFeature[],
+	});
+>>>>>>> Stashed changes
 
 /**
  * Classify how much of the Stripe resource set on `candidatePrice` can be

--- a/shared/utils/stripeUtils/classifyStripeResource/isPreviewStripeId.ts
+++ b/shared/utils/stripeUtils/classifyStripeResource/isPreviewStripeId.ts
@@ -1,0 +1,6 @@
+export const PREVIEW_STRIPE_PRICE_ID_PREFIX = "price_PREVIEW_";
+export const PREVIEW_STRIPE_PRODUCT_ID_PREFIX = "prod_PREVIEW_";
+
+export const isPreviewStripeId = ({ stripeId }: { stripeId?: string | null }) =>
+	stripeId?.startsWith(PREVIEW_STRIPE_PRICE_ID_PREFIX) === true ||
+	stripeId?.startsWith(PREVIEW_STRIPE_PRODUCT_ID_PREFIX) === true;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reuses existing Stripe resources when re-adding or tweaking plan items to avoid duplicate products/prices and speed up plan updates. The reuse pass runs during product item handling and in billing plan init, and skips preview-only Stripe IDs.

- **New Features**
  - Added `getPriceStripeReuseLevel` and `copyStripeResourcesToMatchingPrice` with two-pass matching (prefer full over product-only), treating both-null entitlements as the same scope, and returning "full" | "stripeProductOnly" | "none":
    - Full match (identical config + same paired entitlement, or both entitlements absent) → copy all `stripe_*_id` fields and `stripe_event_name`.
    - Product-only match (same feature + entity scope) → copy only `stripe_product_id`.
  - Applied the reuse pass:
    - In product item handling (before DB writes) for new/updated items.
    - Within each product during billing plan init to copy across sibling prices and persist via `PriceService.update`.
  - Moved preview ID detection to `shared/utils/stripeUtils` and ignore preview candidates; added unit tests for both utilities.

- **Bug Fixes**
  - Removed leftover merge markers in the stripe-reuse matcher.

<sup>Written for commit 622393af2797a642d25798eba99605ae6067e756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

