### PR TITLE
chore: fix chart height

### DIFF
--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -322,7 +322,7 @@ export const AnalyticsView = () => {
 			<PageContainer className="text-sm">
 				<OnboardingGuide />
 				{showRevenueMetrics && <RevenueMetricsSection />}
-				<div className="max-h-[400px] min-h-[400px] pb-6 shrink-0">
+				<div className="pb-6 shrink-0">
 					<div className="flex justify-between pb-4 h-10">
 						<div className="text-t3 text-md flex gap-2 items-center">
 							<ChartBarIcon size={16} weight="fill" className="text-subtle" />
@@ -338,9 +338,9 @@ export const AnalyticsView = () => {
 						</div>
 					)}
 
-					<div className="h-full overflow-hidden">
+					<div>
 						{chartData && chartData.data.length > 0 && (
-							<div className="h-full flex flex-col overflow-hidden bg-interactive-secondary border rounded-lg max-h-[350px]">
+							<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1]">
 								<ChartLegend
 									entries={legendEntries}
 									showLabels={!!groupBy || legendEntries.length <= 3}


### PR DESCRIPTION
## Summary
- Remove fixed height constraints on the analytics chart container that were clipping the bottom of the chart
- Use `aspect-[3/1]` so the chart scales naturally with container width

## Test plan
- [ ] Verify chart renders fully without bottom clipping on `/analytics`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bottom clipping of the analytics chart by removing fixed height and overflow constraints. Uses an `aspect-[3/1]` container so the chart scales with width and renders fully on /analytics.

<sup>Written for commit 95cb2f5bc411a81285a5f0b861362741c6f6674a. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1604?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the analytics chart being clipped at the bottom by removing hard-coded `min-h-[400px]`/`max-h-[400px]` and `max-h-[350px]` constraints and replacing them with `aspect-[3/1]` on the chart card container.

- **Bug fixes** — Drops the conflicting `min-h`/`max-h` pixel constraints that were preventing the chart from fully rendering within its bounds.
- **Improvements** — Adopts `aspect-[3/1]` so the chart card scales proportionally with the page width instead of being capped at a fixed pixel height.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted CSS-only tweak with no logic alterations.

Only the chart container's sizing classes are touched. Fixed pixel constraints are replaced with a proportional aspect ratio, which correctly allows the chart to render without clipping. No data-fetching, state management, or rendering logic is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/AnalyticsView.tsx | Removes fixed `min-h`/`max-h` pixel constraints and replaces them with `aspect-[3/1]` on the chart card, fixing bottom clipping of the chart |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix chart height"](https://github.com/useautumn/autumn/commit/95cb2f5bc411a81285a5f0b861362741c6f6674a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32660155)</sub>

<!-- /greptile_comment -->