### PR TITLE
chore: reset free entitlements via webhook when linked stripe interva…

### DIFF
--- a/server/src/external/stripe/stripeSubUtils/stripeSubscriptionToEntInterval.ts
+++ b/server/src/external/stripe/stripeSubUtils/stripeSubscriptionToEntInterval.ts
@@ -1,0 +1,37 @@
+import { EntInterval } from "@autumn/shared";
+import type Stripe from "stripe";
+
+export interface SubscriptionEntInterval {
+	interval: EntInterval;
+	intervalCount: number;
+}
+
+/**
+ * Derives the EntInterval + intervalCount from a Stripe subscription's plan.
+ * Returns null if the subscription has no items or uses an unmappable interval.
+ */
+export const stripeSubscriptionToEntInterval = ({
+	stripeSubscription,
+}: {
+	stripeSubscription: Stripe.Subscription;
+}): SubscriptionEntInterval | null => {
+	const firstItem = stripeSubscription.items.data[0];
+	if (!firstItem?.plan) return null;
+
+	const { interval, interval_count } = firstItem.plan;
+
+	switch (interval) {
+		case "week":
+			return { interval: EntInterval.Week, intervalCount: interval_count };
+		case "month":
+			if (interval_count === 3)
+				return { interval: EntInterval.Quarter, intervalCount: 1 };
+			if (interval_count === 6)
+				return { interval: EntInterval.SemiAnnual, intervalCount: 1 };
+			return { interval: EntInterval.Month, intervalCount: interval_count };
+		case "year":
+			return { interval: EntInterval.Year, intervalCount: interval_count };
+		default:
+			return null;
+	}
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/handleStripeInvoiceCreated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/handleStripeInvoiceCreated.ts
@@ -5,6 +5,7 @@ import {
 	upsertAutumnInvoice,
 } from "@/external/stripe/webhookHandlers/common";
 import { processAllocatedPricesForInvoiceCreated } from "@/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processAllocatedPricesForInvoiceCreated";
+import { processFreeEntitlementsForInvoiceCreated } from "@/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processFreeEntitlementsForInvoiceCreated";
 import { processPrepaidPricesForInvoiceCreated } from "@/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processPrepaidPricesForInvoiceCreated";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext";
 import { setupInvoiceCreatedContext } from "./setupInvoiceCreatedContext";
@@ -35,6 +36,7 @@ export const handleStripeInvoiceCreated = async ({
 	});
 	await processPrepaidPricesForInvoiceCreated({ ctx, eventContext });
 	await processAllocatedPricesForInvoiceCreated({ ctx, eventContext });
+	await processFreeEntitlementsForInvoiceCreated({ ctx, eventContext });
 
 	// Upsert Autumn invoice record
 	const autumnInvoice = await upsertAutumnInvoice({

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processFreeEntitlementsForInvoiceCreated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processFreeEntitlementsForInvoiceCreated.ts
@@ -1,0 +1,119 @@
+import {
+	addCusProductToCusEnt,
+	CusProductStatus,
+	cusEntToCusPrice,
+	EntInterval,
+	type FullCusEntWithFullCusProduct,
+	secondsToMs,
+} from "@autumn/shared";
+import { isStripeInvoiceForNewPeriod } from "@/external/stripe/invoices/utils/classifyStripeInvoice";
+import { subToPeriodStartEnd } from "@/external/stripe/stripeSubUtils/convertSubUtils";
+import { stripeSubscriptionToEntInterval } from "@/external/stripe/stripeSubUtils/stripeSubscriptionToEntInterval";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
+import { RolloverService } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService";
+import { getRolloverUpdates } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils";
+import { getResetBalancesUpdate } from "@/internal/customers/cusProducts/cusEnts/groupByUtils";
+import type { InvoiceCreatedContext } from "../setupInvoiceCreatedContext";
+
+/**
+ * Resets free (non-price-backed) customer entitlements whose interval matches
+ * the subscription's billing cycle. Aligns their next_reset_at with the
+ * subscription period end so they stay in sync with paid entitlements.
+ */
+export const processFreeEntitlementsForInvoiceCreated = async ({
+	ctx,
+	eventContext,
+}: {
+	ctx: StripeWebhookContext;
+	eventContext: InvoiceCreatedContext;
+}): Promise<void> => {
+	const { stripeInvoice, stripeSubscription, fullCustomer } = eventContext;
+
+	if (!isStripeInvoiceForNewPeriod(stripeInvoice)) return;
+
+	const subInterval = stripeSubscriptionToEntInterval({ stripeSubscription });
+	if (!subInterval) return;
+
+	const { end } = subToPeriodStartEnd({ sub: stripeSubscription });
+	const nextResetAt = secondsToMs(end);
+
+	const freeCusEnts = collectMatchingFreeCusEnts({
+		fullCustomer,
+		subInterval: subInterval.interval,
+		subIntervalCount: subInterval.intervalCount,
+	});
+
+	if (freeCusEnts.length === 0) return;
+
+	ctx.logger.info(
+		`[invoice.created] Resetting ${freeCusEnts.length} free entitlement(s) via webhook`,
+	);
+
+	for (const cusEnt of freeCusEnts) {
+		const ent = cusEnt.entitlement;
+
+		const resetUpdate = getResetBalancesUpdate({
+			cusEnt,
+			allowance: ent.allowance ?? 0,
+		});
+
+		await CusEntService.update({
+			ctx,
+			id: cusEnt.id,
+			updates: {
+				...resetUpdate,
+				adjustment: 0,
+				next_reset_at: nextResetAt,
+			},
+		});
+
+		const rolloverUpdate = getRolloverUpdates({
+			cusEnt,
+			nextResetAt,
+		});
+
+		if (rolloverUpdate?.toInsert && rolloverUpdate.toInsert.length > 0) {
+			await RolloverService.insert({
+				ctx,
+				rows: rolloverUpdate.toInsert,
+				fullCusEnt: cusEnt,
+			});
+		}
+	}
+};
+
+/**
+ * Collects free cusEnts with matching interval, regardless of day alignment.
+ * Deliberately broader than the lazy filter — this is the adoption mechanism
+ * that brings misaligned free entitlements onto the subscription's cycle.
+ */
+const collectMatchingFreeCusEnts = ({
+	fullCustomer,
+	subInterval,
+	subIntervalCount,
+}: {
+	fullCustomer: InvoiceCreatedContext["fullCustomer"];
+	subInterval: EntInterval;
+	subIntervalCount: number;
+}): FullCusEntWithFullCusProduct[] => {
+	const result: FullCusEntWithFullCusProduct[] = [];
+
+	for (const cusProduct of fullCustomer.customer_products) {
+		if (cusProduct.status !== CusProductStatus.Active) continue;
+
+		for (const cusEnt of cusProduct.customer_entitlements) {
+			const ent = cusEnt.entitlement;
+			if (!cusEnt.next_reset_at) continue;
+			if (ent.interval !== subInterval) continue;
+			if ((ent.interval_count ?? 1) !== subIntervalCount) continue;
+
+			const cusEntWithProduct = addCusProductToCusEnt({ cusEnt, cusProduct });
+			if (cusEntToCusPrice({ cusEnt: cusEntWithProduct })) continue;
+
+			result.push(cusEntWithProduct);
+		}
+	}
+
+	return result;
+};

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/getCusEntsNeedingReset.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/getCusEntsNeedingReset.ts
@@ -5,6 +5,7 @@ import {
 	fullCustomerToCustomerEntitlements,
 } from "@autumn/shared";
 import { getResettableCustomerEntitlements } from "../resetCustomerEntitlementsV2/getResettableCustomerEntitlements.js";
+import { getWebhookOwnedIntervals } from "./getWebhookOwnedIntervals.js";
 
 /** Collects cusEnts from a FullCustomer that need resetting (next_reset_at < now). */
 export const getCusEntsNeedingReset = ({
@@ -19,5 +20,11 @@ export const getCusEntsNeedingReset = ({
 		inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
 	});
 
-	return getResettableCustomerEntitlements({ customerEntitlements, now });
+	const webhookOwnedIntervals = getWebhookOwnedIntervals({ fullCus });
+
+	return getResettableCustomerEntitlements({
+		customerEntitlements,
+		now,
+		webhookOwnedIntervals,
+	});
 };

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/getWebhookOwnedIntervals.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/getWebhookOwnedIntervals.ts
@@ -1,6 +1,7 @@
 import {
 	BillingInterval,
 	CusProductStatus,
+	EntInterval,
 	type FullCusProduct,
 	type FullCustomer,
 } from "@autumn/shared";
@@ -15,8 +16,8 @@ export interface WebhookOwnedInterval {
 /**
  * Computes the set of intervals that are "webhook-owned" for a customer —
  * i.e. intervals for which a Stripe subscription will trigger invoice.created
- * and handle the reset. Includes the reset day (derived from the price-backed
- * entitlement's next_reset_at) so callers can verify cycle alignment.
+ * and handle the reset. Intervals are normalized to EntInterval values
+ * (month×3 → quarter, month×6 → semi_annual) so they match entitlement rows.
  */
 export const getWebhookOwnedIntervals = ({
 	fullCus,
@@ -34,11 +35,14 @@ export const getWebhookOwnedIntervals = ({
 		if (!cusProduct.subscription_ids?.length) continue;
 
 		for (const cusPrice of cusProduct.customer_prices) {
-			const interval = cusPrice.price.config?.interval;
-			if (!interval || interval === BillingInterval.OneOff) continue;
+			const rawInterval = cusPrice.price.config?.interval;
+			if (!rawInterval || rawInterval === BillingInterval.OneOff) continue;
 
-			const intervalCount = cusPrice.price.config?.interval_count ?? 1;
-			const key = `${interval}:${intervalCount}`;
+			const rawCount = cusPrice.price.config?.interval_count ?? 1;
+			const normalized = normalizeBillingInterval(rawInterval, rawCount);
+			if (!normalized) continue;
+
+			const key = `${normalized.interval}:${normalized.intervalCount}`;
 			if (seen.has(key)) continue;
 
 			seen.add(key);
@@ -49,14 +53,41 @@ export const getWebhookOwnedIntervals = ({
 			});
 
 			result.push({
-				interval,
-				intervalCount,
+				...normalized,
 				resetDayOfMonth: periodEndMs ? getDate(periodEndMs) : null,
 			});
 		}
 	}
 
 	return result;
+};
+
+/**
+ * Maps BillingInterval + count to the EntInterval representation used on
+ * entitlement rows. Must stay in sync with stripeSubscriptionToEntInterval.
+ */
+const normalizeBillingInterval = (
+	interval: string,
+	intervalCount: number,
+): { interval: string; intervalCount: number } | null => {
+	switch (interval) {
+		case BillingInterval.Week:
+			return { interval: EntInterval.Week, intervalCount };
+		case BillingInterval.Month:
+			if (intervalCount === 3)
+				return { interval: EntInterval.Quarter, intervalCount: 1 };
+			if (intervalCount === 6)
+				return { interval: EntInterval.SemiAnnual, intervalCount: 1 };
+			return { interval: EntInterval.Month, intervalCount };
+		case BillingInterval.Quarter:
+			return { interval: EntInterval.Quarter, intervalCount };
+		case BillingInterval.SemiAnnual:
+			return { interval: EntInterval.SemiAnnual, intervalCount };
+		case BillingInterval.Year:
+			return { interval: EntInterval.Year, intervalCount };
+		default:
+			return null;
+	}
 };
 
 const findPriceBackedPeriodEnd = ({

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/getWebhookOwnedIntervals.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/getWebhookOwnedIntervals.ts
@@ -1,0 +1,92 @@
+import {
+	BillingInterval,
+	CusProductStatus,
+	type FullCusProduct,
+	type FullCustomer,
+} from "@autumn/shared";
+import { getDate } from "date-fns";
+
+export interface WebhookOwnedInterval {
+	interval: string;
+	intervalCount: number;
+	resetDayOfMonth: number | null;
+}
+
+/**
+ * Computes the set of intervals that are "webhook-owned" for a customer —
+ * i.e. intervals for which a Stripe subscription will trigger invoice.created
+ * and handle the reset. Includes the reset day (derived from the price-backed
+ * entitlement's next_reset_at) so callers can verify cycle alignment.
+ */
+export const getWebhookOwnedIntervals = ({
+	fullCus,
+	customerProducts,
+}: {
+	fullCus?: FullCustomer;
+	customerProducts?: FullCusProduct[];
+}): WebhookOwnedInterval[] => {
+	const products = customerProducts ?? fullCus?.customer_products ?? [];
+	const seen = new Set<string>();
+	const result: WebhookOwnedInterval[] = [];
+
+	for (const cusProduct of products) {
+		if (cusProduct.status !== CusProductStatus.Active) continue;
+		if (!cusProduct.subscription_ids?.length) continue;
+
+		for (const cusPrice of cusProduct.customer_prices) {
+			const interval = cusPrice.price.config?.interval;
+			if (!interval || interval === BillingInterval.OneOff) continue;
+
+			const intervalCount = cusPrice.price.config?.interval_count ?? 1;
+			const key = `${interval}:${intervalCount}`;
+			if (seen.has(key)) continue;
+
+			seen.add(key);
+
+			const periodEndMs = findPriceBackedPeriodEnd({
+				cusProduct,
+				entitlementId: cusPrice.price.entitlement_id,
+			});
+
+			result.push({
+				interval,
+				intervalCount,
+				resetDayOfMonth: periodEndMs ? getDate(periodEndMs) : null,
+			});
+		}
+	}
+
+	return result;
+};
+
+const findPriceBackedPeriodEnd = ({
+	cusProduct,
+	entitlementId,
+}: {
+	cusProduct: FullCusProduct;
+	entitlementId: string | null | undefined;
+}): number | null => {
+	if (!entitlementId) return null;
+
+	const cusEnt = cusProduct.customer_entitlements.find(
+		(ce) => ce.entitlement_id === entitlementId,
+	);
+
+	return cusEnt?.next_reset_at ?? null;
+};
+
+/**
+ * Returns true if the free entitlement resets on the same day-of-month as
+ * the subscription. When resetDayOfMonth is null (no reference yet), assume
+ * alignment so the webhook can adopt it on first fire.
+ */
+export const isAlignedWithWebhookCycle = ({
+	cusEntNextResetAt,
+	resetDayOfMonth,
+}: {
+	cusEntNextResetAt: number;
+	resetDayOfMonth: number | null;
+}): boolean => {
+	if (resetDayOfMonth === null) return true;
+	return getDate(cusEntNextResetAt) === resetDayOfMonth;
+};

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts
@@ -57,6 +57,7 @@ const isWebhookOwned = ({
 	webhookOwnedIntervals: WebhookOwnedInterval[];
 }): boolean => {
 	if (webhookOwnedIntervals.length === 0) return false;
+	if (!cusEnt.customer_product) return false;
 
 	const entInterval = cusEnt.entitlement.interval;
 	const entIntervalCount = cusEnt.entitlement.interval_count ?? 1;

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts
@@ -3,11 +3,16 @@ import {
 	CusProductStatus,
 	type FullCusEntWithFullCusProduct,
 } from "@autumn/shared";
+import {
+	isAlignedWithWebhookCycle,
+	type WebhookOwnedInterval,
+} from "../resetCustomerEntitlements/getWebhookOwnedIntervals.js";
 
 /**
  * Filters customer entitlements to those needing reset:
  *   - `next_reset_at` is set and overdue (`< now`)
  *   - not price-backed (metered paid entitlements are billed, not reset)
+ *   - not webhook-owned (free ents whose interval matches an active subscription)
  *   - past-due cusEnts are skipped unless the owning product opts in via
  *     `product.config.ignore_past_due === true`
  *
@@ -18,9 +23,11 @@ import {
 export const getResettableCustomerEntitlements = ({
 	customerEntitlements,
 	now,
+	webhookOwnedIntervals = [],
 }: {
 	customerEntitlements: FullCusEntWithFullCusProduct[];
 	now: number;
+	webhookOwnedIntervals?: WebhookOwnedInterval[];
 }): FullCusEntWithFullCusProduct[] => {
 	const result: FullCusEntWithFullCusProduct[] = [];
 
@@ -34,8 +41,34 @@ export const getResettableCustomerEntitlements = ({
 
 		if (cusEntToCusPrice({ cusEnt })) continue;
 
+		if (isWebhookOwned({ cusEnt, webhookOwnedIntervals })) continue;
+
 		result.push(cusEnt);
 	}
 
 	return result;
+};
+
+const isWebhookOwned = ({
+	cusEnt,
+	webhookOwnedIntervals,
+}: {
+	cusEnt: FullCusEntWithFullCusProduct;
+	webhookOwnedIntervals: WebhookOwnedInterval[];
+}): boolean => {
+	if (webhookOwnedIntervals.length === 0) return false;
+
+	const entInterval = cusEnt.entitlement.interval;
+	const entIntervalCount = cusEnt.entitlement.interval_count ?? 1;
+	if (!entInterval || !cusEnt.next_reset_at) return false;
+
+	return webhookOwnedIntervals.some(
+		(owned) =>
+			owned.interval === entInterval &&
+			owned.intervalCount === entIntervalCount &&
+			isAlignedWithWebhookCycle({
+				cusEntNextResetAt: cusEnt.next_reset_at!,
+				resetDayOfMonth: owned.resetDayOfMonth,
+			}),
+	);
 };

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts
@@ -13,6 +13,7 @@ import {
 } from "@/internal/balances/utils/sql/client.js";
 import type { ProcessResetResult } from "../resetCustomerEntitlements/processReset.js";
 import { processReset } from "../resetCustomerEntitlements/processReset.js";
+import { getWebhookOwnedIntervals } from "../resetCustomerEntitlements/getWebhookOwnedIntervals.js";
 import {
 	applyResetResultsToFullSubject,
 	applyResetResultsToNormalized,
@@ -67,9 +68,14 @@ export const lazyResetSubjectEntitlements = async ({
 		inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
 	});
 
+	const webhookOwnedIntervals = getWebhookOwnedIntervals({
+		customerProducts: fullSubject.customer_products,
+	});
+
 	const customerEntitlementsNeedingReset = getResettableCustomerEntitlements({
 		customerEntitlements: allCustomerEntitlements,
 		now,
+		webhookOwnedIntervals,
 	});
 
 	if (customerEntitlementsNeedingReset.length === 0) return false;

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/triggerBatchResetSubjectEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/triggerBatchResetSubjectEntitlements.ts
@@ -5,6 +5,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { type BatchResetCusEntsPayload, workflows } from "@/queue/workflows.js";
+import { getWebhookOwnedIntervals } from "../resetCustomerEntitlements/getWebhookOwnedIntervals.js";
 import { getResettableCustomerEntitlements } from "./getResettableCustomerEntitlements.js";
 
 export const triggerBatchResetSubjectEntitlements = async ({
@@ -22,9 +23,13 @@ export const triggerBatchResetSubjectEntitlements = async ({
 			fullSubject,
 			inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
 		});
+		const webhookOwnedIntervals = getWebhookOwnedIntervals({
+			customerProducts: fullSubject.customer_products,
+		});
 		const cusEntsNeedingReset = getResettableCustomerEntitlements({
 			customerEntitlements,
 			now,
+			webhookOwnedIntervals,
 		});
 
 		if (cusEntsNeedingReset.length === 0) continue;

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -202,6 +202,42 @@ export class CusEntService {
 					),
 			);
 
+		// Exclude free cusEnts whose interval matches a subscription-backed
+		// price on the same customer AND resets on the same day-of-month.
+		// Mirrors isWebhookOwned + isAlignedWithWebhookCycle logic.
+		const notWebhookOwned = () =>
+			notExists(
+				db
+					.select({ one: sql`1` })
+					.from(sql`customer_products cp_sub`)
+					.innerJoin(
+						sql`customer_prices cpr_sub`,
+						sql`cpr_sub.customer_product_id = cp_sub.id`,
+					)
+					.innerJoin(
+						sql`prices p_sub`,
+						sql`p_sub.id = cpr_sub.price_id`,
+					)
+					.innerJoin(
+						sql`customer_entitlements ce_sub`,
+						sql`ce_sub.customer_product_id = cp_sub.id AND ce_sub.entitlement_id = p_sub.entitlement_id`,
+					)
+					.where(
+						sql`cp_sub.internal_customer_id = ${customerEntitlements.internal_customer_id}
+							AND cp_sub.status = 'active'
+							AND cp_sub.subscription_ids IS NOT NULL
+							AND array_length(cp_sub.subscription_ids, 1) > 0
+							AND (p_sub.config->>'interval') = ${entitlements.interval}
+							AND COALESCE((p_sub.config->>'interval_count')::int, 1) = COALESCE(${entitlements.interval_count}::int, 1)
+							AND (p_sub.config->>'interval') != 'one_off'
+							AND (
+								ce_sub.next_reset_at IS NULL
+								OR EXTRACT(DAY FROM to_timestamp(${customerEntitlements.next_reset_at} / 1000.0))
+								 = EXTRACT(DAY FROM to_timestamp(ce_sub.next_reset_at / 1000.0))
+							)`,
+					),
+			);
+
 		while (hasMore) {
 			// Branch 1: cusEnts with no customer_product. Left-join to
 			// customer_products on a false predicate so the row shape matches
@@ -226,6 +262,7 @@ export class CusEntService {
 					and(
 						isNull(customerEntitlements.customer_product_id),
 						commonResetPredicates(),
+						notWebhookOwned(),
 					),
 				);
 
@@ -254,6 +291,7 @@ export class CusEntService {
 						eq(customerProducts.status, CusProductStatus.Active),
 						commonResetPredicates(),
 						notPriceBacked(),
+						notWebhookOwned(),
 					),
 				);
 
@@ -288,6 +326,7 @@ export class CusEntService {
 						sql`(${products.config}->>'ignore_past_due')::boolean = true`,
 						commonResetPredicates(),
 						notPriceBacked(),
+						notWebhookOwned(),
 					),
 				);
 

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -207,6 +207,7 @@ export class CusEntService {
 		// Mirrors isWebhookOwned + isAlignedWithWebhookCycle logic.
 		// LEFT JOIN to ce_sub so that missing entitlement rows (e.g. fixed
 		// prices) still match — null ce_sub means "assume aligned."
+		// Interval normalization: month×3→quarter, month×6→semi_annual.
 		const notWebhookOwned = () =>
 			notExists(
 				db
@@ -229,9 +230,20 @@ export class CusEntService {
 							AND cp_sub.status = 'active'
 							AND cp_sub.subscription_ids IS NOT NULL
 							AND array_length(cp_sub.subscription_ids, 1) > 0
-							AND (p_sub.config->>'interval') = ${entitlements.interval}
-							AND COALESCE((p_sub.config->>'interval_count')::int, 1) = COALESCE(${entitlements.interval_count}::int, 1)
 							AND (p_sub.config->>'interval') != 'one_off'
+							AND (
+								CASE
+									WHEN (p_sub.config->>'interval') = 'month' AND COALESCE((p_sub.config->>'interval_count')::int, 1) = 3 THEN 'quarter'
+									WHEN (p_sub.config->>'interval') = 'month' AND COALESCE((p_sub.config->>'interval_count')::int, 1) = 6 THEN 'semi_annual'
+									ELSE (p_sub.config->>'interval')
+								END
+							) = ${entitlements.interval}
+							AND (
+								CASE
+									WHEN (p_sub.config->>'interval') = 'month' AND COALESCE((p_sub.config->>'interval_count')::int, 1) IN (3, 6) THEN 1
+									ELSE COALESCE((p_sub.config->>'interval_count')::int, 1)
+								END
+							) = COALESCE(${entitlements.interval_count}::int, 1)
 							AND (
 								ce_sub.next_reset_at IS NULL
 								OR EXTRACT(DAY FROM to_timestamp(${customerEntitlements.next_reset_at} / 1000.0))
@@ -264,7 +276,6 @@ export class CusEntService {
 					and(
 						isNull(customerEntitlements.customer_product_id),
 						commonResetPredicates(),
-						notWebhookOwned(),
 					),
 				);
 

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -205,6 +205,8 @@ export class CusEntService {
 		// Exclude free cusEnts whose interval matches a subscription-backed
 		// price on the same customer AND resets on the same day-of-month.
 		// Mirrors isWebhookOwned + isAlignedWithWebhookCycle logic.
+		// LEFT JOIN to ce_sub so that missing entitlement rows (e.g. fixed
+		// prices) still match — null ce_sub means "assume aligned."
 		const notWebhookOwned = () =>
 			notExists(
 				db
@@ -218,7 +220,7 @@ export class CusEntService {
 						sql`prices p_sub`,
 						sql`p_sub.id = cpr_sub.price_id`,
 					)
-					.innerJoin(
+					.leftJoin(
 						sql`customer_entitlements ce_sub`,
 						sql`ce_sub.customer_product_id = cp_sub.id AND ce_sub.entitlement_id = p_sub.entitlement_id`,
 					)

--- a/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-free-entitlement-reset.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-free-entitlement-reset.test.ts
@@ -208,7 +208,7 @@ test(`${chalk.yellowBright("invoice.created free reset: different-interval free 
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// TEST 5: Same interval but misaligned cycles — lazy reset still fires
+// TEST 4: Same interval but misaligned cycles — lazy reset still fires
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
@@ -263,7 +263,7 @@ test(`${chalk.yellowBright("invoice.created free reset: same interval but misali
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// TEST 4: Paid entitlement behavior unchanged (regression)
+// TEST 5: Paid entitlement behavior unchanged (regression)
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**

--- a/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-free-entitlement-reset.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-free-entitlement-reset.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Invoice Created - Free Entitlement Reset Tests
+ *
+ * Verifies that free (non-price-backed) entitlements with the same interval as
+ * a customer's Stripe subscription are reset via the invoice.created webhook
+ * rather than the lazy/cron path. This eliminates timing drift between paid
+ * and free resets.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomer,
+	type ApiCustomerV3,
+	type LimitedItem,
+	ProductItemInterval,
+} from "@autumn/shared";
+import { subDays, subMonths } from "date-fns";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement";
+import { expectProductActive } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { expireCusEntForReset } from "@tests/utils/cusProductUtils/resetTestUtils";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem";
+import chalk from "chalk";
+
+const pause = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Free entitlement resets via invoice.created webhook
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer has Pro with consumable messages (paid) AND a free words feature
+ *   (entitlement-only, no price) on the same product
+ * - Track some words usage, then advance to next billing cycle
+ *
+ * Expected:
+ * - Words balance resets to full allowance via webhook
+ * - next_reset_at moves to subscription period end
+ */
+test(`${chalk.yellowBright("invoice.created free reset: free entitlement resets via webhook when matching sub interval")}`, async () => {
+	const customerId = "inv-created-free-reset";
+
+	const consumableItem = items.consumableMessages({ includedUsage: 100 });
+	const freeWordsItem = items.monthlyWords({ includedUsage: 500 });
+	const pro = products.pro({
+		id: "pro",
+		items: [consumableItem, freeWordsItem],
+	});
+
+	const { autumnV1, autumnV2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({ productId: pro.id, timeout: 2000 }),
+			s.track({ featureId: TestFeature.Words, value: 100, timeout: 2000 }),
+			s.advanceToNextInvoice({ withPause: true }),
+		],
+	});
+
+	await pause(2000);
+
+	const customerAfter =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	// Free words balance should be reset to full allowance
+	expect(customerAfter.features[TestFeature.Words].balance).toBe(500);
+
+	// Product should still be active
+	await expectProductActive({ customer: customerAfter, productId: pro.id });
+
+	// next_reset_at should be in the future (set to subscription period end)
+	const cusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Words,
+	});
+	expect(cusEnt).toBeDefined();
+	expect(cusEnt!.next_reset_at).toBeGreaterThan(Date.now());
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Free entitlement NOT reset by lazy when matching subscription exists
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer has Pro with consumable messages (paid) + free words (entitlement-only)
+ * - Expire the words cusEnt's next_reset_at, then GET customer
+ *
+ * Expected:
+ * - Words balance is NOT reset (lazy skipped it — webhook owns this interval)
+ */
+test(`${chalk.yellowBright("invoice.created free reset: lazy reset skips free entitlement when matching sub exists")}`, async () => {
+	const customerId = "inv-created-free-no-lazy";
+
+	const consumableItem = items.consumableMessages({ includedUsage: 100 });
+	const freeWordsItem = items.monthlyWords({ includedUsage: 500 });
+	const pro = products.pro({
+		id: "pro",
+		items: [consumableItem, freeWordsItem],
+	});
+
+	const { autumnV1, autumnV2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({ productId: pro.id, timeout: 3000 }),
+			s.track({ featureId: TestFeature.Words, value: 100, timeout: 3000 }),
+		],
+	});
+
+	await pause(3000);
+
+	// Verify usage was tracked
+	const before = await autumnV2.customers.get<ApiCustomer>(customerId, {
+		skip_cache: "true",
+	});
+	expect(before.balances[TestFeature.Words].current_balance).toBe(400);
+
+	// Find the paid cusEnt to get its reset day (= subscription period end day)
+	const paidCusEnt = await findCustomerEntitlement({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+	});
+
+	// Expire words to a past date on the SAME day-of-month as the paid period end.
+	const alignedPastMs = subMonths(paidCusEnt!.next_reset_at!, 1).getTime();
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Words,
+		pastTimeMs: alignedPastMs,
+	});
+
+	// GET customer — lazy reset should NOT fire (same interval + same reset day)
+	const after = await autumnV2.customers.get<ApiCustomer>(customerId, {
+		skip_cache: "true",
+	});
+	expect(after.balances[TestFeature.Words].current_balance).toBe(400);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: Different-interval free entitlement still resets via lazy (regression)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer has Pro (monthly sub) with consumable messages + WEEKLY words feature
+ * - Expire the words cusEnt, then GET customer
+ *
+ * Expected:
+ * - Words balance IS reset (weekly != monthly, so lazy handles it normally)
+ */
+test(`${chalk.yellowBright("invoice.created free reset: different-interval free ent still resets lazily")}`, async () => {
+	const customerId = "inv-created-free-diff-int";
+
+	const consumableItem = items.consumableMessages({ includedUsage: 100 });
+	const weeklyWordsItem = constructFeatureItem({
+		featureId: TestFeature.Words,
+		includedUsage: 500,
+		interval: ProductItemInterval.Week,
+	}) as LimitedItem;
+	const pro = products.pro({
+		id: "pro",
+		items: [consumableItem, weeklyWordsItem],
+	});
+
+	const { autumnV1, autumnV2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({ productId: pro.id, timeout: 3000 }),
+			s.track({ featureId: TestFeature.Words, value: 100, timeout: 3000 }),
+		],
+	});
+
+	await pause(3000);
+
+	// Expire the free cusEnt's next_reset_at
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Words,
+	});
+
+	// GET customer — lazy reset SHOULD fire (weekly != monthly sub)
+	const after = await autumnV2.customers.get<ApiCustomer>(customerId, {
+		skip_cache: "true",
+	});
+
+	// Balance should be fully reset (weekly interval not blocked by monthly sub)
+	expect(after.balances[TestFeature.Words].current_balance).toBe(500);
+	expect(after.balances[TestFeature.Words].usage).toBe(0);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 5: Same interval but misaligned cycles — lazy reset still fires
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer has Pro (monthly sub) with consumable messages + free monthly words
+ * - Manually expire the words cusEnt to 3 days before the paid ent's next_reset_at
+ *   (>24h apart = misaligned)
+ *
+ * Expected:
+ * - Words balance IS reset via lazy (not blocked, cycles aren't aligned)
+ */
+test(`${chalk.yellowBright("invoice.created free reset: same interval but misaligned cycle still resets lazily")}`, async () => {
+	const customerId = "inv-created-free-misalign";
+
+	const consumableItem = items.consumableMessages({ includedUsage: 100 });
+	const freeWordsItem = items.monthlyWords({ includedUsage: 500 });
+	const pro = products.pro({
+		id: "pro",
+		items: [consumableItem, freeWordsItem],
+	});
+
+	const { autumnV1, autumnV2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({ productId: pro.id, timeout: 3000 }),
+			s.track({ featureId: TestFeature.Words, value: 100, timeout: 3000 }),
+		],
+	});
+
+	await pause(3000);
+
+	// Expire to 3 days ago — past due AND different day-of-month than the paid
+	// ent's period end (~1 month away), so cycles are misaligned.
+	const threeDaysAgo = subDays(Date.now(), 3).getTime();
+	await expireCusEntForReset({
+		ctx,
+		customerId,
+		featureId: TestFeature.Words,
+		pastTimeMs: threeDaysAgo,
+	});
+
+	// GET customer — lazy reset SHOULD fire (same interval but >24h misaligned)
+	const after = await autumnV2.customers.get<ApiCustomer>(customerId, {
+		skip_cache: "true",
+	});
+	expect(after.balances[TestFeature.Words].current_balance).toBe(500);
+	expect(after.balances[TestFeature.Words].usage).toBe(0);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 4: Paid entitlement behavior unchanged (regression)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer has Pro with consumable messages (monthly, price-backed)
+ * - Track overage usage, advance to next cycle
+ *
+ * Expected:
+ * - Messages balance resets (same as before — price-backed path unchanged)
+ */
+test(`${chalk.yellowBright("invoice.created free reset: paid entitlement reset unchanged (regression)")}`, async () => {
+	const customerId = "inv-created-free-paid-reg";
+
+	const consumableItem = items.consumableMessages({ includedUsage: 100 });
+	const pro = products.pro({ id: "pro", items: [consumableItem] });
+
+	const { autumnV1, autumnV2 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({ productId: pro.id, timeout: 2000 }),
+			s.track({ featureId: TestFeature.Messages, value: 150, timeout: 2000 }),
+			s.advanceToNextInvoice({ withPause: true }),
+		],
+	});
+
+	const customerAfter =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	// Messages balance should be reset to full allowance (price-backed path)
+	expect(customerAfter.features[TestFeature.Messages].balance).toBe(100);
+	await expectProductActive({ customer: customerAfter, productId: pro.id });
+});

--- a/server/tests/unit/customers/reset/getResettableCustomerEntitlements.test.ts
+++ b/server/tests/unit/customers/reset/getResettableCustomerEntitlements.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
 	CusProductStatus,
+	EntInterval,
 	type FullCusEntWithFullCusProduct,
 	type FullCustomerPrice,
 	type FullProduct,
 } from "@autumn/shared";
+import { getDate } from "date-fns";
 import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements";
 import { customerProducts } from "@tests/utils/fixtures/db/customerProducts";
 import { products } from "@tests/utils/fixtures/db/products";
@@ -76,6 +78,42 @@ const buildCusEnt = ({
 		customerPrices,
 		status: productStatus,
 		product,
+	});
+
+	return {
+		...cusEnt,
+		customer_product: cusProduct,
+	};
+};
+
+const buildCusEntWithInterval = ({
+	interval,
+	intervalCount = 1,
+	nextResetAt,
+}: {
+	interval: EntInterval;
+	intervalCount?: number;
+	nextResetAt: number | null;
+}): FullCusEntWithFullCusProduct => {
+	const cusEnt = customerEntitlements.create({
+		featureId: FEATURE_ID,
+		featureName: "Messages",
+		allowance: 100,
+		balance: 50,
+		nextResetAt,
+		customerProductId: CUS_PROD_ID,
+		interval,
+		intervalCount,
+	});
+
+	const baseProduct = products.createFull({ id: PRODUCT_ID });
+	const cusProduct = customerProducts.create({
+		id: CUS_PROD_ID,
+		productId: PRODUCT_ID,
+		customerEntitlements: [cusEnt],
+		customerPrices: [],
+		status: CusProductStatus.Active,
+		product: baseProduct,
 	});
 
 	return {
@@ -235,5 +273,148 @@ describe(chalk.yellowBright("getResettableCustomerEntitlements"), () => {
 
 		expect(result).toHaveLength(1);
 		expect(result[0].customer_product).toBeNull();
+	});
+
+	test("skips free cusEnt when webhookOwnedIntervals contains matching interval and same day", () => {
+		const cusEnt = buildCusEntWithInterval({
+			interval: EntInterval.Month,
+			intervalCount: 1,
+			nextResetAt: PAST,
+		});
+
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements: [cusEnt],
+			now: NOW,
+			webhookOwnedIntervals: [
+				{ interval: "month", intervalCount: 1, resetDayOfMonth: getDate(PAST) },
+			],
+		});
+
+		expect(result).toHaveLength(0);
+	});
+
+	test("returns free cusEnt when interval matches but day-of-month differs", () => {
+		const cusEnt = buildCusEntWithInterval({
+			interval: EntInterval.Month,
+			intervalCount: 1,
+			nextResetAt: PAST,
+		});
+
+		const differentDay = getDate(PAST) === 15 ? 20 : 15;
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements: [cusEnt],
+			now: NOW,
+			webhookOwnedIntervals: [
+				{ interval: "month", intervalCount: 1, resetDayOfMonth: differentDay },
+			],
+		});
+
+		expect(result).toHaveLength(1);
+	});
+
+	test("skips free cusEnt when resetDayOfMonth is null (first cycle, no reference yet)", () => {
+		const cusEnt = buildCusEntWithInterval({
+			interval: EntInterval.Month,
+			intervalCount: 1,
+			nextResetAt: PAST,
+		});
+
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements: [cusEnt],
+			now: NOW,
+			webhookOwnedIntervals: [
+				{ interval: "month", intervalCount: 1, resetDayOfMonth: null },
+			],
+		});
+
+		expect(result).toHaveLength(0);
+	});
+
+	test("returns free cusEnt when interval does NOT match webhookOwnedIntervals", () => {
+		const cusEnt = buildCusEntWithInterval({
+			interval: EntInterval.Week,
+			intervalCount: 1,
+			nextResetAt: PAST,
+		});
+
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements: [cusEnt],
+			now: NOW,
+			webhookOwnedIntervals: [
+				{ interval: "month", intervalCount: 1, resetDayOfMonth: getDate(PAST) },
+			],
+		});
+
+		expect(result).toHaveLength(1);
+	});
+
+	test("returns free cusEnt when webhookOwnedIntervals is empty", () => {
+		const cusEnt = buildCusEntWithInterval({
+			interval: EntInterval.Month,
+			intervalCount: 1,
+			nextResetAt: PAST,
+		});
+
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements: [cusEnt],
+			now: NOW,
+			webhookOwnedIntervals: [],
+		});
+
+		expect(result).toHaveLength(1);
+	});
+
+	test("still skips price-backed cusEnt regardless of webhookOwnedIntervals", () => {
+		const customerEntitlements = [
+			buildCusEnt({
+				productStatus: CusProductStatus.Active,
+				nextResetAt: PAST,
+				withMatchingPrice: true,
+			}),
+		];
+
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements,
+			now: NOW,
+			webhookOwnedIntervals: [],
+		});
+
+		expect(result).toHaveLength(0);
+	});
+
+	test("skips free cusEnt when interval_count matches and same day", () => {
+		const cusEnt = buildCusEntWithInterval({
+			interval: EntInterval.Month,
+			intervalCount: 3,
+			nextResetAt: PAST,
+		});
+
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements: [cusEnt],
+			now: NOW,
+			webhookOwnedIntervals: [
+				{ interval: "month", intervalCount: 3, resetDayOfMonth: getDate(PAST) },
+			],
+		});
+
+		expect(result).toHaveLength(0);
+	});
+
+	test("returns free cusEnt when interval matches but interval_count differs", () => {
+		const cusEnt = buildCusEntWithInterval({
+			interval: EntInterval.Month,
+			intervalCount: 1,
+			nextResetAt: PAST,
+		});
+
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements: [cusEnt],
+			now: NOW,
+			webhookOwnedIntervals: [
+				{ interval: "month", intervalCount: 3, resetDayOfMonth: getDate(PAST) },
+			],
+		});
+
+		expect(result).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
…l exists

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets free (non-price-backed) entitlements via the `invoice.created` webhook when a linked Stripe subscription with a matching interval exists, and blocks lazy/batch resets for aligned intervals. Keeps free entitlements in sync by aligning `next_reset_at` to the subscription period end and adopting misaligned cycles.

