### PR TITLE
ci: migrations

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,120 @@
+name: Run Database Migrations
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+      - dev
+    paths:
+      - "shared/drizzle/**"
+      - "shared/db/**"
+      - "shared/drizzle.config.ts"
+      - ".github/workflows/migrations.yml"
+
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to run migrations against"
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+
+jobs:
+  determine-environment:
+    name: Determine Environment
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.env.outputs.environment }}
+    steps:
+      - name: Determine environment from branch or input
+        id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
+          else
+            BRANCH_NAME=${GITHUB_REF#refs/heads/}
+            case "$BRANCH_NAME" in
+              main)
+                echo "environment=prod" >> $GITHUB_OUTPUT
+                ;;
+              staging)
+                echo "environment=staging" >> $GITHUB_OUTPUT
+                ;;
+              dev)
+                echo "environment=dev" >> $GITHUB_OUTPUT
+                ;;
+            esac
+          fi
+
+  migrate-dev:
+    name: Migrate Dev Database
+    needs: determine-environment
+    if: needs.determine-environment.outputs.environment == 'dev'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
+        run: bun db:migrate
+
+  migrate-staging:
+    name: Migrate Staging Database
+    needs: determine-environment
+    if: needs.determine-environment.outputs.environment == 'staging'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_STAGING }}
+        run: bun db:migrate
+
+  migrate-prod:
+    name: Migrate Production Database
+    needs: determine-environment
+    if: needs.determine-environment.outputs.environment == 'prod'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+        run: bun db:migrate

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -34,7 +34,20 @@ jobs:
         id: env
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
+            SELECTED_ENV="${{ github.event.inputs.environment }}"
+            BRANCH_NAME="${{ github.ref_name }}"
+
+            if [ "$SELECTED_ENV" = "prod" ] && [ "$BRANCH_NAME" != "main" ]; then
+              echo "::error::Production migrations can only be triggered from the main branch"
+              exit 1
+            fi
+
+            if [ "$SELECTED_ENV" = "staging" ] && [ "$BRANCH_NAME" != "staging" ] && [ "$BRANCH_NAME" != "main" ]; then
+              echo "::error::Staging migrations can only be triggered from the staging or main branch"
+              exit 1
+            fi
+
+            echo "environment=$SELECTED_ENV" >> $GITHUB_OUTPUT
           else
             BRANCH_NAME=${GITHUB_REF#refs/heads/}
             case "$BRANCH_NAME" in
@@ -50,11 +63,23 @@ jobs:
             esac
           fi
 
-  migrate-dev:
-    name: Migrate Dev Database
+  migrate:
+    name: Migrate ${{ matrix.env }} Database
     needs: determine-environment
-    if: needs.determine-environment.outputs.environment == 'dev'
+    if: needs.determine-environment.outputs.environment == matrix.env
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - env: dev
+            secret: DATABASE_URL_DEV
+          - env: staging
+            secret: DATABASE_URL_STAGING
+          - env: prod
+            secret: DATABASE_URL_PROD
+            environment: prod
+
+    environment: ${{ matrix.environment }}
 
     steps:
       - name: Checkout code
@@ -70,51 +95,5 @@ jobs:
 
       - name: Run migrations
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
-        run: bun db:migrate
-
-  migrate-staging:
-    name: Migrate Staging Database
-    needs: determine-environment
-    if: needs.determine-environment.outputs.environment == 'staging'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.10
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Run migrations
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_STAGING }}
-        run: bun db:migrate
-
-  migrate-prod:
-    name: Migrate Production Database
-    needs: determine-environment
-    if: needs.determine-environment.outputs.environment == 'prod'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.10
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Run migrations
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+          DATABASE_URL: ${{ secrets[matrix.secret] }}
         run: bun db:migrate

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.env.outputs.environment }}
+      secret_name: ${{ steps.env.outputs.secret_name }}
     steps:
       - name: Determine environment from branch or input
         id: env
@@ -47,39 +48,30 @@ jobs:
               exit 1
             fi
 
