### PR TITLE
fix: dashboard customer cache

### DIFF
--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -14,7 +14,10 @@ import {
 } from "@autumn/shared";
 import * as Sentry from "@sentry/bun";
 import type { AutumnContext, RequestContext } from "@/honoUtils/HonoEnv.js";
-import { getOrgCusProductLimit } from "../misc/edgeConfig/orgLimitsStore.js";
+import {
+	getOrgCusProductLimit,
+	getOrgEntitiesLimit,
+} from "../misc/edgeConfig/orgLimitsStore.js";
 import { triggerBatchResetCustomerEntitlements } from "./actions/resetCustomerEntitlements/triggerBatchResetCustomerEntitlements.js";
 import { CusSearchService } from "./CusSearchService.js";
 import { getCursorPaginatedFullCusQuery } from "./cursorPaginatedFullCusQuery.js";
@@ -324,6 +327,10 @@ export class CusBatchService {
 			orgId: ctx.org.id,
 			orgSlug: ctx.org.slug,
 		});
+		const entitiesLimit = getOrgEntitiesLimit({
+			orgId: ctx.org.id,
+			orgSlug: ctx.org.slug,
+		});
 
 		const statusFilters = (filters?.status ?? []).filter(
 			(s): s is DashboardStatusFilter =>
@@ -373,6 +380,9 @@ export class CusBatchService {
 			env: ctx.env,
 			inStatuses: RELEVANT_STATUSES,
 			withSubs: true,
+			withEntities: true,
+			includeInvoices: true,
+			entitiesLimit,
 			limit: internalIds ? internalIds.length : limit,
 			cursor:
 				!requiresResolveStep && cursor
@@ -403,6 +413,8 @@ export class CusBatchService {
 			replaceables: [],
 			free_trials: [],
 			subscriptions: [],
+			entities: [],
+			invoices: [],
 		}) as unknown as FlattenedCustomerRow;
 
 		const allCustomers = reassembleFlattenedCustomer(flat);

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -16,6 +16,10 @@ export type CursorPaginatedFullCusQueryArgs = {
 	env: AppEnv;
 	inStatuses?: CusProductStatus[];
 	withSubs?: boolean;
+	withEntities?: boolean;
+	includeInvoices?: boolean;
+	entitiesLimit?: number;
+	invoicesLimit?: number;
 	limit: number;
 	cursor?: StandardCursorFields;
 	internalCustomerIds?: string[];
@@ -38,6 +42,10 @@ export const getCursorPaginatedFullCusQuery = ({
 	env,
 	inStatuses,
 	withSubs = true,
+	withEntities = false,
+	includeInvoices = false,
+	entitiesLimit = 300,
+	invoicesLimit = 10,
 	limit,
 	cursor,
 	internalCustomerIds,
@@ -85,6 +93,42 @@ export const getCursorPaginatedFullCusQuery = ({
 				) s
 			) AS subscriptions`
 		: sql`'[]'::json AS subscriptions`;
+
+	const entitiesCte = withEntities
+		? sql`, entities_all AS MATERIALIZED (
+				SELECT e.internal_customer_id, row_to_json(e) AS row_json
+				FROM cr
+				JOIN LATERAL (
+					SELECT e.*
+					FROM entities e
+					WHERE e.internal_customer_id = cr.internal_id
+					ORDER BY e.internal_id DESC
+					LIMIT ${entitiesLimit}
+				) e ON true
+			)`
+		: sql``;
+
+	const invoicesCte = includeInvoices
+		? sql`, invoices_all AS MATERIALIZED (
+				SELECT i.internal_customer_id, row_to_json(i) AS row_json
+				FROM cr
+				JOIN LATERAL (
+					SELECT i.*
+					FROM invoices i
+					WHERE i.internal_customer_id = cr.internal_id
+					ORDER BY i.created_at DESC, i.id DESC
+					LIMIT ${invoicesLimit}
+				) i ON true
+			)`
+		: sql``;
+
+	const entitiesSelect = withEntities
+		? sql`, (SELECT COALESCE(json_agg(row_json), '[]'::json) FROM entities_all) AS entities`
+		: sql``;
+
+	const invoicesSelect = includeInvoices
+		? sql`, (SELECT COALESCE(json_agg(row_json), '[]'::json) FROM invoices_all) AS invoices`
+		: sql``;
 
 	return sql`
 		WITH cr AS MATERIALIZED (
@@ -155,6 +199,8 @@ export const getCursorPaginatedFullCusQuery = ({
 			UNION ALL
 			SELECT id, entitlement_id FROM ces_loose
 		)
+		${entitiesCte}
+		${invoicesCte}
 		SELECT
 			(SELECT COALESCE(json_agg(row_json), '[]'::json) FROM cr) AS customers,
 			(SELECT COALESCE(json_agg(row_json), '[]'::json) FROM cps_ranked) AS customer_products,
@@ -184,5 +230,7 @@ export const getCursorPaginatedFullCusQuery = ({
 				JOIN free_trials ft ON ft.id = cps.free_trial_id
 			) AS free_trials,
 			${subscriptionsSelect}
+			${entitiesSelect}
+			${invoicesSelect}
 	`;
 };

--- a/server/src/internal/customers/reassembleFlattenedCustomer/reassembleFlattenedCustomer.ts
+++ b/server/src/internal/customers/reassembleFlattenedCustomer/reassembleFlattenedCustomer.ts
@@ -49,16 +49,41 @@ export const reassembleFlattenedCustomer = (
 		subscriptionByStripeId: maps.subscriptionByStripeId,
 	});
 
+	const entitiesByCusId = groupByInternalCustomerId(flat.entities);
+	const invoicesByCusId = groupByInternalCustomerId(flat.invoices);
+
 	const out: FullCustomer[] = [];
 	for (const c of flat.customers) {
 		const internalId = c.internal_id as string;
-		out.push({
+		const hydrated: Record<string, unknown> = {
 			...c,
 			created_at: toTimestamp(c.created_at),
 			customer_products: cpsByCusId.get(internalId) ?? [],
 			extra_customer_entitlements: looseCesByCusId.get(internalId) ?? [],
 			subscriptions: subsByCusId.get(internalId) ?? [],
-		} as unknown as FullCustomer);
+		};
+		if (flat.entities !== undefined) {
+			hydrated.entities = entitiesByCusId.get(internalId) ?? [];
+		}
+		if (flat.invoices !== undefined) {
+			hydrated.invoices = invoicesByCusId.get(internalId) ?? [];
+		}
+		out.push(hydrated as unknown as FullCustomer);
+	}
+	return out;
+};
+
+const groupByInternalCustomerId = (
+	rows: { internal_customer_id?: string; [k: string]: unknown }[] | undefined,
+): Map<string, unknown[]> => {
+	const out = new Map<string, unknown[]>();
+	if (!rows) return out;
+	for (const row of rows) {
+		const cusId = row.internal_customer_id;
+		if (!cusId) continue;
+		const list = out.get(cusId);
+		if (list) list.push(row);
+		else out.set(cusId, [row]);
 	}
 	return out;
 };

--- a/server/src/internal/customers/reassembleFlattenedCustomer/types.ts
+++ b/server/src/internal/customers/reassembleFlattenedCustomer/types.ts
@@ -9,6 +9,8 @@ export type FlattenedCustomerRow = {
 	replaceables: any[];
 	free_trials: any[];
 	subscriptions: any[];
+	entities?: any[];
+	invoices?: any[];
 };
 
 export type FlatCustomerEntitlement = {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes dashboard customer caching by returning a stable, complete customer payload that includes entities and invoices with sensible limits. Prevents cache churn and missing data in the dashboard.

- **Bug Fixes**
  - Added `withEntities`, `includeInvoices`, `entitiesLimit`, and `invoicesLimit` to the batch customer query; dashboard fetch enables entities and invoices.
  - Capped entity fetches per org via `getOrgEntitiesLimit`.
  - Reassembler now groups and attaches `entities` and `invoices` by `internal_customer_id`.
  - Ensured fallback payloads include empty `entities` and `invoices` arrays for a consistent shape.

<sup>Written for commit 6389dd1b64a90ff8574b21850e0ef62a701fc311. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1612?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the dashboard customer cache to include `entities` and `invoices` alongside the existing customer data fetched in a single batched query.

- **[Bug fixes / Improvements]** Adds two optional LATERAL-join CTEs (`entities_all`, `invoices_all`) to `getCursorPaginatedFullCusQuery`, flat-aggregating all entity and invoice rows into JSON arrays that are then grouped by `internal_customer_id` in `reassembleFlattenedCustomer`; the per-org `entitiesLimit` (from `getOrgEntitiesLimit`) is respected while invoices use a fixed default of 10.
- **[Bug fixes]** `FlattenedCustomerRow` gains optional `entities?` and `invoices?` fields, and the reassembly step only attaches them to the hydrated customer when the fields are present, preserving backward compatibility with callers that omit the new flags.
- **[Improvements]** A new `groupByInternalCustomerId` helper centralises flat-array grouping logic for both entities and invoices.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new LATERAL CTEs follow an established pattern used by subscriptions and customer products, org-scoped filtering is transitively applied through `cr`, and the TypeScript reassembly correctly falls back to empty arrays for customers with no entities or invoices.

The entities and invoices CTEs are additive and do not alter any existing query paths; the optional fields on `FlattenedCustomerRow` maintain backward compatibility; and the flat-then-regroup approach mirrors how subscriptions are already handled elsewhere in this file.

No files require special attention. The main query file (`cursorPaginatedFullCusQuery.ts`) is the most impactful change but the SQL structure is straightforward and consistent with existing CTEs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cursorPaginatedFullCusQuery.ts | Adds optional `withEntities` and `includeInvoices` CTEs using per-customer LATERAL joins; follows the same flat-aggregation pattern as the existing subscriptions/customer_products CTEs. |
| server/src/internal/customers/CusBatchService.ts | Wires `withEntities: true`, `includeInvoices: true`, and `entitiesLimit` (from the org-level config) into `getDashboardCursorPage`; invoices use the hardcoded default of 10. |
| server/src/internal/customers/reassembleFlattenedCustomer/reassembleFlattenedCustomer.ts | Extracts `groupByInternalCustomerId` helper and conditionally attaches `entities`/`invoices` arrays to each customer only when the fields are present in the flat row. |
| server/src/internal/customers/reassembleFlattenedCustomer/types.ts | Makes `entities` and `invoices` optional fields on `FlattenedCustomerRow` to keep backward compatibility with callers that don't request them. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant CusBatchService
    participant DB as PostgreSQL
    participant Reassemble as reassembleFlattenedCustomer

    Client->>CusBatchService: getDashboardCursorPage(ctx, search, filters, cursor, limit)
    CusBatchService->>CusBatchService: getOrgEntitiesLimit(orgId, orgSlug)
    CusBatchService->>DB: "getCursorPaginatedFullCusQuery(withEntities=true, includeInvoices=true, entitiesLimit)"
    Note over DB: WITH cr AS MATERIALIZED (customers)<br/>entities_all (LATERAL, LIMIT entitiesLimit per customer)<br/>invoices_all (LATERAL, LIMIT 10 per customer)<br/>SELECT customers, ..., entities, invoices
    DB-->>CusBatchService: "FlattenedCustomerRow { customers[], ..., entities[], invoices[] }"
    CusBatchService->>Reassemble: reassembleFlattenedCustomer(flat)
    Reassemble->>Reassemble: groupByInternalCustomerId(flat.entities)
    Reassemble->>Reassemble: groupByInternalCustomerId(flat.invoices)
    loop for each customer
        Reassemble->>Reassemble: attach entities and invoices by internalId
    end
    Reassemble-->>CusBatchService: FullCustomer[]
    CusBatchService-->>Client: "{ fullCustomers, next_cursor }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/dashboard-c..."](https://github.com/useautumn/autumn/commit/b12f155f1db6c7e9d7d8047d1a61eba98dbe4542) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32770663)</sub>

<!-- /greptile_comment -->