### PR TITLE
feat(workbench): 🎸 add Stripe-style workbench panel for customer API logs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -525,6 +525,7 @@
         "react-dom": "^18.2.0",
         "react-grab": "^0.1.29",
         "react-hotkeys-hook": "^4.6.1",
+        "react-resizable-panels": "^4.11.0",
         "react-router": "^7.3.0",
         "react-router-dom": "^7.6.2",
         "recharts": "^3.3.0",
@@ -538,6 +539,7 @@
         "tailwindcss": "^4.0.13",
         "tailwindcss-animate": "^1.0.7",
         "use-stick-to-bottom": "^1.1.1",
+        "vaul": "^1.1.2",
         "zod": "^3.25.23",
         "zustand": "^5.0.8",
       },
@@ -4871,6 +4873,8 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
+    "react-resizable-panels": ["react-resizable-panels@4.11.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-LPk/AkFDGkg7SsbOyL93ojrE6E7lhrxxDwnYNjfmnSeI6BE7Sje6dB24PXgZk8DeugdeXNk1LO+ohRqIjhxiLw=="],
+
     "react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
 
     "react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
@@ -5576,6 +5580,8 @@
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -52,6 +52,7 @@
 		"@aws-sdk/client-s3": "^3.1017.0",
 		"@aws-sdk/client-scheduler": "^3.1004.0",
 		"@aws-sdk/client-sqs": "^3.958.0",
+		"@axiomhq/js": "^1.6.1",
 		"@axiomhq/pino": "^1.3.1",
 		"@better-auth/dash": "catalog:",
 		"@better-auth/oauth-provider": "catalog:",

--- a/server/src/external/axiom/aplUtils.ts
+++ b/server/src/external/axiom/aplUtils.ts
@@ -1,0 +1,74 @@
+export const escapeApl = (value: string): string =>
+	value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+
+export type StatusBucket = "all" | "2xx" | "4xx" | "5xx";
+export type HttpMethodFilter =
+	| "all"
+	| "GET"
+	| "POST"
+	| "PUT"
+	| "PATCH"
+	| "DELETE";
+
+const statusBucketClause = (bucket: StatusBucket): string | null => {
+	switch (bucket) {
+		case "2xx":
+			return "statusCode >= 200 and statusCode < 300";
+		case "4xx":
+			return "statusCode >= 400 and statusCode < 500";
+		case "5xx":
+			return "statusCode >= 500 and statusCode < 600";
+		default:
+			return null;
+	}
+};
+
+export const buildRequestLogsQuery = ({
+	orgSlug,
+	env,
+	customerId,
+	method,
+	statusBucket,
+	search,
+	limit = 200,
+	rangeDays = 7,
+}: {
+	orgSlug: string;
+	env: string;
+	customerId: string;
+	method?: HttpMethodFilter;
+	statusBucket?: StatusBucket;
+	search?: string;
+	limit?: number;
+	rangeDays?: number;
+}): string => {
+	const filters: string[] = [
+		`_time > ago(${rangeDays}d)`,
+		`isnotnull(statusCode)`,
+		`isnotnull(['req.url'])`,
+		`(['context.org_slug'] == '${escapeApl(orgSlug)}' or orgSlug == '${escapeApl(orgSlug)}')`,
+		`(['context.env'] == '${escapeApl(env)}' or env == '${escapeApl(env)}')`,
+		`(['req.customer_id'] == '${escapeApl(customerId)}' or customer_id == '${escapeApl(customerId)}')`,
+	];
+
+	if (method && method !== "all") {
+		filters.push(`['req.method'] == '${escapeApl(method)}'`);
+	}
+
+	const statusClause = statusBucketClause(statusBucket ?? "all");
+	if (statusClause) filters.push(statusClause);
+
+	if (search?.trim()) {
+		const needle = escapeApl(search.trim());
+		filters.push(
+			`(['req.url'] contains '${needle}' or msg contains '${needle}')`,
+		);
+	}
+
+	const wheres = filters.map((f) => `| where ${f}`).join("\n");
+
+	return `['express']
+${wheres}
+| order by _time desc
+| limit ${limit}`;
+};

--- a/server/src/external/axiom/initAxiom.ts
+++ b/server/src/external/axiom/initAxiom.ts
@@ -1,0 +1,20 @@
+import { Axiom } from "@axiomhq/js";
+
+const AXIOM_ADMIN_TOKEN = process.env.AXIOM_ADMIN_TOKEN;
+const AXIOM_ORG_ID = process.env.AXIOM_ORG_ID;
+
+export const axiomClient: Axiom | null = AXIOM_ADMIN_TOKEN
+	? new Axiom({
+			token: AXIOM_ADMIN_TOKEN,
+			orgId: AXIOM_ORG_ID,
+		})
+	: null;
+
+export const getAxiomClient = (): Axiom => {
+	if (!axiomClient) {
+		throw new Error("Axiom is not configured (AXIOM_ADMIN_TOKEN missing)");
+	}
+	return axiomClient;
+};
+
+export const isAxiomConfigured = (): boolean => axiomClient !== null;

--- a/server/src/internal/workbench/handlers/handleListRequestLogs.ts
+++ b/server/src/internal/workbench/handlers/handleListRequestLogs.ts
@@ -1,0 +1,143 @@
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
+import { z } from "zod/v4";
+import {
+	buildRequestLogsQuery,
+	type HttpMethodFilter,
+	type StatusBucket,
+} from "@/external/axiom/aplUtils.js";
+import {
+	getAxiomClient,
+	isAxiomConfigured,
+} from "@/external/axiom/initAxiom.js";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { CusService } from "@/internal/customers/CusService.js";
+
+const ListRequestLogsSchema = z.object({
+	customer_id: z.string().min(1),
+	method: z.enum(["all", "GET", "POST", "PUT", "PATCH", "DELETE"]).optional(),
+	status: z.enum(["all", "2xx", "4xx", "5xx"]).optional(),
+	search: z.string().optional(),
+});
+
+export interface RequestLogEntry {
+	id: string;
+	time: string;
+	statusCode: number;
+	durationMs: number | null;
+	method: string | null;
+	url: string | null;
+	path: string | null;
+	reqId: string | null;
+	ip: string | null;
+	userAgent: string | null;
+	customerId: string | null;
+	msg: string | null;
+	raw: Record<string, unknown>;
+}
+
+const extractPath = (url: string | null | undefined): string | null => {
+	if (!url) return null;
+	try {
+		return new URL(url).pathname;
+	} catch {
+		return url;
+	}
+};
+
+const pickString = (
+	d: Record<string, unknown>,
+	keys: string[],
+): string | null => {
+	for (const k of keys) {
+		const v = d[k];
+		if (typeof v === "string" && v.length > 0) return v;
+	}
+	return null;
+};
+
+const pickNumber = (
+	d: Record<string, unknown>,
+	keys: string[],
+): number | null => {
+	for (const k of keys) {
+		const v = d[k];
+		if (typeof v === "number") return v;
+	}
+	return null;
+};
+
+export const handleListRequestLogs = createRoute({
+	scopes: [Scopes.Superuser],
+	body: ListRequestLogsSchema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { org, env } = ctx;
+		const { customer_id, method, status, search } = c.req.valid("json");
+
+		const customer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customer_id,
+		});
+
+		if (!customer) {
+			throw new RecaseError({
+				message: "Customer not found",
+				code: ErrCode.CustomerNotFound,
+				statusCode: StatusCodes.NOT_FOUND,
+			});
+		}
+
+		if (!isAxiomConfigured()) {
+			return c.json({ logs: [], unconfigured: true });
+		}
+
+		const apl = buildRequestLogsQuery({
+			orgSlug: org.slug,
+			env,
+			customerId: customer.id ?? customer_id,
+			method: method as HttpMethodFilter | undefined,
+			statusBucket: status as StatusBucket | undefined,
+			search,
+		});
+
+		try {
+			const axiom = getAxiomClient();
+			const result = await axiom.query(apl);
+			const matches = result.matches ?? [];
+
+			const logs: RequestLogEntry[] = matches.map((entry, i) => {
+				const raw = (entry.data ?? {}) as Record<string, unknown>;
+				const url = pickString(raw, ["req.url", "url"]);
+				return {
+					id: pickString(raw, ["req.id", "reqId"]) ?? `${entry._time}-${i}`,
+					time: entry._time,
+					statusCode: pickNumber(raw, ["statusCode"]) ?? 0,
+					durationMs: pickNumber(raw, ["durationMs"]),
+					method: pickString(raw, ["req.method", "method"]),
+					url,
+					path: extractPath(url),
+					reqId: pickString(raw, ["req.id", "reqId"]),
+					ip: pickString(raw, ["req.ip_address"]),
+					userAgent: pickString(raw, ["req.user_agent"]),
+					customerId: pickString(raw, [
+						"req.customer_id",
+						"customer_id",
+						"cusId",
+					]),
+					msg: pickString(raw, ["msg", "message"]),
+					raw,
+				};
+			});
+
+			return c.json({ logs });
+		} catch (err) {
+			ctx.logger?.error("Axiom workbench query failed", { err });
+			throw new RecaseError({
+				message: "Failed to query request logs",
+				code: ErrCode.InternalError,
+				statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+			});
+		}
+	},
+});

