### PR TITLE
chore: fix invoice refund select z-index in dialog

### DIFF
--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -389,14 +389,14 @@ export function InvoiceDetailSheet({
 					</Button>
 				)}
 			</div>
-			{canRefund && (
-				<RefundInvoiceDialog
-					open={refundDialogOpen}
-					onOpenChange={setRefundDialogOpen}
-					invoice={invoice}
-				/>
-			)}
-		</div>
+		{canRefund && (
+			<RefundInvoiceDialog
+				open={refundDialogOpen}
+				onOpenChange={setRefundDialogOpen}
+				invoice={invoice}
+			/>
+		)}
+	</div>
 	);
 }
 

--- a/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
+++ b/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
@@ -12,15 +12,19 @@ import {
 	DialogTitle,
 } from "@/components/v2/dialogs/Dialog";
 import { Input } from "@/components/v2/inputs/Input";
-import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 
 type RefundMode = "full" | "partial";
-
-const REFUND_MODE_OPTIONS: RefundMode[] = ["full", "partial"];
 
 export function RefundInvoiceDialog({
 	open,
@@ -112,15 +116,19 @@ export function RefundInvoiceDialog({
 						<span className="text-sm font-medium text-foreground">
 							Refund type
 						</span>
-						<SearchableSelect<RefundMode>
-							value={mode}
-							onValueChange={(value) => setMode(value as RefundMode)}
-							options={REFUND_MODE_OPTIONS}
-							getOptionValue={(option) => option}
-							getOptionLabel={(option) =>
-								option === "full" ? "Full" : "Partial"
-							}
-						/>
+					<Select
+						value={mode}
+						onValueChange={(value) => setMode(value as RefundMode)}
+						items={{ full: "Full", partial: "Partial" }}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="Select refund type" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="full">Full</SelectItem>
+							<SelectItem value="partial">Partial</SelectItem>
+						</SelectContent>
+					</Select>
 					</div>
 
 					{mode === "partial" && (


### PR DESCRIPTION
## Summary
- Replace `SearchableSelect` (Popover-based) with `Select` (base-ui Select) in `RefundInvoiceDialog`
- Fixes dropdown rendering behind the dialog overlay due to Popover portal nesting inside Dialog portal
- Matches the pattern used by all other dialogs with selects (CopyProduct, AddCoupon, TransferProduct, etc.)

## Test plan
- [ ] Open customer invoice detail sheet → click Refund Invoice
- [ ] Verify the refund type dropdown opens above the dialog
- [ ] Select "Partial", confirm amount input appears
- [ ] Submit a refund and verify success

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the refund type dropdown rendering behind the dialog by replacing `SearchableSelect` (popover-based) with base `Select` in `RefundInvoiceDialog`. The dropdown now renders above the overlay and matches the select pattern used in other dialogs.

<sup>Written for commit 091f2e84c694ed5055dfb50331687e5d5dc1010f. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1601?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the z-index bug where the refund type dropdown rendered behind the dialog overlay by swapping the Popover-based `SearchableSelect` for the base-ui `Select`, which uses its own portal with `z-[300]` — matching the pattern already used by other dialogs in the codebase.

- **Bug fixes**: Replace `SearchableSelect` (Popover portal) with `Select` (base-ui portal) in `RefundInvoiceDialog` so the dropdown renders above the dialog overlay.
- **Improvements**: Remove the now-unused `REFUND_MODE_OPTIONS` constant alongside the `SearchableSelect` import.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; the core fix is correct and the only remaining issues are cosmetic indentation and a redundant prop.

The switch from SearchableSelect to Select is well-targeted and consistent with the patterns used across other dialogs. The redundant `items` prop and misaligned indentation on the Select block are the only loose ends — neither affects runtime behavior.

No files require special attention beyond the minor style issues in `RefundInvoiceDialog.tsx`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx | Replaces SearchableSelect (Popover-based) with base-ui Select (portal-based) to fix dropdown z-index behind the dialog; minor indentation misalignment and a redundant `items` prop on Select. |
| vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx | Pure indentation change to the RefundInvoiceDialog usage; no functional or behavioral change. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant InvoiceDetailSheet
    participant RefundInvoiceDialog
    participant Select (base-ui)
    participant Portal (body)

    User->>InvoiceDetailSheet: Click "Refund Invoice"
    InvoiceDetailSheet->>RefundInvoiceDialog: "open=true"
    RefundInvoiceDialog->>Select (base-ui): Render trigger inside Dialog
    User->>Select (base-ui): Click trigger
    Select (base-ui)->>Portal (body): Mount dropdown via SelectPrimitive.Portal (z-[300])
    Portal (body)-->>User: Dropdown visible above dialog overlay
    User->>Select (base-ui): Choose Full or Partial
    Select (base-ui)-->>RefundInvoiceDialog: onValueChange(value)
    User->>RefundInvoiceDialog: Click Refund
    RefundInvoiceDialog->>InvoiceDetailSheet: POST /refund success
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx`, line 115-132 ([link](https://github.com/useautumn/autumn/blob/091f2e84c694ed5055dfb50331687e5d5dc1010f/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx#L115-L132)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The `<Select>` opening tag is indented one level less than its sibling `<span>`, making it appear to sit outside the `<div className="flex flex-col gap-1.5">` parent. The indentation should match the `<span>` above it.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
   Line: 115-132

   Comment:
   The `<Select>` opening tag is indented one level less than its sibling `<span>`, making it appear to sit outside the `<div className="flex flex-col gap-1.5">` parent. The indentation should match the `<span>` above it.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx:115-132
The `<Select>` opening tag is indented one level less than its sibling `<span>`, making it appear to sit outside the `<div className="flex flex-col gap-1.5">` parent. The indentation should match the `<span>` above it.

```suggestion
					<div className="flex flex-col gap-1.5">
						<span className="text-sm font-medium text-foreground">
							Refund type
						</span>
						<Select
							value={mode}
							onValueChange={(value) => setMode(value as RefundMode)}
						>
							<SelectTrigger>
								<SelectValue placeholder="Select refund type" />
							</SelectTrigger>
							<SelectContent>
								<SelectItem value="full">Full</SelectItem>
								<SelectItem value="partial">Partial</SelectItem>
							</SelectContent>
						</Select>
					</div>
```

### Issue 2 of 2
vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx:122
**Redundant `items` prop** — `items={{ full: "Full", partial: "Partial" }}` is unnecessary here. The same items are already explicitly rendered as `SelectItem` children inside `SelectContent`, which is what base-ui uses for display and keyboard navigation. Passing `items` again adds no behaviour and could confuse future maintainers.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix invoice refund select z-index..."](https://github.com/useautumn/autumn/commit/091f2e84c694ed5055dfb50331687e5d5dc1010f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32658804)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->