-            echo "environment=$SELECTED_ENV" >> $GITHUB_OUTPUT
+            ENV="$SELECTED_ENV"
           else
             BRANCH_NAME=${GITHUB_REF#refs/heads/}
             case "$BRANCH_NAME" in
-              main)
-                echo "environment=prod" >> $GITHUB_OUTPUT
-                ;;
-              staging)
-                echo "environment=staging" >> $GITHUB_OUTPUT
-                ;;
-              dev)
-                echo "environment=dev" >> $GITHUB_OUTPUT
-                ;;
+              main) ENV="prod" ;;
+              staging) ENV="staging" ;;
+              dev) ENV="dev" ;;
             esac
           fi
 
-  migrate:
-    name: Migrate ${{ matrix.env }} Database
-    needs: determine-environment
-    if: needs.determine-environment.outputs.environment == matrix.env
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - env: dev
-            secret: DATABASE_URL_DEV
-          - env: staging
-            secret: DATABASE_URL_STAGING
-          - env: prod
-            secret: DATABASE_URL_PROD
-            environment: prod
+          echo "environment=$ENV" >> $GITHUB_OUTPUT
 
-    environment: ${{ matrix.environment }}
+          case "$ENV" in
+            dev) echo "secret_name=DATABASE_URL_DEV" >> $GITHUB_OUTPUT ;;
+            staging) echo "secret_name=DATABASE_URL_STAGING" >> $GITHUB_OUTPUT ;;
+            prod) echo "secret_name=DATABASE_URL_PROD" >> $GITHUB_OUTPUT ;;
+          esac
+
+  migrate:
+    name: Migrate ${{ needs.determine-environment.outputs.environment }} Database
+    needs: determine-environment
+    if: needs.determine-environment.outputs.environment != ''
+    runs-on: ubuntu-latest
+    environment: ${{ needs.determine-environment.outputs.environment == 'prod' && 'prod' || '' }}
 
     steps:
       - name: Checkout code
@@ -95,5 +87,5 @@ jobs:
 
       - name: Run migrations
         env:
-          DATABASE_URL: ${{ secrets[matrix.secret] }}
+          DATABASE_URL: ${{ secrets[needs.determine-environment.outputs.secret_name] }}
         run: bun db:migrate

--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,6 @@ next-env.d.ts
 *.rdb
 
 
-shared/drizzle
 
 
 run.sh

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1715600000000,
+			"tag": "0010_steady_ares",
+			"breakpoints": true
+		}
+	]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to run Drizzle migrations on dev, staging, and prod on push and on manual dispatch, with prod protected by approvals. Tracks the Drizzle journal and un-ignores `shared/drizzle`.

- **New Features**
  - Auto-selects environment (`main`→prod, `staging`→staging, `dev`→dev); manual input allowed with branch guards (prod only from `main`, staging from `staging`/`main`).
  - Single job with dynamic secret selection via `determine-environment` outputs; prod runs under the `prod` GitHub Environment for required approval.
  - Uses `bun` 1.3.10 to run `bun db:migrate` with `DATABASE_URL_*` secrets.
  - Triggers only on changes to `shared/drizzle/**`, `shared/db/**`, `shared/drizzle.config.ts`, or the workflow file.

- **Migration**
  - Set GitHub secrets: `DATABASE_URL_DEV`, `DATABASE_URL_STAGING`, `DATABASE_URL_PROD`.
  - Create a GitHub Environment named `prod` with required reviewers.
  - Ensure a `bun db:migrate` script exists and reads `DATABASE_URL`.

<sup>Written for commit d0b9e28cdb7f3144345ecaa4fd888b825572030e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a GitHub Actions workflow that automatically runs Drizzle database migrations when changes land on the `dev`, `staging`, or `main` branches. It also un-gitignores `shared/drizzle` and commits the first tracked migration file (`0010_steady_ares`).

- **[Improvements]** New `migrations.yml` workflow maps branch names to environments (dev \u2192 dev, staging \u2192 staging, main \u2192 prod) and supports manual dispatch with an explicit environment choice.
- **[Improvements]** `shared/drizzle` removed from `.gitignore` so migration SQL files and the Drizzle journal are now version-controlled.
- **[Bug fixes]** `shared/drizzle/meta/_journal.json` added as the migration journal, though only idx 10 is present \u2014 migrations 0000\u20130009 remain absent from source control.
</details>