--- a/server/src/internal/workbench/workbenchRouter.ts
+++ b/server/src/internal/workbench/workbenchRouter.ts
@@ -1,0 +1,7 @@
+import { Hono } from "hono";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { handleListRequestLogs } from "./handlers/handleListRequestLogs.js";
+
+export const workbenchRouter = new Hono<HonoEnv>();
+
+workbenchRouter.post("/requests", ...handleListRequestLogs);

--- a/server/src/routers/internalRouter.ts
+++ b/server/src/routers/internalRouter.ts
@@ -20,6 +20,7 @@ import { pricingAgentRouter } from "../internal/misc/pricingAgent/pricingAgentRo
 import { savedViewsRouter } from "../internal/misc/savedViews/savedViewsRouter";
 import { internalOrgRouter } from "../internal/orgs/orgRouter";
 import { internalProductRouter } from "../internal/products/internalProductRouter";
+import { workbenchRouter } from "../internal/workbench/workbenchRouter";
 
 export const internalRouter = new Hono<HonoEnv>();
 
@@ -45,6 +46,7 @@ internalRouter.route("/trmnl", internalTrmnlRouter);
 internalRouter.route("/feedback", feedbackRouter);
 internalRouter.route("/saved_views", savedViewsRouter);
 internalRouter.route("/query", internalAnalyticsRouter);
+internalRouter.route("/workbench", workbenchRouter);
 
 // Autumn SDK handler (requires session auth)
 if (process.env.AUTUMN_SECRET_KEY) {

--- a/vite/package.json
+++ b/vite/package.json
@@ -64,6 +64,7 @@
 		"react-dom": "^18.2.0",
 		"react-grab": "^0.1.29",
 		"react-hotkeys-hook": "^4.6.1",
+		"react-resizable-panels": "^4.11.0",
 		"react-router": "^7.3.0",
 		"react-router-dom": "^7.6.2",
 		"recharts": "^3.3.0",
@@ -77,6 +78,7 @@
 		"tailwindcss": "^4.0.13",
 		"tailwindcss-animate": "^1.0.7",
 		"use-stick-to-bottom": "^1.1.1",
+		"vaul": "^1.1.2",
 		"zod": "^3.25.23",
 		"zustand": "^5.0.8"
 	},

--- a/vite/src/components/ui/resizable.tsx
+++ b/vite/src/components/ui/resizable.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as ResizablePrimitive from "react-resizable-panels"
+
+import { cn } from "@/lib/utils"
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: ResizablePrimitive.GroupProps) {
+  return (
+    <ResizablePrimitive.Group
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full aria-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: ResizablePrimitive.SeparatorProps & {
+  withHandle?: boolean
+}) {
+  return (
+    <ResizablePrimitive.Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "relative flex w-px items-center justify-center bg-border ring-offset-background after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="z-10 flex h-6 w-1 shrink-0 rounded-lg bg-border" />
+      )}
+    </ResizablePrimitive.Separator>
+  )
+}
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup }

--- a/vite/src/hooks/queries/useCusRequestLogsQuery.tsx
+++ b/vite/src/hooks/queries/useCusRequestLogsQuery.tsx
@@ -1,0 +1,93 @@
+import { useQuery } from "@tanstack/react-query";
+import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import {
+	useWorkbenchStore,
+	type WorkbenchMethod,
+	type WorkbenchStatus,
+} from "@/hooks/stores/useWorkbenchStore";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+export interface RequestLogEntry {
+	id: string;
+	time: string;
+	statusCode: number;
+	durationMs: number | null;
+	method: string | null;
+	url: string | null;
+	path: string | null;
+	reqId: string | null;
+	ip: string | null;
+	userAgent: string | null;
+	customerId: string | null;
+	msg: string | null;
+	raw: Record<string, unknown>;
+}
+
+interface ListResponse {
+	logs: RequestLogEntry[];
+	unconfigured?: boolean;
+}
+
+export const useCusRequestLogsQuery = ({
+	customerId,
+	enabled,
+}: {
+	customerId: string | undefined;
+	enabled: boolean;
+}) => {
+	const axiosInstance = useAxiosInstance();
+	const buildKey = useQueryKeyFactory();
+	const filters = useWorkbenchStore((s) => s.filters);
+
+	const { data, isLoading, isFetching, error, refetch } =
+		useQuery<ListResponse>({
+			queryKey: buildKey([
+				"customer_request_logs",
+				customerId,
+				filters.method,
+				filters.status,
+				filters.search,
+			]),
+			queryFn: async () => {
+				const { data } = await axiosInstance.post<ListResponse>(
+					"/workbench/requests",
+					{
+						customer_id: customerId,
+						method: filters.method,
+						status: filters.status,
+						search: filters.search || undefined,
+					},
+				);
+				return data;
+			},
+			enabled: enabled && !!customerId,
+			staleTime: 30_000,
+			refetchOnWindowFocus: true,
+			placeholderData: (prev) => prev,
+		});
+
+	return {
+		logs: data?.logs ?? [],
+		unconfigured: data?.unconfigured === true,
+		isLoading,
+		isFetching,
+		error,
+		refetch,
+	};
+};
+
+export const filterMethods: { value: WorkbenchMethod; label: string }[] = [
+	{ value: "all", label: "All methods" },
+	{ value: "GET", label: "GET" },
+	{ value: "POST", label: "POST" },
+	{ value: "PUT", label: "PUT" },
+	{ value: "PATCH", label: "PATCH" },
+	{ value: "DELETE", label: "DELETE" },
+];
+
+export const filterStatuses: { value: WorkbenchStatus; label: string }[] = [
+	{ value: "all", label: "All statuses" },
+	{ value: "2xx", label: "2xx" },
+	{ value: "4xx", label: "4xx" },
+	{ value: "5xx", label: "5xx" },
+];

