### PR TITLE
fix: auto-detect chromium path via playwright-core

### DIFF
--- a/server/tests/utils/browserPool/browserConfig.ts
+++ b/server/tests/utils/browserPool/browserConfig.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { chromium } from "playwright-core";
 
 // ============================================================================
 // Browser test configuration — toggle these for local development / debugging
@@ -11,9 +12,16 @@ export const USE_KERNEL = !!process.env.USE_KERNEL_BROWSER;
 /** Run browsers in headless mode (set false to watch the browser) */
 export const HEADLESS = true;
 
-/** Path to local Chromium/Chrome executable (auto-detected if not set in env) */
-export const CHROMIUM_PATH =
-	process.env.TESTS_CHROMIUM_PATH || "/opt/homebrew/bin/chromium";
+/** Path to local Chromium/Chrome executable (env → playwright-core → fallback) */
+const resolveChromiumPath = (): string => {
+	if (process.env.TESTS_CHROMIUM_PATH) return process.env.TESTS_CHROMIUM_PATH;
+	try {
+		return chromium.executablePath();
+	} catch {
+		return "/opt/homebrew/bin/chromium";
+	}
+};
+export const CHROMIUM_PATH = resolveChromiumPath();
 
 /** Kernel browser session timeout in seconds */
 export const KERNEL_TIMEOUT_SECONDS = 30;


### PR DESCRIPTION
## Summary
- Resolves Chromium executable path through a fallback chain: `TESTS_CHROMIUM_PATH` env var → `playwright-core` auto-detection → hardcoded `/opt/homebrew/bin/chromium`
- Tests now find Chromium regardless of install method

## Test plan
- [ ] Verify tests run locally without `TESTS_CHROMIUM_PATH` set
- [ ] Verify `TESTS_CHROMIUM_PATH` env var still takes priority when set

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detect the Chromium executable for tests to remove manual setup. Order: `TESTS_CHROMIUM_PATH` → `playwright-core` detection (`chromium.executablePath()`) → `/opt/homebrew/bin/chromium`.

<sup>Written for commit 06ba7cf86bc018a88d296cbd44bffc867eebb130. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1594?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves Chromium path resolution in the browser test configuration by introducing a fallback chain: `TESTS_CHROMIUM_PATH` env var → `playwright-core` auto-detection → hardcoded `/opt/homebrew/bin/chromium`. However, the fallback to the hardcoded path is currently unreachable because `chromium.executablePath()` never throws.

- **Bug fixes** — Replaces the single-fallback `TESTS_CHROMIUM_PATH || "/opt/homebrew/bin/chromium"` pattern with a three-step resolution chain so tests can find Chromium regardless of install method.
- **Bug fixes** — The `try/catch` around `chromium.executablePath()` does not protect against the most common failure scenario (no browsers installed), since `playwright-core`'s `executablePath()` returns a non-existent path string rather than throwing; an `fs.existsSync` guard is needed to make the hardcoded fallback reachable.
</details>

<h3>Confidence Score: 3/5</h3>

The change has a logic gap that makes the hardcoded fallback dead code, so the fix does not fully achieve its stated goal of supporting all Chromium install methods.

The playwright-core executablePath() call returns a computed path without checking whether the binary exists, so the surrounding try/catch never fires its catch branch. Any developer relying on a Homebrew Chromium without having run npx playwright install will get a silent wrong-path error at launch time rather than the intended fallback.

server/tests/utils/browserPool/browserConfig.ts — the fallback logic needs an existence check to function correctly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/utils/browserPool/browserConfig.ts | Adds playwright-core auto-detection for Chromium path, but the fallback to the hardcoded path is unreachable because `executablePath()` never throws — a filesystem existence check is needed to make the fallback work correctly. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveChromiumPath called] --> B{TESTS_CHROMIUM_PATH set?}
    B -- Yes --> C[Return env var path]
    B -- No --> D[Call chromium.executablePath]
    D --> E{Throws?}
    E -- Yes --> F[Return /opt/homebrew/bin/chromium]
    E -- No --> G[Return playwright-core path\nMay not exist on disk!]
    G -.->|intended but unreachable| F

    style G fill:#f99,stroke:#c00
    style F fill:#ffd,stroke:#999
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/utils/browserPool/browserConfig.ts:1-23
`chromium.executablePath()` in `playwright-core` never throws — it unconditionally returns a computed path string even when no browser has been installed via `npx playwright install`. Because the exception is the only signal being checked, the `try/catch` will never fall through to the `/opt/homebrew/bin/chromium` fallback. This means the hardcoded fallback is dead code, and any user who hasn't run `npx playwright install` (e.g., someone relying on a Homebrew Chromium) will get a non-existent path and a confusing launch error instead of the intended fallback. Adding a filesystem existence check after calling `executablePath()` makes the fallback actually reachable.

```suggestion
import "dotenv/config";
import fs from "fs";
import { chromium } from "playwright-core";

// ============================================================================
// Browser test configuration — toggle these for local development / debugging
// ============================================================================

/** Use Kernel cloud browsers instead of local Chromium */
export const USE_KERNEL = !!process.env.USE_KERNEL_BROWSER;
// export const USE_KERNEL = false;

/** Run browsers in headless mode (set false to watch the browser) */
export const HEADLESS = true;

/** Path to local Chromium/Chrome executable (env → playwright-core → fallback) */
const resolveChromiumPath = (): string => {
	if (process.env.TESTS_CHROMIUM_PATH) return process.env.TESTS_CHROMIUM_PATH;
	try {
		const pwPath = chromium.executablePath();
		if (fs.existsSync(pwPath)) return pwPath;
	} catch {
		// fall through to hardcoded fallback
	}
	return "/opt/homebrew/bin/chromium";
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: auto-detect chromium path via playw..."](https://github.com/useautumn/autumn/commit/06ba7cf86bc018a88d296cbd44bffc867eebb130) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32599296)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->