- **New Features**
  - Added `processFreeEntitlementsForInvoiceCreated` to reset matching free entitlements on new periods, adopt misaligned cycles, align `next_reset_at`, and handle rollovers.
  - Introduced `stripeSubscriptionToEntInterval` and normalized webhook-owned intervals (`getWebhookOwnedIntervals` + `isAlignedWithWebhookCycle`) to map Stripe month×3/6 → `Quarter`/`SemiAnnual` and use day-of-month alignment; wired into lazy (`getResettableCustomerEntitlements`) and batch paths with a matching SQL predicate in `CusEntitlementService`.
  - Added tests for webhook reset, lazy skip on aligned cycles, misalignment behavior, `interval_count` variants (including quarter/semi-annual), and paid-entitlement regression.

<sup>Written for commit b8f5fd844dfb494dfa89878a8e582bc7ee975d9f. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1591?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes the reset of free (non-price-backed) customer entitlements through the `invoice.created` Stripe webhook when a linked subscription exists, preventing timing drift between paid and free entitlement resets. It introduces a \"webhook-owned interval\" concept to suppress the lazy/batch reset paths for entitlements the webhook now manages.

- **Bug fixes / Improvements** — `processFreeEntitlementsForInvoiceCreated` is a new webhook task that resets matching free entitlements and advances their `next_reset_at` to the subscription period end; `getWebhookOwnedIntervals` and `isWebhookOwned` gate the lazy/batch reset paths to skip those same entitlements; the batch SQL path in `CusEntitlementService` adds a `notWebhookOwned()` predicate to all three reset branches.
- **Bug fixes** — `stripeSubscriptionToEntInterval` is a new utility that normalises Stripe plan intervals (including month\u00d73 \u2192 `Quarter`, month\u00d76 \u2192 `SemiAnnual`) into `EntInterval` values for the webhook handler to use.
- **Improvements** — Integration and unit tests cover monthly reset via webhook, lazy-skip on matching subscription, different-interval regression, misaligned-cycle regression, and paid-entitlement regression.
</details>

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — two defects in the blocking guard mean quarterly/semi-annual customers and product-less free entitlements may receive incorrect reset behaviour.

