### PR TITLE
fix: server tsconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ server/.turbo
 
 ./AGENTS.md
 ./CLAUDE.md
+
+notes.txt

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -41,13 +41,7 @@
 
 			// Explicitly set drizzle-orm path to avoid monorepo issues
 			"drizzle-orm": ["../node_modules/drizzle-orm"],
-			"drizzle-orm/*": ["../node_modules/drizzle-orm/*"],
-
-			"@better-auth/core": ["../node_modules/@better-auth/core"],
-			"@better-auth/core/*": ["../node_modules/@better-auth/core/*"],
-
-			"hono": ["../node_modules/hono"],
-			"hono/*": ["../node_modules/hono/*"]
+			"drizzle-orm/*": ["../node_modules/drizzle-orm/*"]
 		}
 	},
 	"include": ["src", "tests", "scripts", "experiments", "perf"],


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the server TypeScript configuration by removing explicit path aliases for `@better-auth/core` and `hono` from `server/tsconfig.json`, while retaining the `drizzle-orm` alias which has a comment explaining it's needed to avoid monorepo resolution issues. It also adds `notes.txt` to `.gitignore`.

- **[Bug fixes]** Removes unnecessary `@better-auth/core` and `hono` path overrides from `server/tsconfig.json`, allowing TypeScript to resolve these packages through standard module resolution rather than pinned monorepo-relative paths.
- **[Improvements]** Adds `notes.txt` to `.gitignore` to prevent accidental commits of local scratch files.
- **[Improvements]** Bumps the `ai` git submodule to a newer commit.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes two path overrides that were forcing TypeScript to a monorepo-level copy of `@better-auth/core` and `hono`, letting standard resolution take over.

Both removed aliases pointed packages to `../node_modules/…`, which can cause incorrect type resolution in a monorepo when a package has its own copy in `server/node_modules`. Removing them is the correct fix; `drizzle-orm` keeps its alias with an explanatory comment. The `.gitignore` and submodule changes are benign.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tsconfig.json | Removes explicit path aliases for `@better-auth/core` and `hono`, retaining only the `drizzle-orm` alias that guards against monorepo resolution issues. |
| .gitignore | Adds `notes.txt` to `.gitignore` and fixes missing newline at end of previous entry. |
| ai | Submodule pointer bumped from `761b842` to `ade6ce6`; no structural changes visible at this level. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TypeScript Compiler] -->|resolves| B{Path aliases in tsconfig}
    B -->|drizzle-orm| C["../node_modules/drizzle-orm pinned"]
    B -->|local aliases| E[Local src paths]
    B -->|better-auth and hono| D[Standard node_modules resolution]
    D -->|before this PR| F["../node_modules pinned override"]
    D -->|after this PR| G[Normal resolution picks up correct version]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Your commit message here"](https://github.com/useautumn/autumn/commit/4b808138715d97bdfe80536a49d14f0a8a1d9026) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32457758)</sub>

<!-- /greptile_comment -->