### PR TITLE
chore: cleanup migration ui

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5884,13 +5884,7 @@
 
     "@asyncapi/parser/node-fetch": ["node-fetch@2.6.7", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ=="],
 
-    "@autumn/openapi/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
     "@autumn/openapi/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
-
-    "@autumn/scripts/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
-    "@autumn/server/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@autumn/server/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
@@ -5901,8 +5895,6 @@
     "@autumn/server/ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
 
     "@autumn/shared/@date-fns/utc": ["@date-fns/utc@2.1.0", "", {}, "sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA=="],
-
-    "@autumn/shared/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@autumn/vite/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
@@ -6884,8 +6876,6 @@
 
     "atmn/@tanstack/react-query": ["@tanstack/react-query@5.100.10", "", { "dependencies": { "@tanstack/query-core": "5.100.10" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q=="],
 
-    "atmn/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
     "atmn/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "atmn/@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260511.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260511.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260511.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260511.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-cUyY4Sr6065280lB6hCwTMCBMTxlEIGjSLzHym28yikA5sFiEsAzlwiU0i+XkTUIqr5K5M/SzSJiioDN+vpjtA=="],
@@ -6899,8 +6889,6 @@
     "atmn/react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "atmn/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
-    "atmn-tests/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "autumn-js/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
@@ -6963,8 +6951,6 @@
     "camelcase-keys/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "checkout/@tanstack/react-query": ["@tanstack/react-query@5.100.10", "", { "dependencies": { "@tanstack/query-core": "5.100.10" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q=="],
-
-    "checkout/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "checkout/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -7674,12 +7660,6 @@
 
     "@asyncapi/parser/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "@autumn/openapi/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "@autumn/scripts/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "@autumn/server/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
     "@autumn/server/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@autumn/server/@typescript/native-preview/@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260511.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SYrqVOlapDxDG7FzHBIJbfgaix+mXPkYzYGqwpz/TAhoPA7sgbfAoGLaqi3ut9N88C/OYNhEX4tjz/0PC9i1nw=="],
@@ -7719,8 +7699,6 @@
     "@autumn/server/ink/type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "@autumn/server/ink/widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
-
-    "@autumn/shared/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@autumn/vite/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -8564,11 +8542,7 @@
 
     "artillery/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
-    "atmn-tests/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
     "atmn/@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.100.10", "", {}, "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w=="],
-
-    "atmn/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "atmn/@typescript/native-preview/@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260511.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SYrqVOlapDxDG7FzHBIJbfgaix+mXPkYzYGqwpz/TAhoPA7sgbfAoGLaqi3ut9N88C/OYNhEX4tjz/0PC9i1nw=="],
 
@@ -8655,8 +8629,6 @@
     "cacheable-request/get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
     "checkout/@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.100.10", "", {}, "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w=="],
-
-    "checkout/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "checkout/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -9210,15 +9182,9 @@
 
     "@artilleryio/int-core/socket.io-client/engine.io-client/xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
 
-    "@autumn/openapi/@types/bun/bun-types/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
-
-    "@autumn/scripts/@types/bun/bun-types/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
-
     "@autumn/server/ink/@alcalzone/ansi-tokenize/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "@autumn/server/ink/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
-
-    "@autumn/shared/@types/bun/bun-types/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
     "@autumn/website/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
@@ -9686,10 +9652,6 @@
 
     "artillery/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
-    "atmn-tests/@types/bun/bun-types/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
-
-    "atmn/@types/bun/bun-types/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
-
     "atmn/eslint-plugin-react-hooks/eslint/@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
 
     "atmn/eslint-plugin-react-hooks/eslint/@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
@@ -9725,8 +9687,6 @@
     "autumn-js/next/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "ava/cli-truncate/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "checkout/@types/bun/bun-types/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
     "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -9916,12 +9876,6 @@
 
     "@artilleryio/int-core/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
-    "@autumn/openapi/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "@autumn/scripts/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "@autumn/shared/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
     "@aws-sdk/client-sso-oidc/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-http/@smithy/util-stream/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@4.1.3", "", { "dependencies": { "@smithy/protocol-http": "^4.1.8", "@smithy/querystring-builder": "^3.0.11", "@smithy/types": "^3.7.2", "@smithy/util-base64": "^3.0.0", "tslib": "^2.6.2" } }, "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA=="],
 
     "@aws-sdk/client-sso-oidc/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-http/@smithy/util-stream/@smithy/util-buffer-from": ["@smithy/util-buffer-from@3.0.0", "", { "dependencies": { "@smithy/is-array-buffer": "^3.0.0", "tslib": "^2.6.2" } }, "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA=="],
