### PR TITLE
fix: frontend attach & billing UI fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "autumn",

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -16,7 +16,6 @@ import {
 	isFreeProductV2,
 	isOneOffProductV2,
 	productV2ToFrontendProduct,
-	UsageModel,
 } from "@autumn/shared";
 import { useStore } from "@tanstack/react-form";
 import {
@@ -276,8 +275,7 @@ export function AttachFormProvider({
 		[fullCustomer?.customer_products],
 	);
 
-	const disableProration =
-		isFreeToPaidTransition && !hasActiveSubscription;
+	const disableProration = isFreeToPaidTransition && !hasActiveSubscription;
 
 	const { prepaidItems } = usePrepaidItems({ product: effectiveProduct });
 
@@ -324,19 +322,16 @@ export function AttachFormProvider({
 			resetGrantFree();
 		}
 
-		// Initialize prepaid options for the selected product
+		// Initialize prepaid options for the selected product.
+		// Values start as undefined (not 0) so that unset quantities are omitted
+		// from the request — the backend carries over existing prepaid balances
+		// when no option is provided for a feature.
 		if (product) {
-			const newInitialPrepaidOptions: Record<string, number> = {};
-			for (const item of product.items) {
-				if (item.usage_model === UsageModel.Prepaid && item.feature_id) {
-					newInitialPrepaidOptions[item.feature_id] = 0;
-				}
-			}
 			const currentPrepaidOptions = form.store.state.values.prepaidOptions;
 			const resolvedPrepaidOptions =
 				isProductChange || Object.keys(currentPrepaidOptions).length === 0
-					? newInitialPrepaidOptions
-					: { ...newInitialPrepaidOptions, ...currentPrepaidOptions };
+					? {}
+					: { ...currentPrepaidOptions };
 			form.setFieldValue("prepaidOptions", resolvedPrepaidOptions);
 			setInitialPrepaidOptions(
 				resolvedPrepaidOptions as Record<string, number>,

--- a/vite/src/components/forms/shared/SendInvoiceStage.tsx
+++ b/vite/src/components/forms/shared/SendInvoiceStage.tsx
@@ -363,8 +363,7 @@ export function SendInvoiceStageWithPreview({
 	scheduledStartDate?: number | null;
 }) {
 	const previewData = previewQuery.data;
-	const effectiveScheduledStartDate =
-		scheduledStartDate ?? previewData?.next_cycle?.starts_at ?? null;
+	const effectiveScheduledStartDate = scheduledStartDate ?? null;
 
 	const totals = useMemo(
 		() => buildAttachPreviewTotals({ previewData, startDate: null }),

--- a/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
+++ b/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
@@ -105,18 +105,18 @@ const AutoTopupRow = ({
 			<div className="ml-auto flex items-center gap-1.5 shrink-0">
 				<Pill>Threshold: {autoTopup.threshold.toLocaleString()}</Pill>
 				<Pill>Qty: {autoTopup.quantity.toLocaleString()}</Pill>
-				{purchaseLimit && (
-					<Pill className="hidden lg:inline">
-						{hasExpandedLimit
-							? `${purchaseLimit.count}/${purchaseLimit.limit} per ${purchaseLimit.interval}`
-							: `Limit: ${purchaseLimit.limit} per ${purchaseLimit.interval}`}
-					</Pill>
-				)}
-				{hasExpandedLimit && purchaseLimit.next_reset_at && (
-					<Pill className="hidden xl:inline">
-						Resets {format(new Date(purchaseLimit.next_reset_at), "MMM d")}
-					</Pill>
-				)}
+			{purchaseLimit && purchaseLimit.limit != null && purchaseLimit.interval != null && (
+				<Pill className="hidden lg:inline">
+					{hasExpandedLimit
+						? `${purchaseLimit.count}/${purchaseLimit.limit} per ${purchaseLimit.interval}`
+						: `Limit: ${purchaseLimit.limit} per ${purchaseLimit.interval}`}
+				</Pill>
+			)}
+			{hasExpandedLimit && purchaseLimit.next_reset_at && (
+				<Pill className="hidden xl:inline">
+					Resets {format(new Date(purchaseLimit.next_reset_at), "MMM d")}
+				</Pill>
+			)}
 			</div>
 		</button>
 	);

--- a/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/AttachProductSheet.tsx
@@ -18,7 +18,7 @@ import { AttachFooterV3 } from "@/components/forms/attach-v2/components/AttachFo
 import {
 	buildAttachPreviewTotals,
 	getAttachPreviewLineItems,
-	getAttachScheduledStartDate,
+	isFutureStartDate,
 } from "@/components/forms/attach-v2/utils/buildAttachPreviewTotals";
 import {
 	GenerateCheckoutStageWithPreview,
@@ -369,10 +369,7 @@ function SendInvoiceContent() {
 	const { setSheet } = useSheetStore();
 	const itemId = useSheetStore((s) => s.itemId);
 	const startDate = useStore(form.store, (state) => state.values.startDate);
-	const scheduledStartDate = getAttachScheduledStartDate({
-		startDate,
-		previewData: previewQuery.data,
-	});
+	const scheduledStartDate = isFutureStartDate(startDate) ? startDate : null;
 
 	return (
 		<SendInvoiceStageWithPreview

--- a/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx
@@ -86,7 +86,7 @@ export function BillingAutoTopupSheet() {
 		existingItem?.quantity?.toString() ?? "",
 	);
 	const [hasPurchaseLimit, setHasPurchaseLimit] = useState(
-		!!existingItem?.purchase_limit,
+		!!existingItem?.purchase_limit?.limit && !!existingItem?.purchase_limit?.interval,
 	);
 	const [purchaseLimitInterval, setPurchaseLimitInterval] = useState(
 		existingItem?.purchase_limit?.interval ?? "",

--- a/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx
@@ -1,4 +1,5 @@
 import type { Entity, FullCustomer } from "@autumn/shared";
+import { LATEST_VERSION } from "@autumn/shared";
 import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -26,7 +27,7 @@ export function RecordUsageSheet() {
 	const [scopeEntityId, setScopeEntityId] = useSheetScopeEntityId(
 		customer as FullCustomer | undefined,
 	);
-	const axiosInstance = useAxiosInstance();
+	const axiosInstance = useAxiosInstance({ version: LATEST_VERSION });
 	const queryClient = useQueryClient();
 
 	const fullCustomer = customer as FullCustomer | null;


### PR DESCRIPTION
## Summary
- **Prepaid options initialization**: Changed prepaid option values to start as `undefined` instead of `0` so unset quantities are omitted from the request — the backend carries over existing prepaid balances when no option is provided for a feature
- **Scheduled start date**: Simplified scheduled start date logic to only use the user-provided start date, removing fallback to `next_cycle.starts_at` from preview data
- **Auto top-up purchase limit display**: Added null checks for `purchase_limit.limit` and `purchase_limit.interval` before rendering limit pills, preventing display of incomplete data
- **Auto top-up sheet toggle**: Fixed the purchase limit toggle to only show as enabled when both `limit` and `interval` are set on the existing item
- **Record usage versioning**: Use `LATEST_VERSION` for the axios instance in RecordUsageSheet
- **Minor formatting**: Cleaned up line wrapping and removed unused `UsageModel` import

## Test plan
- [ ] Attach a product with prepaid items and verify existing balances are preserved when no new quantity is set
- [ ] Verify scheduled invoice start date displays correctly
- [ ] Check auto top-up rows with partial purchase limit data don't render broken pills
- [ ] Open auto top-up sheet for items with/without purchase limits and verify toggle state
- [ ] Record usage from customer page and verify it uses the latest API version

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes prepaid attach and billing UI to preserve prepaid balances, show the correct scheduled start date, and prevent partial purchase-limit UI. Also updates usage recording to the latest API version.

- **Bug Fixes**
  - Prepaid options now initialize as undefined, so unset quantities are omitted and existing balances are kept.
  - Scheduled start date uses only the user-selected date; removed fallback to preview’s next cycle.
  - Auto top-up: render limit pills only when both `limit` and `interval` exist; toggle shows enabled only when both are set.
  - Record Usage sheet uses the latest API via `useAxiosInstance({ version: LATEST_VERSION })` from `@autumn/shared`.

<sup>Written for commit 8c40f10cfe468936a9e391e2da3b4d263116f734. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ships a collection of frontend bug fixes across the attach flow and billing UI. The changes tighten prepaid-option initialisation, simplify scheduled-start-date logic, guard against rendering billing pills with incomplete data, and wire the record-usage sheet to the latest API version.

- **Prepaid options initialisation** — [Bug fixes] Options now start as an empty object instead of `{ feature_id: 0 }`, so unset quantities are omitted from attach requests and the backend correctly carries over existing prepaid balances.
- **Scheduled start date / auto top-up pill guards** — [Bug fixes] `effectiveScheduledStartDate` drops its fallback to `previewData.next_cycle.starts_at`; the purchase-limit toggle initialises correctly; and `limit`/`interval` null-checks prevent broken pill rendering.
- **Record usage API version** — [Improvements] `RecordUsageSheet` now passes `LATEST_VERSION` to its axios instance, aligning it with the rest of the customer-facing sheets.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are contained UI fixes with no backend contract changes.

The prepaid-option, toggle, and pill-guard changes are straightforward and well-scoped. The only rough edge is in CustomerBillingControlsSection: the "Resets" pill can appear without its companion "Limit" pill when a purchase-limit object has `count` and `next_reset_at` but null `limit`/`interval`, producing a slightly orphaned badge. This is cosmetic and unlikely in practice, but worth tidying.

vite/src/views/customers2/components/CustomerBillingControlsSection.tsx — pill indentation and the "Resets" pill guard

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx | Prepaid options now initialize as an empty object instead of `{ feature_id: 0 }`, so unset quantities are omitted from attach requests and the backend preserves existing balances. Unused `UsageModel` import removed. |
| vite/src/components/forms/shared/SendInvoiceStage.tsx | Simplified `effectiveScheduledStartDate` to drop the `previewData.next_cycle.starts_at` fallback; now returns only the user-provided `startDate` or `null`. |
| vite/src/views/customers2/components/CustomerBillingControlsSection.tsx | Added `limit != null && interval != null` guards on the purchase-limit pill. Pill elements were moved to the wrong indentation level (visually outside the parent flex `div`, though structurally correct in JSX). "Resets" pill lacks the same null guards as the Limit pill. |
| vite/src/views/customers2/components/sheets/AttachProductSheet.tsx | Replaced `getAttachScheduledStartDate` (which fell back to preview data) with an inline `isFutureStartDate` check so only an explicit future `startDate` is passed downstream. |
| vite/src/views/customers2/components/sheets/BillingAutoTopupSheet.tsx | Purchase-limit toggle now initialises as `true` only when both `limit` and `interval` are set on the existing item, preventing a toggled-on state for partially-populated limits. |
| vite/src/views/customers2/components/sheets/RecordUsageSheet.tsx | Axios instance now uses `LATEST_VERSION` so record-usage calls go through the latest API version. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Attach sheet] --> B{Product changed\nor no prepaid options?}
    B -- Yes --> C[Reset prepaidOptions to empty object\nundefined quantities omitted from request]
    B -- No --> D[Keep existing prepaidOptions]
    C --> E[Backend preserves\nexisting prepaid balances]
    D --> E

    F[User sets startDate] --> G{isFutureStartDate?}
    G -- Yes --> H[scheduledStartDate = startDate]
    G -- No --> I[scheduledStartDate = null]

    J[AutoTopupRow renders] --> K{purchaseLimit exists\nAND limit != null\nAND interval != null?}
    K -- Yes --> L[Render Limit pill]
    K -- No --> M[Skip Limit pill]
    L --> N{hasExpandedLimit\nAND next_reset_at?}
    M --> N
    N -- Yes --> O[Render Resets pill]
    N -- No --> P[Skip Resets pill]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers2/components/CustomerBillingControlsSection.tsx:115-119
**"Resets" pill can render without its "Limit" sibling**

The limit pill now requires both `purchaseLimit.limit != null && purchaseLimit.interval != null`, but the "Resets" pill only checks `hasExpandedLimit` (which just tests for the `count` key) and `next_reset_at`. In a state where `purchaseLimit` has `count` and `next_reset_at` but a null `limit` or `interval`, the "Resets on MMM d" badge will appear on its own with no "Limit: X per Y" context, which is confusing for users. The reset-date pill should guard on the same `limit != null && interval != null` condition as the pill it supplements.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["frontend fixes"](https://github.com/useautumn/autumn/commit/8c40f10cfe468936a9e391e2da3b4d263116f734) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31768721)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->