The webhook reset path itself is correct, but the guard that prevents the lazy/batch path from also firing uses BillingInterval values from the price config while the entitlement stores EntInterval values. For quarterly and semi-annual plans these string values don’t match, so isWebhookOwned silently returns false and both paths can run. Separately, notWebhookOwned() is applied to Branch 1 covering entitlements with no customer_product_id, but the webhook handler only iterates over product-owned entitlements — those entitlements can be permanently excluded from reset by both paths.

getWebhookOwnedIntervals.ts (interval type mismatch) and CusEntitlementService.ts (Branch 1 over-exclusion) need attention before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/stripeSubUtils/stripeSubscriptionToEntInterval.ts | New utility that maps a Stripe subscription's plan interval/count to EntInterval; correctly normalises month×3 → Quarter and month×6 → SemiAnnual. |
| server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processFreeEntitlementsForInvoiceCreated.ts | New webhook task that resets free (non-price-backed) entitlements on invoice.created using EntInterval-level matching; logic is correct for monthly plans but paired with a broken blocking guard elsewhere for quarterly/semi-annual. |
| server/src/internal/customers/actions/resetCustomerEntitlements/getWebhookOwnedIntervals.ts | Produces webhook-owned intervals from BillingInterval price config values, but isWebhookOwned compares these against EntInterval values in entitlements — mismatched for Quarter/SemiAnnual, causing the lazy-reset block to silently fail for those intervals. |
| server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts | Adds isWebhookOwned guard to filter out entitlements managed by the webhook; guard logic is correct for monthly plans but inherits the interval type mismatch from getWebhookOwnedIntervals for quarterly/semi-annual. |
| server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts | Adds notWebhookOwned() SQL predicate to all three batch-reset branches; Branch 1 (no customer_product) is incorrectly guarded — the webhook never processes product-less entitlements, so these would be permanently blocked from reset. |
| server/src/internal/customers/actions/resetCustomerEntitlements/getCusEntsNeedingReset.ts | Correctly wires getWebhookOwnedIntervals into getCusEntsNeedingReset and passes it to getResettableCustomerEntitlements. |
| server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts | Correctly computes webhook-owned intervals from customer_products and passes them to getResettableCustomerEntitlements. |
| server/src/internal/customers/actions/resetCustomerEntitlementsV2/triggerBatchResetSubjectEntitlements.ts | Correctly threads webhookOwnedIntervals into triggerBatchResetSubjectEntitlements alongside getCusEntsNeedingReset. |
| server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/handleStripeInvoiceCreated.ts | Adds processFreeEntitlementsForInvoiceCreated call after existing invoice tasks; ordering looks correct. |
| server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-free-entitlement-reset.test.ts | Good coverage for monthly plans, misaligned cycles, different intervals, and regressions; test 5 and test 4 section headers appear in the wrong order. |
| server/tests/unit/customers/reset/getResettableCustomerEntitlements.test.ts | Thorough unit tests covering all new webhookOwnedIntervals cases including interval mismatch, day-of-month alignment, null resetDayOfMonth, and interval_count variants. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
server/src/internal/customers/actions/resetCustomerEntitlements/getWebhookOwnedIntervals.ts:36-56
**Quarterly/semi-annual interval type mismatch — lazy reset not blocked**

