### PR TITLE
fix: duplicate stripe customer id

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -40,7 +40,12 @@
 			"url": "https://mcp.plain.com/mcp",
 			"oauth": {}
 		},
-		"autumn-internal": {
+		"slack": {
+			"type": "remote",
+			"url": "https://mcp.slack.com/mcp",
+			"oauth": {}
+		},
+		"autumn_prod_internal": {
 			"type": "local",
 			"command": [
 				"sh",
@@ -48,7 +53,20 @@
 				"cd \"/Users/johnyeocx/Autumn/autumn-cloud\" && exec infisical run --env=prod --recursive -- bun run \"/Users/johnyeocx/Autumn/autumn-cloud/ai/src/mcp/index.ts\""
 			],
 			"env": {
-				"AUTUMN_CLOUD_ROOT": "/Users/johnyeocx/Autumn/autumn-cloud"
+				"AUTUMN_CLOUD_ROOT": "/Users/johnyeocx/Autumn/autumn-cloud",
+				"AUTUMN_MCP_ENV": "prod"
+			}
+		},
+		"autumn_dev_internal": {
+			"type": "local",
+			"command": [
+				"sh",
+				"-c",
+				"cd \"/Users/johnyeocx/Autumn/autumn-cloud\" && exec infisical run --env=dev --recursive -- bun run \"/Users/johnyeocx/Autumn/autumn-cloud/ai/src/mcp/index.ts\""
+			],
+			"env": {
+				"AUTUMN_CLOUD_ROOT": "/Users/johnyeocx/Autumn/autumn-cloud",
+				"AUTUMN_MCP_ENV": "dev"
 			}
 		}
 	},

