### PR TITLE
chore: make frontend more consistent

### DIFF
--- a/vite/src/components/general/PageContainer.tsx
+++ b/vite/src/components/general/PageContainer.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+
+interface PageContainerProps {
+	children: React.ReactNode;
+	className?: string;
+}
+
+export function PageContainer({ children, className }: PageContainerProps) {
+	return (
+		<div
+			className={cn(
+				"flex flex-col gap-4 relative w-full pb-8 max-w-5xl mx-auto pt-4 sm:pt-8 px-4 sm:px-10",
+				className,
+			)}
+		>
+			{children}
+		</div>
+	);
+}

--- a/vite/src/views/customers/CustomersPage.tsx
+++ b/vite/src/views/customers/CustomersPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PageContainer } from "@/components/general/PageContainer";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useProductStore } from "@/hooks/stores/useProductStore";
@@ -43,14 +44,14 @@ function CustomersPageContent() {
 				customers,
 			}}
 		>
-			<div className="px-4 sm:px-10 flex flex-col relative w-full pb-8 max-w-5xl mx-auto pt-4 sm:pt-8 gap-8">
+			<PageContainer>
 				<OnboardingGuide />
 				<CustomerListTable
 					key={org?.id}
 					customers={customers}
 					isFetchingUncached={isFetchingUncached}
 				/>
-			</div>
+			</PageContainer>
 		</CustomersContext.Provider>
 	);
 }

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -4,6 +4,7 @@ import type { AgGridReact } from "ag-grid-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
+import { PageContainer } from "@/components/general/PageContainer";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { Card, CardContent } from "@/components/v2/cards/Card";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
@@ -335,7 +336,7 @@ export const AnalyticsView = () => {
 				planNames,
 			}}
 		>
-			<div className="flex flex-col gap-4 h-full relative w-full text-sm pb-8 max-w-5xl mx-auto px-4 sm:px-10 pt-4 sm:pt-8">
+			<PageContainer className="h-full text-sm">
 				<OnboardingGuide />
 				{showRevenueMetrics && <RevenueMetricsSection />}
 				<div className="max-h-[400px] min-h-[400px] pb-6 shrink-0">
@@ -414,7 +415,7 @@ export const AnalyticsView = () => {
 						</div>
 					)}
 				</div>
-			</div>
+			</PageContainer>
 		</AnalyticsContext.Provider>
 	);
 };

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListSearchBar.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListSearchBar.tsx
@@ -48,7 +48,7 @@ export function CustomerListSearchBar() {
 				setLocalQuery(raw);
 				debouncedSearch(raw.trim());
 			}}
-				className="pl-8! text-sm w-sm"
+				className="pl-8! text-sm w-full"
 				placeholder={`Search ${Intl.NumberFormat("en-US").format(totalCount)} customers`}
 			/>
 		</div>

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -1,5 +1,5 @@
 import { AppEnv, type FullCustomer } from "@autumn/shared";
