### PR TITLE
fix: sync entity id

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases.ts
@@ -83,6 +83,7 @@ export const computeSyncFuturePhases = ({
 				accessStartsAt: productContext.accessStartsAt,
 				subscriptionId: stripeSubscription?.id,
 				subscriptionScheduleId: stripeSchedule?.id,
+				internalEntityId: productContext.plan.internal_entity_id,
 			});
 			insertCustomerProducts.push(cusProduct);
 			phaseIds.push(cusProduct.id);

--- a/server/src/internal/billing/v2/actions/sync/compute/initImmediateSyncCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/sync/compute/initImmediateSyncCustomerProduct.ts
@@ -67,6 +67,7 @@ export const initImmediateSyncCustomerProduct = ({
 			status: stripeSubscriptionToAutumnStatus({
 				stripeStatus: stripeSubscription.status,
 			}),
+			internalEntityId: plan.internal_entity_id,
 		},
 	});
 };

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerProduct.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerProduct.ts
@@ -40,8 +40,14 @@ export const initCustomerProduct = ({
 		onTrialEnd,
 	} = initOptions ?? {};
 
-	const internalEntityId = fullCustomer.entity?.internal_id;
-	const entityId = fullCustomer.entity?.id;
+	const internalEntityId =
+		initOptions?.internalEntityId ?? fullCustomer.entity?.internal_id;
+	const entityId =
+		initOptions?.internalEntityId && initOptions.internalEntityId !== fullCustomer.entity?.internal_id
+			? fullCustomer.entities?.find(
+					(e) => e.internal_id === initOptions.internalEntityId,
+				)?.id
+			: fullCustomer.entity?.id;
 
 	const startsAt = initOptions?.startsAt ?? now;
 	const endedAt = initOptions?.endedAt;

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/initScheduledCustomerProduct.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/initScheduledCustomerProduct.ts
@@ -28,6 +28,7 @@ export const initScheduledCustomerProduct = ({
 	externalId,
 	subscriptionId,
 	subscriptionScheduleId,
+	internalEntityId,
 }: {
 	ctx: AutumnContext;
 	fullCustomer: FullCustomer;
@@ -44,6 +45,7 @@ export const initScheduledCustomerProduct = ({
 	 * Stripe linkage and downstream actions (cancel, restore) can find it. */
 	subscriptionId?: string;
 	subscriptionScheduleId?: string;
+	internalEntityId?: string;
 }): FullCusProduct => {
 	return initFullCustomerProduct({
 		ctx,
@@ -64,6 +66,7 @@ export const initScheduledCustomerProduct = ({
 			externalId,
 			subscriptionId,
 			subscriptionScheduleId,
+			internalEntityId,
 		},
 	});
 };

--- a/server/tests/_temp/sync-v2-entity-binding.test.ts
+++ b/server/tests/_temp/sync-v2-entity-binding.test.ts
@@ -1,0 +1,98 @@
+/**
+ * TDD repro for syncV2 entity binding bug.
+ *
+ * Bug: When the caller passes `phases[].plans[].internal_entity_id` to
+ * `billing.sync_v2`, the inserted customer product is NOT bound to that
+ * entity. `initCustomerProduct` sources `internal_entity_id` only from
+ * `fullCustomer.entity` (the customer's currently-set entity context),
+ * ignoring the plan's intent. The data DOES flow through SyncPlanInstance →
+ * SyncProductContext.plan (it's even logged in logSyncContext), but
+ * `initImmediateSyncCustomerProduct` never threads it down to
+ * `initFullCustomerProduct`, and `InitFullCustomerProductOptions` has no
+ * field to receive it.
+ *
+ * Red (current): cusProduct.internal_entity_id is null after sync.
+ * Green (after fix): cusProduct.internal_entity_id === plan.internal_entity_id.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import { createStripeSubscriptionFromProduct } from "@tests/integration/billing/sync/utils/syncTestUtils";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { CusService } from "@/internal/customers/CusService";
+import { EntityService } from "@/internal/api/entities/EntityService";
+
+test(
+	chalk.yellowBright(
+		"sync-v2 entity binding: plan.internal_entity_id must propagate to inserted customer product",
+	),
+	async () => {
+		const customerId = "sync-v2-entity-bind";
+
+		const pro = products.pro({
+			id: "sync-v2-entity-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [],
+		});
+
+		const fullCustomerBefore = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+
+		const entityList = await EntityService.list({
+			db: ctx.db,
+			internalCustomerId: fullCustomerBefore.internal_id,
+		});
+		expect(entityList.length).toBeGreaterThan(0);
+		const targetEntity = entityList[0];
+		const targetEntityInternalId = targetEntity.internal_id;
+
+		const stripeSubscription = await createStripeSubscriptionFromProduct({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+		expect(stripeSubscription.status).toBe("active");
+
+		await autumnV1.post("/billing.sync_v2", {
+			customer_id: customerId,
+			stripe_subscription_id: stripeSubscription.id,
+			phases: [
+				{
+					starts_at: "now",
+					plans: [
+						{
+							plan_id: pro.id,
+							internal_entity_id: targetEntityInternalId,
+						},
+					],
+				},
+			],
+		});
+
+		const fullCustomerAfter = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+
+		const cusProduct = fullCustomerAfter.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		);
+		expect(cusProduct).toBeDefined();
+		expect(cusProduct!.internal_entity_id).toBe(targetEntityInternalId);
+	},
+);

--- a/shared/models/billingModels/customerProduct/initFullCustomerProductContext.ts
+++ b/shared/models/billingModels/customerProduct/initFullCustomerProductContext.ts
@@ -80,6 +80,9 @@ export interface InitFullCustomerProductOptions {
 	/** When true, preserve subscription_ids even for non-paid-recurring products (used by sync). */
 	keepSubscriptionIds?: boolean;
 
+	/** Override the entity the customer product is bound to. Used by sync to honor `plan.internal_entity_id` instead of falling back to `fullCustomer.entity`. */
+	internalEntityId?: string;
+
 	previousCustomerProductId?: string;
 	onTrialEnd?: TrialOnEnd;
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes entity binding in `/billing.sync_v2`: customer products now correctly bind to `plan.internal_entity_id` for both immediate and scheduled syncs.

- **Bug Fixes**
  - Thread `internalEntityId` from sync plan context into customer product creation (immediate and future phases).
  - Added `internalEntityId` to `InitFullCustomerProductOptions` and propagate it through init calls.
  - Updated `initCustomerProduct` to honor the override and resolve `entityId` when the override differs from the current customer entity.
  - Added a test to ensure the inserted customer product’s `internal_entity_id` matches the plan’s value.

<sup>Written for commit 6f48b4724706506fe682ce4771bbfcbb81417fd5. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1607?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a bug where `plan.internal_entity_id` supplied in `billing.sync_v2` phases was silently dropped — inserted customer products always had `null` for `internal_entity_id` because the field was never threaded from `SyncProductContext.plan` down to `initFullCustomerProduct`.

- **Bug fixes** — `initImmediateSyncCustomerProduct` and `computeSyncFuturePhases` now forward `plan.internal_entity_id` as `internalEntityId` into their respective `initCustomerProduct` / `initScheduledCustomerProduct` calls.
- **Improvements** — `InitFullCustomerProductOptions` gains the `internalEntityId` override field; `initCustomerProduct` uses it (with nullish-coalescing) before falling back to `fullCustomer.entity`, and derives the matching `entity_id` by searching `fullCustomer.entities`.
- **Improvements** — A TDD integration test is added to document the before/after behaviour and guard against regression.
</details>

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; it unblocks a clearly broken sync path and the scope is narrow.

The entity-ID propagation is correct end-to-end, but the `entityId` derivation in `initCustomerProduct` carries a slightly convoluted guard that silently returns `undefined` for `entity_id` in the mismatch branch if the target entity is absent from `fullCustomer.entities`. The integration test lives in `_temp/` and may not run in CI, leaving the regression guard weaker than it appears.

The `entityId` resolution logic in `initCustomerProduct.ts` and the test file location in `_temp/` are both worth a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerProduct.ts | Core fix: resolves `internalEntityId` and `entityId` from `initOptions.internalEntityId` override before falling back to `fullCustomer.entity`; the compound guard for `entityId` could be simplified. |
| server/src/internal/billing/v2/actions/sync/compute/initImmediateSyncCustomerProduct.ts | Threads `plan.internal_entity_id` into `initOptions.internalEntityId` for the immediate-phase customer product; straightforward one-line addition. |
| server/src/internal/billing/v2/actions/sync/compute/computeSyncFuturePhases.ts | Mirrors the immediate-phase fix for scheduled (future) phases by passing `productContext.plan.internal_entity_id` to `initScheduledCustomerProduct`. |
| server/src/internal/billing/v2/utils/initFullCustomerProduct/initScheduledCustomerProduct.ts | Adds `internalEntityId` param to the function signature and forwards it to `initFullCustomerProduct`; clean pass-through change. |
| shared/models/billingModels/customerProduct/initFullCustomerProductContext.ts | Adds the `internalEntityId` field to `InitFullCustomerProductOptions` with clear JSDoc; no structural concerns. |
| server/tests/_temp/sync-v2-entity-binding.test.ts | New integration test verifying `internal_entity_id` propagation; placed in `_temp/` which may exclude it from CI runs. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tests/_temp/sync-v2-entity-binding.test.ts:1-10
**Test file in `_temp/` directory**

This test appears to be the TDD repro that drove the fix. Tests under `_temp/` are typically excluded from CI and may not be picked up by the default test runner configuration. If this test is intended to protect the fix from regression, it should be moved to a permanent test directory alongside the other billing integration tests.

### Issue 2 of 2
server/src/internal/billing/v2/utils/initFullCustomerProduct/initCustomerProduct.ts:45-50
The extra condition `initOptions.internalEntityId !== fullCustomer.entity?.internal_id` is a premature optimisation that adds complexity without a meaningful benefit. When the override matches the context entity, the `find` would still return the correct `id` (since `fullCustomer.entities` contains that same entity). Removing the guard makes the logic a single linear branch and eliminates the diverging code path that could silently return `undefined` for `entityId` only in the mismatch case.

```suggestion
	const entityId = initOptions?.internalEntityId
		? fullCustomer.entities?.find(
				(e) => e.internal_id === initOptions.internalEntityId,
			)?.id
		: fullCustomer.entity?.id;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: sync entity ID"](https://github.com/useautumn/autumn/commit/6f48b4724706506fe682ce4771bbfcbb81417fd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32675146)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->