### PR TITLE
chore: cmd k cleanup

### DIFF
--- a/vite/src/components/ui/command.tsx
+++ b/vite/src/components/ui/command.tsx
@@ -17,7 +17,7 @@ function Command({
 		<CommandPrimitive
 			data-slot="command"
 			className={cn(
-				"bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden",
+				"bg-interactive-secondary text-t2 flex h-full w-full flex-col overflow-hidden rounded-lg",
 				className,
 			)}
 			{...props}
@@ -45,15 +45,10 @@ function CommandDialog({
 				<DialogDescription>{description}</DialogDescription>
 			</DialogHeader>
 			<DialogContent
-				className={cn("overflow-hidden p-0", className)}
+				className={cn("overflow-hidden p-0 bg-interactive-secondary", className)}
 				showCloseButton={showCloseButton}
 			>
-				<Command
-					shouldFilter={false}
-					className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]]:py-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-1"
-				>
-					{children}
-				</Command>
+				<Command shouldFilter={false}>{children}</Command>
 			</DialogContent>
 		</Dialog>
 	);
@@ -66,13 +61,12 @@ function CommandInput({
 	return (
 		<div
 			data-slot="command-input-wrapper"
-			className="flex max-h-9 items-center gap-2 border-b px-3"
+			className="flex h-10 items-center gap-2 border-b border-border/50 px-3"
 		>
-			{/* <SearchIcon className="size-3.5 shrink-0 opacity-50" /> */}
 			<CommandPrimitive.Input
 				data-slot="command-input"
 				className={cn(
-					"placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 outline-hidden disabled:cursor-not-allowed disabled:opacity-50 text-xs",
+					"placeholder:text-muted-foreground flex h-full w-full bg-transparent text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
 					className,
 				)}
 				{...props}
@@ -148,7 +142,7 @@ function CommandItem({
 		<CommandPrimitive.Item
 			data-slot="command-item"
 			className={cn(
-				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}

--- a/vite/src/views/command-bar/CommandBar.tsx
+++ b/vite/src/views/command-bar/CommandBar.tsx
@@ -404,11 +404,17 @@ const CommandBar = () => {
 			: []),
 	];
 
+	const filteredNavigationItems = showResults
+		? navigationItems.filter((item) =>
+				item.title.toLowerCase().includes(search.toLowerCase()),
+			)
+		: navigationItems;
+
 	const renderMainPage = () => (
 		<>
-			{!showResults && (
+			{filteredNavigationItems.length > 0 && (
 				<CommandGroup className="p-1.5">
-					{navigationItems.map((item) => (
+					{filteredNavigationItems.map((item) => (
 						<CommandRow
 							key={item.title}
 							icon={item.icon}

--- a/vite/src/views/command-bar/command-row.tsx
+++ b/vite/src/views/command-bar/command-row.tsx
@@ -91,18 +91,15 @@ export const CommandRow = React.forwardRef<HTMLDivElement, CommandRowProps>(
 			<CommandItem
 				ref={ref}
 				onSelect={onSelect}
-				className={cn(
-					"text-body h-8 flex justify-between items-center px-2 rounded-lg",
-					className,
-				)}
+				className={cn("flex justify-between items-center", className)}
 			>
 				<div className="flex items-center gap-2 min-w-0 flex-1">
 					{renderIcon(icon)}
-					<span className="text-body truncate shrink-0 max-w-[50%]">
-						{title}
-					</span>
+					<span className="text-sm truncate shrink-0 max-w-[50%]">{title}</span>
 					{subtext && (
-						<span className="text-tiny truncate text-t3">{subtext}</span>
+						<span className="text-xs truncate text-muted-foreground">
+							{subtext}
+						</span>
 					)}
 				</div>
 				{renderShortcuts()}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up the Command Palette (Cmd+K) UI and improved search behavior. Uses new design tokens, tighter spacing, and shows filtered navigation items while typing.

- **Bug Fixes**
  - Navigation items now filter by the query and display when matches exist, instead of disappearing during search.

- **Refactors**
  - Updated styles to `bg-interactive-secondary`, `text-t2`, and rounded container; set dialog content background; simplified nested command classes.
  - Standardized input and item sizing: input wrapper to h-10 with subtle border, input to text-sm, item spacing tightened; command row uses smaller title text and muted subtext with proper truncation.

<sup>Written for commit 2f0cda98905e163c6e056156a59c389d0e1119c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a visual cleanup of the Cmd+K command bar. It replaces generic Tailwind/shadcn tokens with project-specific design tokens (`bg-interactive-secondary`, `text-t2`), strips out a large block of inline cmdk CSS overrides in `CommandDialog`, and tightens up `CommandItem` and `CommandInput` spacing. It also changes navigation-item behavior during search: instead of hiding all nav items when a search term is present, they are now filtered client-side and shown alongside API results.

- **[Improvements]** `CommandDialog` simplified — large `[&_[cmdk-...]]` selector block removed, `Command` now carries consistent rounded background by default.
- **[Improvements]** Navigation items are now searchable in the command bar: `filteredNavigationItems` replaces the previous all-or-nothing `!showResults` guard.
- **[Improvements]** `CommandRow` updated to use standard Tailwind text sizes (`text-sm`, `text-xs`) instead of design-token shorthands, and inherits padding/radius from the updated `CommandItem` base.
</details>


<h3>Confidence Score: 4/5</h3>

The command-bar logic and style changes are straightforward. The main area to double-check is whether other consumers of the bare Command component (SearchableSelect, model-selector) look correct with the new background token and the removed default SVG color rule.

The navigation-item filtering change is correct and safe. The design-token updates in command.tsx are intentional but have a wider blast radius than the command bar alone — `bg-interactive-secondary` and the dropped SVG color selector affect every component that embeds a bare Command, so a visual pass on those surfaces is warranted before merging.

vite/src/components/ui/command.tsx — the background-token and SVG-color changes ripple into SearchableSelect and model-selector.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/ui/command.tsx | Visual redesign: switches Command bg to `bg-interactive-secondary`/`text-t2` design tokens, removes heavy cmdk CSS overrides from CommandDialog, adjusts CommandInput height and border, and tightens CommandItem spacing — the bg change affects every consumer of Command (including SearchableSelect). |
| vite/src/views/command-bar/CommandBar.tsx | Adds client-side filtering of navigation items by search term when showResults is true, replacing the previous "hide all nav items on search" behavior — logic is correct and safe. |
| vite/src/views/command-bar/command-row.tsx | Style-only cleanup: removes explicit h-8/px-2/rounded-lg from CommandItem, replaces design-token text classes (text-body, text-tiny) with standard Tailwind (text-sm, text-xs), inheriting spacing from the updated CommandItem base class. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Cmd+K] --> B{User types search?}
    B -- No --> C[Show all navigationItems]
    B -- Yes --> D[filteredNavigationItems = navigationItems filtered by search]
    D --> E{Any matches?}
    E -- Yes --> F[Show filtered nav items + API results below]
    E -- No --> G[Hide nav group, Show API results only]
    C --> H[CommandGroup rendered]
    F --> H
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/components/ui/command.tsx`, line 142-150 ([link](https://github.com/useautumn/autumn/blob/2f0cda98905e163c6e056156a59c389d0e1119c5/vite/src/components/ui/command.tsx#L142-L150)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Removed default SVG color for uncolored icons in CommandItem**

   The old class `[&_svg:not([class*='text-'])]:text-muted-foreground` auto-applied `text-muted-foreground` to any SVG inside a `CommandItem` that didn't carry its own text color. That rule is now gone. `CommandRow` is safe because `renderIcon` always injects `text-t3`, but other direct `CommandItem` usages in `SearchableSelect` or `model-selector` may render plain SVG icons that will now fall back to the inherited foreground color instead of the muted tone.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/components/ui/command.tsx
   Line: 142-150

   Comment:
   **Removed default SVG color for uncolored icons in CommandItem**

   The old class `[&_svg:not([class*='text-'])]:text-muted-foreground` auto-applied `text-muted-foreground` to any SVG inside a `CommandItem` that didn't carry its own text color. That rule is now gone. `CommandRow` is safe because `renderIcon` always injects `text-t3`, but other direct `CommandItem` usages in `SearchableSelect` or `model-selector` may render plain SVG icons that will now fall back to the inherited foreground color instead of the muted tone.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/components/ui/command.tsx:18-22
**Background token change affects non-dialog Command consumers**

The `Command` base component now uses `bg-interactive-secondary` instead of `bg-popover`. `SearchableSelect` (`vite/src/components/v2/selects/SearchableSelect.tsx`) and the AI model selector embed a bare `Command` (no `CommandDialog`) directly inside a `Popover`/dropdown, so they'll pick up this new background and `rounded-lg` shape rather than inheriting the popover surface color they used before. Worth a visual check on those surfaces to confirm the new token looks intentional there too.

### Issue 2 of 2
vite/src/components/ui/command.tsx:142-150
**Removed default SVG color for uncolored icons in CommandItem**

The old class `[&_svg:not([class*='text-'])]:text-muted-foreground` auto-applied `text-muted-foreground` to any SVG inside a `CommandItem` that didn't carry its own text color. That rule is now gone. `CommandRow` is safe because `renderIcon` always injects `text-t3`, but other direct `CommandItem` usages in `SearchableSelect` or `model-selector` may render plain SVG icons that will now fall back to the inherited foreground color instead of the muted tone.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: cmd k cleanup"](https://github.com/useautumn/autumn/commit/2f0cda98905e163c6e056156a59c389d0e1119c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32125333)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->