### PR TITLE
fix: resolve #1567 merge conflicts in migration pickers

### DIFF
--- a/vite/src/views/migrations/migration/filters/FilterGroup.tsx
+++ b/vite/src/views/migrations/migration/filters/FilterGroup.tsx
@@ -41,12 +41,15 @@ function useSuggestionsForField(
 	if (field === "customer_id") {
 		return customers
 			.filter((c): c is typeof c & { id: string } => Boolean(c.id))
-			.map((c) => ({
-				value: c.id,
-				label: c.name ?? c.email ?? c.id,
-				secondaryLabel: c.id,
-				icon: <UserIcon size={14} className="text-t3" />,
-			}));
+			.map((c) => {
+				const label = c.name ?? c.email ?? c.id;
+				return {
+					value: c.id,
+					label,
+					secondaryLabel: label === c.id ? undefined : c.id,
+					icon: <UserIcon size={14} className="text-t3" />,
+				};
+			});
 	}
 	if (field === "plan_id") return buildPlanSuggestions(products);
 	if (field === "item_feature_id") {

--- a/vite/src/views/migrations/migration/shared/ValuePicker.tsx
+++ b/vite/src/views/migrations/migration/shared/ValuePicker.tsx
@@ -109,11 +109,14 @@ export function ValuePicker({
 							<CommandGroup>
 								{suggestions.map((suggestion) => {
 									const isSelected = selectedValues.includes(suggestion.value);
+									const keywords = [suggestion.label];
+									if (suggestion.secondaryLabel)
+										keywords.push(suggestion.secondaryLabel);
 									return (
 										<CommandItem
 											key={suggestion.value}
 											value={suggestion.value}
-											keywords={[suggestion.label]}
+											keywords={keywords}
 											onSelect={() => onToggle(suggestion.value)}
 											className="text-sm"
 										>
@@ -123,8 +126,11 @@ export function ValuePicker({
 											<span className="flex-1 truncate">
 												{suggestion.label}
 											</span>
-											{(suggestion.secondaryLabel ?? (suggestion.value !== suggestion.label ? suggestion.value : null)) && (
-												<span className="text-t4 text-xs truncate shrink-0">
+											{(suggestion.secondaryLabel ??
+												(suggestion.value !== suggestion.label
+													? suggestion.value
+													: null)) && (
+												<span className="shrink-0 max-w-48 truncate text-t3 text-xs font-mono">
 													{suggestion.secondaryLabel ?? suggestion.value}
 												</span>
 											)}

--- a/vite/src/views/migrations/migration/shared/planSuggestions.tsx
+++ b/vite/src/views/migrations/migration/shared/planSuggestions.tsx
@@ -15,7 +15,7 @@ export function buildPlanSuggestions(
 		.map((p) => ({
 			value: p.id,
 			label: p.name || p.id,
-			secondaryLabel: p.id,
+			secondaryLabel: p.name ? p.id : undefined,
 			icon: <PackageIcon size={14} weight="duotone" className="text-t3" />,
 		}));
 }


### PR DESCRIPTION
Resolves the merge conflicts blocking PR #1567 (`main` → `dev`) in the migration UI picker files.

### Changes
- `FilterGroup.tsx` — compute label once, conditionally hide `secondaryLabel` when it equals the label
- `ValuePicker.tsx` — add `keywords` array for searching by ID, apply monospace styling to sublabels
- `planSuggestions.tsx` — conditionally set `secondaryLabel` only when plan has a name

### Resolution strategy
Kept `dev`'s `secondaryLabel` naming (already used across 4 files on `dev`) while merging in `main`'s UX improvements. After this PR is merged into `dev`, PR #1567 should be rebase/merge-conflict-free for these files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves merge conflicts in migration value pickers and brings `main`’s UX tweaks while keeping `dev`’s `secondaryLabel` API. Unblocks PR #1567.

- **Bug Fixes**
  - FilterGroup: compute label once; hide `secondaryLabel` when it matches the label.
  - ValuePicker: add `secondaryLabel` (ID) to `keywords` so search matches label or ID; monospace styling for sublabels.
  - planSuggestions: set `secondaryLabel` only when the plan has a name.

<sup>Written for commit f8fe1b80f5ac925e215b6e52c69224ec4e89996a. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1571?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR resolves merge conflicts between `main` and `dev` in the migration UI picker files, preserving `dev`'s `secondaryLabel` naming while bringing in `main`'s UX improvements that avoid redundant label display.

- **[Bug fixes]** `FilterGroup.tsx` and `planSuggestions.tsx` now suppress `secondaryLabel` when it would duplicate the primary label (e.g., a plan or customer whose label is already its ID), preventing a redundant subtitle from showing in the picker.
- **[Improvements]** `ValuePicker.tsx` adds `secondaryLabel` to the `CommandItem` `keywords` array so users can search by ID, and applies `font-mono` styling to sublabels for visual clarity.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — all logic changes are correct and the component renders properly; the only rough edge is cosmetic indentation left over from the conflict resolution.

The conditional secondaryLabel logic in all three files is correctly equivalent, and the keywords array addition in ValuePicker is a straightforward improvement. The merge resolution left the closing section of ValuePicker.tsx indented one extra level throughout, which does not affect runtime behavior but makes the hierarchy harder to read.

vite/src/views/migrations/migration/shared/ValuePicker.tsx — closing tags and the function's return block are over-indented by one level from the merge conflict resolution.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/migrations/migration/filters/FilterGroup.tsx | Computes customer label once and conditionally hides secondaryLabel when it equals the customer ID — correct and clean, avoids redundant display when label and ID are the same. |
| vite/src/views/migrations/migration/shared/ValuePicker.tsx | Adds secondaryLabel to CommandItem keywords (enabling ID search), applies monospace styling to sublabels; logic is correct but the merge resolution left the closing section one indent level too deep throughout. |
| vite/src/views/migrations/migration/shared/planSuggestions.tsx | Conditionally sets secondaryLabel only when plan has a name — mirrors the FilterGroup logic and correctly avoids showing the ID twice when the label already is the ID. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/migrations/migration/shared/ValuePicker.tsx:138-146
**Indentation off by one level in closing block**

The merge conflict resolution introduced an extra tab level on the entire inner section (lines ~87–146). Closing tags for `</div>`, `</Popover>`, and `</PopoverContent>` each appear one indent level deeper than their corresponding opening tags, and the `);` / `}` that close the function's `return` are also one level too deep. The JSX structure is semantically correct and will compile fine, but the mismatched indentation makes the hierarchy hard to follow at a glance.

### Issue 2 of 2
vite/src/views/migrations/migration/shared/ValuePicker.tsx:111-113
Mutating a `const` array is valid JS/TS but reads oddly here — a one-liner ternary initialization is cleaner and communicates intent more directly.

```suggestion
										const isSelected = selectedValues.includes(suggestion.value);
										const keywords = suggestion.secondaryLabel
											? [suggestion.label, suggestion.secondaryLabel]
											: [suggestion.label];
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve #1567 merge conflicts in mi..."](https://github.com/useautumn/autumn/commit/0f654ca8202d72dc8ee41aa2643d89376af17c32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32335795)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->