### PR TITLE
fix: checkout session race

### DIFF
--- a/server/src/external/redis/initRedisV2.ts
+++ b/server/src/external/redis/initRedisV2.ts
@@ -8,23 +8,16 @@ import {
 	waitForRedisReady,
 } from "./initRedis.js";
 import {
-	getRedisV2ConnectionConfig,
 	REDIS_V2_COMMAND_TIMEOUT_MS,
 	supportsUpstashShebangForRedisV2,
 } from "./initUtils/redisV2Config.js";
 
-const redisV2Config = getRedisV2ConnectionConfig({
-	cacheV2Url: process.env.CACHE_V2_DRAGONFLY_URL,
-	primaryCacheUrl: process.env.CACHE_URL,
-	currentRegion,
-	instanceName: "dragonfly",
+export const redisV2: Redis = createRedisConnection({
+	cacheUrl: process.env.CACHE_V2_DRAGONFLY_URL?.trim() || "",
+	region: `${currentRegion}:v2`,
+	supportsUpstashShebang: false,
+	commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
 });
-
-export const hasRedisV2Config = Boolean(redisV2Config);
-
-export const redisV2: Redis = redisV2Config
-	? createRedisConnection(redisV2Config)
-	: redis;
 
 const alternateInstanceUrls: Partial<Record<RedisV2InstanceName, string>> = {
 	upstash: process.env.CACHE_V2_UPSTASH_URL?.trim() || undefined,

--- a/server/src/external/redis/initRedisV2.ts
+++ b/server/src/external/redis/initRedisV2.ts
@@ -14,9 +14,10 @@ import {
 } from "./initUtils/redisV2Config.js";
 
 const redisV2Config = getRedisV2ConnectionConfig({
-	cacheV2Url: process.env.CACHE_V2_UPSTASH_URL,
+	cacheV2Url: process.env.CACHE_V2_DRAGONFLY_URL,
 	primaryCacheUrl: process.env.CACHE_URL,
 	currentRegion,
+	instanceName: "dragonfly",
 });
 
 export const hasRedisV2Config = Boolean(redisV2Config);
@@ -26,6 +27,7 @@ export const redisV2: Redis = redisV2Config
 	: redis;
 
 const alternateInstanceUrls: Partial<Record<RedisV2InstanceName, string>> = {
+	upstash: process.env.CACHE_V2_UPSTASH_URL?.trim() || undefined,
 	redis: process.env.CACHE_V2_REDIS_URL?.trim() || undefined,
 	dragonfly: process.env.CACHE_V2_DRAGONFLY_URL?.trim() || undefined,
 };

--- a/server/src/external/redis/initUtils/createRedisClient.ts
+++ b/server/src/external/redis/initUtils/createRedisClient.ts
@@ -13,7 +13,7 @@ const REDIS_COMMAND_TIMEOUT_MS =
 export const createRedisClient = ({
 	cacheUrl,
 	region,
-	supportsUpstashShebang = true,
+	supportsUpstashShebang = false,
 	commandTimeout = REDIS_COMMAND_TIMEOUT_MS,
 }: {
 	cacheUrl: string;

--- a/server/src/external/redis/initUtils/redisV2Availability.ts
+++ b/server/src/external/redis/initUtils/redisV2Availability.ts
@@ -1,15 +1,9 @@
-import {
-	hasRedisV2Config,
-	redisV2,
-} from "../initRedisV2.js";
+import { redisV2 } from "../initRedisV2.js";
 import {
 	createRedisAvailability,
 	type RedisAvailabilitySnapshot,
 } from "./createRedisAvailability.js";
-import {
-	getRedisAvailability,
-	shouldUseRedis,
-} from "./redisAvailability.js";
+import { getRedisAvailability, shouldUseRedis } from "./redisAvailability.js";
 import { redis as primaryRedis } from "./redisClientRegistry.js";
 
 const usesPrimaryRedis = redisV2 === primaryRedis;
@@ -18,7 +12,7 @@ const getPrimaryBackedRedisV2Availability = (): RedisAvailabilitySnapshot => {
 	const availability = getRedisAvailability();
 
 	return {
-		configured: hasRedisV2Config,
+		configured: true,
 		state: availability.state,
 		status: availability.status,
 	};
@@ -34,7 +28,7 @@ const redisV2Availability = usesPrimaryRedis
 		}
 	: createRedisAvailability({
 			redis: redisV2,
-			hasConfig: hasRedisV2Config,
+			hasConfig: true,
 			logPrefix: "RedisV2",
 			logType: "redis_v2_availability_state_set",
 		});
@@ -50,7 +44,7 @@ const {
 export {
 	getRedisV2Availability,
 	primeRedisV2Monitor,
+	shouldUseRedisV2,
 	startRedisV2Monitor,
 	stopRedisV2Monitor,
-	shouldUseRedisV2,
 };

--- a/server/src/external/redis/initUtils/redisV2Config.ts
+++ b/server/src/external/redis/initUtils/redisV2Config.ts
@@ -6,16 +6,18 @@ export const getRedisV2ConnectionConfig = ({
 	cacheV2Url,
 	primaryCacheUrl,
 	currentRegion,
+	instanceName,
 }: {
 	cacheV2Url?: string;
 	primaryCacheUrl?: string;
 	currentRegion: string;
+	instanceName: RedisV2InstanceName;
 }) =>
 	cacheV2Url?.trim() && cacheV2Url.trim() !== primaryCacheUrl?.trim()
 		? {
 				cacheUrl: cacheV2Url.trim(),
 				region: `${currentRegion}:v2`,
-				supportsUpstashShebang: supportsUpstashShebangForRedisV2("upstash"),
+				supportsUpstashShebang: supportsUpstashShebangForRedisV2(instanceName),
 				commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
 			}
 		: null;

--- a/server/src/external/redis/initUtils/redisV2Config.ts
+++ b/server/src/external/redis/initUtils/redisV2Config.ts
@@ -4,16 +4,14 @@ export const REDIS_V2_COMMAND_TIMEOUT_MS = 1_000;
 
 export const getRedisV2ConnectionConfig = ({
 	cacheV2Url,
-	primaryCacheUrl,
 	currentRegion,
 	instanceName,
 }: {
 	cacheV2Url?: string;
-	primaryCacheUrl?: string;
 	currentRegion: string;
 	instanceName: RedisV2InstanceName;
 }) =>
-	cacheV2Url?.trim() && cacheV2Url.trim() !== primaryCacheUrl?.trim()
+	cacheV2Url?.trim()
 		? {
 				cacheUrl: cacheV2Url.trim(),
 				region: `${currentRegion}:v2`,

--- a/server/src/external/redis/resolveRedisV2.ts
+++ b/server/src/external/redis/resolveRedisV2.ts
@@ -22,7 +22,7 @@ export const resolveRedisV2 = (): Redis => {
 		lastLoggedInstance = activeInstance;
 	}
 
-	if (activeInstance === "upstash") return redisV2Primary;
+	if (activeInstance === "dragonfly") return redisV2Primary;
 
 	const alternate = getAlternateRedisV2Instance(activeInstance);
 	return alternate ?? redisV2Primary;

--- a/server/src/external/stripe/webhookHandlers/common/subscriptionSync/shouldSkipSubscriptionSync.ts
+++ b/server/src/external/stripe/webhookHandlers/common/subscriptionSync/shouldSkipSubscriptionSync.ts
@@ -19,9 +19,14 @@ export type SkipSubscriptionSyncResult =
 export const shouldSkipSubscriptionSync = ({
 	subscription,
 	fullCustomer,
+	requireRecent = true,
 }: {
 	subscription: Stripe.Subscription;
 	fullCustomer: FullCustomer;
+	/** For sub.created, pass false: any prior Autumn management is enough to
+	 * skip. For sub.updated (default), only a recent stamp suppresses sync so
+	 * later genuine changes still get picked up. */
+	requireRecent?: boolean;
 }): SkipSubscriptionSyncResult => {
 	const alreadyLinked = fullCustomer.customer_products?.some(
 		(customerProduct) =>
@@ -33,6 +38,7 @@ export const shouldSkipSubscriptionSync = ({
 
 	const metadataDecision = isAutumnManagedSubscriptionMetadata({
 		metadata: subscription.metadata,
+		requireRecent,
 	});
 	if (metadataDecision.skip) {
 		return { skip: true, reason: metadataDecision.reason ?? "autumn metadata" };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/setupStripeSubscriptionCreatedContext.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/setupStripeSubscriptionCreatedContext.ts
@@ -3,7 +3,6 @@ import type Stripe from "stripe";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { getFullStripeSub } from "../../stripeSubUtils.js";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext.js";
-import { shouldSkipSubscriptionSync } from "../common/subscriptionSync/shouldSkipSubscriptionSync.js";
 
 export type StripeSubscriptionCreatedContext = {
 	subscription: Stripe.Subscription;
@@ -16,7 +15,7 @@ export const setupStripeSubscriptionCreatedContext = async ({
 }: {
 	ctx: StripeWebhookContext;
 }): Promise<StripeSubscriptionCreatedContext | undefined> => {
-	const { db, org, env, fullCustomer, stripeCli, stripeEvent, logger } = ctx;
+	const { db, org, env, fullCustomer, stripeCli, stripeEvent } = ctx;
 	const stripeObject = stripeEvent.data.object as Stripe.Subscription;
 
 	// No auto-provisioning — only sync subs for customers already in Autumn.
@@ -26,14 +25,6 @@ export const setupStripeSubscriptionCreatedContext = async ({
 		getFullStripeSub({ stripeCli, stripeId: stripeObject.id }),
 		ProductService.listFull({ db, orgId: org.id, env }),
 	]);
-
-	const skip = shouldSkipSubscriptionSync({ subscription, fullCustomer });
-	if (skip.skip) {
-		logger.info(
-			`sub.created auto-sync: skipping stripe sub ${subscription.id} (${skip.reason})`,
-		);
-		return undefined;
-	}
 
 	return { subscription, fullCustomer, candidateProducts };
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/autoSyncFromSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/autoSyncFromSubscription.ts
@@ -2,6 +2,8 @@ import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/
 import { billingActions } from "@/internal/billing/v2/actions";
 import { canAutoSync } from "@/internal/billing/v2/actions/sync/canAutoSync.js";
 import { subscriptionToSyncParams } from "@/internal/billing/v2/actions/sync/subscriptionToSyncParams.js";
+import { isAutumnCheckoutSubscription } from "@/internal/billing/v2/actions/sync/utils/isAutumnCheckoutSubscription.js";
+import { shouldSkipSubscriptionSync } from "../../common/subscriptionSync/shouldSkipSubscriptionSync.js";
 import type { StripeSubscriptionCreatedContext } from "../setupStripeSubscriptionCreatedContext.js";
 
 /**
@@ -21,9 +23,28 @@ export const autoSyncFromSubscription = async ({
 	ctx: StripeWebhookContext;
 	subscriptionCreatedContext: StripeSubscriptionCreatedContext;
 }) => {
-	const { logger } = ctx;
+	const { logger, stripeCli } = ctx;
 	const { subscription, fullCustomer } = subscriptionCreatedContext;
 	const customerId = fullCustomer.id ?? fullCustomer.internal_id;
+
+	const skip = shouldSkipSubscriptionSync({
+		subscription,
+		fullCustomer,
+		requireRecent: false,
+	});
+	if (skip.skip) {
+		logger.info(
+			`sub.created auto-sync skipping ${subscription.id} (${skip.reason})`,
+		);
+		return;
+	}
+
+	if (await isAutumnCheckoutSubscription({ stripeCli, subscription })) {
+		logger.info(
+			`sub.created auto-sync skipping ${subscription.id}: originated from Autumn checkout session`,
+		);
+		return;
+	}
 
 	const { match, params } = await subscriptionToSyncParams({
 		ctx,

--- a/server/src/internal/billing/v2/actions/sync/utils/isAutumnCheckoutSubscription.ts
+++ b/server/src/internal/billing/v2/actions/sync/utils/isAutumnCheckoutSubscription.ts
@@ -1,0 +1,23 @@
+import type Stripe from "stripe";
+
+/**
+ * True when `subscription` was created by an Autumn-managed Checkout Session.
+ *
+ * Why: `checkout.session.completed` materializes the cus_product itself, so
+ * auto-sync from `customer.subscription.created` would race and produce a
+ * duplicate row on the same Stripe sub.
+ */
+export const isAutumnCheckoutSubscription = async ({
+	stripeCli,
+	subscription,
+}: {
+	stripeCli: Stripe;
+	subscription: Stripe.Subscription;
+}): Promise<boolean> => {
+	const sessions = await stripeCli.checkout.sessions.list({
+		subscription: subscription.id,
+		limit: 1,
+	});
+	const session = sessions.data[0];
+	return Boolean(session?.metadata?.autumn_metadata_id);
+};

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.ts
@@ -26,14 +26,23 @@ export const buildAutumnSubscriptionMetadata = ({
 	return meta;
 };
 
+/**
+ * @param requireRecent — when true (default), `autumn_managed_at` only counts
+ *   if it falls within `windowMs`. Used by sub.updated where a stale stamp
+ *   shouldn't suppress a genuinely new change. Pass false from sub.created:
+ *   once a sub has ever been Autumn-managed, auto-sync should never run on
+ *   its creation event.
+ */
 export const isAutumnManagedSubscriptionMetadata = ({
 	metadata,
 	windowMs = RECENT_AUTUMN_ACTION_WINDOW_MS,
 	now = Date.now(),
+	requireRecent = true,
 }: {
 	metadata: Stripe.Metadata | null | undefined;
 	windowMs?: number;
 	now?: number;
+	requireRecent?: boolean;
 }): { skip: boolean; reason?: string } => {
 	if (!metadata) return { skip: false };
 
@@ -49,9 +58,13 @@ export const isAutumnManagedSubscriptionMetadata = ({
 	if (!managedAtRaw) return { skip: false };
 
 	const managedAt = Number(managedAtRaw);
-	if (!Number.isFinite(managedAt) || now - managedAt >= windowMs) {
-		return { skip: false };
+	if (!Number.isFinite(managedAt)) return { skip: false };
+
+	if (!requireRecent) {
+		return { skip: true, reason: `autumn_managed_at present (source=unknown)` };
 	}
+
+	if (now - managedAt >= windowMs) return { skip: false };
 
 	return {
 		skip: true,

--- a/server/src/internal/misc/redisV2Cache/redisV2CacheSchemas.ts
+++ b/server/src/internal/misc/redisV2Cache/redisV2CacheSchemas.ts
@@ -4,7 +4,7 @@ export const RedisV2InstanceName = z.enum(["upstash", "redis", "dragonfly"]);
 export type RedisV2InstanceName = z.infer<typeof RedisV2InstanceName>;
 
 export const RedisV2CacheConfigSchema = z.object({
-	activeInstance: RedisV2InstanceName.default("upstash"),
+	activeInstance: RedisV2InstanceName.default("dragonfly"),
 });
 
 export type RedisV2CacheConfig = z.infer<typeof RedisV2CacheConfigSchema>;

--- a/server/src/internal/misc/redisV2Cache/redisV2CacheStore.ts
+++ b/server/src/internal/misc/redisV2Cache/redisV2CacheStore.ts
@@ -11,7 +11,7 @@ import {
 const store = createEdgeConfigStore<RedisV2CacheConfig>({
 	s3Key: ADMIN_REDIS_V2_CACHE_CONFIG_KEY,
 	schema: RedisV2CacheConfigSchema,
-	defaultValue: () => ({ activeInstance: "upstash" }),
+	defaultValue: () => ({ activeInstance: "dragonfly" }),
 	pollIntervalMs: ms.seconds(10),
 });
 

--- a/server/tests/integration/billing/stripe-webhooks/subscription-created/sub-created-checkout-session-guard.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-created/sub-created-checkout-session-guard.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test";
+import { completeStripeCheckoutFormV2 } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import ctx, {
+	type TestContext,
+} from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { isAutumnCheckoutSubscription } from "@/internal/billing/v2/actions/sync/utils/isAutumnCheckoutSubscription";
+import { CusService } from "@/internal/customers/CusService";
+
+const getLatestStripeSubscription = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+}): Promise<Stripe.Subscription> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const stripeCustomerId = fullCustomer.processor?.id;
+	if (!stripeCustomerId) {
+		throw new Error(`Customer ${customerId} has no Stripe customer ID`);
+	}
+	const subs = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCustomerId,
+		limit: 1,
+	});
+	const sub = subs.data[0];
+	if (!sub) throw new Error(`Customer ${customerId} has no Stripe subs`);
+	return sub;
+};
+
+test(`${chalk.yellowBright("isAutumnCheckoutSubscription: true for sub from Autumn checkout")}`, async () => {
+	const customerId = "checkout-guard-positive";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		ctx,
+		setup: [s.customer({ testClock: true }), s.products({ list: [pro] })],
+		actions: [],
+	});
+
+	const attachResult = await autumnV1.billing.attach(
+		{ customer_id: customerId, product_id: pro.id },
+		{ timeout: 0 },
+	);
+	expect(attachResult.payment_url).toContain("checkout.stripe.com");
+
+	await completeStripeCheckoutFormV2({ url: attachResult.payment_url! });
+	await timeout(8000);
+
+	const subscription = await getLatestStripeSubscription({ ctx, customerId });
+
+	const isFromCheckout = await isAutumnCheckoutSubscription({
+		stripeCli: ctx.stripeCli,
+		subscription,
+	});
+	expect(isFromCheckout).toBe(true);
+});
+
+test(`${chalk.yellowBright("isAutumnCheckoutSubscription: false for sub created directly")}`, async () => {
+	const customerId = "checkout-guard-negative";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	await initScenario({
+		customerId,
+		ctx,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.billing.attach({ productId: pro.id })],
+	});
+
+	const subscription = await getLatestStripeSubscription({ ctx, customerId });
+
+	const isFromCheckout = await isAutumnCheckoutSubscription({
+		stripeCli: ctx.stripeCli,
+		subscription,
+	});
+	expect(isFromCheckout).toBe(false);
+});

--- a/server/tests/integration/others/redis/invalidate-cached-full-subject.test.ts
+++ b/server/tests/integration/others/redis/invalidate-cached-full-subject.test.ts
@@ -11,18 +11,60 @@ import {
 	buildFullSubjectKey,
 	buildFullSubjectViewEpochKey,
 	getCachedFullSubject,
-	getOrSetCachedFullSubject,
 	invalidateCachedFullSubject,
 } from "@/internal/customers/cache/fullSubject/index.js";
-import { cleanupFullSubjectScenario } from "../../integration/db/full-subject/utils/cleanupFullSubjectScenario.js";
-import { buildEntitySubjectScenario } from "../../integration/db/full-subject/utils/fullSubjectScenarioBuilders.js";
-import { insertFullSubjectScenario } from "../../integration/db/full-subject/utils/insertFullSubjectScenario.js";
+import { normalizedToCachedFullSubject } from "@/internal/customers/cache/fullSubject/fullSubjectCacheModel.js";
+import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+import { cleanupFullSubjectScenario } from "../../db/full-subject/utils/cleanupFullSubjectScenario.js";
+import { buildEntitySubjectScenario } from "../../db/full-subject/utils/fullSubjectScenarioBuilders.js";
+import { insertFullSubjectScenario } from "../../db/full-subject/utils/insertFullSubjectScenario.js";
 
 const describeDb = process.env.TESTS_ORG ? describe : describe.skip;
 
 describeDb("invalidateCachedFullSubject", () => {
 	let ctx: TestContext;
 	let scenario: ReturnType<typeof buildEntitySubjectScenario>;
+
+	const cleanupScenarioState = async () => {
+		const customerKeys = await ctx.redisV2.keys(`{${scenario.ids.customerId}}:*`);
+		if (customerKeys.length > 0) await ctx.redisV2.unlink(...customerKeys);
+
+		await cleanupFullSubjectScenario({ ctx, scenario });
+	};
+
+	const getSubjectViewEpoch = async () => {
+		const epoch = await ctx.redisV2.get(
+			buildFullSubjectViewEpochKey({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId: scenario.ids.customerId,
+			}),
+		);
+
+		return epoch ? Number.parseInt(epoch, 10) : 0;
+	};
+
+	const seedCachedFullSubject = async ({ entityId }: { entityId?: string } = {}) => {
+		const result = await getFullSubjectNormalized({
+			ctx,
+			customerId: scenario.ids.customerId,
+			entityId,
+		});
+		if (!result) throw new Error("Failed to build full subject cache fixture");
+
+		const cached = normalizedToCachedFullSubject({
+			normalized: result.normalized,
+			subjectViewEpoch: await getSubjectViewEpoch(),
+		});
+		const subjectKey = buildFullSubjectKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId: scenario.ids.customerId,
+			entityId,
+		});
+
+		await ctx.redisV2.set(subjectKey, JSON.stringify(cached));
+	};
 
 	beforeAll(async () => {
 		const { createTestContext } = await import(
@@ -36,36 +78,19 @@ describeDb("invalidateCachedFullSubject", () => {
 	});
 
 	beforeEach(async () => {
+		await cleanupScenarioState();
 		await insertFullSubjectScenario({ ctx, scenario });
-		await getOrSetCachedFullSubject({
-			ctx,
-			customerId: scenario.ids.customerId,
-			source: "invalidateCachedFullSubjectTest",
-		});
-		await getOrSetCachedFullSubject({
-			ctx,
-			customerId: scenario.ids.customerId,
-			entityId: scenario.ids.entityIds[0],
-			source: "invalidateCachedFullSubjectTest",
-		});
-		await getOrSetCachedFullSubject({
-			ctx,
-			customerId: scenario.ids.customerId,
-			entityId: scenario.ids.entityIds[1],
-			source: "invalidateCachedFullSubjectTest",
-		});
+		await seedCachedFullSubject();
+		await seedCachedFullSubject({ entityId: scenario.ids.entityIds[0] });
+		await seedCachedFullSubject({ entityId: scenario.ids.entityIds[1] });
 	});
 
 	afterEach(async () => {
-		const customerKeys = await ctx.redisV2.keys(`{${scenario.ids.customerId}}:*`);
-		if (customerKeys.length > 0) {
-			await ctx.redisV2.unlink(...customerKeys);
-		}
-
-		await cleanupFullSubjectScenario({ ctx, scenario });
+		await cleanupScenarioState();
 	});
 
 	test("invalidates direct entity cache and increments subject view epoch", async () => {
+		const initialSubjectViewEpoch = await getSubjectViewEpoch();
 		const entityAKey = buildFullSubjectKey({
 			orgId: ctx.org.id,
 			env: ctx.env,
@@ -93,18 +118,11 @@ describeDb("invalidateCachedFullSubject", () => {
 		expect(await ctx.redisV2.exists(customerKey)).toBe(0);
 		expect(await ctx.redisV2.exists(entityAKey)).toBe(0);
 		expect(await ctx.redisV2.exists(entityBKey)).toBe(1);
-		expect(
-			await ctx.redisV2.get(
-				buildFullSubjectViewEpochKey({
-					orgId: ctx.org.id,
-					env: ctx.env,
-					customerId: scenario.ids.customerId,
-				}),
-			),
-		).toBe("1");
+		expect(await getSubjectViewEpoch()).toBe(initialSubjectViewEpoch + 1);
 	});
 
 	test("increments subject view epoch for customer invalidation", async () => {
+		const initialSubjectViewEpoch = await getSubjectViewEpoch();
 		const entityAKey = buildFullSubjectKey({
 			orgId: ctx.org.id,
 			env: ctx.env,
@@ -131,7 +149,9 @@ describeDb("invalidateCachedFullSubject", () => {
 
 		expect(await ctx.redisV2.exists(entityAKey)).toBe(1);
 		expect(await ctx.redisV2.exists(entityBKey)).toBe(1);
-		expect(await ctx.redisV2.get(epochKey)).toBe("1");
+		expect(Number.parseInt((await ctx.redisV2.get(epochKey)) ?? "0", 10)).toBe(
+			initialSubjectViewEpoch + 1,
+		);
 	});
 
 	test("sibling entity cache becomes stale after direct entity invalidation", async () => {

--- a/server/tests/unit/billing/update-subscription/compute-update-subscription-intent.spec.ts
+++ b/server/tests/unit/billing/update-subscription/compute-update-subscription-intent.spec.ts
@@ -17,7 +17,8 @@ import chalk from "chalk";
 import { setupUpdateSubscriptionIntent } from "@/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionIntent";
 
 const customerProduct = {
-	prices: [],
+	customer_prices: [],
+	customer_entitlements: [],
 } as unknown as FullCusProduct;
 
 const baseParams: UpdateSubscriptionV1Params = {

--- a/server/tests/unit/redis/redis-v2-config.spec.ts
+++ b/server/tests/unit/redis/redis-v2-config.spec.ts
@@ -6,27 +6,42 @@ import {
 } from "@/external/redis/initUtils/redisV2Config.js";
 
 describe("redis V2 connection config", () => {
-	test("uses a distinct CACHE_V2_UPSTASH_URL with the Upstash shebang", () => {
+	test("uses a distinct CACHE_V2_DRAGONFLY_URL without the Upstash shebang", () => {
 		expect(
 			getRedisV2ConnectionConfig({
 				cacheV2Url: " redis://v2 ",
 				primaryCacheUrl: "redis://primary",
 				currentRegion: "us-west-2",
+				instanceName: "dragonfly",
 			}),
 		).toEqual({
 			cacheUrl: "redis://v2",
 			region: "us-west-2:v2",
-			supportsUpstashShebang: true,
+			supportsUpstashShebang: false,
 			commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
 		});
 	});
 
-	test("falls back to primary Redis when CACHE_V2_UPSTASH_URL is absent or matches primary", () => {
+	test("uses the Upstash shebang when the upstash instance is selected", () => {
+		expect(
+			getRedisV2ConnectionConfig({
+				cacheV2Url: " redis://v2 ",
+				primaryCacheUrl: "redis://primary",
+				currentRegion: "us-west-2",
+				instanceName: "upstash",
+			}),
+		).toMatchObject({
+			supportsUpstashShebang: true,
+		});
+	});
+
+	test("falls back to primary Redis when the V2 URL is absent or matches primary", () => {
 		expect(
 			getRedisV2ConnectionConfig({
 				cacheV2Url: undefined,
 				primaryCacheUrl: "redis://primary",
 				currentRegion: "us-west-2",
+				instanceName: "dragonfly",
 			}),
 		).toBeNull();
 		expect(
@@ -34,6 +49,7 @@ describe("redis V2 connection config", () => {
 				cacheV2Url: " redis://primary ",
 				primaryCacheUrl: "redis://primary",
 				currentRegion: "us-west-2",
+				instanceName: "dragonfly",
 			}),
 		).toBeNull();
 	});

--- a/server/tests/unit/redis/redis-v2-config.spec.ts
+++ b/server/tests/unit/redis/redis-v2-config.spec.ts
@@ -1,59 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-	getRedisV2ConnectionConfig,
-	REDIS_V2_COMMAND_TIMEOUT_MS,
-	supportsUpstashShebangForRedisV2,
-} from "@/external/redis/initUtils/redisV2Config.js";
+import { supportsUpstashShebangForRedisV2 } from "@/external/redis/initUtils/redisV2Config.js";
 
 describe("redis V2 connection config", () => {
-	test("uses a distinct CACHE_V2_DRAGONFLY_URL without the Upstash shebang", () => {
-		expect(
-			getRedisV2ConnectionConfig({
-				cacheV2Url: " redis://v2 ",
-				primaryCacheUrl: "redis://primary",
-				currentRegion: "us-west-2",
-				instanceName: "dragonfly",
-			}),
-		).toEqual({
-			cacheUrl: "redis://v2",
-			region: "us-west-2:v2",
-			supportsUpstashShebang: false,
-			commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
-		});
-	});
-
-	test("uses the Upstash shebang when the upstash instance is selected", () => {
-		expect(
-			getRedisV2ConnectionConfig({
-				cacheV2Url: " redis://v2 ",
-				primaryCacheUrl: "redis://primary",
-				currentRegion: "us-west-2",
-				instanceName: "upstash",
-			}),
-		).toMatchObject({
-			supportsUpstashShebang: true,
-		});
-	});
-
-	test("falls back to primary Redis when the V2 URL is absent or matches primary", () => {
-		expect(
-			getRedisV2ConnectionConfig({
-				cacheV2Url: undefined,
-				primaryCacheUrl: "redis://primary",
-				currentRegion: "us-west-2",
-				instanceName: "dragonfly",
-			}),
-		).toBeNull();
-		expect(
-			getRedisV2ConnectionConfig({
-				cacheV2Url: " redis://primary ",
-				primaryCacheUrl: "redis://primary",
-				currentRegion: "us-west-2",
-				instanceName: "dragonfly",
-			}),
-		).toBeNull();
-	});
-
 	test("enables the Upstash shebang only for the upstash instance", () => {
 		expect(supportsUpstashShebangForRedisV2("upstash")).toBe(true);
 		expect(supportsUpstashShebangForRedisV2("redis")).toBe(false);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race between `checkout.session.completed` and `customer.subscription.created` that could create duplicate customer-product rows. Auto-sync on `sub.created` now skips for Autumn Checkout subscriptions or any sub with prior Autumn management metadata.

- **Bug Fixes**
  - Skip `sub.created` auto-sync for subscriptions created via Autumn Checkout using `isAutumnCheckoutSubscription`.
  - Broaden metadata guard with `requireRecent: false` for `sub.created`; `sub.updated` still requires a recent stamp.
  - Centralize skip logic in `autoSyncFromSubscription` and log skip reasons.
  - Add integration tests for Autumn Checkout vs direct Stripe subscription creation.

- **Refactors**
  - Default Redis V2 to `dragonfly` and disable Upstash shebang by default; simplify init/availability and resolve `dragonfly` as primary; update tests.

<sup>Written for commit 1075dd477c32ff9d7db8215344c54d3af498190f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition between `customer.subscription.created` and `checkout.session.completed` webhooks that could produce a duplicate `cus_product` row when a subscription is created through an Autumn-managed Stripe Checkout Session.

- **Bug fixes** — The `shouldSkipSubscriptionSync` call is moved from `setupStripeSubscriptionCreatedContext` into `autoSyncFromSubscription` with `requireRecent: false`, so that any prior Autumn management of a subscription suppresses auto-sync on creation (not just within the 10-minute recency window).
- **Bug fixes** — A new `isAutumnCheckoutSubscription` helper is introduced: it calls `stripeCli.checkout.sessions.list({ subscription })` and checks for `autumn_metadata_id` in the session metadata, skipping auto-sync for subscriptions that originated from an Autumn checkout.
- **Improvements** — `linkScheduledCustomerProductsToSubscription` now runs unconditionally for all known Autumn customers (the previous guard was scoped to auto-sync, not scheduled linking), and integration tests for both the positive and negative cases are added.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the race condition fix is well-scoped and the dual-guard approach is robust.

The core logic is correct: `autumn_metadata_id` is reliably stamped on every Autumn checkout session (both old and new billing paths), and the `requireRecent: false` change correctly broadens the metadata guard for `sub.created`. The most notable behavioral change is that `linkScheduledCustomerProductsToSubscription` now runs unconditionally for known customers, where previously the skip check would have blocked it too — this appears intentional. The new Stripe API call in `isAutumnCheckoutSubscription` has no error fallback, but a thrown exception causes Stripe to retry the webhook, which is acceptable. Integration tests cover both cases.

No files require special attention; `isAutumnCheckoutSubscription.ts` is new and worth a second read to confirm the `autumn_metadata_id` presence assumption holds for all checkout paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/utils/isAutumnCheckoutSubscription.ts | New helper that queries Stripe for checkout sessions linked to the subscription and checks for `autumn_metadata_id`; correctly identifies Autumn-owned sessions but has no fallback if the Stripe API call fails mid-webhook. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/autoSyncFromSubscription.ts | Guard logic correctly moved here from the context-setup layer; dual-guard order (metadata check first, then Stripe API call) is efficient and correct. |
| server/src/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.ts | Added `requireRecent` flag cleanly separates the stale-ok (sub.created) from the must-be-recent (sub.updated) semantics without breaking existing callers. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/setupStripeSubscriptionCreatedContext.ts | Skip check removed from context setup; context is now always returned for known customers, allowing `linkScheduledCustomerProductsToSubscription` to run even for Autumn-managed subscriptions. |
| server/tests/integration/billing/stripe-webhooks/subscription-created/sub-created-checkout-session-guard.test.ts | Tests cover positive (Autumn checkout) and negative (direct attach) cases; relies on an 8-second hardcoded wait that may be flaky in slow environments. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: checkout session race condition"](https://github.com/useautumn/autumn/commit/d28ef4ffe771d48067ad34c95a5cc7b22b643d2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32093752)</sub>

<!-- /greptile_comment -->