`getWebhookOwnedIntervals` reads `cusPrice.price.config?.interval` which stores the raw Stripe `BillingInterval` (e.g. `"month"` with `interval_count: 3` for a quarterly plan). `isWebhookOwned` then compares `owned.interval === cusEnt.entitlement.interval`, but the entitlement stores the mapped `EntInterval` (e.g. `"quarter"` for what Stripe calls month×3). For quarterly and semi-annual subscriptions, `"month" !== "quarter"`, so `isWebhookOwned` returns `false`, the lazy/batch path is not blocked — even though `processFreeEntitlementsForInvoiceCreated` (using `stripeSubscriptionToEntInterval`) correctly maps month×3 → `EntInterval.Quarter` and fires the webhook reset. Both paths run for these customers, resulting in a race between lazy and webhook resets each billing cycle.

The same mismatch exists in the SQL `notWebhookOwned()` predicate: `(p_sub.config->>'interval') = ${entitlements.interval}` compares `"month"` against `"quarter"`.

To fix this, `getWebhookOwnedIntervals` should map `BillingInterval` + `interval_count` through the same conversion used by `stripeSubscriptionToEntInterval` (i.e. produce `EntInterval.Quarter`/`EntInterval.SemiAnnual` and normalise the count to 1) before returning `WebhookOwnedInterval`, and the SQL predicate should apply the same mapping logic.

