### PR TITLE
Fix : Prevent copy product API call when required fields are missing

### DIFF
--- a/vite/src/views/products/products/components/CopyProductDialog.tsx
+++ b/vite/src/views/products/products/components/CopyProductDialog.tsx
@@ -56,7 +56,12 @@ export const CopyProductDialog = ({
 	const envLabel = effectiveEnv === AppEnv.Sandbox ? "Sandbox" : "Production";
 
 	const handleCopy = async () => {
-		// 1. If env is the same and id is same, throw error
+		// 1. If Name and Id is empty, throw error
+		if(!name || !id) {
+            toast.error("Name and id cannot be empty, id must contain only letters, numbers, underscores, hyphens");
+            return;
+        }
+		// 2. If env is the same and id is same, throw error
 		if (env === effectiveEnv && id === product.id) {
 			toast.error("Plan ID already exists");
 			return;

--- a/vite/src/views/products/products/components/CopyProductDialog.tsx
+++ b/vite/src/views/products/products/components/CopyProductDialog.tsx
@@ -57,10 +57,11 @@ export const CopyProductDialog = ({
 
 	const handleCopy = async () => {
 		// 1. If Name and Id is empty, throw error
-		if(!name || !id) {
-            toast.error("Name and id cannot be empty, id must contain only letters, numbers, underscores, hyphens");
-            return;
-        }
+		if (!name || !id) {
+			if (!name) toast.error("Name cannot be empty");
+			else toast.error("ID cannot be empty");
+			return;
+		}
 		// 2. If env is the same and id is same, throw error
 		if (env === effectiveEnv && id === product.id) {
 			toast.error("Plan ID already exists");


### PR DESCRIPTION
## Summary
Added validation in the Copy Product modal to prevent unnecessary API calls when both `name` and `id` fields are empty.

## Changes
- Added client-side validation before triggering the copy API
- Display validation error toast when required fields are missing
- Prevent API execution if invalid input is provided

<img width="1112" height="609" alt="Screenshot 2026-05-17 at 2 56 16 PM" src="https://github.com/user-attachments/assets/ba573e08-9ad1-47a7-ac5d-7410cbbffb6d" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add client-side validation to the Copy Product dialog to stop the copy API when Name or ID is empty. Show field-specific error toasts (“Name cannot be empty” or “ID cannot be empty”) to prevent unnecessary requests.

<sup>Written for commit 8cc8d306feadd27712618a585c2437d34355a77e. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1585?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



