### PR TITLE
fix: disable stripe tax for vercel and make metadata optional with default

### DIFF
--- a/server/src/external/vercel/handlers/resources/handleCreateResource.ts
+++ b/server/src/external/vercel/handlers/resources/handleCreateResource.ts
@@ -21,7 +21,7 @@ export const handleCreateResource = createRoute({
 	body: z.object({
 		productId: z.string().min(1),
 		name: z.string().min(1),
-		metadata: z.record(z.any(), z.any()),
+		metadata: z.record(z.any(), z.any()).optional().default({}),
 		billingPlanId: z.string().min(1),
 		externalId: z.string().optional(),
 		protocolSettings: z
@@ -147,6 +147,7 @@ export const handleCreateResource = createRoute({
 				},
 			});
 		} catch (error) {
+			console.error(error);
 			return c.json(
 				{
 					error: {

--- a/server/src/external/vercel/misc/vercelMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelMiddleware.ts
@@ -18,6 +18,8 @@ export const vercelSeederMiddleware = async (
 
 	const org =
 		!ctx.org && orgId ? await OrgService.get({ db: ctx.db, orgId }) : ctx.org;
+
+	org.config.automatic_tax = false;
 	const env = ctx.env !== routeEnv ? (routeEnv as AppEnv) : ctx.env;
 
 	const features =

--- a/server/src/external/vercel/misc/vercelMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelMiddleware.ts
@@ -19,7 +19,9 @@ export const vercelSeederMiddleware = async (
 	const org =
 		!ctx.org && orgId ? await OrgService.get({ db: ctx.db, orgId }) : ctx.org;
 
-	org.config.automatic_tax = false;
+	if (org?.config) {
+		org.config.automatic_tax = false;
+	}
 	const env = ctx.env !== routeEnv ? (routeEnv as AppEnv) : ctx.env;
 
 	const features =


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Stripe automatic tax for Vercel orgs in middleware, with a null-safe guard on `org.config` to prevent crashes. Make `metadata` optional with default `{}` when creating Vercel resources, and add error logging for creation failures.

<sup>Written for commit ff2f757d576feda150ba9aa306dca139e9aa6c91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR disables Stripe automatic tax for all Vercel integration requests by mutating `org.config.automatic_tax` in the middleware, and relaxes the `metadata` field on the create-resource body schema to be optional with a default of `{}`.

- **Bug fixes** — `metadata` in `handleCreateResource` is now optional with a default empty object, preventing failures when Vercel omits the field from its request payload.
- **Improvements** — `console.error` logging added to the outer catch block in `handleCreateResource` to surface errors that were previously silent.
- **Bug fixes** — Stripe automatic tax is disabled for Vercel requests via `org.config.automatic_tax = false` in `vercelSeederMiddleware`, though the assignment is currently unguarded against a potentially undefined `org`.
</details>

<h3>Confidence Score: 3/5</h3>

The middleware change is risky: it directly mutates `org.config` without guarding against a null/undefined `org`, which can crash any Vercel request where `org` is not resolved.

The middleware change is risky: it directly mutates `org.config` without guarding against a null/undefined `org`, which can crash any Vercel request where `org` is not resolved. The `metadata` schema change and the added error logging are straightforward and safe.

server/src/external/vercel/misc/vercelMiddleware.ts needs a null guard before the `org.config.automatic_tax` assignment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/vercel/misc/vercelMiddleware.ts | Adds `org.config.automatic_tax = false` to disable Stripe tax for all Vercel requests, but the assignment is unguarded and will throw a TypeError when `org` is undefined. |
| server/src/external/vercel/handlers/resources/handleCreateResource.ts | Makes `metadata` optional with a default of `{}` in the Zod schema and adds `console.error` logging to the catch block; the `?? {}` fallback inside the handler is now redundant. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Vercel
    participant vercelSeederMiddleware
    participant OrgService
    participant handleCreateResource
    participant Stripe

    Vercel->>vercelSeederMiddleware: POST /resources (body may omit metadata)
    vercelSeederMiddleware->>OrgService: get(orgId) if ctx.org missing
    OrgService-->>vercelSeederMiddleware: org
    vercelSeederMiddleware->>vercelSeederMiddleware: "org.config.automatic_tax = false"
    vercelSeederMiddleware->>handleCreateResource: next() with ctx.org patched

    handleCreateResource->>handleCreateResource: "parse body (metadata defaults to {})"
    handleCreateResource->>Stripe: customers.retrieve(customer.processor.id)
    Stripe-->>handleCreateResource: stripeCustomer
    handleCreateResource->>handleCreateResource: db.transaction → createVercelSubscription
    handleCreateResource-->>Vercel: 200 resource response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/external/vercel/misc/vercelMiddleware.ts:22
**Unguarded null access on `org`**

`org` can be `undefined` here — the ternary on line 19 falls back to `ctx.org`, which may itself be falsy when `orgId` is absent from route params. Accessing `org.config.automatic_tax` on a `undefined` value will throw a `TypeError` at runtime. The guard that checks `org` for nullability already exists later (line 45: `const routedCtx = org ? ...`), confirming this is a real nullable path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: disable stripe tax for vercel and m..."](https://github.com/useautumn/autumn/commit/9bd11bda7d8bac31dff91333803e69c06db2045b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32173870)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->