### PR TITLE
chore: 🤖 minimum bun release age

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,3 +10,7 @@ timeout = 0
 
 [test.env]
 NODE_ENV = "test"
+
+[install]
+# Only install package versions published at least 3 days ago
+minimumReleaseAge = 259200 # seconds


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set `bun` installs to only allow package versions at least 3 days old by adding `install.minimumReleaseAge = 259200` in `bunfig.toml`. This helps avoid breakage from fresh or yanked releases and stabilizes installs/CI.

<sup>Written for commit 0312e948def3283310d35366d8c56c01cea58d36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `minimumReleaseAge = 259200` (seconds) entry to the `[install]` section of `bunfig.toml`, instructing Bun to skip package versions published less than 3 days ago. This is a supply-chain security hardening measure that matches the official Bun documentation example verbatim.

- **[Improvements]** Adds `minimumReleaseAge = 259200` to `bunfig.toml`'s `[install]` section, preventing Bun from installing packages released fewer than 3 days ago — a standard mitigation against typosquatting and fast-publish supply-chain attacks.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds a single well-documented Bun configuration entry with no logic changes.

The change is a one-liner config addition. The value 259200 seconds (3 days) is the exact example from the official Bun documentation, and the unit (seconds) is correct for this field. No code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| bunfig.toml | Adds [install] section with minimumReleaseAge = 259200 seconds (3 days) — value and units match the official Bun documentation example exactly; no issues found. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun install] --> B{minimumReleaseAge\nconfigured?}
    B -- No --> C[Resolve latest\nmatching version]
    B -- Yes\n259200s = 3 days --> D[Fetch candidate\npackage versions]
    D --> E{Published >= 3 days\nago?}
    E -- Yes --> F[Include version\nin resolution]
    E -- No --> G[Filter out version\ntoo recent]
    F --> H[Install resolved\npackages]
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: 🤖 minimum bun release age"](https://github.com/useautumn/autumn/commit/0312e948def3283310d35366d8c56c01cea58d36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31939931)</sub>

<!-- /greptile_comment -->