--- a/server/src/internal/billing/v2/actions/attach/attach.ts
+++ b/server/src/internal/billing/v2/actions/attach/attach.ts
@@ -42,6 +42,7 @@ export async function attach({
 		ctx,
 		params,
 		contextOverride,
+		preview,
 	});
 
 	logAttachContext({ ctx, billingContext });

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -39,10 +39,12 @@ export const setupAttachBillingContext = async ({
 	ctx,
 	params,
 	contextOverride = {},
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: AttachParamsV1;
 	contextOverride?: BillingContextOverride;
+	preview?: boolean;
 }): Promise<AttachBillingContext> => {
 	const { fullCustomer: fullCustomerOverride } = contextOverride;
 
@@ -139,6 +141,7 @@ export const setupAttachBillingContext = async ({
 		params,
 		newBillingSubscription: shouldForceNewSubscription,
 		skipBillingFetching,
+		createStripeCustomerIfMissing: !preview,
 	});
 
 	const featureQuantities = setupFeatureQuantitiesContext({

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -106,9 +106,11 @@ const setupImmediateMultiProductTrialContext = async ({
 export const setupImmediateMultiProductBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
+	preview?: boolean;
 }): Promise<MultiAttachBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
 		ctx,
@@ -179,6 +181,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		params,
 		skipSubscriptionFetching: fullProducts.every(isOneOffProduct),
 		newBillingSubscription: params.new_billing_subscription || undefined,
+		createStripeCustomerIfMissing: !preview,
 	});
 
 	const invoiceMode = setupInvoiceModeContext({ params });

--- a/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/previewCreateSchedule.ts
@@ -27,6 +27,7 @@ export const previewCreateScheduleWithContext = async ({
 	const billingContext = await setupCreateScheduleBillingContext({
 		ctx,
 		params,
+		preview: true,
 	});
 
 	await handleCreateScheduleErrors({

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -70,9 +70,11 @@ const setupCreateScheduleCheckoutMode = ({
 export const setupCreateScheduleBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: CreateScheduleParamsV0;
+	preview?: boolean;
 }): Promise<CreateScheduleBillingContext> => {
 	const normalizedPhases = normalizeCreateSchedulePhases({
 		phases: params.phases,
@@ -99,6 +101,7 @@ export const setupCreateScheduleBillingContext = async ({
 	const billingContext = await setupImmediateMultiProductBillingContext({
 		ctx,
 		params: immediateParams,
+		preview,
 	});
 
 	validateCreateSchedulePhasePlans({

--- a/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock.ts
+++ b/server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock.ts
@@ -1,5 +1,5 @@
 import type { BillingContext, BillingPlan } from "@autumn/shared";
-import { ErrCode, RecaseError } from "@autumn/shared";
+import { AppEnv, ErrCode, RecaseError } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { CreateAutumnCheckoutResult } from "@/internal/billing/v2/common/createAutumnCheckout";
 import { hashJson } from "@/utils/hash/hashJson";
@@ -52,6 +52,18 @@ export const checkCheckoutSessionLock = async <T extends BillingContext>({
 
 		ctx.logger.info(
 			`Expiring old checkout session ${existingLock.checkoutSessionId} for customer ${customerId} (params changed)`,
+		);
+		await checkoutSessionLock.expireAndClear({
+			ctx,
+			customerId,
+			checkoutSessionId: existingLock.checkoutSessionId,
+		});
+		return null;
+	}
+
+	if (ctx.env === AppEnv.Sandbox) {
+		ctx.logger.info(
+			`Sandbox: clearing checkout session lock for customer ${customerId} (session ${existingLock.checkoutSessionId}) to allow non-checkout billing action`,
 		);
 		await checkoutSessionLock.expireAndClear({
 			ctx,

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -34,6 +34,7 @@ export async function multiAttach({
 	const billingContext = await setupMultiAttachBillingContext({
 		ctx,
 		params,
+		preview,
 	});
 
 	// 2. Errors

--- a/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/setup/setupMultiAttachBillingContext.ts
@@ -11,11 +11,14 @@ import { setupImmediateMultiProductBillingContext } from "../../common/immediate
 export const setupMultiAttachBillingContext = async ({
 	ctx,
 	params,
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: MultiAttachParamsV0;
+	preview?: boolean;
 }): Promise<MultiAttachBillingContext> =>
 	setupImmediateMultiProductBillingContext({
 		ctx,
 		params,
+		preview,
 	});

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -41,10 +41,12 @@ export const setupUpdateSubscriptionBillingContext = async ({
 	ctx,
 	params,
 	contextOverride = {},
+	preview = false,
 }: {
 	ctx: AutumnContext;
 	params: UpdateSubscriptionV1Params;
 	contextOverride?: UpdateSubscriptionBillingContextOverride;
+	preview?: boolean;
 }): Promise<UpdateSubscriptionBillingContext> => {
 	const fullCustomer = await setupFullCustomerContext({
 		ctx,
@@ -105,6 +107,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		skipBillingFetching,
 		product: fullProduct,
 		skipSubscriptionFetching: isUpdatingFreeCustomerProduct,
+		createStripeCustomerIfMissing: !preview,
 	});
 
 	const currentEpochMs = testClockFrozenTime ?? Date.now();

--- a/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
@@ -44,6 +44,7 @@ export async function updateSubscription({
 		ctx,
 		params,
 		contextOverride,
+		preview,
 	});
 
 	logUpdateSubscriptionContext({ ctx, billingContext });

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
@@ -1,6 +1,9 @@
 import type { FullCustomer } from "@autumn/shared";
 import { createStripeCli } from "@server/external/connect/createStripeCli";
-import { getOrCreateStripeCustomer } from "@server/external/stripe/customers";
+import {
+	getExpandedStripeCustomer,
+	getOrCreateStripeCustomer,
+} from "@server/external/stripe/customers";
 import { listCusPaymentMethods } from "@server/external/stripe/stripeCusUtils";
 import type { AutumnContext } from "@server/honoUtils/HonoEnv";
 import type Stripe from "stripe";
@@ -8,17 +11,24 @@ import type Stripe from "stripe";
 export const fetchStripeCustomerForBilling = async ({
 	ctx,
 	fullCus,
+	createIfMissing = true,
 }: {
 	ctx: AutumnContext;
 	fullCus: FullCustomer;
+	createIfMissing?: boolean;
 }) => {
 	const { org, env } = ctx;
 	const stripeCli = createStripeCli({ org, env });
 
-	const stripeCus = await getOrCreateStripeCustomer({
-		ctx,
-		customer: fullCus,
-	});
+	const stripeCus = createIfMissing
+		? await getOrCreateStripeCustomer({
+				ctx,
+				customer: fullCus,
+			})
+		: await getExpandedStripeCustomer({
+				ctx,
+				stripeCustomerId: fullCus.processor?.id,
+			});
 
 	if (!stripeCus) {
 		return {

--- a/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
@@ -26,6 +26,7 @@ export const setupStripeBillingContext = async ({
 	newBillingSubscription,
 	skipBillingFetching,
 	skipSubscriptionFetching,
+	createStripeCustomerIfMissing = true,
 }: {
 	ctx: AutumnContext;
 	fullCustomer: FullCustomer;
@@ -36,6 +37,7 @@ export const setupStripeBillingContext = async ({
 	newBillingSubscription?: boolean;
 	skipBillingFetching?: boolean;
 	skipSubscriptionFetching?: boolean;
+	createStripeCustomerIfMissing?: boolean;
 }) => {
 	const { stripeBillingContext } = contextOverride;
 
@@ -66,6 +68,7 @@ export const setupStripeBillingContext = async ({
 			return fetchStripeCustomerForBilling({
 				ctx,
 				fullCus: fullCustomer,
+				createIfMissing: createStripeCustomerIfMissing,
 			});
 		},
 		async stripeSubscription() {

--- a/server/src/internal/billing/v2/setup/setupFullCustomerContext.ts
+++ b/server/src/internal/billing/v2/setup/setupFullCustomerContext.ts
@@ -1,6 +1,6 @@
 import { EntityNotFoundError } from "@autumn/shared";
 import type { AutumnContext } from "@server/honoUtils/HonoEnv";
-import { getOrSetCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/getOrSetCachedFullCustomer";
+import { CusService } from "@/internal/customers/CusService";
 
 export const setupFullCustomerContext = async ({
 	ctx,
@@ -11,11 +11,19 @@ export const setupFullCustomerContext = async ({
 }) => {
 	const { customer_id: customerId } = params;
 
-	const fullCustomer = await getOrSetCachedFullCustomer({
+	// const fullCustomer = await getOrSetCachedFullCustomer({
+	// 	ctx,
+	// 	customerId,
+	// 	entityId: params.entity_id ?? undefined,
+	// 	source: "setupFullCustomerContext",
+	// });
+
+	const fullCustomer = await CusService.getFull({
 		ctx,
-		customerId,
+		idOrInternalId: customerId,
+		withEntities: true,
+		withSubs: true,
 		entityId: params.entity_id ?? undefined,
-		source: "setupFullCustomerContext",
 	});
 
 	if (params.entity_id && !fullCustomer.entity) {

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
@@ -10,6 +10,7 @@ import { applyLiveAggregatedBalances } from "../../balances/applyLiveAggregatedB
 import { getCachedFeatureBalancesBatch } from "../../balances/getCachedFeatureBalances.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
 import { buildFullSubjectViewEpochKey } from "../../builders/buildFullSubjectViewEpochKey.js";
+import { buildSharedFullSubjectBalanceKey } from "../../builders/buildSharedFullSubjectBalanceKey.js";
 import { filterNormalizedFullSubjectByFeatureIds } from "../../filterFullSubjectByFeatureIds.js";
 import {
 	type CachedFullSubject,
@@ -233,6 +234,28 @@ export const getCachedPartialFullSubject = async ({
 			source: "partial-incomplete",
 		});
 
+	if (featureBalancesOutcome.kind === "missing") {
+		const probeFeatureId =
+			meteredFeatureIdsToFetch[0] ?? cached.meteredFeatures[0];
+		if (probeFeatureId) {
+			const balanceKey = buildSharedFullSubjectBalanceKey({
+				orgId: org.id,
+				env,
+				customerId,
+				featureId: probeFeatureId,
+			});
+			const [hlenRaw, ttlRaw] = await Promise.all([
+				redisV2.hlen(balanceKey).catch(() => -99),
+				redisV2.ttl(balanceKey).catch(() => -99),
+			]);
+			const expectedIds =
+				cached.customerEntitlementIdsByFeatureId[probeFeatureId] ?? [];
+			ctx.logger.warn(
+				`[incomplete-debug] ${subjectLabel} feature=${probeFeatureId} reason=${featureBalancesOutcome.reason} hlen=${hlenRaw} ttl=${ttlRaw} expected=${expectedIds.join(",")}`,
+			);
+		}
+	}
+
 	const balancesPresent = await tryOrInvalidate({
 		ctx,
 		operation: () =>
@@ -240,7 +263,7 @@ export const getCachedPartialFullSubject = async ({
 				? undefined
 				: featureBalancesOutcome.value,
 		invalidate: invalidateIncomplete,
-		warnMessage: `[getCachedPartialFullSubject] Incomplete cache for ${subjectLabel}, source: ${source}`,
+		warnMessage: `[getCachedPartialFullSubject] Incomplete cache for ${subjectLabel}, source: ${source}, reason: ${featureBalancesOutcome.kind === "missing" ? featureBalancesOutcome.reason : "n/a"}`,
 	});
 	if (balancesPresent === undefined) {
 		return {

--- a/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
+++ b/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
@@ -17,11 +17,11 @@ export type FeatureBalanceResult = {
 
 export type FeatureBalanceOutcome =
 	| { kind: "ok"; value: FeatureBalanceResult }
-	| { kind: "missing" };
+	| { kind: "missing"; reason: string };
 
 export type FeatureBalancesBatchOutcome =
 	| { kind: "ok"; value: FeatureBalanceResult[] }
-	| { kind: "missing" };
+	| { kind: "missing"; reason: string };
 
 const readFeatureBalancesFromMaster = async ({
 	ctx,
@@ -82,12 +82,16 @@ export const getCachedFeatureBalance = async ({
 		redisInstance: redisV2,
 	});
 
-	if (!results) return { kind: "missing" };
+	if (!results) return { kind: "missing", reason: "single_pipeline_null" };
 
 	const balances: SubjectBalance[] = [];
 	for (let i = 0; i < customerEntitlementIds.length; i++) {
 		const entryJson = results[i];
-		if (!entryJson) return { kind: "missing" };
+		if (!entryJson)
+			return {
+				kind: "missing",
+				reason: `single_field_null:${featureId}:${customerEntitlementIds[i]}`,
+			};
 		try {
 			const parsedBalance = JSON.parse(entryJson) as SubjectBalance;
 			balances.push(
@@ -98,7 +102,10 @@ export const getCachedFeatureBalance = async ({
 				}),
 			);
 		} catch {
-			return { kind: "missing" };
+			return {
+				kind: "missing",
+				reason: `single_parse_failed:${featureId}:${customerEntitlementIds[i]}`,
+			};
 		}
 	}
 
@@ -145,7 +152,7 @@ export const getCachedFeatureBalancesBatch = async ({
 		redisInstance: redisV2,
 	});
 
-	if (!results) return { kind: "missing" };
+	if (!results) return { kind: "missing", reason: "batch_pipeline_null" };
 
 	const featureBalances: FeatureBalanceResult[] = [];
 
@@ -153,7 +160,11 @@ export const getCachedFeatureBalancesBatch = async ({
 		const customerEntitlementIds =
 			customerEntitlementIdsByFeatureId[featureIds[i]] ?? [];
 		const allValues = results[i]?.[1] as (string | null)[] | null;
-		if (!allValues) return { kind: "missing" };
+		if (!allValues)
+			return {
+				kind: "missing",
+				reason: `batch_hash_missing:${featureIds[i]}`,
+			};
 
 		let aggregated: AggregatedFeatureBalance | undefined;
 		let ceValues: (string | null)[];
@@ -176,11 +187,19 @@ export const getCachedFeatureBalancesBatch = async ({
 		}
 
 		if (ceValues.length !== customerEntitlementIds.length)
-			return { kind: "missing" };
+			return {
+				kind: "missing",
+				reason: `batch_length_mismatch:${featureIds[i]}:got=${ceValues.length}:expected=${customerEntitlementIds.length}`,
+			};
 
 		const balances: SubjectBalance[] = [];
-		for (const entryJson of ceValues) {
-			if (!entryJson) return { kind: "missing" };
+		for (let j = 0; j < ceValues.length; j++) {
+			const entryJson = ceValues[j];
+			if (!entryJson)
+				return {
+					kind: "missing",
+					reason: `batch_field_null:${featureIds[i]}:${customerEntitlementIds[j]}`,
+				};
 			try {
 				const parsedBalance = JSON.parse(entryJson) as SubjectBalance;
 				balances.push(
@@ -191,7 +210,10 @@ export const getCachedFeatureBalancesBatch = async ({
 					}),
 				);
 			} catch {
-				return { kind: "missing" };
+				return {
+					kind: "missing",
+					reason: `batch_parse_failed:${featureIds[i]}:${customerEntitlementIds[j]}`,
+				};
 			}
 		}
 

--- a/server/tests/_groups/temp.ts
+++ b/server/tests/_groups/temp.ts
@@ -2,14 +2,13 @@ import type { TestGroup } from "./types";
 
 export const temp: TestGroup = {
 	name: "temp",
-	description: "patch-style custom plan update coverage",
+	description: "failed retry tests",
 	tier: "domain",
 	paths: [
-		"integration/billing/update-subscription/custom-plan-patch/patch-update-items.test.ts",
-		"integration/billing/update-subscription/custom-plan-patch/patch-update-price.test.ts",
-		"integration/billing/update-subscription/custom-plan-patch/patch-update-paid-features.test.ts",
-		"integration/billing/update-subscription/custom-plan-patch/patch-update-items-carry-usage.test.ts",
-		"integration/billing/update-subscription/custom-plan-patch/patch-update-items-carry-rollover.test.ts",
-		"integration/billing/update-subscription/custom-plan-patch/patch-update-with-others.test.ts",
+		"integration/billing/setup-payment/setup-payment-with-plan.test.ts",
+		"integration/crud/customers/customer-processors.test.ts",
+		"integration/crud/customers/get-customer-aggregated-balances.test.ts",
+		"integration/billing/stripe-webhooks/subscription-updated/subscription-updated-past-due.test.ts",
+		"integration/billing/stripe-webhooks/invoice-created/invoice-created-entity-consumable.test.ts",
 	],
 };

--- a/server/tests/_temp/preview-attach-no-stripe-customer-create.test.ts
+++ b/server/tests/_temp/preview-attach-no-stripe-customer-create.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression: `billing.preview_attach` was provisioning a brand-new Stripe
+ * customer (via getOrCreateStripeCustomer) on every call whenever the Autumn
+ * customer had no `processor.id`. Because preview_attach is not in the
+ * refresh-cache allowlist, the FullCustomer Redis cache stayed populated with
+ * processor.id=null after each call, so subsequent preview_attach calls kept
+ * minting fresh Stripe customers. Customers reported 5+ Stripe customers for
+ * a single Autumn customer (athena, popfly tickets on 11 May 2026).
+ *
+ * Red-failure mode (current behavior):
+ *  - After clearing the Autumn customer's processor and calling
+ *    billing.preview_attach twice, the customer's processor.id is non-null
+ *    (preview wrote a fresh stripe customer to the DB).
+ *
+ * Green-success criteria (after fix):
+ *  - preview_attach must not call createStripeCustomer; the Autumn customer's
+ *    processor.id remains null after multiple preview_attach calls.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { CusService } from "@/internal/customers/CusService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+
+test(
+	`${chalk.yellowBright("preview_attach with no stripe customer: does not create one")}`,
+	async () => {
+		const customerId = "preview-no-stripe-cus-create";
+
+		const pro = products.pro({
+			id: "pro-no-stripe-cus",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await CusService.update({
+			ctx,
+			idOrInternalId: customerId,
+			update: { processor: null as unknown as undefined },
+		});
+		await deleteCachedFullCustomer({
+			ctx,
+			customerId,
+			source: "test-clear-processor",
+			skipGuard: true,
+		});
+
+		await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: `pro-no-stripe-cus_${customerId}`,
+		});
+		await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: `pro-no-stripe-cus_${customerId}`,
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+
+		expect(fullCustomer.processor?.id ?? null).toBeNull();
+	},
+	300_000,
+);

--- a/server/tests/integration/crud/customers/get-customer.test.ts
+++ b/server/tests/integration/crud/customers/get-customer.test.ts
@@ -1,17 +1,17 @@
 import { expect, test } from "bun:test";
 import {
-	type ApiCustomer,
-	ApiCustomerSchema,
-	type AttachParamsV1Input,
-	CustomerExpand,
+    type ApiCustomer,
+    ApiCustomerSchema,
+    type AttachParamsV1Input,
+    CustomerExpand,
 } from "@autumn/shared";
 import {
-	type ApiCustomerV5,
-	ApiCustomerV5Schema,
+    type ApiCustomerV5,
+    ApiCustomerV5Schema,
 } from "@shared/api/customers/apiCustomerV5";
 import {
-	type ApiCustomerV3,
-	ApiCustomerV3Schema,
+    type ApiCustomerV3,
+    ApiCustomerV3Schema,
 } from "@shared/api/customers/previousVersions/apiCustomerV3";
 import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
 import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect";
@@ -127,18 +127,18 @@ test.concurrent(`${chalk.yellowBright("get-customer: multi-entity customer retur
 	});
 
 	const refDir = `${import.meta.dir}/../../../references`;
-	await Bun.write(
-		`${refDir}/getCustomerV1Response.json`,
-		JSON.stringify(cusV1, null, 2),
-	);
-	await Bun.write(
-		`${refDir}/getCustomerV2_1Response.json`,
-		JSON.stringify(cusV2_1, null, 2),
-	);
-	await Bun.write(
-		`${refDir}/getCustomerV2_2Response.json`,
-		JSON.stringify(cusV2_2, null, 2),
-	);
+	// await Bun.write(
+	// 	`${refDir}/getCustomerV1Response.json`,
+	// 	JSON.stringify(cusV1, null, 2),
+	// );
+	// await Bun.write(
+	// 	`${refDir}/getCustomerV2_1Response.json`,
+	// 	JSON.stringify(cusV2_1, null, 2),
+	// );
+	// await Bun.write(
+	// 	`${refDir}/getCustomerV2_2Response.json`,
+	// 	JSON.stringify(cusV2_2, null, 2),
+	// );
 });
 
 test.concurrent(`${chalk.yellowBright("get-customer: expand empty array returns items")}`, async () => {

--- a/server/tests/setup-integration-tests.ts
+++ b/server/tests/setup-integration-tests.ts
@@ -6,6 +6,12 @@ import {
 } from "./utils/testInitUtils/createTestContext";
 
 const loadInfisicalSecrets = async () => {
+	// `bun test:integration` wraps the run in `infisical run --env=dev`, which
+	// already injects every secret into the parent process. Workers inherit
+	// those, so re-running the infisical CLI per worker is redundant churn
+	// (and a flake source). Skip when env is clearly already populated.
+	if (process.env.STRIPE_TEST_KEY || process.env.TESTS_ORG) return;
+
 	try {
 		const secrets = execSync(
 			"infisical secrets --env=dev --output=dotenv --recursive --silent",
@@ -33,10 +39,9 @@ const loadInfisicalSecrets = async () => {
  * export is a Proxy that reads the stash lazily, sidestepping import-order
  * races and top-level-await TDZ.
  *
- * `createTestContext` is wrapped in try/catch so pure-unit lanes (no
- * TESTS_ORG) still preload cleanly — unit tests don't read the default ctx.
- * argv-based unit/integration branching isn't reliable (bun only passes the
- * first path).
+ * Unit-only lanes (no TESTS_ORG) skip init entirely — unit tests don't read
+ * the default ctx. Integration lanes let any init error throw so the worker
+ * dies loudly instead of every test reporting the opaque Proxy error.
  */
 
 declare global {
@@ -48,14 +53,11 @@ console.log("--- Setup integration tests ---");
 await loadInfisicalSecrets();
 loadLocalEnv({ force: true });
 
-try {
+// Unit-only lanes don't set TESTS_ORG; silently skip there. Anything else
+// must succeed — a swallowed init failure here resurfaces as the opaque
+// "Default TestContext is not initialized" Proxy error from every test
+// scheduled on this worker.
+if (process.env.TESTS_ORG) {
 	globalThis.__autumnTestContext = await createTestContext();
 	console.log("--- Setup integration tests complete ---");
-} catch (err) {
-	console.warn(
-		"[preload] Skipping master-org TestContext initialization. " +
-			"Integration tests that read the default ctx will fail with a clear " +
-			"error. Reason:",
-		err instanceof Error ? err.message : err,
-	);
 }

--- a/server/tests/utils/testInitUtils/createTestContext.ts
+++ b/server/tests/utils/testInitUtils/createTestContext.ts
@@ -25,6 +25,35 @@ import { generateId } from "../../../src/utils/genUtils.js";
 
 const DEFAULT_ENV = AppEnv.Sandbox;
 
+// Retry transient DB/network failures during worker preload. Many workers
+// open pools simultaneously, occasionally tripping connection limits or
+// cold-start blips against PlanetScale.
+const withRetry = async <T>(
+	fn: () => Promise<T>,
+	{ label }: { label: string },
+): Promise<T> => {
+	const delays = [100, 300, 700];
+	let lastErr: unknown;
+	for (let attempt = 0; attempt <= delays.length; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastErr = err;
+			const message = err instanceof Error ? err.message : String(err);
+			const transient =
+				/ECONNRESET|ETIMEDOUT|ENETUNREACH|ECONNREFUSED|EAI_AGAIN|socket hang up|Connection terminated|pool|timeout/i.test(
+					message,
+				);
+			if (!transient || attempt === delays.length) throw err;
+			console.warn(
+				`[createTestContext] transient failure on "${label}" (attempt ${attempt + 1}): ${message}`,
+			);
+			await new Promise((r) => setTimeout(r, delays[attempt]));
+		}
+	}
+	throw lastErr;
+};
+
 export interface TestContext extends AutumnContext {
 	org: Organization;
 	env: AppEnv;
@@ -46,14 +75,20 @@ export const createTestContext = async () => {
 		);
 	}
 
-	const org = await OrgService.getBySlug({ db, slug: orgSlug });
+	const org = await withRetry(
+		() => OrgService.getBySlug({ db, slug: orgSlug }),
+		{ label: "OrgService.getBySlug" },
+	);
 	if (!org) {
 		throw new Error(`Org with slug "${orgSlug}" not found`);
 	}
 
 	const env = DEFAULT_ENV;
 	const stripeCli = createStripeCli({ org, env });
-	const features = await FeatureService.list({ db, orgId: org.id, env });
+	const features = await withRetry(
+		() => FeatureService.list({ db, orgId: org.id, env }),
+		{ label: "FeatureService.list" },
+	);
 
 	// Org secret key, set by test runner.
 	const orgSecretKey = process.env.UNIT_TEST_AUTUMN_SECRET_KEY || "";


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop preview billing calls from creating new Stripe customers to prevent duplicate Stripe customer IDs. Previews are now side‑effect free and respect existing state.

- **Bug Fixes**
  - Skip Stripe customer creation in preview flows (`preview_attach`, `multi_attach`, `update_subscription`, `create_schedule`) by propagating `preview` and setting `createStripeCustomerIfMissing: false`.
  - Stripe billing setup now honors `createIfMissing` and uses `getExpandedStripeCustomer` when previewing.
  - Read customers via `CusService.getFull` instead of the cached getter to avoid stale `processor.id`.
  - In Sandbox, clear active checkout-session locks to allow non-checkout actions.
  - Added clearer logs when feature balance cache is incomplete with reasons.

- **Tests**
  - Added regression test to confirm `billing.preview_attach` does not create a Stripe customer when missing.
  - Improved integration test stability with secret loading guard and transient retry on preload.

<sup>Written for commit bdb49a31269f06dcd2f66b3de183ef8b5c5bcab0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `previewAttach`, `previewUpdateSubscription`, and `previewCreateSchedule` were silently minting new Stripe customers on every call for customers with no existing `processor.id`. Because preview operations didn't refresh the Redis cache after writing the new Stripe customer ID to the DB, each subsequent preview call still saw `processor.id = null` and created another Stripe customer.

- **Bug fixes**: A `preview` flag is threaded through all billing context setup functions; when `true`, it sets `createStripeCustomerIfMissing: false` so `fetchStripeCustomerForBilling` calls `getExpandedStripeCustomer` (returns `undefined` for missing IDs) instead of `getOrCreateStripeCustomer`.
- **Bug fixes / Improvements**: `setupFullCustomerContext` now calls `CusService.getFull` directly instead of the cached `getOrSetCachedFullCustomer`, removing the stale-cache vector that allowed `processor.id = null` to persist across preview calls; a dedicated regression test confirms the fix.
- **Improvements**: Cache-miss diagnostics in `getCachedFeatureBalances` now include a `reason` string; sandbox checkout session locks are auto-cleared; test worker setup is hardened with retry logic and fails loudly on init errors instead of surfacing an opaque proxy error.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core fix is correct and well-tested; the main trade-off is that all billing context setups now bypass the Redis cache, which is worth revisiting for performance if traffic is high.

The fix correctly stops preview operations from creating Stripe customers by gating on a `preview` flag propagated through every relevant code path and confirmed by a dedicated regression test. The cache bypass in `setupFullCustomerContext` resolves the root cause but affects all billing operations, not just preview — dead commented-out code is also left in place. These are non-blocking quality concerns.

server/src/internal/billing/v2/setup/setupFullCustomerContext.ts — cache bypass scope and leftover commented code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts | Added `createIfMissing` flag; when false, calls `getExpandedStripeCustomer` with the optional processor ID — safely returns undefined when processor.id is absent, preventing Stripe customer creation during preview. |
| server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts | Threads new `createStripeCustomerIfMissing` option through to `fetchStripeCustomerForBilling`; clean propagation with safe default. |
| server/src/internal/billing/v2/setup/setupFullCustomerContext.ts | Replaced cached lookup with direct `CusService.getFull` DB read to avoid stale processor.id in Redis; effective fix but bypasses cache for all billing operations, not just preview. Dead commented-out code left in place. |
| server/src/internal/billing/v2/actions/locks/checkoutSessionLock/checkCheckoutSessionLock.ts | Sandbox environments now auto-clear checkout session locks, allowing non-checkout billing actions to proceed without being blocked by leftover test locks. |
| server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts | Added `reason` discriminant to all `{ kind: "missing" }` returns for improved cache-miss diagnostics; non-breaking, type-safe improvement. |
| server/tests/_temp/preview-attach-no-stripe-customer-create.test.ts | New regression test verifying that calling `previewAttach` twice on a customer with no Stripe ID leaves processor.id null; well-documented with clear red/green criteria. |
| server/tests/utils/testInitUtils/createTestContext.ts | Added `withRetry` helper with exponential back-off for transient DB/network failures during test worker preload. |
| server/tests/setup-integration-tests.ts | Optimised secret loading (skip infisical CLI when env already populated) and changed init to only run when TESTS_ORG is set, letting init errors surface loudly instead of being swallowed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as handlePreviewAttach
    participant Attach as attach()
    participant Setup as setupAttachBillingContext
    participant StripeBilling as setupStripeBillingContext
    participant Fetch as fetchStripeCustomerForBilling
    participant Stripe

    Client->>Handler: POST /billing/preview_attach
    Handler->>Attach: "attach({ preview: true })"
    Attach->>Setup: "setupAttachBillingContext({ preview: true })"
    Setup->>StripeBilling: "setupStripeBillingContext({ createStripeCustomerIfMissing: false })"
    StripeBilling->>Fetch: "fetchStripeCustomerForBilling({ createIfMissing: false })"

    alt processor.id exists
        Fetch->>Stripe: getExpandedStripeCustomer(processor.id)
        Stripe-->>Fetch: ExpandedStripeCustomer
        Fetch-->>StripeBilling: stripeCus + paymentMethod
    else processor.id is null/undefined
        Fetch->>Fetch: getExpandedStripeCustomer(undefined) returns undefined
        Fetch-->>StripeBilling: stripeCus undefined
        Note over StripeBilling: No Stripe customer created
    end

    StripeBilling-->>Setup: BillingContext (no new Stripe customer)
    Setup-->>Attach: AttachBillingContext
    Attach-->>Handler: billingContext + billingPlan
    Handler-->>Client: Preview response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/setup/setupFullCustomerContext.ts:14-19
**Commented-out dead code**

The old `getOrSetCachedFullCustomer` block is left as comments rather than removed. Now that `CusService.getFull` is the chosen implementation, the stale comment adds noise without providing useful context — the git history preserves the previous approach if it ever needs to be revisited.

### Issue 2 of 2
server/src/internal/billing/v2/setup/setupFullCustomerContext.ts:21-27
**Cache bypass applies to all billing operations, not just preview**

`setupFullCustomerContext` now always calls `CusService.getFull` (a direct DB read) for every billing context setup — including non-preview attach, update-subscription, and multi-attach. The root cause of the duplicate Stripe customer bug was that preview writes the new customer ID to the DB but never refreshes the Redis cache, so the next preview call still saw `processor.id = null`. A more surgical fix would be to bypass the cache only on the preview path (or to invalidate the cached entry after a Stripe customer is created). The current approach is safe and correct but silently removes the cache benefit for all billing setup calls under load.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["updated billing endpoints to read from c..."](https://github.com/useautumn/autumn/commit/bdb49a31269f06dcd2f66b3de183ef8b5c5bcab0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31740668)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->