### PR TITLE
feat: 🎸 unlimited decutions + collapse plan id

### DIFF
--- a/server/src/internal/analytics/actions/listByCursor.ts
+++ b/server/src/internal/analytics/actions/listByCursor.ts
@@ -105,15 +105,21 @@ export const listByCursor = async ({
 		if (row.deductions) {
 			try {
 				const parsed = JSON.parse(row.deductions);
-				if (Array.isArray(parsed)) {
-					deductions = parsed as TrackDeduction[];
-				} else if (parsed && Array.isArray(parsed.list)) {
-					deductions = parsed.list as TrackDeduction[];
+				// Tinybird's JSON column re-encodes nested-object array items
+				// as strings; second parse brings them back to TrackDeduction.
+				const rawList = Array.isArray(parsed)
+					? parsed
+					: parsed && Array.isArray(parsed.list)
+						? parsed.list
+						: null;
+				if (rawList) {
+					deductions = rawList.map((item: unknown) =>
+						typeof item === "string"
+							? (JSON.parse(item) as TrackDeduction)
+							: (item as TrackDeduction),
+					);
 				}
-			} catch {
-				// Invalid JSON — leave null so the caller can distinguish missing
-				// vs explicit empty.
-			}
+			} catch {}
 		}
 
 		lastRowMicros = tinybirdTimestampToEpochMicros(row.timestamp);

--- a/server/src/internal/analytics/actions/listByCursor.ts
+++ b/server/src/internal/analytics/actions/listByCursor.ts
@@ -113,11 +113,14 @@ export const listByCursor = async ({
 						? parsed.list
 						: null;
 				if (rawList) {
-					deductions = rawList.map((item: unknown) =>
-						typeof item === "string"
-							? (JSON.parse(item) as TrackDeduction)
-							: (item as TrackDeduction),
-					);
+					deductions = rawList.map((item: unknown) => {
+						if (typeof item !== "string") return item as TrackDeduction;
+						try {
+							return JSON.parse(item) as TrackDeduction;
+						} catch {
+							return item as unknown as TrackDeduction;
+						}
+					});
 				}
 			} catch {}
 		}

--- a/server/src/internal/analytics/actions/listEvents.ts
+++ b/server/src/internal/analytics/actions/listEvents.ts
@@ -91,15 +91,21 @@ export const listEvents = async ({
 		if (row.deductions) {
 			try {
 				const parsed = JSON.parse(row.deductions);
-				if (Array.isArray(parsed)) {
-					deductions = parsed as TrackDeduction[];
-				} else if (parsed && Array.isArray(parsed.list)) {
-					deductions = parsed.list as TrackDeduction[];
+				// Tinybird's JSON column re-encodes nested-object array items
+				// as strings; second parse brings them back to TrackDeduction.
+				const rawList = Array.isArray(parsed)
+					? parsed
+					: parsed && Array.isArray(parsed.list)
+						? parsed.list
+						: null;
+				if (rawList) {
+					deductions = rawList.map((item: unknown) =>
+						typeof item === "string"
+							? (JSON.parse(item) as TrackDeduction)
+							: (item as TrackDeduction),
+					);
 				}
-			} catch {
-				// Invalid JSON — leave null so the caller can distinguish missing
-				// vs explicit empty.
-			}
+			} catch {}
 		}
 
 		return {

--- a/server/src/internal/analytics/actions/listEvents.ts
+++ b/server/src/internal/analytics/actions/listEvents.ts
@@ -99,11 +99,14 @@ export const listEvents = async ({
 						? parsed.list
 						: null;
 				if (rawList) {
-					deductions = rawList.map((item: unknown) =>
-						typeof item === "string"
-							? (JSON.parse(item) as TrackDeduction)
-							: (item as TrackDeduction),
-					);
+					deductions = rawList.map((item: unknown) => {
+						if (typeof item !== "string") return item as TrackDeduction;
+						try {
+							return JSON.parse(item) as TrackDeduction;
+						} catch {
+							return item as unknown as TrackDeduction;
+						}
+					});
 				}
 			} catch {}
 		}

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -14,8 +14,10 @@ import { assertTinybirdAvailable } from "@/external/tinybird/tinybirdUtils.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { getCustomerNames } from "@/internal/analytics/actions/getCustomerNames.js";
 import { getEntityNames } from "@/internal/analytics/actions/getEntityNames.js";
+import { ProductService } from "@/internal/products/ProductService.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { eventActions } from "../actions/eventActions.js";
+import { collapsePlanIdGroups } from "./utils/collapsePlanIdGroups.js";
 
 const STANDARD_INTERVAL_DAYS: Record<string, number> = {
 	"24h": 1,
@@ -129,6 +131,30 @@ export const handleInternalAggregateEvents = createRoute({
 			return { start: aligned.getTime(), end: now.getTime() };
 		})();
 
+		const isPlanIdGrouping = group_by === "plan_id" || group_by === "$plan_id";
+		let internalIdToPublicId: Record<string, string> | undefined;
+		let planNames: Record<string, string> | undefined;
+		let effectiveMaxGroups: number | undefined;
+
+		if (isPlanIdGrouping) {
+			const allProductRows = await ProductService.listCachedAllVersions({
+				db,
+				orgId: org.id,
+				env,
+			});
+			effectiveMaxGroups = Math.max(
+				allProductRows.length + 1,
+				max_groups ?? 0,
+				10,
+			);
+			internalIdToPublicId = {};
+			planNames = {};
+			for (const p of allProductRows) {
+				internalIdToPublicId[p.internal_id] = p.id;
+				planNames[p.id] = p.name ?? p.id;
+			}
+		}
+
 		const [{ formatted: events, truncated }, totals] = await Promise.all([
 			eventActions.aggregate({
 				ctx,
@@ -143,7 +169,7 @@ export const handleInternalAggregateEvents = createRoute({
 					group_by: group_by,
 					customer,
 					timezone: timezone,
-					max_groups,
+					max_groups: isPlanIdGrouping ? effectiveMaxGroups : max_groups,
 				},
 			}),
 			eventActions.getCountAndSum({
@@ -160,6 +186,10 @@ export const handleInternalAggregateEvents = createRoute({
 				},
 			}),
 		]);
+
+		if (isPlanIdGrouping && events?.data && internalIdToPublicId) {
+			collapsePlanIdGroups({ events, internalIdToPublicId });
+		}
 
 		// When grouping by entity_id, resolve entity names from ClickHouse
 		let entityNames: Record<string, string> | undefined;
@@ -214,6 +244,7 @@ export const handleInternalAggregateEvents = createRoute({
 			truncated,
 			entityNames,
 			customerNames,
+			planNames,
 		});
 	},
 });

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -131,7 +131,16 @@ export const handleInternalAggregateEvents = createRoute({
 			return { start: aligned.getTime(), end: now.getTime() };
 		})();
 
-		const isPlanIdGrouping = group_by === "plan_id" || group_by === "$plan_id";
+		let resolvedGroupBy = group_by;
+		if (group_by === "$customer_id") {
+			resolvedGroupBy = "customer_id";
+		} else if (group_by === "$entity_id") {
+			resolvedGroupBy = "entity_id";
+		} else if (group_by === "$plan_id") {
+			resolvedGroupBy = "plan_id";
+		}
+
+		const isPlanIdGrouping = resolvedGroupBy === "plan_id";
 		let internalIdToPublicId: Record<string, string> | undefined;
 		let planNames: Record<string, string> | undefined;
 		let effectiveMaxGroups: number | undefined;
@@ -166,7 +175,7 @@ export const handleInternalAggregateEvents = createRoute({
 					event_names,
 					bin_size: binSize,
 					aggregateAll,
-					group_by: group_by,
+					group_by: resolvedGroupBy,
 					customer,
 					timezone: timezone,
 					max_groups: isPlanIdGrouping ? effectiveMaxGroups : max_groups,
@@ -193,7 +202,7 @@ export const handleInternalAggregateEvents = createRoute({
 
 		// When grouping by entity_id, resolve entity names from ClickHouse
 		let entityNames: Record<string, string> | undefined;
-		if (group_by === "entity_id" && events?.data) {
+		if (resolvedGroupBy === "entity_id" && events?.data) {
 			const entityIds = [
 				...new Set(
 					events.data
@@ -214,7 +223,7 @@ export const handleInternalAggregateEvents = createRoute({
 		}
 
 		let customerNames: Record<string, string> | undefined;
-		if (group_by === "customer_id" && events?.data) {
+		if (resolvedGroupBy === "customer_id" && events?.data) {
 			const customerIds = [
 				...new Set(
 					events.data

--- a/server/src/internal/analytics/internalHandlers/utils/collapsePlanIdGroups.ts
+++ b/server/src/internal/analytics/internalHandlers/utils/collapsePlanIdGroups.ts
@@ -1,0 +1,42 @@
+import { Decimal } from "decimal.js";
+import type { ClickHouseResult } from "@autumn/shared";
+
+export const collapsePlanIdGroups = ({
+	events,
+	internalIdToPublicId,
+}: {
+	events: ClickHouseResult;
+	internalIdToPublicId: Record<string, string>;
+}) => {
+	const collapsed = new Map<string, Record<string, string | number>>();
+
+	for (const row of events.data) {
+		const planId = String(row.plan_id ?? "");
+		const collapsedId =
+			planId === "" || planId === "AUTUMN_RESERVED"
+				? planId
+				: internalIdToPublicId[planId] ?? planId;
+
+		const key = `${row.period}|${collapsedId}`;
+		const existing = collapsed.get(key);
+
+		if (!existing) {
+			collapsed.set(key, {
+				...row,
+				plan_id: collapsedId,
+			});
+			continue;
+		}
+
+		for (const [k, v] of Object.entries(row)) {
+			if (k === "period" || k === "plan_id") continue;
+			existing[k] = new Decimal(existing[k] ?? 0)
+				.plus(new Decimal(v as number))
+				.toDecimalPlaces(10)
+				.toNumber();
+		}
+	}
+
+	events.data = Array.from(collapsed.values());
+	events.rows = events.data.length;
+};

--- a/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
@@ -109,6 +109,7 @@ export const executePostgresDeductionV2 = async ({
 				rollovers,
 				customerEntitlements,
 				unlimitedFeatureIds,
+				unlimitedCusEnt,
 				lock: preparedLock,
 			} = prepareFeatureDeductionV2({
 				ctx,
@@ -128,6 +129,25 @@ export const executePostgresDeductionV2 = async ({
 						overrideLockValue: toDeduct,
 						redisInstance: ctx.redisV2,
 					});
+				}
+				// Attribute the event to the unlimited plan even though we skip
+				// the actual deduction. Without this, resolveInternalProductIdForEvent
+				// gets an empty mutation log and the event lands in "No plan".
+				if (unlimitedCusEnt) {
+					const syntheticDelta = -(toDeduct ?? deduction.deduction ?? 1);
+					if (syntheticDelta !== 0) {
+						allMutationLogs.push({
+							target_type: "customer_entitlement",
+							customer_entitlement_id: unlimitedCusEnt.id,
+							rollover_id: null,
+							entity_id: entityId ?? null,
+							credit_cost: 1,
+							balance_delta: syntheticDelta,
+							adjustment_delta: 0,
+							usage_delta: 0,
+							value_delta: 0,
+						});
+					}
 				}
 				continue;
 			}

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -120,6 +120,7 @@ export const executeRedisDeductionV2 = async ({
 			rollovers,
 			customerEntitlements,
 			unlimitedFeatureIds,
+			unlimitedCusEnt,
 			lock: preparedLock,
 		} = prepareFeatureDeductionV2({
 			ctx,
@@ -139,6 +140,25 @@ export const executeRedisDeductionV2 = async ({
 					overrideLockValue: toDeduct,
 					redisInstance: redisInstance ?? ctx.redisV2,
 				});
+			}
+			// Attribute the event to the unlimited plan even though we skip
+			// the actual deduction. Without this, resolveInternalProductIdForEvent
+			// gets an empty mutation log and the event lands in "No plan".
+			if (unlimitedCusEnt) {
+				const syntheticDelta = -(toDeduct ?? deduction.deduction ?? 1);
+				if (syntheticDelta !== 0) {
+					allMutationLogs.push({
+						target_type: "customer_entitlement",
+						customer_entitlement_id: unlimitedCusEnt.id,
+						rollover_id: null,
+						entity_id: entityId ?? null,
+						credit_cost: 1,
+						balance_delta: syntheticDelta,
+						adjustment_delta: 0,
+						usage_delta: 0,
+						value_delta: 0,
+					});
+				}
 			}
 			continue;
 		}

--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -1,5 +1,7 @@
 import {
+	AllowanceType,
 	cusEntToStartingBalance,
+	type FullCusEntWithFullCusProduct,
 	type FullSubject,
 	fullSubjectToCustomerEntitlements,
 	fullSubjectToOverageAllowedByFeatureId,
@@ -58,6 +60,15 @@ export const prepareFeatureDeductionV2 = ({
 	});
 
 	const unlimitedFeatureIds: string[] = [];
+	// Track the chosen unlimited cusEnt so the deduction short-circuit can
+	// still attribute the event to a plan. Prefer cusEnts whose feature
+	// matches the tracked one (over credit-system parents); within that,
+	// take the first match in the already-sorted customerEntitlements list.
+	let unlimitedCusEntPrimary: FullCusEntWithFullCusProduct | undefined;
+	let unlimitedCusEntFallback: FullCusEntWithFullCusProduct | undefined;
+	const isUnlimitedCusEnt = (ce: FullCusEntWithFullCusProduct): boolean =>
+		ce.entitlement.allowance_type === AllowanceType.Unlimited ||
+		Boolean(ce.unlimited);
 
 	for (const relevantFeature of relevantFeatures) {
 		const { unlimited: featureUnlimited } = getUnlimitedAndUsageAllowed({
@@ -67,8 +78,21 @@ export const prepareFeatureDeductionV2 = ({
 
 		if (featureUnlimited) {
 			unlimitedFeatureIds.push(relevantFeature.id);
+			const matchingCusEnt = customerEntitlements.find(
+				(ce) =>
+					ce.internal_feature_id === relevantFeature.internal_id &&
+					isUnlimitedCusEnt(ce),
+			);
+			if (!matchingCusEnt) continue;
+			if (relevantFeature.id === feature.id) {
+				unlimitedCusEntPrimary ??= matchingCusEnt;
+			} else {
+				unlimitedCusEntFallback ??= matchingCusEnt;
+			}
 		}
 	}
+
+	const unlimitedCusEnt = unlimitedCusEntPrimary ?? unlimitedCusEntFallback;
 
 	const effectiveFeatureIds = relevantFeatures.map((candidate) => candidate.id);
 	const spendLimitByFeatureId = fullSubjectToSpendLimitByFeatureId({
@@ -194,6 +218,7 @@ export const prepareFeatureDeductionV2 = ({
 			credit_cost: rollover.credit_cost,
 		})),
 		unlimitedFeatureIds,
+		unlimitedCusEnt,
 		lock: preparedLock,
 	};
 };

--- a/server/src/internal/balances/utils/types/deductionTypes.ts
+++ b/server/src/internal/balances/utils/types/deductionTypes.ts
@@ -45,6 +45,11 @@ export type PreparedFeatureDeduction = {
 	// rolloverIds: string[];
 	rollovers: RolloverDeduction[];
 	unlimitedFeatureIds: string[];
+	// Chosen unlimited cusEnt to attribute events to when the deduction
+	// short-circuits via unlimitedFeatureIds. Prefers a cusEnt matching the
+	// tracked feature over a credit-system parent. Undefined when no
+	// unlimited cusEnt is present.
+	unlimitedCusEnt?: FullCusEntWithFullCusProduct;
 	lock?: {
 		enabled: true;
 		lock_id?: string;

--- a/server/src/internal/products/ProductService.ts
+++ b/server/src/internal/products/ProductService.ts
@@ -28,7 +28,11 @@ import {
 import { StatusCodes } from "http-status-codes";
 import type { Logger } from "@/external/logtail/logtailUtils";
 import { queryWithCache } from "@/utils/cacheUtils/queryWithCache";
-import { buildProductsCacheKey, PRODUCTS_CACHE_TTL } from "./productCacheUtils";
+import {
+	buildAllVersionsProductsCacheKey,
+	buildProductsCacheKey,
+	PRODUCTS_CACHE_TTL,
+} from "./productCacheUtils";
 import { getLatestProducts, isFreeProduct } from "./productUtils";
 import { sortFullProducts } from "./productUtils/sortProductUtils";
 
@@ -294,6 +298,31 @@ export class ProductService {
 				version ? eq(products.version, version) : undefined,
 			),
 			orderBy: [desc(products.version)],
+		});
+	}
+
+	static async listCachedAllVersions({
+		db,
+		orgId,
+		env,
+	}: {
+		db: DrizzleCli;
+		orgId: string;
+		env: AppEnv;
+	}): Promise<Array<{ internal_id: string; id: string; name: string; version: number }>> {
+		return queryWithCache({
+			key: buildAllVersionsProductsCacheKey({ orgId, env }),
+			ttl: PRODUCTS_CACHE_TTL,
+			fn: () =>
+				db
+					.select({
+						internal_id: products.internal_id,
+						id: products.id,
+						name: products.name,
+						version: products.version,
+					})
+					.from(products)
+					.where(and(eq(products.org_id, orgId), eq(products.env, env))),
 		});
 	}
 

--- a/server/src/internal/products/productCacheUtils.ts
+++ b/server/src/internal/products/productCacheUtils.ts
@@ -57,6 +57,17 @@ export const buildProductsCacheKey = ({
 	return `${prefix}:${hash}`;
 };
 
+/** Builds the cache key for all product versions (unfiltered, no joins) */
+export const buildAllVersionsProductsCacheKey = ({
+	orgId,
+	env,
+}: {
+	orgId: string;
+	env: AppEnv;
+}) => {
+	return `${buildProductsCacheKeyPrefix({ orgId, env })}:all_versions`;
+};
+
 /** All possible archived query param values that can be cached */
 const ARCHIVED_VARIANTS = [undefined, false, true] as const;
 
@@ -71,13 +82,16 @@ export const invalidateProductsCache = async ({
 	if (redis.status !== "ready") return;
 
 	// Build all possible cache keys (deterministic based on archived param variants)
-	const keysToDelete = ARCHIVED_VARIANTS.map((archived) =>
-		buildProductsCacheKey({
-			orgId,
-			env,
-			queryParams: archived !== undefined ? { archived } : undefined,
-		}),
-	);
+	const keysToDelete = [
+		...ARCHIVED_VARIANTS.map((archived) =>
+			buildProductsCacheKey({
+				orgId,
+				env,
+				queryParams: archived !== undefined ? { archived } : undefined,
+			}),
+		),
+		buildAllVersionsProductsCacheKey({ orgId, env }),
+	];
 
 	const regions = getConfiguredRegions();
 

--- a/server/tests/clearMasterOrg.ts
+++ b/server/tests/clearMasterOrg.ts
@@ -12,7 +12,9 @@ import { initDrizzle } from "@/db/initDrizzle.js";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { redis } from "@/external/redis/initRedis.js";
 import { redisV2 } from "@/external/redis/initRedisV2.js";
+import { getSqsClient } from "@/queue/initSqs.js";
 import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
+import { PurgeQueueCommand } from "@aws-sdk/client-sqs";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { clearOrg } from "./utils/setup/clearOrg.js";
 import { setupOrg } from "./utils/setup/setupOrg.js";
@@ -138,6 +140,20 @@ export const clearMasterOrg = async () => {
 				);
 			}
 		}
+		const purgeQueue = async (queueUrl: string | undefined, label: string) => {
+			if (!queueUrl) return;
+			try {
+				const sqs = getSqsClient({ queueUrl });
+				await sqs.send(new PurgeQueueCommand({ QueueUrl: queueUrl }));
+				console.log(chalk.green(`✅ Purged ${label} SQS queue.`));
+			} catch (err) {
+				console.log(chalk.yellow(`⚠️  Skipped ${label} SQS purge: ${err}`));
+			}
+		};
+
+		await purgeQueue(process.env.SQS_QUEUE_URL_V2, "primary");
+		await purgeQueue(process.env.TRACK_SQS_QUEUE_URL, "track");
+
 		console.log(chalk.green("\n✅ Master org setup complete!\n"));
 	} catch (error) {
 		console.error(chalk.red("\n❌ Error:"), error);

--- a/server/tests/integration/crud/events/track-unlimited-cusEnt-attribution.test.ts
+++ b/server/tests/integration/crud/events/track-unlimited-cusEnt-attribution.test.ts
@@ -1,0 +1,204 @@
+/**
+ * TDD test: when a customer has both an unlimited and a limited cusEnt for the
+ * same feature, a track event currently short-circuits in
+ * executePostgresDeductionV2 / executeRedisDeductionV2 (`unlimitedFeatureIds.length > 0`)
+ * with zero mutation logs. resolveInternalProductIdForEvent then returns null,
+ * so the persisted event has `internal_product_id = null` and an empty
+ * `deductions` array — exactly the "No plan" bucket we see in Mintlify's
+ * analytics for Anthropic.
+ *
+ * Red-failure mode (current behavior):
+ *  - event.internal_product_id IS NULL
+ *  - event.deductions IS NULL (or empty)
+ *  - track response `deductions` is empty/undefined
+ *
+ * Green-success criteria (after fix):
+ *  - event.internal_product_id === unlimited plan's internal_id
+ *  - event.deductions contains a synthetic entry pointing at the unlimited
+ *    cusEnt with the track call's value (echoed entity_id when present)
+ *  - track response `deductions` contains the same synthetic entry
+ *  - the limited cusEnt's balance is NOT mutated (we only attribute, never
+ *    actually deduct on the unlimited path)
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type TrackResponseV3,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import {
+	cleanupOrgRollout,
+	setOrgRolloutPercent,
+} from "@tests/utils/rolloutTestUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "@/db/initDrizzle.js";
+import {
+	customerEntitlements,
+	events,
+	products as productsTable,
+} from "@autumn/shared";
+
+const TINYBIRD_INGEST_WAIT_MS = 3000;
+
+test(
+	`${chalk.yellowBright("unlimited-cusent-attribution: track on customer with mixed unlimited+limited entitlements attributes the event to the unlimited plan")}`,
+	async () => {
+		const customerId = `unlimited-cusent-attribution-${Date.now()}`;
+
+		// Base plan: limited messages (100/month).
+		const baseProd = products.base({
+			id: "base-limited",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		// Add-on plan: unlimited messages. Anthropic's analogue is enterprise v1
+		// with allowance_type=unlimited stacked alongside enterprise v2.
+		const unlimitedAddon = products.base({
+			id: "unlimited-addon",
+			items: [items.unlimitedMessages()],
+			isAddOn: true,
+		});
+
+		const { ctx, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [baseProd, unlimitedAddon] }),
+			],
+			actions: [
+				s.attach({ productId: baseProd.id }),
+				s.attach({ productId: unlimitedAddon.id }),
+			],
+		});
+
+		const orgId = ctx.org.id;
+
+		try {
+			// Force V3 path (executeRedisDeductionV2 → resolveInternalProductIdForEvent).
+			await setOrgRolloutPercent({ orgId, percent: 100 });
+
+			// initProductsV0 mutates each product's `id` in-place to suffix it
+			// with productPrefix (defaults to customerId), so `unlimitedAddon.id`
+			// is already the final stored id.
+			const unlimitedPlanId = unlimitedAddon.id;
+			const unlimitedProductRow = await db
+				.select({ internal_id: productsTable.internal_id })
+				.from(productsTable)
+				.where(
+					and(
+						eq(productsTable.org_id, orgId),
+						eq(productsTable.env, ctx.env),
+						eq(productsTable.id, unlimitedPlanId),
+					),
+				)
+				.limit(1);
+			const expectedUnlimitedInternalId =
+				unlimitedProductRow[0]?.internal_id ?? null;
+			expect(expectedUnlimitedInternalId).not.toBeNull();
+
+			// Track usage. Anthropic's calls are AI_CREDITS with value 1..N; we
+			// use value=7 here so the synthetic deduction is unambiguous.
+			const TRACK_VALUE = 7;
+			const trackResponse = (await autumnV2_2.track({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: TRACK_VALUE,
+			})) as TrackResponseV3;
+
+			// ---- Synchronous track response assertions ----------------------
+			// After the fix, the synthetic mutation log flows through
+			// projectMutationLogsToTrackDeductionsV2 → response.deductions.
+			expect(trackResponse.deductions).toBeDefined();
+			expect(trackResponse.deductions ?? []).toHaveLength(1);
+			const responseDeduction = (trackResponse.deductions ?? [])[0];
+			expect(responseDeduction?.feature_id).toBe(TestFeature.Messages);
+			expect(responseDeduction?.plan_id).toBe(unlimitedPlanId);
+			expect(responseDeduction?.value).toBe(TRACK_VALUE);
+
+			// ---- Persisted event assertions ---------------------------------
+			// Wait for the event batch flush (globalEventBatchingManager).
+			await timeout(TINYBIRD_INGEST_WAIT_MS);
+
+			const customer = (await autumnV2_2.customers.get(customerId, {
+				with_autumn_id: true,
+			})) as ApiCustomerV5 & { autumn_id?: string };
+			const internalCustomerId = customer.autumn_id;
+			expect(internalCustomerId).toBeDefined();
+
+			const eventRows = await db
+				.select({
+					id: events.id,
+					event_name: events.event_name,
+					value: events.value,
+					entity_id: events.entity_id,
+					internal_product_id: events.internal_product_id,
+					deductions: events.deductions,
+				})
+				.from(events)
+				.where(
+					and(
+						eq(events.org_id, orgId),
+						eq(events.env, ctx.env),
+						eq(events.internal_customer_id, internalCustomerId as string),
+					),
+				)
+				.orderBy(desc(events.created_at))
+				.limit(5);
+
+			expect(eventRows.length).toBeGreaterThan(0);
+			const latestEvent = eventRows[0];
+
+			// The fix: the event is attributed to the unlimited plan.
+			expect(latestEvent.internal_product_id).toBe(
+				expectedUnlimitedInternalId,
+			);
+
+			// The deductions array on the persisted event mirrors the synthetic
+			// mutation log: one entry with the unlimited plan's id and the
+			// tracked value.
+			expect(latestEvent.deductions).not.toBeNull();
+			expect(latestEvent.deductions ?? []).toHaveLength(1);
+			const persistedDeduction = (latestEvent.deductions ?? [])[0];
+			expect(persistedDeduction?.feature_id).toBe(TestFeature.Messages);
+			expect(persistedDeduction?.plan_id).toBe(unlimitedPlanId);
+			expect(persistedDeduction?.value).toBe(TRACK_VALUE);
+
+			// The track call had no entity_id, so the synthetic mutation log
+			// should echo null and the persisted event row should have entity_id
+			// = null. (See "Echo the track calls entity ID" requirement.)
+			expect(latestEvent.entity_id).toBeNull();
+
+			// ---- Non-mutation invariant -------------------------------------
+			// The synthetic mutation log is in-memory only; no cusEnt row should
+			// be touched. Query both cusEnt balances directly: the limited
+			// one stays at 100 (its starting allowance), and the unlimited one
+			// stays at whatever it started at.
+			const cusEntRows = await db
+				.select({
+					id: customerEntitlements.id,
+					balance: customerEntitlements.balance,
+					unlimited: customerEntitlements.unlimited,
+				})
+				.from(customerEntitlements)
+				.where(
+					eq(
+						customerEntitlements.internal_customer_id,
+						internalCustomerId as string,
+					),
+				);
+			const limitedRow = cusEntRows.find((r) => !r.unlimited);
+			const unlimitedRow = cusEntRows.find((r) => r.unlimited);
+			expect(limitedRow?.balance).toBe(100);
+			expect(unlimitedRow?.unlimited).toBe(true);
+		} finally {
+			await cleanupOrgRollout({ orgId });
+		}
+	},
+	{ timeout: 120_000 },
+);

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { PageContainer } from "@/components/general/PageContainer";
-import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
 import { useEnv } from "@/utils/envUtils";
 import { OnboardingGuide } from "@/views/onboarding4/OnboardingGuide";
@@ -32,6 +31,7 @@ export const AnalyticsView = () => {
 	const [clickHouseDisabled, setClickHouseDisabled] = useState(false);
 	const [hasCleared, setHasCleared] = useState(false);
 	const [groupFilter, setGroupFilter] = useState<string | null>(null);
+	const [planDeselected, setPlanDeselected] = useState<Set<string>>(new Set());
 	const navigate = useNavigate();
 
 	const env = useEnv();
@@ -50,60 +50,10 @@ export const AnalyticsView = () => {
 		truncated,
 		entityNames,
 		customerNames,
+		planNames,
 		totals,
 		eventNames: responseEventNames,
 	} = useAnalyticsData({ hasCleared });
-
-	// Build internal_product_id → display name from the products cache so the
-	// chart can label plan_id groups (backend ships raw internal ids).
-	// `/products/products` only returns the latest version per public id, so
-	// historical versions (e.g. a customer still on v1 after we ship v2) get
-	// merged in from `customer.customer_products`. When the same public id has
-	// multiple versions in scope, suffix with ` v{version}`.
-	const { products } = useProductsQuery({ allVersions: true });
-	const planNames = useMemo(() => {
-		type Entry = {
-			internal_id: string;
-			id: string;
-			name: string;
-			version: number;
-		};
-		const entries: Entry[] = [];
-		const seen = new Set<string>();
-		const push = (e: Partial<Entry> & { internal_id?: string | null }) => {
-			if (!e.internal_id || seen.has(e.internal_id)) return;
-			seen.add(e.internal_id);
-			entries.push({
-				internal_id: e.internal_id,
-				id: e.id ?? e.internal_id,
-				name: e.name ?? e.id ?? e.internal_id,
-				version: e.version ?? 1,
-			});
-		};
-
-		for (const p of products) push(p);
-		for (const cp of customer?.customer_products ?? []) {
-			push({
-				internal_id: cp.product?.internal_id,
-				id: cp.product?.id,
-				name: cp.product?.name,
-				version: cp.product?.version,
-			});
-		}
-
-		// Count public id occurrences so we only suffix when there's ambiguity.
-		const idCount = new Map<string, number>();
-		for (const e of entries) {
-			idCount.set(e.id, (idCount.get(e.id) ?? 0) + 1);
-		}
-
-		const map: Record<string, string> = {};
-		for (const e of entries) {
-			const showVersion = (idCount.get(e.id) ?? 0) >= 2;
-			map[e.internal_id] = showVersion ? `${e.name} v${e.version}` : e.name;
-		}
-		return map;
-	}, [products, customer]);
 
 	// Show toast when data is truncated due to too many unique group values
 	const hasShownTruncationToast = useRef(false);
@@ -119,9 +69,9 @@ export const AnalyticsView = () => {
 		}
 	}, [truncated, groupBy]);
 
-	// Clear the filter when groupBy changes
 	useEffect(() => {
 		setGroupFilter(null);
+		setPlanDeselected(new Set());
 	}, [groupBy]);
 
 	// Extract unique group values from events data for filtering
@@ -165,16 +115,20 @@ export const AnalyticsView = () => {
 			return { chartData: null, chartConfig: null };
 		}
 
-		// Apply frontend filter if a group filter is selected. Use an
-		// explicit null check because empty string is a meaningful filter
-		// value for plan_id ("no plan").
 		let filteredEvents = events;
-		if (groupBy && groupFilter !== null) {
-			// Handle special case for column-based operators (not a property)
+		if (groupBy === "plan_id" && planDeselected.size > 0) {
+			const filteredData = events.data.filter(
+				(row: Record<string, string | number>) =>
+					!planDeselected.has(String(row.plan_id ?? "")),
+			);
+			filteredEvents = {
+				...events,
+				data: filteredData,
+				rows: filteredData.length,
+			};
+		} else if (groupBy && groupBy !== "plan_id" && groupFilter !== null) {
 			const groupByColumn =
-				groupBy === "customer_id" ||
-				groupBy === "entity_id" ||
-				groupBy === "plan_id"
+				groupBy === "customer_id" || groupBy === "entity_id"
 					? groupBy
 					: `properties.${groupBy}`;
 			const filteredData = events.data.filter(
@@ -206,7 +160,7 @@ export const AnalyticsView = () => {
 			});
 
 		return { chartData: transformed, chartConfig: config };
-	}, [events, features, groupBy, groupFilter, entityNames, customerNames, planNames]);
+	}, [events, features, groupBy, groupFilter, planDeselected, entityNames, customerNames, planNames]);
 
 	// Build legend entries (sorted desc, zero-values filtered). The
 	// width-aware overflow logic lives in ChartLegend.
@@ -313,6 +267,8 @@ export const AnalyticsView = () => {
 				propertyKeys,
 				groupFilter,
 				setGroupFilter,
+				planDeselected,
+				setPlanDeselected,
 				availableGroupValues,
 				entityNames,
 				customerNames,
@@ -356,7 +312,7 @@ export const AnalyticsView = () => {
 							</div>
 						)}
 
-						{!chartData && !queryLoading && (
+						{(!chartData || chartData.data.length === 0) && !queryLoading && (
 							<div className="flex-1 px-10 pt-6">
 								<p className="text-t3 text-sm">
 									No events found. Please widen your filters.{" "}

--- a/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
@@ -54,7 +54,13 @@ export const SelectGroupByDropdown = ({
 		});
 	};
 
-	const allPlansSelected = (planDeselected?.size ?? 0) === 0;
+	const activeDeselectedCount = availableGroupValues.reduce(
+		(acc: number, v: string) => acc + (planDeselected?.has(v) ? 1 : 0),
+		0,
+	);
+	const selectedPlanCount =
+		availableGroupValues.length - activeDeselectedCount;
+	const allPlansSelected = activeDeselectedCount === 0;
 	const handlePlanSelectAll = (e: React.MouseEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
@@ -274,8 +280,7 @@ export const SelectGroupByDropdown = ({
 										<span className="text-xs">Filter plans</span>
 										{!allPlansSelected && (
 											<span className="text-xs text-t3 bg-muted px-1 py-0 rounded-md">
-												{availableGroupValues.length -
-													(planDeselected?.size ?? 0)}
+												{selectedPlanCount}
 											</span>
 										)}
 									</DropdownMenuSubTrigger>
@@ -304,10 +309,7 @@ export const SelectGroupByDropdown = ({
 															: (planNames?.[value] ?? value);
 												const isChecked = !planDeselected?.has(value);
 												const wouldDeselectLast =
-													isChecked &&
-													availableGroupValues.length -
-														(planDeselected?.size ?? 0) ===
-														1;
+													isChecked && selectedPlanCount === 1;
 												return (
 													<DropdownMenuItem
 														key={value}

--- a/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
@@ -7,13 +7,16 @@ import { Check } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { IconButton } from "@/components/v2/buttons/IconButton";
+import { Checkbox } from "@/components/v2/checkboxes/Checkbox";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
-	DropdownMenuGroup,
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@/components/v2/dropdowns/DropdownMenu";
 import { cn } from "@/lib/utils";
@@ -34,11 +37,29 @@ export const SelectGroupByDropdown = ({
 	const {
 		groupFilter,
 		setGroupFilter,
+		planDeselected,
+		setPlanDeselected,
 		availableGroupValues,
 		entityNames,
 		customerNames,
 		planNames,
 	} = useAnalyticsContext();
+
+	const togglePlanDeselected = (value: string) => {
+		setPlanDeselected((prev: Set<string>) => {
+			const next = new Set(prev);
+			if (next.has(value)) next.delete(value);
+			else next.add(value);
+			return next;
+		});
+	};
+
+	const allPlansSelected = (planDeselected?.size ?? 0) === 0;
+	const handlePlanSelectAll = (e: React.MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setPlanDeselected(new Set());
+	};
 
 	const currentGroupBy = searchParams.get("group_by") || "";
 	const customerId = searchParams.get("customer_id");
@@ -244,11 +265,82 @@ export const SelectGroupByDropdown = ({
 						</>
 					)}
 
-					{/* Filter section - only shown when a groupBy is selected */}
-					{currentGroupBy && availableGroupValues.length > 0 && (
-						<>
-							<DropdownMenuSeparator />
-							<DropdownMenuGroup>
+					{currentGroupBy === "plan_id" &&
+						availableGroupValues.length > 0 && (
+							<>
+								<DropdownMenuSeparator />
+								<DropdownMenuSub>
+									<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
+										<span className="text-xs">Filter plans</span>
+										{!allPlansSelected && (
+											<span className="text-xs text-t3 bg-muted px-1 py-0 rounded-md">
+												{availableGroupValues.length -
+													(planDeselected?.size ?? 0)}
+											</span>
+										)}
+									</DropdownMenuSubTrigger>
+									<DropdownMenuSubContent className="min-w-56 max-w-none w-max !overflow-x-visible">
+										<div className="flex items-center justify-between px-2 h-6">
+											<button
+												type="button"
+												onClick={handlePlanSelectAll}
+												className={cn(
+													"px-1 h-5 flex items-center gap-1 text-t2 text-xs hover:text-t1 bg-accent cursor-pointer rounded-md",
+													allPlansSelected &&
+														"bg-primary/10 text-primary hover:text-primary/80",
+												)}
+											>
+												Select all
+											</button>
+										</div>
+										<DropdownMenuSeparator />
+										<div className="max-h-64 overflow-y-auto overflow-x-visible">
+											{availableGroupValues.map((value: string) => {
+												const displayValue =
+													value === "AUTUMN_RESERVED"
+														? "Other values"
+														: value === ""
+															? "No plan"
+															: (planNames?.[value] ?? value);
+												const isChecked = !planDeselected?.has(value);
+												const wouldDeselectLast =
+													isChecked &&
+													availableGroupValues.length -
+														(planDeselected?.size ?? 0) ===
+														1;
+												return (
+													<DropdownMenuItem
+														key={value}
+														closeOnClick={false}
+														disabled={wouldDeselectLast}
+														onClick={(e) => {
+															e.preventDefault();
+															if (wouldDeselectLast) return;
+															togglePlanDeselected(value);
+														}}
+														className="flex items-center gap-2 cursor-pointer"
+													>
+														<Checkbox
+															checked={isChecked}
+															className="border-border"
+														/>
+														<span className="text-xs whitespace-nowrap">
+															{displayValue}
+														</span>
+													</DropdownMenuItem>
+												);
+											})}
+										</div>
+									</DropdownMenuSubContent>
+								</DropdownMenuSub>
+							</>
+						)}
+
+					{currentGroupBy &&
+						currentGroupBy !== "plan_id" &&
+						availableGroupValues.length > 0 && (
+							<>
+								<DropdownMenuSeparator />
 								<DropdownMenuLabel className="text-xs text-t4 font-normal">
 									Filter by value
 								</DropdownMenuLabel>
@@ -266,15 +358,11 @@ export const SelectGroupByDropdown = ({
 									const displayValue =
 										value === "AUTUMN_RESERVED"
 											? "Other values"
-											: value === "" && currentGroupBy === "plan_id"
-												? "No plan"
-												: currentGroupBy === "entity_id"
-													? (entityNames?.[value] ?? value)
-													: currentGroupBy === "customer_id"
-														? (customerNames?.[value] ?? value)
-														: currentGroupBy === "plan_id"
-															? (planNames?.[value] ?? value)
-															: value;
+											: currentGroupBy === "entity_id"
+												? (entityNames?.[value] ?? value)
+												: currentGroupBy === "customer_id"
+													? (customerNames?.[value] ?? value)
+													: value;
 									return (
 										<DropdownMenuItem
 											key={value}
@@ -291,9 +379,8 @@ export const SelectGroupByDropdown = ({
 										</DropdownMenuItem>
 									);
 								})}
-							</DropdownMenuGroup>
-						</>
-					)}
+							</>
+						)}
 				</div>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -100,6 +100,7 @@ export const useAnalyticsData = ({
 		truncated: data?.truncated ?? false,
 		entityNames: (data?.entityNames as Record<string, string>) ?? undefined,
 		customerNames: (data?.customerNames as Record<string, string>) ?? undefined,
+		planNames: (data?.planNames as Record<string, string>) ?? undefined,
 		totals:
 			(data?.totals as
 				| Record<string, { count: number; sum: number }>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes track events to unlimited plans and collapse `plan_id` groups by public plan ID in analytics, eliminating the “No plan” bucket and merging plan versions. The API now returns `planNames`, and the UI adds a multi-select plan filter with “Select all” and an accurate selected-count badge.

- **New Features**
  - Attribute track events to the unlimited customer entitlement without changing balances; add a synthetic entry so events carry the plan and `deductions`.
  - Collapse `plan_id` groups server-side to public IDs and merge rows per period; return `planNames` for labels.
  - UI: when grouped by `plan_id`, add a checkbox plan filter with “Select all”; show “No plan” and “Other values” where applicable.

- **Bug Fixes**
  - `deductions` parsing: re-parse Tinybird’s stringified items and preserve valid entries when a single item fails to parse in both `listByCursor` and `listEvents`.
  - Grouping by `plan_id`: normalize the `$plan_id` alias to `plan_id` and auto-raise `max_groups` to reduce truncation after collapsing.
  - Plan filter: derive the selected count from active values and prevent deselecting the last remaining plan.

<sup>Written for commit e2016ca59e8d23e94a6437ec9f293f164f0589a0. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1608?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two distinct analytics gaps: events attributed to customers on unlimited entitlements were landing in a \"No plan\" bucket (fixed by injecting a synthetic in-memory mutation log), and the plan-ID grouping in the analytics API was returning one row per internal product version instead of one row per public plan (fixed by collapsing on the backend using a new `collapsePlanIdGroups` utility). The frontend filter for plan-ID grouping is updated to a multi-select pattern to match the collapsed data.

- **Bug fixes** – `executePostgresDeductionV2` / `executeRedisDeductionV2` now emit a synthetic mutation log when the deduction short-circuits through the unlimited path, so `resolveInternalProductIdForEvent` can correctly attribute the event to a plan rather than returning `null`.
- **Improvements** – `handleInternalAggregateEvents` fetches all product versions, maps `internal_id → public_id`, collapses multi-version groups on the backend, and ships a `planNames` map to the frontend, replacing a heavier client-side `useMemo`.
- **Improvements** – `listByCursor` / `listEvents` add a second-pass JSON parse to handle Tinybird's re-encoding of nested array objects as strings.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge for the Postgres/Redis deduction and frontend changes; the aggregate handler has a routing gap that silently produces wrong plan analytics when group_by equals the dollar-prefixed plan_id form.

The dollar-prefixed plan_id branch of isPlanIdGrouping is recognised but not normalised before being forwarded to aggregate() and collapsePlanIdGroups(). Both functions only handle the literal string plan_id, so any caller sending the public-API prefix form would receive plan analytics where every event is bucketed under the empty/no-plan group. All other changes — the unlimited-cusEnt synthetic log, product cache helpers, and frontend multi-select filter — look correct and are covered by the new integration test.

server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts needs the dollar-prefixed plan_id normalisation before the aggregate call and the isPlanIdGrouping guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts | Adds plan-ID collapse logic; isPlanIdGrouping includes the dollar-prefixed form but aggregate() and collapsePlanIdGroups() only handle plain plan_id, silently producing wrong data if the alternate form is used. |
| server/src/internal/analytics/internalHandlers/utils/collapsePlanIdGroups.ts | New utility that merges aggregated rows sharing the same public plan ID; Decimal coercion of non-numeric fields is unguarded. |
| server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts | Adds synthetic mutation log for unlimited entitlement attribution; log is in-memory only and never persisted to the DB. |
| server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts | Adds unlimitedCusEnt selection with correct primary/fallback chaining. |
| server/src/internal/products/ProductService.ts | Adds listCachedAllVersions() — a thin cached SELECT returning internal_id, id, name, version for all products. |
| server/src/internal/products/productCacheUtils.ts | Adds buildAllVersionsProductsCacheKey and correctly includes it in invalidateProductsCache. |
| server/src/internal/analytics/actions/listByCursor.ts | Adds double-parse for Tinybird re-encoding; a single malformed item now silently nulls the entire deductions array. |
| vite/src/views/customers/customer/analytics/AnalyticsView.tsx | Moves planNames resolution to the backend; switches plan filtering to multi-select with correct memoization deps. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as handleInternalAggregateEvents
    participant PS as ProductService
    participant EA as eventActions.aggregate
    participant Collapse as collapsePlanIdGroups

    Client->>Handler: "GET aggregate (group_by=plan_id)"
    Handler->>PS: listCachedAllVersions(orgId, env)
    PS-->>Handler: "[{internal_id, id, name, version}...]"
    Note over Handler: build internalIdToPublicId + planNames
    Handler->>EA: "aggregate(group_by=plan_id, max_groups=effectiveMaxGroups)"
    EA-->>Handler: ClickHouseResult (rows keyed by internal_id)
    Handler->>Collapse: collapsePlanIdGroups(events, internalIdToPublicId)
    Note over Collapse: merge rows sharing same public_id per period
    Collapse-->>Handler: events.data mutated to public IDs
    Handler-->>Client: "{events, planNames, truncated}"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts:134-172
**`"$plan_id"` silently corrupts plan analytics**

`isPlanIdGrouping` fires for `group_by === "$plan_id"`, but `group_by` is forwarded to `eventActions.aggregate()` unchanged. The `aggregate` function only special-cases `"plan_id"`; `"$plan_id"` falls through to the generic property-lookup path, naming the output column `"$plan_id"` instead of `"plan_id"`. `collapsePlanIdGroups` then reads `row.plan_id` — `undefined` for every row — so every row maps to `collapsedId = ""` and all periods collapse into a single no-plan bucket per period, silently returning garbage analytics data. `handleExternalAggregateEvents` already normalises this — the same strip is needed here before both the `isPlanIdGrouping` check and the `aggregate` call.

### Issue 2 of 3
server/src/internal/analytics/internalHandlers/utils/collapsePlanIdGroups.ts:31-37
When merging a duplicate row into an existing bucket, every non-skipped field is passed to `new Decimal(v as number)`. If a value is a non-numeric string (e.g. from an unexpected column or schema evolution), the `Decimal` constructor throws and the entire request crashes with a 500. A `typeof v !== "number"` guard prevents this.

```suggestion
		for (const [k, v] of Object.entries(row)) {
			if (k === "period" || k === "plan_id") continue;
			if (typeof v !== "number") continue;
			existing[k] = new Decimal(existing[k] ?? 0)
				.plus(new Decimal(v))
				.toDecimalPlaces(10)
				.toNumber();
		}
```

### Issue 3 of 3
server/src/internal/analytics/actions/listByCursor.ts:115-122
**Per-item parse failure silently nulls the entire deductions array**

`JSON.parse(item)` inside the `.map()` is wrapped by the outer `try/catch {}`. If a single string element in `rawList` is malformed JSON, the outer catch fires and leaves `deductions = null` — discarding valid deductions from all other items. Wrapping the inner parse in its own `try/catch` that falls back to the raw item would preserve valid entries. The identical pattern in `listEvents.ts` has the same exposure.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 unlimited decutions + collapse ..."](https://github.com/useautumn/autumn/commit/f9e475ef087e126221bc9bb81635c63698e486c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32675738)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->