### PR TITLE
fix: debug invalidation

### DIFF
--- a/server/src/external/redis/initUtils/createRedisClient.ts
+++ b/server/src/external/redis/initUtils/createRedisClient.ts
@@ -1,5 +1,6 @@
 import { Redis } from "ioredis";
 import { instrumentRedis } from "../otel/instrumentRedis.js";
+import { instrumentBalanceMutations } from "../utils/instrumentBalanceMutations.js";
 import { cacheBackupUrl } from "./redisConfig.js";
 import { registerRedisCommands } from "./registerRedisCommands.js";
 
@@ -41,6 +42,7 @@ export const createRedisClient = ({
 	// instrumentRedis must run first so its defineCommand patch
 	// is in place when commands are registered.
 	instrumentRedis({ redis: instance, region });
+	instrumentBalanceMutations({ redis: instance });
 	registerRedisCommands({ redisInstance: instance, supportsUpstashShebang });
 
 	return instance;

--- a/server/src/external/redis/utils/instrumentBalanceMutations.ts
+++ b/server/src/external/redis/utils/instrumentBalanceMutations.ts
@@ -1,0 +1,28 @@
+import type { Redis } from "ioredis";
+import { logger } from "@/external/logtail/logtailUtils.js";
+
+/**
+ * Wraps a Redis client's `hdel`, `del`, `unlink` so any call targeting a
+ * `shared_balances:*` key is logged. Diagnostic only — remove once the
+ * silent-deletion bug is identified.
+ */
+export const instrumentBalanceMutations = ({ redis }: { redis: Redis }) => {
+	const wrap = (method: "hdel" | "del" | "unlink") => {
+		const original = redis[method].bind(redis) as (
+			...args: unknown[]
+		) => Promise<unknown>;
+		(redis as unknown as Record<string, unknown>)[method] = (
+			...args: unknown[]
+		) => {
+			const first = args[0];
+			if (typeof first === "string" && first.includes("shared_balances")) {
+				logger.warn(`[balance-mutation] ${method.toUpperCase()} ${first}`);
+			}
+			return original(...args);
+		};
+	};
+
+	wrap("hdel");
+	wrap("del");
+	wrap("unlink");
+};

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts
@@ -1,5 +1,6 @@
 import type { AppEnv, Feature } from "@autumn/shared";
 import type { Redis } from "ioredis";
+import { logger } from "@/external/logtail/logtailUtils.js";
 import { batchDeleteCachedFullCustomers } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/batchDeleteCachedFullCustomers.js";
 import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildFullSubjectKey } from "../../builders/buildFullSubjectKey.js";
@@ -77,7 +78,11 @@ const batchInvalidateCachedFullSubjectsOnRedis = async ({
 				featureIds = orgFeatures.map((feature) => feature.id);
 			}
 
-			for (const featureId of new Set(featureIds)) {
+			const featureIdSet = Array.from(new Set(featureIds));
+			logger.warn(
+				`[batchInvalidateCachedFullSubjects] UNLINK customer=${customerId} features=${featureIdSet.join(",")}`,
+			);
+			for (const featureId of featureIdSet) {
 				writePipeline.unlink(
 					buildSharedFullSubjectBalanceKey({
 						orgId,

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateCustomerEntitlementBalance.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateCustomerEntitlementBalance.ts
@@ -1,4 +1,5 @@
 import type { Redis } from "ioredis";
+import { logger } from "@/external/logtail/logtailUtils.js";
 import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { buildSharedFullSubjectBalanceKey } from "../../builders/buildSharedFullSubjectBalanceKey.js";
 import { AGGREGATED_BALANCE_FIELD } from "../../config/fullSubjectCacheConfig.js";
@@ -35,6 +36,10 @@ export const invalidateCustomerEntitlementBalance = async ({
 		customerId,
 		featureId,
 	});
+
+	logger.warn(
+		`[invalidateCustomerEntitlementBalance] HDEL customer=${customerId} feature=${featureId} cusEnt=${customerEntitlementId}`,
+	);
 
 	await tryRedisWrite(
 		() =>

--- a/server/src/internal/customers/cache/fullSubject/actions/setCachedFullSubject/logSetCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/setCachedFullSubject/logSetCachedFullSubject.ts
@@ -1,0 +1,47 @@
+import type { NormalizedFullSubject } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { addToExtraLogs } from "@/utils/logging/addToExtraLogs.js";
+import type { CachedFullSubject } from "../../fullSubjectCacheModel.js";
+import type { SetCachedFullSubjectResult } from "./fullSubjectWriteTypes.js";
+import type { SharedBalanceWrite } from "./setSharedFullSubjectBalances.js";
+
+export const logSetCachedFullSubject = ({
+	ctx,
+	subjectLabel,
+	result,
+	cached,
+	balanceWrites,
+	normalized,
+}: {
+	ctx: AutumnContext;
+	subjectLabel: string;
+	result: SetCachedFullSubjectResult;
+	cached: CachedFullSubject;
+	balanceWrites: SharedBalanceWrite[];
+	normalized: NormalizedFullSubject;
+}): void => {
+	addToExtraLogs({
+		ctx,
+		extras: {
+			setCachedFullSubject: {
+				result,
+				subjectLabel,
+				customerEntitlementIdsByFeatureId:
+					cached.customerEntitlementIdsByFeatureId,
+				meteredFeatures: cached.meteredFeatures,
+				balanceWrites: balanceWrites.map(({ balanceKey, fields }) => ({
+					balanceKey,
+					fieldNames: Object.keys(fields),
+				})),
+				normalizedCustomerEntitlementIds: normalized.customer_entitlements.map(
+					(ce) => ({
+						id: ce.id,
+						feature_id: ce.feature_id,
+						internal_entity_id: ce.internal_entity_id ?? null,
+						customer_product_id: ce.customer_product_id ?? null,
+					}),
+				),
+			},
+		},
+	});
+};

--- a/server/src/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.ts
@@ -9,6 +9,7 @@ import {
 } from "../../config/fullSubjectCacheConfig.js";
 import { normalizedToCachedFullSubject } from "../../fullSubjectCacheModel.js";
 import type { SetCachedFullSubjectResult } from "./fullSubjectWriteTypes.js";
+import { logSetCachedFullSubject } from "./logSetCachedFullSubject.js";
 import { buildSharedBalanceWrites } from "./setSharedFullSubjectBalances.js";
 
 export type { SetCachedFullSubjectResult } from "./fullSubjectWriteTypes.js";
@@ -81,6 +82,15 @@ export const setCachedFullSubject = async ({
 	logger.info(
 		`[setCachedFullSubject] ${subjectLabel}: ${result ?? "FAILED"}, balances=${cached.meteredFeatures.length}`,
 	);
+
+	logSetCachedFullSubject({
+		ctx,
+		subjectLabel,
+		result: result ?? "FAILED",
+		cached,
+		balanceWrites,
+		normalized,
+	});
 
 	return result ?? "FAILED";
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add diagnostic instrumentation and structured logs around Redis balance invalidation to trace and debug unexpected deletions of `shared_balances:*` keys. This makes it easier to see when and why balances are unlinked/HDEL’d during cache writes and invalidations.

- **Bug Fixes**
  - Instrumented `ioredis` client to wrap `hdel`, `del`, and `unlink` and warn when touching `shared_balances:*` keys; enabled during client init.
  - Added warn logs in batch and single invalidation paths with customer/feature IDs and target keys before `UNLINK`/`HDEL`.
  - Logged `setCachedFullSubject` details to extra logs: result, CE IDs by feature, metered features, planned balance writes (key + field names), and normalized CE mappings.

<sup>Written for commit 8940db9ececefab370574ac56676801f843c2617. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds diagnostic logging around Redis `shared_balances` cache mutations to help track down a silent-deletion bug. No production behaviour is changed — all additions are observability-only.

- **[Bug fixes / Improvements]** `instrumentBalanceMutations` monkey-patches `hdel`, `del`, and `unlink` on the Redis client at creation time so any direct call touching a `shared_balances:*` key is emitted as a warning; wired into `createRedisClient` after `instrumentRedis`.
- **[Improvements]** Explicit `logger.warn` statements added to `batchInvalidateCachedFullSubjects` and `invalidateCustomerEntitlementBalance` to log exactly which keys and fields are being removed, covering the pipeline-based invalidation path that the client-level monkey-patch misses.
- **[Improvements]** New `logSetCachedFullSubject` helper captures a structured snapshot of every cache write (balance keys, field names, customer entitlement IDs) via `addToExtraLogs` for correlation with deletion events.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are diagnostic logging with no mutations to production data paths

Every change is observability-only and the Redis operations themselves are untouched. The main gap is that instrumentBalanceMutations only intercepts direct client calls and silently misses pipeline-queued unlink/del commands (the dominant invalidation path), and multi-key calls only log the first key. These gaps reduce how useful the diagnostic tool is for hunting the silent-deletion bug, but they don't risk incorrect production behavior.

server/src/external/redis/utils/instrumentBalanceMutations.ts — the pipeline blind-spot and multi-key logging gap are worth revisiting if the instrumentation doesn't surface the expected signals

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/utils/instrumentBalanceMutations.ts | New diagnostic wrapper that monkey-patches hdel/del/unlink on the Redis client; doesn't intercept pipeline commands and only logs the first key for multi-key calls |
| server/src/external/redis/initUtils/createRedisClient.ts | Wires in instrumentBalanceMutations after instrumentRedis — order is safe; straightforward one-liner addition |
| server/src/internal/customers/cache/fullSubject/actions/invalidate/batchInvalidateCachedFullSubjects.ts | Adds logger.warn before the pipeline unlink loop; correctly deduplicates featureIds before logging and iterating |
| server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateCustomerEntitlementBalance.ts | Adds logger.warn before the hdel call; logs customer, feature and entitlement IDs clearly |
| server/src/internal/customers/cache/fullSubject/actions/setCachedFullSubject/logSetCachedFullSubject.ts | New helper that emits structured cache-write details via addToExtraLogs; clean and focused |
| server/src/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.ts | Calls the new logSetCachedFullSubject after the write completes; no logic changes |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant setCachedFullSubject
    participant redisV2
    participant instrumentBalanceMutations
    participant batchInvalidate as batchInvalidateCachedFullSubjects
    participant invalidateBalance as invalidateCustomerEntitlementBalance

    Caller->>setCachedFullSubject: write cache
    setCachedFullSubject->>redisV2: setCachedFullSubject (Lua via pipeline)
    setCachedFullSubject->>setCachedFullSubject: logSetCachedFullSubject (addToExtraLogs)

    Caller->>batchInvalidate: invalidate customers
    batchInvalidate->>batchInvalidate: "logger.warn UNLINK customer=X features=Y"
    batchInvalidate->>redisV2: pipeline.unlink(sharedBalanceKey)
    Note over redisV2,instrumentBalanceMutations: Pipeline bypasses monkey-patch

    Caller->>invalidateBalance: invalidate single balance
    invalidateBalance->>invalidateBalance: "logger.warn HDEL customer=X"
    invalidateBalance->>redisV2: redisV2.hdel(balanceKey, ...)
    redisV2->>instrumentBalanceMutations: hdel intercepted → logger.warn [balance-mutation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/redis/utils/instrumentBalanceMutations.ts:10-22
**Pipeline commands bypass the monkey-patch**

Wrapping `redis.hdel`/`del`/`unlink` only intercepts direct client calls. Commands queued through a pipeline (`redis.pipeline().unlink(...)`) run on the pipeline object's own methods, not through these patched properties. In practice, `batchInvalidateCachedFullSubjects` already adds its own explicit `logger.warn`, so that path is covered — but any other pipeline-based `shared_balances` mutations (present or introduced later) won't be caught by this instrumentation. If the silent-deletion bug originates from a pipeline code path that doesn't have explicit logging, this wrapper will silently miss it.

### Issue 2 of 2
server/src/external/redis/utils/instrumentBalanceMutations.ts:17-19
**Multi-key `del`/`unlink` calls only log the first key**

ioredis accepts both `redis.del(key1, key2, ...)` and `redis.del([key1, key2, ...])`. In the array form `args[0]` is an array, so `typeof first === "string"` is false and nothing is logged. Even in the variadic form only `first` (the first key) is logged while additional `shared_balances` keys in the same call are silently omitted. For the `hdel` case the first arg is always the hash key, so there's no issue there.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: debug invalidation"](https://github.com/useautumn/autumn/commit/8940db9ececefab370574ac56676801f843c2617) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31755177)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->