### Issue 2 of 4
server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts:262-266
**Branch 1 entitlements blocked from reset by both paths**

`notWebhookOwned()` is applied here to Branch 1, which covers `customer_entitlements` with `customer_product_id IS NULL`. However, `processFreeEntitlementsForInvoiceCreated` (the webhook handler) iterates only over `fullCustomer.customer_products[*].customer_entitlements` — it never visits entitlements that have no owning product. So a free entitlement with `customer_product_id = null` that happens to share an interval with a subscription on the same customer will be excluded from the batch reset by `notWebhookOwned()`, but will also never be processed by the webhook. Those entitlements will never reset. The same gap exists in the in-memory path (`lazyResetSubjectEntitlements`), where `isWebhookOwned` applies to all entitlements while the webhook only handles product-owned ones. Consider skipping `notWebhookOwned()` for Branch 1 (no-product entitlements are structurally out of scope for the webhook).

### Issue 3 of 4
server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-free-entitlement-reset.test.ts:210-212
Test numbering is out of order — "TEST 5" appears before "TEST 4" in the file. Swapping the section titles to match the order in the file avoids confusion when cross-referencing test output.

```suggestion
// ═══════════════════════════════════════════════════════════════════════════════
// TEST 4: Same interval but misaligned cycles — lazy reset still fires
// ═══════════════════════════════════════════════════════════════════════════════
```

### Issue 4 of 4
server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-free-entitlement-reset.test.ts:265-267
Corresponding section title should read "TEST 5" to match the now-renumbered ordering above.

```suggestion
// ═══════════════════════════════════════════════════════════════════════════════
// TEST 5: Paid entitlement behavior unchanged (regression)
// ═══════════════════════════════════════════════════════════════════════════════
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: reset free entitlements via webho..."](https://github.com/useautumn/autumn/commit/0d1bbb59fefd2e6f2e97da5bccc789caf2ed8182) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32593766)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->