### PR TITLE
fix: resolve one-off item duplication in subscription detail sheet

### DIFF
--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -83,7 +83,7 @@ function SubscriptionDetailItems({
 
 		return (
 			<PlanFeatureRow
-				key={item.feature_id || item.price_id || index}
+				key={`${index}-${item.feature_id ?? ""}-${item.price_id ?? ""}-${item.entitlement_id ?? ""}`}
 				item={item}
 				index={index}
 				readOnly={true}

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -56,7 +56,7 @@ export const PlanFeatureRow = ({
 		(queryStates.step !== OnboardingStep.Playground ||
 			playgroundMode !== "edit");
 
-	const item = product.items?.[index] || itemProp;
+	const item = readOnly ? itemProp : (product.items?.[index] || itemProp);
 
 	const display = getProductItemDisplay({
 		item,


### PR DESCRIPTION
## Summary
- Fix duplicate React keys in `SubscriptionDetailItems` — items sharing the same `feature_id` (e.g. one-off and recurring credits) produced identical keys, causing React reconciliation to create extra DOM nodes on re-renders while the sheet stayed open.
- In read-only mode (`PlanFeatureRow`), always use the passed item prop instead of falling through to the global Zustand product store which may hold unrelated data.

## Test plan
- Open a subscription detail sheet for a plan with multiple one-off prepaid items sharing the same feature (e.g. Enterprise with credits)
- Verify items don't duplicate while the sheet remains open
- Verify closing and reopening still shows the correct items
- Verify the plan editor (non-read-only) still works as expected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicated items in the subscription detail sheet by generating unique React keys and using the passed item in read-only rows. Prevents extra DOM nodes during re-renders and keeps the plan editor behavior unchanged.

- **Bug Fixes**
  - Generate composite keys in `SubscriptionDetailItems`: `${index}-${feature_id}-${price_id}-${entitlement_id}`.
  - In `PlanFeatureRow`, use the `item` prop when `readOnly` to avoid stale store data.

<sup>Written for commit d6d841e27a4e3dba6e74d692af0115d2e74bc80e. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs that caused one-off items to appear duplicated in the subscription detail sheet. The key generation and item-source logic in `PlanFeatureRow` are both corrected.

- **[Bug fixes]** The React list key in `SubscriptionDetailItems` now always includes the array `index` as a prefix, preventing collisions when items share the same `feature_id` (e.g. one-off and recurring credit items on the same plan).
- **[Bug fixes]** `PlanFeatureRow` in read-only mode now always uses the passed `item` prop directly, instead of first consulting the global Zustand product store which could hold data from a different plan being edited elsewhere.
</details>

<h3>Confidence Score: 5/5</h3>

Both changes are small, targeted, and correct — safe to merge.

The key change in SubscriptionDetailSheet guarantees unique React keys by always prefixing with the array index, which is valid for this static read-only list. The PlanFeatureRow change is a one-line guard that strictly narrows when the global store is consulted, with no effect on non-readOnly callers. No edge cases were found that would cause incorrect data display or crashes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx | Key generation for PlanFeatureRow updated to always include the array index, preventing duplicate keys when multiple items share the same feature_id. |
| vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx | Item resolution now short-circuits to itemProp when readOnly=true, avoiding accidental reads from the global Zustand product store in non-editor contexts. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SubscriptionDetailSheet] -->|productV2.items| B[SubscriptionDetailItems]
    B -->|sortPlanItems| C[visibleItems + collapsedBooleanItems]
    C -->|renderRow with index| D[key includes index + feature_id + price_id + entitlement_id]
    D --> E[PlanFeatureRow readOnly=true]
    E --> F{readOnly?}
    F -->|Yes - Fixed| G[Use itemProp directly]
    F -->|No| H[product.items at index OR itemProp]
    G --> I[getProductItemDisplay]
    H --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve one-off item duplication in..."](https://github.com/useautumn/autumn/commit/d6d841e27a4e3dba6e74d692af0115d2e74bc80e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32353010)</sub>

<!-- /greptile_comment -->