### PR TITLE
fix: public dragofly and migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,9 +92,11 @@
 		"migrate-functions:prod": "infisical run --env=prod --recursive -- bun scripts/migrations/migrate-functions.ts",
 		"validate-schema": "infisical run --env=prod --recursive -- bun scripts/migrations/validate-schema.ts",
 		"validate-shebangs": "infisical run --env=prod --recursive -- bun scripts/migrations/validate-fullsubject-shebangs.ts",
-		"tinybird:info": "cd server && infisical run --env=dev --recursive -- bunx tinybird info",
-		"tinybird:deploy:dev:check": "cd server && infisical run --env=dev --recursive -- bunx tinybird deploy --check",
-		"tinybird:deploy:dev": "cd server && infisical run --env=dev --recursive -- bunx tinybird deploy",
+
+		"tb": "bun scripts/tinybird/index.ts",
+		"tb:prod": "bun scripts/tinybird/index.ts prod",
+		"tb:prod-legacy": "bun scripts/tinybird/index.ts prod-legacy",
+
 		"trigger:deploy": "bunx trigger.dev deploy",
 		"setupci": "node scripts/setup/setupci.js",
 		"replicate": "bun scripts/db/replicate.ts",

--- a/scripts/tinybird/index.ts
+++ b/scripts/tinybird/index.ts
@@ -1,0 +1,137 @@
+import path from "node:path";
+
+type ProfileName = "dev" | "prod" | "prod-legacy";
+type TinybirdTarget = "new" | "legacy";
+
+type Profile = {
+	infisicalEnv: "dev" | "prod";
+	target: TinybirdTarget;
+};
+
+const PROFILE_ARG_VALUES = new Set(["prod", "prod-legacy"]);
+
+const profiles: Record<ProfileName, Profile> = {
+	dev: {
+		infisicalEnv: "dev",
+		target: "new",
+	},
+	prod: {
+		infisicalEnv: "prod",
+		target: "new",
+	},
+	"prod-legacy": {
+		infisicalEnv: "prod",
+		target: "legacy",
+	},
+};
+
+const commandAliases: Record<string, string[]> = {
+	info: ["info"],
+	"deploy:check": ["deploy", "--check"],
+	deploy: ["deploy"],
+};
+
+const usage = `Usage:
+  bun tb info
+  bun tb deploy:check
+  bun tb deploy
+  bun tb:prod <tinybird command...>
+  bun tb:prod-legacy <tinybird command...>
+
+Targets:
+  bun tb             Infisical dev, new Tinybird instance
+  bun tb:prod       Infisical prod, new Tinybird instance
+  bun tb:prod-legacy Infisical prod, legacy Tinybird instance`;
+
+const rootDir = path.resolve(import.meta.dir, "../..");
+const serverDir = path.join(rootDir, "server");
+
+const run = async (
+	cmd: string[],
+	options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+) => {
+	const proc = Bun.spawn(cmd, {
+		cwd: options?.cwd ?? rootDir,
+		env: options?.env,
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+
+	return proc.exited;
+};
+
+const requireEnv = (name: string) => {
+	const value = process.env[name];
+	if (!value) {
+		console.error(`${name} is not set`);
+		process.exit(1);
+	}
+	return value;
+};
+
+const resolveTinybirdArgs = (args: string[]) => {
+	if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+		console.log(usage);
+		process.exit(args.length === 0 ? 1 : 0);
+	}
+
+	return commandAliases[args[0]] ?? args;
+};
+
+const executeTinybird = async () => {
+	const target = requireEnv("AUTUMN_TINYBIRD_TARGET") as TinybirdTarget;
+	const env = { ...process.env };
+
+	if (target === "new") {
+		env.TINYBIRD_API_URL = requireEnv("TINYBIRD_US_EAST_API_URL");
+		env.TINYBIRD_TOKEN = requireEnv("TINYBIRD_US_EAST_TOKEN");
+	} else {
+		requireEnv("TINYBIRD_API_URL");
+		requireEnv("TINYBIRD_TOKEN");
+	}
+
+	const args = resolveTinybirdArgs(Bun.argv.slice(2));
+	const exitCode = await run(["bunx", "tinybird", ...args], {
+		cwd: serverDir,
+		env,
+	});
+	process.exit(exitCode);
+};
+
+const main = async () => {
+	if (process.env.AUTUMN_TINYBIRD_BOOTSTRAPPED === "1") {
+		await executeTinybird();
+		return;
+	}
+
+	const rawArgs = Bun.argv.slice(2);
+	const profileName = PROFILE_ARG_VALUES.has(rawArgs[0])
+		? (rawArgs.shift() as ProfileName)
+		: "dev";
+	const profile = profiles[profileName];
+	const args = resolveTinybirdArgs(rawArgs);
+
+	const exitCode = await run(
+		[
+			"infisical",
+			"run",
+			`--env=${profile.infisicalEnv}`,
+			"--recursive",
+			"--",
+			"bun",
+			"scripts/tinybird/index.ts",
+			...args,
+		],
+		{
+			env: {
+				...process.env,
+				AUTUMN_TINYBIRD_BOOTSTRAPPED: "1",
+				AUTUMN_TINYBIRD_TARGET: profile.target,
+			},
+		},
+	);
+	process.exit(exitCode);
+};
+
+await main();

--- a/server/src/external/aws/ecs/onAwsEcs.ts
+++ b/server/src/external/aws/ecs/onAwsEcs.ts
@@ -1,0 +1,9 @@
+/**
+ * True iff this process is running inside an AWS ECS / Fargate task.
+ * `ECS_CONTAINER_METADATA_URI_V4` is auto-injected by the ECS runtime
+ * and unset everywhere else (local dev, trigger.dev workers, scripts),
+ * so it's the canonical "am I on AWS?" gate — same one
+ * `awsTaskIdentity` uses to discover the running service.
+ */
+export const onAwsEcs = (): boolean =>
+	Boolean(process.env.ECS_CONTAINER_METADATA_URI_V4);

--- a/server/src/external/redis/getReachableDragonflyUrl.ts
+++ b/server/src/external/redis/getReachableDragonflyUrl.ts
@@ -1,0 +1,30 @@
+import { onAwsEcs } from "@/external/aws/ecs/onAwsEcs.js";
+
+/**
+ * Map a stored dragonfly URL to one that is actually reachable from the
+ * current process.
+ *
+ * Background: orgs whose `redis_config` points at the SHARED dragonfly
+ * instance store its private VPC URL (`CACHE_V2_DRAGONFLY_URL`) in the
+ * config row. That URL is only reachable from inside our AWS Fargate
+ * tasks. Off-AWS callers (local dev, trigger.dev workers) need the
+ * public mirror `CACHE_V2_DRAGONFLY_PUBLIC_URL` instead.
+ *
+ * Heuristic: if the URL equals the private shared URL AND we're not on
+ * AWS, swap to public. Anything else (per-org dragonfly, Upstash, Redis
+ * Cloud, etc.) is returned untouched — we have no opinion about those.
+ *
+ * Returns the same input string when no swap applies, so callers can use
+ * it transparently in place of the raw URL.
+ */
+export const getReachableDragonflyUrl = (url: string): string => {
+	if (onAwsEcs()) return url;
+
+	const privateUrl = process.env.CACHE_V2_DRAGONFLY_URL?.trim();
+	if (!privateUrl || url.trim() !== privateUrl) return url;
+
+	const publicUrl = process.env.CACHE_V2_DRAGONFLY_PUBLIC_URL?.trim();
+	if (!publicUrl) return url;
+
+	return publicUrl;
+};

--- a/server/src/external/redis/initRedisV2.ts
+++ b/server/src/external/redis/initRedisV2.ts
@@ -1,6 +1,7 @@
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import type { RedisV2InstanceName } from "@/internal/misc/redisV2Cache/redisV2CacheSchemas.js";
+import { getReachableDragonflyUrl } from "./getReachableDragonflyUrl.js";
 import {
 	createRedisConnection,
 	currentRegion,
@@ -12,8 +13,13 @@ import {
 	supportsUpstashShebangForRedisV2,
 } from "./initUtils/redisV2Config.js";
 
+const rawDragonflyUrl = process.env.CACHE_V2_DRAGONFLY_URL?.trim();
+const dragonflyUrl = rawDragonflyUrl
+	? getReachableDragonflyUrl(rawDragonflyUrl)
+	: undefined;
+
 export const redisV2: Redis = createRedisConnection({
-	cacheUrl: process.env.CACHE_V2_DRAGONFLY_URL?.trim() || "",
+	cacheUrl: dragonflyUrl || "",
 	region: `${currentRegion}:v2`,
 	supportsUpstashShebang: false,
 	commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
@@ -22,7 +28,7 @@ export const redisV2: Redis = createRedisConnection({
 const alternateInstanceUrls: Partial<Record<RedisV2InstanceName, string>> = {
 	upstash: process.env.CACHE_V2_UPSTASH_URL?.trim() || undefined,
 	redis: process.env.CACHE_V2_REDIS_URL?.trim() || undefined,
-	dragonfly: process.env.CACHE_V2_DRAGONFLY_URL?.trim() || undefined,
+	dragonfly: dragonflyUrl,
 };
 
 const instancePool = new Map<RedisV2InstanceName, Redis>();

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -4,6 +4,7 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { decryptData } from "@/utils/encryptUtils.js";
+import { getReachableDragonflyUrl } from "./getReachableDragonflyUrl.js";
 import { createRedisConnection, currentRegion } from "./initRedis.js";
 import { REDIS_V2_COMMAND_TIMEOUT_MS } from "./initUtils/redisV2Config.js";
 import { resolveRedisV2 } from "./resolveRedisV2.js";
@@ -69,7 +70,7 @@ export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
 	}
 
 	const instance = createOrgRedisConnection({
-		connectionString,
+		connectionString: getReachableDragonflyUrl(connectionString),
 		orgId: org.id,
 	});
 	pool.set(org.id, { instance, url: org.redis_config.url });

--- a/server/src/external/tinybird/migrations/migrationItemEventsDataSource.ts
+++ b/server/src/external/tinybird/migrations/migrationItemEventsDataSource.ts
@@ -8,7 +8,17 @@ import {
 	Tinybird,
 	t,
 } from "@tinybirdco/sdk";
-import { tinybirdConfig } from "../tinybirdUtils.js";
+
+const TINYBIRD_US_EAST_API_URL = process.env.TINYBIRD_US_EAST_API_URL;
+const TINYBIRD_US_EAST_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
+
+const migrationTinybirdConfig =
+	TINYBIRD_US_EAST_API_URL && TINYBIRD_US_EAST_TOKEN
+		? {
+				baseUrl: TINYBIRD_US_EAST_API_URL,
+				token: TINYBIRD_US_EAST_TOKEN,
+			}
+		: null;
 
 export type MigrationItemEventStatus = "succeeded" | "skipped" | "failed";
 
@@ -110,7 +120,7 @@ export const listMigrationItemEventsEndpoint = defineEndpoint(
 	},
 );
 
-export const migrationTinybird = tinybirdConfig
+export const migrationTinybird = migrationTinybirdConfig
 	? new Tinybird({
 			datasources: {
 				itemEvents: migrationItemEventsDatasource,
@@ -118,7 +128,7 @@ export const migrationTinybird = tinybirdConfig
 			pipes: {
 				listItemEvents: listMigrationItemEventsEndpoint,
 			},
-			...tinybirdConfig,
+			...migrationTinybirdConfig,
 			devMode: false,
 		})
 	: null;

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.ts
@@ -20,7 +20,13 @@ const invalidateCachedFullSubjectOnRedis = async ({
 	source?: string;
 	redisV2: Redis;
 }): Promise<void> => {
-	if (redisV2.status !== "ready") return;
+	if (redisV2.status !== "ready") {
+		const subjectLabel = entityId ? `${customerId}:${entityId}` : customerId;
+		ctx.logger.warn(
+			`[invalidateCachedFullSubject] redisV2 not_ready (status=${redisV2.status}), skipping subject: ${subjectLabel}, source: ${source}`,
+		);
+		return;
+	}
 
 	await invalidateSharedBalanceFields({
 		ctx,

--- a/server/src/internal/migrations/v2/actions/migrationRun/withMigrationRunClaim.ts
+++ b/server/src/internal/migrations/v2/actions/migrationRun/withMigrationRunClaim.ts
@@ -22,12 +22,14 @@ export const withMigrationRunClaim = async ({
 	migration,
 	dryRun,
 	lazyRun = false,
+	onlyIds,
 	claimed,
 }: {
 	ctx: AutumnContext;
 	migration: Migration;
 	dryRun: boolean;
 	lazyRun?: boolean;
+	onlyIds?: string[] | null;
 	claimed: (
 		migrationRunId: string,
 	) => Promise<{ triggerRunId?: string } | undefined>;
@@ -38,6 +40,7 @@ export const withMigrationRunClaim = async ({
 			migration_internal_id: migration.internal_id,
 			dry_run: dryRun,
 			lazy_run: lazyRun,
+			only_ids: onlyIds && onlyIds.length > 0 ? onlyIds : null,
 		},
 	});
 

--- a/server/src/internal/migrations/v2/filters/runFilter.ts
+++ b/server/src/internal/migrations/v2/filters/runFilter.ts
@@ -53,6 +53,31 @@ export const runFilter = async ({
 	});
 	const count = await countCustomers({ ctx, filter, checkpoint });
 
+	ctx.logger.info("runFilter: customer scope resolved", {
+		data: {
+			migrationRunId,
+			matchedCount: count,
+			only: controls?.only,
+			retryFailed: migration.retry_failed === true,
+			effectiveFilter: filter,
+			checkpointExcludedStatuses: checkpoint?.excludedStatuses,
+		},
+	});
+	if (count === 0) {
+		ctx.logger.warn(
+			"runFilter: no customers matched — nothing to migrate. " +
+				"Common causes: customer is excluded by a previous item_run " +
+				"(set retry_failed=true to re-run failed items), or the customer " +
+				"does not match other filter clauses (plan, addon, etc.)",
+			{
+				data: {
+					migrationRunId,
+					only: controls?.only,
+				},
+			},
+		);
+	}
+
 	const iterate = async function* () {
 		for await (const batch of filterCustomers({ ctx, filter, checkpoint })) {
 			yield batch.map(

--- a/server/src/internal/migrations/v2/handlers/handleCancelMigrationRun.ts
+++ b/server/src/internal/migrations/v2/handlers/handleCancelMigrationRun.ts
@@ -1,0 +1,79 @@
+import {
+	ErrCode,
+	MigrationRunStatus,
+	RecaseError,
+	Scopes,
+} from "@autumn/shared";
+import { runs } from "@trigger.dev/sdk/v3";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler";
+import {
+	migrationRepo,
+	migrationRunRepo,
+} from "@/internal/migrations/v2/repos/index.js";
+
+const CancelMigrationRunBody = z.object({
+	id: z.string(),
+});
+
+/** POST /migrations.cancel_run — cancel the active migration_run for a
+ *  migration, if any. Marks the run as `canceled` and best-effort
+ *  cancels the trigger.dev task. Errors if no active run exists. */
+export const handleCancelMigrationRun = createRoute({
+	scopes: [Scopes.Migrations.Write],
+	body: CancelMigrationRunBody,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { id } = c.req.valid("json");
+
+		const migration = await migrationRepo.find({ ctx, id });
+
+		const activeRuns = await migrationRunRepo.list({
+			ctx,
+			migrationInternalId: migration.internal_id,
+			active: true,
+		});
+		const activeRun = activeRuns[0];
+
+		if (!activeRun) {
+			throw new RecaseError({
+				message: `No active migration run for ${id}`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 404,
+			});
+		}
+
+		if (activeRun.trigger_run_id) {
+			try {
+				await runs.cancel(activeRun.trigger_run_id);
+			} catch (error) {
+				ctx.logger.warn(
+					"cancel-migration-run: trigger.dev cancel failed (continuing to mark canceled)",
+					{
+						data: {
+							runId: activeRun.internal_id,
+							triggerRunId: activeRun.trigger_run_id,
+							error: error instanceof Error ? error.message : String(error),
+						},
+					},
+				);
+			}
+		}
+
+		await migrationRunRepo.update({
+			ctx,
+			internalId: activeRun.internal_id,
+			updates: {
+				status: MigrationRunStatus.Canceled,
+				error_message: "Canceled by user",
+				finished_at: Date.now(),
+			},
+		});
+
+		return c.json({
+			migration_id: id,
+			run_id: activeRun.internal_id,
+			canceled: true,
+		});
+	},
+});

--- a/server/src/internal/migrations/v2/handlers/handleRunMigration.ts
+++ b/server/src/internal/migrations/v2/handlers/handleRunMigration.ts
@@ -26,7 +26,7 @@ const getRunMigrationTriggerOptions = ({
 	orgId: string;
 	isDev: boolean;
 }) => ({
-	...(isDev ? { region: "eu-west-1" } : {}),
+	...(isDev ? { region: "eu-central-1" } : {}),
 	concurrencyKey: orgId,
 });
 
@@ -59,6 +59,7 @@ export const handleRunMigration = createRoute({
 			migration,
 			dryRun,
 			lazyRun,
+			onlyIds: only,
 			claimed: async (migrationRunId) => {
 				const handle = await runMigrationTask.trigger(
 					{

--- a/server/src/internal/migrations/v2/migrationRouter.ts
+++ b/server/src/internal/migrations/v2/migrationRouter.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { handleCancelMigrationRun } from "./handlers/handleCancelMigrationRun.js";
 import { handleCreateMigration } from "./handlers/handleCreateMigration.js";
 import { handleDeleteMigration } from "./handlers/handleDeleteMigration.js";
 import { handleLazyRunMigration } from "./handlers/handleLazyRunMigration.js";
@@ -29,6 +30,7 @@ migrationRpcRouter.post(
 );
 migrationRpcRouter.post("/migrations.run", ...handleRunMigration);
 migrationRpcRouter.post("/migrations.lazy_run", ...handleLazyRunMigration);
+migrationRpcRouter.post("/migrations.cancel_run", ...handleCancelMigrationRun);
 migrationRpcRouter.post("/migrations.runs.list", ...handleListMigrationRuns);
 migrationRpcRouter.post(
 	"/migrations.item_events.list",

--- a/server/src/internal/migrations/v2/repos/migrationRun/insertMigrationRun.ts
+++ b/server/src/internal/migrations/v2/repos/migrationRun/insertMigrationRun.ts
@@ -18,7 +18,7 @@ export const insertMigrationRun = async ({
 	ctx: RepoContext;
 	insert: Pick<
 		MigrationRunInsert,
-		"migration_internal_id" | "dry_run" | "lazy_run"
+		"migration_internal_id" | "dry_run" | "lazy_run" | "only_ids"
 	>;
 }): Promise<MigrationRun | null> => {
 	const now = Date.now();
@@ -33,6 +33,7 @@ export const insertMigrationRun = async ({
 			status: MigrationRunStatus.Queued,
 			dry_run: insert.dry_run,
 			lazy_run: insert.lazy_run ?? false,
+			only_ids: insert.only_ids ?? null,
 			created_at: now,
 			updated_at: null,
 			started_at: null,

--- a/server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts
@@ -13,8 +13,12 @@ export type IterateScopeSummary<T> = {
 
 /**
  * Generic iteration over any kind-tagged scope iterator. Calls `perItem`
- * for every item, collecting per-item results into a summary. Sequential
- * by default; concurrency layer is intentionally out of scope here.
+ * for every item, collecting per-item results into a summary.
+ *
+ * `concurrency` (default 1): max parallel `perItem` invocations. The
+ * iterator's batch boundaries are preserved — work for batch N starts
+ * only after the source yields it, but within and across batches up to
+ * `concurrency` items run concurrently via a sliding worker pool.
  *
  * On error: keeps going with `onError: "continue"` (default), or rethrows
  * the first error with `onError: "throw"`. Either way every visited
@@ -24,29 +28,55 @@ export const iterateScope = async <T>({
 	iterate,
 	perItem,
 	onError = "continue",
+	concurrency = 1,
 }: {
 	iterate: () => AsyncGenerator<RunScopeItem[]>;
 	perItem: (item: RunScopeItem) => Promise<T>;
 	onError?: "throw" | "continue";
+	concurrency?: number;
 }): Promise<IterateScopeSummary<T>> => {
 	const results: IterateScopeItemResult<T>[] = [];
 	let succeeded = 0;
 	let failed = 0;
+	const maxParallel = Math.max(1, Math.floor(concurrency));
+
+	const runItem = async (item: RunScopeItem) => {
+		try {
+			const value = await perItem(item);
+			results.push({ status: "ok", item, value });
+			succeeded++;
+		} catch (raw) {
+			const error = raw instanceof Error ? raw : new Error(String(raw));
+			results.push({ status: "failed", item, error });
+			failed++;
+			if (onError === "throw") throw error;
+		}
+	};
+
+	if (maxParallel === 1) {
+		for await (const batch of iterate()) {
+			for (const item of batch) await runItem(item);
+		}
+		return { processed: succeeded + failed, succeeded, failed, results };
+	}
+
+	const inflight = new Set<Promise<void>>();
+	const schedule = (item: RunScopeItem) => {
+		const p = runItem(item).finally(() => {
+			inflight.delete(p);
+		});
+		inflight.add(p);
+	};
 
 	for await (const batch of iterate()) {
 		for (const item of batch) {
-			try {
-				const value = await perItem(item);
-				results.push({ status: "ok", item, value });
-				succeeded++;
-			} catch (raw) {
-				const error = raw instanceof Error ? raw : new Error(String(raw));
-				results.push({ status: "failed", item, error });
-				failed++;
-				if (onError === "throw") throw error;
+			schedule(item);
+			if (inflight.size >= maxParallel) {
+				await Promise.race(inflight);
 			}
 		}
 	}
+	await Promise.all(inflight);
 
 	return { processed: succeeded + failed, succeeded, failed, results };
 };

--- a/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/runScopeIteration.ts
@@ -62,6 +62,15 @@ export const runScopeIteration = async ({
 				`runMigration: per-item handler missing for kind "${item.kind}"`,
 			);
 
+		itemCtx.logger.info("run-migration: processing customer", {
+			data: {
+				migrationRunId,
+				customerId: item.id ?? item.internal_id,
+				internalId: item.internal_id,
+				dryRun,
+			},
+		});
+
 		const run = () =>
 			migrateCustomer({
 				ctx: itemCtx,
@@ -89,6 +98,7 @@ export const runScopeIteration = async ({
 		return iterateScope({
 			iterate,
 			perItem: (item) => perItem({ item, itemCtx: ctx }),
+			concurrency: controls?.concurrency,
 		});
 	}
 

--- a/server/src/trigger/migrations/runMigrationCustomerTask.ts
+++ b/server/src/trigger/migrations/runMigrationCustomerTask.ts
@@ -1,6 +1,7 @@
 import { AppEnv } from "@autumn/shared";
 import { task } from "@trigger.dev/sdk/v3";
 import { z } from "zod/v4";
+import { warmupRegionalRedis } from "@/external/redis/initUtils/redisWarmup.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { withMigrationItemTracking } from "@/internal/migrations/v2/actions/migrationItem/index.js";
 import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
@@ -45,6 +46,14 @@ export const runMigrationCustomerTask = task({
 			env,
 			triggerCtx,
 			customerId: customerId ?? customerInternalId,
+		});
+
+		await warmupRegionalRedis().catch((error) => {
+			logger.warn("run-migration-customer: redis warmup failed (continuing)", {
+				data: {
+					error: error instanceof Error ? error.message : String(error),
+				},
+			});
 		});
 
 		logger.info("run-migration-customer: starting", {

--- a/server/src/trigger/migrations/runMigrationTask.ts
+++ b/server/src/trigger/migrations/runMigrationTask.ts
@@ -1,6 +1,7 @@
 import { AppEnv } from "@autumn/shared";
 import { task } from "@trigger.dev/sdk/v3";
 import { z } from "zod/v4";
+import { warmupRegionalRedis } from "@/external/redis/initUtils/redisWarmup.js";
 import { withMigrationRunTracking } from "@/internal/migrations/v2/actions/migrationRun/index.js";
 import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
 import { runMigration } from "@/internal/migrations/v2/run/runMigration.js";
@@ -30,6 +31,7 @@ export const runMigrationTaskQueue = {
 export const runMigrationTask = task({
 	id: "run-migration",
 	queue: runMigrationTaskQueue,
+	machine: "medium-1x",
 	maxDuration: 3600,
 	run: async (rawPayload: unknown, { ctx: triggerCtx }) => {
 		const { orgId, env, migrationId, migrationRunId, dryRun, controls } =
@@ -41,8 +43,29 @@ export const runMigrationTask = task({
 			triggerCtx,
 		});
 
+		// Trigger.dev tasks start with cold Redis connections — wait for
+		// readiness before touching the migration so cache invalidations
+		// (deleteCachedFullCustomer, invalidateSharedBalanceFields,
+		// invalidateCachedFullSubject) actually fire instead of being
+		// short-circuited by the `not_ready` availability gate.
+		await warmupRegionalRedis().catch((error) => {
+			logger.warn("run-migration: redis warmup failed (continuing)", {
+				data: {
+					error: error instanceof Error ? error.message : String(error),
+				},
+			});
+		});
+
 		logger.info("run-migration: starting", {
-			data: { migrationId, dryRun },
+			data: {
+				migrationId,
+				migrationRunId,
+				dryRun,
+				only: controls?.only,
+				onlyCount: controls?.only?.length,
+				limit: controls?.limit,
+				concurrency: controls?.concurrency,
+			},
 		});
 
 		await withMigrationRunTracking({
@@ -51,12 +74,31 @@ export const runMigrationTask = task({
 			run: async () => {
 				const migration = await migrationRepo.find({ ctx, id: migrationId });
 
+				// Default concurrency: 10 normally, 25 when no_billing_changes
+				// because we're not hitting Stripe per customer. Caller can still
+				// override via controls.concurrency.
+				const defaultConcurrency =
+					migration.no_billing_changes === true ? 25 : 10;
+				const effectiveControls = {
+					...(controls ?? {}),
+					concurrency: controls?.concurrency ?? defaultConcurrency,
+				};
+
+				logger.info("run-migration: resolved controls", {
+					data: {
+						migrationRunId,
+						noBillingChanges: migration.no_billing_changes === true,
+						concurrency: effectiveControls.concurrency,
+						concurrencyExplicit: controls?.concurrency !== undefined,
+					},
+				});
+
 				await runMigration({
 					ctx,
 					migration,
 					dryRun,
 					migrationRunId,
-					controls: controls ?? undefined,
+					controls: effectiveControls,
 				});
 			},
 		});

--- a/server/src/utils/logging/initLogger.ts
+++ b/server/src/utils/logging/initLogger.ts
@@ -77,11 +77,19 @@ const levelNames: Record<number | string, string> = {
 	FATAL: "FATAL",
 };
 
-/** Bun-friendly pino sink that prints `<ts> <LEVEL> <msg> <extras>`. */
+/** Bun-friendly pino sink that prints `<ts> <LEVEL> <msg> <extras>`.
+ *
+ *  `useConsoleLog` routes the formatted line through `console.log` instead
+ *  of `process.stdout.write`. Trigger.dev's run UI instruments `console.*`
+ *  but not raw stdout, so dual-mode loggers (used inside trigger tasks)
+ *  flip this on to make their lines render inline in the timeline. Visually
+ *  identical in `bun d` since console.log just appends a newline. */
 const createDevLogStream = ({
 	trailingNewline = true,
+	useConsoleLog = false,
 }: {
 	trailingNewline?: boolean;
+	useConsoleLog?: boolean;
 } = {}) =>
 	new Writable({
 		write(chunk, _encoding, callback) {
@@ -114,13 +122,31 @@ const createDevLogStream = ({
 
 				const formattedLog = `${colors.gray}${timestamp}${colors.reset} ${levelColor}${colors.bright}${levelName}${colors.reset} ${message}${trailingNewline ? "\n" : ""}`;
 
-				process.stdout.write(formattedLog);
+				if (useConsoleLog) {
+					console.log(formattedLog);
+				} else {
+					process.stdout.write(formattedLog);
+				}
 				callback();
 			} catch (_error) {
 				// Fallback for malformed JSON
-				process.stdout.write(chunk);
+				if (useConsoleLog) {
+					console.log(chunk.toString());
+				} else {
+					process.stdout.write(chunk);
+				}
 				callback();
 			}
+		},
+	});
+
+/** Raw JSON sink routed through `console.log` so trigger.dev's run UI
+ *  (which only instruments console.*) picks up dual-mode prod lines. */
+const createConsoleJsonStream = () =>
+	new Writable({
+		write(chunk, _encoding, callback) {
+			console.log(chunk.toString().trimEnd());
+			callback();
 		},
 	});
 
@@ -150,8 +176,11 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 		streams.push({
 			level: isDevOrTest ? "debug" : "info",
 			stream: isDevOrTest
-				? createDevLogStream({ trailingNewline: false })
-				: process.stdout,
+				? createDevLogStream({
+						trailingNewline: false,
+						useConsoleLog: true,
+					})
+				: createConsoleJsonStream(),
 		});
 		if (process.env.AXIOM_TOKEN) {
 			streams.push({

--- a/shared/models/migrationV2Models/migrationRunTable.ts
+++ b/shared/models/migrationV2Models/migrationRunTable.ts
@@ -15,6 +15,7 @@ export const MigrationRunStatus = {
 	Running: "running",
 	Succeeded: "succeeded",
 	Failed: "failed",
+	Canceled: "canceled",
 } as const;
 
 export type MigrationRunStatus =
@@ -37,6 +38,11 @@ export const migrationRuns = pgTable(
 		lazy_run: boolean().notNull().default(false),
 		trigger_run_id: text(),
 		error_message: text(),
+		/** When set, the run only processes items with these IDs (the `only`
+		 *  param on /migrations.run). Item kind matches the operation scope
+		 *  — typically customer IDs for customer ops, plan IDs for plan
+		 *  ops, etc. Null = unscoped run-all. */
+		only_ids: text("only_ids").array(),
 		created_at: numeric({ mode: "number" }).notNull(),
 		updated_at: numeric({ mode: "number" }),
 		started_at: numeric({ mode: "number" }),

--- a/vite/src/hooks/queries/useMigrationsQuery.tsx
+++ b/vite/src/hooks/queries/useMigrationsQuery.tsx
@@ -109,6 +109,18 @@ export const useMigrationsQuery = () => {
 		onSuccess: invalidate,
 	});
 
+	const cancelRunMutation = useMutation({
+		mutationFn: async (body: { id: string }) => {
+			const { data } = await axiosInstance.post<{
+				migration_id: string;
+				run_id: string;
+				canceled: boolean;
+			}>("/migrations.cancel_run", body);
+			return data;
+		},
+		onSuccess: invalidate,
+	});
+
 	return {
 		migrations: (data?.list ?? []) as Migration[],
 		isLoading,
@@ -124,5 +136,7 @@ export const useMigrationsQuery = () => {
 		isPreparing: prepareMutation.isPending,
 		runMigration: runMutation.mutateAsync,
 		isRunning: runMutation.isPending,
+		cancelRun: cancelRunMutation.mutateAsync,
+		isCanceling: cancelRunMutation.isPending,
 	};
 };

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -112,4 +112,17 @@ export class CusService {
 		);
 		return data;
 	}
+
+	static async clearCache({
+		axios,
+		customer_id,
+	}: {
+		axios: AxiosInstance;
+		customer_id: string;
+	}): Promise<{ success: boolean }> {
+		const { data } = await axios.post(`/customers/clear_cache`, {
+			customer_id,
+		});
+		return data;
+	}
 }

--- a/vite/src/views/customers2/customer/CustomerActions.tsx
+++ b/vite/src/views/customers2/customer/CustomerActions.tsx
@@ -4,6 +4,7 @@ import {
 	ArrowSquareOutIcon,
 	ArrowsClockwiseIcon,
 	BracketsSquareIcon,
+	BroomIcon,
 	CaretDownIcon,
 	PencilSimpleIcon,
 	SubtractIcon,
@@ -54,6 +55,7 @@ export function CustomerActions() {
 	const [actionsOpen, setActionsOpen] = useState(false);
 	const [portalLoading, setPortalLoading] = useState(false);
 	const [showObjectOpen, setShowObjectOpen] = useState(false);
+	const [clearCacheLoading, setClearCacheLoading] = useState(false);
 	const { customer } = useCusQuery();
 	const { features } = useFeaturesQuery();
 	const { org } = useOrg();
@@ -87,6 +89,23 @@ export function CustomerActions() {
 		isOpen: actionsOpen,
 		setIsOpen: setActionsOpen,
 	});
+
+	const handleClearCache = async () => {
+		if (!customer) return;
+		setClearCacheLoading(true);
+		try {
+			await CusService.clearCache({
+				axios: axiosInstance,
+				customer_id: customer.id || customer.internal_id,
+			});
+			toast.success("Customer cache cleared");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to clear cache"));
+		} finally {
+			setClearCacheLoading(false);
+			setActionsOpen(false);
+		}
+	};
 
 	const handleOpenBillingPortal = async () => {
 		if (!customer) return;
@@ -230,6 +249,17 @@ export function CustomerActions() {
 						>
 							<ArrowSquareOutIcon className="size-3.5" />
 							Open in Admin Panel
+						</DropdownMenuItem>
+					)}
+					{isAdmin && (
+						<DropdownMenuItem
+							onClick={handleClearCache}
+							className="flex gap-2"
+							disabled={clearCacheLoading}
+							shortcut="x"
+						>
+							<BroomIcon />
+							{clearCacheLoading ? "Clearing..." : "Clear cache"}
 						</DropdownMenuItem>
 					)}
 					{((customer?.processor?.id &&

--- a/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
+++ b/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
@@ -11,6 +11,7 @@ import {
 	EyeIcon,
 	ListMagnifyingGlassIcon,
 	PlayIcon,
+	StopIcon,
 	UsersIcon,
 	WarningIcon,
 	XIcon,
@@ -45,6 +46,8 @@ import {
 	SelectValue,
 } from "@/components/v2/selects/Select";
 import { useMigrationFilterPreview } from "@/hooks/queries/useMigrationFilterPreview";
+import { useMigrationsQuery } from "@/hooks/queries/useMigrationsQuery";
+import { toast } from "sonner";
 import {
 	type MigrationItemEvent,
 	useMigrationRunsQuery,
@@ -161,6 +164,8 @@ export function MigrationLiveView({
 	});
 	const [dismissedError, setDismissedError] = useState<string | null>(null);
 	const [isRunDialogOpen, setIsRunDialogOpen] = useState(false);
+	const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+	const { cancelRun, isCanceling } = useMigrationsQuery();
 
 	const debouncedSetSearch = useMemo(
 		() => debounce((q: string) => setDebouncedSearch(q), 350),
@@ -218,16 +223,34 @@ export function MigrationLiveView({
 		? "running"
 		: ((activeRun?.status as ActiveRunStatus) ?? null);
 	const activeRunId = activeRun?.internal_id ?? null;
+	const activeRunOnlyIds = useMemo(
+		() =>
+			activeRun?.only_ids && activeRun.only_ids.length > 0
+				? new Set(activeRun.only_ids)
+				: null,
+		[activeRun?.only_ids],
+	);
 
 	const enrichedCustomers = useMemo(
 		(): CustomerRow[] =>
-			customers.map((c) => ({
-				...c,
-				_event: eventsByCustomer.get(c.internal_id),
-				_activeStatus: activeRunStatus,
-				_activeRunId: activeRunId ?? undefined,
-			})),
-		[customers, eventsByCustomer, activeRunStatus, activeRunId],
+			customers.map((c) => {
+				const inScope =
+					activeRunOnlyIds === null ||
+					(c.id != null && activeRunOnlyIds.has(c.id));
+				return {
+					...c,
+					_event: eventsByCustomer.get(c.internal_id),
+					_activeStatus: inScope ? activeRunStatus : null,
+					_activeRunId: activeRunId ?? undefined,
+				};
+			}),
+		[
+			customers,
+			eventsByCustomer,
+			activeRunStatus,
+			activeRunId,
+			activeRunOnlyIds,
+		],
 	);
 
 	const filteredCustomers = useMemo(() => {
@@ -337,6 +360,17 @@ export function MigrationLiveView({
 						Previous
 					</Button>
 				)}
+				{activeRun && (
+					<Button
+						variant="secondary"
+						size="default"
+						onClick={() => setIsCancelDialogOpen(true)}
+						isLoading={isCanceling}
+					>
+						<StopIcon size={14} weight="fill" />
+						Cancel run
+					</Button>
+				)}
 				<div className="flex items-center">
 					<Button
 						variant="primary"
@@ -372,6 +406,48 @@ export function MigrationLiveView({
 						</DropdownMenuContent>
 					</DropdownMenu>
 				</div>
+
+				<Dialog
+					open={isCancelDialogOpen}
+					onOpenChange={setIsCancelDialogOpen}
+				>
+					<DialogContent showCloseButton={false}>
+						<DialogHeader>
+							<DialogTitle>Cancel running migration?</DialogTitle>
+							<DialogDescription>
+								This stops the active run. Customers already processed in this
+								run will keep their migrated state — only pending customers are
+								affected.
+							</DialogDescription>
+						</DialogHeader>
+						<DialogFooter>
+							<Button
+								variant="secondary"
+								onClick={() => setIsCancelDialogOpen(false)}
+							>
+								Keep running
+							</Button>
+							<Button
+								variant="primary"
+								isLoading={isCanceling}
+								onClick={async () => {
+									try {
+										await cancelRun({ id: migrationId });
+										toast.success("Migration run canceled");
+										invalidateRuns();
+									} catch {
+										toast.error("Failed to cancel migration run");
+									} finally {
+										setIsCancelDialogOpen(false);
+									}
+								}}
+							>
+								<StopIcon size={14} weight="fill" />
+								Cancel run
+							</Button>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
 
 				<Dialog open={isRunDialogOpen} onOpenChange={setIsRunDialogOpen}>
 					<DialogContent showCloseButton={false}>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Redis connectivity by auto-switching to the public Dragonfly URL when off AWS, and adds safer, more observable migration runs. Also introduces a Tinybird helper and a UI/endpoint to cancel running migrations.

- **New Features**
  - Cancel active runs via `/migrations.cancel_run` and a new “Cancel run” button; runs are marked `canceled`.
  - Scope runs with `only_ids` (stored on the run); the live view shows in-scope customers only.
  - Add per-item concurrency in the orchestrator; default 10 (25 when `no_billing_changes`), overridable via controls.
  - Tinybird helper scripts: `tb`, `tb:prod`, `tb:prod-legacy` for simplified deploy/info flows.

- **Bug Fixes**
  - Auto-swap Dragonfly URL to `CACHE_V2_DRAGONFLY_PUBLIC_URL` when not on AWS; applied to shared and per-org Redis.
  - Warm up Redis in migration tasks; when Redis isn’t ready, invalidations are skipped with clear logs.
  - Improve migration logging (scope resolution, per-customer start, resolved controls) and route prod logs via `console` for better visibility in trigger runs; tinybird migrations now use `TINYBIRD_US_EAST_*`.

<sup>Written for commit dbd0a0f1495b933f5bd130afcfd96db2373238c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Dragonfly (Redis) reachability for off-AWS callers (local dev, trigger.dev workers) by introducing a URL-swap helper, wires in a Redis warmup before migration tasks run, adds a cancel-run endpoint and UI, and extends the Tinybird CLI wrapper to handle multiple deployment targets.

- **Bug fixes / Improvements**: `getReachableDragonflyUrl` swaps the private VPC Dragonfly URL for its public mirror when the process is not running inside ECS, so cache invalidations fired from trigger.dev tasks now actually land instead of being silently skipped by the `not_ready` gate.
- **Improvements**: Migration runs gain configurable concurrency (default 10, 25 when `no_billing_changes`), a `machine: \"medium-1x\"` upgrade, and richer structured logging across the migration pipeline.
- **Bug fixes / API changes**: New `/migrations.cancel_run` endpoint (+ matching UI) marks an active run as `Canceled` and best-effort cancels the trigger.dev task; the `only_ids` column is added to `migration_runs` to record scoped runs.
</details>

<h3>Confidence Score: 4/5</h3>

The server-side migration and Redis changes are solid; the Tinybird CLI wrapper has a double alias-expansion bug that turns `deploy:check` (dry-run) into a real `deploy`.

The Tinybird script re-invokes itself through infisical with already-expanded alias args (`["deploy", "--check"]`), then in the bootstrapped path calls `resolveTinybirdArgs` a second time — which looks up `commandAliases["deploy"]` and returns `["deploy"]`, silently dropping `--check`. Running `bun tb deploy:check` would execute a live deployment rather than the intended validation step.

scripts/tinybird/index.ts — the bootstrapped execution path incorrectly re-applies alias resolution to already-resolved args.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/tinybird/index.ts | New Tinybird CLI wrapper with a bootstrapping mechanism; double application of alias resolution causes `deploy:check` to silently run a real deploy instead of a dry-run check. |
| server/src/external/redis/getReachableDragonflyUrl.ts | New helper that swaps the private VPC Dragonfly URL for the public mirror when running off-AWS; well-documented and narrowly scoped. |
| server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts | Adds a sliding-window concurrent worker pool (default 1 = sequential); implementation is correct for the default `onError: "continue"` path used in production. |
| server/src/internal/migrations/v2/handlers/handleCancelMigrationRun.ts | New cancel-run endpoint that best-effort cancels the trigger.dev task and marks the run as Canceled; error handling and status checks look correct. |
| shared/models/migrationV2Models/migrationRunTable.ts | Adds `only_ids text[]` column and `Canceled` status to the migration run table; requires a corresponding DB migration. |
| vite/src/views/migrations/migration/live/MigrationLiveView.tsx | Adds cancel-run dialog and scopes customer status badges to `only_ids`; `activeRun` is correctly limited to queued/running states. |
| server/src/trigger/migrations/runMigrationTask.ts | Adds Redis warmup before migration, upgrades machine size to `medium-1x`, and sets default concurrency (10 normal / 25 no-billing-changes). |
| server/src/utils/logging/initLogger.ts | Adds `useConsoleLog` mode and a `createConsoleJsonStream` so dual-mode trigger.dev loggers surface in the run timeline UI. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as MigrationLiveView
    participant API as /migrations.cancel_run
    participant DB as migration_runs
    participant TDev as trigger.dev

    UI->>API: "POST {id: migrationId}"
    API->>DB: "list active runs (status=queued|running)"
    DB-->>API: activeRun
    alt no active run
        API-->>UI: 404 No active run
    else active run found
        alt has trigger_run_id
            API->>TDev: runs.cancel(trigger_run_id)
            TDev-->>API: ok / error (best-effort)
        end
        API->>DB: "update status=canceled, finished_at=now"
        API-->>UI: "{canceled: true}"
        UI->>UI: invalidateRuns()
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/tinybird/index.ts:94-95
`resolveTinybirdArgs` is called in both `main()` (line 113) and `executeTinybird()` (line 94), so alias expansion is applied twice. When you run `bun tb deploy:check`, `main()` correctly expands the alias to `["deploy", "--check"]` and passes those args to the bootstrapped process. But in the bootstrapped process, `executeTinybird()` calls `resolveTinybirdArgs(["deploy", "--check"])`, which looks up `commandAliases["deploy"]` and returns `["deploy"]` — silently dropping `--check`. The final command becomes `bunx tinybird deploy` (a real deploy) instead of `bunx tinybird deploy --check` (a dry-run check).

```suggestion
	const args = Bun.argv.slice(2);
	const exitCode = await run(["bunx", "tinybird", ...args], {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: clean up migrations"](https://github.com/useautumn/autumn/commit/dbd0a0f1495b933f5bd130afcfd96db2373238c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32307209)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->