### PR TITLE
chore: polish analytics chart and table

### DIFF
--- a/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { memo, startTransition, useCallback, useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
 import { useAnalyticsContext } from "./AnalyticsContext";
 import type { Row } from "./components/analytics-types";
 import {
@@ -19,7 +20,35 @@ interface ChartSeriesConfig {
 	fill: string;
 }
 
-export function EventsBarChart({
+const MAX_TOOLTIP_ITEMS = 5;
+const CHART_STYLE = { cursor: "default" } as const;
+const X_TICK = { fontSize: 11, fill: "#666" } as const;
+const Y_TICK = {
+	fontSize: 11,
+	fill: "#666",
+	textAnchor: "middle" as const,
+	dx: -15,
+	dy: -3,
+} as const;
+
+function TooltipItem({ item, label }: { item: any; label: string }) {
+	return (
+		<div className="flex items-center gap-2">
+			<span
+				className="h-2.5 w-2.5 shrink-0 rounded-sm"
+				style={{ background: item.color }}
+			/>
+			<span className="flex-1 truncate text-tertiary-foreground">
+				{label}
+			</span>
+			<span className="tabular-nums text-muted-foreground">
+				{Number(item.value).toLocaleString()}
+			</span>
+		</div>
+	);
+}
+
+export const EventsBarChart = memo(function EventsBarChart({
 	data,
 	chartConfig,
 }: {
@@ -31,14 +60,28 @@ export function EventsBarChart({
 	chartConfig: ChartSeriesConfig[];
 }) {
 	const { selectedInterval } = useAnalyticsContext();
+	const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 
-	const formatXAxis = (value: string): string => {
-		const date = parseUTCTimestamp(value);
-		if (!Number.isFinite(date.getTime())) return value;
-		return selectedInterval === "24h"
-			? formatHourMinute(date)
-			: formatDateShort(date);
-	};
+	const handleBarMouseEnter = useCallback(
+		(dataKey: string) => () =>
+			startTransition(() => setHoveredKey(dataKey)),
+		[],
+	);
+	const handleBarMouseLeave = useCallback(
+		() => startTransition(() => setHoveredKey(null)),
+		[],
+	);
+
+	const formatXAxis = useCallback(
+		(value: string): string => {
+			const date = parseUTCTimestamp(value);
+			if (!Number.isFinite(date.getTime())) return value;
+			return selectedInterval === "24h"
+				? formatHourMinute(date)
+				: formatDateShort(date);
+		},
+		[selectedInterval],
+	);
 
 	const rechartsConfig: ChartConfig = useMemo(() => {
 		const config: ChartConfig = {};
@@ -48,77 +91,113 @@ export function EventsBarChart({
 		return config;
 	}, [chartConfig]);
 
-	return (
-		<ChartContainer config={rechartsConfig} className="h-full w-full">
-			<BarChart data={data.data} className="pt-3 pr-2" barCategoryGap={4}>
-				<CartesianGrid
-					vertical={false}
-					strokeDasharray="2 2"
-					stroke="var(--chart-grid-stroke)"
-					strokeWidth={1}
-				/>
-				<XAxis
-					dataKey="period"
-					tickLine={false}
-					tickMargin={4}
-					axisLine={false}
-					interval="equidistantPreserveStart"
-					tick={{ fontSize: 11, fill: "#666" }}
-					tickFormatter={formatXAxis}
-				/>
-				<YAxis
-					tickLine={false}
-					axisLine={false}
-					width={40}
-					tickMargin={0}
-					tickCount={5}
-					tick={{ fontSize: 11, fill: "#666", textAnchor: "middle", dx: -15, dy: -3 }}
-					tickFormatter={formatCompactNumber}
-				/>
-				<Tooltip
-					content={({ active, payload, label }) => {
-						if (!active || !payload?.length) return null;
-						const sorted = [...payload].sort(
-							(a, b) => (b.value as number) - (a.value as number),
-						);
-						return (
-							<div className="border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl">
-								<div className="font-medium">
-									{formatXAxis(label as string)}
-								</div>
-								<div className="grid gap-1">
-									{sorted.map((item) => {
-										const key = String(item.dataKey);
-										return (
-											<div key={key} className="flex items-center gap-2">
-												<span
-													className="h-2.5 w-2.5 shrink-0 rounded-sm"
-													style={{ background: item.color }}
-												/>
-												<span className="flex-1 truncate text-tertiary-foreground">
-													{rechartsConfig[key]?.label ?? key}
-												</span>
-												<span className="tabular-nums text-muted-foreground">
-													{Number(item.value).toLocaleString()}
-												</span>
-											</div>
-										);
-									})}
-								</div>
+	const tooltipContent = useCallback(
+		({ active, payload, label }: { active?: boolean; payload?: any[]; label?: string | number }) => {
+			if (!active || !payload?.length) return null;
+			const items = hoveredKey
+				? payload.filter((p: any) => String(p.dataKey) === hoveredKey && Number(p.value) !== 0)
+				: [...payload].filter((p: any) => Number(p.value) !== 0).sort((a: any, b: any) => (b.value as number) - (a.value as number));
+			if (!items.length) return null;
+			const visible = items.slice(0, MAX_TOOLTIP_ITEMS);
+			const overflow = items.length - visible.length;
+			const overflowSum = overflow > 0
+				? items.slice(MAX_TOOLTIP_ITEMS).reduce((s: number, p: any) => s + Number(p.value), 0)
+				: 0;
+			return (
+				<div className="bg-popover text-popover-foreground grid min-w-[8rem] items-start gap-1.5 rounded-lg px-2.5 py-1.5 text-xs shadow-md ring-1 ring-foreground/10">
+					<div className="font-medium">{formatXAxis(String(label))}</div>
+					<div className="grid gap-1">
+						{visible.map((item: any) => (
+							<TooltipItem
+								key={String(item.dataKey)}
+								item={item}
+								label={rechartsConfig[String(item.dataKey)]?.label as string ?? String(item.dataKey)}
+							/>
+						))}
+						{overflow > 0 && (
+							<div className="flex items-center gap-2 text-muted-foreground">
+								<span className="h-2.5 w-2.5 shrink-0" />
+								<span className="flex-1">+{overflow} more</span>
+								<span className="tabular-nums">{overflowSum.toLocaleString()}</span>
 							</div>
-						);
-					}}
-				/>
-				{chartConfig.map((series) => (
-					<Bar
-						key={series.yKey}
-						dataKey={series.yKey}
-						stackId="a"
-						fill={series.fill}
-						barSize={20}
-					/>
-				))}
-			</BarChart>
-		</ChartContainer>
+						)}
+					</div>
+				</div>
+			);
+		},
+		[hoveredKey, formatXAxis, rechartsConfig],
 	);
-}
+
+	const barHandlers = useMemo(
+		() =>
+			chartConfig.map((series) => ({
+				onMouseEnter: handleBarMouseEnter(series.yKey),
+				onMouseLeave: handleBarMouseLeave,
+			})),
+		[chartConfig, handleBarMouseEnter, handleBarMouseLeave],
+	);
+
+	return (
+		<div className="h-full w-full">
+			<ChartContainer
+				config={rechartsConfig}
+				className={cn(
+					"h-full w-full",
+					"[&_*:focus]:outline-none",
+					"[&_.recharts-bar-rectangle]:transition-opacity [&_.recharts-bar-rectangle]:duration-150",
+					"[&:has(.recharts-bar-rectangle:hover)_.recharts-bar-rectangle:not(:hover)]:opacity-35",
+				)}
+			>
+				<BarChart
+					data={data.data}
+					className="pt-3 pr-2"
+					barCategoryGap="10%"
+					style={CHART_STYLE}
+					throttleDelay="raf"
+				>
+					<CartesianGrid
+						vertical={false}
+						strokeDasharray="2 2"
+						stroke="var(--chart-grid-stroke)"
+						strokeWidth={1}
+					/>
+					<XAxis
+						dataKey="period"
+						tickLine={false}
+						tickMargin={4}
+						axisLine={false}
+						interval="equidistantPreserveStart"
+						tick={X_TICK}
+						tickFormatter={formatXAxis}
+					/>
+					<YAxis
+						tickLine={false}
+						axisLine={false}
+						width={40}
+						tickMargin={0}
+						tickCount={5}
+						tick={Y_TICK}
+						tickFormatter={formatCompactNumber}
+					/>
+					<Tooltip
+						cursor={false}
+						isAnimationActive={false}
+						content={tooltipContent}
+					/>
+					{chartConfig.map((series, si) => (
+						<Bar
+							key={series.yKey}
+							dataKey={series.yKey}
+							stackId="a"
+							fill={series.fill}
+							activeBar={false}
+							style={CHART_STYLE}
+							onMouseEnter={barHandlers[si].onMouseEnter}
+							onMouseLeave={barHandlers[si].onMouseLeave}
+						/>
+					))}
+				</BarChart>
+			</ChartContainer>
+		</div>
+	);
+});

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -1,6 +1,6 @@
 import { ErrCode } from "@autumn/shared";
 import { ChartBarIcon } from "@phosphor-icons/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { PageContainer } from "@/components/general/PageContainer";
@@ -36,8 +36,6 @@ export const AnalyticsView = () => {
 
 	const env = useEnv();
 	const { flags, isLoading: isFeatureFlagsLoading } = useFeatureFlags();
-
-	const customerId = searchParams.get("customer_id");
 
 	const {
 		customer,
@@ -148,9 +146,17 @@ export const AnalyticsView = () => {
 			groupBy,
 		});
 
-		// Generate chart config with different colors per group
+		const nonEmptyData = transformed.data.filter((row) => {
+			for (const key in row) {
+				if (key === "period") continue;
+				if (Number(row[key]) !== 0) return true;
+			}
+			return false;
+		});
+		const trimmed = { ...transformed, data: nonEmptyData, rows: nonEmptyData.length };
+
 		const config = generateChartConfig({
-				events: transformed,
+				events: trimmed,
 				features,
 				groupBy,
 				originalColors: colors,
@@ -159,7 +165,7 @@ export const AnalyticsView = () => {
 				planNames,
 			});
 
-		return { chartData: transformed, chartConfig: config };
+		return { chartData: trimmed, chartConfig: config };
 	}, [events, features, groupBy, groupFilter, planDeselected, entityNames, customerNames, planNames]);
 
 	// Build legend entries (sorted desc, zero-values filtered). The
@@ -227,6 +233,73 @@ export const AnalyticsView = () => {
 		}
 	}, [error]);
 
+	const selectedInterval = searchParams.get("interval") || "30d";
+	const selectedBinSize = searchParams.get("bin_size") || "day";
+
+	const setSelectedInterval = useCallback(
+		(interval: string) => {
+			const newParams = new URLSearchParams(searchParams);
+			newParams.set("interval", interval);
+			navigate(`${location.pathname}?${newParams.toString()}`);
+		},
+		[searchParams, navigate],
+	);
+
+	const setSelectedBinSize = useCallback(
+		(binSize: string) => {
+			const newParams = new URLSearchParams(searchParams);
+			newParams.set("bin_size", binSize);
+			navigate(`${location.pathname}?${newParams.toString()}`);
+		},
+		[searchParams, navigate],
+	);
+
+	const contextValue = useMemo(
+		() => ({
+			customer,
+			eventNames,
+			selectedInterval,
+			setSelectedInterval,
+			selectedBinSize,
+			setSelectedBinSize,
+			setEventNames,
+			featureIds,
+			setFeatureIds,
+			features,
+			bcExclusionFlag,
+			hasCleared,
+			setHasCleared,
+			propertyKeys,
+			groupFilter,
+			setGroupFilter,
+			planDeselected,
+			setPlanDeselected,
+			availableGroupValues,
+			entityNames,
+			customerNames,
+			planNames,
+		}),
+		[
+			customer,
+			eventNames,
+			selectedInterval,
+			setSelectedInterval,
+			selectedBinSize,
+			setSelectedBinSize,
+			featureIds,
+			features,
+			bcExclusionFlag,
+			hasCleared,
+			propertyKeys,
+			groupFilter,
+			planDeselected,
+			availableGroupValues,
+			entityNames,
+			customerNames,
+			planNames,
+		],
+	);
+
 	if (clickHouseDisabled) {
 		return (
 			<div className="flex flex-col items-center justify-center h-full">
@@ -241,40 +314,7 @@ export const AnalyticsView = () => {
 		!flags.maintenanceModes.analytics.disableRevenueMetrics;
 
 	return (
-		<AnalyticsContext.Provider
-			value={{
-				customer,
-				eventNames,
-				selectedInterval: searchParams.get("interval") || "30d",
-				setSelectedInterval: (interval: string) => {
-					const newParams = new URLSearchParams(searchParams);
-					newParams.set("interval", interval);
-					navigate(`${location.pathname}?${newParams.toString()}`);
-				},
-				selectedBinSize: searchParams.get("bin_size") || "day",
-				setSelectedBinSize: (binSize: string) => {
-					const newParams = new URLSearchParams(searchParams);
-					newParams.set("bin_size", binSize);
-					navigate(`${location.pathname}?${newParams.toString()}`);
-				},
-				setEventNames,
-				featureIds,
-				setFeatureIds,
-				features,
-				bcExclusionFlag,
-				hasCleared,
-				setHasCleared,
-				propertyKeys,
-				groupFilter,
-				setGroupFilter,
-				planDeselected,
-				setPlanDeselected,
-				availableGroupValues,
-				entityNames,
-				customerNames,
-				planNames,
-			}}
-		>
+		<AnalyticsContext.Provider value={contextValue}>
 			<PageContainer className="text-sm">
 				<OnboardingGuide />
 				{showRevenueMetrics && <RevenueMetricsSection />}
@@ -287,55 +327,39 @@ export const AnalyticsView = () => {
 						<QueryTopbar />
 					</div>
 					{queryLoading && (
-						<div className="flex-1">
-							<p className="text-tertiary-foreground text-sm shimmer w-fit">
-								Loading chart {customerId ? `for ${customerId}` : ""}
+						<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1] animate-pulse" />
+					)}
+					{!queryLoading && chartData && chartData.data.length > 0 && (
+						<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1]">
+							<ChartLegend
+								entries={legendEntries}
+								showLabels={!!groupBy || legendEntries.length <= 3}
+							/>
+							<div className="flex-1 min-h-0">
+								<EventsBarChart
+									data={chartData as Parameters<typeof EventsBarChart>[0]["data"]}
+									chartConfig={chartConfig}
+								/>
+							</div>
+						</div>
+					)}
+					{!queryLoading && (!chartData || chartData.data.length === 0) && (
+						<div className="flex-1 px-10 pt-6">
+							<p className="text-tertiary-foreground text-sm">
+								No events found. Please widen your filters.{" "}
+								{eventNames.length === 0
+									? "Try to select some events in the dropdown above."
+									: ""}
 							</p>
 						</div>
 					)}
-
-					<div>
-						{chartData && chartData.data.length > 0 && (
-							<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1]">
-								<ChartLegend
-									entries={legendEntries}
-									showLabels={!!groupBy || legendEntries.length <= 3}
-								/>
-								<div className="flex-1 min-h-0">
-									<EventsBarChart
-										data={
-											chartData as Parameters<typeof EventsBarChart>[0]["data"]
-										}
-										chartConfig={chartConfig}
-									/>
-								</div>
-							</div>
-						)}
-
-						{(!chartData || chartData.data.length === 0) && !queryLoading && (
-							<div className="flex-1 px-10 pt-6">
-								<p className="text-tertiary-foreground text-sm">
-									No events found. Please widen your filters.{" "}
-									{eventNames.length === 0
-										? "Try to select some events in the dropdown above."
-										: ""}
-								</p>
-							</div>
-						)}
-					</div>
 				</div>
 
 				<div className="flex-1 min-h-[400px] pb-8">
-					{rawQueryLoading && (
-						<div className="flex-1">
-							<p className="text-tertiary-foreground text-sm shimmer w-fit">
-								Loading events {customerId ? `for ${customerId}` : ""}
-							</p>
-						</div>
-					)}
-					{rawEvents && !rawQueryLoading && (
-						<EventsTable data={rawEvents.data} />
-					)}
+					<EventsTable
+						data={rawEvents?.data ?? []}
+						isLoading={rawQueryLoading}
+					/>
 				</div>
 			</PageContainer>
 		</AnalyticsContext.Provider>

--- a/vite/src/views/customers/customer/analytics/components/EventsTable.tsx
+++ b/vite/src/views/customers/customer/analytics/components/EventsTable.tsx
@@ -1,7 +1,8 @@
 import { CaretLeftIcon, CaretRightIcon, DatabaseIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { Table } from "@/components/general/table";
 import { IconButton } from "@/components/v2/buttons/IconButton";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
 	Select,
 	SelectContent,
@@ -10,28 +11,59 @@ import {
 	SelectValue,
 } from "@/components/v2/selects/Select";
 import { cn } from "@/lib/utils";
+import type { ColumnDef } from "@tanstack/react-table";
 import type { IRow } from "./analytics-types";
 import { createEventsColumns } from "./EventsColumns";
 import { RowClickDialog } from "./RowClickDialog";
 import { useEventsTable } from "../hooks/useEventsTable";
 
-const PAGE_SIZE_OPTIONS = [100, 500, 1000];
+const PAGE_SIZE_OPTIONS = [100, 500, 1000] as const;
 const columns = createEventsColumns();
 
-export function EventsTable({ data }: { data: IRow[] }) {
+const SKELETON_CELL_WIDTHS = ["w-28", "w-20", "w-8", "w-40"] as const;
+
+const skeletonColumns: ColumnDef<IRow, unknown>[] = columns.map((col, i) => ({
+	...col,
+	cell: () => <Skeleton className={cn("h-3 rounded-sm", SKELETON_CELL_WIDTHS[i])} />,
+}));
+
+const PLACEHOLDER_ROWS: IRow[] = Array.from({ length: 15 }, (_, i) => ({
+	timestamp: "",
+	event_name: "",
+	value: 0,
+	properties: "",
+	idempotency_key: String(i),
+	entity_id: "",
+	customer_id: "",
+}));
+
+export const EventsTable = memo(function EventsTable({
+	data,
+	isLoading = false,
+}: {
+	data: IRow[];
+	isLoading?: boolean;
+}) {
 	const [selectedEvent, setSelectedEvent] = useState<IRow | null>(null);
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
-	const table = useEventsTable({ data, columns });
+
+	const tableData = isLoading ? PLACEHOLDER_ROWS : data;
+	const activeColumns = isLoading ? skeletonColumns : columns;
+	const table = useEventsTable({ data: tableData, columns: activeColumns });
+
 	const { pageIndex, pageSize } = table.getState().pagination;
 	const totalPages = table.getPageCount();
 	const currentPage = pageIndex + 1;
 	const canGoPrev = table.getCanPreviousPage();
 	const canGoNext = table.getCanNextPage();
+	const isDisabled = isLoading;
 
-	const handleRowClick = (row: IRow) => {
-		setSelectedEvent(row);
-		setIsDialogOpen(true);
-	};
+	const handleRowClick = isLoading
+		? undefined
+		: (row: IRow) => {
+				setSelectedEvent(row);
+				setIsDialogOpen(true);
+			};
 
 	return (
 		<>
@@ -47,6 +79,7 @@ export function EventsTable({ data }: { data: IRow[] }) {
 							table.setPageSize(Number(value));
 							table.setPageIndex(0);
 						}}
+						disabled={isDisabled}
 					>
 						<SelectTrigger className="h-7 w-fit px-2 text-xs">
 							<SelectValue />
@@ -64,33 +97,34 @@ export function EventsTable({ data }: { data: IRow[] }) {
 						size="default"
 						icon={<CaretLeftIcon size={12} weight="bold" />}
 						onClick={() => table.previousPage()}
-						disabled={!canGoPrev}
-						className={cn(!canGoPrev && "pointer-events-none opacity-50")}
+						disabled={!canGoPrev || isDisabled}
+						className={cn((!canGoPrev || isDisabled) && "pointer-events-none opacity-50")}
 					/>
 					<span className="text-muted-foreground text-xs font-medium">
-						{currentPage} / {Math.max(totalPages, 1)}
+						{isLoading ? "–" : `${currentPage} / ${Math.max(totalPages, 1)}`}
 					</span>
 					<IconButton
 						variant="secondary"
 						size="default"
 						icon={<CaretRightIcon size={12} weight="bold" />}
 						onClick={() => table.nextPage()}
-						disabled={!canGoNext}
-						className={cn(!canGoNext && "pointer-events-none opacity-50")}
+						disabled={!canGoNext || isDisabled}
+						className={cn((!canGoNext || isDisabled) && "pointer-events-none opacity-50")}
 					/>
 				</div>
 			</div>
 			<Table.Provider
 				config={{
 					table,
-					numberOfColumns: columns.length,
+					numberOfColumns: activeColumns.length,
 					isLoading: false,
-					enableSorting: true,
+					enableSorting: !isLoading,
 					onRowClick: handleRowClick,
-					rowClassName: "h-10",
+					rowClassName: "h-8",
 					flexibleTableColumns: true,
 					virtualization: {
 						containerHeight: "calc(100vh - 700px)",
+						rowHeight: 32,
 					},
 				}}
 			>
@@ -109,4 +143,4 @@ export function EventsTable({ data }: { data: IRow[] }) {
 			)}
 		</>
 	);
-}
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polished the analytics chart and events table for a cleaner UI and smoother loading. Improves chart hover/tooltip behavior, trims empty series from the chart, and adds a skeleton-loading state to the events table.

- **New Features**
  - Chart: hover fade for bars, focused tooltips (filters zeros, caps to 5 items with “+N more”), and cleaner axis ticks.
  - Chart: cursor disabled and transitions for smoother interaction; tooltip respects the hovered series.
  - Table: skeleton rows/columns while loading with controls disabled; row click disabled during load.
  - Table: denser row height and stable virtualization.

- **Refactors**
  - Memoized chart (`memo`) and event handlers (`useCallback`/`startTransition`); `tooltip` content extracted and optimized.
  - Filters out zero-only periods before generating config to reduce noise and legend clutter.
  - `AnalyticsContext` value and URL param setters memoized; replaces text loaders with visual skeletons.
  - Normalized table data handling (`[]` fallback, `isLoading` prop) and simplified rendering paths.

<sup>Written for commit 5fa80412224c297b9c15a4223a4b917f4177317a. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1613?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR polishes the analytics chart and table with performance optimisations and improved loading/hover UX — no functional changes to data fetching or API surface.

- **Improvements** — `EventsBarChart` and `EventsTable` are wrapped in `memo`; context value and navigation callbacks are memoised via `useMemo`/`useCallback`, reducing unnecessary re-renders across the analytics view.
- **Improvements** — Bar chart gains per-bar hover dimming (CSS `:has()`), a capped tooltip (max 5 items + overflow sum), and `raf`-throttled mouse events; events table gains a full skeleton loading state with disabled pagination controls instead of a shimmer text placeholder.
- **Improvements** — All-zero time-bucket rows are now trimmed from chart data before rendering, removing noisy empty periods at the edges of the selected range.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are UI-only with no API or data-model impact.

The trimming of all-zero time buckets from chart data removes periods that fall mid-range, meaning non-contiguous dates can appear adjacent on the X-axis without a visual gap indicator — worth a second look before shipping.

AnalyticsView.tsx — specifically the nonEmptyData filter and how the chart renders periods that may no longer be contiguous in time.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx | Refactored to use memo, added hover-state dimming via CSS :has(), custom memoised tooltip with overflow handling, and raf-throttled mouse events — all clean with no logic issues. |
| vite/src/views/customers/customer/analytics/AnalyticsView.tsx | Context value memoised, callbacks stabilised, loading skeleton added. The new all-zero period filter may produce non-contiguous X-axis time buckets without a gap indicator. |
| vite/src/views/customers/customer/analytics/components/EventsTable.tsx | Adds skeleton loading state with placeholder rows and disabled pagination controls; memo wrap and isLoading prop integration are clean and correct. SKELETON_CELL_WIDTHS aligns exactly with the 4-column definition in EventsColumns.tsx. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers/customer/analytics/AnalyticsView.tsx:149-156
**All-zero period removal can produce non-contiguous X-axis**

Removing every period where all event values are zero before passing data to the bar chart means that recharts renders the remaining periods in contiguous array order. If a zero period sits in the middle of the selected date range (e.g. Jan 1 and Jan 3 with Jan 2 all-zero), the chart will display Jan 1 and Jan 3 side by side as if they are adjacent, with no visible indication of the gap. This could mislead users into thinking there was no activity between those dates rather than a genuine data gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: polish analytics chart and table"](https://github.com/useautumn/autumn/commit/5fa80412224c297b9c15a4223a4b917f4177317a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32783394)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->