### PR TITLE
Revert "Tinybird reads cutover us east"

### DIFF
--- a/scripts/setup/AGENT_README.md
+++ b/scripts/setup/AGENT_README.md
@@ -58,7 +58,7 @@ Set these in the process environment before running `bun dev:agent` and they wil
 | PostgreSQL | 5432 | Database: `autumn`, user: `postgres`, password: `postgres` |
 | Redis Stack | 6379 | Used for `CACHE_URL` and `CACHE_URL_US_EAST` (RedisJSON required) |
 | ElasticMQ | 9324 | Local SQS replacement, queue: `autumn.fifo` |
-| ClickHouse | 8123 | Used for `TINYBIRD_US_EAST_CLICKHOUSE_URL` |
+| ClickHouse | 8123 | Used for `TINYBIRD_CLICKHOUSE_URL` |
 | Server | 8080 | Autumn API server |
 | Vite | 3000 | Frontend dev server |
 | Checkout | 3001 | Checkout app dev server |

--- a/scripts/setup/writeAgentEnv.ts
+++ b/scripts/setup/writeAgentEnv.ts
@@ -67,7 +67,7 @@ AWS_ACCESS_KEY_ID=x
 AWS_SECRET_ACCESS_KEY=x
 
 # ClickHouse (local)
-TINYBIRD_US_EAST_CLICKHOUSE_URL=http://localhost:8123
+TINYBIRD_CLICKHOUSE_URL=http://localhost:8123
 
 # App URLs
 BETTER_AUTH_URL=http://localhost:${serverPort}

--- a/server/src/external/tinybird/initClickhouse.ts
+++ b/server/src/external/tinybird/initClickhouse.ts
@@ -3,8 +3,8 @@ import { type ClickHouseClient, createClient } from "@clickhouse/client";
 // ClickHouse URL is different from API URL
 // API: https://api.europe-west2.gcp.tinybird.co
 // ClickHouse: https://europe-west2.gcp.clickhouse.tinybird.co
-const TINYBIRD_CLICKHOUSE_URL = process.env.TINYBIRD_US_EAST_CLICKHOUSE_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
+const TINYBIRD_CLICKHOUSE_URL = process.env.TINYBIRD_CLICKHOUSE_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
 
 // Debug logging
 if (TINYBIRD_CLICKHOUSE_URL && TINYBIRD_TOKEN) {

--- a/server/src/external/tinybird/initTinybirdV2.ts
+++ b/server/src/external/tinybird/initTinybirdV2.ts
@@ -1,19 +1,19 @@
 import { createTinybirdApi } from "@tinybirdco/sdk";
 
-// Dual-write safety net during the us-east cutover. Reads the legacy
-// us-west env vars; delete with the dual-write logic in `sendEvents.ts`
-// once us-east is stable.
-const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
+const TINYBIRD_US_EAST_API_URL = process.env.TINYBIRD_US_EAST_API_URL;
+const TINYBIRD_US_EAST_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
 
-/** Secondary Tinybird API client for dual-write during region cutover. */
-export const tinybirdSecondaryApi =
-	TINYBIRD_API_URL && TINYBIRD_TOKEN
-		? createTinybirdApi({ baseUrl: TINYBIRD_API_URL, token: TINYBIRD_TOKEN })
+/** Secondary Tinybird API client (us-east region) for dual-write during migration. */
+export const tinybirdUsEastApi =
+	TINYBIRD_US_EAST_API_URL && TINYBIRD_US_EAST_TOKEN
+		? createTinybirdApi({
+				baseUrl: TINYBIRD_US_EAST_API_URL,
+				token: TINYBIRD_US_EAST_TOKEN,
+			})
 		: null;
 
-if (tinybirdSecondaryApi) {
+if (tinybirdUsEastApi) {
 	console.log(
-		`[Tinybird] secondary dual-write configured with URL: ${TINYBIRD_API_URL}`,
+		`[Tinybird] us-east dual-write configured with URL: ${TINYBIRD_US_EAST_API_URL}`,
 	);
 }

--- a/server/src/external/tinybird/sendEvents/sendEvents.ts
+++ b/server/src/external/tinybird/sendEvents/sendEvents.ts
@@ -3,7 +3,7 @@ import type { EventInsert } from "@autumn/shared";
 import * as Sentry from "@sentry/bun";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { tinybirdIngest } from "../initTinybird.js";
-import { tinybirdSecondaryApi } from "../initTinybirdV2.js";
+import { tinybirdUsEastApi } from "../initTinybirdV2.js";
 import { isTinybirdConfigured } from "../tinybirdUtils.js";
 import { mapToTinybirdEvent } from "./mapEvent.js";
 
@@ -35,7 +35,7 @@ export const sendEventsToTinybird = async ({
 
 	const tinybirdEvents = events.map(mapToTinybirdEvent);
 
-	const reportFailure = (error: unknown, region: "primary" | "secondary") => {
+	const reportFailure = (error: unknown, region: "primary" | "us-east") => {
 		const errorId = generateErrorId();
 		const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -81,21 +81,24 @@ export const sendEventsToTinybird = async ({
 		})
 		.catch((error: unknown) => reportFailure(error, "primary"));
 
-	const secondaryWrite = tinybirdSecondaryApi
-		? tinybirdSecondaryApi
+	const usEastWrite = tinybirdUsEastApi
+		? tinybirdUsEastApi
 				.ingestBatch("events", tinybirdEvents)
 				.then((result) => {
-					logger?.info(`Sent ${events.length} events to Tinybird (secondary)`, {
-						data: {
-							region: "secondary",
-							eventCount: events.length,
-							successfulRows: result?.successful_rows,
-							quarantinedRows: result?.quarantined_rows,
+					logger?.info(
+						`Sent ${events.length} events to Tinybird (us-east)`,
+						{
+							data: {
+								region: "us-east",
+								eventCount: events.length,
+								successfulRows: result?.successful_rows,
+								quarantinedRows: result?.quarantined_rows,
+							},
 						},
-					});
+					);
 				})
-				.catch((error: unknown) => reportFailure(error, "secondary"))
+				.catch((error: unknown) => reportFailure(error, "us-east"))
 		: Promise.resolve();
 
-	await Promise.all([primaryWrite, secondaryWrite]);
+	await Promise.all([primaryWrite, usEastWrite]);
 };

--- a/server/src/external/tinybird/tinybirdUtils.ts
+++ b/server/src/external/tinybird/tinybirdUtils.ts
@@ -1,8 +1,8 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 
-const TINYBIRD_API_URL = process.env.TINYBIRD_US_EAST_API_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
+const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
 
 export type TinybirdConfig = {
 	baseUrl: string;


### PR DESCRIPTION
Reverts useautumn/autumn#1593

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Tinybird read cutover to us-east. Primary reads and ingest now use the default region again; dual-write to us-east remains optional.

- **Refactors**
  - Restore primary Tinybird config to `TINYBIRD_API_URL` and `TINYBIRD_TOKEN`.
  - Use explicit us-east client `tinybirdUsEastApi` with `TINYBIRD_US_EAST_API_URL` and `TINYBIRD_US_EAST_TOKEN` for dual-write.
  - Switch ClickHouse env back to `TINYBIRD_CLICKHOUSE_URL` and update setup docs.
  - Update logs to label the secondary write as "us-east".

<sup>Written for commit 78f35b52738b176dfe2247d1e17b8592cea0abce. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1606?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

