### PR TITLE
fix: save lock receipt for unlimited balance features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,11 +126,7 @@ Only update when the current work IS part of a project (see default-off rule abo
 
 Do NOT update context during normal coding work. Work first, compact at breakpoints.
 
-<<<<<<< HEAD
 A STATUS.md entry should record changes to the project itself -- not one-off work that merely uses the project (e.g. writing a consumer script of a framework is not a framework-project update).
-=======
-A STATUS.md entry should record changes to the project itself — not one-off work that merely uses the project (e.g. writing a consumer script of a framework is not a framework-project update).
->>>>>>> a62195ba706f12fbd35f7ecf48b4701011115101
 
 ### Compaction quality
 STATUS.md must be:

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "autumn",

--- a/server/src/internal/api/events/EventService.ts
+++ b/server/src/internal/api/events/EventService.ts
@@ -48,7 +48,7 @@ export class EventService {
 		env: string;
 		limit?: number;
 	}) {
-		if (process.env.NODE_ENV !== "development") return [];
+		if (process.env.NODE_ENV === "production") return [];
 		const results = await db
 			.select({
 				id: events.id,

--- a/server/src/internal/balances/finalizeLock/buildFinalizeLockContext.ts
+++ b/server/src/internal/balances/finalizeLock/buildFinalizeLockContext.ts
@@ -52,7 +52,11 @@ export const buildFinalizeLockContext = async ({
 		source: "runFinalizeLock",
 	});
 
-	const lockValue = calculateLockValue({ items: receipt.items });
+	const calculatedLockValue = calculateLockValue({ items: receipt.items });
+	const lockValue =
+		receipt.items.length === 0
+			? (receipt.overrideLockValue ?? calculatedLockValue)
+			: calculatedLockValue;
 	const finalValue =
 		params.action === "release" ? 0 : (params.override_value ?? lockValue);
 

--- a/server/src/internal/balances/utils/deduction/executePostgresDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/executePostgresDeduction.ts
@@ -118,8 +118,19 @@ export const executePostgresDeduction = async ({
 				options,
 			});
 
-			if (customerEntitlements.length === 0 || unlimitedFeatureIds.length > 0)
+			if (customerEntitlements.length === 0 || unlimitedFeatureIds.length > 0) {
+				if (unlimitedFeatureIds.length > 0 && preparedLock?.enabled) {
+					await saveLockReceipt({
+						lock: preparedLock,
+						customerId: fullCustomer.id || customerId,
+						featureId: feature.id,
+						entityId,
+						items: [],
+						overrideLockValue: toDeduct,
+					});
+				}
 				continue;
+			}
 
 			// Call the stored function to deduct from entitlements with credit costs
 			const result = await db.execute(

--- a/server/src/internal/balances/utils/deduction/executeRedisDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/executeRedisDeduction.ts
@@ -11,6 +11,7 @@ import { rollbackDeduction } from "@/internal/balances/utils/paidAllocatedFeatur
 import { buildFullCustomerCacheKey } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/fullCustomerCacheConfig.js";
 import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import { fireTrackWebhooks } from "../../trackWebhooks/fireTrackWebhooks.js";
+import { saveLockReceipt } from "../lock/saveLockReceipt.js";
 import type { DeductionOptions } from "../types/deductionTypes.js";
 import type { DeductionUpdate } from "../types/deductionUpdate.js";
 import type { FeatureDeduction } from "../types/featureDeduction.js";
@@ -116,6 +117,17 @@ export const executeRedisDeduction = async ({
 		});
 
 		if (unlimitedFeatureIds.length > 0) {
+			if (preparedLock) {
+				await saveLockReceipt({
+					lock: preparedLock,
+					customerId,
+					featureId: feature.id,
+					entityId,
+					items: [],
+					overrideLockValue: toDeduct,
+					redisInstance,
+				});
+			}
 			continue;
 		}
 

--- a/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
@@ -125,6 +125,7 @@ export const executePostgresDeductionV2 = async ({
 						featureId: feature.id,
 						entityId,
 						items: [],
+						overrideLockValue: toDeduct,
 						redisInstance: ctx.redisV2,
 					});
 				}

--- a/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
@@ -117,8 +117,19 @@ export const executePostgresDeductionV2 = async ({
 				options: resolvedOptions,
 			});
 
-			if (customerEntitlements.length === 0 || unlimitedFeatureIds.length > 0)
+			if (customerEntitlements.length === 0 || unlimitedFeatureIds.length > 0) {
+				if (unlimitedFeatureIds.length > 0 && preparedLock?.enabled) {
+					await saveLockReceiptV2({
+						lock: preparedLock,
+						customerId: fullSubject.customerId || customerId,
+						featureId: feature.id,
+						entityId,
+						items: [],
+						redisInstance: ctx.redisV2,
+					});
+				}
 				continue;
+			}
 
 			const result = await db.execute(
 				sql`SELECT * FROM deduct_from_cus_ents(

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -13,6 +13,7 @@ import {
 } from "@/internal/balances/track/v3/trackIdempotencyKey.js";
 import { fireTrackWebhooks } from "@/internal/balances/trackWebhooks/fireTrackWebhooks.js";
 import { createAllocatedInvoice } from "@/internal/balances/utils/allocatedInvoice/createAllocatedInvoice.js";
+import { saveLockReceiptV2 } from "@/internal/balances/utils/lockV2/saveLockReceiptV2.js";
 import { buildDeductFromSubjectBalancesKeys } from "@/internal/customers/cache/fullSubject/builders/buildDeductFromSubjectBalancesKeys.js";
 import { buildFullSubjectKey } from "@/internal/customers/cache/fullSubject/builders/buildFullSubjectKey.js";
 import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
@@ -128,6 +129,16 @@ export const executeRedisDeductionV2 = async ({
 		});
 
 		if (unlimitedFeatureIds.length > 0) {
+			if (preparedLock) {
+				await saveLockReceiptV2({
+					lock: preparedLock,
+					customerId,
+					featureId: feature.id,
+					entityId,
+					items: [],
+					redisInstance: redisInstance ?? ctx.redisV2,
+				});
+			}
 			continue;
 		}
 

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -136,6 +136,7 @@ export const executeRedisDeductionV2 = async ({
 					featureId: feature.id,
 					entityId,
 					items: [],
+					overrideLockValue: toDeduct,
 					redisInstance: redisInstance ?? ctx.redisV2,
 				});
 			}

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -129,7 +129,7 @@ export const executeRedisDeductionV2 = async ({
 		});
 
 		if (unlimitedFeatureIds.length > 0) {
-			if (preparedLock) {
+			if (preparedLock?.enabled) {
 				await saveLockReceiptV2({
 					lock: preparedLock,
 					customerId,

--- a/server/src/internal/balances/utils/lock/fetchLockReceipt.ts
+++ b/server/src/internal/balances/utils/lock/fetchLockReceipt.ts
@@ -14,6 +14,7 @@ export type LockReceipt = {
 	entity_id?: string | null;
 	expires_at?: number | null;
 	region?: string | null;
+	overrideLockValue?: number | null;
 	items: MutationLogItem[];
 };
 
@@ -62,6 +63,26 @@ const fetchAndClaimLockReceiptV2FromCandidates = async ({
 	return { found: false as const };
 };
 
+const isRedisWrongTypeError = (error: unknown) =>
+	error instanceof Error &&
+	/WRONGTYPE|wrong Redis type|wrong kind of value/i.test(error.message);
+
+const fetchLegacyLockReceiptJson = async ({
+	lockReceiptKey,
+}: {
+	lockReceiptKey: string;
+}) =>
+	tryRedisRead(async () => {
+		try {
+			return (await redis.call("JSON.GET", lockReceiptKey, "$")) as
+				| string
+				| null;
+		} catch (error) {
+			if (isRedisWrongTypeError(error)) return null;
+			throw error;
+		}
+	}, redis);
+
 export const fetchLockReceipt = async ({
 	ctx,
 	lockId,
@@ -81,11 +102,7 @@ export const fetchLockReceipt = async ({
 	// During org Redis migrations, V2 checks both shared and dedicated Redis.
 	// V1 half stays a plain JSON.GET — V1 finalize still claims via Lua afterwards.
 	const [rawReceiptV1, v2Result] = await Promise.all([
-		tryRedisRead(
-			() =>
-				redis.call("JSON.GET", lockReceiptKey, "$") as Promise<string | null>,
-			redis,
-		),
+		fetchLegacyLockReceiptJson({ lockReceiptKey }),
 		fetchAndClaimLockReceiptV2FromCandidates({
 			ctx,
 			lockId,

--- a/server/src/internal/balances/utils/lock/saveLockReceipt.ts
+++ b/server/src/internal/balances/utils/lock/saveLockReceipt.ts
@@ -10,6 +10,7 @@ export const saveLockReceipt = async ({
 	featureId,
 	entityId,
 	items,
+	overrideLockValue,
 	redisInstance,
 }: {
 	lock: {
@@ -24,6 +25,7 @@ export const saveLockReceipt = async ({
 	featureId: string;
 	entityId?: string;
 	items: MutationLogItem[];
+	overrideLockValue?: number;
 	redisInstance?: Redis;
 }) => {
 	const targetRedis = redisInstance ?? redis;
@@ -53,6 +55,7 @@ export const saveLockReceipt = async ({
 					entity_id: entityId ?? null,
 					expires_at: lock.expires_at ?? null,
 					created_at: lock.created_at,
+					overrideLockValue: overrideLockValue ?? null,
 					items,
 				}),
 			) as Promise<"OK" | null>,

--- a/server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts
+++ b/server/src/internal/balances/utils/lockV2/buildFinalizeLockContextV2.ts
@@ -48,7 +48,11 @@ export const buildFinalizeLockContextV2 = async ({
 		source: "runFinalizeLockV2",
 	});
 
-	const lockValue = calculateLockValue({ items: receipt.items });
+	const calculatedLockValue = calculateLockValue({ items: receipt.items });
+	const lockValue =
+		receipt.items.length === 0
+			? (receipt.overrideLockValue ?? calculatedLockValue)
+			: calculatedLockValue;
 	const finalValue =
 		params.action === "release" ? 0 : (params.override_value ?? lockValue);
 

--- a/server/src/internal/balances/utils/lockV2/saveLockReceiptV2.ts
+++ b/server/src/internal/balances/utils/lockV2/saveLockReceiptV2.ts
@@ -16,6 +16,7 @@ export const saveLockReceiptV2 = async ({
 	featureId,
 	entityId,
 	items,
+	overrideLockValue,
 	redisInstance,
 }: {
 	lock: {
@@ -30,6 +31,7 @@ export const saveLockReceiptV2 = async ({
 	featureId: string;
 	entityId?: string;
 	items: MutationLogItem[];
+	overrideLockValue?: number;
 	redisInstance: Redis;
 }) => {
 	const payload = JSON.stringify({
@@ -42,6 +44,7 @@ export const saveLockReceiptV2 = async ({
 		entity_id: entityId ?? null,
 		expires_at: lock.expires_at ?? null,
 		created_at: lock.created_at,
+		overrideLockValue: overrideLockValue ?? null,
 		items,
 	});
 

--- a/server/tests/integration/balances/lock/check-with-lock-unlimited.test.ts
+++ b/server/tests/integration/balances/lock/check-with-lock-unlimited.test.ts
@@ -17,6 +17,7 @@
 
 import { expect, test } from "bun:test";
 import type { ApiCustomerV5 } from "@autumn/shared";
+import { expectCustomerEventsCorrect } from "@tests/integration/balances/utils/events/expectCustomerEventsCorrect.js";
 import { deleteLock } from "@tests/integration/balances/utils/lockUtils/deleteLock.js";
 import { expectLockReceiptDeleted } from "@tests/integration/balances/utils/lockUtils/expectLockReceiptDeleted.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
@@ -24,6 +25,7 @@ import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { timeout } from "@/utils/genUtils";
 
 const makeUnlimitedProd = () =>
 	products.base({
@@ -65,6 +67,10 @@ test.concurrent(`${chalk.yellowBright("lock-unlimited: check with lock on unlimi
 	expect(finalizeResponse.success).toBe(true);
 
 	await expectLockReceiptDeleted({ ctx, lockId: lockKey });
+	await expectCustomerEventsCorrect({
+		customerId,
+		events: [{ value: 10 }],
+	});
 
 	const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
 	expect(customer).toBeDefined();
@@ -103,7 +109,13 @@ test.concurrent(`${chalk.yellowBright("lock-unlimited: check with lock on unlimi
 
 	expect(finalizeResponse.success).toBe(true);
 
+	await timeout(4000);
+
 	await expectLockReceiptDeleted({ ctx, lockId: lockKey });
+	await expectCustomerEventsCorrect({
+		customerId,
+		events: [{ value: -5 }, { value: 5 }],
+	});
 });
 
 // ── Contract assertion 3: check with lock=0 on unlimited, finalize confirm → success ──
@@ -140,4 +152,8 @@ test.concurrent(`${chalk.yellowBright("lock-unlimited: lock=0 on unlimited featu
 	expect(finalizeResponse.success).toBe(true);
 
 	await expectLockReceiptDeleted({ ctx, lockId: lockKey });
+	await expectCustomerEventsCorrect({
+		customerId,
+		events: [{ value: 0 }],
+	});
 });

--- a/server/tests/integration/balances/lock/check-with-lock-unlimited.test.ts
+++ b/server/tests/integration/balances/lock/check-with-lock-unlimited.test.ts
@@ -1,0 +1,143 @@
+/**
+ * TDD test for lock + finalize on unlimited balance features.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - check with lock=true on unlimited feature → allowed=true, lock receipt saved
+ *     - finalize confirm on unlimited lock → success, receipt deleted
+ *     - finalize release on unlimited lock → success, receipt deleted
+ *   Side effects:
+ *     - Lock receipt is saved to Redis with empty items for unlimited features
+ *     - Lock receipt is cleaned up after finalize
+ *
+ * Pre-fix red: check with lock on unlimited skips lock receipt save entirely,
+ *   so finalize throws "Lock not found for ID: ...".
+ * Post-fix green: empty lock receipt is saved, finalize finds and deletes it.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import { deleteLock } from "@tests/integration/balances/utils/lockUtils/deleteLock.js";
+import { expectLockReceiptDeleted } from "@tests/integration/balances/utils/lockUtils/expectLockReceiptDeleted.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const makeUnlimitedProd = () =>
+	products.base({
+		id: "unlimited",
+		items: [items.unlimitedMessages()],
+	});
+
+// ── Contract assertion 1: check with lock on unlimited → allowed, finalize confirm → success ──
+test.concurrent(`${chalk.yellowBright("lock-unlimited: check with lock on unlimited feature, finalize confirm succeeds")}`, async () => {
+	const unlimitedProd = makeUnlimitedProd();
+	const customerId = "lock-unlimited-confirm";
+	const lockKey = `${customerId}-lock`;
+
+	const { autumnV2_1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [unlimitedProd] }),
+		],
+		actions: [s.attach({ productId: unlimitedProd.id })],
+	});
+
+	await deleteLock({ ctx, lockId: lockKey });
+
+	const checkResponse = await autumnV2_1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		required_balance: 10,
+		lock: { enabled: true, lock_id: lockKey },
+	});
+
+	expect(checkResponse.allowed).toBe(true);
+
+	const finalizeResponse = await autumnV2_1.balances.finalize({
+		lock_id: lockKey,
+		action: "confirm",
+	});
+
+	expect(finalizeResponse.success).toBe(true);
+
+	await expectLockReceiptDeleted({ ctx, lockId: lockKey });
+
+	const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(customer).toBeDefined();
+});
+
+// ── Contract assertion 2: check with lock on unlimited → allowed, finalize release → success ──
+test.concurrent(`${chalk.yellowBright("lock-unlimited: check with lock on unlimited feature, finalize release succeeds")}`, async () => {
+	const unlimitedProd = makeUnlimitedProd();
+	const customerId = "lock-unlimited-release";
+	const lockKey = `${customerId}-lock`;
+
+	const { autumnV2_1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [unlimitedProd] }),
+		],
+		actions: [s.attach({ productId: unlimitedProd.id })],
+	});
+
+	await deleteLock({ ctx, lockId: lockKey });
+
+	const checkResponse = await autumnV2_1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		required_balance: 5,
+		lock: { enabled: true, lock_id: lockKey },
+	});
+
+	expect(checkResponse.allowed).toBe(true);
+
+	const finalizeResponse = await autumnV2_1.balances.finalize({
+		lock_id: lockKey,
+		action: "release",
+	});
+
+	expect(finalizeResponse.success).toBe(true);
+
+	await expectLockReceiptDeleted({ ctx, lockId: lockKey });
+});
+
+// ── Contract assertion 3: check with lock=0 on unlimited, finalize confirm → success ──
+test.concurrent(`${chalk.yellowBright("lock-unlimited: lock=0 on unlimited feature, finalize confirm succeeds")}`, async () => {
+	const unlimitedProd = makeUnlimitedProd();
+	const customerId = "lock-unlimited-zero";
+	const lockKey = `${customerId}-lock`;
+
+	const { autumnV2_1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [unlimitedProd] }),
+		],
+		actions: [s.attach({ productId: unlimitedProd.id })],
+	});
+
+	await deleteLock({ ctx, lockId: lockKey });
+
+	const checkResponse = await autumnV2_1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		required_balance: 0,
+		lock: { enabled: true, lock_id: lockKey },
+	});
+
+	expect(checkResponse.allowed).toBe(true);
+
+	const finalizeResponse = await autumnV2_1.balances.finalize({
+		lock_id: lockKey,
+		action: "confirm",
+	});
+
+	expect(finalizeResponse.success).toBe(true);
+
+	await expectLockReceiptDeleted({ ctx, lockId: lockKey });
+});


### PR DESCRIPTION
## Summary
- When `check` is called with `lock: true` on an unlimited-balance feature, both deduction executors (`executeRedisDeductionV2` and `executePostgresDeductionV2`) skipped the entire loop iteration — including the lock receipt save — causing `finalize` to fail with "Lock not found for ID: ..."
- Now saves an empty lock receipt (with `items: []`) before continuing, so `finalize` can find, claim, and delete it as a no-op (lockValue=0, finalValue=0)
- Adds integration test with 3 cases: confirm, release, and zero-value lock on unlimited features

## Test plan
- [ ] `server/tests/integration/balances/lock/check-with-lock-unlimited.test.ts` — 3 concurrent tests covering confirm, release, and lock=0 on unlimited features
- [ ] Verify existing lock edge-case tests still pass
- [ ] Verify finalize on unlimited features no longer throws "Lock not found"

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Save an empty lock receipt when `check` is called with `lock: true` on unlimited-balance features, storing the requested amount as `overrideLockValue` so `finalize` can confirm/release cleanly, write correct events, and avoid "Lock not found". Also ensures events are available outside production for testing.

- **Bug Fixes**
  - V1 and V2 deduction executors (Redis and Postgres) now save lock receipts with `items: []` and `overrideLockValue` for unlimited features when a lock is present.
  - Finalize contexts (`buildFinalizeLockContext`, `buildFinalizeLockContextV2`) read `overrideLockValue` when receipts have no items, ensuring confirm/release compute the right values and insert correct events.
  - Lock receipt I/O: `fetchLockReceipt` tolerates legacy Redis WRONGTYPE during migrations; `saveLockReceipt`/`saveLockReceiptV2` persist `overrideLockValue`.
  - `EventService` returns events when `NODE_ENV` is not `production`, enabling verification in tests; added integration tests covering confirm, release, and zero-value locks on unlimited features, including receipt save, cleanup, and event assertions.

<sup>Written for commit fa43131b45beb16589ae8f6dee70b1140c12df83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where calling `check` with `lock: true` on an unlimited-balance feature caused `finalize` to throw "Lock not found" because both deduction executors skipped the lock-receipt save when the feature was unlimited. The fix saves an empty receipt (with `items: []`) so `finalize` can locate, claim, and clean it up as a no-op.

- **Bug fixes**: `executePostgresDeductionV2` and `executeRedisDeductionV2` now call `saveLockReceiptV2(items: [])` before `continue`-ing on unlimited features when a lock is present, ensuring `finalize` always finds the receipt.
- **Improvements**: New integration test (`check-with-lock-unlimited.test.ts`) covers confirm, release, and zero-value-lock scenarios concurrently.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix is narrow, correctly guarded, and backed by integration tests covering all three finalize paths.

Both executors correctly save an empty lock receipt for unlimited features. The only notable gap is a style inconsistency: the Redis executor uses `if (preparedLock)` while Postgres uses `if (preparedLock?.enabled)`. These are equivalent given the schema today, but the mismatch is worth aligning.

The Redis executor in `executeRedisDeductionV2.ts` has the minor condition mismatch worth a quick look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts | Saves an empty lock receipt for unlimited features when lock is enabled, fixing finalize's "Lock not found" error; guarded by both `unlimitedFeatureIds.length > 0` and `preparedLock?.enabled`. |
| server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts | Mirrors the Postgres fix for the Redis path; uses `if (preparedLock)` rather than `if (preparedLock?.enabled)` — a minor style inconsistency (functionally equivalent given the schema). |
| server/tests/integration/balances/lock/check-with-lock-unlimited.test.ts | New integration test with three concurrent cases (confirm, release, zero-value) covering the fixed unlimited-lock flow end-to-end. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant CheckHandler
    participant executeRedisDeductionV2
    participant saveLockReceiptV2
    participant Redis
    participant FinalizeHandler

    Client->>CheckHandler: "check(feature, lock: {enabled: true, lock_id})"
    CheckHandler->>executeRedisDeductionV2: "deduct(lock=preparedLock)"
    executeRedisDeductionV2->>executeRedisDeductionV2: prepareFeatureDeductionV2()
    alt "unlimitedFeatureIds.length > 0"
        Note over executeRedisDeductionV2: Before: continue (no receipt saved)
        Note over executeRedisDeductionV2: After: save empty receipt, then continue
        executeRedisDeductionV2->>saveLockReceiptV2: "saveLockReceiptV2(items=[])"
        saveLockReceiptV2->>Redis: SET key payload NX EXAT ttl
        Redis-->>saveLockReceiptV2: OK
    else limited feature
        executeRedisDeductionV2->>Redis: deductFromSubjectBalances (Lua)
        Redis-->>executeRedisDeductionV2: result
        executeRedisDeductionV2->>saveLockReceiptV2: "saveLockReceiptV2(items=mutationLogs)"
        saveLockReceiptV2->>Redis: SET key payload NX EXAT ttl
    end
    CheckHandler-->>Client: "{allowed: true}"

    Client->>FinalizeHandler: "finalize(lock_id, action: confirm|release)"
    FinalizeHandler->>Redis: GET lock receipt key
    Redis-->>FinalizeHandler: "receipt (items=[])"
    FinalizeHandler->>Redis: DEL lock receipt key
    FinalizeHandler-->>Client: "{success: true}"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts:131-133
The condition `if (preparedLock)` is a plain truthy check, whereas the parallel Postgres executor explicitly guards with `preparedLock?.enabled`. Since `LockParams.enabled` is typed as `z.literal(true)`, the two are functionally equivalent today — but the inconsistency makes the intent less obvious and could silently allow a receipt save if a lock object with `enabled: false` were ever produced upstream.

```suggestion
		if (unlimitedFeatureIds.length > 0) {
			if (preparedLock?.enabled) {
				await saveLockReceiptV2({
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: save lock receipt for unlimited bal..."](https://github.com/useautumn/autumn/commit/9ae91bc54c4d9fae466f493bab57608c3974db60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31796574)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->