### PR TITLE
fix: hardcode webhooks flag and fix saved views dropdown

### DIFF
--- a/vite/src/hooks/common/useAutumnFlags.tsx
+++ b/vite/src/hooks/common/useAutumnFlags.tsx
@@ -8,7 +8,7 @@ export const useAutumnFlags = () => {
 
 	const [flags, setFlags] = useLocalStorage("autumn.flags", {
 		pkey: false,
-		webhooks: false,
+		webhooks: true,
 		stripe_key: false,
 		platform: false,
 		vercel: false,
@@ -20,7 +20,7 @@ export const useAutumnFlags = () => {
 
 		const nextFlags = {
 			pkey: notNullish(customer.flags.pkey),
-			webhooks: notNullish(customer.flags.webhooks),
+			webhooks: true,
 			stripe_key: notNullish(customer.flags.stripe_key),
 			platform: notNullish(customer.flags.platform),
 			vercel: notNullish(customer.flags.vercel),
@@ -40,5 +40,5 @@ export const useAutumnFlags = () => {
 		}
 	}, [customer?.flags]);
 
-	return flags;
+	return { ...flags, webhooks: true };
 };

--- a/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
@@ -82,10 +82,10 @@ export const SavedViews = ({
 
 	return (
 		<>
-			<DropdownMenuLabel className="p-0 pt-1 px-3">
-				<span className="text-t3 text-xs">Saved views</span>
-			</DropdownMenuLabel>
 			<DropdownMenuGroup className="p-1">
+				<DropdownMenuLabel className="p-0 pt-1 px-3">
+					<span className="text-t3 text-xs">Saved views</span>
+				</DropdownMenuLabel>
 				{views.map((view: SavedView) => (
 					<div
 						key={view.id}


### PR DESCRIPTION
## Summary
- Hardcode webhooks flag to `true` to unblock dashboard users while SDK zod v4-mini optional field parsing issue is resolved
- Fix saved views dropdown label positioning

## Context
The SDK's `optional` helper was changed from `z.optional(z.union([...]))` to `z.union([z.undefined(), ...])` in the latest Speakeasy codegen. Zod v4-mini rejects missing object keys with the new pattern (`invalid_type: expected "nonoptional"`), causing `useCustomer()` to fail for users whose customer records omit optional fields. This prevents `useAutumnFlags` from reading `customer.flags`, hiding webhooks and other gated features.

## Test plan
- [ ] Verify webhooks section is visible on dashboard for all users
- [ ] Verify saved views dropdown renders correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcode the `webhooks` feature flag to true to unblock users affected by the `zod` v4-mini optional field parsing change. Also fixes the Saved Views dropdown label alignment.

- **Bug Fixes**
  - Force `webhooks` to true in `useAutumnFlags` (default, computed, and return) so the Webhooks section is always visible until the SDK issue is resolved.
  - Move the "Saved views" label inside `DropdownMenuGroup` to correct spacing and positioning.

<sup>Written for commit 4c19cfd53a38274bbd33b0bd80fdc6c5278b068f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR applies two targeted fixes: a temporary hardcode to unblock dashboard users from the SDK Zod v4-mini optional-field parsing regression, and a structural correction to the saved views dropdown label.

- **[Bug fix]** `useAutumnFlags.tsx`: Hardcodes `webhooks` to `true` at the localStorage default, the `useEffect` setter, and the return statement so the webhooks section is visible for all dashboard users while the upstream SDK issue is resolved.
- **[Bug fix]** `SavedViews.tsx`: Moves `DropdownMenuLabel` inside `DropdownMenuGroup` so the "Saved views" label renders in the correct position within the dropdown.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are narrow and intentional, with the only risk being a multi-site revert when the upstream SDK fix lands.

Both changes are small and well-scoped. The SavedViews fix is a trivial structural move. The useAutumnFlags change achieves its goal, but hardcodes the flag at three independent locations rather than just one — when the SDK fix arrives, restoring correct behavior requires reverting all three sites, and missing any one of them would leave stale data in localStorage or skip the real flag read entirely.

vite/src/hooks/common/useAutumnFlags.tsx — the triple hardcode should be reduced to the return-level override with a tracking comment before the upstream SDK fix is merged.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/hooks/common/useAutumnFlags.tsx | Hardcodes webhooks flag to `true` at three separate points (default state, useEffect setter, and return value) as a temporary workaround for the SDK Zod v4-mini parsing issue; the triple hardcode is redundant given the return-level override and complicates future revert. |
| vite/src/views/customers/components/filter-dropdown/SavedViews.tsx | Moves DropdownMenuLabel inside DropdownMenuGroup to fix label positioning in the saved views dropdown; straightforward structural fix. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useAutumnFlags called] --> B{customer?.flags exists?}
    B -- No --> C[return localStorage flags\n + webhooks:true override]
    B -- Yes --> D[Build nextFlags\npkey/stripe_key/etc from customer.flags\nwebhooks = true hardcoded]
    D --> E{Any flag values changed?}
    E -- Yes --> F[setFlags to localStorage]
    E -- No --> G[Skip update]
    F --> H[return ...flags + webhooks:true]
    G --> H
    C --> I[Caller always receives webhooks:true]
    H --> I

    style D fill:#ffe0b2
    style C fill:#ffe0b2
    style I fill:#c8e6c9
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/hooks/common/useAutumnFlags.tsx:9-24
The `webhooks` flag is hardcoded to `true` in three separate places: the localStorage default (line 11), the `nextFlags` object inside the `useEffect` (line 23), and the return statement (line 43). The return-level override `{ ...flags, webhooks: true }` alone is sufficient to guarantee callers always receive `true`, making the other two changes redundant. When the SDK issue is resolved and this temporary fix is reverted, a developer must remember to restore all three sites — missing any one of them could leave stale `true` values in localStorage or silently skip the real flag read. Reducing the hardcode to just the return site, with a `TODO` comment, makes the eventual revert a single-line change and the intent unmistakable.

```suggestion
	const [flags, setFlags] = useLocalStorage("autumn.flags", {
		pkey: false,
		webhooks: false,
		stripe_key: false,
		platform: false,
		vercel: false,
		revenuecat: false,
	});

	useEffect(() => {
		if (!customer?.flags) return;

		const nextFlags = {
			pkey: notNullish(customer.flags.pkey),
			// TODO: restore notNullish(customer.flags.webhooks) once SDK Zod v4-mini optional parsing is fixed
			webhooks: notNullish(customer.flags.webhooks),
			stripe_key: notNullish(customer.flags.stripe_key),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: hardcode webhooks flag and fix save..."](https://github.com/useautumn/autumn/commit/4c19cfd53a38274bbd33b0bd80fdc6c5278b068f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32056999)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->