### PR TITLE
add FORWARD_QUERY to events.datasource for deductions deploy

### DIFF
--- a/server/tinybird/datasources/events.datasource
+++ b/server/tinybird/datasources/events.datasource
@@ -22,3 +22,22 @@ SCHEMA >
 ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "org_id, env, customer_id, event_name, timestamp"
+
+FORWARD_QUERY >
+    SELECT
+        id,
+        org_id,
+        org_slug,
+        internal_customer_id,
+        env,
+        created_at,
+        timestamp,
+        event_name,
+        idempotency_key,
+        value,
+        set_usage,
+        entity_id,
+        internal_entity_id,
+        customer_id,
+        properties,
+        defaultValueOfTypeName('JSON(max_dynamic_paths = 16, max_dynamic_types = 2)') AS deductions


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a FORWARD_QUERY to the Tinybird `events.datasource` to expose a stable schema for the deductions rollout, including a `deductions` JSON field with a default type. This enables the production deductions deploy and prevents schema errors in downstream pipes.

<sup>Written for commit e453cad605438a43eb439e24364af1fb339d4cc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

