### PR TITLE
fix: hotfix deductions null to Tinybird quarantine

### DIFF
--- a/server/src/external/tinybird/sendEvents/mapEvent.ts
+++ b/server/src/external/tinybird/sendEvents/mapEvent.ts
@@ -47,6 +47,6 @@ export const mapToTinybirdEvent = (event: EventInsert): TinybirdEvent => {
 		internal_entity_id: event.internal_entity_id ?? null,
 		customer_id: event.customer_id,
 		properties: event.properties ? JSON.stringify(event.properties) : null,
-		deductions: event.deductions ? JSON.stringify(event.deductions) : null,
+		deductions: event.deductions ? JSON.stringify(event.deductions) : "[]",
 	};
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent Tinybird quarantine by defaulting `deductions` to "[]" instead of null when absent in events.

<sup>Written for commit 48258468560f77b2705a7a4d7c1c66784c53be41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

