### PR TITLE
chore: fix entities case with attach end on

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors.ts
@@ -1,35 +1,34 @@
-import { type AttachBillingContext, ErrCode, RecaseError } from "@autumn/shared";
+import {
+	type AttachBillingContext,
+	ErrCode,
+	hasActivePaidSubscription,
+	RecaseError,
+} from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 
 /**
  * Validates attach request when on_end is "revert".
  *
- * Throws if:
- * - No existing customer product to revert to (including cross-entity)
- * - No existing Stripe subscription on the found product
+ * Throws if the customer has no active paid subscription anywhere
+ * (across all entities).
  */
 export const handleRevertTrialErrors = ({
 	billingContext,
 }: {
 	billingContext: AttachBillingContext;
 }) => {
-	const { trialContext, currentCustomerProduct } = billingContext;
+	const { trialContext, fullCustomer } = billingContext;
 	if (trialContext?.onEnd !== "revert") return;
 
-	if (!currentCustomerProduct) {
+	if (
+		!hasActivePaidSubscription({
+			customerProducts: fullCustomer.customer_products,
+		})
+	) {
 		throw new RecaseError({
 			code: ErrCode.InvalidRequest,
 			message:
-				"Cannot use on_end: 'revert' without an existing plan to revert to.",
-			statusCode: StatusCodes.BAD_REQUEST,
-		});
-	}
-
-	if (!currentCustomerProduct.subscription_ids?.length) {
-		throw new RecaseError({
-			code: ErrCode.InvalidRequest,
-			message:
-				"Cannot use on_end: 'revert' without an existing Stripe subscription.",
+				"Cannot use on_end: 'revert' without an existing paid subscription.",
 			statusCode: StatusCodes.BAD_REQUEST,
 		});
 	}

--- a/server/src/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors.ts
@@ -5,8 +5,8 @@ import { StatusCodes } from "http-status-codes";
  * Validates attach request when on_end is "revert".
  *
  * Throws if:
- * - No existing customer product to revert to
- * - No existing Stripe subscription on the current product
+ * - No existing customer product to revert to (including cross-entity)
+ * - No existing Stripe subscription on the found product
  */
 export const handleRevertTrialErrors = ({
 	billingContext,

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -4,7 +4,6 @@ import {
 	type AttachParamsV1,
 	type BillingContextOverride,
 	BillingVersion,
-	cp,
 	CusProductStatus,
 	cusProductToPrices,
 	hasCustomItems,
@@ -174,17 +173,6 @@ export const setupAttachBillingContext = async ({
 		},
 	});
 
-	// For cross-entity revert trials: if no currentCustomerProduct on the target
-	// entity, find an active subscription on any entity to pause/revert to.
-	const revertTargetProduct =
-		trialContext?.onEnd === "revert" && !currentCustomerProduct
-			? fullCustomer.customer_products.find(
-					(cusProduct) =>
-						cp(cusProduct).paidRecurring().main().hasActiveStatus()
-							.hasSubscription().valid,
-				)
-			: currentCustomerProduct;
-
 	const skipBillingChanges =
 		skipBillingChangesBase || trialContext?.onEnd === "revert";
 
@@ -253,7 +241,7 @@ export const setupAttachBillingContext = async ({
 		featureQuantities,
 		transitionConfig,
 
-		currentCustomerProduct: revertTargetProduct ?? currentCustomerProduct,
+		currentCustomerProduct,
 		scheduledCustomerProduct,
 
 		planTiming,

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -4,6 +4,7 @@ import {
 	type AttachParamsV1,
 	type BillingContextOverride,
 	BillingVersion,
+	cp,
 	CusProductStatus,
 	cusProductToPrices,
 	hasCustomItems,
@@ -173,6 +174,17 @@ export const setupAttachBillingContext = async ({
 		},
 	});
 
+	// For cross-entity revert trials: if no currentCustomerProduct on the target
+	// entity, find an active subscription on any entity to pause/revert to.
+	const revertTargetProduct =
+		trialContext?.onEnd === "revert" && !currentCustomerProduct
+			? fullCustomer.customer_products.find(
+					(cusProduct) =>
+						cp(cusProduct).paidRecurring().main().hasActiveStatus()
+							.hasSubscription().valid,
+				)
+			: currentCustomerProduct;
+
 	const skipBillingChanges =
 		skipBillingChangesBase || trialContext?.onEnd === "revert";
 
@@ -241,7 +253,7 @@ export const setupAttachBillingContext = async ({
 		featureQuantities,
 		transitionConfig,
 
-		currentCustomerProduct,
+		currentCustomerProduct: revertTargetProduct ?? currentCustomerProduct,
 		scheduledCustomerProduct,
 
 		planTiming,

--- a/server/tests/integration/billing/attach/free-trial/revert/trial-revert-attach.test.ts
+++ b/server/tests/integration/billing/attach/free-trial/revert/trial-revert-attach.test.ts
@@ -264,9 +264,9 @@ test.concurrent(
  * - Attach enterprise with on_end: "revert" on entity 2
  *
  * Expected:
- * - Pro on entity 1 is paused
- * - Enterprise trial on entity 2 is created with correct previous_customer_product_id
- * - on_trial_end = "revert" on the enterprise cusProduct
+ * - Pro on entity 1 stays active (not paused -- different entity)
+ * - Enterprise trial on entity 2 has no previous_customer_product_id
+ * - Trial expires to nothing on entity 2
  */
 test.concurrent(
 	`${chalk.yellowBright("trial-revert-attach 4: cross-entity revert — pro on entity 1, enterprise revert on entity 2")}`,
@@ -332,21 +332,13 @@ test.concurrent(
 		expect(proCusProduct).toBeDefined();
 		expect(enterpriseCusProduct).toBeDefined();
 
-		// Pro on entity 1 should be paused
-		expect(proCusProduct!.status).toBe(CusProductStatus.Paused);
-		expect(proCusProduct!.canceled).toBe(false);
+		// Pro on entity 1 stays active (different entity, not paused)
+		expect(proCusProduct!.status).toBe(CusProductStatus.Active);
 
-		// Enterprise on entity 2 should be trialing with revert
+		// Enterprise on entity 2: revert trial with no previous product link
 		expect(enterpriseCusProduct!.status).toBe(CusProductStatus.Active);
 		expect(enterpriseCusProduct!.on_trial_end).toBe("revert");
-		expect(enterpriseCusProduct!.previous_customer_product_id).toBe(
-			proCusProduct!.id,
-		);
+		expect(enterpriseCusProduct!.previous_customer_product_id).toBeNull();
 		expect(enterpriseCusProduct!.trial_ends_at).toBeDefined();
-		expect(
-			Math.abs(
-				enterpriseCusProduct!.trial_ends_at! - (advancedTo + ms.days(14)),
-			),
-		).toBeLessThan(ms.hours(1));
 	},
 );

--- a/server/tests/integration/billing/attach/free-trial/revert/trial-revert-attach.test.ts
+++ b/server/tests/integration/billing/attach/free-trial/revert/trial-revert-attach.test.ts
@@ -253,3 +253,100 @@ test.concurrent(
 		expect(enterpriseCusProduct!.previous_customer_product_id).toBeNull();
 	},
 );
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 4: Cross-entity revert — pro on entity 1, enterprise revert on entity 2
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer has pro ($20/mo) on entity 1 with a Stripe subscription
+ * - Attach enterprise with on_end: "revert" on entity 2
+ *
+ * Expected:
+ * - Pro on entity 1 is paused
+ * - Enterprise trial on entity 2 is created with correct previous_customer_product_id
+ * - on_trial_end = "revert" on the enterprise cusProduct
+ */
+test.concurrent(
+	`${chalk.yellowBright("trial-revert-attach 4: cross-entity revert — pro on entity 1, enterprise revert on entity 2")}`,
+	async () => {
+		const customerId = "trial-revert-cross-entity";
+
+		const proMessages = items.monthlyMessages({ includedUsage: 500 });
+		const pro = products.pro({ id: "pro", items: [proMessages] });
+
+		const enterpriseMessages = items.monthlyMessages({ includedUsage: 2000 });
+		const enterprisePrice = items.monthlyPrice({ price: 50 });
+		const enterprise = products.base({
+			id: "enterprise",
+			items: [enterpriseMessages, enterprisePrice],
+		});
+
+		const { autumnV2, ctx, entities, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, enterprise] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id, entityIndex: 0 }),
+			],
+		});
+
+		// Attach enterprise with revert trial on entity 2
+		const params: AttachParamsV1Input = {
+			customer_id: customerId,
+			entity_id: entities[1].id,
+			plan_id: enterprise.id,
+			redirect_mode: "if_required",
+			customize: {
+				free_trial: {
+					duration_length: 14,
+					duration_type: FreeTrialDuration.Day,
+					card_required: false,
+					on_end: "revert",
+				},
+			},
+		};
+
+		await autumnV2.billing.attach<AttachParamsV1Input>(params);
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+			withEntities: true,
+		});
+
+		// Find pro on entity 1 and enterprise on entity 2
+		const proCusProduct = fullCustomer.customer_products.find(
+			(cp) => cp.product_id === pro.id && cp.entity_id === entities[0].id,
+		);
+		const enterpriseCusProduct = fullCustomer.customer_products.find(
+			(cp) =>
+				cp.product_id === enterprise.id && cp.entity_id === entities[1].id,
+		);
+
+		expect(proCusProduct).toBeDefined();
+		expect(enterpriseCusProduct).toBeDefined();
+
+		// Pro on entity 1 should be paused
+		expect(proCusProduct!.status).toBe(CusProductStatus.Paused);
+		expect(proCusProduct!.canceled).toBe(false);
+
+		// Enterprise on entity 2 should be trialing with revert
+		expect(enterpriseCusProduct!.status).toBe(CusProductStatus.Active);
+		expect(enterpriseCusProduct!.on_trial_end).toBe("revert");
+		expect(enterpriseCusProduct!.previous_customer_product_id).toBe(
+			proCusProduct!.id,
+		);
+		expect(enterpriseCusProduct!.trial_ends_at).toBeDefined();
+		expect(
+			Math.abs(
+				enterpriseCusProduct!.trial_ends_at! - (advancedTo + ms.days(14)),
+			),
+		).toBeLessThan(ms.hours(1));
+	},
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the attach flow for free trials with on_end: "revert" across entities. We no longer pause subscriptions on other entities; if the target entity has no product, the trial runs and ends without a revert link.

- **Bug Fixes**
  - Validation now requires the customer to have an active paid subscription somewhere to use "revert" (via `hasActivePaidSubscription`).
  - Added integration test: pro on entity 1 stays active; enterprise trial on entity 2 has on_end: "revert", no `previous_customer_product_id`, and a trial end timestamp.

<sup>Written for commit 1348b96a88c3fbf32fe059e3921bd555c3eac75f. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1581?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the revert-trial attach flow to support cross-entity scenarios: when a customer attaches a product with `on_end: "revert"` on an entity that has no existing subscription, the system now searches across all entities to find an active paid product to revert to.

- **Bug fixes** — `setupAttachBillingContext` derives `revertTargetProduct` by scanning `customer_products` for any active paid recurring subscription when no same-entity `currentCustomerProduct` exists, then exposes it as `currentCustomerProduct` in the returned billing context.
- **Bug fixes** — `handleRevertTrialErrors` doc comment updated to reflect the expanded cross-entity lookup.
- **Improvements** — New integration test (test 4) validates the end-to-end cross-entity revert scenario: pro subscription on entity 1 is paused, enterprise trial on entity 2 is created with correct `previous_customer_product_id`.
</details>

<h3>Confidence Score: 3/5</h3>

The core attach flow works for the single cross-entity case tested, but the product-selection logic silently picks an arbitrary subscription when a customer has active paid products on more than one entity — potentially pausing the wrong subscription with no error surfaced to the caller.

The `find` over all customer products has no tie-breaking or uniqueness guarantee. A customer with active subscriptions on two or more other entities who starts a revert trial will have an unpredictable subscription paused, and neither the API response nor any error path signals the ambiguity. The test covers only the single-candidate scenario, leaving the multi-candidate edge case untested.

server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts — the `revertTargetProduct` `find` logic needs a determinism guarantee or an explicit guard against multiple candidates.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts | Adds cross-entity revert-target resolution via a `find` over all customer products; the first-match semantics are ambiguous when multiple entities carry active paid subscriptions, and the `??` fallback on the returned `currentCustomerProduct` field is unreachable. |
| server/src/internal/billing/v2/actions/attach/errors/handleRevertTrialErrors.ts | Doc comment updated to reflect cross-entity revert support; no logic changes. |
| server/tests/integration/billing/attach/free-trial/revert/trial-revert-attach.test.ts | New concurrent integration test (test 4) covering the cross-entity revert scenario; covers the happy path but has no test for the ambiguous multi-entity case. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts:181-185
**Non-deterministic revert target when multiple entities have active subscriptions**

`Array.prototype.find` returns the first match in insertion order. If a customer has active paid subscriptions on more than one entity (e.g., pro on entity 1 and on entity 3), the product chosen as the revert target depends entirely on the order of `customer_products` in the DB result. Whichever subscription was created first (or returned first by the query) will be paused — silently and unexpectedly. Consider either rejecting the attach with a clear error when there are multiple candidates, or exposing a `revert_to_entity_id` / `revert_to_customer_product_id` param so the caller can be explicit.

### Issue 2 of 2
server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts:256
The `??` fallback is unreachable. When the ternary condition is `false`, `revertTargetProduct` is already set to `currentCustomerProduct`, so `revertTargetProduct ?? currentCustomerProduct` reduces to `currentCustomerProduct ?? currentCustomerProduct`. When the condition is `true` and `find` returns `undefined`, `revertTargetProduct` is `undefined` and `currentCustomerProduct` is also `undefined` (required by the `!currentCustomerProduct` guard), so the fallback still yields `undefined`. The `??` adds no value and obscures intent.

```suggestion
		currentCustomerProduct: revertTargetProduct,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix entities case with attach end..."](https://github.com/useautumn/autumn/commit/d7840accb8879229adb9df0a012e43679d531613) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32449651)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->