@@ -10058,10 +10012,6 @@
 
     "artillery/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
-    "atmn-tests/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "atmn/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
     "atmn/eslint-plugin-react-hooks/eslint/@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "atmn/eslint-plugin-react-hooks/eslint/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -10077,8 +10027,6 @@
     "atmn/eslint-plugin-react-hooks/eslint/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "atmn/eslint-plugin-react-hooks/eslint/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "checkout/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "find-cache-dir/pkg-dir/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
 

--- a/vite/src/hooks/queries/useMigrationsQuery.tsx
+++ b/vite/src/hooks/queries/useMigrationsQuery.tsx
@@ -96,6 +96,7 @@ export const useMigrationsQuery = () => {
 			limit?: number;
 			only?: string[];
 			concurrency?: number;
+			lazy_run?: boolean;
 		}) => {
 			const { data } = await axiosInstance.post<{
 				migration_id: string;

--- a/vite/src/views/migrations/migration-list/MigrationListTable.tsx
+++ b/vite/src/views/migrations/migration-list/MigrationListTable.tsx
@@ -23,12 +23,10 @@ export function MigrationListTable() {
 		},
 	});
 
-	const hasRows = table.getRowModel().rows.length > 0;
-
 	const getRowHref = (row: Migration) =>
 		pushPage({ path: `/migrations/${row.id}` });
 
