### PR TITLE
Support separate worker Redis endpoint in admin ui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   AWS_REGION: us-west-2
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: axiom-ingest-cuts
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: axiom-ingest-cuts private-public-org-redis-endpoints
 
 jobs:
   checks:

--- a/server/src/external/redis/customerRedisRoutingInfo.ts
+++ b/server/src/external/redis/customerRedisRoutingInfo.ts
@@ -1,4 +1,5 @@
 import type { OrgRedisConfig } from "@autumn/shared";
+import { getOrgRedisEndpoint } from "./orgRedisEndpoint.js";
 import type { OrgWithRedisConfig } from "./orgRedisPool.js";
 
 export type CustomerRedisRoutingInfo = {
@@ -33,10 +34,11 @@ export const getCustomerRedisRoutingInfoForOrg = ({
 
 	const bucket = getCustomerBucket(customerId);
 	const usesDedicatedRedis = bucket < org.redis_config.migrationPercent;
+	const redisEndpoint = getOrgRedisEndpoint({ redisConfig: org.redis_config });
 
 	return {
 		bucket,
-		redisUrl: usesDedicatedRedis ? org.redis_config.url : undefined,
+		redisUrl: usesDedicatedRedis ? redisEndpoint.url : undefined,
 		usesDedicatedRedis,
 	};
 };

--- a/server/src/external/redis/orgRedisEndpoint.ts
+++ b/server/src/external/redis/orgRedisEndpoint.ts
@@ -1,0 +1,32 @@
+import type { OrgRedisConfig } from "@autumn/shared";
+
+export type OrgRedisRuntime = "default" | "worker";
+
+export const getOrgRedisRuntime = (): OrgRedisRuntime =>
+	process.env.AUTUMN_PROCESS_TYPE === "worker" ? "worker" : "default";
+
+export const getOrgRedisEndpoint = ({
+	redisConfig,
+	runtime = getOrgRedisRuntime(),
+}: {
+	redisConfig: OrgRedisConfig;
+	runtime?: OrgRedisRuntime;
+}) => {
+	if (
+		runtime === "worker" &&
+		redisConfig.workerConnectionString &&
+		redisConfig.workerUrl
+	) {
+		return {
+			connectionString: redisConfig.workerConnectionString,
+			url: redisConfig.workerUrl,
+			runtime,
+		};
+	}
+
+	return {
+		connectionString: redisConfig.connectionString,
+		url: redisConfig.url,
+		runtime: "default" as const,
+	};
+};

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -6,6 +6,7 @@ import { OrgService } from "@/internal/orgs/OrgService.js";
 import { decryptData } from "@/utils/encryptUtils.js";
 import { createRedisConnection, currentRegion } from "./initRedis.js";
 import { REDIS_V2_COMMAND_TIMEOUT_MS } from "./initUtils/redisV2Config.js";
+import { getOrgRedisEndpoint } from "./orgRedisEndpoint.js";
 import { resolveRedisV2 } from "./resolveRedisV2.js";
 
 export type OrgWithRedisConfig = {
@@ -48,19 +49,20 @@ const createOrgRedisConnection = ({
 export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
 	if (!org.redis_config) return resolveRedisV2();
 
+	const endpoint = getOrgRedisEndpoint({ redisConfig: org.redis_config });
 	const existing = pool.get(org.id);
 	if (existing) {
-		if (existing.url === org.redis_config.url) return existing.instance;
+		if (existing.url === endpoint.url) return existing.instance;
 		existing.instance.disconnect();
 		pool.delete(org.id);
 	}
 
 	let connectionString: string;
 	try {
-		connectionString = decryptData(org.redis_config.connectionString);
+		connectionString = decryptData(endpoint.connectionString);
 	} catch (error) {
 		logger.error(
-			`[OrgRedis] Failed to decrypt redis_config for org ${org.id}, falling back to shared Redis V2`,
+			`[OrgRedis] Failed to decrypt ${endpoint.runtime} redis_config for org ${org.id}, falling back to shared Redis V2`,
 		);
 		if (error instanceof Error) {
 			logger.error(error);
@@ -72,7 +74,7 @@ export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
 		connectionString,
 		orgId: org.id,
 	});
-	pool.set(org.id, { instance, url: org.redis_config.url });
+	pool.set(org.id, { instance, url: endpoint.url });
 	return instance;
 };
 

--- a/server/src/internal/admin/handleAdminOrgRedisConfig.ts
+++ b/server/src/internal/admin/handleAdminOrgRedisConfig.ts
@@ -9,6 +9,37 @@ import { encryptData } from "@/utils/encryptUtils.js";
 const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
 
 const orgIdParam = z.object({ org_id: z.string().min(1) });
+const redisConfigBody = z.object({
+	connectionString: z.string().optional(),
+	workerConnectionString: z.string().optional(),
+});
+
+const parseRedisUrl = ({
+	connectionString,
+	label,
+}: {
+	connectionString: string;
+	label: string;
+}) => {
+	try {
+		const redisUrl = new URL(connectionString);
+		if (!REDIS_PROTOCOLS.has(redisUrl.protocol)) {
+			throw new RecaseError({
+				message: `Invalid ${label}: expected redis:// or rediss://`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		return redisUrl;
+	} catch (error) {
+		if (error instanceof RecaseError) throw error;
+		throw new RecaseError({
+			message: `Invalid ${label}: could not parse URL`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+};
 
 /**
  * GET /admin/orgs/:org_id/redis
@@ -28,6 +59,7 @@ export const handleGetAdminOrgRedisConfig = createRoute({
 			redis_config: org.redis_config
 				? {
 						host: org.redis_config.url,
+						workerHost: org.redis_config.workerUrl ?? null,
 						migrationPercent: org.redis_config.migrationPercent,
 						previousMigrationPercent: org.redis_config.previousMigrationPercent,
 						migrationChangedAt: org.redis_config.migrationChangedAt,
@@ -38,61 +70,86 @@ export const handleGetAdminOrgRedisConfig = createRoute({
 });
 
 /**
- * PATCH /admin/orgs/:org_id/redis  body: { connectionString }
- * Initial-create the redis_config for the target org. Encrypts connection
- * string, stores host separately, sets migrationPercent: 0.
+ * PATCH /admin/orgs/:org_id/redis
+ * Creates redis_config for the target org, or updates endpoints while the
+ * migration is still at 0%. Connection strings are encrypted; hosts are stored
+ * separately so the frontend can show non-secret routing state.
  */
 export const handleUpsertAdminOrgRedisConfig = createRoute({
 	scopes: [Scopes.Superuser],
 	params: orgIdParam,
-	body: z.object({ connectionString: z.string().min(1) }),
+	body: redisConfigBody,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, logger } = ctx;
 		const { org_id: orgId } = c.req.param();
-		const { connectionString: rawConnectionString } = c.req.valid("json");
-		const connectionString = rawConnectionString.trim();
+		const {
+			connectionString: rawConnectionString,
+			workerConnectionString: rawWorkerConnectionString,
+		} = c.req.valid("json");
+		const connectionString = rawConnectionString?.trim();
+		const workerConnectionString = rawWorkerConnectionString?.trim();
 
 		const org = await OrgService.get({ db, orgId });
 
-		if (org.redis_config) {
+		if (!org.redis_config && !connectionString) {
 			throw new RecaseError({
-				message:
-					"Redis config already exists for this org. Remove it before creating a new one.",
+				message: "Connection string is required",
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});
 		}
 
-		let redisUrl: URL;
-		try {
-			redisUrl = new URL(connectionString);
-		} catch {
+		if (org.redis_config && org.redis_config.migrationPercent > 0) {
 			throw new RecaseError({
-				message: "Invalid connection string: could not parse URL",
+				message: `Cannot update Redis endpoints while migrationPercent is ${org.redis_config.migrationPercent}%. Set it to 0 first.`,
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});
 		}
-		if (!REDIS_PROTOCOLS.has(redisUrl.protocol)) {
-			throw new RecaseError({
-				message: "Invalid connection string: expected redis:// or rediss://",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
+
+		const redisUrl = connectionString
+			? parseRedisUrl({
+					connectionString,
+					label: "connection string",
+				})
+			: undefined;
+		const workerRedisUrl = workerConnectionString
+			? parseRedisUrl({
+					connectionString: workerConnectionString,
+					label: "worker connection string",
+				})
+			: undefined;
 
 		const now = Date.now();
+		const nextConnectionString = connectionString
+			? encryptData(connectionString)
+			: org.redis_config?.connectionString;
+		const nextUrl = redisUrl?.host ?? org.redis_config?.url;
+
+		if (!nextConnectionString || !nextUrl) {
+			throw new RecaseError({
+				message: "Connection string is required",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
 		const updatedOrg = await OrgService.update({
 			db,
 			orgId: org.id,
 			updates: {
 				redis_config: {
-					connectionString: encryptData(connectionString),
-					url: redisUrl.host,
-					migrationPercent: 0,
-					previousMigrationPercent: 0,
-					migrationChangedAt: now,
+					connectionString: nextConnectionString,
+					workerConnectionString: workerConnectionString
+						? encryptData(workerConnectionString)
+						: org.redis_config?.workerConnectionString,
+					url: nextUrl,
+					workerUrl: workerRedisUrl?.host ?? org.redis_config?.workerUrl,
+					migrationPercent: org.redis_config?.migrationPercent ?? 0,
+					previousMigrationPercent:
+						org.redis_config?.previousMigrationPercent ?? 0,
+					migrationChangedAt: org.redis_config?.migrationChangedAt ?? now,
 				},
 			},
 		});
@@ -101,7 +158,7 @@ export const handleUpsertAdminOrgRedisConfig = createRoute({
 			getOrgRedis({ org: updatedOrg });
 			await clearOrgCache({ db, orgId: org.id, env: ctx.env, logger });
 			logger.info(
-				`[admin/handleUpsertAdminOrgRedisConfig] org=${org.id}: redis_config created, url=${redisUrl.host}, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
+				`[admin/handleUpsertAdminOrgRedisConfig] org=${org.id}: redis_config upserted, url=${redisUrl?.host ?? org.redis_config?.url}, workerUrl=${workerRedisUrl?.host ?? org.redis_config?.workerUrl ?? "none"}, actor=${ctx.user?.email ?? ctx.userId ?? "unknown"}`,
 			);
 		}
 

--- a/server/src/internal/admin/handleListAdminOrgs.ts
+++ b/server/src/internal/admin/handleListAdminOrgs.ts
@@ -1,4 +1,4 @@
-import { member, organizations, user, Scopes } from "@autumn/shared";
+import { member, organizations, Scopes, user } from "@autumn/shared";
 import { and, desc, eq, gt, gte, ilike, inArray, lt, or } from "drizzle-orm";
 import { createRoute } from "../../honoMiddlewares/routeHandler";
 import { getRequestBlockConfigFromSource } from "../misc/requestBlocks/requestBlockStore.js";
@@ -107,6 +107,7 @@ export const handleListAdminOrgs = createRoute({
 					redis_config: rawRedisConfig
 						? {
 								url: rawRedisConfig.url,
+								workerUrl: rawRedisConfig.workerUrl,
 								migrationPercent: rawRedisConfig.migrationPercent,
 							}
 						: null,

--- a/server/src/internal/orgs/handlers/handleRedisConfig.ts
+++ b/server/src/internal/orgs/handlers/handleRedisConfig.ts
@@ -7,17 +7,50 @@ import { OrgService } from "../OrgService.js";
 import { clearOrgCache } from "../orgUtils/clearOrgCache.js";
 
 const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
+const redisConfigBody = z.object({
+	connectionString: z.string().min(1),
+	workerConnectionString: z.string().optional(),
+});
+
+const parseRedisUrl = ({
+	connectionString,
+	label,
+}: {
+	connectionString: string;
+	label: string;
+}) => {
+	try {
+		const redisUrl = new URL(connectionString);
+		if (!REDIS_PROTOCOLS.has(redisUrl.protocol)) {
+			throw new RecaseError({
+				message: `Invalid ${label}: expected redis:// or rediss://`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		return redisUrl;
+	} catch (error) {
+		if (error instanceof RecaseError) throw error;
+		throw new RecaseError({
+			message: `Invalid ${label}: could not parse URL`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+};
 
 export const handleUpsertRedisConfig = createRoute({
 	scopes: [Scopes.Organisation.Write],
-	body: z.object({
-		connectionString: z.string().min(1),
-	}),
+	body: redisConfigBody,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, org, logger } = ctx;
-		const { connectionString: rawConnectionString } = c.req.valid("json");
+		const {
+			connectionString: rawConnectionString,
+			workerConnectionString: rawWorkerConnectionString,
+		} = c.req.valid("json");
 		const connectionString = rawConnectionString.trim();
+		const workerConnectionString = rawWorkerConnectionString?.trim();
 
 		if (!connectionString) {
 			throw new RecaseError({
@@ -36,23 +69,16 @@ export const handleUpsertRedisConfig = createRoute({
 			});
 		}
 
-		let redisUrl: URL;
-		try {
-			redisUrl = new URL(connectionString);
-		} catch {
-			throw new RecaseError({
-				message: "Invalid connection string: could not parse URL",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-		if (!REDIS_PROTOCOLS.has(redisUrl.protocol)) {
-			throw new RecaseError({
-				message: "Invalid connection string: expected redis:// or rediss://",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
+		const redisUrl = parseRedisUrl({
+			connectionString,
+			label: "connection string",
+		});
+		const workerRedisUrl = workerConnectionString
+			? parseRedisUrl({
+					connectionString: workerConnectionString,
+					label: "worker connection string",
+				})
+			: undefined;
 
 		const now = Date.now();
 		const updatedOrg = await OrgService.update({
@@ -61,7 +87,11 @@ export const handleUpsertRedisConfig = createRoute({
 			updates: {
 				redis_config: {
 					connectionString: encryptData(connectionString),
+					workerConnectionString: workerConnectionString
+						? encryptData(workerConnectionString)
+						: undefined,
 					url: redisUrl.host,
+					workerUrl: workerRedisUrl?.host,
 					migrationPercent: 0,
 					previousMigrationPercent: 0,
 					migrationChangedAt: now,

--- a/server/src/internal/orgs/orgUtils.ts
+++ b/server/src/internal/orgs/orgUtils.ts
@@ -268,6 +268,7 @@ export const createOrgResponse = ({
 		redis_config: org.redis_config
 			? {
 					host: org.redis_config.url,
+					workerHost: org.redis_config.workerUrl ?? null,
 					migrationPercent: org.redis_config.migrationPercent,
 				}
 			: null,

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -1,6 +1,8 @@
 import "dotenv/config";
 import cluster from "node:cluster";
 
+process.env.AUTUMN_PROCESS_TYPE = "worker";
+
 import { initInfisical } from "./external/infisical/initInfisical.js";
 import { logger } from "./external/logtail/logtailUtils.js";
 import {
@@ -104,11 +106,8 @@ if (cluster.isPrimary) {
 	const { primeRedisMonitor } = await import(
 		"./external/redis/initUtils/redisAvailability.js"
 	);
-	const {
-		primeRedisV2Monitor,
-		startRedisV2Monitor,
-		stopRedisV2Monitor,
-	} = await import("./external/redis/initUtils/redisV2Availability.js");
+	const { primeRedisV2Monitor, startRedisV2Monitor, stopRedisV2Monitor } =
+		await import("./external/redis/initUtils/redisV2Availability.js");
 	const { startRedisMonitor, stopRedisMonitor } = await import(
 		"./external/redis/initRedis.js"
 	);

--- a/server/tests/unit/redis/org-redis-endpoint-selection.test.ts
+++ b/server/tests/unit/redis/org-redis-endpoint-selection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import type { OrgRedisConfig } from "@autumn/shared";
+import {
+	getOrgRedisEndpoint,
+	getOrgRedisRuntime,
+} from "@/external/redis/orgRedisEndpoint.js";
+
+const makeRedisConfig = (
+	overrides: Partial<OrgRedisConfig> = {},
+): OrgRedisConfig => ({
+	connectionString: "encrypted-private",
+	workerConnectionString: "encrypted-public",
+	url: "private.dragonflydb.cloud:6379",
+	workerUrl: "public.dragonflydb.cloud:6385",
+	migrationPercent: 50,
+	previousMigrationPercent: 0,
+	migrationChangedAt: 1000,
+	...overrides,
+});
+
+describe("org Redis endpoint selection", () => {
+	test("uses the primary endpoint for API/default runtime", () => {
+		expect(
+			getOrgRedisEndpoint({
+				redisConfig: makeRedisConfig(),
+				runtime: "default",
+			}),
+		).toEqual({
+			connectionString: "encrypted-private",
+			url: "private.dragonflydb.cloud:6379",
+			runtime: "default",
+		});
+	});
+
+	test("uses the worker endpoint for worker runtime when configured", () => {
+		expect(
+			getOrgRedisEndpoint({
+				redisConfig: makeRedisConfig(),
+				runtime: "worker",
+			}),
+		).toEqual({
+			connectionString: "encrypted-public",
+			url: "public.dragonflydb.cloud:6385",
+			runtime: "worker",
+		});
+	});
+
+	test("falls back to the primary endpoint for workers without a worker endpoint", () => {
+		expect(
+			getOrgRedisEndpoint({
+				redisConfig: makeRedisConfig({
+					workerConnectionString: undefined,
+					workerUrl: undefined,
+				}),
+				runtime: "worker",
+			}),
+		).toEqual({
+			connectionString: "encrypted-private",
+			url: "private.dragonflydb.cloud:6379",
+			runtime: "default",
+		});
+	});
+
+	test("detects worker runtime from AUTUMN_PROCESS_TYPE", () => {
+		const originalProcessType = process.env.AUTUMN_PROCESS_TYPE;
+
+		process.env.AUTUMN_PROCESS_TYPE = "worker";
+		expect(getOrgRedisRuntime()).toBe("worker");
+
+		process.env.AUTUMN_PROCESS_TYPE = "server";
+		expect(getOrgRedisRuntime()).toBe("default");
+
+		if (originalProcessType === undefined) {
+			delete process.env.AUTUMN_PROCESS_TYPE;
+		} else {
+			process.env.AUTUMN_PROCESS_TYPE = originalProcessType;
+		}
+	});
+});

--- a/shared/models/orgModels/frontendOrg.ts
+++ b/shared/models/orgModels/frontendOrg.ts
@@ -27,6 +27,7 @@ export const FrontendOrgSchema = z.object({
 	redis_config: z
 		.object({
 			host: z.string(),
+			workerHost: z.string().nullable().optional(),
 			migrationPercent: z.number(),
 		})
 		.nullable(),

--- a/shared/models/orgModels/orgTable.ts
+++ b/shared/models/orgModels/orgTable.ts
@@ -44,8 +44,12 @@ export type StripeConnectConfig = {
 export type OrgRedisConfig = {
 	/** AES-256-CBC encrypted full Redis connection string via encryptData() */
 	connectionString: string;
+	/** Optional worker-specific encrypted Redis connection string */
+	workerConnectionString?: string;
 	/** Plain domain/host only, used for pool URL-change detection */
 	url: string;
+	/** Optional worker-specific plain domain/host */
+	workerUrl?: string;
 	/** Percentage of customers routed to the dedicated Redis (0-100) */
 	migrationPercent: number;
 	/** The migrationPercent before the last change, used for staleness detection */

--- a/vite/src/views/admin/AdminOrgColumns.tsx
+++ b/vite/src/views/admin/AdminOrgColumns.tsx
@@ -18,6 +18,7 @@ export type AdminOrg = {
 	};
 	redis_config: {
 		url: string;
+		workerUrl?: string;
 		migrationPercent: number;
 	} | null;
 };

--- a/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
+++ b/vite/src/views/admin/components/OrgRedisConfigDialog.tsx
@@ -30,6 +30,7 @@ type AdminOrgRedisConfigResponse = {
 	org_slug: string;
 	redis_config: {
 		host: string;
+		workerHost: string | null;
 		migrationPercent: number;
 		previousMigrationPercent: number;
 		migrationChangedAt: number;
@@ -52,6 +53,7 @@ export function OrgRedisConfigDialog({
 	const axiosInstance = useAxiosInstance();
 
 	const [connectionString, setConnectionString] = useState("");
+	const [workerConnectionString, setWorkerConnectionString] = useState("");
 	// `null` = "show the current server value". A string means the admin has
 	// typed something; that draft takes precedence until a successful update
 	// or a dialog reopen clears it. Deriving `migrationInput` during render
@@ -80,6 +82,11 @@ export function OrgRedisConfigDialog({
 	const cfg = data?.redis_config ?? null;
 	const migrationInput =
 		migrationInputDraft ?? (cfg ? String(cfg.migrationPercent) : "");
+	const endpointUpdateDisabled = !!cfg && cfg.migrationPercent > 0;
+	const canSubmitEndpoints = cfg
+		? !endpointUpdateDisabled &&
+			!!(connectionString.trim() || workerConnectionString.trim())
+		: !!connectionString.trim();
 
 	// Surface load failures as a toast — only when there's no data to fall
 	// back on. After a successful mutation triggers a refetch, transient GET
@@ -96,6 +103,7 @@ export function OrgRedisConfigDialog({
 	useEffect(() => {
 		if (open && orgId) {
 			setConnectionString("");
+			setWorkerConnectionString("");
 			setRemoveConfirm("");
 			setMigrationInputDraft(null);
 		}
@@ -121,17 +129,33 @@ export function OrgRedisConfigDialog({
 	};
 
 	const handleConnect = async () => {
-		if (!orgId || !connectionString.trim()) return;
+		const primaryConnectionString = connectionString.trim();
+		const workerRedisConnectionString = workerConnectionString.trim();
+		if (!orgId) return;
+		if (!cfg && !primaryConnectionString) return;
+		if (cfg && !primaryConnectionString && !workerRedisConnectionString) return;
+
 		setSaving(true);
 		try {
 			await axiosInstance.patch(`/admin/orgs/${orgId}/redis`, {
-				connectionString: connectionString.trim(),
+				...(primaryConnectionString
+					? { connectionString: primaryConnectionString }
+					: {}),
+				...(workerRedisConnectionString
+					? { workerConnectionString: workerRedisConnectionString }
+					: {}),
 			});
 			setConnectionString("");
-			toast.success("Redis connected");
+			setWorkerConnectionString("");
+			toast.success(cfg ? "Redis endpoints updated" : "Redis connected");
 			await refreshAfterMutation();
 		} catch (error) {
-			toast.error(getBackendErr(error, "Failed to connect Redis"));
+			toast.error(
+				getBackendErr(
+					error,
+					cfg ? "Failed to update Redis endpoints" : "Failed to connect Redis",
+				),
+			);
 		} finally {
 			setSaving(false);
 		}
@@ -192,8 +216,51 @@ export function OrgRedisConfigDialog({
 				) : cfg ? (
 					<div className="flex flex-col gap-4">
 						<div className="flex flex-col gap-1">
-							<FormLabel>Connected host</FormLabel>
+							<FormLabel>API/server host</FormLabel>
 							<Input value={cfg.host} readOnly className="font-mono text-xs" />
+						</div>
+
+						<div className="flex flex-col gap-1">
+							<FormLabel>Worker host</FormLabel>
+							<Input
+								value={cfg.workerHost ?? "Using API/server host"}
+								readOnly
+								className="font-mono text-xs"
+							/>
+						</div>
+
+						<div className="flex flex-col gap-2 border-t border-stroke pt-4">
+							<FormLabel>Update endpoints</FormLabel>
+							{endpointUpdateDisabled && (
+								<span className="text-t4 text-xs">
+									Set migration percentage to 0 before changing endpoints.
+								</span>
+							)}
+							<div className="flex flex-col gap-1">
+								<Input
+									value={connectionString}
+									onChange={(e) => setConnectionString(e.target.value)}
+									placeholder="Leave blank to keep current API/server URI"
+									disabled={endpointUpdateDisabled}
+									className="font-mono text-xs"
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Input
+									value={workerConnectionString}
+									onChange={(e) => setWorkerConnectionString(e.target.value)}
+									placeholder="Optional worker URI; blank keeps current"
+									disabled={endpointUpdateDisabled}
+									className="font-mono text-xs"
+								/>
+							</div>
+							<Button
+								onClick={handleConnect}
+								disabled={saving || !canSubmitEndpoints}
+								size="sm"
+							>
+								{saving ? "Updating…" : "Update endpoints"}
+							</Button>
 						</div>
 
 						<div className="flex flex-col gap-1">
@@ -261,21 +328,33 @@ export function OrgRedisConfigDialog({
 					</div>
 				) : (
 					<div className="flex flex-col gap-3">
-						<FormLabel>Redis connection string</FormLabel>
-						<Input
-							value={connectionString}
-							onChange={(e) => setConnectionString(e.target.value)}
-							placeholder="rediss://default:password@host:port"
-							className="font-mono text-xs"
-						/>
+						<div className="flex flex-col gap-1">
+							<FormLabel>API/server Redis connection string</FormLabel>
+							<Input
+								value={connectionString}
+								onChange={(e) => setConnectionString(e.target.value)}
+								placeholder="rediss://default:password@private-host:6379"
+								className="font-mono text-xs"
+							/>
+						</div>
+						<div className="flex flex-col gap-1">
+							<FormLabel>Worker Redis connection string</FormLabel>
+							<Input
+								value={workerConnectionString}
+								onChange={(e) => setWorkerConnectionString(e.target.value)}
+								placeholder="Optional: rediss://default:password@public-host:6385"
+								className="font-mono text-xs"
+							/>
+						</div>
 						<span className="text-t4 text-[11px]">
 							Stored encrypted (AES-256-CBC). Frontend never sees the connection
-							string after save — only the host. Migration starts at 0% (no
-							traffic routed) until you bump it.
+							strings after save — only hosts. Workers use their own URI when
+							set; otherwise they use the API/server URI. Migration starts at 0%
+							until you bump it.
 						</span>
 						<Button
 							onClick={handleConnect}
-							disabled={saving || !connectionString.trim()}
+							disabled={saving || !canSubmitEndpoints}
 						>
 							{saving ? "Connecting…" : "Connect Redis"}
 						</Button>

--- a/vite/src/views/developer/configure-redis/ConfigureRedis.tsx
+++ b/vite/src/views/developer/configure-redis/ConfigureRedis.tsx
@@ -163,6 +163,16 @@ export const ConfigureRedis = () => {
 									className="font-mono text-xs"
 								/>
 							</div>
+							{redisConfig.workerHost && (
+								<div className="flex flex-col gap-1">
+									<FormLabel>Worker Host</FormLabel>
+									<Input
+										value={redisConfig.workerHost}
+										readOnly
+										className="font-mono text-xs"
+									/>
+								</div>
+							)}
 							<div className="flex flex-col gap-1">
 								<FormLabel>Migration Percentage</FormLabel>
 								<div className="flex items-center gap-2">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for a separate worker Redis endpoint. Workers can use a public endpoint while the API/server uses the primary endpoint, with safe fallback when a worker endpoint isn’t set.

- New Features
  - Runtime-aware endpoint selection via `getOrgRedisEndpoint`; workers set `AUTUMN_PROCESS_TYPE=worker` and fall back to the primary endpoint if no worker URI is configured.
  - Org model adds `workerConnectionString` and `workerUrl`; values are encrypted and used by the Redis pool and customer routing.
  - Admin/org APIs: PATCH accepts `connectionString` and optional `workerConnectionString`; updates to endpoints are blocked unless `migrationPercent` is 0; GET/LIST include worker host; strict URL validation.
  - Admin UI: shows API/server and worker hosts; allows updating endpoints only when migration is 0%; clearer copy and toasts. Developer view surfaces worker host.
  - Tests: unit coverage for runtime detection, endpoint selection, and fallback.

<sup>Written for commit e2d21ddcb246ec736d991fbeaef1c481cd3befeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