--- a/vite/src/hooks/stores/useWorkbenchStore.ts
+++ b/vite/src/hooks/stores/useWorkbenchStore.ts
@@ -1,0 +1,64 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type WorkbenchMethod =
+	| "all"
+	| "GET"
+	| "POST"
+	| "PUT"
+	| "PATCH"
+	| "DELETE";
+export type WorkbenchStatus = "all" | "2xx" | "4xx" | "5xx";
+
+export const WORKBENCH_MIN_HEIGHT = 200;
+export const WORKBENCH_MAX_HEIGHT_RATIO = 0.92;
+export const WORKBENCH_DEFAULT_HEIGHT = 360;
+
+interface WorkbenchFilters {
+	method: WorkbenchMethod;
+	status: WorkbenchStatus;
+	search: string;
+}
+
+interface WorkbenchState {
+	isOpen: boolean;
+	height: number;
+	filters: WorkbenchFilters;
+	selectedLogId: string | null;
+
+	open: () => void;
+	close: () => void;
+	toggle: () => void;
+	setHeight: (height: number) => void;
+	setFilters: (filters: Partial<WorkbenchFilters>) => void;
+	setSelectedLogId: (id: string | null) => void;
+}
+
+const DEFAULT_FILTERS: WorkbenchFilters = {
+	method: "all",
+	status: "all",
+	search: "",
+};
+
+export const useWorkbenchStore = create<WorkbenchState>()(
+	persist(
+		(set) => ({
+			isOpen: false,
+			height: WORKBENCH_DEFAULT_HEIGHT,
+			filters: DEFAULT_FILTERS,
+			selectedLogId: null,
+
+			open: () => set({ isOpen: true }),
+			close: () => set({ isOpen: false }),
+			toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+			setHeight: (height) => set({ height }),
+			setFilters: (filters) =>
+				set((s) => ({ filters: { ...s.filters, ...filters } })),
+			setSelectedLogId: (id) => set({ selectedLogId: id }),
+		}),
+		{
+			name: "workbench-store",
+			partialize: (s) => ({ height: s.height }),
+		},
+	),
+);

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -37,6 +37,7 @@ import { CustomerPageDetails } from "./CustomerPageDetails";
 import { CustomerSheets } from "./CustomerSheets";
 import { SelectedEntityDetails } from "./components/SelectedEntityDetails";
 import { SHEET_ANIMATION } from "./customerAnimations";