-import { ArrowSquareOutIcon } from "@phosphor-icons/react";
+import { ArrowSquareOutIcon, UsersIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { Table } from "@/components/general/table";
@@ -36,7 +36,6 @@ export function CustomerListTable({
 	const { org } = useOrg();
 	const env = useEnv();
 
-	// Account for sandbox banner height (40px) in table container height
 	const tableContainerHeight =
 		env === AppEnv.Sandbox ? "calc(100vh - 174px)" : "calc(100vh - 134px)";
 
@@ -51,8 +50,6 @@ export function CustomerListTable({
 	const { queryStates } = useCustomerFilters();
 	const buildKey = useQueryKeyFactory();
 
-	// Subscribe to full_customers query to get reactive updates
-	// Query key must match useFullCusSearchQuery for proper cache sharing
 	const {
 		data: fullCustomersData,
 		isLoading: isFullCustomersLoading,
@@ -68,13 +65,10 @@ export function CustomerListTable({
 			queryStates.processor,
 			queryStates.q,
 		]),
-		// Placeholder queryFn - actual fetching is done by useFullCusSearchQuery
 		queryFn: () => Promise.resolve({ fullCustomers: [] }),
-		// Don't fetch - just subscribe to existing data from useFullCusSearchQuery
 		enabled: false,
 	});
 
-	// Build map from full customers data for quick lookup
 	const fullCustomersMap = useMemo(() => {
 		const map = new Map<string, FullCustomer>();
 		if (fullCustomersData?.fullCustomers) {
@@ -86,13 +80,11 @@ export function CustomerListTable({
 		return map;
 	}, [fullCustomersData]);
 
-	// Determine if full data is still loading (includes refetches for search/pagination)
 	const isFullDataLoading =
 		isFullCustomersLoading ||
 		isFullCustomersFetching ||
 		fullCustomersMap.size === 0;
 
-	// Merge basic customer data with full customer data (for balance info)
 	const mergedCustomers = useMemo(() => {
 		return customers.map((customer) => {
 			const key = customer.id || customer.internal_id;
@@ -110,7 +102,6 @@ export function CustomerListTable({
 		? `customer-list:${org.id}`
 		: "customer-list";
 
-	// Create columns including dynamic usage columns from metered features
 	const { columns, defaultVisibleColumnIds, columnGroups } =
 		useCustomerListColumns({
 			features,
@@ -147,8 +138,6 @@ export function CustomerListTable({
 			preserveParams: false,
 		});
 
-	const enableSorting = false;
-
 	const hasRows = table.getRowModel().rows.length > 0;
 	const hasSearchQuery = Boolean(queryStates.q?.trim());
 	const hasFilters =
@@ -158,7 +147,6 @@ export function CustomerListTable({
 		queryStates.processor.length > 0;
 	const hasActiveFiltersOrSearch = hasSearchQuery || hasFilters;
 
-	// Only show empty state if org has NO customers (no filters/search active and no results)
 	if (!hasRows && !hasActiveFiltersOrSearch) {
 		return (
 			<EmptyState
@@ -190,7 +178,7 @@ export function CustomerListTable({
 			config={{
 				table,
 				numberOfColumns: columns.length,
-				enableSorting,
+				enableSorting: false,
 				isLoading: isFetchingUncached,
 				getRowHref,
 				emptyStateText: "No matching results found.",
@@ -208,20 +196,22 @@ export function CustomerListTable({
 			}}
 		>
 			<div>
-				<div className="flex flex-col lg:flex-row w-full lg:items-center gap-2 lg:gap-5 pb-4">
-					<div className="flex items-center gap-2 lg:flex-1">
-						<CustomerListSearchBar />
-						<CustomerListFilterButton />
-						<Table.ColumnVisibility />
-					</div>
-					<div className="flex items-center justify-between lg:contents">
-						<div className="flex items-center gap-2 lg:justify-center">
-							<CustomerListPagination />
-							<CustomerListPageSizeSelector />
-						</div>
-						<div className="flex items-center lg:flex-1 justify-end">
-							<CustomerListCreateButton />
-						</div>
+				<Table.Toolbar>
+					<Table.Heading>
+						<UsersIcon size={16} weight="fill" className="text-subtle" />
+						Customers
+					</Table.Heading>
+					<Table.Actions>
+						<CustomerListCreateButton />
+					</Table.Actions>
+				</Table.Toolbar>
+				<div className="flex items-center gap-2 pb-4">
+					<CustomerListFilterButton />
+					<Table.ColumnVisibility />
+					<CustomerListSearchBar />
+					<div className="flex items-center gap-2 shrink-0">
+						<CustomerListPagination />
+						<CustomerListPageSizeSelector />
 					</div>
 				</div>
 				{!hasRows && hasActiveFiltersOrSearch ? (

--- a/vite/src/views/developer/DevView.tsx
+++ b/vite/src/views/developer/DevView.tsx
@@ -2,6 +2,7 @@
 
 import "svix-react/style.css";
 import { AppPortal } from "svix-react";
+import { PageContainer } from "@/components/general/PageContainer";
 import { useTheme } from "@/contexts/ThemeProvider";
 import { useAppQueryStates } from "@/hooks/common/useAppQueryStates";
 import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
@@ -27,27 +28,22 @@ export default function DevScreen() {
 	if (isLoading) return <LoadingScreen />;
 
 	return (
-		<div className="flex flex-col gap-4 h-fit relative w-full max-w-5xl mx-auto text-sm pt-4 sm:pt-8 pb-8 px-4 sm:px-10">
+		<PageContainer className="text-sm">
 			<OnboardingGuide />
-
 			{(tab === "api_keys" || !tab) && (
 				<div className="flex flex-col gap-16">
 					<ApiKeysPage />
 					{pkey && <PublishableKeySection />}
 				</div>
 			)}
-
 			{tab === "stripe" && <ConfigureStripe />}
 			{tab === "webhooks" && webhooks && svixDashboardUrl && (
 				<ConfigureWebhookSection dashboardUrl={svixDashboardUrl} />
 			)}
-
 			{tab === "vercel" && vercel && <ConfigureVercel />}
-
 			{tab === "revenuecat" && revenuecat && <ConfigureRevenueCat />}
-
 			{tab === "redis" && isAdmin && <ConfigureRedis />}
-		</div>
+		</PageContainer>
 	);
 }
 
@@ -60,13 +56,7 @@ const ConfigureWebhookSection = ({ dashboardUrl }: any) => {
 				<AppPortal
 					url={dashboardUrl}
 					darkMode={isDark}
-					style={{
-						height: "100%",
-						borderRadius: "none",
-						// marginTop: "0.5rem",
-						// paddingLeft: "1rem",
-						// paddingRight: "1rem",
-					}}
+					style={{ height: "100%", borderRadius: "none" }}
 					fullSize
 				/>
 			) : (

--- a/vite/src/views/migrations/MigrationsView.tsx
+++ b/vite/src/views/migrations/MigrationsView.tsx
@@ -1,11 +1,10 @@
+import { PageContainer } from "@/components/general/PageContainer";
 import { MigrationListTable } from "./migration-list/MigrationListTable";
 
 export const MigrationsView = () => {
 	return (
-		<div className="flex flex-col gap-4 h-fit relative w-full pb-8 max-w-5xl mx-auto pt-4 sm:pt-8">
-			<div className="h-fit max-h-full px-4 sm:px-10">
-				<MigrationListTable />
-			</div>
-		</div>
+		<PageContainer>
+			<MigrationListTable />
+		</PageContainer>
 	);
 };

--- a/vite/src/views/products/ProductsView.tsx
+++ b/vite/src/views/products/ProductsView.tsx
@@ -2,6 +2,7 @@
 
 import type { AppEnv } from "@autumn/shared";
 import { useEffect } from "react";
+import { PageContainer } from "@/components/general/PageContainer";
 import { useAppQueryStates } from "@/hooks/common/useAppQueryStates";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
@@ -23,7 +24,6 @@ function ProductsView({ env: _env }: { env: AppEnv }) {
 	useSheetCleanup();
 	const resetProductStore = useProductStore((s) => s.reset);
 
-	// reset product store when the view mounts
 	useEffect(() => {
 		resetProductStore();
 	}, [resetProductStore]);
@@ -38,16 +38,12 @@ function ProductsView({ env: _env }: { env: AppEnv }) {
 	const tab = queryStates.tab;
 	return (
 		<ProductsContext.Provider value={{}}>
-			<div className="flex flex-col gap-4 h-fit relative w-full pb-8 max-w-5xl mx-auto pt-4 sm:pt-8">
-				{/* Onboarding Guide - visible on all tabs */}
-				<div className="px-4 sm:px-10">
-					<OnboardingGuide />
-				</div>
-
+			<PageContainer>
+				<OnboardingGuide />
 				{tab === "products" && <ProductsPage />}
 				{tab === "features" && <FeaturesPage />}
 				{tab === "rewards" && <RewardsPage />}
-			</div>
+			</PageContainer>
 		</ProductsContext.Provider>
 	);
 }

--- a/vite/src/views/products/features/FeaturesPage.tsx
+++ b/vite/src/views/products/features/FeaturesPage.tsx
@@ -1,9 +1,5 @@
 import { FeatureListTable } from "./feature-list/FeatureListTable";
 
 export const FeaturesPage = () => {
-	return (
-		<div className="h-fit max-h-full px-4 sm:px-10">
-			<FeatureListTable />
-		</div>
-	);
+	return <FeatureListTable />;
 };

--- a/vite/src/views/products/products/ProductsPage.tsx
+++ b/vite/src/views/products/products/ProductsPage.tsx
@@ -13,7 +13,6 @@ import { ProductListMenuButton } from "./components/product-list/ProductListMenu
 import { ProductListTable } from "./components/product-list/ProductListTable";
 
 export const ProductsPage = () => {
-	// Clean up onboarding-related query params after a delay
 	useClearQueryParams({ queryParams: ["step", "product_id"] });
 
 	const [viewMode, setViewMode] = useState<ProductsViewMode>("list");
@@ -21,23 +20,17 @@ export const ProductsPage = () => {
 
 	const hasPlans = products && products.length > 0;
 
-	// Show empty state without the header when no plans exist
 	if (!isLoading && !hasPlans) {
-		return (
-			<div className="h-fit max-h-full px-4 sm:px-10">
-				<EmptyState type="plans" actionButton={<ProductListCreateButton />} />
-			</div>
-		);
+		return <EmptyState type="plans" actionButton={<ProductListCreateButton />} />;
 	}
 
 	return (
-		<div className="h-fit max-h-full px-4 sm:px-10">
+		<div>
 			<ProductsPageHeader>
 				<ProductsViewToggle value={viewMode} onValueChange={setViewMode} />
 				<ProductListCreateButton />
 				<ProductListMenuButton />
 			</ProductsPageHeader>
-
 			{viewMode === "list" ? <ProductListTable /> : <ProductsAIChatView />}
 		</div>
 	);

--- a/vite/src/views/products/rewards/RewardsPage.tsx
+++ b/vite/src/views/products/rewards/RewardsPage.tsx
@@ -43,46 +43,41 @@ export const RewardsPage = () => {
 	}
 
 	return (
-		<div className="h-fit max-h-full px-4 sm:px-10">
-			<div className="flex flex-col gap-8">
-				{/* Rewards Table */}
-				<div>
-					<Table.Toolbar>
-						<div className="flex w-full justify-between items-center">
-							<Table.Heading>
-								<GiftIcon size={16} weight="fill" className="text-subtle" />
-								Rewards
-							</Table.Heading>
-							<Table.Actions>
-								<CreateRewardSheet
-									open={createSheetOpen}
-									onOpenChange={setCreateSheetOpen}
-								/>
-							</Table.Actions>
-						</div>
-					</Table.Toolbar>
-					<RewardsTable />
-				</div>
-
-				{/* Referral Programs Table */}
-				<div>
-					<Table.Toolbar>
-						<div className="flex w-full justify-between items-center">
-							<Table.Heading>
-								<UsersThreeIcon
-									size={16}
-									weight="fill"
-									className="text-subtle"
-								/>
-								Referral Programs
-							</Table.Heading>
-							<Table.Actions>
-								<CreateRewardProgramSheet />
-							</Table.Actions>
-						</div>
-					</Table.Toolbar>
-					<RewardProgramsTable />
-				</div>
+		<div className="flex flex-col gap-8">
+			<div>
+				<Table.Toolbar>
+					<div className="flex w-full justify-between items-center">
+						<Table.Heading>
+							<GiftIcon size={16} weight="fill" className="text-subtle" />
+							Rewards
+						</Table.Heading>
+						<Table.Actions>
+							<CreateRewardSheet
+								open={createSheetOpen}
+								onOpenChange={setCreateSheetOpen}
+							/>
+						</Table.Actions>
+					</div>
+				</Table.Toolbar>
+				<RewardsTable />
+			</div>
+			<div>
+				<Table.Toolbar>
+					<div className="flex w-full justify-between items-center">
+						<Table.Heading>
+							<UsersThreeIcon
+								size={16}
+								weight="fill"
+								className="text-subtle"
+							/>
+							Referral Programs
+						</Table.Heading>
+						<Table.Actions>
+							<CreateRewardProgramSheet />
+						</Table.Actions>
+					</div>
+				</Table.Toolbar>
+				<RewardProgramsTable />
 			</div>
 		</div>
 	);

--- a/vite/src/views/settings/SettingsView.tsx
+++ b/vite/src/views/settings/SettingsView.tsx
@@ -56,7 +56,7 @@ export const SettingsView = () => {
 	};
 
 	return (
-		<PageContainer className="flex-row gap-10">
+		<PageContainer className="flex-row gap-10 h-full">
 			<nav className="hidden sm:flex flex-col w-44 shrink-0 pt-1">
 				<h1 className="text-sm font-semibold text-t1 mb-4">Settings</h1>
 				<div className="flex flex-col gap-0.5">

--- a/vite/src/views/settings/SettingsView.tsx
+++ b/vite/src/views/settings/SettingsView.tsx
@@ -5,6 +5,7 @@ import {
 	UsersIcon,
 } from "lucide-react";
 import { useSearchParams } from "react-router";
+import { PageContainer } from "@/components/general/PageContainer";
 import { cn } from "@/lib/utils";
 import { AccountSection } from "./sections/AccountSection";
 import { OrganizationSection } from "./sections/OrganizationSection";
@@ -55,7 +56,7 @@ export const SettingsView = () => {
 	};
 
 	return (
-		<div className="flex h-full w-full max-w-5xl mx-auto pt-4 sm:pt-8 pb-8 px-4 sm:px-10 gap-10">
+		<PageContainer className="flex-row gap-10">
 			<nav className="hidden sm:flex flex-col w-44 shrink-0 pt-1">
 				<h1 className="text-sm font-semibold text-t1 mb-4">Settings</h1>
 				<div className="flex flex-col gap-0.5">
@@ -80,6 +81,6 @@ export const SettingsView = () => {
 			<div className="flex-1 min-w-0">
 				<ActiveSection />
 			</div>
-		</div>
+		</PageContainer>
 	);
 };


### PR DESCRIPTION
## Summary
- Extract shared `PageContainer` component for consistent page padding (`px-4 sm:px-10`, `pt-4 sm:pt-8`, `pb-8`, `max-w-5xl mx-auto`, `gap-4`) across all top-level views
- Add `Table.Toolbar` heading with `UsersIcon` to the customers list table, matching the migrations page pattern
- Align customer list filter controls: Filter + Display on the left, full-width search bar, pagination on the right
- Remove narrating comments and dead code across touched files

## Test plan
- [ ] Verify customers page renders with correct heading and filter layout
- [ ] Verify plans/products page has consistent padding with customers page
- [ ] Verify developer, migrations, settings, and analytics pages all have matching padding
- [ ] Confirm no visual regressions on responsive breakpoints (mobile vs desktop)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized page layout with a new `PageContainer` and aligned table toolbars and filters for a more consistent frontend. Restores full-height layout in Settings and keeps behavior unchanged across Customers, Products, Migrations, Developer, Analytics, and Settings.

- **Refactors**
  - Added `PageContainer` (shared padding, width, spacing) across top-level views.
  - Customers list: added `Table.Toolbar` heading with `UsersIcon`; aligned controls (Filter + Columns, full-width Search, Pagination + Page Size).
  - Restored `h-full` on Settings container to maintain full-height layout.
  - Removed dead code and narrating comments; simplified wrappers in Products, Features, Rewards, Migrations, Dev, Analytics.

<sup>Written for commit 3023646d80eed25e2e0908267d402f89f3866ffb. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1595?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts a shared `PageContainer` component and applies it consistently across all top-level views, eliminating duplicated inline padding/layout classes. It also restructures the customer-list toolbar to add a `Table.Heading` matching the migrations pattern, and makes the search bar full-width between the filter controls and pagination.

- **Improvements** — New `PageContainer` component (`flex flex-col gap-4 … max-w-5xl`) replaces repeated inline `div` wrappers in seven views, reducing layout drift and making future padding changes a single-file edit.
- **Improvements** — `CustomerListTable` toolbar refactored: `Table.Heading` with `UsersIcon` added, filter controls reordered (Filter → Column Visibility → full-width Search → Pagination), and the dead `enableSorting` variable inlined.
- **Improvements** — Narrating comments and dead/commented-out code removed across all touched files.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are purely visual layout refactors with no logic or data-handling modifications.

All changes are Tailwind class reorganisations delegated to the new PageContainer component. The two minor points worth verifying before merging: SettingsView drops `h-full` compared to the original container, and CustomersPage's gap between the onboarding guide and the table shrinks from 8 to 4. Neither will break functionality, but they are silent visual differences from the previous layout.

vite/src/views/settings/SettingsView.tsx (missing h-full vs original) and vite/src/views/customers/CustomersPage.tsx (gap reduction).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/general/PageContainer.tsx | New shared layout wrapper encoding the standard page padding, max-width, and flex-col structure — straightforward and correct. |
| vite/src/views/settings/SettingsView.tsx | Migrated to PageContainer with flex-row override; the original div included `h-full` which is missing from the new version, potentially causing the settings layout to no longer fill its container vertically. |
| vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx | Toolbar restructured with Table.Heading, Table.Actions, and a new filter-bar row; search bar wrapper already carries flex-1 so full-width expansion works correctly. |
| vite/src/views/customers2/components/table/customer-list/CustomerListSearchBar.tsx | Input width changed from `w-sm` to `w-full`; parent wrapper is already `flex-1 min-w-0` so the search bar correctly expands to fill available space. |
| vite/src/views/customers/CustomersPage.tsx | Wrapping div replaced with PageContainer; vertical gap between OnboardingGuide and CustomerListTable silently changes from gap-8 to gap-4. |
| vite/src/views/products/ProductsView.tsx | Collapsed outer div + inner padded div into PageContainer; OnboardingGuide now lives directly inside PageContainer rather than a padded wrapper. |
| vite/src/views/migrations/MigrationsView.tsx | Collapsed nested divs into a single PageContainer; clean simplification with no behavior change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PC[PageContainer\nflex flex-col gap-4\nmax-w-5xl mx-auto\npt-4 sm:pt-8 pb-8\npx-4 sm:px-10]

    CP[CustomersPage\nPageContainer]
    AV[AnalyticsView\nPageContainer\nclassName='h-full text-sm']
    DV[DevView\nPageContainer\nclassName='text-sm']
    MV[MigrationsView\nPageContainer]
    PV[ProductsView\nPageContainer]
    SV[SettingsView\nPageContainer\nclassName='flex-row gap-10']

    PC --> CP
    PC --> AV
    PC --> DV
    PC --> MV
    PC --> PV
    PC --> SV

    PV --> PP[ProductsPage\nplain div]
    PV --> FP[FeaturesPage\ndirect table]
    PV --> RP[RewardsPage\ngap-8 wrapper]

    CP --> CLT[CustomerListTable\nTable.Toolbar heading\nFilter→ColVis→Search→Pagination]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/settings/SettingsView.tsx:59
The original `SettingsView` container had `h-full` so the flex row would stretch to fill the parent's height. `PageContainer` doesn't include that class, and passing only `flex-row gap-10` via `className` leaves the height unset. On taller viewports the sidebar could now be shorter than the content area, and any future styling (e.g. a border or background on the nav) would appear cut short.

```suggestion
		<PageContainer className="flex-row gap-10 h-full">
```

### Issue 2 of 2
vite/src/views/customers/CustomersPage.tsx:47
The original wrapper used `gap-8` between `OnboardingGuide` and `CustomerListTable`, but `PageContainer` defaults to `gap-4`. This halves the vertical breathing room between the onboarding banner and the table. If this reduction is intentional it's fine, but it's worth confirming it doesn't feel cramped when the guide is visible.

```suggestion
			<PageContainer className="gap-8">
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: make frontend more consistent"](https://github.com/useautumn/autumn/commit/266fc52068f36b418eb7df51a3f5ed3bd4bf6639) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32601561)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->