### PR TITLE
fix: rename secondaryLabel → sublabel in migration pickers

### DIFF
--- a/vite/src/views/migrations/migration/filters/FilterGroup.tsx
+++ b/vite/src/views/migrations/migration/filters/FilterGroup.tsx
@@ -46,7 +46,7 @@ function useSuggestionsForField(
 				return {
 					value: c.id,
 					label,
-					secondaryLabel: label === c.id ? undefined : c.id,
+					sublabel: label === c.id ? undefined : c.id,
 					icon: <UserIcon size={14} className="text-t3" />,
 				};
 			});

--- a/vite/src/views/migrations/migration/shared/ValuePicker.tsx
+++ b/vite/src/views/migrations/migration/shared/ValuePicker.tsx
@@ -21,7 +21,7 @@ const MAX_VISIBLE_CHIPS = 3;
 export type ValuePickerOption = {
 	value: string;
 	label: string;
-	secondaryLabel?: string;
+	sublabel?: string;
 	icon?: ReactNode;
 };
 
@@ -110,8 +110,7 @@ export function ValuePicker({
 								{suggestions.map((suggestion) => {
 									const isSelected = selectedValues.includes(suggestion.value);
 									const keywords = [suggestion.label];
-									if (suggestion.secondaryLabel)
-										keywords.push(suggestion.secondaryLabel);
+									if (suggestion.sublabel) keywords.push(suggestion.sublabel);
 									return (
 										<CommandItem
 											key={suggestion.value}
@@ -126,12 +125,12 @@ export function ValuePicker({
 											<span className="flex-1 truncate">
 												{suggestion.label}
 											</span>
-											{(suggestion.secondaryLabel ??
+											{(suggestion.sublabel ??
 												(suggestion.value !== suggestion.label
 													? suggestion.value
 													: null)) && (
 												<span className="shrink-0 max-w-48 truncate text-t3 text-xs font-mono">
-													{suggestion.secondaryLabel ?? suggestion.value}
+													{suggestion.sublabel ?? suggestion.value}
 												</span>
 											)}
 											{isSelected && (

--- a/vite/src/views/migrations/migration/shared/featureSuggestions.tsx
+++ b/vite/src/views/migrations/migration/shared/featureSuggestions.tsx
@@ -8,7 +8,7 @@ export function buildFeatureSuggestions(
 	return features.map((f) => ({
 		value: f.id,
 		label: f.name || f.id,
-		secondaryLabel: f.id,
+		sublabel: f.id,
 		icon: getFeatureIcon({ feature: f }),
 	}));
 }

--- a/vite/src/views/migrations/migration/shared/planSuggestions.tsx
+++ b/vite/src/views/migrations/migration/shared/planSuggestions.tsx
@@ -15,7 +15,7 @@ export function buildPlanSuggestions(
 		.map((p) => ({
 			value: p.id,
 			label: p.name || p.id,
-			secondaryLabel: p.name ? p.id : undefined,
+			sublabel: p.name ? p.id : undefined,
 			icon: <PackageIcon size={14} weight="duotone" className="text-t3" />,
 		}));
 }


### PR DESCRIPTION
Aligns `dev` branch naming with `main` so PR #1572 (`dev` → `main`) merges cleanly.

### Problem
PR #1572 has merge conflicts in the 3 migration picker files because `main` uses `sublabel` and `dev` uses `secondaryLabel` for the same feature (ID sublabels in pickers + search-by-ID keywords).

### Changes
Renames `secondaryLabel` → `sublabel` in all 4 migration picker files on `dev`:
- `FilterGroup.tsx`
- `ValuePicker.tsx`
- `planSuggestions.tsx`
- `featureSuggestions.tsx`

This is a no-op functionally — the property already did the same thing on both branches, just with different names.

After this merges into `dev`, PR #1572 should be conflict-free.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `secondaryLabel` to `sublabel` across migration pickers to match `main`, removing merge conflicts for PR #1572. No behavior changes; it still shows ID sublabels and includes them in search.

- **Refactors**
  - Swapped `secondaryLabel` → `sublabel` in `FilterGroup.tsx`, `ValuePicker.tsx`, `featureSuggestions.tsx`, and `planSuggestions.tsx`, and updated keyword checks accordingly.

<sup>Written for commit e2e6ed2fe0cba110847c48d434bd3f55dd838b68. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1573?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Renames the `secondaryLabel` property to `sublabel` across the four migration picker files to align the `dev` branch with `main`, unblocking PR #1572 from merging cleanly. This is a purely mechanical rename with no behavioral change.

- **[Bug fixes]** `ValuePicker.tsx`: type definition and all three consumption sites (`keywords` push, conditional render guard, display value) updated from `secondaryLabel` → `sublabel`, consistent with how `sublabel` is already used elsewhere in the codebase (e.g. `DiscountRow.tsx`, `discountOptionUtils.ts`).
- **[Bug fixes]** `FilterGroup.tsx`, `featureSuggestions.tsx`, `planSuggestions.tsx`: corresponding suggestion-object construction sites updated to match the renamed type field.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a property rename with no logic changes and no remaining `secondaryLabel` references in the codebase.

Every construction site and every consumption site has been updated in lock-step. A grep across the entire `vite/src` tree confirms zero remaining `secondaryLabel` usages, and `sublabel` is already the established convention in other components. There is no functional difference introduced by this change.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/migrations/migration/shared/ValuePicker.tsx | Type definition and all consumption sites updated from `secondaryLabel` to `sublabel`; change is internally consistent and matches existing codebase convention. |
| vite/src/views/migrations/migration/filters/FilterGroup.tsx | Single property rename from `secondaryLabel` to `sublabel` in suggestion object construction; no logic change. |
| vite/src/views/migrations/migration/shared/featureSuggestions.tsx | Single property rename from `secondaryLabel` to `sublabel`; no logic change. |
| vite/src/views/migrations/migration/shared/planSuggestions.tsx | Single property rename from `secondaryLabel` to `sublabel`; no logic change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildFeatureSuggestions] -->|sublabel: f.id| D[ValuePickerOption]
    B[buildPlanSuggestions] -->|sublabel: p.name ? p.id : undefined| D
    C[useSuggestionsForField\nFilterGroup] -->|sublabel: label === c.id ? undefined : c.id| D
    D --> E[ValuePicker]
    E -->|keywords search| F[sublabel pushed to keywords array]
    E -->|render| G[sublabel shown as mono secondary text]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: rename secondaryLabel → sublabel in..."](https://github.com/useautumn/autumn/commit/e2e6ed2fe0cba110847c48d434bd3f55dd838b68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32338693)</sub>

<!-- /greptile_comment -->