-	if (!isLoading && !hasRows) {
+	if (!isLoading && migrations.length === 0) {
 		return (
 			<EmptyState
 				type="migrations"

--- a/vite/src/views/migrations/migration/hooks/useRealtimeSubscriptions.ts
+++ b/vite/src/views/migrations/migration/hooks/useRealtimeSubscriptions.ts
@@ -42,6 +42,7 @@ export function useRealtimeSubscriptions({
 				dry_run: dryRun,
 				limit,
 				only,
+				lazy_run: true,
 			});
 			if (result.trigger_run_id && result.public_access_token) {
 				setSubscriptions((prev) => [

--- a/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
+++ b/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
@@ -8,6 +8,7 @@ import {
 	CaretDownIcon,
 	CaretLeftIcon,
 	CaretRightIcon,
+	CheckIcon,
 	EyeIcon,
 	ListMagnifyingGlassIcon,
 	PlayIcon,
@@ -23,6 +24,7 @@ import { Table } from "@/components/general/table";
 import { Badge } from "@/components/v2/badges/Badge";
 import { Button } from "@/components/v2/buttons/Button";
 import { IconButton } from "@/components/v2/buttons/IconButton";
+import { ShortcutButton } from "@/components/v2/buttons/ShortcutButton";
 import {
 	Dialog,
 	DialogContent,
@@ -165,6 +167,13 @@ export function MigrationLiveView({
 	const [dismissedError, setDismissedError] = useState<string | null>(null);
 	const [isRunDialogOpen, setIsRunDialogOpen] = useState(false);
 	const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+	const [sample, setSample] = useState({
+		open: false,
+		mode: "limit" as "limit" | "select",
+		limit: "10",
+		customerIds: [] as string[],
+		running: null as "dry" | "live" | null,
+	});
 	const { cancelRun, isCanceling } = useMigrationsQuery();
 
 	const debouncedSetSearch = useMemo(
@@ -384,7 +393,7 @@ export function MigrationLiveView({
 					<Button
 						variant="primary"
 						size="default"
-						className="rounded-r-none"
+						className="rounded-r-none border-r-0"
 						onClick={() => setIsRunDialogOpen(true)}
 						isLoading={isRunning}
 					>
@@ -407,10 +416,10 @@ export function MigrationLiveView({
 								Dry Run All
 							</DropdownMenuItem>
 							<DropdownMenuItem
-								onClick={() => triggerRun({ dryRun: false, limit: 10 })}
+								onClick={() => setSample((s) => ({ ...s, open: true }))}
 							>
 								<PlayIcon size={14} weight="fill" />
-								Sample (10)
+								Run Sample
 							</DropdownMenuItem>
 						</DropdownMenuContent>
 					</DropdownMenu>
@@ -499,6 +508,167 @@ export function MigrationLiveView({
 								<PlayIcon size={14} weight="fill" />
 								Run
 							</Button>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
+
+				<Dialog
+					open={sample.open}
+					onOpenChange={(open) => setSample((s) => ({ ...s, open }))}
+				>
+					<DialogContent showCloseButton={false}>
+						<DialogHeader>
+							<DialogTitle>Run Sample</DialogTitle>
+							<DialogDescription>
+								Run the migration on a subset of customers.
+							</DialogDescription>
+						</DialogHeader>
+						<div className="flex flex-col gap-3">
+							<div className="flex border-b border-border">
+								<button
+									type="button"
+									onClick={() =>
+										setSample((s) => ({ ...s, mode: "limit" }))
+									}
+									className={cn(
+										"flex-1 pb-2 text-sm font-medium transition-colors border-b-2 -mb-px",
+										sample.mode === "limit"
+											? "border-primary text-t1"
+											: "border-transparent text-t3 hover:text-t2",
+									)}
+								>
+									By count
+								</button>
+								<button
+									type="button"
+									onClick={() =>
+										setSample((s) => ({ ...s, mode: "select" }))
+									}
+									className={cn(
+										"flex-1 pb-2 text-sm font-medium transition-colors border-b-2 -mb-px",
+										sample.mode === "select"
+											? "border-primary text-t1"
+											: "border-transparent text-t3 hover:text-t2",
+									)}
+								>
+									Select customers
+								</button>
+							</div>
+							<div className="min-h-[220px]">
+								{sample.mode === "limit" ? (
+									<div className="flex flex-col gap-1.5">
+										<label className="text-xs text-t3">
+											Number of customers
+										</label>
+										<Input
+											type="number"
+											min={1}
+											value={sample.limit}
+											onChange={(e) =>
+												setSample((s) => ({
+													...s,
+													limit: e.target.value,
+												}))
+											}
+											placeholder="10"
+										/>
+										<SampleCustomerPreview
+											customers={enrichedCustomers}
+											limit={Number(sample.limit) || 0}
+										/>
+										<span className="text-xs text-t3">
+											{Math.min(
+												Number(sample.limit) || 0,
+												enrichedCustomers.filter((c) => !c._event).length,
+											)}{" "}
+											customers
+										</span>
+									</div>
+								) : (
+									<div className="flex flex-col gap-1.5">
+										<label className="text-xs text-t3">
+											Select customers to run
+										</label>
+										<SampleCustomerPicker
+											customers={enrichedCustomers}
+											selectedIds={sample.customerIds}
+											onChange={(ids) =>
+												setSample((s) => ({ ...s, customerIds: ids }))
+											}
+										/>
+									</div>
+								)}
+							</div>
+						</div>
+						<DialogFooter className="sm:flex-col gap-2">
+							<ShortcutButton
+								className="w-full"
+								variant="secondary"
+								isLoading={sample.running === "dry"}
+								disabled={
+									sample.running !== null ||
+									(sample.mode === "limit"
+										? !sample.limit || Number(sample.limit) < 1
+										: sample.customerIds.length === 0)
+								}
+								onClick={async () => {
+									setSample((s) => ({ ...s, running: "dry" }));
+									if (sample.mode === "limit") {
+										const topIds = enrichedCustomers
+											.filter((c) => !c._event)
+											.slice(0, Number(sample.limit))
+											.map((c) => c.id ?? c.internal_id);
+										await triggerRun({
+											dryRun: true,
+											only: topIds,
+										});
+									} else {
+										await triggerRun({
+											dryRun: true,
+											only: sample.customerIds,
+										});
+									}
+									setSample((s) => ({ ...s, running: null, open: false }));
+								}}
+							>
+								<EyeIcon size={14} />
+								Dry Run{" "}
+								{sample.mode === "limit"
+									? `(${sample.limit || 0})`
+									: `(${sample.customerIds.length})`}
+							</ShortcutButton>
+							<ShortcutButton
+								className="w-full"
+								metaShortcut="enter"
+								isLoading={sample.running === "live"}
+								disabled={
+									sample.running !== null ||
+									(sample.mode === "limit"
+										? !sample.limit || Number(sample.limit) < 1
+										: sample.customerIds.length === 0)
+								}
+								onClick={async () => {
+									setSample((s) => ({ ...s, running: "live" }));
+									if (sample.mode === "limit") {
+										await triggerRun({
+											dryRun: false,
+											limit: Number(sample.limit),
+										});
+									} else {
+										await triggerRun({
+											dryRun: false,
+											only: sample.customerIds,
+										});
+									}
+									setSample((s) => ({ ...s, running: null, open: false }));
+								}}
+							>
+								<PlayIcon size={14} weight="fill" />
+								Run Live{" "}
+								{sample.mode === "limit"
+									? `(${sample.limit || 0})`
+									: `(${sample.customerIds.length})`}
+							</ShortcutButton>
 						</DialogFooter>
 					</DialogContent>
 				</Dialog>
@@ -593,6 +763,130 @@ export function MigrationLiveView({
 					</Table.Content>
 				</Table.Container>
 			</Table.Provider>
+		</div>
+	);
+}
+
+function SampleCustomerPreview({
+	customers,
+	limit,
+}: {
+	customers: CustomerRow[];
+	limit: number;
+}) {
+	const unrun = customers.filter((c) => !c._event);
+	const previewed = unrun.slice(0, limit);
+	if (limit === 0) return null;
+	return (
+		<div className="h-48 overflow-y-auto rounded-xl border border-border mt-1.5">
+			{previewed.length === 0 ? (
+				<div className="px-3 py-4 text-center text-xs text-t4">
+					No customers to preview
+				</div>
+			) : (
+				previewed.map((c) => (
+					<div
+						key={c.internal_id}
+						className="flex items-center gap-2 w-full px-3 py-1.5 text-sm"
+					>
+						<span className="flex-1 truncate text-t1">
+							{c.name || c.id || c.internal_id}
+						</span>
+						{c.email && (
+							<span className="text-xs text-t4 truncate max-w-32">
+								{c.email}
+							</span>
+						)}
+					</div>
+				))
+			)}
+		</div>
+	);
+}
+
+function SampleCustomerPicker({
+	customers,
+	selectedIds,
+	onChange,
+}: {
+	customers: CustomerRow[];
+	selectedIds: string[];
+	onChange: (ids: string[]) => void;
+}) {
+	const [search, setSearch] = useState("");
+	const filtered = useMemo(() => {
+		if (!search) return customers;
+		const q = search.toLowerCase();
+		return customers.filter(
+			(c) =>
+				c.name?.toLowerCase().includes(q) ||
+				c.id?.toLowerCase().includes(q) ||
+				c.email?.toLowerCase().includes(q),
+		);
+	}, [customers, search]);
+
+	const toggle = (id: string) => {
+		onChange(
+			selectedIds.includes(id)
+				? selectedIds.filter((v) => v !== id)
+				: [...selectedIds, id],
+		);
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<Input
+				value={search}
+				onChange={(e) => setSearch(e.target.value)}
+				placeholder="Search customers..."
+				className="text-sm"
+			/>
+			<div className="h-48 overflow-y-auto rounded-xl border border-border">
+				{filtered.length === 0 ? (
+					<div className="px-3 py-4 text-center text-xs text-t4">
+						No customers found
+					</div>
+				) : (
+					filtered.map((c) => {
+						const isSelected = selectedIds.includes(c.id ?? c.internal_id);
+						return (
+							<button
+								key={c.internal_id}
+								type="button"
+								onClick={() => toggle(c.id ?? c.internal_id)}
+								className={cn(
+									"flex items-center gap-2 w-full px-3 py-1.5 text-left text-sm hover:bg-muted/50 cursor-pointer transition-colors",
+									isSelected && "bg-primary/5",
+								)}
+							>
+								<div
+									className={cn(
+										"size-4 rounded border flex items-center justify-center shrink-0",
+										isSelected
+											? "border-primary bg-primary"
+											: "border-border",
+									)}
+								>
+									{isSelected && (
+										<CheckIcon size={10} className="text-white" />
+									)}
+								</div>
+								<span className="flex-1 truncate text-t1">
+									{c.name || c.id || c.internal_id}
+								</span>
+								{c.email && (
+									<span className="text-xs text-t4 truncate max-w-32">
+										{c.email}
+									</span>
+								)}
+							</button>
+						);
+					})
+				)}
+			</div>
+			<span className="text-xs text-t3">
+				{selectedIds.length} selected
+			</span>
 		</div>
 	);
 }

--- a/vite/src/views/migrations/migration/operations/OperationsForm.tsx
+++ b/vite/src/views/migrations/migration/operations/OperationsForm.tsx
@@ -10,6 +10,7 @@ import {
 	CheckIcon,
 	PackageIcon,
 	PencilSimpleIcon,
+	PlusIcon,
 } from "@phosphor-icons/react";
 
 import {
@@ -19,6 +20,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/v2/dropdowns/DropdownMenu";
 import { ActionCard } from "../shared/ActionCard";
+import { DASHED_BUTTON_CLASS } from "../shared/AddButton";
 import { AutumnMark, StripeMark } from "../shared/BillingScopeMarks";
 import { AddPlansSection } from "./AddPlanOpForm";
 import { UpdatePlanOpForm } from "./UpdatePlanOpForm";
@@ -184,45 +186,41 @@ export function OperationsForm({
 						</>
 					)}
 
-					<div className="border-t mt-3 pt-3 flex flex-col gap-2">
-						<span className="text-sm font-medium text-t1">Add Operation</span>
-						<div className="flex gap-3">
-							<ActionCard
-								icon={
-									<PencilSimpleIcon
-										size={20}
-										weight="duotone"
-										className="text-t3 shrink-0"
-									/>
-								}
-								heading="Update Plan"
-								subheading="Modify existing customer plans"
-								onClick={() =>
-									setOperations([...operations, DEFAULT_UPDATE_PLAN])
-								}
-								className="flex-1"
-							/>
-							{!hasAddPlans && (
-								<ActionCard
-									icon={
-										<PackageIcon
-											size={20}
-											weight="duotone"
-											className="text-t3 shrink-0"
-										/>
-									}
-									heading="Add Plan"
-									subheading="Assign a new plan to customers"
+					<div className="border-t mt-3 pt-3">
+						<DropdownMenu>
+							<DropdownMenuTrigger className={DASHED_BUTTON_CLASS}>
+								<PlusIcon size={10} />
+								Add Operation
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								align="start"
+								className="w-(--anchor-width)"
+							>
+								<DropdownMenuItem
+									closeOnClick
 									onClick={() =>
-										setOperations([
-											...operations,
-											{ type: "add_plan", plan_id: "" },
-										])
+										setOperations([...operations, DEFAULT_UPDATE_PLAN])
 									}
-									className="flex-1"
-								/>
-							)}
-						</div>
+								>
+									<PencilSimpleIcon size={14} weight="duotone" />
+									Update Plan
+								</DropdownMenuItem>
+								{!hasAddPlans && (
+									<DropdownMenuItem
+										closeOnClick
+										onClick={() =>
+											setOperations([
+												...operations,
+												{ type: "add_plan", plan_id: "" },
+											])
+										}
+									>
+										<PackageIcon size={14} weight="duotone" />
+										Add Plan
+									</DropdownMenuItem>
+								)}
+							</DropdownMenuContent>
+						</DropdownMenu>
 					</div>
 				</>
 			)}

--- a/vite/src/views/migrations/migration/operations/UpdatePlanOpForm.tsx
+++ b/vite/src/views/migrations/migration/operations/UpdatePlanOpForm.tsx
@@ -42,18 +42,21 @@ import {
 import { RemoveItemRows } from "./RemoveItemRows";
 
 function useVersionOptions(planFilter: UpdatePlanOp["plan_filter"]) {
-	const { products } = useProductsQuery();
+	const { products } = useProductsQuery({ allVersions: true });
 
-	const targetPlanId =
-		typeof planFilter.plan_id === "string" && planFilter.plan_id
-			? planFilter.plan_id
-			: null;
+	const targetIds = extractPlanIds(planFilter.plan_id);
+	const idSet = new Set(targetIds);
 
-	const matchingProducts = targetPlanId
-		? products.filter((p) => p.id === targetPlanId)
-		: [];
+	const matchingProducts =
+		idSet.size > 0 ? products.filter((p) => idSet.has(p.id)) : [];
 
+	const seen = new Set<number>();
 	return matchingProducts
+		.filter((p) => {
+			if (seen.has(p.version)) return false;
+			seen.add(p.version);
+			return true;
+		})
 		.map((p) => ({
 			value: String(p.version),
 			label: `v${p.version}`,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up the migrations UI and added a “Run Sample” flow so you can test a subset of customers before a full run. Also improved operations editing, version selection, and added `lazy_run` support for safer real-time runs.

- New Features
  - “Run Sample” dialog: run by count or select customers, with preview/search. Supports Dry Run and Live, with keyboard shortcut via `ShortcutButton`.
  - Added `lazy_run` to migration runs and use it in realtime subscriptions.

- Refactors
  - Replaced “Add Operation” cards with a compact dropdown (dashed button). Still prevents multiple “Add Plan” ops.
  - Update Plan form now loads all product versions, supports multiple plan IDs, and de-dupes version options.
  - Simpler empty-state check in the migration list.
  - Minor UI polish on run buttons.
  - Lockfile cleanup removing stray `@types/bun` entries.

<sup>Written for commit 1bd2277f3577f3c8c84f9aafc39ce6e60a50d2b5. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1605?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR cleans up the migration UI by replacing fixed \"Sample (10)\" behaviour with a configurable \"Run Sample\" dialog (limit or customer-select mode), collapsing the \"Add Operation\" action cards into a dropdown, and enabling version-aware plan filtering in `UpdatePlanOpForm`.

- **Improvements**: \"Run Sample\" dialog replaces the hardcoded 10-customer sample with limit-by-count and select-by-customer modes; `useRealtimeSubscriptions` now always passes `lazy_run: true` to the backend.
- **Improvements**: \"Add Operation\" section converted from two always-visible `ActionCard` components to a compact dropdown menu.
- **Improvements**: `useVersionOptions` in `UpdatePlanOpForm` now fetches all product versions and deduplicates correctly, enabling multi-plan-ID version filtering.
</details>


<h3>Confidence Score: 3/5</h3>

The "Run Sample" dialog has a mismatch between what the dry-run preview shows and the customers the live run actually processes in limit mode — users could be misled about which customers get migrated.

In limit mode, the dry-run resolves the top-N IDs from the frontend list and sends them as `only`, so users see exactly which customers would run. The live-run sends only `limit: N` to the backend, which applies its own ordering independently. Any difference in ordering means different customers are migrated than what the user reviewed. Given that migrations are a destructive billing operation, this silent mismatch is a meaningful correctness concern.

vite/src/views/migrations/migration/live/MigrationLiveView.tsx — the Run Sample dialog's "Run Live" path in limit mode.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/migrations/migration/live/MigrationLiveView.tsx | Adds "Run Sample" dialog with limit and customer-select modes; dry-run and live-run use different customer-selection strategies in limit mode (frontend-resolved IDs vs. backend limit count), which can silently mismatch. |
| vite/src/views/migrations/migration/hooks/useRealtimeSubscriptions.ts | Hardcodes `lazy_run: true` for all migration runs; straightforward and intentional. |
| vite/src/hooks/queries/useMigrationsQuery.tsx | Adds optional `lazy_run` parameter to the `runMigration` call type; clean, low-risk change. |
| vite/src/views/migrations/migration-list/MigrationListTable.tsx | Removes intermediate `hasRows` variable and checks `migrations.length === 0` directly; correct and equivalent. |
| vite/src/views/migrations/migration/operations/OperationsForm.tsx | Replaces two ActionCards with a DropdownMenu for adding operations; clean UI refactor. |
| vite/src/views/migrations/migration/operations/UpdatePlanOpForm.tsx | Switches `useVersionOptions` to fetch all product versions and deduplicates by version number using a Set; logic is correct. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant Dialog as Run Sample Dialog
    participant LV as MigrationLiveView
    participant Hook as useRealtimeSubscriptions
    participant API as Backend API

    User->>LV: Click "Run Sample" dropdown item
    LV->>Dialog: "setSample({ open: true })"

    alt Limit mode - Dry Run
        User->>Dialog: Set limit N, click Dry Run
        Dialog->>LV: "topIds = enrichedCustomers.filter(!_event).slice(0,N).map(id)"
        LV->>Hook: "triggerRun({ dryRun: true, only: topIds })"
        Hook->>API: "POST /migration { dry_run: true, only: topIds, lazy_run: true }"
    else Limit mode - Live Run
        User->>Dialog: Set limit N, click Run Live
        LV->>Hook: "triggerRun({ dryRun: false, limit: N })"
        Hook->>API: "POST /migration { dry_run: false, limit: N, lazy_run: true }"
        Note over Hook,API: Backend selects by its own ordering — may differ from dry-run preview
    else Select mode
        User->>Dialog: Pick customer IDs, click run
        LV->>Hook: "triggerRun({ dryRun, only: sample.customerIds })"
        Hook->>API: "POST /migration { dry_run, only: customerIds, lazy_run: true }"
    end

    API-->>Hook: "{ trigger_run_id, public_access_token, run_id }"
    Hook-->>LV: toast + subscription added
    LV->>Dialog: "setSample({ running: null, open: false })"
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `vite/src/views/migrations/migration/live/MigrationLiveView.tsx`, line 408-422 ([link](https://github.com/useautumn/autumn/blob/1bd2277f3577f3c8c84f9aafc39ce6e60a50d2b5/vite/src/views/migrations/migration/live/MigrationLiveView.tsx#L408-L422)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Dry-run and live-run operate on different customer sets in "limit" mode**

   In limit mode, the dry-run resolves the top-N customer IDs from the current frontend list (`only: topIds`) and previews exactly those rows. The live run, however, sends `limit: N` to the backend, which selects customers using its own ordering. If the backend's ordering differs from the frontend's (e.g., pagination state, different sort key, or customers added between the two requests), the live run processes a completely different cohort than what the dry run showed — defeating the purpose of the sample preview.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/migrations/migration/live/MigrationLiveView.tsx
   Line: 408-422

   Comment:
   **Dry-run and live-run operate on different customer sets in "limit" mode**

   In limit mode, the dry-run resolves the top-N customer IDs from the current frontend list (`only: topIds`) and previews exactly those rows. The live run, however, sends `limit: N` to the backend, which selects customers using its own ordering. If the backend's ordering differs from the frontend's (e.g., pagination state, different sort key, or customers added between the two requests), the live run processes a completely different cohort than what the dry run showed — defeating the purpose of the sample preview.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `vite/src/views/migrations/migration/live/MigrationLiveView.tsx`, line 372-397 ([link](https://github.com/useautumn/autumn/blob/1bd2277f3577f3c8c84f9aafc39ce6e60a50d2b5/vite/src/views/migrations/migration/live/MigrationLiveView.tsx#L372-L397)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Dialog stays closed after a failed run**

   Both the "Dry Run" and "Run Live" `onClick` handlers call `setSample(…open: false)` unconditionally after `await triggerRun(…)`. Because `triggerRun` catches all errors internally and never rethrows, this line always executes — even when the API call fails. On failure the user sees a toast but the dialog has already been dismissed, so they must reopen the sample dialog to retry.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/migrations/migration/live/MigrationLiveView.tsx
   Line: 372-397

   Comment:
   **Dialog stays closed after a failed run**

   Both the "Dry Run" and "Run Live" `onClick` handlers call `setSample(…open: false)` unconditionally after `await triggerRun(…)`. Because `triggerRun` catches all errors internally and never rethrows, this line always executes — even when the API call fails. On failure the user sees a toast but the dialog has already been dismissed, so they must reopen the sample dialog to retry.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/migrations/migration/live/MigrationLiveView.tsx:408-422
**Dry-run and live-run operate on different customer sets in "limit" mode**

In limit mode, the dry-run resolves the top-N customer IDs from the current frontend list (`only: topIds`) and previews exactly those rows. The live run, however, sends `limit: N` to the backend, which selects customers using its own ordering. If the backend's ordering differs from the frontend's (e.g., pagination state, different sort key, or customers added between the two requests), the live run processes a completely different cohort than what the dry run showed — defeating the purpose of the sample preview.

### Issue 2 of 2
vite/src/views/migrations/migration/live/MigrationLiveView.tsx:372-397
**Dialog stays closed after a failed run**

Both the "Dry Run" and "Run Live" `onClick` handlers call `setSample(…open: false)` unconditionally after `await triggerRun(…)`. Because `triggerRun` catches all errors internally and never rethrows, this line always executes — even when the API call fails. On failure the user sees a toast but the dialog has already been dismissed, so they must reopen the sample dialog to retry.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: cleanup migration ui"](https://github.com/useautumn/autumn/commit/1bd2277f3577f3c8c84f9aafc39ce6e60a50d2b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32662266)</sub>

<!-- /greptile_comment -->