### PR TITLE
fix: intentionally remove platform check call

### DIFF
--- a/server/src/internal/platform/platformBeta/platformBetaRouter.ts
+++ b/server/src/internal/platform/platformBeta/platformBetaRouter.ts
@@ -1,4 +1,3 @@
-import { Autumn } from "autumn-js";
 import { Hono } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { handleCreatePlatformOrg } from "./handlers/handleCreatePlatformOrg.js";
@@ -24,12 +23,13 @@ platformBetaRouter.use("*", async (c, next) => {
 	}
 
 	try {
-		const autumn = new Autumn();
-		const { allowed } = await autumn.check({
-			customerId: org.id,
-			featureId: "platform",
-		});
+		// const autumn = new Autumn();
+		// const { allowed } = await autumn.check({
+		// 	customerId: org.id,
+		// 	featureId: "platform",
+		// });
 
+		const allowed = true;
 		if (!allowed) {
 			return c.json(
 				{


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bypassed the platform feature gate in the platform beta router by removing the `autumn-js` check and defaulting to allowed = true. This unblocks access to platform endpoints for all orgs during the beta.

<sup>Written for commit 21ec54b670e94bedd69580cb34ce3b9e1a8daaa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR intentionally removes the Autumn feature-check call that gated access to the platform API, replacing it with `const allowed = true` so all authenticated organizations can reach the platform endpoints unconditionally.

- **Bug fixes** — Removes the `autumn-js` Autumn check that was blocking platform API access; hardcodes `allowed = true` as a stopgap while the proper gate is evaluated.
- **Improvements** — Drops the `autumn-js` import that is no longer used.
</details>


<h3>Confidence Score: 4/5</h3>

The change is intentional and safe to merge; it opens the platform API to all authenticated orgs rather than blocking on a feature check.

The hardcoded `allowed = true` leaves an unreachable `if (!allowed)` guard and a `try/catch` that now only wraps `await next()`, which is leftover dead code worth cleaning up but does not affect runtime correctness.

server/src/internal/platform/platformBeta/platformBetaRouter.ts — the commented-out feature check and the dead 403 branch could be removed to keep the middleware clean.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/platform/platformBeta/platformBetaRouter.ts | Replaces the Autumn feature-gate check with a hardcoded `allowed = true`, intentionally opening the platform API to all authenticated orgs; the `if (!allowed)` 403 branch is now dead code. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as platformBetaRouter middleware
    participant Handler as Platform Handler

    Client->>Middleware: "Request to /platform-beta/*"

    alt AUTUMN_SECRET_KEY not set
        Middleware->>Handler: next() (bypass)
    else AUTUMN_SECRET_KEY set (after this PR)
        Note over Middleware: allowed = true (hardcoded)
        Middleware->>Handler: next() (always allowed)
    end

    Handler-->>Client: Response
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/platform/platformBeta/platformBetaRouter.ts`, line 33-42 ([link](https://github.com/useautumn/autumn/blob/21ec54b670e94bedd69580cb34ce3b9e1a8daaa0/server/src/internal/platform/platformBeta/platformBetaRouter.ts#L33-L42)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unreachable 403 branch** — with `allowed` hardcoded to `true`, the `if (!allowed)` block can never execute, making the entire guard and its 403 response dead code. If the intent is to temporarily open access to all orgs, the block (and likely the wrapping `try/catch` that now only calls `await next()`) can be removed to keep the middleware honest about what it actually does.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/platform/platformBeta/platformBetaRouter.ts
   Line: 33-42

   Comment:
   **Unreachable 403 branch** — with `allowed` hardcoded to `true`, the `if (!allowed)` block can never execute, making the entire guard and its 403 response dead code. If the intent is to temporarily open access to all orgs, the block (and likely the wrapping `try/catch` that now only calls `await next()`) can be removed to keep the middleware honest about what it actually does.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/platform/platformBeta/platformBetaRouter.ts:33-42
**Unreachable 403 branch** — with `allowed` hardcoded to `true`, the `if (!allowed)` block can never execute, making the entire guard and its 403 response dead code. If the intent is to temporarily open access to all orgs, the block (and likely the wrapping `try/catch` that now only calls `await next()`) can be removed to keep the middleware honest about what it actually does.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: intentionally remove platform check..."](https://github.com/useautumn/autumn/commit/21ec54b670e94bedd69580cb34ce3b9e1a8daaa0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32002696)</sub>

<!-- /greptile_comment -->