### PR TITLE
chore: fix chart height

### DIFF
--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -322,7 +322,7 @@ export const AnalyticsView = () => {
 			<PageContainer className="text-sm">
 				<OnboardingGuide />
 				{showRevenueMetrics && <RevenueMetricsSection />}
-				<div className="max-h-[400px] min-h-[400px] pb-6 shrink-0">
+				<div className="pb-6 shrink-0">
 					<div className="flex justify-between pb-4 h-10">
 						<div className="text-t3 text-md flex gap-2 items-center">
 							<ChartBarIcon size={16} weight="fill" className="text-subtle" />
@@ -338,9 +338,9 @@ export const AnalyticsView = () => {
 						</div>
 					)}
 
-					<div className="h-full overflow-hidden">
+					<div>
 						{chartData && chartData.data.length > 0 && (
-							<div className="h-full flex flex-col overflow-hidden bg-interactive-secondary border rounded-lg max-h-[350px]">
+							<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1]">
 								<ChartLegend
 									entries={legendEntries}
 									showLabels={!!groupBy || legendEntries.length <= 3}


### PR DESCRIPTION
## Summary
- Remove fixed height constraints on the analytics chart container that were clipping the bottom of the chart
- Use `aspect-[3/1]` so the chart scales naturally with container width

## Test plan
- [ ] Verify chart renders fully without bottom clipping on `/sandbox/analytics`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix chart clipping in the customer analytics view by removing fixed heights and switching to an aspect-ratio container. The chart now scales with width and renders fully on /sandbox/analytics.

<sup>Written for commit ac44cff3288ca03415cca8131a8f1215791f221c. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1603?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the fixed `min-h-[400px] max-h-[400px]` constraints and `overflow-hidden` classes from the analytics chart container that were clipping the bottom of the chart. The container now uses `aspect-[3/1]` to scale naturally with its parent width.

- **Bug fixes**: Removes `overflow-hidden` and conflicting fixed-height classes on the chart wrapper that caused the chart to be clipped at the bottom; the chart now fills its `aspect-[3/1]` container correctly.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted CSS-only fix with no logic or data-flow impact.

Three Tailwind class changes on a single chart wrapper: fixed height and overflow clipping are removed, and an aspect-ratio class is added. The flex-1 min-h-0 inner layout remains intact, so the chart still fills the available space correctly. No state, data, or API surface is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/AnalyticsView.tsx | Removes fixed min-h/max-h constraints and overflow-hidden that were clipping the chart bottom; replaces them with aspect-[3/1] for natural responsive sizing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix chart height"](https://github.com/useautumn/autumn/commit/ac44cff3288ca03415cca8131a8f1215791f221c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32659891)</sub>

<!-- /greptile_comment -->