<h3>Confidence Score: 3/5</h3>

The production migration job runs automatically on every push to main with no human approval step, making this risky to merge without adding environment protection rules first.

Any merge to main immediately triggers a live production database migration. Combined with the absence of the first 10 historical migrations from source control, there are two distinct gaps that could cause production data issues before this workflow is hardened.

.github/workflows/migrations.yml needs a GitHub Environment protection rule on the prod job. shared/drizzle/meta/_journal.json should ideally include the complete migration history (0000-0009).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/migrations.yml | New CI workflow that auto-runs database migrations on push to main/staging/dev; production job has no environment protection gate, running migrations immediately without approval on every main push. |
| shared/drizzle/meta/_journal.json | First committed Drizzle migration journal; only contains idx 10, omitting the 10 prior migrations that were previously gitignored and are now irrecoverable from source control. |
| .gitignore | Removes `shared/drizzle` from gitignore so migration files are now tracked in version control. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([push / workflow_dispatch]) --> B[determine-environment]
    B -->|branch = dev or input = dev| C[migrate-dev\nDATABASE_URL_DEV]
    B -->|branch = staging or input = staging| D[migrate-staging\nDATABASE_URL_STAGING]
    B -->|branch = main or input = prod| E[migrate-prod\nDATABASE_URL_PROD]

    C --> C1[bun install]
    C1 --> C2[bun db:migrate]

    D --> D1[bun install]
    D1 --> D2[bun db:migrate]

    E --> E1[bun install]
    E1 --> E2[bun db:migrate]

    style E fill:#ff9999,stroke:#cc0000
    style E1 fill:#ff9999,stroke:#cc0000
    style E2 fill:#ff9999,stroke:#cc0000
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.github/workflows/migrations.yml:93-120
**No approval gate before production migrations run**

The `migrate-prod` job fires automatically on every push to `main` with no GitHub [Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) protection rules. If a bad migration lands on `main` — even accidentally — it will execute against the production database immediately without any human review step. Adding a GitHub Environment named `prod` with required reviewers would pause execution and require an explicit approval before the migration runs.

### Issue 2 of 3
shared/drizzle/meta/_journal.json:1-13
**Historical migrations 0000–0009 are absent from the repository**

The journal starts at `idx: 10` (`0010_steady_ares`) but the preceding 10 SQL migration files are not committed. While existing databases that had those migrations applied before `shared/drizzle` was gitignored will still work, any fresh database (e.g., a new dev environment or disaster-recovery restore) will only receive migration 10, leaving the schema incomplete and the first 10 migrations unrecoverable from source control.

### Issue 3 of 3
.github/workflows/migrations.yml:53-120
The three migration jobs are structurally identical — only the secret name and condition differ. A matrix strategy would eliminate the duplication and make future changes (e.g., adding a new Bun version pin or step) require a single edit instead of three.

```suggestion
  migrate:
    name: Migrate ${{ matrix.env }} Database
    needs: determine-environment
    if: needs.determine-environment.outputs.environment == matrix.env
    runs-on: ubuntu-latest
    strategy:
      matrix:
        include:
          - env: dev
            secret: DATABASE_URL_DEV
          - env: staging
            secret: DATABASE_URL_STAGING
          - env: prod
            secret: DATABASE_URL_PROD
            environment: prod

    environment: ${{ matrix.environment }}

    steps:
      - name: Checkout code
        uses: actions/checkout@v4

      - name: Set up Bun
        uses: oven-sh/setup-bun@v2
        with:
          bun-version: 1.3.10

      - name: Install dependencies
        run: bun install

      - name: Run migrations
        env:
          DATABASE_URL: ${{ secrets[matrix.secret] }}
        run: bun db:migrate
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: migrations"](https://github.com/useautumn/autumn/commit/7ed9ef733ce7e98d30589faa0fa2917e98f81fd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31945496)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->