### PR TITLE
Reuse Stripe resources across plan versions

### DIFF
--- a/server/src/external/stripe/createStripePrice/createStripePrice.ts
+++ b/server/src/external/stripe/createStripePrice/createStripePrice.ts
@@ -11,6 +11,7 @@ import { getBillingType } from "@server/internal/products/prices/priceUtils";
 import Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { createStripePrepaidPriceV2 } from "@/external/stripe/createStripePrice/createStripePrepaidPriceV2.js";
+import { assertNoPreviewStripeIdsOnProduct } from "@/external/stripe/previewStripeResourceIds.js";
 import { getStripePrice } from "@/external/stripe/prices/operations/getStripePrice.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { billingIntervalToStripe } from "../stripePriceUtils.js";
@@ -140,6 +141,7 @@ export const createStripePriceIFNotExist = async ({
 	// Fetch latest price data...
 
 	const { org, logger, db, env } = ctx;
+	assertNoPreviewStripeIdsOnProduct({ product });
 	const stripeCli = createStripeCli({ org, env });
 
 	const billingType = getBillingType(price.config!);

--- a/server/src/external/stripe/previewStripeResourceIds.ts
+++ b/server/src/external/stripe/previewStripeResourceIds.ts
@@ -7,7 +7,10 @@ import {
 	findCustomerProductById,
 	InternalError,
 	isPrepaidPrice,
+	isPreviewStripeId,
 	isUsagePrice,
+	PREVIEW_STRIPE_PRICE_ID_PREFIX,
+	PREVIEW_STRIPE_PRODUCT_ID_PREFIX,
 	type Price,
 	ProcessorType,
 	type Product,
@@ -19,15 +22,8 @@ import {
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { hashJson } from "@/utils/hash/hashJson";
 
-export const PREVIEW_STRIPE_PRICE_ID_PREFIX = "price_PREVIEW_";
-export const PREVIEW_STRIPE_PRODUCT_ID_PREFIX = "prod_PREVIEW_";
-
 const previewHash = ({ value }: { value: unknown }) =>
 	hashJson({ value }).slice(0, 24);
-
-export const isPreviewStripeId = ({ stripeId }: { stripeId?: string | null }) =>
-	stripeId?.startsWith(PREVIEW_STRIPE_PRICE_ID_PREFIX) === true ||
-	stripeId?.startsWith(PREVIEW_STRIPE_PRODUCT_ID_PREFIX) === true;
 
 export const assertNotPreviewStripeId = ({
 	stripeId,

--- a/server/src/external/stripe/previewStripeResourceIds.ts
+++ b/server/src/external/stripe/previewStripeResourceIds.ts
@@ -1,0 +1,155 @@
+import {
+	type FullProduct,
+	InternalError,
+	isPrepaidPrice,
+	type Price,
+	ProcessorType,
+	type Product,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import { hashJson } from "@/utils/hash/hashJson";
+
+export const PREVIEW_STRIPE_PRICE_ID_PREFIX = "price_PREVIEW_";
+export const PREVIEW_STRIPE_PRODUCT_ID_PREFIX = "prod_PREVIEW_";
+
+const previewHash = ({ value }: { value: unknown }) =>
+	hashJson({ value }).slice(0, 24);
+
+export const isPreviewStripeId = ({ stripeId }: { stripeId?: string | null }) =>
+	stripeId?.startsWith(PREVIEW_STRIPE_PRICE_ID_PREFIX) === true ||
+	stripeId?.startsWith(PREVIEW_STRIPE_PRODUCT_ID_PREFIX) === true;
+
+export const assertNotPreviewStripeId = ({
+	stripeId,
+	fieldName,
+}: {
+	stripeId?: string | null;
+	fieldName: string;
+}) => {
+	if (!isPreviewStripeId({ stripeId })) return;
+
+	throw new InternalError({
+		message: `Refusing to persist preview Stripe id in ${fieldName}`,
+	});
+};
+
+export const previewStripeProductIdForProduct = ({
+	product,
+}: {
+	product: Product;
+}) =>
+	`${PREVIEW_STRIPE_PRODUCT_ID_PREFIX}${previewHash({
+		value: {
+			env: product.env,
+			internalProductId: product.internal_id,
+			productId: product.id,
+		},
+	})}`;
+
+const previewStripeProductIdForPrice = ({
+	price,
+	product,
+	internalEntityId,
+}: {
+	price: Price;
+	product: Product;
+	internalEntityId?: string;
+}) => {
+	const config = price.config as Partial<UsagePriceConfig>;
+	return `${PREVIEW_STRIPE_PRODUCT_ID_PREFIX}${previewHash({
+		value: {
+			env: product.env,
+			featureId: config.feature_id,
+			internalEntityId,
+			internalFeatureId: config.internal_feature_id,
+			internalProductId: product.internal_id,
+			productId: product.id,
+		},
+	})}`;
+};
+
+const previewStripePriceIdForPrice = ({
+	price,
+	product,
+	fieldName,
+}: {
+	price: Price;
+	product: Product;
+	fieldName: string;
+}) =>
+	`${PREVIEW_STRIPE_PRICE_ID_PREFIX}${previewHash({
+		value: {
+			config: price.config,
+			fieldName,
+			internalProductId: product.internal_id,
+		},
+	})}`;
+
+export const applyPreviewStripeResourcesToProduct = ({
+	product,
+	internalEntityId,
+}: {
+	product: FullProduct;
+	internalEntityId?: string;
+}) => {
+	const productProcessorId =
+		product.processor?.id ?? previewStripeProductIdForProduct({ product });
+
+	product.processor = {
+		id: productProcessorId,
+		type: ProcessorType.Stripe,
+	};
+
+	for (const price of product.prices) {
+		const config = price.config as Partial<UsagePriceConfig>;
+
+		config.stripe_price_id ??= previewStripePriceIdForPrice({
+			price,
+			product,
+			fieldName: "stripe_price_id",
+		});
+
+		if ("feature_id" in config && config.feature_id) {
+			config.stripe_product_id ??= previewStripeProductIdForPrice({
+				price,
+				product,
+				internalEntityId,
+			});
+		}
+
+		if (isPrepaidPrice(price)) {
+			config.stripe_prepaid_price_v2_id ??= previewStripePriceIdForPrice({
+				price,
+				product,
+				fieldName: "stripe_prepaid_price_v2_id",
+			});
+		}
+	}
+};
+
+export const assertNoPreviewStripeIdsOnProduct = ({
+	product,
+}: {
+	product: FullProduct;
+}) => {
+	assertNotPreviewStripeId({
+		stripeId: product.processor?.id,
+		fieldName: "product.processor.id",
+	});
+
+	for (const price of product.prices) {
+		const config = price.config as Partial<UsagePriceConfig>;
+		for (const fieldName of [
+			"stripe_price_id",
+			"stripe_product_id",
+			"stripe_empty_price_id",
+			"stripe_placeholder_price_id",
+			"stripe_prepaid_price_v2_id",
+		] as const) {
+			assertNotPreviewStripeId({
+				stripeId: config[fieldName],
+				fieldName: `price.config.${fieldName}`,
+			});
+		}
+	}
+};

--- a/server/src/external/stripe/previewStripeResourceIds.ts
+++ b/server/src/external/stripe/previewStripeResourceIds.ts
@@ -1,12 +1,22 @@
 import {
+	type AutumnBillingPlan,
+	type BillingContext,
+	cusProductToProduct,
+	type FullCusProduct,
 	type FullProduct,
+	findCustomerProductById,
 	InternalError,
 	isPrepaidPrice,
+	isUsagePrice,
 	type Price,
 	ProcessorType,
 	type Product,
 	type UsagePriceConfig,
 } from "@autumn/shared";
+import {
+	applyCustomerProductPatch,
+	getPatchCustomerProducts,
+} from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { hashJson } from "@/utils/hash/hashJson";
 
 export const PREVIEW_STRIPE_PRICE_ID_PREFIX = "price_PREVIEW_";
@@ -109,7 +119,7 @@ export const applyPreviewStripeResourcesToProduct = ({
 			fieldName: "stripe_price_id",
 		});
 
-		if ("feature_id" in config && config.feature_id) {
+		if (isUsagePrice({ price })) {
 			config.stripe_product_id ??= previewStripeProductIdForPrice({
 				price,
 				product,
@@ -124,6 +134,81 @@ export const applyPreviewStripeResourcesToProduct = ({
 				fieldName: "stripe_prepaid_price_v2_id",
 			});
 		}
+	}
+};
+
+const applyPreviewStripeResourcesToCustomerProduct = ({
+	customerProduct,
+	internalEntityId,
+}: {
+	customerProduct: FullCusProduct;
+	internalEntityId?: string;
+}) => {
+	const product = cusProductToProduct({ cusProduct: customerProduct });
+	applyPreviewStripeResourcesToProduct({ product, internalEntityId });
+	customerProduct.product.processor = product.processor ?? null;
+};
+
+/** Stamp preview Stripe IDs onto every customer product touched by a dry-run billing plan. */
+export const applyPreviewStripeResourcesToBillingPlan = ({
+	autumnBillingPlan,
+	billingContext,
+}: {
+	autumnBillingPlan: AutumnBillingPlan;
+	billingContext: BillingContext;
+}) => {
+	const { fullCustomer } = billingContext;
+	const internalEntityId = fullCustomer.entity?.internal_id;
+	const patchCustomerProducts = getPatchCustomerProducts({ autumnBillingPlan });
+	const patchedCustomerProductIds = new Set(
+		patchCustomerProducts.map(
+			(patchCustomerProduct) => patchCustomerProduct.customerProduct.id,
+		),
+	);
+
+	for (const customerProduct of autumnBillingPlan.insertCustomerProducts) {
+		applyPreviewStripeResourcesToCustomerProduct({
+			customerProduct,
+			internalEntityId,
+		});
+	}
+
+	for (const patchCustomerProduct of patchCustomerProducts) {
+		const matchingCustomerProduct =
+			findCustomerProductById({
+				fullCustomer,
+				customerProductId: patchCustomerProduct.customerProduct.id,
+			}) ?? patchCustomerProduct.customerProduct;
+		const patchedCustomerProduct = applyCustomerProductPatch({
+			customerProduct: matchingCustomerProduct,
+			patch: patchCustomerProduct,
+		});
+
+		applyPreviewStripeResourcesToCustomerProduct({
+			customerProduct: patchedCustomerProduct,
+			internalEntityId,
+		});
+
+		if (matchingCustomerProduct === patchCustomerProduct.customerProduct) {
+			continue;
+		}
+
+		applyPreviewStripeResourcesToCustomerProduct({
+			customerProduct: applyCustomerProductPatch({
+				customerProduct: patchCustomerProduct.customerProduct,
+				patch: patchCustomerProduct,
+			}),
+			internalEntityId,
+		});
+	}
+
+	for (const customerProduct of fullCustomer.customer_products) {
+		if (patchedCustomerProductIds.has(customerProduct.id)) continue;
+
+		applyPreviewStripeResourcesToCustomerProduct({
+			customerProduct,
+			internalEntityId,
+		});
 	}
 };
 

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -43,6 +43,7 @@ export async function attach({
 		params,
 		contextOverride,
 	});
+	billingContext.dryRunStripe = preview;
 
 	logAttachContext({ ctx, billingContext });
 

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -41,9 +41,9 @@ export async function attach({
 	const billingContext = await setupAttachBillingContext({
 		ctx,
 		params,
+		preview,
 		contextOverride,
 	});
-	billingContext.dryRunStripe = preview;
 
 	logAttachContext({ ctx, billingContext });
 

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -38,10 +38,12 @@ import { setupAttachTrialContext } from "./setupAttachTrialContext";
 export const setupAttachBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 	contextOverride = {},
 }: {
 	ctx: AutumnContext;
 	params: AttachParamsV1;
+	preview?: boolean;
 	contextOverride?: BillingContextOverride;
 }): Promise<AttachBillingContext> => {
 	const { fullCustomer: fullCustomerOverride } = contextOverride;
@@ -194,7 +196,8 @@ export const setupAttachBillingContext = async ({
 		});
 
 	const billingStartsAt =
-		params.starts_at ?? (planTiming === "end_of_cycle" ? endOfCycleMs : undefined);
+		params.starts_at ??
+		(planTiming === "end_of_cycle" ? endOfCycleMs : undefined);
 	const hasFutureStartDate = isFutureStartDate(
 		params.starts_at,
 		currentEpochMs,
@@ -277,6 +280,7 @@ export const setupAttachBillingContext = async ({
 		externalId: params.subscription_id,
 
 		skipBillingChanges,
+		dryRunStripe: preview,
 
 		anchorResetRefund: setupAnchorResetRefund({
 			billingCycleAnchor: params.billing_cycle_anchor,

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -106,9 +106,11 @@ const setupImmediateMultiProductTrialContext = async ({
 export const setupImmediateMultiProductBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
+	preview?: boolean;
 }): Promise<MultiAttachBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
 		ctx,
@@ -254,5 +256,6 @@ export const setupImmediateMultiProductBillingContext = async ({
 		successUrl:
 			params.success_url ?? orgToReturnUrl({ org: ctx.org, env: ctx.env }),
 		checkoutSessionParams: params.checkout_session_params,
+		dryRunStripe: preview,
 	};
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -27,8 +27,8 @@ export const previewCreateScheduleWithContext = async ({
 	const billingContext = await setupCreateScheduleBillingContext({
 		ctx,
 		params,
+		preview: true,
 	});
-	billingContext.dryRunStripe = true;
 
 	await handleCreateScheduleErrors({
 		db: ctx.db,

--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -28,6 +28,7 @@ export const previewCreateScheduleWithContext = async ({
 		ctx,
 		params,
 	});
+	billingContext.dryRunStripe = true;
 
 	await handleCreateScheduleErrors({
 		db: ctx.db,

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -70,9 +70,11 @@ const setupCreateScheduleCheckoutMode = ({
 export const setupCreateScheduleBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: CreateScheduleParamsV0;
+	preview?: boolean;
 }): Promise<CreateScheduleBillingContext> => {
 	const normalizedPhases = normalizeCreateSchedulePhases({
 		phases: params.phases,
@@ -99,6 +101,7 @@ export const setupCreateScheduleBillingContext = async ({
 	const billingContext = await setupImmediateMultiProductBillingContext({
 		ctx,
 		params: immediateParams,
+		preview,
 	});
 
 	validateCreateSchedulePhasePlans({

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -34,8 +34,8 @@ export async function multiAttach({
 	const billingContext = await setupMultiAttachBillingContext({
 		ctx,
 		params,
+		preview,
 	});
-	billingContext.dryRunStripe = preview;
 
 	// 2. Errors
 	await handleMultiAttachErrors({

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -35,6 +35,7 @@ export async function multiAttach({
 		ctx,
 		params,
 	});
+	billingContext.dryRunStripe = preview;
 
 	// 2. Errors
 	await handleMultiAttachErrors({

--- a/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
@@ -11,11 +11,14 @@ import { setupImmediateMultiProductBillingContext } from "../../common/immediate
 export const setupMultiAttachBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
+	preview?: boolean;
 }): Promise<MultiAttachBillingContext> =>
 	setupImmediateMultiProductBillingContext({
 		ctx,
 		params,
+		preview,
 	});

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -40,10 +40,12 @@ const FIELDS_WITH_BILLING_CHANGES = [
 export const setupUpdateSubscriptionBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 	contextOverride = {},
 }: {
 	ctx: AutumnContext;
 	params: UpdateSubscriptionV1Params;
+	preview?: boolean;
 	contextOverride?: UpdateSubscriptionBillingContextOverride;
 }): Promise<UpdateSubscriptionBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
@@ -207,6 +209,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		actionSource: "updateSubscription",
 
 		skipBillingChanges,
+		dryRunStripe: preview,
 
 		checkoutMode,
 

--- a/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
@@ -45,6 +45,7 @@ export async function updateSubscription({
 		params,
 		contextOverride,
 	});
+	billingContext.dryRunStripe = preview;
 
 	logUpdateSubscriptionContext({ ctx, billingContext });
 
@@ -96,12 +97,12 @@ export async function updateSubscription({
 	) {
 		const autumnCheckoutResult =
 			await createAutumnCheckout<UpdateSubscriptionBillingContext>({
-			ctx,
-			action: CheckoutAction.UpdateSubscription,
-			params,
-			billingContext,
-			billingPlan,
-		});
+				ctx,
+				action: CheckoutAction.UpdateSubscription,
+				params,
+				billingContext,
+				billingPlan,
+			});
 
 		return autumnCheckoutResult;
 	}

--- a/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
@@ -43,9 +43,9 @@ export async function updateSubscription({
 	const billingContext = await setupUpdateSubscriptionBillingContext({
 		ctx,
 		params,
+		preview,
 		contextOverride,
 	});
-	billingContext.dryRunStripe = preview;
 
 	logUpdateSubscriptionContext({ ctx, billingContext });
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -1,7 +1,9 @@
 import {
 	type AutumnBillingPlan,
 	type BillingContext,
+	copyStripeResourcesToMatchingPrice,
 	cusProductToProduct,
+	type FullProduct,
 	isFixedPrice,
 	isFreeProduct,
 	isPrepaidPrice,
@@ -15,12 +17,43 @@ import {
 	applyCustomerProductPatch,
 	getPatchCustomerProducts,
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
+import { PriceService } from "@/internal/products/prices/PriceService";
 import { checkStripeProductExists } from "@/internal/products/productUtils";
 
 const shouldInitializeStripePrice = ({ price }: { price: Price }) => {
 	if (!isFixedPrice(price)) return true;
 
 	return (price.config.amount ?? 0) > 0;
+};
+
+const applyStripeReuseWithinProduct = async ({
+	db,
+	product,
+}: {
+	db: AutumnContext["db"];
+	product: FullProduct;
+}) => {
+	for (const targetPrice of product.prices) {
+		const candidatePrices = product.prices.filter(
+			(price) => price.id !== targetPrice.id,
+		);
+		if (candidatePrices.length === 0) continue;
+
+		const { copiedFields } = copyStripeResourcesToMatchingPrice({
+			targetPrice,
+			candidatePrices,
+			targetEntitlements: product.entitlements,
+			candidateEntitlements: product.entitlements,
+		});
+
+		if (copiedFields.length === 0) continue;
+
+		await PriceService.update({
+			db,
+			id: targetPrice.id,
+			update: { config: targetPrice.config },
+		});
+	}
 };
 
 export const initStripeResourcesForBillingPlan = async ({
@@ -87,6 +120,12 @@ export const initStripeResourcesForBillingPlan = async ({
 
 	const allProducts = [...newProducts, ...patchProducts, ...existingProducts];
 	const internalEntityId = fullCustomer.entity?.internal_id;
+
+	await Promise.all(
+		allProducts.map((product) =>
+			applyStripeReuseWithinProduct({ db, product }),
+		),
+	);
 
 	const batchProductUpdates = [];
 	for (const product of allProducts) {

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -2,16 +2,33 @@ import {
 	type AutumnBillingPlan,
 	type BillingContext,
 	cusProductToProduct,
+	type FullCusProduct,
+	type FullProduct,
+	findCustomerProductById,
+	isFixedPrice,
 	isPrepaidPrice,
 	nullish,
+	type Price,
 } from "@autumn/shared";
 import { createStripePriceIFNotExist } from "@/external/stripe/createStripePrice/createStripePrice";
+import { applyPreviewStripeResourcesToProduct } from "@/external/stripe/previewStripeResourceIds";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import {
 	applyCustomerProductPatch,
 	getPatchCustomerProducts,
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { checkStripeProductExists } from "@/internal/products/productUtils";
+
+const shouldInitializeStripePrice = ({ price }: { price: Price }) => {
+	if (!isFixedPrice(price)) return true;
+
+	return (price.config.amount ?? 0) > 0;
+};
+
+const productNeedsPlanStripeProduct = ({ product }: { product: FullProduct }) =>
+	product.prices.some(
+		(price) => isFixedPrice(price) && shouldInitializeStripePrice({ price }),
+	);
 
 export const initStripeResourcesForBillingPlan = async ({
 	ctx,
@@ -26,22 +43,22 @@ export const initStripeResourcesForBillingPlan = async ({
 
 	const { fullCustomer } = billingContext;
 	const { insertCustomerProducts } = autumnBillingPlan;
+	const patchCustomerProducts = getPatchCustomerProducts({ autumnBillingPlan });
 
-	const newProducts = insertCustomerProducts.flatMap((cp) =>
-		cusProductToProduct({ cusProduct: cp }),
+	const newProducts = insertCustomerProducts.flatMap((customerProduct) =>
+		cusProductToProduct({ cusProduct: customerProduct }),
 	);
 
-	const patchProducts = getPatchCustomerProducts({ autumnBillingPlan }).map(
-		(patchCustomerProduct) =>
-			cusProductToProduct({
-				cusProduct: applyCustomerProductPatch({
-					customerProduct: patchCustomerProduct.customerProduct,
-					patch: patchCustomerProduct,
-				}),
+	const patchProducts = patchCustomerProducts.map((patchCustomerProduct) =>
+		cusProductToProduct({
+			cusProduct: applyCustomerProductPatch({
+				customerProduct: patchCustomerProduct.customerProduct,
+				patch: patchCustomerProduct,
 			}),
+		}),
 	);
 	const patchedCustomerProductIds = new Set(
-		getPatchCustomerProducts({ autumnBillingPlan }).map(
+		patchCustomerProducts.map(
 			(patchCustomerProduct) => patchCustomerProduct.customerProduct.id,
 		),
 	);
@@ -57,9 +74,10 @@ export const initStripeResourcesForBillingPlan = async ({
 			...product,
 			prices: product.prices.filter(
 				(price) =>
-					nullish(price.config.stripe_price_id) ||
-					(isPrepaidPrice(price) &&
-						nullish(price.config.stripe_prepaid_price_v2_id)),
+					shouldInitializeStripePrice({ price }) &&
+					(nullish(price.config.stripe_price_id) ||
+						(isPrepaidPrice(price) &&
+							nullish(price.config.stripe_prepaid_price_v2_id))),
 			),
 		}))
 		.filter(
@@ -67,10 +85,67 @@ export const initStripeResourcesForBillingPlan = async ({
 		);
 
 	const allProducts = [...newProducts, ...patchProducts, ...existingProducts];
+	const internalEntityId = fullCustomer.entity?.internal_id;
+
+	if (billingContext.dryRunStripe) {
+		const applyPreviewStripeResourcesToCustomerProduct = ({
+			customerProduct,
+		}: {
+			customerProduct: FullCusProduct;
+		}) => {
+			const product = cusProductToProduct({ cusProduct: customerProduct });
+			applyPreviewStripeResourcesToProduct({ product, internalEntityId });
+			customerProduct.product.processor = product.processor ?? null;
+		};
+
+		for (const customerProduct of insertCustomerProducts) {
+			applyPreviewStripeResourcesToCustomerProduct({
+				customerProduct,
+			});
+		}
+
+		for (const patchCustomerProduct of patchCustomerProducts) {
+			const matchingCustomerProduct =
+				findCustomerProductById({
+					fullCustomer,
+					customerProductId: patchCustomerProduct.customerProduct.id,
+				}) ?? patchCustomerProduct.customerProduct;
+			const patchedCustomerProduct = applyCustomerProductPatch({
+				customerProduct: matchingCustomerProduct,
+				patch: patchCustomerProduct,
+			});
+
+			applyPreviewStripeResourcesToCustomerProduct({
+				customerProduct: patchedCustomerProduct,
+			});
+
+			if (matchingCustomerProduct === patchCustomerProduct.customerProduct) {
+				continue;
+			}
+
+			applyPreviewStripeResourcesToCustomerProduct({
+				customerProduct: applyCustomerProductPatch({
+					customerProduct: patchCustomerProduct.customerProduct,
+					patch: patchCustomerProduct,
+				}),
+			});
+		}
+
+		for (const customerProduct of fullCustomer.customer_products) {
+			if (patchedCustomerProductIds.has(customerProduct.id)) continue;
+
+			applyPreviewStripeResourcesToCustomerProduct({
+				customerProduct,
+			});
+		}
+
+		return;
+	}
 
 	const batchProductUpdates = [];
 	for (const product of allProducts) {
 		if (product.processor?.id != null) continue;
+		if (!productNeedsPlanStripeProduct({ product })) continue;
 
 		batchProductUpdates.push(
 			checkStripeProductExists({
@@ -86,10 +161,10 @@ export const initStripeResourcesForBillingPlan = async ({
 
 	const batchPriceUpdates = [];
 
-	const internalEntityId = fullCustomer.entity?.internal_id;
-
 	for (const product of allProducts) {
 		for (const price of product.prices) {
+			if (!shouldInitializeStripePrice({ price })) continue;
+
 			batchPriceUpdates.push(
 				createStripePriceIFNotExist({
 					ctx,

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -2,16 +2,13 @@ import {
 	type AutumnBillingPlan,
 	type BillingContext,
 	cusProductToProduct,
-	type FullCusProduct,
-	type FullProduct,
-	findCustomerProductById,
 	isFixedPrice,
 	isPrepaidPrice,
 	nullish,
 	type Price,
 } from "@autumn/shared";
 import { createStripePriceIFNotExist } from "@/external/stripe/createStripePrice/createStripePrice";
-import { applyPreviewStripeResourcesToProduct } from "@/external/stripe/previewStripeResourceIds";
+import { applyPreviewStripeResourcesToBillingPlan } from "@/external/stripe/previewStripeResourceIds";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import {
 	applyCustomerProductPatch,
@@ -25,11 +22,6 @@ const shouldInitializeStripePrice = ({ price }: { price: Price }) => {
 	return (price.config.amount ?? 0) > 0;
 };
 
-const productNeedsPlanStripeProduct = ({ product }: { product: FullProduct }) =>
-	product.prices.some(
-		(price) => isFixedPrice(price) && shouldInitializeStripePrice({ price }),
-	);
-
 export const initStripeResourcesForBillingPlan = async ({
 	ctx,
 	autumnBillingPlan,
@@ -40,6 +32,14 @@ export const initStripeResourcesForBillingPlan = async ({
 	billingContext: BillingContext;
 }) => {
 	const { db, org, env, logger } = ctx;
+
+	if (billingContext.dryRunStripe) {
+		applyPreviewStripeResourcesToBillingPlan({
+			autumnBillingPlan,
+			billingContext,
+		});
+		return;
+	}
 
 	const { fullCustomer } = billingContext;
 	const { insertCustomerProducts } = autumnBillingPlan;
@@ -87,65 +87,17 @@ export const initStripeResourcesForBillingPlan = async ({
 	const allProducts = [...newProducts, ...patchProducts, ...existingProducts];
 	const internalEntityId = fullCustomer.entity?.internal_id;
 
-	if (billingContext.dryRunStripe) {
-		const applyPreviewStripeResourcesToCustomerProduct = ({
-			customerProduct,
-		}: {
-			customerProduct: FullCusProduct;
-		}) => {
-			const product = cusProductToProduct({ cusProduct: customerProduct });
-			applyPreviewStripeResourcesToProduct({ product, internalEntityId });
-			customerProduct.product.processor = product.processor ?? null;
-		};
-
-		for (const customerProduct of insertCustomerProducts) {
-			applyPreviewStripeResourcesToCustomerProduct({
-				customerProduct,
-			});
-		}
-
-		for (const patchCustomerProduct of patchCustomerProducts) {
-			const matchingCustomerProduct =
-				findCustomerProductById({
-					fullCustomer,
-					customerProductId: patchCustomerProduct.customerProduct.id,
-				}) ?? patchCustomerProduct.customerProduct;
-			const patchedCustomerProduct = applyCustomerProductPatch({
-				customerProduct: matchingCustomerProduct,
-				patch: patchCustomerProduct,
-			});
-
-			applyPreviewStripeResourcesToCustomerProduct({
-				customerProduct: patchedCustomerProduct,
-			});
-
-			if (matchingCustomerProduct === patchCustomerProduct.customerProduct) {
-				continue;
-			}
-
-			applyPreviewStripeResourcesToCustomerProduct({
-				customerProduct: applyCustomerProductPatch({
-					customerProduct: patchCustomerProduct.customerProduct,
-					patch: patchCustomerProduct,
-				}),
-			});
-		}
-
-		for (const customerProduct of fullCustomer.customer_products) {
-			if (patchedCustomerProductIds.has(customerProduct.id)) continue;
-
-			applyPreviewStripeResourcesToCustomerProduct({
-				customerProduct,
-			});
-		}
-
-		return;
-	}
-
 	const batchProductUpdates = [];
 	for (const product of allProducts) {
 		if (product.processor?.id != null) continue;
-		if (!productNeedsPlanStripeProduct({ product })) continue;
+		if (
+			!product.prices.some(
+				(price) =>
+					isFixedPrice(price) && shouldInitializeStripePrice({ price }),
+			)
+		) {
+			continue;
+		}
 
 		batchProductUpdates.push(
 			checkStripeProductExists({

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -3,6 +3,7 @@ import {
 	type BillingContext,
 	cusProductToProduct,
 	isFixedPrice,
+	isFreeProduct,
 	isPrepaidPrice,
 	nullish,
 	type Price,
@@ -90,14 +91,7 @@ export const initStripeResourcesForBillingPlan = async ({
 	const batchProductUpdates = [];
 	for (const product of allProducts) {
 		if (product.processor?.id != null) continue;
-		if (
-			!product.prices.some(
-				(price) =>
-					isFixedPrice(price) && shouldInitializeStripePrice({ price }),
-			)
-		) {
-			continue;
-		}
+		if (isFreeProduct({ prices: product.prices })) continue;
 
 		batchProductUpdates.push(
 			checkStripeProductExists({

--- a/server/src/internal/billing/v2/providers/stripe/utils/stripeItemSpec/cusPriceToStripeItemSpec/cusPriceToStripeItemSpec.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/stripeItemSpec/cusPriceToStripeItemSpec/cusPriceToStripeItemSpec.ts
@@ -1,6 +1,7 @@
 import {
 	type BillingContext,
 	cusPriceToCusEntWithCusProduct,
+	type FixedPriceConfig,
 	type FullCusProduct,
 	type FullCustomerPrice,
 	isAllocatedPrice,
@@ -38,6 +39,9 @@ export const cusPriceToStripeItemSpec = ({
 
 	// 1. Fixed / one-off price (no entitlement needed)
 	if (isFixedPrice(price)) {
+		const config = price.config as FixedPriceConfig;
+		if ((config.amount ?? 0) <= 0) return null;
+
 		spec = fixedPriceToStripeItemSpec({ cusPrice, cusProduct });
 	} else {
 		// Resolve cusEntWithCusProduct for usage-based prices

--- a/server/src/internal/products/handlers/handleVersionProduct.ts
+++ b/server/src/internal/products/handlers/handleVersionProduct.ts
@@ -98,7 +98,7 @@ export const handleVersionProductV2 = async ({
 		newItems: newProductV2.items,
 		features,
 		product: newProduct,
-		logger: console,
+		logger: ctx.logger,
 		isCustom: false,
 		newVersion: true,
 	});

--- a/server/src/internal/products/product-items/productItemUtils/handleNewProductItems.ts
+++ b/server/src/internal/products/product-items/productItemUtils/handleNewProductItems.ts
@@ -1,5 +1,6 @@
 import {
 	type AppEnv,
+	copyStripeResourcesToMatchingPrice,
 	type Entitlement,
 	type Feature,
 	isFeatureItem,
@@ -10,6 +11,7 @@ import {
 	type ProductItem,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
+import type { Logger } from "@server/external/logtail/logtailUtils.js";
 import { FeatureService } from "@server/internal/features/FeatureService.js";
 import { EntitlementService } from "@server/internal/products/entitlements/EntitlementService.js";
 import { PriceService } from "@server/internal/products/prices/PriceService.js";
@@ -76,7 +78,7 @@ const updateDbPricesAndEnts = async ({
 			ids: deletedEntIds,
 		});
 	} else {
-		const updateOrDelete: any = [];
+		const updateOrDelete: Promise<unknown>[] = [];
 		for (const ent of deletedEnts) {
 			const hasCustomPrice = customPrices.some(
 				(price) => price.entitlement_id === ent.id,
@@ -106,8 +108,7 @@ const updateDbPricesAndEnts = async ({
 	}
 };
 
-const handleCustomProductItems = async ({
-	db,
+const handleCustomProductItems = ({
 	newPrices,
 	newEnts,
 	updatedPrices,
@@ -116,7 +117,6 @@ const handleCustomProductItems = async ({
 	sameEnts,
 	features,
 }: {
-	db: DrizzleCli;
 	newPrices: Price[];
 	newEnts: Entitlement[];
 	updatedPrices: Price[];
@@ -124,17 +124,36 @@ const handleCustomProductItems = async ({
 	samePrices: Price[];
 	sameEnts: Entitlement[];
 	features: Feature[];
+}) => ({
+	prices: [...newPrices, ...updatedPrices, ...samePrices],
+	entitlements: [...newEnts, ...updatedEnts, ...sameEnts].map((ent) => ({
+		...ent,
+		feature: features.find((f) => f.id === ent.feature_id),
+	})),
+	customPrices: [...newPrices, ...updatedPrices],
+	customEnts: [...newEnts, ...updatedEnts],
+	features,
+});
+
+const carryForwardStripeResources = ({
+	targetPrices,
+	targetEntitlements,
+	candidatePrices,
+	candidateEntitlements,
+}: {
+	targetPrices: Price[];
+	targetEntitlements: Entitlement[];
+	candidatePrices: Price[];
+	candidateEntitlements: Entitlement[];
 }) => {
-	return {
-		prices: [...newPrices, ...updatedPrices, ...samePrices],
-		entitlements: [...newEnts, ...updatedEnts, ...sameEnts].map((ent) => ({
-			...ent,
-			feature: features.find((f) => f.id === ent.feature_id),
-		})),
-		customPrices: [...newPrices, ...updatedPrices],
-		customEnts: [...newEnts, ...updatedEnts],
-		features,
-	};
+	for (const targetPrice of targetPrices) {
+		copyStripeResourcesToMatchingPrice({
+			targetPrice,
+			candidatePrices,
+			targetEntitlements,
+			candidateEntitlements,
+		});
+	}
 };
 
 export const handleNewProductItems = async ({
@@ -155,7 +174,7 @@ export const handleNewProductItems = async ({
 	newItems: ProductItem[];
 	features: Feature[];
 	product: Product;
-	logger: any;
+	logger: Logger;
 	isCustom: boolean;
 	newVersion?: boolean;
 	saveToDb?: boolean;
@@ -249,6 +268,13 @@ export const handleNewProductItems = async ({
 		}
 	}
 
+	carryForwardStripeResources({
+		targetPrices: [...newPrices, ...updatedPrices],
+		targetEntitlements: [...newEnts, ...updatedEnts, ...sameEnts],
+		candidatePrices: curPrices,
+		candidateEntitlements: curEnts,
+	});
+
 	const printLogs = false;
 	if (printLogs) {
 		logPrices({ prices: newPrices, prefix: "New prices" });
@@ -272,7 +298,6 @@ export const handleNewProductItems = async ({
 
 	if ((isCustom || newVersion) && saveToDb) {
 		return handleCustomProductItems({
-			db,
 			newPrices,
 			newEnts,
 			updatedPrices,

--- a/server/src/internal/products/productUtils.ts
+++ b/server/src/internal/products/productUtils.ts
@@ -23,6 +23,7 @@ import {
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
 import { createStripeCli } from "@server/external/connect/createStripeCli.js";
 import { createStripePriceIFNotExist } from "@server/external/stripe/createStripePrice/createStripePrice.js";
+import { assertNoPreviewStripeIdsOnProduct } from "@server/external/stripe/previewStripeResourceIds.js";
 import { getBillingType } from "@server/internal/products/prices/priceUtils.js";
 import RecaseError from "@server/utils/errorUtils.js";
 import { generateId, notNullish } from "@server/utils/genUtils.js";
@@ -244,6 +245,7 @@ export const checkStripeProductExists = async ({
 	logger: any;
 }) => {
 	let createNew = false;
+	assertNoPreviewStripeIdsOnProduct({ product });
 	const stripeCli = createStripeCli({
 		org,
 		env,

--- a/server/tests/unit/billing/init-stripe-resources-for-products.test.ts
+++ b/server/tests/unit/billing/init-stripe-resources-for-products.test.ts
@@ -3,15 +3,18 @@ import {
 	type AutumnBillingPlan,
 	type BillingContext,
 	BillingInterval,
+	BillWhen,
 	type FullCusProduct,
 	type FullCustomerPrice,
 	type Price,
 	PriceType,
+	type UsagePriceConfig,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
 const mockState = {
 	priceIds: [] as string[],
+	productCalls: 0,
 };
 
 mock.module("@/external/stripe/createStripePrice/createStripePrice", () => ({
@@ -21,12 +24,21 @@ mock.module("@/external/stripe/createStripePrice/createStripePrice", () => ({
 }));
 
 mock.module("@/internal/products/productUtils", () => ({
-	checkStripeProductExists: async () => undefined,
+	checkStripeProductExists: async () => {
+		mockState.productCalls++;
+	},
 }));
 
 import { initStripeResourcesForBillingPlan } from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts";
+import { customerProductToStripeItemSpecs } from "@/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerProductToStripeItemSpecs";
 
-const fixedPrice = ({ id }: { id: string }): Price => ({
+const fixedPrice = ({
+	id,
+	amount = 10,
+}: {
+	id: string;
+	amount?: number;
+}): Price => ({
 	id,
 	internal_product_id: "prod_internal",
 	org_id: "org_1",
@@ -37,12 +49,36 @@ const fixedPrice = ({ id }: { id: string }): Price => ({
 	proration_config: null,
 	config: {
 		type: PriceType.Fixed,
-		amount: 10,
+		amount,
 		interval: BillingInterval.Month,
 		stripe_price_id: null,
 		stripe_product_id: null,
 		feature_id: null,
 		internal_feature_id: null,
+	},
+});
+
+const prepaidPrice = ({ id }: { id: string }): Price => ({
+	id,
+	internal_product_id: "prod_internal",
+	org_id: "org_1",
+	created_at: 1,
+	tier_behavior: null,
+	is_custom: false,
+	entitlement_id: "ent_1",
+	proration_config: null,
+	config: {
+		type: PriceType.Usage,
+		bill_when: BillWhen.StartOfPeriod,
+		billing_units: 1,
+		internal_feature_id: "feature_internal",
+		feature_id: "messages",
+		usage_tiers: [{ amount: 10, to: -1 }],
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		stripe_price_id: null,
+		stripe_product_id: null,
+		stripe_prepaid_price_v2_id: null,
 	},
 });
 
@@ -109,6 +145,174 @@ const customerProduct = ({
 describe("initStripeResourcesForBillingPlan", () => {
 	beforeEach(() => {
 		mockState.priceIds = [];
+		mockState.productCalls = 0;
+	});
+
+	test("uses preview Stripe IDs without initializing Stripe resources during dry run", async () => {
+		const basePrice = fixedPrice({ id: "price_base" });
+		const messagesPrice = prepaidPrice({ id: "price_messages" });
+		const baseCustomerPrice = customerPrice({
+			id: "cus_price_base",
+			price: basePrice,
+		});
+		const messagesCustomerPrice = customerPrice({
+			id: "cus_price_messages",
+			price: messagesPrice,
+		});
+		const newCustomerProduct = customerProduct({
+			customerPrices: [baseCustomerPrice, messagesCustomerPrice],
+		});
+
+		await initStripeResourcesForBillingPlan({
+			ctx: {
+				db: {},
+				org: { id: "org_1" },
+				env: "sandbox",
+				logger: { debug: () => undefined },
+			} as unknown as AutumnContext,
+			billingContext: {
+				dryRunStripe: true,
+				fullCustomer: {
+					internal_id: "cus_internal",
+					customer_products: [],
+				},
+			} as unknown as BillingContext,
+			autumnBillingPlan: {
+				customerId: "cus_1",
+				insertCustomerProducts: [newCustomerProduct],
+			} as AutumnBillingPlan,
+		});
+
+		const messagesConfig = messagesPrice.config as UsagePriceConfig;
+
+		expect(mockState.productCalls).toBe(0);
+		expect(mockState.priceIds).toEqual([]);
+		expect(newCustomerProduct.product.processor?.id).toStartWith(
+			"prod_PREVIEW_",
+		);
+		expect(basePrice.config.stripe_price_id).toStartWith("price_PREVIEW_");
+		expect(messagesConfig.stripe_price_id).toStartWith("price_PREVIEW_");
+		expect(messagesConfig.stripe_product_id).toStartWith("prod_PREVIEW_");
+		expect(messagesConfig.stripe_prepaid_price_v2_id).toStartWith(
+			"price_PREVIEW_",
+		);
+	});
+
+	test("uses preview Stripe IDs for patched customer products during dry run", async () => {
+		const keptPrice = fixedPrice({ id: "price_kept" });
+		const insertedPrice = prepaidPrice({ id: "price_inserted" });
+		const originalCustomerProduct = customerProduct({
+			customerPrices: [
+				customerPrice({
+					id: "cus_price_kept",
+					price: keptPrice,
+				}),
+			],
+		});
+		const insertedCustomerPrice = customerPrice({
+			id: "cus_price_inserted",
+			price: insertedPrice,
+		});
+
+		await initStripeResourcesForBillingPlan({
+			ctx: {
+				db: {},
+				org: { id: "org_1" },
+				env: "sandbox",
+				logger: { debug: () => undefined },
+			} as unknown as AutumnContext,
+			billingContext: {
+				dryRunStripe: true,
+				fullCustomer: {
+					internal_id: "cus_internal",
+					customer_products: [originalCustomerProduct],
+				},
+			} as unknown as BillingContext,
+			autumnBillingPlan: {
+				customerId: "cus_1",
+				insertCustomerProducts: [],
+				patchCustomerProducts: [
+					{
+						customerProduct: originalCustomerProduct,
+						insertCustomerPrices: [insertedCustomerPrice],
+						insertCustomerEntitlements: [],
+						deleteCustomerPrices: [],
+						deleteCustomerEntitlements: [],
+					},
+				],
+			} as AutumnBillingPlan,
+		});
+
+		const insertedConfig = insertedPrice.config as UsagePriceConfig;
+
+		expect(mockState.productCalls).toBe(0);
+		expect(mockState.priceIds).toEqual([]);
+		expect(originalCustomerProduct.product.processor?.id).toStartWith(
+			"prod_PREVIEW_",
+		);
+		expect(keptPrice.config.stripe_price_id).toStartWith("price_PREVIEW_");
+		expect(insertedConfig.stripe_price_id).toStartWith("price_PREVIEW_");
+		expect(insertedConfig.stripe_product_id).toStartWith("prod_PREVIEW_");
+		expect(insertedConfig.stripe_prepaid_price_v2_id).toStartWith(
+			"price_PREVIEW_",
+		);
+	});
+
+	test("does not initialize Stripe resources for zero fixed prices", async () => {
+		const zeroPrice = fixedPrice({ id: "price_free", amount: 0 });
+		const freeCustomerProduct = customerProduct({
+			customerPrices: [
+				customerPrice({
+					id: "cus_price_free",
+					price: zeroPrice,
+				}),
+			],
+		});
+
+		await initStripeResourcesForBillingPlan({
+			ctx: {
+				db: {},
+				org: { id: "org_1" },
+				env: "sandbox",
+				logger: { debug: () => undefined },
+			} as unknown as AutumnContext,
+			billingContext: {
+				fullCustomer: {
+					internal_id: "cus_internal",
+					customer_products: [],
+				},
+			} as unknown as BillingContext,
+			autumnBillingPlan: {
+				customerId: "cus_1",
+				insertCustomerProducts: [freeCustomerProduct],
+			} as AutumnBillingPlan,
+		});
+
+		expect(mockState.productCalls).toBe(0);
+		expect(mockState.priceIds).toEqual([]);
+		expect(zeroPrice.config.stripe_price_id).toBeNull();
+	});
+
+	test("omits zero fixed prices from Stripe item specs", () => {
+		const zeroPrice = fixedPrice({ id: "price_free", amount: 0 });
+		const freeCustomerProduct = customerProduct({
+			customerPrices: [
+				customerPrice({
+					id: "cus_price_free",
+					price: zeroPrice,
+				}),
+			],
+		});
+
+		const stripeItemSpecs = customerProductToStripeItemSpecs({
+			ctx: {} as AutumnContext,
+			customerProduct: freeCustomerProduct,
+		});
+
+		expect(stripeItemSpecs).toEqual({
+			oneOffItems: [],
+			recurringItems: [],
+		});
 	});
 
 	test("does not initialize Stripe resources for prices removed by a patch", async () => {
@@ -138,7 +342,7 @@ describe("initStripeResourcesForBillingPlan", () => {
 					internal_id: "cus_internal",
 					customer_products: [originalCustomerProduct],
 				},
-			} as BillingContext,
+			} as unknown as BillingContext,
 			autumnBillingPlan: {
 				customerId: "cus_1",
 				insertCustomerProducts: [],

--- a/server/tests/unit/products/handle-new-product-items-versioning.test.ts
+++ b/server/tests/unit/products/handle-new-product-items-versioning.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	AllowanceType,
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	EntInterval,
+	type Entitlement,
+	type Feature,
+	FeatureType,
+	FeatureUsageType,
+	type FixedPriceConfig,
+	type Price,
+	PriceType,
+	type Product,
+	type ProductItem,
+	ProductItemInterval,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+
+const insertCalls: {
+	features: unknown[][];
+	prices: unknown[][];
+	ents: unknown[][];
+} = {
+	features: [],
+	prices: [],
+	ents: [],
+};
+
+mock.module("@server/internal/features/FeatureService", () => ({
+	FeatureService: {
+		insert: async ({ data }: { data: unknown[] }) => {
+			insertCalls.features.push(data);
+		},
+	},
+}));
+
+mock.module(
+	"@server/internal/products/entitlements/EntitlementService",
+	() => ({
+		EntitlementService: {
+			insert: async ({ data }: { data: unknown[] }) => {
+				insertCalls.ents.push(data);
+			},
+			upsert: async () => {},
+			deleteInIds: async () => {},
+			update: async () => {},
+		},
+	}),
+);
+
+mock.module("@server/internal/products/prices/PriceService", () => ({
+	PriceService: {
+		insert: async ({ data }: { data: unknown[] }) => {
+			insertCalls.prices.push(data);
+		},
+		upsert: async () => {},
+		deleteInIds: async () => {},
+		getCustomInEntIds: async () => [],
+	},
+}));
+
+import type { DrizzleCli } from "@server/db/initDrizzle";
+import { handleNewProductItems } from "@/internal/products/product-items/productItemUtils/handleNewProductItems";
+
+const orgId = "org_versioning";
+const previousProductInternalId = "prod_internal_v1";
+const newProductInternalId = "prod_internal_v2";
+const now = 1_800_000_000_000;
+
+const feature: Feature = {
+	internal_id: "feat_internal_ai_credits",
+	id: "ai_credits",
+	name: "AI Credits",
+	type: FeatureType.Metered,
+	config: { usage_type: FeatureUsageType.Single },
+	org_id: orgId,
+	env: AppEnv.Sandbox,
+	created_at: now,
+	archived: false,
+	event_names: [],
+};
+
+const previousEntitlement: Entitlement = {
+	id: "ent_v1",
+	org_id: orgId,
+	created_at: now,
+	is_custom: false,
+	internal_product_id: previousProductInternalId,
+	internal_feature_id: feature.internal_id,
+	feature_id: feature.id,
+	allowance: 100,
+	allowance_type: AllowanceType.Fixed,
+	interval: EntInterval.Month,
+	interval_count: 1,
+	carry_from_previous: false,
+	entity_feature_id: undefined,
+	usage_limit: null,
+	rollover: null,
+};
+
+const previousUsageConfig: UsagePriceConfig = {
+	type: PriceType.Usage,
+	bill_when: BillWhen.EndOfPeriod,
+	billing_units: 1,
+	should_prorate: false,
+	internal_feature_id: feature.internal_id,
+	feature_id: feature.id,
+	usage_tiers: [{ amount: 0.1, to: TierInfinite }],
+	interval: BillingInterval.Month,
+	interval_count: 1,
+	stripe_product_id: "prod_ai_credits",
+	stripe_price_id: "price_ai_credits",
+	stripe_meter_id: "meter_ai_credits",
+	stripe_event_name: "ai_credits_used",
+	stripe_empty_price_id: "price_ai_credits_empty",
+};
+
+const previousUsagePrice: Price = {
+	id: "pr_v1",
+	org_id: orgId,
+	created_at: now,
+	internal_product_id: previousProductInternalId,
+	is_custom: false,
+	config: previousUsageConfig,
+	entitlement_id: previousEntitlement.id,
+	proration_config: null,
+	tier_behavior: null,
+};
+
+const previousFixedConfig: FixedPriceConfig = {
+	type: PriceType.Fixed,
+	amount: 500,
+	interval: BillingInterval.Month,
+	interval_count: 1,
+	stripe_product_id: null,
+	feature_id: null,
+	internal_feature_id: null,
+	stripe_price_id: "price_base_v1",
+};
+
+const previousFixedPrice: Price = {
+	id: "pr_fixed_v1",
+	org_id: orgId,
+	created_at: now,
+	internal_product_id: previousProductInternalId,
+	is_custom: false,
+	config: previousFixedConfig,
+	proration_config: null,
+};
+
+const newProduct: Product = {
+	id: "enterprise",
+	name: "Enterprise",
+	description: null,
+	is_add_on: false,
+	is_default: false,
+	version: 2,
+	group: "",
+	env: AppEnv.Sandbox,
+	internal_id: newProductInternalId,
+	org_id: orgId,
+	created_at: now,
+	processor: null,
+	base_variant_id: null,
+	archived: false,
+	config: { ignore_past_due: false },
+};
+
+const baseItem: ProductItem = {
+	price: 500,
+	interval: ProductItemInterval.Month,
+	interval_count: 1,
+	price_id: previousFixedPrice.id,
+};
+
+const aiCreditsItem: ProductItem = {
+	feature_id: feature.id,
+	included_usage: 100,
+	price: 0.1,
+	interval: ProductItemInterval.Month,
+	interval_count: 1,
+	usage_model: "pay_per_use" as ProductItem["usage_model"],
+	billing_units: 1,
+	reset_usage_when_enabled: true,
+	price_id: previousUsagePrice.id,
+	entitlement_id: previousEntitlement.id,
+};
+
+const noopLogger = {
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined,
+	child: () => noopLogger,
+} as never;
+
+describe("handleNewProductItems versioning carries forward Stripe IDs", () => {
+	beforeEach(() => {
+		insertCalls.features = [];
+		insertCalls.prices = [];
+		insertCalls.ents = [];
+	});
+
+	test("copies every Stripe resource field onto the new version when config matches", async () => {
+		const result = await handleNewProductItems({
+			db: {} as DrizzleCli,
+			curPrices: [previousFixedPrice, previousUsagePrice],
+			curEnts: [previousEntitlement],
+			newItems: [baseItem, aiCreditsItem],
+			features: [feature],
+			product: newProduct,
+			logger: noopLogger,
+			isCustom: false,
+			newVersion: true,
+			saveToDb: false,
+		});
+
+		const fixedNew = result.prices.find(
+			(price) => price.config.type === PriceType.Fixed,
+		);
+		const usageNew = result.prices.find(
+			(price) => price.config.type === PriceType.Usage,
+		);
+
+		expect(fixedNew).toBeDefined();
+		expect(usageNew).toBeDefined();
+		expect((fixedNew?.config as FixedPriceConfig).stripe_price_id).toBe(
+			"price_base_v1",
+		);
+		const usageConfig = usageNew?.config as UsagePriceConfig;
+		expect(usageConfig.stripe_product_id).toBe("prod_ai_credits");
+		expect(usageConfig.stripe_price_id).toBe("price_ai_credits");
+		expect(usageConfig.stripe_meter_id).toBe("meter_ai_credits");
+		expect(usageConfig.stripe_event_name).toBe("ai_credits_used");
+		expect(usageConfig.stripe_empty_price_id).toBe("price_ai_credits_empty");
+	});
+
+	test("falls back to stripe_product_id only when the usage tier changes", async () => {
+		const changedAiCreditsItem: ProductItem = {
+			...aiCreditsItem,
+			price: 0.2,
+		};
+
+		const result = await handleNewProductItems({
+			db: {} as DrizzleCli,
+			curPrices: [previousUsagePrice],
+			curEnts: [previousEntitlement],
+			newItems: [changedAiCreditsItem],
+			features: [feature],
+			product: newProduct,
+			logger: noopLogger,
+			isCustom: false,
+			newVersion: true,
+			saveToDb: false,
+		});
+
+		const usageNew = result.prices.find(
+			(price) => price.config.type === PriceType.Usage,
+		);
+		expect(usageNew).toBeDefined();
+		const usageConfig = usageNew?.config as UsagePriceConfig;
+		expect(usageConfig.stripe_product_id).toBe("prod_ai_credits");
+		expect(usageConfig.stripe_price_id).toBeUndefined();
+		expect(usageConfig.stripe_meter_id).toBe("meter_ai_credits");
+		expect(usageConfig.stripe_empty_price_id).toBeUndefined();
+	});
+});

--- a/server/tests/unit/products/handle-new-product-items-versioning.test.ts
+++ b/server/tests/unit/products/handle-new-product-items-versioning.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
 	AllowanceType,
 	AppEnv,
@@ -18,50 +18,6 @@ import {
 	TierInfinite,
 	type UsagePriceConfig,
 } from "@autumn/shared";
-
-const insertCalls: {
-	features: unknown[][];
-	prices: unknown[][];
-	ents: unknown[][];
-} = {
-	features: [],
-	prices: [],
-	ents: [],
-};
-
-mock.module("@server/internal/features/FeatureService", () => ({
-	FeatureService: {
-		insert: async ({ data }: { data: unknown[] }) => {
-			insertCalls.features.push(data);
-		},
-	},
-}));
-
-mock.module(
-	"@server/internal/products/entitlements/EntitlementService",
-	() => ({
-		EntitlementService: {
-			insert: async ({ data }: { data: unknown[] }) => {
-				insertCalls.ents.push(data);
-			},
-			upsert: async () => {},
-			deleteInIds: async () => {},
-			update: async () => {},
-		},
-	}),
-);
-
-mock.module("@server/internal/products/prices/PriceService", () => ({
-	PriceService: {
-		insert: async ({ data }: { data: unknown[] }) => {
-			insertCalls.prices.push(data);
-		},
-		upsert: async () => {},
-		deleteInIds: async () => {},
-		getCustomInEntIds: async () => [],
-	},
-}));
-
 import type { DrizzleCli } from "@server/db/initDrizzle";
 import { handleNewProductItems } from "@/internal/products/product-items/productItemUtils/handleNewProductItems";
 
@@ -198,12 +154,6 @@ const noopLogger = {
 } as never;
 
 describe("handleNewProductItems versioning carries forward Stripe IDs", () => {
-	beforeEach(() => {
-		insertCalls.features = [];
-		insertCalls.prices = [];
-		insertCalls.ents = [];
-	});
-
 	test("copies every Stripe resource field onto the new version when config matches", async () => {
 		const result = await handleNewProductItems({
 			db: {} as DrizzleCli,

--- a/server/tests/unit/shared/copyStripeResourcesToMatchingPrice.test.ts
+++ b/server/tests/unit/shared/copyStripeResourcesToMatchingPrice.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	copyStripeResourcesToMatchingPrice,
+	EntInterval,
+	type Entitlement,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+
+const orgId = "org_copy";
+const internalProductId = "prod_internal_copy";
+const now = 1_800_000_000_000;
+
+const baseConfig: UsagePriceConfig = {
+	type: PriceType.Usage,
+	bill_when: BillWhen.EndOfPeriod,
+	billing_units: 1,
+	should_prorate: false,
+	internal_feature_id: "feat_internal_ai_credits",
+	feature_id: "ai_credits",
+	usage_tiers: [{ amount: 0.1, to: TierInfinite }],
+	interval: BillingInterval.Month,
+	interval_count: 1,
+	stripe_product_id: "prod_ai_credits",
+	stripe_price_id: "price_ai_credits",
+	stripe_meter_id: "meter_ai_credits",
+	stripe_event_name: "ai_credits_used",
+};
+
+const candidate = (overrides: Partial<Price> = {}): Price => ({
+	id: "pr_existing",
+	org_id: orgId,
+	created_at: now,
+	internal_product_id: internalProductId,
+	is_custom: false,
+	config: { ...baseConfig },
+	entitlement_id: "ent_existing",
+	proration_config: null,
+	tier_behavior: null,
+	...overrides,
+});
+
+const target = (overrides: Partial<Price> = {}): Price => ({
+	id: "pr_new",
+	org_id: orgId,
+	created_at: now,
+	internal_product_id: internalProductId,
+	is_custom: false,
+	config: {
+		...baseConfig,
+		stripe_product_id: undefined,
+		stripe_price_id: undefined,
+		stripe_meter_id: undefined,
+		stripe_event_name: undefined,
+	} as UsagePriceConfig,
+	entitlement_id: "ent_new",
+	proration_config: null,
+	tier_behavior: null,
+	...overrides,
+});
+
+const entitlement = (overrides: Partial<Entitlement> = {}): Entitlement => ({
+	id: "ent_existing",
+	org_id: orgId,
+	created_at: now,
+	is_custom: false,
+	internal_product_id: internalProductId,
+	internal_feature_id: baseConfig.internal_feature_id!,
+	feature_id: baseConfig.feature_id!,
+	allowance: 100,
+	allowance_type: AllowanceType.Fixed,
+	interval: EntInterval.Month,
+	interval_count: 1,
+	carry_from_previous: false,
+	entity_feature_id: undefined,
+	usage_limit: null,
+	rollover: null,
+	...overrides,
+});
+
+describe("copyStripeResourcesToMatchingPrice", () => {
+	test("prefers a full match over a stripeProductOnly match", () => {
+		const fullCandidate = candidate({ id: "pr_full" });
+		const productOnlyCandidate = candidate({
+			id: "pr_cheaper",
+			config: {
+				...baseConfig,
+				usage_tiers: [{ amount: 0.05, to: TierInfinite }],
+				stripe_product_id: "prod_other_credits",
+				stripe_price_id: "price_other_credits",
+			},
+			entitlement_id: "ent_existing_cheaper",
+		});
+		const newPrice = target();
+
+		const result = copyStripeResourcesToMatchingPrice({
+			targetPrice: newPrice,
+			candidatePrices: [productOnlyCandidate, fullCandidate],
+			targetEntitlements: [entitlement({ id: "ent_new" })],
+			candidateEntitlements: [
+				entitlement(),
+				entitlement({
+					id: "ent_existing_cheaper",
+					allowance: 200,
+				}),
+			],
+		});
+
+		const config = newPrice.config as UsagePriceConfig;
+		expect(result.copiedFields).toContain("stripe_product_id");
+		expect(config.stripe_product_id).toBe("prod_ai_credits");
+		expect(config.stripe_price_id).toBe("price_ai_credits");
+		expect(config.stripe_meter_id).toBe("meter_ai_credits");
+		expect(config.stripe_event_name).toBe("ai_credits_used");
+	});
+
+	test("copies only stripe_product_id from a stripeProductOnly match", () => {
+		const productOnlyCandidate = candidate({
+			id: "pr_cheaper",
+			config: {
+				...baseConfig,
+				usage_tiers: [{ amount: 0.05, to: TierInfinite }],
+				stripe_product_id: "prod_other_credits",
+				stripe_price_id: "price_other_credits",
+				stripe_meter_id: "meter_other_credits",
+			},
+		});
+		const newPrice = target();
+
+		const result = copyStripeResourcesToMatchingPrice({
+			targetPrice: newPrice,
+			candidatePrices: [productOnlyCandidate],
+			targetEntitlements: [entitlement({ id: "ent_new" })],
+			candidateEntitlements: [entitlement()],
+		});
+
+		const config = newPrice.config as UsagePriceConfig;
+		expect(result.copiedFields).toEqual(["stripe_product_id"]);
+		expect(config.stripe_product_id).toBe("prod_other_credits");
+		expect(config.stripe_price_id).toBeUndefined();
+		expect(config.stripe_meter_id).toBeUndefined();
+	});
+
+	test("returns no copied fields when nothing matches", () => {
+		const unrelatedCandidate = candidate({
+			id: "pr_unrelated",
+			config: {
+				...baseConfig,
+				feature_id: "other_feature",
+				internal_feature_id: "feat_internal_other",
+			},
+		});
+
+		const newPrice = target();
+		const result = copyStripeResourcesToMatchingPrice({
+			targetPrice: newPrice,
+			candidatePrices: [unrelatedCandidate],
+			targetEntitlements: [entitlement({ id: "ent_new" })],
+			candidateEntitlements: [entitlement()],
+		});
+
+		const config = newPrice.config as UsagePriceConfig;
+		expect(result.copiedFields).toEqual([]);
+		expect(config.stripe_product_id).toBeUndefined();
+	});
+});

--- a/server/tests/unit/shared/getPriceStripeReuseLevel.test.ts
+++ b/server/tests/unit/shared/getPriceStripeReuseLevel.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	EntInterval,
+	type Entitlement,
+	type FixedPriceConfig,
+	getPriceStripeReuseLevel,
+	PREVIEW_STRIPE_PRICE_ID_PREFIX,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+
+const orgId = "org_match";
+const internalProductId = "prod_internal_match";
+const now = 1_800_000_000_000;
+
+const usageConfig: UsagePriceConfig = {
+	type: PriceType.Usage,
+	bill_when: BillWhen.EndOfPeriod,
+	billing_units: 1,
+	should_prorate: false,
+	internal_feature_id: "feat_internal_ai_credits",
+	feature_id: "ai_credits",
+	usage_tiers: [{ amount: 0.1, to: TierInfinite }],
+	interval: BillingInterval.Month,
+	interval_count: 1,
+	stripe_product_id: "prod_ai_credits",
+	stripe_price_id: "price_ai_credits",
+	stripe_meter_id: "meter_ai_credits",
+	stripe_event_name: "ai_credits_used",
+};
+
+const usagePrice = (overrides: Partial<Price> = {}): Price => ({
+	id: "pr_ai_credits",
+	org_id: orgId,
+	created_at: now,
+	internal_product_id: internalProductId,
+	is_custom: false,
+	config: { ...usageConfig },
+	entitlement_id: "ent_ai_credits",
+	proration_config: null,
+	tier_behavior: null,
+	...overrides,
+});
+
+const entitlement = (overrides: Partial<Entitlement> = {}): Entitlement => ({
+	id: "ent_ai_credits",
+	org_id: orgId,
+	created_at: now,
+	is_custom: false,
+	internal_product_id: internalProductId,
+	internal_feature_id: usageConfig.internal_feature_id!,
+	feature_id: usageConfig.feature_id!,
+	allowance: 100,
+	allowance_type: AllowanceType.Fixed,
+	interval: EntInterval.Month,
+	interval_count: 1,
+	carry_from_previous: false,
+	entity_feature_id: undefined,
+	usage_limit: null,
+	rollover: null,
+	...overrides,
+});
+
+describe("getPriceStripeReuseLevel", () => {
+	test("returns full when configs and paired entitlements match", () => {
+		const level = getPriceStripeReuseLevel({
+			newPrice: usagePrice({ id: "pr_new" }),
+			candidatePrice: usagePrice(),
+			newEntitlements: [entitlement()],
+			candidateEntitlements: [entitlement()],
+		});
+
+		expect(level).toBe("full");
+	});
+
+	test("returns stripeProductOnly when config differs but feature scope matches", () => {
+		const cheaper = usagePrice({
+			id: "pr_cheaper",
+			config: {
+				...usageConfig,
+				usage_tiers: [{ amount: 0.05, to: TierInfinite }],
+			},
+		});
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: cheaper,
+			candidatePrice: usagePrice(),
+			newEntitlements: [entitlement()],
+			candidateEntitlements: [entitlement()],
+		});
+
+		expect(level).toBe("stripeProductOnly");
+	});
+
+	test("returns none when entity scope differs", () => {
+		const level = getPriceStripeReuseLevel({
+			newPrice: usagePrice({
+				id: "pr_new",
+				entitlement_id: "ent_per_seat",
+			}),
+			candidatePrice: usagePrice(),
+			newEntitlements: [
+				entitlement({ id: "ent_per_seat", entity_feature_id: "seat" }),
+			],
+			candidateEntitlements: [entitlement()],
+		});
+
+		expect(level).toBe("none");
+	});
+
+	test("returns none when candidate has preview-only Stripe IDs", () => {
+		const previewCandidate = usagePrice({
+			config: {
+				...usageConfig,
+				stripe_product_id: `${PREVIEW_STRIPE_PRICE_ID_PREFIX}ai_credits`,
+			},
+		});
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: usagePrice({ id: "pr_new" }),
+			candidatePrice: previewCandidate,
+			newEntitlements: [entitlement()],
+			candidateEntitlements: [entitlement()],
+		});
+
+		expect(level).toBe("none");
+	});
+
+	test("returns full for matching fixed prices regardless of paired entitlements", () => {
+		const fixed: Price = {
+			id: "pr_base",
+			org_id: orgId,
+			created_at: now,
+			internal_product_id: internalProductId,
+			is_custom: false,
+			config: {
+				type: PriceType.Fixed,
+				amount: 500,
+				interval: BillingInterval.Month,
+				interval_count: 1,
+				stripe_product_id: null,
+				feature_id: null,
+				internal_feature_id: null,
+				stripe_price_id: "price_fixed",
+			} satisfies FixedPriceConfig,
+			proration_config: null,
+		};
+		const fixedTarget: Price = {
+			...fixed,
+			id: "pr_base_new",
+			config: {
+				...(fixed.config as FixedPriceConfig),
+				stripe_price_id: null,
+			},
+		};
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: fixedTarget,
+			candidatePrice: fixed,
+			newEntitlements: [],
+			candidateEntitlements: [],
+		});
+
+		expect(level).toBe("full");
+	});
+});

--- a/server/tests/unit/shared/getPriceStripeReuseLevel.test.ts
+++ b/server/tests/unit/shared/getPriceStripeReuseLevel.test.ts
@@ -132,6 +132,41 @@ describe("getPriceStripeReuseLevel", () => {
 		expect(level).toBe("none");
 	});
 
+	test("returns full when both usage prices share configs and lack paired entitlements", () => {
+		const orphan = usagePrice({ id: "pr_orphan", entitlement_id: null });
+		const orphanNew = usagePrice({ id: "pr_orphan_new", entitlement_id: null });
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: orphanNew,
+			candidatePrice: orphan,
+			newEntitlements: [],
+			candidateEntitlements: [],
+		});
+
+		expect(level).toBe("full");
+	});
+
+	test("returns stripeProductOnly when both usage prices lack entitlements but configs differ", () => {
+		const cheaper = usagePrice({
+			id: "pr_orphan_cheaper",
+			entitlement_id: null,
+			config: {
+				...usageConfig,
+				usage_tiers: [{ amount: 0.05, to: TierInfinite }],
+			},
+		});
+		const original = usagePrice({ id: "pr_orphan", entitlement_id: null });
+
+		const level = getPriceStripeReuseLevel({
+			newPrice: cheaper,
+			candidatePrice: original,
+			newEntitlements: [],
+			candidateEntitlements: [],
+		});
+
+		expect(level).toBe("stripeProductOnly");
+	});
+
 	test("returns full for matching fixed prices regardless of paired entitlements", () => {
 		const fixed: Price = {
 			id: "pr_base",

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -85,6 +85,7 @@ export interface BillingContext {
 	userMetadata?: Record<string, string>;
 
 	skipBillingChanges?: boolean;
+	dryRunStripe?: boolean;
 
 	checkoutMode?: CheckoutMode;
 

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -25,13 +25,12 @@ export * from "./cusProductUtils/index";
 // Cus utils
 export * from "./cusUtils/index";
 export * from "./expandUtils";
-
+export * from "./featureUtils";
 // Feature utils
 export * from "./featureUtils/apiFeatureToDbFeature";
 export * from "./featureUtils/convertFeatureUtils";
 export * from "./featureUtils/findFeatureUtils";
 export * from "./featureUtils/index";
-export * from "./featureUtils";
 
 // INTERVAL UTILS
 export * from "./intervalUtils/addBillingInterval";
@@ -48,17 +47,24 @@ export * from "./productUtils/entUtils/index";
 export * from "./productUtils/freeTrialUtils";
 export * from "./productUtils/index";
 export * from "./productUtils/isProductUpgrade";
-export * from "./productUtils/priceUtils/index";
 export * from "./productUtils/priceUtils";
+export * from "./productUtils/priceUtils/index";
+// Price match utils
+export * from "./productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice";
+export * from "./productUtils/priceUtils/match/getPriceStripeReuseLevel";
 export * from "./productV2Utils/mapToProductV2";
 export * from "./productV2Utils/productItemUtils/classifyItemUtils";
 export * from "./productV2Utils/productItemUtils/getItemType";
-export * from "./productV2Utils/productItemUtils/matchPlanItem";
-export * from "./productV2Utils/productItemUtils/sortPlanItems";
 // Item utils
 export * from "./productV2Utils/productItemUtils/mapToItem";
+export * from "./productV2Utils/productItemUtils/matchPlanItem";
 export * from "./productV2Utils/productItemUtils/productItemUtils";
+export * from "./productV2Utils/productItemUtils/sortPlanItems";
 export * from "./productV2Utils/productV2ToFrontendProduct";
 export * from "./productV2Utils/productV2ToV1";
 export * from "./productV3Utils/productItemUtils/productV3ItemUtils";
+
+// Stripe resource utils
+export * from "./stripeUtils/classifyStripeResource/isPreviewStripeId";
+
 export * from "./utils";

--- a/shared/utils/productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice.ts
+++ b/shared/utils/productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice.ts
@@ -1,0 +1,106 @@
+import { type Entitlement, nullish, type Price } from "@autumn/shared";
+import { getPriceStripeReuseLevel } from "./getPriceStripeReuseLevel.js";
+
+const stripeResourceFields = [
+	"stripe_product_id",
+	"stripe_price_id",
+	"stripe_empty_price_id",
+	"stripe_placeholder_price_id",
+	"stripe_prepaid_price_v2_id",
+	"stripe_meter_id",
+	"stripe_event_name",
+] as const;
+
+export type StripeResourceField = (typeof stripeResourceFields)[number];
+
+type StripeResourceConfig = Partial<Record<StripeResourceField, string | null>>;
+
+const copyField = ({
+	fromConfig,
+	toConfig,
+	field,
+}: {
+	fromConfig: StripeResourceConfig;
+	toConfig: StripeResourceConfig;
+	field: StripeResourceField;
+}) => {
+	if (!nullish(toConfig[field])) return false;
+	if (nullish(fromConfig[field])) return false;
+
+	toConfig[field] = fromConfig[field];
+	return true;
+};
+
+/**
+ * Copy Stripe resource IDs (and `stripe_event_name`) from the best-matching
+ * candidate price onto `targetPrice.config`, in place. Returns the fields that
+ * were copied.
+ *
+ * Two-pass search: a "full" match (identical config + paired entitlement) is
+ * preferred over a "stripeProductOnly" match (same feature/entity scope). For
+ * "full" matches every Stripe resource field is copied; for "stripeProductOnly"
+ * only `stripe_product_id` is copied so a fresh price is later minted under the
+ * existing per-feature Stripe product.
+ */
+export const copyStripeResourcesToMatchingPrice = ({
+	targetPrice,
+	candidatePrices,
+	targetEntitlements,
+	candidateEntitlements,
+}: {
+	targetPrice: Price;
+	candidatePrices: Price[];
+	targetEntitlements: Entitlement[];
+	candidateEntitlements: Entitlement[];
+}): { copiedFields: StripeResourceField[] } => {
+	const levels = candidatePrices.map((candidatePrice) => ({
+		candidatePrice,
+		level: getPriceStripeReuseLevel({
+			newPrice: targetPrice,
+			candidatePrice,
+			newEntitlements: targetEntitlements,
+			candidateEntitlements,
+		}),
+	}));
+
+	const fullMatch = levels.find((entry) => entry.level === "full");
+	const productOnlyMatch =
+		fullMatch ?? levels.find((entry) => entry.level === "stripeProductOnly");
+
+	const productSource = productOnlyMatch?.candidatePrice;
+	const fullSource = fullMatch?.candidatePrice;
+
+	const targetConfig = targetPrice.config as StripeResourceConfig;
+	const copiedFields: StripeResourceField[] = [];
+
+	if (productSource) {
+		const fromConfig = productSource.config as StripeResourceConfig;
+		if (
+			copyField({
+				fromConfig,
+				toConfig: targetConfig,
+				field: "stripe_product_id",
+			})
+		) {
+			copiedFields.push("stripe_product_id");
+		}
+	}
+
+	if (fullSource) {
+		const fromConfig = fullSource.config as StripeResourceConfig;
+		for (const field of stripeResourceFields) {
+			if (field === "stripe_product_id") continue;
+			if (
+				copyField({
+					fromConfig,
+					toConfig: targetConfig,
+					field,
+				})
+			) {
+				copiedFields.push(field);
+			}
+		}
+	}
+
+	return { copiedFields };
+};

--- a/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
+++ b/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
@@ -1,0 +1,107 @@
+import {
+	type Entitlement,
+	entsAreSame,
+	isPreviewStripeId,
+	type Price,
+	PriceType,
+	pricesAreSame,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+
+export type PriceStripeReuseLevel = "full" | "stripeProductOnly" | "none";
+
+const stripeResourceFields = [
+	"stripe_product_id",
+	"stripe_price_id",
+	"stripe_empty_price_id",
+	"stripe_placeholder_price_id",
+	"stripe_prepaid_price_v2_id",
+	"stripe_meter_id",
+	"stripe_event_name",
+] as const;
+
+const priceHasPreviewStripeId = ({ price }: { price: Price }) => {
+	const config = price.config as Partial<
+		Record<(typeof stripeResourceFields)[number], string | null>
+	>;
+	return stripeResourceFields.some((field) =>
+		isPreviewStripeId({ stripeId: config[field] }),
+	);
+};
+
+const findPairedEntitlement = ({
+	price,
+	entitlements,
+}: {
+	price: Price;
+	entitlements: Entitlement[];
+}) =>
+	price.entitlement_id
+		? entitlements.find(
+				(entitlement) => entitlement.id === price.entitlement_id,
+			)
+		: undefined;
+
+/**
+ * Classify how much of the Stripe resource set on `candidatePrice` can be
+ * carried forward onto `newPrice` when the two represent the same logical
+ * Autumn price across a plan-update or version transition.
+ *
+ * - "full"               — config + paired entitlement are identical; reuse all stripe_*_id + stripe_event_name fields.
+ * - "stripeProductOnly"  — same (feature_id, entity_feature_id) usage scope; reuse just stripe_product_id so a new price is created under the existing plan-feature Stripe product.
+ * - "none"               — no reuse, or candidate is preview-only.
+ */
+export const getPriceStripeReuseLevel = ({
+	newPrice,
+	candidatePrice,
+	newEntitlements,
+	candidateEntitlements,
+}: {
+	newPrice: Price;
+	candidatePrice: Price;
+	newEntitlements: Entitlement[];
+	candidateEntitlements: Entitlement[];
+}): PriceStripeReuseLevel => {
+	if (priceHasPreviewStripeId({ price: candidatePrice })) return "none";
+	if (newPrice.config?.type !== candidatePrice.config?.type) return "none";
+
+	if (pricesAreSame(candidatePrice, newPrice, false)) {
+		if (newPrice.config?.type !== PriceType.Usage) return "full";
+
+		const newEnt = findPairedEntitlement({
+			price: newPrice,
+			entitlements: newEntitlements,
+		});
+		const candidateEnt = findPairedEntitlement({
+			price: candidatePrice,
+			entitlements: candidateEntitlements,
+		});
+
+		if (!newEnt || !candidateEnt) return "none";
+		if (entsAreSame(candidateEnt, newEnt)) return "full";
+	}
+
+	if (newPrice.config?.type !== PriceType.Usage) return "none";
+
+	const newUsageConfig = newPrice.config as UsagePriceConfig;
+	const candidateUsageConfig = candidatePrice.config as UsagePriceConfig;
+	if (newUsageConfig.feature_id !== candidateUsageConfig.feature_id) {
+		return "none";
+	}
+
+	const newEnt = findPairedEntitlement({
+		price: newPrice,
+		entitlements: newEntitlements,
+	});
+	const candidateEnt = findPairedEntitlement({
+		price: candidatePrice,
+		entitlements: candidateEntitlements,
+	});
+
+	if (!newEnt || !candidateEnt) return "none";
+	if (newEnt.entity_feature_id !== candidateEnt.entity_feature_id) {
+		return "none";
+	}
+
+	return "stripeProductOnly";
+};

--- a/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
+++ b/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
@@ -1,10 +1,12 @@
 import {
 	type Entitlement,
+	type EntitlementWithFeature,
 	entsAreSame,
 	isPreviewStripeId,
 	type Price,
 	PriceType,
 	pricesAreSame,
+	priceToEnt,
 	type UsagePriceConfig,
 } from "@autumn/shared";
 
@@ -35,20 +37,11 @@ const findPairedEntitlement = ({
 }: {
 	price: Price;
 	entitlements: Entitlement[];
-<<<<<<< Updated upstream
-}) =>
-	price.entitlement_id
-		? entitlements.find(
-				(entitlement) => entitlement.id === price.entitlement_id,
-			)
-		: undefined;
-=======
 }): Entitlement | undefined =>
 	priceToEnt({
 		price,
 		entitlements: entitlements as EntitlementWithFeature[],
 	});
->>>>>>> Stashed changes
 
 /**
  * Classify how much of the Stripe resource set on `candidatePrice` can be

--- a/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
+++ b/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
@@ -77,6 +77,8 @@ export const getPriceStripeReuseLevel = ({
 			entitlements: candidateEntitlements,
 		});
 
+		// Both null = same (null) entity scope; both have ents = compare them.
+		if (!newEnt && !candidateEnt) return "full";
 		if (!newEnt || !candidateEnt) return "none";
 		if (entsAreSame(candidateEnt, newEnt)) return "full";
 	}
@@ -98,6 +100,7 @@ export const getPriceStripeReuseLevel = ({
 		entitlements: candidateEntitlements,
 	});
 
+	if (!newEnt && !candidateEnt) return "stripeProductOnly";
 	if (!newEnt || !candidateEnt) return "none";
 	if (newEnt.entity_feature_id !== candidateEnt.entity_feature_id) {
 		return "none";

--- a/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
+++ b/shared/utils/productUtils/priceUtils/match/getPriceStripeReuseLevel.ts
@@ -35,12 +35,20 @@ const findPairedEntitlement = ({
 }: {
 	price: Price;
 	entitlements: Entitlement[];
+<<<<<<< Updated upstream
 }) =>
 	price.entitlement_id
 		? entitlements.find(
 				(entitlement) => entitlement.id === price.entitlement_id,
 			)
 		: undefined;
+=======
+}): Entitlement | undefined =>
+	priceToEnt({
+		price,
+		entitlements: entitlements as EntitlementWithFeature[],
+	});
+>>>>>>> Stashed changes
 
 /**
  * Classify how much of the Stripe resource set on `candidatePrice` can be

--- a/shared/utils/stripeUtils/classifyStripeResource/isPreviewStripeId.ts
+++ b/shared/utils/stripeUtils/classifyStripeResource/isPreviewStripeId.ts
@@ -1,0 +1,6 @@
+export const PREVIEW_STRIPE_PRICE_ID_PREFIX = "price_PREVIEW_";
+export const PREVIEW_STRIPE_PRODUCT_ID_PREFIX = "prod_PREVIEW_";
+
+export const isPreviewStripeId = ({ stripeId }: { stripeId?: string | null }) =>
+	stripeId?.startsWith(PREVIEW_STRIPE_PRICE_ID_PREFIX) === true ||
+	stripeId?.startsWith(PREVIEW_STRIPE_PRODUCT_ID_PREFIX) === true;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reuse existing Stripe resources across plan versions and within a plan, and add a preview-safe flow that never calls Stripe. Previews now use deterministic preview Stripe IDs, and zero-amount fixed prices are ignored.

- **New Features**
  - Carry forward Stripe IDs when creating a new plan version in `handleNewProductItems`: full matches copy all IDs (product, price, empty/placeholder, meter, event, prepaid); if tiers change but feature/entity scope matches, copy only `stripe_product_id`; if scope changes, copy none.
  - Reuse Stripe resources for repeated items within the same product during billing-plan Stripe initialization to avoid creating duplicate Stripe objects.
  - Preview flow: propagate `preview` into billing contexts to set `dryRunStripe`, stamp deterministic preview product/price IDs, never call Stripe, and reject persisting preview IDs via `assertNoPreviewStripeIdsOnProduct`.
  - Skip zero-amount fixed prices: no Stripe resources are created and they are omitted from subscription item specs.

<sup>Written for commit 292db09bdad30465455498d0afb4b6503057d413. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

