### PR TITLE
chore: fix invoice refund select z-index in dialog

### DIFF
--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -389,14 +389,14 @@ export function InvoiceDetailSheet({
 					</Button>
 				)}
 			</div>
-			{canRefund && (
-				<RefundInvoiceDialog
-					open={refundDialogOpen}
-					onOpenChange={setRefundDialogOpen}
-					invoice={invoice}
-				/>
-			)}
-		</div>
+		{canRefund && (
+			<RefundInvoiceDialog
+				open={refundDialogOpen}
+				onOpenChange={setRefundDialogOpen}
+				invoice={invoice}
+			/>
+		)}
+	</div>
 	);
 }
 

--- a/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
+++ b/vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx
@@ -12,15 +12,19 @@ import {
 	DialogTitle,
 } from "@/components/v2/dialogs/Dialog";
 import { Input } from "@/components/v2/inputs/Input";
-import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 
 type RefundMode = "full" | "partial";
-
-const REFUND_MODE_OPTIONS: RefundMode[] = ["full", "partial"];
 
 export function RefundInvoiceDialog({
 	open,
@@ -112,15 +116,19 @@ export function RefundInvoiceDialog({
 						<span className="text-sm font-medium text-foreground">
 							Refund type
 						</span>
-						<SearchableSelect<RefundMode>
-							value={mode}
-							onValueChange={(value) => setMode(value as RefundMode)}
-							options={REFUND_MODE_OPTIONS}
-							getOptionValue={(option) => option}
-							getOptionLabel={(option) =>
-								option === "full" ? "Full" : "Partial"
-							}
-						/>
+					<Select
+						value={mode}
+						onValueChange={(value) => setMode(value as RefundMode)}
+						items={{ full: "Full", partial: "Partial" }}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="Select refund type" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="full">Full</SelectItem>
+							<SelectItem value="partial">Partial</SelectItem>
+						</SelectContent>
+					</Select>
 					</div>
 
 					{mode === "partial" && (


### PR DESCRIPTION
## Summary
- Replace `SearchableSelect` (Popover-based) with `Select` (base-ui Select) in `RefundInvoiceDialog`
- Fixes dropdown rendering behind the dialog overlay due to Popover portal nesting inside Dialog portal
- Matches the pattern used by all other dialogs with selects (CopyProduct, AddCoupon, TransferProduct, etc.)
- Cherry-picked from #1601

## Test plan
- [ ] Open customer invoice detail sheet → click Refund Invoice
- [ ] Verify the refund type dropdown opens above the dialog
- [ ] Select "Partial", confirm amount input appears
- [ ] Submit a refund and verify success

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the refund type dropdown rendering behind the dialog by replacing the popover-based `SearchableSelect` with the base `Select` in `RefundInvoiceDialog`. Aligns with the select pattern used in other dialogs and ensures the menu renders above the overlay.

- **Bug Fixes**
  - Replaced `SearchableSelect` with `Select` to resolve portal/z-index issues causing the dropdown to appear under the dialog overlay.

<sup>Written for commit 1ee592c5007ad091f6aeba26da01d9afd31db449. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1602?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the refund type dropdown rendering behind the dialog overlay by replacing `SearchableSelect` (a Popover-based component) with the base-ui `Select` component, which uses a portal with a high fixed z-index (`z-[300]`) and avoids the Popover-inside-Dialog stacking conflict.

- **Bug fixes** — Swap `SearchableSelect` for base-ui `Select` in `RefundInvoiceDialog`, aligning it with the pattern used by every other dialog with a select (CopyProduct, AddCoupon, TransferProduct).
- **Bug fixes** — Re-indent the `{canRefund && <RefundInvoiceDialog />}` block in `InvoiceDetailSheet` to reflect its correct nesting level outside the sticky button `div`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core change is a targeted component swap with no logic modifications.

The component swap is straightforward and matches the pattern already in use across other dialogs in the codebase. The only cosmetic issues are a minor indentation misalignment in the new Select block and a redundant `items` prop alongside explicit `SelectItem` children, neither of which affects runtime behavior.

RefundInvoiceDialog.tsx has a small indentation inconsistency (Select one tab shallower than its sibling span) and the redundant `items` prop worth tidying up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx | Replaces SearchableSelect (Popover-based) with the base-ui Select to fix z-index stacking inside Dialog; minor indentation inconsistency and a redundant `items` prop introduced alongside explicit SelectItem children. |
| vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx | Re-indentation only — moves the RefundInvoiceDialog conditional one level out to match the surrounding JSX structure; no logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant InvoiceDetailSheet
    participant Dialog (portal)
    participant Select (base-ui portal)

    User->>InvoiceDetailSheet: Click "Refund Invoice"
    InvoiceDetailSheet->>Dialog (portal): open=true → mounts in body portal
    User->>Dialog (portal): Interact with refund type dropdown
    Dialog (portal)->>Select (base-ui portal): Trigger click
    Note over Select (base-ui portal): SelectContent renders via SelectPrimitive.Portal<br/>with positionMethod="fixed" and z-[300]<br/>— always above Dialog overlay
    Select (base-ui portal)-->>User: Dropdown visible above dialog
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers2/components/sheets/RefundInvoiceDialog.tsx:119-131
**Redundant `items` prop alongside explicit `SelectItem` children**

The `items={{ full: "Full", partial: "Partial" }}` prop is passed to `Select` at the same time as explicit `SelectItem` children are rendered inside `SelectContent`. Looking at the base-ui `SelectPrimitive.Root` API, `items` is intended for driving item state internally (e.g., keyboard loop navigation) — not for rendering. Providing both isn't harmful today, but it creates a second source of truth for the select's options. If someone adds or removes a `SelectItem` in the children without updating `items` (or vice-versa), the two lists can silently diverge. The other dialog selects in the codebase (e.g., CopyProduct, AddCoupon) omit the `items` prop and rely solely on `SelectItem` children.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix invoice refund select z-index..."](https://github.com/useautumn/autumn/commit/1ee592c5007ad091f6aeba26da01d9afd31db449) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32658879)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->