### PR TITLE
fix: schedule customization fixes and stale schedule cleanup

### DIFF
--- a/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
@@ -1,6 +1,7 @@
 import {
 	type CreateScheduleBillingContext,
 	ErrCode,
+	isFreeProduct,
 	ms,
 	RecaseError,
 } from "@autumn/shared";
@@ -46,4 +47,35 @@ export const handleCreateScheduleErrors = async ({
 		});
 	}
 
+	const allImmediateProductsFree = billingContext.fullProducts.every(
+		(product) => isFreeProduct({ prices: product.prices }),
+	);
+
+	if (allImmediateProductsFree && billingContext.stripeSubscription) {
+		const subId = billingContext.stripeSubscription.id;
+
+		const productsOnSub =
+			billingContext.fullCustomer.customer_products.filter((cp) =>
+				cp.subscription_ids?.includes(subId),
+			);
+
+		const transitioningOutIds = new Set(
+			billingContext.productContexts
+				.map((ctx) => ctx.currentCustomerProduct?.id)
+				.filter(Boolean),
+		);
+
+		const subscriptionWillBeCanceled = productsOnSub.every((cp) =>
+			transitioningOutIds.has(cp.id),
+		);
+
+		if (subscriptionWillBeCanceled) {
+			throw new RecaseError({
+				message:
+					"Cannot create a schedule with a free first phase while the customer has an active subscription. Please cancel the existing subscription first.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+	}
 };

--- a/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts
@@ -65,9 +65,9 @@ export const handleCreateScheduleErrors = async ({
 				.filter(Boolean),
 		);
 
-		const subscriptionWillBeCanceled = productsOnSub.every((cp) =>
-			transitioningOutIds.has(cp.id),
-		);
+		const subscriptionWillBeCanceled =
+			productsOnSub.length > 0 &&
+			productsOnSub.every((cp) => transitioningOutIds.has(cp.id));
 
 		if (subscriptionWillBeCanceled) {
 			throw new RecaseError({

--- a/server/src/internal/customers/cusUtils/getFullCustomerSchedule.ts
+++ b/server/src/internal/customers/cusUtils/getFullCustomerSchedule.ts
@@ -33,6 +33,9 @@ export const getFullCustomerSchedule = async ({
 		.where(eq(schedulePhases.schedule_id, schedule.id))
 		.orderBy(asc(schedulePhases.starts_at));
 
+	// Treat a schedule with no future phases as non-existent.
+	if (!phases.some((phase) => phase.starts_at > Date.now())) return undefined;
+
 	return { ...schedule, phases };
 };
 
@@ -61,10 +64,14 @@ export const getAllCustomerSchedules = async ({
 		)
 		.orderBy(asc(schedulePhases.starts_at));
 
-	return allSchedules.map((schedule) => ({
-		...schedule,
-		phases: allPhases.filter((phase) => phase.schedule_id === schedule.id),
-	}));
+	return allSchedules
+		.map((schedule) => ({
+			...schedule,
+			phases: allPhases.filter((phase) => phase.schedule_id === schedule.id),
+		}))
+		.filter((schedule) =>
+			schedule.phases.some((phase) => phase.starts_at > Date.now()),
+		);
 };
 
 export const hydrateFullCustomerSchedule = async ({

--- a/vite/src/components/forms/create-schedule/components/CopyFromPreviousPhaseButton.tsx
+++ b/vite/src/components/forms/create-schedule/components/CopyFromPreviousPhaseButton.tsx
@@ -1,0 +1,29 @@
+import { CopySimpleIcon } from "@phosphor-icons/react";
+import { useCreateScheduleFormContext } from "../context/CreateScheduleFormProvider";
+
+export function CopyFromPreviousPhaseButton({
+	phaseIndex,
+}: {
+	phaseIndex: number;
+}) {
+	const { formValues, handleCopyFromPreviousPhase, isPhaseLocked } =
+		useCreateScheduleFormContext();
+
+	const previousPhase = formValues.phases[phaseIndex - 1];
+	const hasPreviousPlans = previousPhase?.plans.some((p) => p.productId);
+
+	if (phaseIndex < 1 || !hasPreviousPlans || isPhaseLocked({ phaseIndex })) {
+		return null;
+	}
+
+	return (
+		<button
+			type="button"
+			className="flex w-full items-center gap-2 px-2 py-1.5 text-xs text-t3 hover:bg-interactive-secondary-hover transition-colors border-b border-border/50"
+			onClick={() => handleCopyFromPreviousPhase({ phaseIndex })}
+		>
+			<CopySimpleIcon size={12} />
+			Copy from previous phase
+		</button>
+	);
+}

--- a/vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx
+++ b/vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx
@@ -2,6 +2,7 @@ import type { FullCustomer } from "@autumn/shared";
 import { PlusIcon } from "@phosphor-icons/react";
 import { useStore } from "@tanstack/react-form";
 import { Button } from "@/components/v2/buttons/Button";
+import { InlineAction } from "@/components/v2/buttons/InlineAction";
 import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
 import {
 	SheetFooter,
@@ -33,12 +34,10 @@ export function CreateScheduleSheetContent() {
 	const entities = (customer as FullCustomer | null)?.entities ?? [];
 
 	const canSubmit = useStore(form.store, (state) => state.canSubmit);
-	const isDisabled = !canSubmit || !!error;
-	const disabledReason = error
-		? error.message
-		: !canSubmit
-			? "Please fill in all required fields"
-			: null;
+	const isDisabled = !canSubmit;
+	const disabledReason = !canSubmit
+		? "Please fill in all required fields"
+		: null;
 
 	return (
 		<div className="flex flex-col h-full">
@@ -85,14 +84,13 @@ export function CreateScheduleSheetContent() {
 						))}
 					</div>
 
-					<button
-						type="button"
-						className="mt-3 flex items-center gap-1.5 text-xs text-t4 hover:text-t2 transition-colors py-1"
-						onClick={handleAddPhase}
-					>
-						<PlusIcon size={11} />
-						Add phase
-					</button>
+				<InlineAction
+					icon={<PlusIcon size={11} />}
+					onClick={handleAddPhase}
+					className="mt-3"
+				>
+					Add phase
+				</InlineAction>
 				</SheetSection>
 			</div>
 

--- a/vite/src/components/forms/create-schedule/components/SchedulePhaseCard.tsx
+++ b/vite/src/components/forms/create-schedule/components/SchedulePhaseCard.tsx
@@ -1,4 +1,5 @@
 import { InfoIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
+import { InlineAction } from "@/components/v2/buttons/InlineAction";
 import { CalendarIcon } from "lucide-react";
 import { DateInputUnix } from "@/components/general/DateInputUnix";
 import {
@@ -160,15 +161,13 @@ export function SchedulePhaseCard({
 							usedKeys={usedKeys}
 						/>
 					))}
-					<button
-						type="button"
-						className="flex items-center gap-1 text-xs text-t4 hover:text-t2 transition-colors py-1 disabled:opacity-40 disabled:pointer-events-none"
+					<InlineAction
+						icon={<PlusIcon size={11} />}
 						onClick={() => handleAddPlan({ phaseIndex })}
 						disabled={allPlansAdded || isLocked}
 					>
-						<PlusIcon size={11} />
 						Add plan
-					</button>
+					</InlineAction>
 				</div>
 			</div>
 		</div>

--- a/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
+++ b/vite/src/components/forms/create-schedule/components/SchedulePlanRow.tsx
@@ -12,6 +12,7 @@ import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
 import { useOrg } from "@/hooks/common/useOrg";
 import { cn } from "@/lib/utils";
 import { useCreateScheduleFormContext } from "../context/CreateScheduleFormProvider";
+import { CopyFromPreviousPhaseButton } from "./CopyFromPreviousPhaseButton";
 
 export function getSchedulePlanPriceProduct({
 	product,
@@ -114,6 +115,9 @@ export function SchedulePlanRow({
 								)}
 						</>
 					)}
+					header={
+						<CopyFromPreviousPhaseButton phaseIndex={phaseIndex} />
+					}
 					placeholder="Select product..."
 					searchable
 					searchPlaceholder="Search products..."

--- a/vite/src/components/forms/create-schedule/context/CreateScheduleFormProvider.tsx
+++ b/vite/src/components/forms/create-schedule/context/CreateScheduleFormProvider.tsx
@@ -60,6 +60,11 @@ interface CreateScheduleFormContextValue {
 		phaseIndex: number;
 		planIndex: number;
 	}) => void;
+	handleCopyFromPreviousPhase: ({
+		phaseIndex,
+	}: {
+		phaseIndex: number;
+	}) => void;
 
 	editingPlan: EditingPlan | null;
 	editingPlanValue: SchedulePlan | null;
@@ -132,6 +137,7 @@ export function CreateScheduleFormProvider({
 		handleRemovePhase,
 		handleAddPlan,
 		handleRemovePlan,
+		handleCopyFromPreviousPhase,
 		handlePlanEditSave,
 	} = useSchedulePhaseHandlers({ form, nowMs, editingPlan, setEditingPlan });
 
@@ -219,6 +225,7 @@ export function CreateScheduleFormProvider({
 			handleRemovePhase,
 			handleAddPlan,
 			handleRemovePlan,
+			handleCopyFromPreviousPhase,
 			editingPlan,
 			editingPlanValue,
 			setEditingPlan,
@@ -247,6 +254,7 @@ export function CreateScheduleFormProvider({
 			handleRemovePhase,
 			handleAddPlan,
 			handleRemovePlan,
+			handleCopyFromPreviousPhase,
 			editingPlan,
 			editingPlanValue,
 			setEditingPlan,

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleMutation.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleMutation.ts
@@ -68,6 +68,9 @@ export function useCreateScheduleMutation({
 
 			if (customerId) {
 				queryClient.invalidateQueries({ queryKey: ["customer", customerId] });
+				queryClient.invalidateQueries({
+					queryKey: ["customer-schedule", customerId],
+				});
 			}
 		},
 		onError: (error) => {

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
@@ -76,7 +76,8 @@ export function buildCustomizeBasePrice({ items }: { items: ProductItem[] }) {
 	const priceItem = items.find(
 		(item) => item.price != null && !item.feature_id,
 	);
-	if (!priceItem?.price || !priceItem.interval) return undefined;
+	if (!priceItem || priceItem.price === 0) return null;
+	if (!priceItem.interval) return undefined;
 	return {
 		amount: priceItem.price,
 		interval: priceItem.interval,
@@ -100,10 +101,10 @@ export function buildCustomize({
 	if (!items) return undefined;
 	const planItems = buildCustomizeItems({ items, features });
 	const basePrice = buildCustomizeBasePrice({ items });
-	if (!planItems && !basePrice) return undefined;
+	if (!planItems && basePrice === undefined) return undefined;
 	return {
 		...(planItems ? { items: planItems } : {}),
-		...(basePrice ? { price: basePrice } : {}),
+		...(basePrice !== undefined ? { price: basePrice } : {}),
 	};
 }
 

--- a/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts
@@ -21,7 +21,6 @@ type CreatePlanItemParams = Omit<
 
 import {
 	getCreateSchedulePhaseTimingError,
-	hasPersistedCreateSchedule,
 	type SchedulePhase,
 } from "../createScheduleFormSchema";
 
@@ -130,11 +129,9 @@ export function buildCreateScheduleRequestBody({
 	const now = nowMs ?? Date.now();
 	if (!customerId || phases.length === 0) return null;
 	if (getCreateSchedulePhaseTimingError({ phases, nowMs: now })) return null;
-	const hasPersistedSchedule = hasPersistedCreateSchedule({ phases });
 
 	const apiPhases = phases.map((phase, index) => {
-		const startsAt =
-			index === 0 && !hasPersistedSchedule ? now : phase.startsAt;
+		const startsAt = index === 0 ? now : phase.startsAt;
 		if (startsAt === null) return null;
 
 		const plans = phase.plans

--- a/vite/src/components/forms/create-schedule/hooks/useSchedulePhaseHandlers.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useSchedulePhaseHandlers.ts
@@ -78,6 +78,25 @@ export function useSchedulePhaseHandlers({
 		[form, isPhaseLocked],
 	);
 
+	const handleCopyFromPreviousPhase = useCallback(
+		({ phaseIndex }: { phaseIndex: number }) => {
+			if (phaseIndex < 1 || isPhaseLocked({ phaseIndex })) return;
+
+			const previousPlans =
+				form.store.state.values.phases[phaseIndex - 1]?.plans;
+			if (!previousPlans?.length) return;
+
+			const copiedPlans = previousPlans.map((plan) => ({
+				...plan,
+				prepaidOptions: { ...plan.prepaidOptions },
+				items: plan.items ? [...plan.items] : null,
+			}));
+
+			form.setFieldValue(`phases[${phaseIndex}].plans`, copiedPlans);
+		},
+		[form, isPhaseLocked],
+	);
+
 	const handlePlanEditSave = useCallback(
 		({ plan }: { plan: SchedulePlan }) => {
 			if (!editingPlan) return;
@@ -96,6 +115,7 @@ export function useSchedulePhaseHandlers({
 		handleRemovePhase,
 		handleAddPlan,
 		handleRemovePlan,
+		handleCopyFromPreviousPhase,
 		handlePlanEditSave,
 	};
 }

--- a/vite/src/components/v2/buttons/InlineAction.tsx
+++ b/vite/src/components/v2/buttons/InlineAction.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface InlineActionProps extends ComponentProps<"button"> {
+	icon?: ReactNode;
+}
+
+export function InlineAction({
+	icon,
+	children,
+	className,
+	...props
+}: InlineActionProps) {
+	return (
+		<button
+			type="button"
+			className={cn(
+				"flex items-center gap-1 text-xs text-t4 hover:text-t2 transition-colors py-1 disabled:opacity-40 disabled:pointer-events-none",
+				className,
+			)}
+			{...props}
+		>
+			{icon}
+			{children}
+		</button>
+	);
+}

--- a/vite/src/components/v2/selects/SearchableSelect.tsx
+++ b/vite/src/components/v2/selects/SearchableSelect.tsx
@@ -34,6 +34,7 @@ export type SearchableSelectProps<T> = {
 	triggerClassName?: string;
 	contentClassName?: string;
 	defaultOpen?: boolean;
+	header?: ReactNode;
 	footer?: ReactNode;
 };
 
@@ -54,6 +55,7 @@ export function SearchableSelect<T>({
 	triggerClassName,
 	contentClassName,
 	defaultOpen = false,
+	header,
 	footer,
 }: SearchableSelectProps<T>) {
 	const [open, setOpen] = useState(false);
@@ -151,6 +153,7 @@ export function SearchableSelect<T>({
 								}
 							>
 								{searchable && <CommandInput placeholder={searchPlaceholder} />}
+								{header}
 								<CommandList>
 									<CommandEmpty className="text-t3">{emptyText}</CommandEmpty>
 									<CommandGroup>

--- a/vite/src/views/customers2/components/sheets/CreateScheduleSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/CreateScheduleSheet.tsx
@@ -67,9 +67,9 @@ function reconstructCustomItems({
 	const customerFeatureIds = new Set(
 		customerItems.map((item) => item.feature_id).filter(Boolean),
 	);
-	const customerHasBasePrice = customerItems.some(
-		(item) => !item.feature_id && item.price != null,
-	);
+	const customerHasBasePrice =
+		prices.length === 0 ||
+		customerItems.some((item) => !item.feature_id && item.price != null);
 	const missingProductItems =
 		product?.items?.filter((item) => {
 			if (!item.feature_id) return !customerHasBasePrice;

--- a/vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx
+++ b/vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/forms/shared/utils/planCustomizationUtils";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/v2/buttons/Button";
+import { InlineAction } from "@/components/v2/buttons/InlineAction";
 import { InlinePlanEditor } from "@/components/v2/inline-custom-plan-editor/InlinePlanEditor";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
@@ -521,14 +522,12 @@ export function SubscriptionEditorView({
 										}
 									/>
 								))}
-								<button
-									type="button"
-									onClick={() => handleAddPlan(phaseIndex)}
-									className="flex items-center gap-1 text-xs text-t4 hover:text-t2 transition-colors py-1"
-								>
-									<PlusIcon size={11} />
-									Add plan
-								</button>
+							<InlineAction
+								icon={<PlusIcon size={11} />}
+								onClick={() => handleAddPlan(phaseIndex)}
+							>
+								Add plan
+							</InlineAction>
 							</div>
 						</div>
 					);

--- a/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
+++ b/vite/tests/components/forms/create-schedule/hooks/build-create-schedule-request-body.test.ts
@@ -87,10 +87,17 @@ describe("buildCustomizeBasePrice", () => {
 		expect(result!.interval).toBe("month");
 	});
 
-	test("returns undefined when no base price item exists", () => {
+	test("returns null when base price item was removed", () => {
 		const result = buildCustomizeBasePrice({ items: [featurePriceItem] });
 
-		expect(result).toBeUndefined();
+		expect(result).toBeNull();
+	});
+
+	test("returns null when price is zero (free)", () => {
+		const zeroPriceItem = { ...basePriceItem, price: 0 } as ProductItem;
+		const result = buildCustomizeBasePrice({ items: [zeroPriceItem] });
+
+		expect(result).toBeNull();
 	});
 
 	test("returns undefined when price item has no interval", () => {
@@ -118,7 +125,7 @@ describe("buildCustomizeBasePrice", () => {
 	test("ignores feature items that happen to have a price", () => {
 		const result = buildCustomizeBasePrice({ items: [featurePriceItem] });
 
-		expect(result).toBeUndefined();
+		expect(result).toBeNull();
 	});
 });
 
@@ -207,11 +214,12 @@ describe("buildCustomize", () => {
 		expect(result).toBeUndefined();
 	});
 
-	test("returns items when only free features are present", () => {
+	test("returns items and price:null when base price was removed", () => {
 		const result = buildCustomize({ items: [freeFeatureItem], features });
 
 		expect(result).toBeDefined();
 		expect(result!.items).toBeDefined();
+		expect(result!.price).toBeNull();
 	});
 
 	test("returns price when only base price is customized", () => {
@@ -223,12 +231,12 @@ describe("buildCustomize", () => {
 		expect(result).not.toHaveProperty("items");
 	});
 
-	test("returns items when only feature items are customized", () => {
+	test("returns items and price:null when items have no base price", () => {
 		const result = buildCustomize({ items: [featurePriceItem], features });
 
 		expect(result).toBeDefined();
 		expect(result!.items).toBeDefined();
-		expect(result).not.toHaveProperty("price");
+		expect(result!.price).toBeNull();
 	});
 
 	test("returns both price and items when fully customized", () => {


### PR DESCRIPTION
## Summary
- Treat schedules with no future phases as non-existent so the frontend no longer blocks cancel/update actions behind the ScheduledPlanGuard
- Invalidate the `customer-schedule` query cache when a schedule is created/updated so the UI refreshes without a manual page reload
- Fix catalog base price backfill on free custom schedule plans
- Add "copy from previous phase" button to schedule product selector
- Fix `price:null` when schedule plan customize removes base price

## Test plan
- [ ] Create a schedule with multiple phases, let all phases pass, verify the customer page shows "Create Schedule" (not "Update Schedule") and allows normal cancel/update
- [ ] Create or update a schedule and verify the UI reflects the change immediately without a manual refresh
- [ ] Verify free custom plans in schedule phases don't incorrectly backfill a base price

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schedule customization edge cases and cleans up stale schedules. The UI now refreshes instantly after create/update and adds a quick “copy from previous phase” action.

- **Bug Fixes**
  - Treat schedules with no future phases as non-existent to unblock cancel/update (bypasses ScheduledPlanGuard).
  - Invalidate `customer-schedule` cache on create/update so changes appear without reload.
  - Send `price: null` when base price is removed or zero to avoid falling back to catalog pricing.
  - Prevent catalog base price backfill on free custom schedules.
  - Block creating schedules with a free first phase when an active subscription would be canceled; require cancel first, and avoid false positives when the Stripe subscription has no linked products.

- **New Features**
  - Add “Copy from previous phase” to the schedule product selector.
  - Introduce `InlineAction` button and a `header` slot in `SearchableSelect` to support the new action.

<sup>Written for commit 80fe92a1265ed584bf9d69aa9f1b660abdca7cd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses several schedule-related correctness bugs and adds a UX improvement for multi-phase schedule editing. The backend treats schedules whose every phase has already started as non-existent, unblocking cancel/update flows; the frontend now invalidates the `customer-schedule` query cache immediately after a mutation so the UI refreshes without a reload.

- **Bug fixes**: Stale schedule cleanup (`getFullCustomerSchedule`) returns `undefined` when all phases are in the past; `buildCustomizeBasePrice` distinguishes `null` (explicit free/removed price) from `undefined` (no customization), fixing `price:null` on free custom schedule plans; `reconstructCustomItems` no longer backfills a catalog base price for free plans (`prices.length === 0`).
- **Improvements**: `useCreateScheduleMutation` invalidates `customer-schedule` cache on success; phase-0 `startsAt` is always `now` (server ignores the value for updates anyway); `InlineAction` button component is extracted and reused.
- **Improvements**: "Copy from previous phase" button added to the product-selector dropdown, letting users replicate a prior phase's plan configuration in one click.
</details>

<h3>Confidence Score: 4/5</h3>

The bulk of the changes are safe; one edge case in the new subscription guard could incorrectly block schedule creation for customers with inconsistently-linked Stripe subscriptions.

The subscriptionWillBeCanceled check uses Array.prototype.every on productsOnSub, which returns true for an empty array. If the Stripe subscription exists but carries no associated customer_products records, the guard throws a blocking error even though no subscription is actually being canceled. All other changes are straightforward and test-covered.

server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts — the empty-array edge case in the subscription cancellation guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts | Adds a guard that prevents creating a free-phase schedule when an active subscription would be canceled, but uses Array.prototype.every on productsOnSub which vacuously returns true for an empty array, causing a false-positive error. |
| server/src/internal/customers/cusUtils/getFullCustomerSchedule.ts | Filters out stale schedules (all phases in the past) so the frontend no longer blocks actions behind a ScheduledPlanGuard that should no longer apply. |
| vite/src/components/forms/create-schedule/hooks/useCreateScheduleRequestBody.ts | Fixes price:null handling in custom plans: buildCustomizeBasePrice now returns null (explicit removal) vs undefined (no-op), and phase-0 startsAt is always now since the server ignores the value for updates. |
| vite/src/views/customers2/components/sheets/CreateScheduleSheet.tsx | Fixes base price backfill for free custom schedule plans by treating prices.length === 0 as customer already has base price handled, preventing catalog price injection. |
| vite/src/components/forms/create-schedule/hooks/useCreateScheduleMutation.ts | Adds customer-schedule query invalidation on schedule create/update so the UI refreshes without a manual page reload. |
| vite/src/components/v2/buttons/InlineAction.tsx | New reusable InlineAction button component extracted from repeated inline button patterns, consolidating icon+text action buttons. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getFullCustomerSchedule] --> B{Any phase starts_at > now?}
    B -- No --> C[return undefined - stale schedule treated as non-existent]
    B -- Yes --> D[return schedule with phases]

    E[buildCustomizeBasePrice] --> F{priceItem found?}
    F -- No or price === 0 --> G[return null - explicit free/removed]
    F -- Yes, no interval --> H[return undefined - no customization]
    F -- Yes, has interval --> I[return price object]

    N[handleCreateScheduleErrors] --> O{allImmediateProductsFree AND stripeSubscription?}
    O -- No --> P[pass]
    O -- Yes --> Q{productsOnSub.every in transitioningOutIds?}
    Q -- Yes --> R[throw: cannot create free first phase]
    Q -- No --> P
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/actions/createSchedule/errors/handleCreateScheduleErrors.ts:68-70
Vacuous-truth false positive on empty `productsOnSub`. `Array.prototype.every` returns `true` for an empty array, so when `productsOnSub` is empty (e.g., the Stripe subscription exists but no Autumn `customer_products` carry its ID — possible for imported or inconsistently-linked subscriptions), `subscriptionWillBeCanceled` becomes `true` and the error fires even though nothing is actually being canceled.

```suggestion
		const subscriptionWillBeCanceled =
			productsOnSub.length > 0 &&
			productsOnSub.every((cp) => transitioningOutIds.has(cp.id));
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: treat schedules with no future phas..."](https://github.com/useautumn/autumn/commit/1dba1e819e6255f408f077af2be100dc878ee9fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32159815)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->