+import { Workbench } from "./workbench/Workbench";
 
 export default function CustomerView2() {
 	const {
@@ -228,6 +229,7 @@ export default function CustomerView2() {
 				</motion.div>
 
 				<CustomerSheets />
+				<Workbench />
 			</div>
 		</CustomerContext.Provider>
 	);

--- a/vite/src/views/customers2/customer/workbench/Workbench.tsx
+++ b/vite/src/views/customers2/customer/workbench/Workbench.tsx
@@ -1,0 +1,153 @@
+import {
+	ArrowClockwiseIcon,
+	TerminalWindowIcon,
+	XIcon,
+} from "@phosphor-icons/react";
+import { Drawer as DrawerPrimitive } from "vaul";
+import {
+	ResizableHandle,
+	ResizablePanel,
+	ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { IconButton } from "@/components/v2/buttons/IconButton";
+import { useCusRequestLogsQuery } from "@/hooks/queries/useCusRequestLogsQuery";
+import { useWorkbenchStore } from "@/hooks/stores/useWorkbenchStore";
+import { cn } from "@/lib/utils";
+import { useCustomerContext } from "../CustomerContext";
+import { useWorkbenchEscape } from "./hooks/useWorkbenchEscape";
+import { useWorkbenchResize } from "./hooks/useWorkbenchResize";
+import { WorkbenchFilters } from "./WorkbenchFilters";
+import { WorkbenchLogDetail } from "./WorkbenchLogDetail";
+import { WorkbenchLogList } from "./WorkbenchLogList";
+
+export const Workbench = () => {
+	const { customer } = useCustomerContext();
+	const isOpen = useWorkbenchStore((s) => s.isOpen);
+	const height = useWorkbenchStore((s) => s.height);
+	const close = useWorkbenchStore((s) => s.close);
+
+	const { handleProps } = useWorkbenchResize();
+	useWorkbenchEscape();
+
+	const { refetch, isFetching } = useCusRequestLogsQuery({
+		customerId: customer?.id,
+		enabled: isOpen,
+	});
+
+	return (
+		<DrawerPrimitive.Root
+			open={isOpen}
+			onOpenChange={(open) => {
+				if (!open) close();
+			}}
+			modal={false}
+			dismissible={false}
+			autoFocus={false}
+			repositionInputs={false}
+			noBodyStyles
+		>
+			<DrawerPrimitive.Portal>
+				<DrawerPrimitive.Content
+					style={{ height: `${height}px` }}
+					className={cn(
+						"fixed inset-x-0 bottom-0 z-[40] flex flex-col bg-card border-t border-border outline-none shadow-2xl",
+						"focus:outline-none",
+					)}
+				>
+					<DrawerPrimitive.Title className="sr-only">
+						Workbench
+					</DrawerPrimitive.Title>
+
+					<WorkbenchHeader
+						onRefresh={() => refetch()}
+						isFetching={isFetching}
+						onClose={close}
+						handleProps={handleProps}
+					/>
+
+					<div className="flex-1 min-h-0 overflow-hidden">
+						<ResizablePanelGroup direction="horizontal">
+							<ResizablePanel
+								defaultSize={42}
+								minSize={25}
+								className="!flex flex-col min-h-0"
+							>
+								<WorkbenchLogList customerId={customer?.id} isOpen={isOpen} />
+							</ResizablePanel>
+							<ResizableHandle className="!w-px bg-border hover:bg-t4 transition-colors cursor-col-resize after:!w-2 after:cursor-col-resize" />
+							<ResizablePanel
+								defaultSize={58}
+								minSize={35}
+								className="!flex flex-col min-h-0"
+							>
+								<WorkbenchLogDetail customerId={customer?.id} isOpen={isOpen} />
+							</ResizablePanel>
+						</ResizablePanelGroup>
+					</div>
+				</DrawerPrimitive.Content>
+			</DrawerPrimitive.Portal>
+		</DrawerPrimitive.Root>
+	);
+};
+
+type ResizeHandleProps = ReturnType<typeof useWorkbenchResize>["handleProps"];
+
+const WorkbenchHeader = ({
+	onRefresh,
+	isFetching,
+	onClose,
+	handleProps,
+}: {
+	onRefresh: () => void;
+	isFetching: boolean;
+	onClose: () => void;
+	handleProps: ResizeHandleProps;
+}) => (
+	<div className="relative flex items-center justify-between px-3 h-9 border-b border-border shrink-0">
+		<button
+			type="button"
+			{...handleProps}
+			aria-label="Resize workbench"
+			className="absolute -top-1 inset-x-0 h-2 cursor-row-resize group z-10 bg-transparent border-0 p-0"
+		>
+			<div className="absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 w-10 h-0.5 rounded-full bg-border group-hover:bg-t4 transition-colors" />
+		</button>
+
+		<div className="flex items-center gap-2 min-w-0">
+			<div className="flex items-center gap-1.5 text-t1 text-xs font-semibold shrink-0">
+				<TerminalWindowIcon size={13} weight="fill" />
+				Workbench
+			</div>
+			<div className="h-3 w-px bg-border shrink-0" />
+			<div className="text-xs text-t1 font-medium px-1.5 py-0.5 rounded bg-interactive-secondary shrink-0">
+				Logs
+			</div>
+		</div>
+
+		<div className="flex items-center gap-2 shrink-0">
+			<WorkbenchFilters />
+			<div className="h-3 w-px bg-border" />
+			<IconButton
+				variant="skeleton"
+				size="icon"
+				onClick={onRefresh}
+				icon={
+					<ArrowClockwiseIcon
+						size={12}
+						className={cn(isFetching && "animate-spin")}
+					/>
+				}
+				title="Refresh"
+				className="cursor-pointer"
+			/>
+			<IconButton
+				variant="skeleton"
+				size="icon"
+				onClick={onClose}
+				icon={<XIcon size={12} />}
+				title="Close"
+				className="cursor-pointer"
+			/>
+		</div>
+	</div>
+);

--- a/vite/src/views/customers2/customer/workbench/WorkbenchButton.tsx
+++ b/vite/src/views/customers2/customer/workbench/WorkbenchButton.tsx
@@ -1,0 +1,52 @@
+import { TerminalWindowIcon } from "@phosphor-icons/react";
+import { useMatch } from "react-router";
+import { useWorkbenchStore } from "@/hooks/stores/useWorkbenchStore";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { cn } from "@/lib/utils";
+import { useAdmin } from "@/views/admin/hooks/useAdmin";
+import { useSidebarContext } from "@/views/main-sidebar/SidebarContext";
+
+export const WorkbenchButton = () => {
+	const { isAdmin } = useAdmin();
+	const onCustomerView = useMatch("/customers/:customer_id");
+	const onCustomerSubView = useMatch("/customers/:customer_id/*");
+	const isMobile = useIsMobile();
+	const { expanded } = useSidebarContext();
+
+	const toggle = useWorkbenchStore((s) => s.toggle);
+	const isOpen = useWorkbenchStore((s) => s.isOpen);
+
+	if (!isAdmin || isMobile || (!onCustomerView && !onCustomerSubView)) {
+		return null;
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={(e) => {
+				e.currentTarget.blur();
+				toggle();
+			}}
+			className={cn(
+				"cursor-pointer font-medium text-sm flex items-center text-t2 px-2 h-7 rounded-lg w-full hover:text-t1 border border-transparent focus:outline-none focus-visible:outline-none",
+				isOpen && "border border-border !text-t1 bg-interactive-secondary",
+			)}
+		>
+			<div className="flex items-center gap-2">
+				<div className="flex justify-center w-4 h-4 items-center rounded-sm">
+					<TerminalWindowIcon size={16} weight="duotone" />
+				</div>
+				<span
+					className={cn(
+						"whitespace-nowrap",
+						expanded
+							? "opacity-100 translate-x-0"
+							: "opacity-0 -translate-x-2 pointer-events-none w-0 m-0 p-0",
+					)}
+				>
+					Workbench
+				</span>
+			</div>
+		</button>
+	);
+};

--- a/vite/src/views/customers2/customer/workbench/WorkbenchEmptyState.tsx
+++ b/vite/src/views/customers2/customer/workbench/WorkbenchEmptyState.tsx
@@ -1,0 +1,12 @@
+export const WorkbenchEmptyState = ({
+	title,
+	children,
+}: {
+	title: string;
+	children: React.ReactNode;
+}) => (
+	<div className="p-6 text-xs text-t3">
+		<p className="font-medium text-t2 mb-1">{title}</p>
+		<p>{children}</p>
+	</div>
+);

--- a/vite/src/views/customers2/customer/workbench/WorkbenchFilterSelect.tsx
+++ b/vite/src/views/customers2/customer/workbench/WorkbenchFilterSelect.tsx
@@ -1,0 +1,43 @@
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+} from "@/components/v2/selects/Select";
+
+interface FilterOption<T extends string> {
+	value: T;
+	label: string;
+}
+
+export const WorkbenchFilterSelect = <T extends string>({
+	value,
+	options,
+	onChange,
+	placeholder,
+}: {
+	value: T;
+	options: readonly FilterOption<T>[];
+	onChange: (next: T) => void;
+	placeholder: string;
+}) => {
+	const label = options.find((o) => o.value === value)?.label ?? placeholder;
+
+	return (
+		<Select value={value} onValueChange={(v) => onChange(v as T)}>
+			<SelectTrigger
+				size="sm"
+				className="!h-7 !text-xs !min-w-[120px] px-2.5 cursor-pointer"
+			>
+				<span className="truncate">{label}</span>
+			</SelectTrigger>
+			<SelectContent align="end">
+				{options.map((o) => (
+					<SelectItem key={o.value} value={o.value} className="cursor-pointer">
+						{o.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+};

--- a/vite/src/views/customers2/customer/workbench/WorkbenchFilters.tsx
+++ b/vite/src/views/customers2/customer/workbench/WorkbenchFilters.tsx
@@ -1,0 +1,58 @@
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	filterMethods,
+	filterStatuses,
+} from "@/hooks/queries/useCusRequestLogsQuery";
+import { useWorkbenchStore } from "@/hooks/stores/useWorkbenchStore";
+import { WorkbenchFilterSelect } from "./WorkbenchFilterSelect";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export const WorkbenchFilters = () => {
+	const filters = useWorkbenchStore((s) => s.filters);
+	const setFilters = useWorkbenchStore((s) => s.setFilters);
+
+	const [searchInput, setSearchInput] = useState(filters.search);
+
+	useEffect(() => {
+		if (searchInput === filters.search) return;
+		const t = setTimeout(
+			() => setFilters({ search: searchInput }),
+			SEARCH_DEBOUNCE_MS,
+		);
+		return () => clearTimeout(t);
+	}, [searchInput, filters.search, setFilters]);
+
+	return (
+		<div className="flex items-center gap-2">
+			<div className="relative">
+				<Input
+					value={searchInput}
+					onChange={(e) => setSearchInput(e.target.value)}
+					placeholder="Search path or body"
+					className="!h-7 !text-xs !min-w-0 pl-2 pr-7 w-52"
+				/>
+				<MagnifyingGlassIcon
+					size={12}
+					className="absolute right-2 top-1/2 -translate-y-1/2 text-t4 pointer-events-none z-10"
+				/>
+			</div>
+
+			<WorkbenchFilterSelect
+				value={filters.method}
+				options={filterMethods}
+				onChange={(method) => setFilters({ method })}
+				placeholder="All methods"
+			/>
+
+			<WorkbenchFilterSelect
+				value={filters.status}
+				options={filterStatuses}
+				onChange={(status) => setFilters({ status })}
+				placeholder="All statuses"
+			/>
+		</div>
+	);
+};

--- a/vite/src/views/customers2/customer/workbench/WorkbenchJsonViewer.tsx
+++ b/vite/src/views/customers2/customer/workbench/WorkbenchJsonViewer.tsx
@@ -1,0 +1,145 @@
+import Editor, { type OnMount } from "@monaco-editor/react";
+import { useCallback, useMemo, useRef } from "react";
+import CopyButton from "@/components/general/CopyButton";
+
+const AUTUMN_DARK_THEME = "autumn-workbench-dark";
+const AUTUMN_LIGHT_THEME = "autumn-workbench-light";
+
+export const WorkbenchJsonViewer = ({
+	data,
+	height = "400px",
+}: {
+	data: unknown;
+	height?: string;
+}) => {
+	const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+
+	const formatted = useMemo(() => {
+		try {
+			return JSON.stringify(data, null, 2);
+		} catch {
+			return String(data);
+		}
+	}, [data]);
+
+	const onMount: OnMount = useCallback((editor, monaco) => {
+		editorRef.current = editor;
+
+		monaco.editor.defineTheme(AUTUMN_DARK_THEME, {
+			base: "vs-dark",
+			inherit: true,
+			rules: [],
+			colors: {
+				"editor.background": "#00000000",
+				"editor.foreground": "#e7e7e7",
+				"editorLineNumber.foreground": "#4a4a4a",
+				"editorLineNumber.activeForeground": "#8a8a8a",
+				"editor.lineHighlightBackground": "#ffffff08",
+				"editor.selectionBackground": "#3b82f640",
+				"editor.inactiveSelectionBackground": "#3b82f620",
+				"editorIndentGuide.background1": "#2a2a2a",
+				"editorIndentGuide.activeBackground1": "#3a3a3a",
+				"editorBracketMatch.background": "#3b82f620",
+				"editorBracketMatch.border": "#3b82f680",
+				"editorWidget.background": "#1a1a1a",
+				"editorWidget.border": "#2a2a2a",
+				"input.background": "#0f0f0f",
+				"input.border": "#2a2a2a",
+				"editor.findMatchBackground": "#fbbf2440",
+				"editor.findMatchHighlightBackground": "#fbbf2420",
+				"scrollbarSlider.background": "#ffffff14",
+				"scrollbarSlider.hoverBackground": "#ffffff20",
+				"scrollbarSlider.activeBackground": "#ffffff30",
+			},
+		});
+
+		monaco.editor.defineTheme(AUTUMN_LIGHT_THEME, {
+			base: "vs",
+			inherit: true,
+			rules: [],
+			colors: {
+				"editor.background": "#00000000",
+				"editorLineNumber.foreground": "#c0c0c0",
+				"editor.lineHighlightBackground": "#00000005",
+			},
+		});
+
+		const isDark = document.documentElement.classList.contains("dark");
+		monaco.editor.setTheme(isDark ? AUTUMN_DARK_THEME : AUTUMN_LIGHT_THEME);
+
+		let folded = false;
+		const foldChildren = () => {
+			if (folded) return;
+			editor.getAction("editor.foldLevel2")?.run();
+			folded = true;
+		};
+
+		const sub = editor.onDidChangeModelDecorations(() => {
+			foldChildren();
+			sub.dispose();
+		});
+		setTimeout(() => {
+			foldChildren();
+			sub.dispose();
+		}, 250);
+	}, []);
+
+	return (
+		<div className="relative border border-border/40 rounded overflow-hidden bg-stone-50 dark:bg-stone-950/60">
+			<div className="absolute top-1.5 right-1.5 z-10 flex items-center gap-1">
+				<button
+					type="button"
+					onClick={() => {
+						editorRef.current?.getAction("actions.find")?.run();
+					}}
+					className="text-[10px] font-mono text-t4 hover:text-t2 cursor-pointer px-1.5 py-0.5 rounded bg-stone-100 dark:bg-stone-800/80 border border-border/40"
+					title="Find (Ctrl+F)"
+				>
+					⌘F
+				</button>
+				<CopyButton
+					text={formatted}
+					className="bg-stone-100 dark:bg-stone-800/80 shadow-none hover:bg-stone-200 dark:hover:bg-stone-800 w-5 gap-0 h-5 !px-0 py-0 flex items-center justify-center text-t3 cursor-pointer border border-border/40 rounded"
+				/>
+			</div>
+			<Editor
+				height={height}
+				language="json"
+				value={formatted}
+				onMount={onMount}
+				options={{
+					readOnly: true,
+					domReadOnly: true,
+					minimap: { enabled: false },
+					lineNumbers: "on",
+					lineNumbersMinChars: 3,
+					folding: true,
+					foldingStrategy: "auto",
+					showFoldingControls: "always",
+					foldingHighlight: true,
+					scrollBeyondLastLine: false,
+					fontSize: 11,
+					fontFamily:
+						"ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+					tabSize: 2,
+					wordWrap: "on",
+					renderLineHighlight: "none",
+					glyphMargin: false,
+					contextmenu: false,
+					quickSuggestions: false,
+					occurrencesHighlight: "off",
+					padding: { top: 8, bottom: 8 },
+					scrollbar: {
+						verticalScrollbarSize: 8,
+						horizontalScrollbarSize: 8,
+						useShadows: false,
+					},
+					overviewRulerLanes: 0,
+					hideCursorInOverviewRuler: true,
+					overviewRulerBorder: false,
+					stickyScroll: { enabled: false },
+				}}
+			/>
+		</div>
+	);
+};

--- a/vite/src/views/customers2/customer/workbench/WorkbenchLogDetail.tsx
+++ b/vite/src/views/customers2/customer/workbench/WorkbenchLogDetail.tsx
@@ -1,0 +1,174 @@
+import CopyButton from "@/components/general/CopyButton";
+import {
+	type RequestLogEntry,
+	useCusRequestLogsQuery,
+} from "@/hooks/queries/useCusRequestLogsQuery";
+import { useWorkbenchStore } from "@/hooks/stores/useWorkbenchStore";
+import { cn } from "@/lib/utils";
+import { WorkbenchJsonViewer } from "./WorkbenchJsonViewer";
+import {
+	extractRes,
+	extractScope,
+	formatLogDateTime,
+	methodColorClass,
+	statusBadgeClass,
+	statusText,
+} from "./workbenchUtils";
+
+export const WorkbenchLogDetail = ({
+	customerId,
+	isOpen,
+}: {
+	customerId: string | undefined;
+	isOpen: boolean;
+}) => {
+	const selectedLogId = useWorkbenchStore((s) => s.selectedLogId);
+	const { logs } = useCusRequestLogsQuery({ customerId, enabled: isOpen });
+
+	const log = logs.find((l) => l.id === selectedLogId) ?? null;
+
+	if (!log) {
+		return (
+			<div className="flex-1 min-h-0 flex items-center justify-center text-xs text-t4">
+				Select a request to view details
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex-1 min-h-0 overflow-y-auto p-4 text-sm">
+			<DetailHeader log={log} />
+			<DetailRows log={log} />
+			<ReqResSplit raw={log.raw} />
+			<ContextViewer raw={log.raw} />
+			<RawJsonViewer raw={log.raw} />
+		</div>
+	);
+};
+
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+	<div className="text-[10px] uppercase tracking-wide text-t4 font-semibold mb-1.5">
+		{children}
+	</div>
+);
+
+const ReqResSplit = ({ raw }: { raw: Record<string, unknown> }) => {
+	const req = extractScope(raw, "req");
+	const res = extractRes(raw);
+	const reqData = Object.keys(req).length > 0 ? req : {};
+	const resData =
+		res && typeof res === "object" && Object.keys(res).length > 0 ? res : {};
+
+	return (
+		<div className="mt-6 grid grid-cols-2 gap-3">
+			<div>
+				<SectionLabel>Request</SectionLabel>
+				<WorkbenchJsonViewer data={reqData} height="200px" />
+			</div>
+			<div>
+				<SectionLabel>Response</SectionLabel>
+				<WorkbenchJsonViewer data={resData} height="200px" />
+			</div>
+		</div>
+	);
+};
+
+const ContextViewer = ({ raw }: { raw: Record<string, unknown> }) => {
+	const ctx = extractScope(raw, "context");
+	const data = Object.keys(ctx).length > 0 ? ctx : {};
+	return (
+		<div className="mt-6">
+			<SectionLabel>Context</SectionLabel>
+			<WorkbenchJsonViewer data={data} height="180px" />
+		</div>
+	);
+};
+
+const DetailHeader = ({ log }: { log: RequestLogEntry }) => (
+	<div className="mb-4 pb-3 border-b border-border/40">
+		<div className="text-[10px] uppercase tracking-wide text-t4 font-semibold mb-1">
+			API request
+		</div>
+		<div className="flex items-center gap-2 font-mono text-sm">
+			<span className={cn("font-semibold", methodColorClass(log.method))}>
+				{log.method ?? "—"}
+			</span>
+			<span className="text-t1 break-all">{log.path ?? "(unknown)"}</span>
+		</div>
+	</div>
+);
+
+const Row = ({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) => (
+	<>
+		<dt className="text-t3 text-xs py-1">{label}</dt>
+		<dd className="text-t1 text-xs py-1 min-w-0">{children}</dd>
+	</>
+);
+
+const DetailRows = ({ log }: { log: RequestLogEntry }) => (
+	<dl className="grid grid-cols-[110px_1fr] gap-x-4">
+		<Row label="Status">
+			<span
+				className={cn(
+					"inline-flex items-center px-1.5 py-0 rounded text-[11px] font-medium border tabular-nums",
+					statusBadgeClass(log.statusCode),
+				)}
+			>
+				{statusText(log.statusCode)}
+			</span>
+		</Row>
+
+		{log.reqId && (
+			<Row label="Request ID">
+				<div className="flex items-center gap-1.5 min-w-0">
+					<span className="font-mono break-all">{log.reqId}</span>
+					<CopyButton
+						text={log.reqId}
+						className="bg-transparent shadow-none hover:bg-stone-200 dark:hover:bg-stone-800 w-5 gap-0 h-5 !px-0 py-0 flex items-center justify-center text-t3 shrink-0"
+					/>
+				</div>
+			</Row>
+		)}
+
+		<Row label="Time">
+			<span>{formatLogDateTime(log.time)}</span>
+		</Row>
+
+		{log.durationMs != null && (
+			<Row label="Duration">
+				<span className="tabular-nums">{log.durationMs}ms</span>
+			</Row>
+		)}
+
+		{log.ip && (
+			<Row label="IP address">
+				<span className="font-mono">{log.ip}</span>
+			</Row>
+		)}
+
+		{log.userAgent && (
+			<Row label="User agent">
+				<span className="break-all">{log.userAgent}</span>
+			</Row>
+		)}
+
+		{log.customerId && (
+			<Row label="Customer ID">
+				<span className="font-mono break-all">{log.customerId}</span>
+			</Row>
+		)}
+	</dl>
+);
+
+const RawJsonViewer = ({ raw }: { raw: Record<string, unknown> }) => (
+	<div className="mt-6">
+		<SectionLabel>Raw event</SectionLabel>
+		<WorkbenchJsonViewer data={raw} height="320px" />
+	</div>
+);

--- a/vite/src/views/customers2/customer/workbench/WorkbenchLogList.tsx
+++ b/vite/src/views/customers2/customer/workbench/WorkbenchLogList.tsx
@@ -1,0 +1,86 @@
+import { useCusRequestLogsQuery } from "@/hooks/queries/useCusRequestLogsQuery";
+import { useWorkbenchStore } from "@/hooks/stores/useWorkbenchStore";
+import { WorkbenchEmptyState } from "./WorkbenchEmptyState";
+import { WorkbenchLogRow } from "./WorkbenchLogRow";
+import { groupLogsByDay } from "./workbenchUtils";
+
+const LoadingSkeleton = () => (
+	<div className="p-3 space-y-1.5">
+		{Array.from({ length: 12 }).map((_, i) => (
+			<div
+				key={i}
+				className="h-7 bg-stone-100 dark:bg-stone-800/40 rounded animate-pulse"
+				style={{ animationDelay: `${i * 40}ms` }}
+			/>
+		))}
+	</div>
+);
+
+export const WorkbenchLogList = ({
+	customerId,
+	isOpen,
+}: {
+	customerId: string | undefined;
+	isOpen: boolean;
+}) => {
+	const selectedLogId = useWorkbenchStore((s) => s.selectedLogId);
+	const setSelectedLogId = useWorkbenchStore((s) => s.setSelectedLogId);
+
+	const { logs, unconfigured, isLoading, isFetching, error } =
+		useCusRequestLogsQuery({ customerId, enabled: isOpen });
+
+	const hasData = logs.length > 0;
+	const groups = groupLogsByDay(logs);
+
+	const renderContent = () => {
+		if (isLoading && !hasData) return <LoadingSkeleton />;
+		if (error) {
+			return (
+				<WorkbenchEmptyState title="Failed to load logs">
+					Check the server logs or your Axiom configuration.
+				</WorkbenchEmptyState>
+			);
+		}
+		if (unconfigured) {
+			return (
+				<WorkbenchEmptyState title="Axiom not configured">
+					Set <code className="text-t2">AXIOM_ADMIN_TOKEN</code> on the server
+					to enable the workbench.
+				</WorkbenchEmptyState>
+			);
+		}
+		if (!hasData) {
+			return (
+				<WorkbenchEmptyState title="No requests found">
+					No API requests for this customer in the last 7 days.
+				</WorkbenchEmptyState>
+			);
+		}
+		return groups.map((group) => (
+			<div key={group.label}>
+				<div className="px-3 py-1 text-[10px] uppercase tracking-wide font-semibold text-t4 bg-stone-50 dark:bg-stone-900/50 border-b border-border/40 sticky top-0 z-10">
+					{group.label}
+				</div>
+				{group.entries.map((log) => (
+					<WorkbenchLogRow
+						key={log.id}
+						log={log}
+						selected={selectedLogId === log.id}
+						onSelect={() => setSelectedLogId(log.id)}
+					/>
+				))}
+			</div>
+		));
+	};
+
+	return (
+		<div className="flex flex-col min-h-0 flex-1 overflow-hidden">
+			<div className="h-0.5 shrink-0">
+				{isFetching && (
+					<div className="h-full w-full bg-blue-500/40 animate-pulse" />
+				)}
+			</div>
+			<div className="flex-1 min-h-0 overflow-y-auto">{renderContent()}</div>
+		</div>
+	);
+};

--- a/vite/src/views/customers2/customer/workbench/WorkbenchLogRow.tsx
+++ b/vite/src/views/customers2/customer/workbench/WorkbenchLogRow.tsx
@@ -1,0 +1,50 @@
+import type { RequestLogEntry } from "@/hooks/queries/useCusRequestLogsQuery";
+import { cn } from "@/lib/utils";
+import {
+	formatLogTime,
+	methodColorClass,
+	statusBadgeClass,
+} from "./workbenchUtils";
+
+export const WorkbenchLogRow = ({
+	log,
+	selected,
+	onSelect,
+}: {
+	log: RequestLogEntry;
+	selected: boolean;
+	onSelect: () => void;
+}) => (
+	<button
+		type="button"
+		onClick={onSelect}
+		className={cn(
+			"w-full flex items-center gap-2.5 px-3 py-1.5 text-xs border-b border-border/40 hover:bg-stone-50 dark:hover:bg-stone-800/30 transition-colors text-left cursor-pointer",
+			selected &&
+				"bg-blue-50 dark:bg-blue-950/30 hover:bg-blue-50 dark:hover:bg-blue-950/30",
+		)}
+	>
+		<span
+			className={cn(
+				"shrink-0 px-1.5 py-0 rounded text-[10px] font-medium border tabular-nums",
+				statusBadgeClass(log.statusCode),
+			)}
+		>
+			{log.statusCode}
+		</span>
+		<span
+			className={cn(
+				"shrink-0 font-mono font-semibold text-[11px] w-11",
+				methodColorClass(log.method),
+			)}
+		>
+			{log.method ?? "—"}
+		</span>
+		<span className="flex-1 font-mono text-t1 text-[11px] truncate">
+			{log.path ?? "(unknown)"}
+		</span>
+		<span className="shrink-0 font-mono text-t4 text-[10px] tabular-nums">
+			{formatLogTime(log.time)}
+		</span>
+	</button>
+);

--- a/vite/src/views/customers2/customer/workbench/hooks/useWorkbenchEscape.ts
+++ b/vite/src/views/customers2/customer/workbench/hooks/useWorkbenchEscape.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useWorkbenchStore } from "@/hooks/stores/useWorkbenchStore";
+
+const shouldDeferEscape = (target: Element | null): boolean => {
+	if (target?.closest(".monaco-editor")) return true;
+	if (useSheetStore.getState().type !== null) return true;
+	return (
+		!!document.querySelector('[role="dialog"][data-state="open"]') ||
+		!!document.querySelector('[role="alertdialog"][data-state="open"]') ||
+		!!document.querySelector("dialog[open]") ||
+		!!document.querySelector("[data-inline-editor-open]")
+	);
+};
+
+export const useWorkbenchEscape = () => {
+	const isOpen = useWorkbenchStore((s) => s.isOpen);
+	const close = useWorkbenchStore((s) => s.close);
+
+	useEffect(() => {
+		if (!isOpen) return;
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== "Escape" || e.defaultPrevented) return;
+			if (shouldDeferEscape(e.target as Element | null)) return;
+			close();
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [isOpen, close]);
+};

--- a/vite/src/views/customers2/customer/workbench/hooks/useWorkbenchResize.ts
+++ b/vite/src/views/customers2/customer/workbench/hooks/useWorkbenchResize.ts
@@ -1,0 +1,52 @@
+import { useEffect, useMemo, useRef } from "react";
+import {
+	useWorkbenchStore,
+	WORKBENCH_MAX_HEIGHT_RATIO,
+	WORKBENCH_MIN_HEIGHT,
+} from "@/hooks/stores/useWorkbenchStore";
+
+const clampHeight = (h: number) =>
+	Math.max(
+		WORKBENCH_MIN_HEIGHT,
+		Math.min(window.innerHeight * WORKBENCH_MAX_HEIGHT_RATIO, h),
+	);
+
+export const useWorkbenchResize = () => {
+	const setHeight = useWorkbenchStore((s) => s.setHeight);
+	const dragStartY = useRef<number | null>(null);
+	const dragStartHeight = useRef(0);
+
+	const handleProps = useMemo(
+		() => ({
+			onPointerDown: (e: React.PointerEvent<HTMLElement>) => {
+				e.preventDefault();
+				dragStartY.current = e.clientY;
+				dragStartHeight.current = useWorkbenchStore.getState().height;
+				e.currentTarget.setPointerCapture(e.pointerId);
+			},
+			onPointerMove: (e: React.PointerEvent<HTMLElement>) => {
+				if (dragStartY.current == null) return;
+				const delta = dragStartY.current - e.clientY;
+				setHeight(clampHeight(dragStartHeight.current + delta));
+			},
+			onPointerUp: (e: React.PointerEvent<HTMLElement>) => {
+				dragStartY.current = null;
+				e.currentTarget.releasePointerCapture(e.pointerId);
+			},
+			onPointerCancel: (e: React.PointerEvent<HTMLElement>) => {
+				dragStartY.current = null;
+				e.currentTarget.releasePointerCapture(e.pointerId);
+			},
+		}),
+		[setHeight],
+	);
+
+	useEffect(() => {
+		const onResize = () =>
+			setHeight(clampHeight(useWorkbenchStore.getState().height));
+		window.addEventListener("resize", onResize);
+		return () => window.removeEventListener("resize", onResize);
+	}, [setHeight]);
+
+	return { handleProps };
+};

--- a/vite/src/views/customers2/customer/workbench/workbenchUtils.ts
+++ b/vite/src/views/customers2/customer/workbench/workbenchUtils.ts
@@ -1,0 +1,125 @@
+import type { RequestLogEntry } from "@/hooks/queries/useCusRequestLogsQuery";
+
+export const statusBadgeClass = (status: number): string => {
+	if (status >= 200 && status < 300) {
+		return "bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-400 dark:border-green-900";
+	}
+	if (status >= 300 && status < 400) {
+		return "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-400 dark:border-blue-900";
+	}
+	if (status >= 400 && status < 500) {
+		return "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:border-amber-900";
+	}
+	return "bg-red-50 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-400 dark:border-red-900";
+};
+
+export const statusText = (status: number): string => {
+	if (status === 200) return "200 OK";
+	if (status === 201) return "201 Created";
+	if (status === 204) return "204 No Content";
+	if (status === 400) return "400 Bad Request";
+	if (status === 401) return "401 Unauthorized";
+	if (status === 403) return "403 Forbidden";
+	if (status === 404) return "404 Not Found";
+	if (status === 409) return "409 Conflict";
+	if (status === 422) return "422 Unprocessable";
+	if (status === 429) return "429 Rate Limited";
+	if (status === 500) return "500 Server Error";
+	return String(status);
+};
+
+export const methodColorClass = (method: string | null): string => {
+	switch (method) {
+		case "GET":
+			return "text-blue-600 dark:text-blue-400";
+		case "POST":
+			return "text-emerald-600 dark:text-emerald-400";
+		case "PUT":
+			return "text-amber-600 dark:text-amber-400";
+		case "PATCH":
+			return "text-purple-600 dark:text-purple-400";
+		case "DELETE":
+			return "text-red-600 dark:text-red-400";
+		default:
+			return "text-t2";
+	}
+};
+
+const dayBucketLabel = (date: Date, now: Date): string => {
+	const y = date.toDateString() === now.toDateString();
+	if (y) return "Today";
+
+	const yesterday = new Date(now);
+	yesterday.setDate(yesterday.getDate() - 1);
+	if (date.toDateString() === yesterday.toDateString()) return "Yesterday";
+
+	return date.toLocaleDateString(undefined, {
+		day: "numeric",
+		month: "short",
+		year: "numeric",
+	});
+};
+
+export const groupLogsByDay = (
+	logs: RequestLogEntry[],
+): { label: string; entries: RequestLogEntry[] }[] => {
+	const now = new Date();
+	const groups = new Map<string, RequestLogEntry[]>();
+
+	for (const log of logs) {
+		const d = new Date(log.time);
+		const label = dayBucketLabel(d, now);
+		const existing = groups.get(label) ?? [];
+		existing.push(log);
+		groups.set(label, existing);
+	}
+
+	return Array.from(groups.entries()).map(([label, entries]) => ({
+		label,
+		entries,
+	}));
+};
+
+export const formatLogTime = (time: string): string =>
+	new Date(time).toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hour12: false,
+	});
+
+export const formatLogDateTime = (time: string): string =>
+	new Date(time).toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+	});
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+	v != null && typeof v === "object" && !Array.isArray(v);
+
+export const extractScope = (
+	raw: Record<string, unknown>,
+	prefix: string,
+): Record<string, unknown> => {
+	const base = prefix.replace(/\.$/, "");
+	const direct = raw[base];
+	if (isPlainObject(direct)) return direct;
+
+	const dotted = `${base}.`;
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(raw)) {
+		if (k.startsWith(dotted)) {
+			out[k.slice(dotted.length)] = v;
+		}
+	}
+	return out;
+};
+
+export const extractRes = (raw: Record<string, unknown>): unknown => {
+	if (raw.res !== undefined) return raw.res ?? {};
+	return extractScope(raw, "res");
+};

--- a/vite/src/views/main-sidebar/SidebarBottom.tsx
+++ b/vite/src/views/main-sidebar/SidebarBottom.tsx
@@ -2,6 +2,7 @@
 
 import { BooksIcon, DiscordLogoIcon } from "@phosphor-icons/react";
 import { useEnv } from "@/utils/envUtils";
+import { WorkbenchButton } from "@/views/customers2/customer/workbench/WorkbenchButton";
 import { FeedbackDialog } from "./FeedbackDialog";
 import { NavButton } from "./NavButton";
 import { SidebarContact } from "./SidebarContact";
@@ -15,20 +16,7 @@ export default function SidebarBottom() {
 	return (
 		<div className="">
 			<div className="px-2 flex flex-col gap-1 mb-2">
-				{/* <NavButton
-          value="integrations/stripe"
-          icon={<Blocks size={14} />}
-          title="Connect to Stripe"
-          env={env}
-        /> */}
-				{/* {env === AppEnv.Sandbox && (
-					<NavButton
-						value="onboarding"
-						icon={<GraduationCap size={14} />}
-						title="Onboarding"
-						env={env}
-					/>
-				)} */}
+				<WorkbenchButton />
 				<NavButton
 					value="docs"
 					icon={<BooksIcon size={16} weight="duotone" />}


### PR DESCRIPTION
- **feat(workbench): 🎸 add Axiom-backed API endpoint for customer request logs**
- **feat(workbench): 🎸 add Stripe-style workbench panel for customer API logs**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Stripe-style Workbench drawer on the customer page to browse per-customer API request logs, backed by a new Axiom-powered endpoint. This gives admins a fast way to filter and inspect requests with a split list/detail view.

- **New Features**
  - Server: internal `POST /workbench/requests` (Superuser only) queries Axiom’s `express` dataset by org, env, customer_id, with method/status/free-text filters; returns normalized entries and raw event; reports `unconfigured` when Axiom is not set.
  - UI: admin-only drawer on the customer view with horizontal list/detail split, vertical drag-to-resize, refresh, method/status selects, and 300ms debounced search; Monaco viewers for request, response, context, and raw JSON; ESC closes when no dialog/editor is focused; sidebar button appears only on customer routes.

- **Migration**
  - Configure `AXIOM_ADMIN_TOKEN` (and `AXIOM_ORG_ID` if applicable) on the server; without this, the Workbench shows “Axiom not configured.”

<sup>Written for commit 1316a737bc075155a40a4910152cb1cfb9abc4dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a Stripe-style "Workbench" developer panel for the customer detail view, backed by Axiom-stored Express request logs. An internal Hono endpoint (`/workbench/requests`) queries Axiom via APL and returns normalised log entries; the frontend renders them in a resizable, keyboard-dismissible drawer with filtering, JSON detail view, and a Monaco-based raw event inspector.

- **[Improvements]** New `workbenchRouter` + `handleListRequestLogs` handler queries Axiom APL with proper single-quote escaping (`\\'`, confirmed correct per Axiom docs), Superuser scope enforcement, and graceful `unconfigured` fallback when `AXIOM_ADMIN_TOKEN` is absent.
- **[Improvements]** Frontend workbench panel built with `vaul` Drawer, `react-resizable-panels`, Zustand store for height persistence/filter state, debounced search, and a Monaco read-only JSON viewer with custom dark/light themes.
- **[API changes]** New POST `/internal/workbench/requests` endpoint added to `internalRouter`; accepts `customer_id`, optional `method`, `status`, and `search` filters.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the new workbench panel is admin/superuser-only and the Axiom integration degrades gracefully when unconfigured. The three findings are non-blocking quality notes.

The backend endpoint is correctly scoped to Superuser, the APL escape function uses the right convention as confirmed by Axiom's own docs, and the unconfigured-Axiom path returns an empty list rather than an error. The open items are: `resizable.tsx` landed in the deprecated `@/components/ui/` folder instead of `@/components/v2/`, `getAxiomClient` throws a plain `Error` rather than the project-standard `InternalError`, and `selectedLogId` is not cleared when navigating between customers (harmless but visually noisy).

`vite/src/components/ui/resizable.tsx` should move to `@/components/v2/`; `server/src/external/axiom/initAxiom.ts` should use `InternalError` for the missing-token guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/axiom/aplUtils.ts | APL query builder with correct `\'` escaping (confirmed against Axiom docs); `limit` and `rangeDays` are not user-configurable from the API, so no injection surface there. |
| server/src/external/axiom/initAxiom.ts | Axiom client initialisation; `getAxiomClient` throws a plain `Error` instead of the expected `InternalError` from `@autumn/shared`. |
| server/src/internal/workbench/handlers/handleListRequestLogs.ts | Superuser-scoped handler that validates the customer exists, checks Axiom configuration, builds and executes the APL query, and normalises results; error handling and access control look correct. |
| vite/src/components/ui/resizable.tsx | Shadcn-style resizable panel wrapper placed in the deprecated `@/components/ui/` directory instead of `@/components/v2/`; also carries a no-op Next.js `"use client"` directive. |
| vite/src/hooks/stores/useWorkbenchStore.ts | Zustand store with height persistence; `selectedLogId` is not cleared on customer navigation, which can cause a stale selection state when switching customers. |
| vite/src/views/customers2/customer/workbench/Workbench.tsx | Root workbench panel using `vaul` Drawer with custom resize handle, split-pane layout, and non-modal, non-dismissible configuration appropriate for a persistent dev panel. |
| vite/src/views/customers2/customer/workbench/workbenchUtils.ts | Pure utility functions for status/method colours, log grouping by day, date formatting, and raw-field extraction; logic is clean and correct. |
| vite/src/hooks/queries/useCusRequestLogsQuery.tsx | React Query hook that posts to `/workbench/requests` with filters from the Zustand store; 30-second stale time and `placeholderData` for smooth UX on refetch. |
| vite/src/views/customers2/customer/workbench/WorkbenchJsonViewer.tsx | Monaco editor read-only JSON viewer with custom light/dark themes; double-dispose guard on `sub` prevents listener leak after fold is triggered. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Workbench (React)
    participant Store as useWorkbenchStore
    participant Query as useCusRequestLogsQuery
    participant API as POST /internal/workbench/requests
    participant CusService as CusService.getFull
    participant Axiom as Axiom APL

    UI->>Store: toggle() / open()
    Store-->>UI: "isOpen = true"
    UI->>Query: "enabled=true, customerId"
    Query->>API: "POST { customer_id, method, status, search }"
    API->>CusService: getFull(customer_id)
    CusService-->>API: "customer | null"
    alt customer not found
        API-->>Query: 404 CustomerNotFound
    else Axiom not configured
        API-->>Query: "{ logs: [], unconfigured: true }"
    else query Axiom
        API->>Axiom: APL query (buildRequestLogsQuery)
        Axiom-->>API: matches[]
        API-->>Query: "{ logs: RequestLogEntry[] }"
    end
    Query-->>UI: logs, unconfigured, isLoading
    UI->>Store: setSelectedLogId(id)
    Store-->>UI: selectedLogId
    UI->>Query: find log by selectedLogId → WorkbenchLogDetail
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
vite/src/components/ui/resizable.tsx:1-4
**New component added to deprecated `@/components/ui/` folder**

Per the CLAUDE.md codebase rule, new features must use `@/components/v2/` — `@/components/ui/` is the deprecated bucket. `resizable.tsx` should be placed in `vite/src/components/v2/resizable.tsx` (or a dedicated `panels/` sub-folder) so it follows the same convention as the rest of the new-generation UI primitives. The same applies to the `"use client"` directive at line 1, which is a Next.js convention that has no effect in a Vite app and should be removed.

### Issue 2 of 3
server/src/external/axiom/initAxiom.ts:13-18
`getAxiomClient` throws a plain `Error` instead of `InternalError` from `@autumn/shared`. The codebase rules say internal/configuration errors should use `InternalError` so they flow correctly through the error-handling middleware. While this path is guarded by `isAxiomConfigured()` in the handler, a direct call from future code would bubble up as an untyped error.

```suggestion
export const getAxiomClient = (): Axiom => {
	if (!axiomClient) {
		throw new InternalError({
			message: "Axiom is not configured (AXIOM_ADMIN_TOKEN missing)",
			code: "axiom_not_configured",
		});
	}
	return axiomClient;
};
```

### Issue 3 of 3
vite/src/hooks/stores/useWorkbenchStore.ts:43-46
**`selectedLogId` persists when navigating between customers**

The Zustand store is a global singleton. When a user opens the workbench on Customer A, selects a log, and then navigates to Customer B, `selectedLogId` still holds the ID from Customer A. `WorkbenchLogDetail` resolves via `logs.find((l) => l.id === selectedLogId)` against the new customer's logs — so it returns `null` and shows the "Select a request…" placeholder, which is benign. However, if the fallback ID format `${entry._time}-${i}` produces a collision (same timestamp and position), the detail pane would momentarily show the wrong customer's log until the query re-runs. Adding a `reset` action and calling it in `CustomerView2` on `customerId` change (or clearing `selectedLogId` inside `close`) would eliminate the ambiguity entirely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(workbench): 🎸 add Stripe-style wor..."](https://github.com/useautumn/autumn/commit/1316a737bc075155a40a4910152cb1cfb9abc4dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31642988)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7dd29fca-a6f0-4168-be5b-a3ea3d587c1c))
- Context used - server/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=7866843d-5d47-47cf-8270-b04b4f695fd8))

<!-- /greptile_comment -->