### PR TITLE
fix: wrap deductions in object to stop Tinybird  quarantine

### DIFF
--- a/server/src/external/tinybird/sendEvents/mapEvent.ts
+++ b/server/src/external/tinybird/sendEvents/mapEvent.ts
@@ -47,6 +47,8 @@ export const mapToTinybirdEvent = (event: EventInsert): TinybirdEvent => {
 		internal_entity_id: event.internal_entity_id ?? null,
 		customer_id: event.customer_id,
 		properties: event.properties ? JSON.stringify(event.properties) : null,
-		deductions: event.deductions ? JSON.stringify(event.deductions) : "[]",
+		deductions: event.deductions
+			? JSON.stringify({ list: event.deductions })
+			: "{}",
 	};
 };

--- a/server/src/internal/analytics/actions/listEvents.ts
+++ b/server/src/internal/analytics/actions/listEvents.ts
@@ -88,7 +88,11 @@ export const listEvents = async ({
 		if (row.deductions) {
 			try {
 				const parsed = JSON.parse(row.deductions);
-				if (Array.isArray(parsed)) deductions = parsed as TrackDeduction[];
+				if (Array.isArray(parsed)) {
+					deductions = parsed as TrackDeduction[];
+				} else if (parsed && Array.isArray(parsed.list)) {
+					deductions = parsed.list as TrackDeduction[];
+				}
 			} catch {
 				// Invalid JSON — leave null so the caller can distinguish missing
 				// vs explicit empty.


### PR DESCRIPTION
- **send empty json**
- **fix: wrap deductions in object for JSON column ingest**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Tinybird from quarantining events by sending `deductions` as a JSON object instead of an array. Reading now supports both the new object shape and the legacy array.

- **Bug Fixes**
  - Map outgoing `deductions` to `JSON.stringify({ list: deductions })`, default `"{}"` when empty.
  - In `listEvents`, parse both legacy arrays and the new `{ list: [...] }` format.

<sup>Written for commit d3b03fba292751a547cc845b5c1329c3f78e350c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

