### PR TITLE
minor: 🧱 api v2.3; cursor based pagination; docs

### DIFF
--- a/apps/docs/api-reference-generator/billing/attach.mdx
+++ b/apps/docs/api-reference-generator/billing/attach.mdx
@@ -3,9 +3,9 @@ title: "Attach"
 openapi: "openapi POST /v1/billing.attach"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
     The attach endpoint subscribes a customer to a plan. It handles new

--- a/apps/docs/api-reference-generator/billing/billingUpdate.mdx
+++ b/apps/docs/api-reference-generator/billing/billingUpdate.mdx
@@ -3,9 +3,9 @@ title: "Update Subscription"
 openapi: "openapi POST /v1/billing.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   The update endpoint modifies an existing subscription. Use this to change prepaid quantities, cancel subscriptions, or modify plan configuration. For subscribing to a new plan, use [attach](/api-reference/billing/attach) instead.

--- a/apps/docs/api-reference-generator/billing/createSchedule.mdx
+++ b/apps/docs/api-reference-generator/billing/createSchedule.mdx
@@ -3,6 +3,6 @@ title: "Create Schedule"
 openapi: "openapi POST /v1/billing.create_schedule"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";

--- a/apps/docs/api-reference-generator/billing/update.mdx
+++ b/apps/docs/api-reference-generator/billing/update.mdx
@@ -3,9 +3,9 @@ title: "Update Subscription"
 openapi: "openapi POST /v1/billing.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   The update endpoint modifies an existing subscription. Use this to change prepaid quantities, cancel subscriptions, or modify plan configuration. For subscribing to a new plan, use [attach](/api-reference/billing/attach) instead.

--- a/apps/docs/api-reference-generator/core/check.mdx
+++ b/apps/docs/api-reference-generator/core/check.mdx
@@ -3,9 +3,9 @@ title: "Check Permissions"
 openapi: "openapi POST /v1/balances.check"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   Check determines if a customer has access to a feature based on their current balance. Returns `allowed: true` if they have sufficient balance, the feature is unlimited, or it's a boolean feature included in their plan.

--- a/apps/docs/api-reference-generator/core/track.mdx
+++ b/apps/docs/api-reference-generator/core/track.mdx
@@ -3,9 +3,9 @@ title: "Track Usage"
 openapi: "openapi POST /v1/balances.track"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   Track records usage events to decrement a customer's balance. Use this to meter feature consumption like API calls, messages sent, or credits used.

--- a/apps/docs/api-reference-generator/customers/getOrCreateCustomer.mdx
+++ b/apps/docs/api-reference-generator/customers/getOrCreateCustomer.mdx
@@ -3,9 +3,9 @@ title: "Get or Create Customer"
 openapi: "openapi POST /v1/customers.get_or_create"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   If the customer already exists and you try to create it again, you will simply be returned the customer object (rather than an error being thrown).

--- a/apps/docs/api-reference-generator/events/aggregateEvents.mdx
+++ b/apps/docs/api-reference-generator/events/aggregateEvents.mdx
@@ -3,9 +3,9 @@ title: "Aggregate Events"
 openapi: "openapi POST /v1/events.aggregate"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Aggregate usage events by time period. Returns usage totals grouped by feature and optionally by a custom property.
 

--- a/apps/docs/api-reference-generator/plans/createPlan.mdx
+++ b/apps/docs/api-reference-generator/plans/createPlan.mdx
@@ -3,9 +3,9 @@ title: "Create a plan"
 openapi: "openapi POST /v1/plans.create"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Creates a new plan with optional base price and feature configurations. See [How plans work](/documentation/concepts/plans) for concepts and [Adding features to plans](/documentation/concepts/plan-items) for item configuration.
 

--- a/apps/docs/api-reference-generator/plans/deletePlan.mdx
+++ b/apps/docs/api-reference-generator/plans/deletePlan.mdx
@@ -3,9 +3,9 @@ title: "Delete a plan"
 openapi: "openapi POST /v1/plans.delete"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Deletes a plan or a specific version of a plan.
 

--- a/apps/docs/api-reference-generator/plans/getPlan.mdx
+++ b/apps/docs/api-reference-generator/plans/getPlan.mdx
@@ -3,9 +3,9 @@ title: "Get a plan"
 openapi: "openapi POST /v1/plans.get"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Retrieves a single plan by its ID. Returns the latest version by default.
 

--- a/apps/docs/api-reference-generator/plans/listPlans.mdx
+++ b/apps/docs/api-reference-generator/plans/listPlans.mdx
@@ -3,9 +3,9 @@ title: "List all plans"
 openapi: "openapi POST /v1/plans.list"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Lists all plans in the current environment.
 

--- a/apps/docs/api-reference-generator/plans/updatePlan.mdx
+++ b/apps/docs/api-reference-generator/plans/updatePlan.mdx
@@ -3,9 +3,9 @@ title: "Update a plan"
 openapi: "openapi POST /v1/plans.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Updates an existing plan. By default, creates a new version of the plan. See [Adding features to plans](/documentation/concepts/plan-items) for item configuration.
 

--- a/apps/docs/mintlify/api-reference/balances/check.mdx
+++ b/apps/docs/mintlify/api-reference/balances/check.mdx
@@ -3,9 +3,9 @@ title: "Check Permissions"
 openapi: "openapi POST /v1/balances.check"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   Check determines if a customer has access to a feature based on their current balance. Returns `allowed: true` if they have sufficient balance, the feature is unlimited, or it's a boolean feature included in their plan.

--- a/apps/docs/mintlify/api-reference/balances/createBalance.mdx
+++ b/apps/docs/mintlify/api-reference/balances/createBalance.mdx
@@ -3,9 +3,9 @@ title: "Create Balance"
 openapi: "openapi POST /v1/balances.create"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/balances/deleteBalance.mdx
+++ b/apps/docs/mintlify/api-reference/balances/deleteBalance.mdx
@@ -3,9 +3,9 @@ title: "Delete Balance"
 openapi: "openapi POST /v1/balances.delete"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/balances/finalizeLock.mdx
+++ b/apps/docs/mintlify/api-reference/balances/finalizeLock.mdx
@@ -3,9 +3,9 @@ title: "Finalize Lock"
 openapi: "openapi POST /v1/balances.finalize"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/balances/track.mdx
+++ b/apps/docs/mintlify/api-reference/balances/track.mdx
@@ -3,9 +3,9 @@ title: "Track Usage"
 openapi: "openapi POST /v1/balances.track"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   Track records usage events to decrement a customer's balance. Use this to meter feature consumption like API calls, messages sent, or credits used.

--- a/apps/docs/mintlify/api-reference/balances/updateBalance.mdx
+++ b/apps/docs/mintlify/api-reference/balances/updateBalance.mdx
@@ -3,9 +3,9 @@ title: "Update Balance"
 openapi: "openapi POST /v1/balances.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/billing/attach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/attach.mdx
@@ -3,9 +3,9 @@ title: "Attach"
 openapi: "openapi POST /v1/billing.attach"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
     The attach endpoint subscribes a customer to a plan. It handles new

--- a/apps/docs/mintlify/api-reference/billing/billingUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/billingUpdate.mdx
@@ -3,9 +3,9 @@ title: "Update Subscription"
 openapi: "openapi POST /v1/billing.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   The update endpoint modifies an existing subscription. Use this to change prepaid quantities, cancel subscriptions, or modify plan configuration. For subscribing to a new plan, use [attach](/api-reference/billing/attach) instead.

--- a/apps/docs/mintlify/api-reference/billing/createSchedule.mdx
+++ b/apps/docs/mintlify/api-reference/billing/createSchedule.mdx
@@ -3,9 +3,9 @@ title: "Create Schedule"
 openapi: "openapi POST /v1/billing.create_schedule"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/billing/multiAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/multiAttach.mdx
@@ -3,9 +3,9 @@ title: "Multi Attach"
 openapi: "openapi POST /v1/billing.multi_attach"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/billing/openCustomerPortal.mdx
+++ b/apps/docs/mintlify/api-reference/billing/openCustomerPortal.mdx
@@ -3,9 +3,9 @@ title: "Open Customer Portal"
 openapi: "openapi POST /v1/billing.open_customer_portal"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/billing/previewAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewAttach.mdx
@@ -3,9 +3,9 @@ title: "Preview Attach"
 openapi: "openapi POST /v1/billing.preview_attach"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/billing/previewMultiAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewMultiAttach.mdx
@@ -3,9 +3,9 @@ title: "Preview Multi Attach"
 openapi: "openapi POST /v1/billing.preview_multi_attach"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/billing/previewUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewUpdate.mdx
@@ -3,9 +3,9 @@ title: "Preview Update"
 openapi: "openapi POST /v1/billing.preview_update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/billing/setupPayment.mdx
+++ b/apps/docs/mintlify/api-reference/billing/setupPayment.mdx
@@ -3,9 +3,9 @@ title: "Setup Payment"
 openapi: "openapi POST /v1/billing.setup_payment"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/core/check.mdx
+++ b/apps/docs/mintlify/api-reference/core/check.mdx
@@ -3,9 +3,9 @@ title: "Check Permissions"
 openapi: "openapi POST /v1/balances.check"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   Check determines if a customer has access to a feature based on their current balance. Returns `allowed: true` if they have sufficient balance, the feature is unlimited, or it's a boolean feature included in their plan.

--- a/apps/docs/mintlify/api-reference/core/track.mdx
+++ b/apps/docs/mintlify/api-reference/core/track.mdx
@@ -3,9 +3,9 @@ title: "Track Usage"
 openapi: "openapi POST /v1/balances.track"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   Track records usage events to decrement a customer's balance. Use this to meter feature consumption like API calls, messages sent, or credits used.

--- a/apps/docs/mintlify/api-reference/customers/deleteCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/deleteCustomer.mdx
@@ -3,9 +3,9 @@ title: "Delete Customer"
 openapi: "openapi POST /v1/customers.delete"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/customers/getCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/getCustomer.mdx
@@ -3,9 +3,9 @@ title: "Get Customer"
 openapi: "openapi POST /v1/customers.get"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/customers/getOrCreateCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/getOrCreateCustomer.mdx
@@ -3,9 +3,9 @@ title: "Get or Create Customer"
 openapi: "openapi POST /v1/customers.get_or_create"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 <Note>
   If the customer already exists and you try to create it again, you will simply be returned the customer object (rather than an error being thrown).

--- a/apps/docs/mintlify/api-reference/customers/listCustomers.mdx
+++ b/apps/docs/mintlify/api-reference/customers/listCustomers.mdx
@@ -3,18 +3,18 @@ title: "List Customers"
 openapi: "openapi POST /v1/customers.list"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 
-<DynamicParamField body="offset" type="integer">
-  Number of items to skip
+<DynamicParamField body="start_cursor" type="string">
+  Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
 </DynamicParamField>
 
 <DynamicParamField body="limit" type="integer">
-  Number of items to return. Default 10, max 1000.
+  Number of items to return. Default 50, hard ceiling 5000.
 </DynamicParamField>
 
 <DynamicParamField body="plans" type="object[]">
@@ -28,22 +28,22 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
 </DynamicParamField>
 
 <DynamicParamField body="subscription_status" type="'active' | 'scheduled'">
-  Filter by customer product status. Defaults to active and scheduled
+  Filter by customer product status. Defaults to active and scheduled.
 </DynamicParamField>
 
 <DynamicParamField body="search" type="string">
-  Search customers by id, name, or email
+  Search customers by id, name, or email.
 </DynamicParamField>
 
 <DynamicParamField body="processors" type="('stripe' | 'revenuecat' | 'vercel')[]">
-  Filter by customer processor type (stripe, revenuecat, vercel)
+  Filter by customer processor type (stripe, revenuecat, vercel).
 </DynamicParamField>
 
 
 ### Response
 
 <DynamicResponseField name="list" type="object[]">
-  Array of items for current page
+  Items for current page.
   <Expandable title="properties">
     <DynamicResponseField name="id" type="string | null">
       Your unique identifier for the customer.
@@ -1184,28 +1184,8 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
   </Expandable>
 </DynamicResponseField>
 
-<DynamicResponseField name="has_more" type="boolean">
-  Whether more results exist after this page
-</DynamicResponseField>
-
-<DynamicResponseField name="offset" type="number">
-  Current offset position
-</DynamicResponseField>
-
-<DynamicResponseField name="limit" type="number">
-  Limit passed in the request
-</DynamicResponseField>
-
-<DynamicResponseField name="total" type="number">
-  Total number of items returned in the current page
-</DynamicResponseField>
-
-<DynamicResponseField name="total_count" type="number">
-  Total number of customers available in the current organization and environment
-</DynamicResponseField>
-
-<DynamicResponseField name="total_filtered_count" type="number">
-  Total number of customers matching the current filter before pagination is applied
+<DynamicResponseField name="next_cursor" type="string | null">
+  Opaque cursor for the next page. Null when there are no more results.
 </DynamicResponseField>
 
 
@@ -1290,12 +1270,7 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
       }
     }
   ],
-  "has_more": false,
-  "offset": 0,
-  "total": 1,
-  "limit": 10,
-  "total_count": 100,
-  "total_filtered_count": 42
+  "next_cursor": null
 }
 ```
 </ResponseExample>

--- a/apps/docs/mintlify/api-reference/customers/updateCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/updateCustomer.mdx
@@ -3,9 +3,9 @@ title: "Update Customer"
 openapi: "openapi POST /v1/customers.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/entities/createEntity.mdx
+++ b/apps/docs/mintlify/api-reference/entities/createEntity.mdx
@@ -3,9 +3,9 @@ title: "Create Entity"
 openapi: "openapi POST /v1/entities.create"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/entities/deleteEntity.mdx
+++ b/apps/docs/mintlify/api-reference/entities/deleteEntity.mdx
@@ -3,9 +3,9 @@ title: "Delete Entity"
 openapi: "openapi POST /v1/entities.delete"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/entities/getEntity.mdx
+++ b/apps/docs/mintlify/api-reference/entities/getEntity.mdx
@@ -3,9 +3,9 @@ title: "Get Entity"
 openapi: "openapi POST /v1/entities.get"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/entities/listEntities.mdx
+++ b/apps/docs/mintlify/api-reference/entities/listEntities.mdx
@@ -3,18 +3,18 @@ title: "List Entities"
 openapi: "openapi POST /v1/entities.list"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 
-<DynamicParamField body="offset" type="integer">
-  Number of items to skip
+<DynamicParamField body="start_cursor" type="string">
+  Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
 </DynamicParamField>
 
 <DynamicParamField body="limit" type="integer">
-  Number of items to return. Default 10, max 1000.
+  Number of items to return. Default 50, hard ceiling 5000.
 </DynamicParamField>
 
 <DynamicParamField body="plans" type="object[]">
@@ -43,7 +43,7 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
 ### Response
 
 <DynamicResponseField name="list" type="object[]">
-  Array of items for current page
+  Items for current page.
   <Expandable title="properties">
     <DynamicResponseField name="id" type="string | null">
       The unique identifier of the entity
@@ -1112,28 +1112,8 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
   </Expandable>
 </DynamicResponseField>
 
-<DynamicResponseField name="has_more" type="boolean">
-  Whether more results exist after this page
-</DynamicResponseField>
-
-<DynamicResponseField name="offset" type="number">
-  Current offset position
-</DynamicResponseField>
-
-<DynamicResponseField name="limit" type="number">
-  Limit passed in the request
-</DynamicResponseField>
-
-<DynamicResponseField name="total" type="number">
-  Total number of items returned in the current page
-</DynamicResponseField>
-
-<DynamicResponseField name="total_count" type="number">
-  Total number of entities available in the current organization and environment
-</DynamicResponseField>
-
-<DynamicResponseField name="total_filtered_count" type="number">
-  Total number of entities matching the current filter before pagination is applied
+<DynamicResponseField name="next_cursor" type="string | null">
+  Opaque cursor for the next page. Null when there are no more results.
 </DynamicResponseField>
 
 
@@ -1197,12 +1177,7 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
       "invoices": []
     }
   ],
-  "has_more": false,
-  "offset": 0,
-  "total": 1,
-  "limit": 10,
-  "total_count": 100,
-  "total_filtered_count": 42
+  "next_cursor": null
 }
 ```
 </ResponseExample>

--- a/apps/docs/mintlify/api-reference/entities/updateEntity.mdx
+++ b/apps/docs/mintlify/api-reference/entities/updateEntity.mdx
@@ -3,9 +3,9 @@ title: "Update Entity"
 openapi: "openapi POST /v1/entities.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/events/aggregateEvents.mdx
+++ b/apps/docs/mintlify/api-reference/events/aggregateEvents.mdx
@@ -3,9 +3,9 @@ title: "Aggregate Events"
 openapi: "openapi POST /v1/events.aggregate"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Aggregate usage events by time period. Returns usage totals grouped by feature and optionally by a custom property.
 

--- a/apps/docs/mintlify/api-reference/events/listEvents.mdx
+++ b/apps/docs/mintlify/api-reference/events/listEvents.mdx
@@ -3,18 +3,18 @@ title: "List Events"
 openapi: "openapi POST /v1/events.list"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 
-<DynamicParamField body="offset" type="integer">
-  Number of items to skip
+<DynamicParamField body="start_cursor" type="string">
+  Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
 </DynamicParamField>
 
 <DynamicParamField body="limit" type="integer">
-  Number of items to return. Default 100, max 1000.
+  Number of items to return. Default 50, hard ceiling 5000.
 </DynamicParamField>
 
 <DynamicParamField body="customer_id" type="string">
@@ -47,7 +47,7 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
 ### Response
 
 <DynamicResponseField name="list" type="object[]">
-  Array of items for current page
+  Items for current page.
   <Expandable title="properties">
     <DynamicResponseField name="id" type="string">
       Event ID (KSUID)
@@ -116,20 +116,8 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
   </Expandable>
 </DynamicResponseField>
 
-<DynamicResponseField name="has_more" type="boolean">
-  Whether more results exist after this page
-</DynamicResponseField>
-
-<DynamicResponseField name="offset" type="number">
-  Current offset position
-</DynamicResponseField>
-
-<DynamicResponseField name="limit" type="number">
-  Limit passed in the request
-</DynamicResponseField>
-
-<DynamicResponseField name="total" type="number">
-  Total number of items returned in the current page
+<DynamicResponseField name="next_cursor" type="string | null">
+  Opaque cursor for the next page. Null when there are no more results.
 </DynamicResponseField>
 
 
@@ -167,10 +155,7 @@ import { DynamicResponseExample } from "/components/dynamic-response-example.jsx
       "deductions": null
     }
   ],
-  "total": 2,
-  "has_more": false,
-  "offset": 0,
-  "limit": 100
+  "next_cursor": "eyJ2IjowLCJpZCI6ImV2dF8zNnhtSHh4akFrcXh1ZkRmOXlIQVBOZlJyTE0iLCJ0IjoxNzY1OTU2NTEyMDU3fQ"
 }
 ```
 </ResponseExample>

--- a/apps/docs/mintlify/api-reference/features/createFeature.mdx
+++ b/apps/docs/mintlify/api-reference/features/createFeature.mdx
@@ -3,9 +3,9 @@ title: "Create Feature"
 openapi: "openapi POST /v1/features.create"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/features/deleteFeature.mdx
+++ b/apps/docs/mintlify/api-reference/features/deleteFeature.mdx
@@ -3,9 +3,9 @@ title: "Delete Feature"
 openapi: "openapi POST /v1/features.delete"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/features/getFeature.mdx
+++ b/apps/docs/mintlify/api-reference/features/getFeature.mdx
@@ -3,9 +3,9 @@ title: "Get Feature"
 openapi: "openapi POST /v1/features.get"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/features/listFeatures.mdx
+++ b/apps/docs/mintlify/api-reference/features/listFeatures.mdx
@@ -3,9 +3,9 @@ title: "List Features"
 openapi: "openapi POST /v1/features.list"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 
 ### Response

--- a/apps/docs/mintlify/api-reference/features/updateFeature.mdx
+++ b/apps/docs/mintlify/api-reference/features/updateFeature.mdx
@@ -3,9 +3,9 @@ title: "Update Feature"
 openapi: "openapi POST /v1/features.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/plans/createPlan.mdx
+++ b/apps/docs/mintlify/api-reference/plans/createPlan.mdx
@@ -3,9 +3,9 @@ title: "Create a plan"
 openapi: "openapi POST /v1/plans.create"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Creates a new plan with optional base price and feature configurations. See [How plans work](/documentation/concepts/plans) for concepts and [Adding features to plans](/documentation/concepts/plan-items) for item configuration.
 

--- a/apps/docs/mintlify/api-reference/plans/deletePlan.mdx
+++ b/apps/docs/mintlify/api-reference/plans/deletePlan.mdx
@@ -3,9 +3,9 @@ title: "Delete a plan"
 openapi: "openapi POST /v1/plans.delete"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Deletes a plan or a specific version of a plan.
 

--- a/apps/docs/mintlify/api-reference/plans/getPlan.mdx
+++ b/apps/docs/mintlify/api-reference/plans/getPlan.mdx
@@ -3,9 +3,9 @@ title: "Get a plan"
 openapi: "openapi POST /v1/plans.get"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Retrieves a single plan by its ID. Returns the latest version by default.
 

--- a/apps/docs/mintlify/api-reference/plans/listPlans.mdx
+++ b/apps/docs/mintlify/api-reference/plans/listPlans.mdx
@@ -3,9 +3,9 @@ title: "List all plans"
 openapi: "openapi POST /v1/plans.list"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Lists all plans in the current environment.
 

--- a/apps/docs/mintlify/api-reference/plans/updatePlan.mdx
+++ b/apps/docs/mintlify/api-reference/plans/updatePlan.mdx
@@ -3,9 +3,9 @@ title: "Update a plan"
 openapi: "openapi POST /v1/plans.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 Updates an existing plan. By default, creates a new version of the plan. See [Adding features to plans](/documentation/concepts/plan-items) for item configuration.
 

--- a/apps/docs/mintlify/api-reference/referrals/createReferralCode.mdx
+++ b/apps/docs/mintlify/api-reference/referrals/createReferralCode.mdx
@@ -3,9 +3,9 @@ title: "Create Referral Code"
 openapi: "openapi POST /v1/referrals.create_code"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api-reference/referrals/redeemReferralCode.mdx
+++ b/apps/docs/mintlify/api-reference/referrals/redeemReferralCode.mdx
@@ -3,9 +3,9 @@ title: "Redeem Referral Code"
 openapi: "openapi POST /v1/referrals.redeem_code"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api/api-reference/billing/attach.mdx
+++ b/apps/docs/mintlify/api/api-reference/billing/attach.mdx
@@ -3,9 +3,9 @@ title: "Attach"
 openapi: "openapi POST /v1/attach"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api/api-reference/customers/deleteCustomer.mdx
+++ b/apps/docs/mintlify/api/api-reference/customers/deleteCustomer.mdx
@@ -3,9 +3,9 @@ title: "Delete Customer"
 openapi: "openapi POST /v1/customers.delete"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api/api-reference/customers/getOrCreate.mdx
+++ b/apps/docs/mintlify/api/api-reference/customers/getOrCreate.mdx
@@ -3,9 +3,9 @@ title: "Get Or Create"
 openapi: "openapi POST /v1/customers.getOrCreate"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api/api-reference/customers/getOrCreateCustomer.mdx
+++ b/apps/docs/mintlify/api/api-reference/customers/getOrCreateCustomer.mdx
@@ -3,9 +3,9 @@ title: "Get Or Create Customer"
 openapi: "openapi POST /v1/customers.getOrCreate"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api/api-reference/customers/listCustomers.mdx
+++ b/apps/docs/mintlify/api/api-reference/customers/listCustomers.mdx
@@ -3,9 +3,9 @@ title: "List Customers"
 openapi: "openapi POST /v1/customers.list"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api/api-reference/customers/updateCustomer.mdx
+++ b/apps/docs/mintlify/api/api-reference/customers/updateCustomer.mdx
@@ -3,9 +3,9 @@ title: "Update Customer"
 openapi: "openapi POST /v1/customers.update"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 ### Body Parameters
 

--- a/apps/docs/mintlify/api/api-reference/plans/list.mdx
+++ b/apps/docs/mintlify/api/api-reference/plans/list.mdx
@@ -3,9 +3,9 @@ title: "List Plans"
 openapi: "openapi GET /v1/products"
 ---
 
-import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";
+import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
 
 ### Response

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -1,10 +1,10 @@
 info:
   title: Autumn API
-  version: 2.2.0
+  version: 2.3.0
 servers:
   - url: https://api.useautumn.com
     description: Production server
-openapi: 3.1.1
+openapi: 3.1.0
 components:
   schemas:
     CustomerId:
@@ -1875,12 +1875,13 @@ paths:
               example: *a2
       x-speakeasy-name-override: getOrCreate
       parameters:
-        - name: x-api-version
+        - &a5
+          name: x-api-version
           in: header
           required: true
           schema:
             type: string
-            default: 2.2.0
+            default: 2.3.0
           x-speakeasy-globals-hidden: true
       x-codeSamples:
         - lang: typescript
@@ -2733,13 +2734,7 @@ paths:
               example: *a4
       x-speakeasy-name-override: get
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -2762,28 +2757,30 @@ paths:
   /v1/customers.list:
     post:
       operationId: listCustomers
-      description: Lists customers with pagination and optional filters.
+      description: 'Lists customers with cursor pagination and optional filters. Pass
+        `start_cursor: ""` (or omit) for the first page; use `next_cursor` from
+        a prior response for subsequent pages.'
       tags:
         - customers
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
               type: object
               properties:
-                offset:
-                  type: integer
-                  minimum: 0
-                  maximum: 9007199254740991
-                  default: 0
-                  description: Number of items to skip
+                start_cursor:
+                  type: string
+                  default: ""
+                  description: Opaque pagination cursor. Empty string (default) requests the first
+                    page; use next_cursor from a prior response for subsequent
+                    pages.
                 limit:
                   type: integer
                   minimum: 1
-                  maximum: 1000
-                  default: 10
-                  description: Number of items to return. Default 10, max 1000.
+                  maximum: 5000
+                  default: 50
+                  description: Number of items to return. Default 50, hard ceiling 5000.
                 plans:
                   type: array
                   items:
@@ -2804,10 +2801,11 @@ paths:
                     - active
                     - scheduled
                   type: string
-                  description: Filter by customer product status. Defaults to active and scheduled
+                  description: Filter by customer product status. Defaults to active and
+                    scheduled.
                 search:
                   type: string
-                  description: Search customers by id, name, or email
+                  description: Search customers by id, name, or email.
                 processors:
                   type: array
                   items:
@@ -2816,13 +2814,13 @@ paths:
                       - revenuecat
                       - vercel
                     type: string
-                  description: Filter by customer processor type (stripe, revenuecat, vercel)
+                  description: Filter by customer processor type (stripe, revenuecat, vercel).
               title: ListCustomersParams
               examples:
-                - &a5
+                - &a6
+                  start_cursor: ""
                   limit: 10
-                  offset: 0
-            example: *a5
+            example: *a6
       responses:
         "200":
           description: OK
@@ -3397,37 +3395,18 @@ paths:
                               feature_id: advanced_workflows
                           config:
                             disable_pooled_balance: false
-                    description: Array of items for current page
-                  has_more:
-                    type: boolean
-                    description: Whether more results exist after this page
-                  offset:
-                    type: number
-                    description: Current offset position
-                  limit:
-                    type: number
-                    description: Limit passed in the request
-                  total:
-                    type: number
-                    description: Total number of items returned in the current page
-                  total_count:
-                    type: number
-                    description: Total number of customers available in the current organization and
-                      environment
-                  total_filtered_count:
-                    type: number
-                    description: Total number of customers matching the current filter before
-                      pagination is applied
+                    description: Items for current page.
+                  next_cursor:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Opaque cursor for the next page. Null when there are no more
+                      results.
                 required:
                   - list
-                  - has_more
-                  - offset
-                  - limit
-                  - total
-                  - total_count
-                  - total_filtered_count
+                  - next_cursor
                 examples:
-                  - &a6
+                  - &a7
                     list:
                       - id: 2ee25a41-0d81-4ad2-8451-ec1aadaefe58
                         name: Patrick
@@ -3488,22 +3467,11 @@ paths:
                             feature_id: advanced_workflows
                         config:
                           disable_pooled_balance: false
-                    has_more: false
-                    offset: 0
-                    total: 1
-                    limit: 10
-                    total_count: 100
-                    total_filtered_count: 42
-              example: *a6
+                    next_cursor: null
+              example: *a7
       x-speakeasy-name-override: list
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -3512,7 +3480,9 @@ paths:
 
             const autumn = new Autumn()
 
-            const result = await autumn.customers.list({});
+            const result = await autumn.customers.list({
+              limit: 10,
+            });
         - lang: python
           label: Python (SDK)
           source: |-
@@ -3520,9 +3490,7 @@ paths:
 
             autumn = Autumn(secret_key="am_sk_test...")
 
-            res = autumn.customers.list(
-                request={},
-            )
+            res = autumn.customers.list(start_cursor="", limit=10)
   /v1/customers.update:
     post:
       operationId: updateCustomer
@@ -3714,11 +3682,11 @@ paths:
                 - customer_id
               title: UpdateCustomerParams
               examples:
-                - &a7
+                - &a8
                   customer_id: cus_123
                   name: Jane Doe
                   email: jane@example.com
-            example: *a7
+            example: *a8
       responses:
         "200":
           description: OK
@@ -4226,7 +4194,7 @@ paths:
                   - balances
                   - flags
                 examples:
-                  - &a8
+                  - &a9
                     id: 2ee25a41-0d81-4ad2-8451-ec1aadaefe58
                     name: Patrick
                     email: patrick@useautumn.com
@@ -4286,16 +4254,10 @@ paths:
                         feature_id: advanced_workflows
                     config:
                       disable_pooled_balance: false
-              example: *a8
+              example: *a9
       x-speakeasy-name-override: update
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -4346,10 +4308,10 @@ paths:
                 - customer_id
               title: DeleteCustomerParams
               examples:
-                - &a9
+                - &a10
                   customer_id: cus_123
                   delete_in_stripe: false
-            example: *a9
+            example: *a10
       responses:
         "200":
           description: OK
@@ -4364,13 +4326,7 @@ paths:
                   - success
       x-speakeasy-name-override: delete
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -4673,7 +4629,7 @@ paths:
                 - name
               title: CreatePlanParams
               examples:
-                - &a10
+                - &a11
                   plan_id: free_plan
                   name: Free
                   auto_enable: true
@@ -4710,7 +4666,7 @@ paths:
                         interval: month
                         billing_units: 1
                         billing_method: prepaid
-            example: *a10
+            example: *a11
       responses:
         "200":
           description: OK
@@ -5118,7 +5074,7 @@ paths:
                 description: A plan defines a set of features, pricing, and entitlements that
                   can be attached to customers.
                 examples:
-                  - &a11
+                  - &a12
                     id: pro
                     name: Pro Plan
                     description: null
@@ -5165,16 +5121,10 @@ paths:
                     baseVariantId: null
                     config:
                       ignore_past_due: false
-              example: *a11
+              example: *a12
       x-speakeasy-name-override: create
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -5251,11 +5201,11 @@ paths:
                 - plan_id
               title: GetPlanParams
               examples:
-                - &a12
+                - &a13
                   plan_id: pro_plan
                 - plan_id: pro_plan
                   version: 2
-            example: *a12
+            example: *a13
       responses:
         "200":
           description: OK
@@ -5663,7 +5613,7 @@ paths:
                 description: A plan defines a set of features, pricing, and entitlements that
                   can be attached to customers.
                 examples:
-                  - &a13
+                  - &a14
                     id: pro
                     name: Pro Plan
                     description: null
@@ -5710,16 +5660,10 @@ paths:
                     baseVariantId: null
                     config:
                       ignore_past_due: false
-              example: *a13
+              example: *a14
       x-speakeasy-name-override: get
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -5770,10 +5714,10 @@ paths:
                   description: If true, includes archived plans in the response.
               title: ListPlansParams
               examples:
-                - &a14 {}
+                - &a15 {}
                 - customer_id: cus_123
                 - include_archived: true
-            example: *a14
+            example: *a15
       responses:
         "200":
           description: OK
@@ -6191,7 +6135,7 @@ paths:
                 required:
                   - list
                 examples:
-                  - &a15
+                  - &a16
                     list:
                       - id: pro
                         name: Pro Plan
@@ -6239,16 +6183,10 @@ paths:
                         baseVariantId: null
                         config:
                           ignore_past_due: false
-              example: *a15
+              example: *a16
       x-speakeasy-name-override: list
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -6557,7 +6495,7 @@ paths:
                 - plan_id
               title: UpdatePlanParams
               examples:
-                - &a16
+                - &a17
                   plan_id: pro_plan
                   name: Pro Plan (Updated)
                   price:
@@ -6567,7 +6505,7 @@ paths:
                   price: null
                 - plan_id: old_plan
                   archived: true
-            example: *a16
+            example: *a17
       responses:
         "200":
           description: OK
@@ -6975,7 +6913,7 @@ paths:
                 description: A plan defines a set of features, pricing, and entitlements that
                   can be attached to customers.
                 examples:
-                  - &a17
+                  - &a18
                     id: pro
                     name: Pro Plan
                     description: null
@@ -7022,16 +6960,10 @@ paths:
                     baseVariantId: null
                     config:
                       ignore_past_due: false
-              example: *a17
+              example: *a18
       x-speakeasy-name-override: update
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -7098,11 +7030,11 @@ paths:
                 - plan_id
               title: DeletePlanParams
               examples:
-                - &a18
+                - &a19
                   plan_id: unused_plan
                 - plan_id: legacy_plan
                   all_versions: true
-            example: *a18
+            example: *a19
       responses:
         "200":
           description: OK
@@ -7117,13 +7049,7 @@ paths:
                   - success
       x-speakeasy-name-override: delete
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -7223,7 +7149,7 @@ paths:
                 - feature_id
               title: CreateFeatureParams
               examples:
-                - &a19
+                - &a20
                   feature_id: api-calls
                   name: API Calls
                   type: metered
@@ -7237,7 +7163,7 @@ paths:
                       credit_cost: 1
                     - metered_feature_id: image-generations
                       credit_cost: 10
-            example: *a19
+            example: *a20
       responses:
         "200":
           description: OK
@@ -7314,7 +7240,7 @@ paths:
                   - consumable
                   - archived
                 examples:
-                  - &a20
+                  - &a21
                     id: api-calls
                     name: API Calls
                     type: metered
@@ -7323,16 +7249,10 @@ paths:
                     display:
                       singular: API call
                       plural: API calls
-              example: *a20
+              example: *a21
       x-speakeasy-name-override: create
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -7383,9 +7303,9 @@ paths:
                 - feature_id
               title: GetFeatureParams
               examples:
-                - &a21
+                - &a22
                   feature_id: api-calls
-            example: *a21
+            example: *a22
       responses:
         "200":
           description: OK
@@ -7462,7 +7382,7 @@ paths:
                   - consumable
                   - archived
                 examples:
-                  - &a22
+                  - &a23
                     id: api-calls
                     name: API Calls
                     type: metered
@@ -7471,16 +7391,10 @@ paths:
                     display:
                       singular: API call
                       plural: API calls
-              example: *a22
+              example: *a23
       x-speakeasy-name-override: get
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -7594,7 +7508,7 @@ paths:
                 required:
                   - list
                 examples:
-                  - &a23
+                  - &a24
                     list:
                       - id: api-calls
                         name: API Calls
@@ -7617,16 +7531,10 @@ paths:
                         display:
                           singular: credit
                           plural: credits
-              example: *a23
+              example: *a24
       x-speakeasy-name-override: list
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -7728,7 +7636,7 @@ paths:
                 - feature_id
               title: UpdateFeatureParams
               examples:
-                - &a24
+                - &a25
                   feature_id: api-calls
                   name: API Requests
                   display:
@@ -7736,7 +7644,7 @@ paths:
                     plural: API requests
                 - feature_id: old-feature
                   archived: true
-            example: *a24
+            example: *a25
       responses:
         "200":
           description: OK
@@ -7813,7 +7721,7 @@ paths:
                   - consumable
                   - archived
                 examples:
-                  - &a25
+                  - &a26
                     id: api-calls
                     name: API Calls
                     type: metered
@@ -7822,16 +7730,10 @@ paths:
                     display:
                       singular: API call
                       plural: API calls
-              example: *a25
+              example: *a26
       x-speakeasy-name-override: update
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -7888,9 +7790,9 @@ paths:
                 - feature_id
               title: DeleteFeatureParams
               examples:
-                - &a26
+                - &a27
                   feature_id: old-feature
-            example: *a26
+            example: *a27
       responses:
         "200":
           description: OK
@@ -7904,18 +7806,12 @@ paths:
                 required:
                   - success
                 examples:
-                  - &a27
+                  - &a28
                     success: true
-              example: *a27
+              example: *a28
       x-speakeasy-name-override: delete
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -8574,10 +8470,10 @@ paths:
                 - plan_id
               title: AttachParams
               examples:
-                - &a28
+                - &a29
                   customer_id: cus_123
                   plan_id: pro_plan
-            example: *a28
+            example: *a29
       responses:
         "200":
           description: OK
@@ -8651,19 +8547,13 @@ paths:
                   - customer_id
                   - payment_url
                 examples:
-                  - &a29
+                  - &a30
                     customer_id: cus_123
                     payment_url: https://checkout.stripe.com/...
-              example: *a29
+              example: *a30
       x-speakeasy-name-override: attach
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -9250,7 +9140,7 @@ paths:
                 - phases
               title: CreateScheduleParams
               examples:
-                - &a30
+                - &a31
                   customer_id: cus_123
                   phases:
                     - starts_at: 1735689600000
@@ -9259,7 +9149,7 @@ paths:
                     - starts_at: 1736899200000
                       plans:
                         - plan_id: pro_plan
-            example: *a30
+            example: *a31
       responses:
         "200":
           description: OK
@@ -9373,7 +9263,7 @@ paths:
                   - payment_url
                 title: CreateScheduleResponse
                 examples:
-                  - &a31
+                  - &a32
                     customer_id: cus_123
                     entity_id: null
                     status: created
@@ -9389,16 +9279,10 @@ paths:
                           - cus_prod_2222
                     invoice: null
                     payment_url: null
-              example: *a31
+              example: *a32
       x-speakeasy-name-override: createSchedule
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -9904,7 +9788,7 @@ paths:
                 - plans
               title: MultiAttachParams
               examples:
-                - &a32
+                - &a33
                   customer_id: cus_123
                   plans:
                     - plan_id: pro_plan
@@ -9912,7 +9796,7 @@ paths:
                       feature_quantities:
                         - feature_id: seats
                           quantity: 5
-            example: *a32
+            example: *a33
       responses:
         "200":
           description: OK
@@ -9986,7 +9870,7 @@ paths:
                   - customer_id
                   - payment_url
                 examples:
-                  - &a33
+                  - &a34
                     customer_id: cus_123
                     invoice:
                       status: paid
@@ -9995,16 +9879,10 @@ paths:
                       currency: usd
                       hosted_invoice_url: https://invoice.stripe.com/...
                     payment_url: null
-              example: *a33
+              example: *a34
       x-speakeasy-name-override: multiAttach
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -10694,10 +10572,10 @@ paths:
                 - plan_id
               title: PreviewAttachParams
               examples:
-                - &a34
+                - &a35
                   customer_id: cus_123
                   plan_id: pro_plan
-            example: *a34
+            example: *a35
       responses:
         "200":
           description: OK
@@ -11093,7 +10971,7 @@ paths:
                   - redirect_to_checkout
                   - checkout_type
                 examples:
-                  - &a35
+                  - &a36
                     customerId: charles
                     lineItems:
                       - display_name: Pro seed
@@ -11104,16 +10982,10 @@ paths:
                     subtotal: 20
                     total: 20
                     currency: usd
-              example: *a35
+              example: *a36
       x-speakeasy-name-override: previewAttach
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -11584,7 +11456,7 @@ paths:
                 - plans
               title: PreviewMultiAttachParams
               examples:
-                - &a36
+                - &a37
                   customer_id: cus_123
                   plans:
                     - plan_id: pro_plan
@@ -11592,7 +11464,7 @@ paths:
                       feature_quantities:
                         - feature_id: seats
                           quantity: 5
-            example: *a36
+            example: *a37
       responses:
         "200":
           description: OK
@@ -11988,7 +11860,7 @@ paths:
                   - redirect_to_checkout
                   - checkout_type
                 examples:
-                  - &a37
+                  - &a38
                     customerId: charles
                     lineItems:
                       - display_name: Pro seed
@@ -11999,16 +11871,10 @@ paths:
                     subtotal: 20
                     total: 20
                     currency: usd
-              example: *a37
+              example: *a38
       x-speakeasy-name-override: previewMultiAttach
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -12616,13 +12482,13 @@ paths:
                 - customer_id
               title: UpdateSubscriptionParams
               examples:
-                - &a38
+                - &a39
                   customer_id: cus_123
                   plan_id: pro_plan
                   feature_quantities:
                     - feature_id: seats
                       quantity: 10
-            example: *a38
+            example: *a39
       responses:
         "200":
           description: OK
@@ -12696,7 +12562,7 @@ paths:
                   - customer_id
                   - payment_url
                 examples:
-                  - &a39
+                  - &a40
                     customer_id: cus_123
                     invoice:
                       status: paid
@@ -12705,16 +12571,10 @@ paths:
                       currency: usd
                       hosted_invoice_url: https://invoice.stripe.com/...
                     payment_url: null
-              example: *a39
+              example: *a40
       x-speakeasy-name-override: update
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -13308,13 +13168,13 @@ paths:
                 - customer_id
               title: PreviewUpdateParams
               examples:
-                - &a40
+                - &a41
                   customer_id: cus_123
                   plan_id: pro_plan
                   feature_quantities:
                     - feature_id: seats
                       quantity: 15
-            example: *a40
+            example: *a41
       responses:
         "200":
           description: OK
@@ -13706,7 +13566,7 @@ paths:
                   - outgoing
                   - intent
                 examples:
-                  - &a41
+                  - &a42
                     customerId: charles
                     lineItems:
                       - display_name: Pro seed
@@ -13717,16 +13577,10 @@ paths:
                     subtotal: 20
                     total: 20
                     currency: usd
-              example: *a41
+              example: *a42
       x-speakeasy-name-override: previewUpdate
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -13792,10 +13646,10 @@ paths:
                 - customer_id
               title: OpenCustomerPortalParams
               examples:
-                - &a42
+                - &a43
                   customer_id: cus_123
                   return_url: https://useautumn.com
-            example: *a42
+            example: *a43
       responses:
         "200":
           description: OK
@@ -13814,19 +13668,13 @@ paths:
                   - customer_id
                   - url
                 examples:
-                  - &a43
+                  - &a44
                     customer_id: cus_123
                     url: https://billing.stripe.com/session/...
-              example: *a43
+              example: *a44
       x-speakeasy-name-override: openCustomerPortal
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -14437,10 +14285,10 @@ paths:
                 - customer_id
               title: SetupPaymentParams
               examples:
-                - &a44
+                - &a45
                   customer_id: cus_123
                   success_url: https://example.com/account/billing
-            example: *a44
+            example: *a45
       responses:
         "200":
           description: OK
@@ -14464,19 +14312,13 @@ paths:
                   - url
                 title: SetupPaymentResponse
                 examples:
-                  - &a45
+                  - &a46
                     customer_id: cus_123
                     url: https://checkout.stripe.com/...
-              example: *a45
+              example: *a46
       x-speakeasy-name-override: setupPayment
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -14592,13 +14434,13 @@ paths:
                 - feature_id
               title: CreateBalanceParams
               examples:
-                - &a46
+                - &a47
                   customer_id: cus_123
                   feature_id: api_calls
                   included: 1000
                   reset:
                     interval: month
-            example: *a46
+            example: *a47
       responses:
         "200":
           description: OK
@@ -14613,13 +14455,7 @@ paths:
                   - success
       x-speakeasy-name-override: create
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -14716,11 +14552,11 @@ paths:
                 - feature_id
               title: UpdateBalanceParams
               examples:
-                - &a47
+                - &a48
                   customer_id: cus_123
                   feature_id: api_calls
                   remaining: 5
-            example: *a47
+            example: *a48
       responses:
         "200":
           description: OK
@@ -14735,13 +14571,7 @@ paths:
                   - success
       x-speakeasy-name-override: update
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -14818,10 +14648,10 @@ paths:
                 - customer_id
               title: DeleteBalanceParams
               examples:
-                - &a48
+                - &a49
                   customer_id: cus_123
                   feature_id: api_calls
-            example: *a48
+            example: *a49
       responses:
         "200":
           description: OK
@@ -14836,13 +14666,7 @@ paths:
                   - success
       x-speakeasy-name-override: delete
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -14904,7 +14728,7 @@ paths:
                 - action
               title: FinalizeBalanceParams
               examples:
-                - &a49
+                - &a50
                   lock_id: lock_abc123
                   action: confirm
                 - lock_id: lock_abc123
@@ -14912,7 +14736,7 @@ paths:
                   override_value: 3
                 - lock_id: lock_abc123
                   action: release
-            example: *a49
+            example: *a50
       responses:
         "200":
           description: OK
@@ -14939,13 +14763,7 @@ paths:
                   - success
       x-speakeasy-name-override: finalize
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -15040,566 +14858,17 @@ paths:
                 - feature_id
               title: CheckParams
               examples:
-                - &a50
+                - &a51
                   customer_id: cus_123
                   feature_id: messages
                 - customer_id: cus_123
                   feature_id: messages
                   required_balance: 3
                   send_event: true
-            example: *a50
+            example: *a51
       responses:
         "200":
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  allowed:
-                    type: boolean
-                    description: Whether the customer is allowed to use the feature. True if they
-                      have sufficient balance or the feature is
-                      unlimited/boolean.
-                  customer_id:
-                    type: string
-                    description: The ID of the customer that was checked.
-                  entity_id:
-                    anyOf:
-                      - type: string
-                      - type: "null"
-                    description: The ID of the entity, if an entity-scoped check was performed.
-                  required_balance:
-                    type: number
-                    description: The required balance that was checked against.
-                  balance:
-                    anyOf:
-                      - $ref: "#/components/schemas/Balance"
-                      - type: "null"
-                    description: The customer's balance for this feature. Null if the customer has
-                      no balance for this feature.
-                  balances:
-                    type: object
-                    propertyNames:
-                      type: string
-                    additionalProperties:
-                      anyOf:
-                        - $ref: "#/components/schemas/Balance"
-                        - type: "null"
-                    description: Map of feature_id to balance for the checked feature and any
-                      related features (e.g. linked credit systems).
-                  flag:
-                    anyOf:
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            description: The unique identifier for this flag.
-                          plan_id:
-                            anyOf:
-                              - type: string
-                              - type: "null"
-                            description: The plan ID this flag originates from, or null for standalone
-                              flags.
-                          expires_at:
-                            anyOf:
-                              - type: number
-                              - type: "null"
-                            description: Timestamp when this flag expires, or null for no expiration.
-                          feature_id:
-                            type: string
-                            description: The feature ID this flag is for.
-                          feature:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                                description: The unique identifier for this feature, used in /check and /track
-                                  calls.
-                              name:
-                                type: string
-                                description: Human-readable name displayed in the dashboard and billing UI.
-                              type:
-                                enum:
-                                  - boolean
-                                  - metered
-                                  - credit_system
-                                type: string
-                                description: "Feature type: 'boolean' for on/off access, 'metered' for
-                                  usage-tracked features, 'credit_system' for
-                                  unified credit pools."
-                              consumable:
-                                type: boolean
-                                description: "For metered features: true if usage resets periodically (API
-                                  calls, credits), false if allocated
-                                  persistently (seats, storage)."
-                              event_names:
-                                type: array
-                                items:
-                                  type: string
-                                description: Event names that trigger this feature's balance. Allows multiple
-                                  features to respond to a single event.
-                              credit_schema:
-                                type: array
-                                items:
-                                  type: object
-                                  properties:
-                                    metered_feature_id:
-                                      type: string
-                                      description: ID of the metered feature that draws from this credit system.
-                                    credit_cost:
-                                      type: number
-                                      description: Credits consumed per unit of the metered feature.
-                                  required:
-                                    - metered_feature_id
-                                    - credit_cost
-                                description: "For credit_system features: maps metered features to their credit
-                                  costs."
-                              display:
-                                type: object
-                                properties:
-                                  singular:
-                                    anyOf:
-                                      - type: string
-                                      - type: "null"
-                                    description: Singular form for UI display (e.g., 'API call', 'seat').
-                                  plural:
-                                    anyOf:
-                                      - type: string
-                                      - type: "null"
-                                    description: Plural form for UI display (e.g., 'API calls', 'seats').
-                                description: Display names for the feature in billing UI and customer-facing
-                                  components.
-                              archived:
-                                type: boolean
-                                description: Whether the feature is archived and hidden from the dashboard.
-                            required:
-                              - id
-                              - name
-                              - type
-                              - consumable
-                              - archived
-                            description: The full feature object if expanded.
-                        required:
-                          - id
-                          - plan_id
-                          - expires_at
-                          - feature_id
-                        examples:
-                          - id: cus_ent_39qmLooixXLAqMywgXywjAz96rV
-                            plan_id: pro_plan
-                            expires_at: null
-                            feature_id: dashboard
-                      - type: "null"
-                    description: The flag associated with this check, if any.
-                  preview:
-                    type: object
-                    properties:
-                      scenario:
-                        enum:
-                          - usage_limit
-                          - feature_flag
-                        type: string
-                        description: The reason access was denied. 'usage_limit' means the customer
-                          exceeded their balance, 'feature_flag' means the
-                          feature is not included in their plan.
-                      title:
-                        type: string
-                        description: A title suitable for displaying in a paywall or upgrade modal.
-                      message:
-                        type: string
-                        description: A message explaining why access was denied.
-                      feature_id:
-                        type: string
-                        description: The ID of the feature that was checked.
-                      feature_name:
-                        type: string
-                        description: The display name of the feature.
-                      products:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: The ID of the product you set when creating the product
-                            name:
-                              type: string
-                              description: The name of the product
-                            group:
-                              anyOf:
-                                - type: string
-                                - type: "null"
-                              description: Product group which this product belongs to
-                            env:
-                              enum:
-                                - sandbox
-                                - live
-                              type: string
-                              description: The environment of the product
-                            is_add_on:
-                              type: boolean
-                              description: Whether the product is an add-on and can be purchased alongside
-                                other products
-                            is_default:
-                              type: boolean
-                              description: Whether the product is the default product
-                            archived:
-                              type: boolean
-                              description: Whether this product has been archived and is no longer available
-                            version:
-                              type: number
-                              description: The current version of the product
-                            created_at:
-                              type: number
-                              description: The timestamp of when the product was created in milliseconds since
-                                epoch
-                            items:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  type:
-                                    anyOf:
-                                      - enum:
-                                          - feature
-                                          - priced_feature
-                                          - price
-                                        type: string
-                                      - type: "null"
-                                    description: The type of the product item
-                                  feature_id:
-                                    anyOf:
-                                      - type: string
-                                      - type: "null"
-                                    description: The feature ID of the product item. If the item is a fixed price,
-                                      should be `null`
-                                  feature_type:
-                                    anyOf:
-                                      - enum:
-                                          - single_use
-                                          - continuous_use
-                                          - boolean
-                                          - static
-                                        type: string
-                                      - type: "null"
-                                    description: Single use features are used once and then depleted, like API calls
-                                      or credits. Continuous use features are
-                                      those being used on an ongoing-basis, like
-                                      storage or seats.
-                                  included_usage:
-                                    anyOf:
-                                      - anyOf:
-                                          - type: number
-                                          - const: inf
-                                      - type: "null"
-                                    description: The amount of usage included for this feature.
-                                  interval:
-                                    anyOf:
-                                      - enum:
-                                          - minute
-                                          - hour
-                                          - day
-                                          - week
-                                          - month
-                                          - quarter
-                                          - semi_annual
-                                          - year
-                                        type: string
-                                      - type: "null"
-                                    description: The reset or billing interval of the product item. If null, feature
-                                      will have no reset date, and if there's a
-                                      price, it will be billed one-off.
-                                  interval_count:
-                                    anyOf:
-                                      - type: number
-                                      - type: "null"
-                                    description: The interval count of the product item.
-                                  price:
-                                    anyOf:
-                                      - type: number
-                                      - type: "null"
-                                    description: The price of the product item. Should be `null` if tiered pricing
-                                      is set.
-                                  tiers:
-                                    anyOf:
-                                      - type: array
-                                        items:
-                                          anyOf:
-                                            - {}
-                                            - type: "null"
-                                      - type: "null"
-                                    description: Tiered pricing for the product item. Not applicable for fixed price
-                                      items.
-                                  tier_behavior:
-                                    anyOf:
-                                      - enum:
-                                          - graduated
-                                          - volume
-                                        type: string
-                                      - type: "null"
-                                    description: "How tiers are applied: graduated (split across bands) or volume
-                                      (flat rate for the matched tier). Defaults
-                                      to graduated."
-                                  usage_model:
-                                    anyOf:
-                                      - enum:
-                                          - prepaid
-                                          - pay_per_use
-                                        type: string
-                                      - type: "null"
-                                    description: Whether the feature should be prepaid upfront or billed for how
-                                      much they use end of billing period.
-                                  billing_units:
-                                    anyOf:
-                                      - type: number
-                                      - type: "null"
-                                    description: The amount per billing unit (eg. $9 / 250 units)
-                                  reset_usage_when_enabled:
-                                    anyOf:
-                                      - type: boolean
-                                      - type: "null"
-                                    description: Whether the usage should be reset when the product is enabled.
-                                  entity_feature_id:
-                                    anyOf:
-                                      - type: string
-                                      - type: "null"
-                                    description: The entity feature ID of the product item if applicable.
-                                  display:
-                                    anyOf:
-                                      - type: object
-                                        properties:
-                                          primary_text:
-                                            type: string
-                                          secondary_text:
-                                            anyOf:
-                                              - type: string
-                                              - type: "null"
-                                        required:
-                                          - primary_text
-                                      - type: "null"
-                                    description: The display of the product item.
-                                  quantity:
-                                    anyOf:
-                                      - type: number
-                                      - type: "null"
-                                    description: Used in customer context. Quantity of the feature the customer has
-                                      prepaid for.
-                                  next_cycle_quantity:
-                                    anyOf:
-                                      - type: number
-                                      - type: "null"
-                                    description: Used in customer context. Quantity of the feature the customer will
-                                      prepay for in the next cycle.
-                                  config:
-                                    anyOf:
-                                      - type: object
-                                        properties:
-                                          rollover:
-                                            anyOf:
-                                              - type: object
-                                                properties:
-                                                  max:
-                                                    anyOf:
-                                                      - type: number
-                                                      - type: "null"
-                                                  max_percentage:
-                                                    anyOf:
-                                                      - type: number
-                                                      - type: "null"
-                                                  duration:
-                                                    enum:
-                                                      - month
-                                                      - forever
-                                                    type: string
-                                                    default: month
-                                                  length:
-                                                    type: number
-                                                required:
-                                                  - length
-                                              - type: "null"
-                                          on_increase:
-                                            anyOf:
-                                              - enum:
-                                                  - bill_immediately
-                                                  - prorate_immediately
-                                                  - prorate_next_cycle
-                                                  - bill_next_cycle
-                                                type: string
-                                              - type: "null"
-                                          on_decrease:
-                                            anyOf:
-                                              - enum:
-                                                  - prorate
-                                                  - prorate_immediately
-                                                  - prorate_next_cycle
-                                                  - none
-                                                  - no_prorations
-                                                type: string
-                                              - type: "null"
-                                      - type: "null"
-                                    description: Configuration for rollover and proration behavior of the feature.
-                                description: Product item defining features and pricing within a product
-                              description: Array of product items that define the product's features and
-                                pricing
-                            free_trial:
-                              anyOf:
-                                - type: object
-                                  properties:
-                                    duration:
-                                      enum:
-                                        - day
-                                        - month
-                                        - year
-                                      type: string
-                                      description: The duration type of the free trial
-                                    length:
-                                      type: number
-                                      description: The length of the duration type specified
-                                    unique_fingerprint:
-                                      type: boolean
-                                      description: Whether the free trial is limited to one per customer fingerprint
-                                    card_required:
-                                      type: boolean
-                                      description: Whether the free trial requires a card. If false, the customer can
-                                        attach the product without going through
-                                        a checkout flow or having a card on
-                                        file.
-                                    on_end:
-                                      anyOf:
-                                        - enum:
-                                            - bill
-                                            - revert
-                                          type: string
-                                        - type: "null"
-                                      description: Behavior when the trial ends. 'bill' charges the customer
-                                        (default). 'revert' expires the trial
-                                        and restores the customer's previous
-                                        plan.
-                                    trial_available:
-                                      anyOf:
-                                        - type: boolean
-                                          default: true
-                                        - type: "null"
-                                      description: Used in customer context. Whether the free trial is available for
-                                        the customer if they were to attach the
-                                        product.
-                                  required:
-                                    - duration
-                                    - length
-                                    - unique_fingerprint
-                                    - card_required
-                                - type: "null"
-                              description: Free trial configuration for this product, if available
-                            base_variant_id:
-                              anyOf:
-                                - type: string
-                                - type: "null"
-                              description: ID of the base variant this product is derived from
-                            scenario:
-                              enum:
-                                - scheduled
-                                - active
-                                - new
-                                - renew
-                                - upgrade
-                                - update_prepaid_quantity
-                                - downgrade
-                                - cancel
-                                - expired
-                                - past_due
-                              type: string
-                              description: Scenario for when this product is used in attach flows
-                            properties:
-                              type: object
-                              properties:
-                                is_free:
-                                  type: boolean
-                                  description: True if the product has no base price or usage prices
-                                is_one_off:
-                                  type: boolean
-                                  description: True if the product only contains a one-time price
-                                interval_group:
-                                  anyOf:
-                                    - type: string
-                                    - type: "null"
-                                  description: The billing interval group for recurring products (e.g., 'monthly',
-                                    'yearly')
-                                has_trial:
-                                  anyOf:
-                                    - type: boolean
-                                    - type: "null"
-                                  description: True if the product includes a free trial
-                                updateable:
-                                  anyOf:
-                                    - type: boolean
-                                    - type: "null"
-                                  description: True if the product can be updated after creation (only applicable
-                                    if there are prepaid recurring prices)
-                              required:
-                                - is_free
-                                - is_one_off
-                          required:
-                            - id
-                            - name
-                            - group
-                            - env
-                            - is_add_on
-                            - is_default
-                            - archived
-                            - version
-                            - created_at
-                            - items
-                            - free_trial
-                            - base_variant_id
-                        description: Products that would grant access to this feature. Use to display
-                          upgrade options.
-                    required:
-                      - scenario
-                      - title
-                      - message
-                      - feature_id
-                      - feature_name
-                      - products
-                    description: Upgrade/upsell information when access is denied. Only present if
-                      with_preview was true and allowed is false.
-                required:
-                  - allowed
-                  - customer_id
-                  - balance
-                  - flag
-                examples:
-                  - &a51
-                    allowed: true
-                    customer_id: cus_123
-                    entity_id: null
-                    required_balance: 1
-                    balance:
-                      feature_id: messages
-                      granted: 100
-                      remaining: 72
-                      usage: 28
-                      unlimited: false
-                      overage_allowed: false
-                      max_purchase: null
-                      next_reset_at: 1773851121437
-                      breakdown:
-                        - id: cus_ent_39qmLooixXLAqMywgXywjAz96rV
-                          plan_id: pro_plan
-                          included_grant: 100
-                          prepaid_grant: 0
-                          remaining: 72
-                          usage: 28
-                          unlimited: false
-                          reset:
-                            interval: month
-                            resets_at: 1773851121437
-                          price: null
-                          expires_at: null
-              example: *a51
-        "202":
-          description: Accepted. Autumn is experiencing degraded service from a downstream
-            provider, so access was allowed fail-open.
           content:
             application/json:
               schema:
@@ -16146,15 +15415,558 @@ paths:
                           price: null
                           expires_at: null
               example: *a52
+        "202":
+          description: Accepted. Autumn is experiencing degraded service from a downstream
+            provider, so access was allowed fail-open.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  allowed:
+                    type: boolean
+                    description: Whether the customer is allowed to use the feature. True if they
+                      have sufficient balance or the feature is
+                      unlimited/boolean.
+                  customer_id:
+                    type: string
+                    description: The ID of the customer that was checked.
+                  entity_id:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: The ID of the entity, if an entity-scoped check was performed.
+                  required_balance:
+                    type: number
+                    description: The required balance that was checked against.
+                  balance:
+                    anyOf:
+                      - $ref: "#/components/schemas/Balance"
+                      - type: "null"
+                    description: The customer's balance for this feature. Null if the customer has
+                      no balance for this feature.
+                  balances:
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      anyOf:
+                        - $ref: "#/components/schemas/Balance"
+                        - type: "null"
+                    description: Map of feature_id to balance for the checked feature and any
+                      related features (e.g. linked credit systems).
+                  flag:
+                    anyOf:
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                            description: The unique identifier for this flag.
+                          plan_id:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                            description: The plan ID this flag originates from, or null for standalone
+                              flags.
+                          expires_at:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                            description: Timestamp when this flag expires, or null for no expiration.
+                          feature_id:
+                            type: string
+                            description: The feature ID this flag is for.
+                          feature:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                description: The unique identifier for this feature, used in /check and /track
+                                  calls.
+                              name:
+                                type: string
+                                description: Human-readable name displayed in the dashboard and billing UI.
+                              type:
+                                enum:
+                                  - boolean
+                                  - metered
+                                  - credit_system
+                                type: string
+                                description: "Feature type: 'boolean' for on/off access, 'metered' for
+                                  usage-tracked features, 'credit_system' for
+                                  unified credit pools."
+                              consumable:
+                                type: boolean
+                                description: "For metered features: true if usage resets periodically (API
+                                  calls, credits), false if allocated
+                                  persistently (seats, storage)."
+                              event_names:
+                                type: array
+                                items:
+                                  type: string
+                                description: Event names that trigger this feature's balance. Allows multiple
+                                  features to respond to a single event.
+                              credit_schema:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    metered_feature_id:
+                                      type: string
+                                      description: ID of the metered feature that draws from this credit system.
+                                    credit_cost:
+                                      type: number
+                                      description: Credits consumed per unit of the metered feature.
+                                  required:
+                                    - metered_feature_id
+                                    - credit_cost
+                                description: "For credit_system features: maps metered features to their credit
+                                  costs."
+                              display:
+                                type: object
+                                properties:
+                                  singular:
+                                    anyOf:
+                                      - type: string
+                                      - type: "null"
+                                    description: Singular form for UI display (e.g., 'API call', 'seat').
+                                  plural:
+                                    anyOf:
+                                      - type: string
+                                      - type: "null"
+                                    description: Plural form for UI display (e.g., 'API calls', 'seats').
+                                description: Display names for the feature in billing UI and customer-facing
+                                  components.
+                              archived:
+                                type: boolean
+                                description: Whether the feature is archived and hidden from the dashboard.
+                            required:
+                              - id
+                              - name
+                              - type
+                              - consumable
+                              - archived
+                            description: The full feature object if expanded.
+                        required:
+                          - id
+                          - plan_id
+                          - expires_at
+                          - feature_id
+                        examples:
+                          - id: cus_ent_39qmLooixXLAqMywgXywjAz96rV
+                            plan_id: pro_plan
+                            expires_at: null
+                            feature_id: dashboard
+                      - type: "null"
+                    description: The flag associated with this check, if any.
+                  preview:
+                    type: object
+                    properties:
+                      scenario:
+                        enum:
+                          - usage_limit
+                          - feature_flag
+                        type: string
+                        description: The reason access was denied. 'usage_limit' means the customer
+                          exceeded their balance, 'feature_flag' means the
+                          feature is not included in their plan.
+                      title:
+                        type: string
+                        description: A title suitable for displaying in a paywall or upgrade modal.
+                      message:
+                        type: string
+                        description: A message explaining why access was denied.
+                      feature_id:
+                        type: string
+                        description: The ID of the feature that was checked.
+                      feature_name:
+                        type: string
+                        description: The display name of the feature.
+                      products:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              description: The ID of the product you set when creating the product
+                            name:
+                              type: string
+                              description: The name of the product
+                            group:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                              description: Product group which this product belongs to
+                            env:
+                              enum:
+                                - sandbox
+                                - live
+                              type: string
+                              description: The environment of the product
+                            is_add_on:
+                              type: boolean
+                              description: Whether the product is an add-on and can be purchased alongside
+                                other products
+                            is_default:
+                              type: boolean
+                              description: Whether the product is the default product
+                            archived:
+                              type: boolean
+                              description: Whether this product has been archived and is no longer available
+                            version:
+                              type: number
+                              description: The current version of the product
+                            created_at:
+                              type: number
+                              description: The timestamp of when the product was created in milliseconds since
+                                epoch
+                            items:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  type:
+                                    anyOf:
+                                      - enum:
+                                          - feature
+                                          - priced_feature
+                                          - price
+                                        type: string
+                                      - type: "null"
+                                    description: The type of the product item
+                                  feature_id:
+                                    anyOf:
+                                      - type: string
+                                      - type: "null"
+                                    description: The feature ID of the product item. If the item is a fixed price,
+                                      should be `null`
+                                  feature_type:
+                                    anyOf:
+                                      - enum:
+                                          - single_use
+                                          - continuous_use
+                                          - boolean
+                                          - static
+                                        type: string
+                                      - type: "null"
+                                    description: Single use features are used once and then depleted, like API calls
+                                      or credits. Continuous use features are
+                                      those being used on an ongoing-basis, like
+                                      storage or seats.
+                                  included_usage:
+                                    anyOf:
+                                      - anyOf:
+                                          - type: number
+                                          - const: inf
+                                      - type: "null"
+                                    description: The amount of usage included for this feature.
+                                  interval:
+                                    anyOf:
+                                      - enum:
+                                          - minute
+                                          - hour
+                                          - day
+                                          - week
+                                          - month
+                                          - quarter
+                                          - semi_annual
+                                          - year
+                                        type: string
+                                      - type: "null"
+                                    description: The reset or billing interval of the product item. If null, feature
+                                      will have no reset date, and if there's a
+                                      price, it will be billed one-off.
+                                  interval_count:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                    description: The interval count of the product item.
+                                  price:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                    description: The price of the product item. Should be `null` if tiered pricing
+                                      is set.
+                                  tiers:
+                                    anyOf:
+                                      - type: array
+                                        items:
+                                          anyOf:
+                                            - {}
+                                            - type: "null"
+                                      - type: "null"
+                                    description: Tiered pricing for the product item. Not applicable for fixed price
+                                      items.
+                                  tier_behavior:
+                                    anyOf:
+                                      - enum:
+                                          - graduated
+                                          - volume
+                                        type: string
+                                      - type: "null"
+                                    description: "How tiers are applied: graduated (split across bands) or volume
+                                      (flat rate for the matched tier). Defaults
+                                      to graduated."
+                                  usage_model:
+                                    anyOf:
+                                      - enum:
+                                          - prepaid
+                                          - pay_per_use
+                                        type: string
+                                      - type: "null"
+                                    description: Whether the feature should be prepaid upfront or billed for how
+                                      much they use end of billing period.
+                                  billing_units:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                    description: The amount per billing unit (eg. $9 / 250 units)
+                                  reset_usage_when_enabled:
+                                    anyOf:
+                                      - type: boolean
+                                      - type: "null"
+                                    description: Whether the usage should be reset when the product is enabled.
+                                  entity_feature_id:
+                                    anyOf:
+                                      - type: string
+                                      - type: "null"
+                                    description: The entity feature ID of the product item if applicable.
+                                  display:
+                                    anyOf:
+                                      - type: object
+                                        properties:
+                                          primary_text:
+                                            type: string
+                                          secondary_text:
+                                            anyOf:
+                                              - type: string
+                                              - type: "null"
+                                        required:
+                                          - primary_text
+                                      - type: "null"
+                                    description: The display of the product item.
+                                  quantity:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                    description: Used in customer context. Quantity of the feature the customer has
+                                      prepaid for.
+                                  next_cycle_quantity:
+                                    anyOf:
+                                      - type: number
+                                      - type: "null"
+                                    description: Used in customer context. Quantity of the feature the customer will
+                                      prepay for in the next cycle.
+                                  config:
+                                    anyOf:
+                                      - type: object
+                                        properties:
+                                          rollover:
+                                            anyOf:
+                                              - type: object
+                                                properties:
+                                                  max:
+                                                    anyOf:
+                                                      - type: number
+                                                      - type: "null"
+                                                  max_percentage:
+                                                    anyOf:
+                                                      - type: number
+                                                      - type: "null"
+                                                  duration:
+                                                    enum:
+                                                      - month
+                                                      - forever
+                                                    type: string
+                                                    default: month
+                                                  length:
+                                                    type: number
+                                                required:
+                                                  - length
+                                              - type: "null"
+                                          on_increase:
+                                            anyOf:
+                                              - enum:
+                                                  - bill_immediately
+                                                  - prorate_immediately
+                                                  - prorate_next_cycle
+                                                  - bill_next_cycle
+                                                type: string
+                                              - type: "null"
+                                          on_decrease:
+                                            anyOf:
+                                              - enum:
+                                                  - prorate
+                                                  - prorate_immediately
+                                                  - prorate_next_cycle
+                                                  - none
+                                                  - no_prorations
+                                                type: string
+                                              - type: "null"
+                                      - type: "null"
+                                    description: Configuration for rollover and proration behavior of the feature.
+                                description: Product item defining features and pricing within a product
+                              description: Array of product items that define the product's features and
+                                pricing
+                            free_trial:
+                              anyOf:
+                                - type: object
+                                  properties:
+                                    duration:
+                                      enum:
+                                        - day
+                                        - month
+                                        - year
+                                      type: string
+                                      description: The duration type of the free trial
+                                    length:
+                                      type: number
+                                      description: The length of the duration type specified
+                                    unique_fingerprint:
+                                      type: boolean
+                                      description: Whether the free trial is limited to one per customer fingerprint
+                                    card_required:
+                                      type: boolean
+                                      description: Whether the free trial requires a card. If false, the customer can
+                                        attach the product without going through
+                                        a checkout flow or having a card on
+                                        file.
+                                    on_end:
+                                      anyOf:
+                                        - enum:
+                                            - bill
+                                            - revert
+                                          type: string
+                                        - type: "null"
+                                      description: Behavior when the trial ends. 'bill' charges the customer
+                                        (default). 'revert' expires the trial
+                                        and restores the customer's previous
+                                        plan.
+                                    trial_available:
+                                      anyOf:
+                                        - type: boolean
+                                          default: true
+                                        - type: "null"
+                                      description: Used in customer context. Whether the free trial is available for
+                                        the customer if they were to attach the
+                                        product.
+                                  required:
+                                    - duration
+                                    - length
+                                    - unique_fingerprint
+                                    - card_required
+                                - type: "null"
+                              description: Free trial configuration for this product, if available
+                            base_variant_id:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                              description: ID of the base variant this product is derived from
+                            scenario:
+                              enum:
+                                - scheduled
+                                - active
+                                - new
+                                - renew
+                                - upgrade
+                                - update_prepaid_quantity
+                                - downgrade
+                                - cancel
+                                - expired
+                                - past_due
+                              type: string
+                              description: Scenario for when this product is used in attach flows
+                            properties:
+                              type: object
+                              properties:
+                                is_free:
+                                  type: boolean
+                                  description: True if the product has no base price or usage prices
+                                is_one_off:
+                                  type: boolean
+                                  description: True if the product only contains a one-time price
+                                interval_group:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
+                                  description: The billing interval group for recurring products (e.g., 'monthly',
+                                    'yearly')
+                                has_trial:
+                                  anyOf:
+                                    - type: boolean
+                                    - type: "null"
+                                  description: True if the product includes a free trial
+                                updateable:
+                                  anyOf:
+                                    - type: boolean
+                                    - type: "null"
+                                  description: True if the product can be updated after creation (only applicable
+                                    if there are prepaid recurring prices)
+                              required:
+                                - is_free
+                                - is_one_off
+                          required:
+                            - id
+                            - name
+                            - group
+                            - env
+                            - is_add_on
+                            - is_default
+                            - archived
+                            - version
+                            - created_at
+                            - items
+                            - free_trial
+                            - base_variant_id
+                        description: Products that would grant access to this feature. Use to display
+                          upgrade options.
+                    required:
+                      - scenario
+                      - title
+                      - message
+                      - feature_id
+                      - feature_name
+                      - products
+                    description: Upgrade/upsell information when access is denied. Only present if
+                      with_preview was true and allowed is false.
+                required:
+                  - allowed
+                  - customer_id
+                  - balance
+                  - flag
+                examples:
+                  - &a53
+                    allowed: true
+                    customer_id: cus_123
+                    entity_id: null
+                    required_balance: 1
+                    balance:
+                      feature_id: messages
+                      granted: 100
+                      remaining: 72
+                      usage: 28
+                      unlimited: false
+                      overage_allowed: false
+                      max_purchase: null
+                      next_reset_at: 1773851121437
+                      breakdown:
+                        - id: cus_ent_39qmLooixXLAqMywgXywjAz96rV
+                          plan_id: pro_plan
+                          included_grant: 100
+                          prepaid_grant: 0
+                          remaining: 72
+                          usage: 28
+                          unlimited: false
+                          reset:
+                            interval: month
+                            resets_at: 1773851121437
+                          price: null
+                          expires_at: null
+              example: *a53
       x-speakeasy-name-override: check
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -16242,160 +16054,14 @@ paths:
                 - customer_id
               title: TrackParams
               examples:
-                - &a53
+                - &a54
                   customer_id: cus_123
                   feature_id: messages
                   value: 1
-            example: *a53
+            example: *a54
       responses:
         "200":
           description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  customer_id:
-                    type: string
-                    description: The ID of the customer whose usage was tracked.
-                  entity_id:
-                    type: string
-                    description: The ID of the entity, if entity-scoped tracking was performed.
-                  event_name:
-                    type: string
-                    description: The event name that was tracked, if event_name was used instead of
-                      feature_id.
-                  value:
-                    type: number
-                    description: The amount of usage that was recorded.
-                  balance:
-                    anyOf:
-                      - $ref: "#/components/schemas/Balance"
-                      - type: "null"
-                    description: The updated balance for the tracked feature. Null if tracking by
-                      event_name that affects multiple features.
-                  balances:
-                    type: object
-                    propertyNames:
-                      type: string
-                    additionalProperties:
-                      anyOf:
-                        - $ref: "#/components/schemas/Balance"
-                        - type: "null"
-                    description: Map of feature_id to updated balance for the tracked feature and
-                      any related features (e.g. linked credit systems). Value
-                      is null when the customer has no balance for that feature.
-                  deductions:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        balance_id:
-                          type: string
-                          description: ID of the underlying balance row that was deducted from
-                            (customer_entitlement or rollover).
-                        feature_id:
-                          type: string
-                          description: The feature this balance belongs to.
-                        plan_id:
-                          anyOf:
-                            - type: string
-                            - type: "null"
-                          description: ID of the plan/product this balance belongs to. Null when the
-                            balance can't be attributed to a single plan (e.g.
-                            it spans multiple).
-                        reset:
-                          anyOf:
-                            - type: object
-                              properties:
-                                interval:
-                                  anyOf:
-                                    - enum:
-                                        - one_off
-                                        - minute
-                                        - hour
-                                        - day
-                                        - week
-                                        - month
-                                        - quarter
-                                        - semi_annual
-                                        - year
-                                      type: string
-                                    - const: multiple
-                                  description: The reset interval (hour, day, week, month, etc.) or 'multiple' if
-                                    combined from different intervals.
-                                interval_count:
-                                  type: number
-                                  description: Number of intervals between resets (eg. 2 for bi-monthly).
-                                resets_at:
-                                  anyOf:
-                                    - type: number
-                                    - type: "null"
-                                  description: Timestamp when the balance will next reset.
-                              required:
-                                - interval
-                                - resets_at
-                            - type: "null"
-                          description: Reset configuration for the balance this deduction came from, or
-                            null if the balance doesn't reset.
-                        value:
-                          type: number
-                          description: Amount deducted from this balance. Positive when usage was
-                            consumed, negative when credit was restored (e.g. a
-                            refund via negative track value).
-                      required:
-                        - balance_id
-                        - feature_id
-                        - plan_id
-                        - reset
-                        - value
-                    description: Per-balance breakdown of what this event deducted. A single event
-                      can consume from multiple balance rows when credit systems
-                      or rollovers are involved; this surfaces each one so
-                      callers can build per-feature usage views without polling.
-                required:
-                  - customer_id
-                  - value
-                  - balance
-                examples:
-                  - &a54
-                    customer_id: cus_123
-                    value: 1
-                    balance:
-                      feature_id: messages
-                      granted: 100
-                      remaining: 72
-                      usage: 28
-                      unlimited: false
-                      overage_allowed: false
-                      max_purchase: null
-                      next_reset_at: 1773851121437
-                      breakdown:
-                        - id: cus_ent_39qmLooixXLAqMywgXywjAz96rV
-                          plan_id: pro_plan
-                          included_grant: 100
-                          prepaid_grant: 0
-                          remaining: 72
-                          usage: 28
-                          unlimited: false
-                          reset:
-                            interval: month
-                            resets_at: 1773851121437
-                          price: null
-                          expires_at: null
-                    deductions:
-                      - balance_id: cus_ent_3DdSDoyFmoA9Neecl2a2Gc507X2
-                        feature_id: messages
-                        plan_id: pro
-                        reset:
-                          interval: month
-                          resets_at: 1781288736881
-                        value: 1
-              example: *a54
-        "202":
-          description: Accepted. Autumn is experiencing degraded service from a downstream
-            provider, so the event was accepted for replay and will be tracked
-            as soon as the service is restored.
           content:
             application/json:
               schema:
@@ -16538,15 +16204,155 @@ paths:
                           resets_at: 1781288736881
                         value: 1
               example: *a55
+        "202":
+          description: Accepted. Autumn is experiencing degraded service from a downstream
+            provider, so the event was accepted for replay and will be tracked
+            as soon as the service is restored.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  customer_id:
+                    type: string
+                    description: The ID of the customer whose usage was tracked.
+                  entity_id:
+                    type: string
+                    description: The ID of the entity, if entity-scoped tracking was performed.
+                  event_name:
+                    type: string
+                    description: The event name that was tracked, if event_name was used instead of
+                      feature_id.
+                  value:
+                    type: number
+                    description: The amount of usage that was recorded.
+                  balance:
+                    anyOf:
+                      - $ref: "#/components/schemas/Balance"
+                      - type: "null"
+                    description: The updated balance for the tracked feature. Null if tracking by
+                      event_name that affects multiple features.
+                  balances:
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      anyOf:
+                        - $ref: "#/components/schemas/Balance"
+                        - type: "null"
+                    description: Map of feature_id to updated balance for the tracked feature and
+                      any related features (e.g. linked credit systems). Value
+                      is null when the customer has no balance for that feature.
+                  deductions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        balance_id:
+                          type: string
+                          description: ID of the underlying balance row that was deducted from
+                            (customer_entitlement or rollover).
+                        feature_id:
+                          type: string
+                          description: The feature this balance belongs to.
+                        plan_id:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description: ID of the plan/product this balance belongs to. Null when the
+                            balance can't be attributed to a single plan (e.g.
+                            it spans multiple).
+                        reset:
+                          anyOf:
+                            - type: object
+                              properties:
+                                interval:
+                                  anyOf:
+                                    - enum:
+                                        - one_off
+                                        - minute
+                                        - hour
+                                        - day
+                                        - week
+                                        - month
+                                        - quarter
+                                        - semi_annual
+                                        - year
+                                      type: string
+                                    - const: multiple
+                                  description: The reset interval (hour, day, week, month, etc.) or 'multiple' if
+                                    combined from different intervals.
+                                interval_count:
+                                  type: number
+                                  description: Number of intervals between resets (eg. 2 for bi-monthly).
+                                resets_at:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                  description: Timestamp when the balance will next reset.
+                              required:
+                                - interval
+                                - resets_at
+                            - type: "null"
+                          description: Reset configuration for the balance this deduction came from, or
+                            null if the balance doesn't reset.
+                        value:
+                          type: number
+                          description: Amount deducted from this balance. Positive when usage was
+                            consumed, negative when credit was restored (e.g. a
+                            refund via negative track value).
+                      required:
+                        - balance_id
+                        - feature_id
+                        - plan_id
+                        - reset
+                        - value
+                    description: Per-balance breakdown of what this event deducted. A single event
+                      can consume from multiple balance rows when credit systems
+                      or rollovers are involved; this surfaces each one so
+                      callers can build per-feature usage views without polling.
+                required:
+                  - customer_id
+                  - value
+                  - balance
+                examples:
+                  - &a56
+                    customer_id: cus_123
+                    value: 1
+                    balance:
+                      feature_id: messages
+                      granted: 100
+                      remaining: 72
+                      usage: 28
+                      unlimited: false
+                      overage_allowed: false
+                      max_purchase: null
+                      next_reset_at: 1773851121437
+                      breakdown:
+                        - id: cus_ent_39qmLooixXLAqMywgXywjAz96rV
+                          plan_id: pro_plan
+                          included_grant: 100
+                          prepaid_grant: 0
+                          remaining: 72
+                          usage: 28
+                          unlimited: false
+                          reset:
+                            interval: month
+                            resets_at: 1773851121437
+                          price: null
+                          expires_at: null
+                    deductions:
+                      - balance_id: cus_ent_3DdSDoyFmoA9Neecl2a2Gc507X2
+                        feature_id: messages
+                        plan_id: pro
+                        reset:
+                          interval: month
+                          resets_at: 1781288736881
+                        value: 1
+              example: *a56
       x-speakeasy-name-override: track
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -16586,18 +16392,18 @@ paths:
             schema:
               type: object
               properties:
-                offset:
-                  type: integer
-                  minimum: 0
-                  maximum: 9007199254740991
-                  default: 0
-                  description: Number of items to skip
+                start_cursor:
+                  type: string
+                  default: ""
+                  description: Opaque pagination cursor. Empty string (default) requests the first
+                    page; use next_cursor from a prior response for subsequent
+                    pages.
                 limit:
                   type: integer
                   minimum: 1
-                  maximum: 1000
-                  default: 100
-                  description: Number of items to return. Default 100, max 1000.
+                  maximum: 5000
+                  default: 50
+                  description: Number of items to return. Default 50, hard ceiling 5000.
                 customer_id:
                   type: string
                   description: Filter events by customer ID
@@ -16626,14 +16432,16 @@ paths:
                   description: Filter events by time range
               title: EventsListParams
               examples:
-                - &a56
+                - &a57
+                  start_cursor: ""
                   customer_id: cus_123
                   limit: 50
-                - feature_id: api_calls
+                - start_cursor: ""
+                  feature_id: api_calls
                   custom_range:
                     start: 1704067200000
                     end: 1706745600000
-            example: *a56
+            example: *a57
       responses:
         "200":
           description: OK
@@ -16747,27 +16555,18 @@ paths:
                         - value
                         - properties
                         - deductions
-                    description: Array of items for current page
-                  has_more:
-                    type: boolean
-                    description: Whether more results exist after this page
-                  offset:
-                    type: number
-                    description: Current offset position
-                  limit:
-                    type: number
-                    description: Limit passed in the request
-                  total:
-                    type: number
-                    description: Total number of items returned in the current page
+                    description: Items for current page.
+                  next_cursor:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Opaque cursor for the next page. Null when there are no more
+                      results.
                 required:
                   - list
-                  - has_more
-                  - offset
-                  - limit
-                  - total
+                  - next_cursor
                 examples:
-                  - &a57
+                  - &a58
                     list:
                       - id: evt_36xpk2TmuQX5zVPPQ8tCtnR5Weg
                         timestamp: 1765958215459
@@ -16790,20 +16589,11 @@ paths:
                         value: 49
                         properties: {}
                         deductions: null
-                    total: 2
-                    has_more: false
-                    offset: 0
-                    limit: 100
-              example: *a57
+                    next_cursor: eyJ2IjowLCJpZCI6ImV2dF8zNnhtSHh4akFrcXh1ZkRmOXlIQVBOZlJyTE0iLCJ0IjoxNzY1OTU2NTEyMDU3fQ
+              example: *a58
       x-speakeasy-name-override: list
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -16813,7 +16603,6 @@ paths:
             const autumn = new Autumn()
 
             const result = await autumn.events.list({
-              limit: 50,
               customerId: "cus_123",
             });
         - lang: python
@@ -16824,7 +16613,7 @@ paths:
             autumn = Autumn(secret_key="am_sk_test...")
 
             res = autumn.events.list(
-                offset=0,
+                start_cursor="",
                 limit=50,
                 customer_id="cus_123",
             )
@@ -16917,7 +16706,7 @@ paths:
                 - feature_id
               title: EventsAggregateParams
               examples:
-                - &a58
+                - &a59
                   customer_id: cus_123
                   feature_id: api_calls
                   range: 30d
@@ -16928,7 +16717,7 @@ paths:
                     - messages
                   range: 7d
                   group_by: properties.model
-            example: *a58
+            example: *a59
       responses:
         "200":
           description: OK
@@ -16990,7 +16779,7 @@ paths:
                   - list
                   - total
                 examples:
-                  - &a59
+                  - &a60
                     list:
                       - period: 1762905600000
                         values:
@@ -17037,16 +16826,10 @@ paths:
                       sessions:
                         count: 2
                         sum: 15
-              example: *a59
+              example: *a60
       x-speakeasy-name-override: aggregate
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -17189,12 +16972,12 @@ paths:
                 - entity_id
               title: CreateEntityParams
               examples:
-                - &a60
+                - &a61
                   customer_id: cus_123
                   entity_id: seat_42
                   feature_id: seats
                   name: Seat 42
-            example: *a60
+            example: *a61
       responses:
         "200":
           description: OK
@@ -17576,7 +17359,7 @@ paths:
                   - balances
                   - flags
                 examples:
-                  - &a61
+                  - &a62
                     id: seat_42
                     name: Seat 42
                     customer_id: cus_123
@@ -17621,16 +17404,10 @@ paths:
                             price: null
                             expires_at: null
                     invoices: []
-              example: *a61
+              example: *a62
       x-speakeasy-name-override: create
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -17686,11 +17463,11 @@ paths:
                 - entity_id
               title: GetEntityParams
               examples:
-                - &a62
+                - &a63
                   entity_id: seat_42
                 - customer_id: cus_123
                   entity_id: seat_42
-            example: *a62
+            example: *a63
       responses:
         "200":
           description: OK
@@ -18072,7 +17849,7 @@ paths:
                   - balances
                   - flags
                 examples:
-                  - &a63
+                  - &a64
                     id: seat_42
                     name: Seat 42
                     customer_id: cus_123
@@ -18117,16 +17894,10 @@ paths:
                             price: null
                             expires_at: null
                     invoices: []
-              example: *a63
+              example: *a64
       x-speakeasy-name-override: get
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -18159,24 +17930,24 @@ paths:
       tags:
         - entities
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
               type: object
               properties:
-                offset:
-                  type: integer
-                  minimum: 0
-                  maximum: 9007199254740991
-                  default: 0
-                  description: Number of items to skip
+                start_cursor:
+                  type: string
+                  default: ""
+                  description: Opaque pagination cursor. Empty string (default) requests the first
+                    page; use next_cursor from a prior response for subsequent
+                    pages.
                 limit:
                   type: integer
                   minimum: 1
-                  maximum: 1000
-                  default: 10
-                  description: Number of items to return. Default 10, max 1000.
+                  maximum: 5000
+                  default: 50
+                  description: Number of items to return. Default 50, hard ceiling 5000.
                 plans:
                   type: array
                   items:
@@ -18215,12 +17986,12 @@ paths:
                     vercel).
               title: ListEntitiesParams
               examples:
-                - &a64
+                - &a65
+                  start_cursor: ""
                   limit: 10
-                  offset: 0
                 - plans:
                     - id: pro_plan
-            example: *a64
+            example: *a65
       responses:
         "200":
           description: OK
@@ -18606,37 +18377,18 @@ paths:
                         - purchases
                         - balances
                         - flags
-                    description: Array of items for current page
-                  has_more:
-                    type: boolean
-                    description: Whether more results exist after this page
-                  offset:
-                    type: number
-                    description: Current offset position
-                  limit:
-                    type: number
-                    description: Limit passed in the request
-                  total:
-                    type: number
-                    description: Total number of items returned in the current page
-                  total_count:
-                    type: number
-                    description: Total number of entities available in the current organization and
-                      environment
-                  total_filtered_count:
-                    type: number
-                    description: Total number of entities matching the current filter before
-                      pagination is applied
+                    description: Items for current page.
+                  next_cursor:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Opaque cursor for the next page. Null when there are no more
+                      results.
                 required:
                   - list
-                  - has_more
-                  - offset
-                  - limit
-                  - total
-                  - total_count
-                  - total_filtered_count
+                  - next_cursor
                 examples:
-                  - &a65
+                  - &a66
                     list:
                       - id: seat_42
                         name: Seat 42
@@ -18682,22 +18434,11 @@ paths:
                                 price: null
                                 expires_at: null
                         invoices: []
-                    has_more: false
-                    offset: 0
-                    total: 1
-                    limit: 10
-                    total_count: 100
-                    total_filtered_count: 42
-              example: *a65
+                    next_cursor: null
+              example: *a66
       x-speakeasy-name-override: list
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -18706,7 +18447,9 @@ paths:
 
             const autumn = new Autumn()
 
-            const result = await autumn.entities.list({});
+            const result = await autumn.entities.list({
+              limit: 10,
+            });
         - lang: python
           label: Python (SDK)
           source: |-
@@ -18714,9 +18457,7 @@ paths:
 
             autumn = Autumn(secret_key="am_sk_test...")
 
-            res = autumn.entities.list(
-                request={},
-            )
+            res = autumn.entities.list(start_cursor="", limit=10)
   /v1/entities.update:
     post:
       operationId: updateEntity
@@ -18818,7 +18559,7 @@ paths:
                 - entity_id
               title: UpdateEntityParams
               examples:
-                - &a66
+                - &a67
                   customer_id: cus_123
                   entity_id: seat_42
                   billing_controls:
@@ -18826,7 +18567,7 @@ paths:
                       - feature_id: messages
                         enabled: true
                         overage_limit: 25
-            example: *a66
+            example: *a67
       responses:
         "200":
           description: OK
@@ -19208,7 +18949,7 @@ paths:
                   - balances
                   - flags
                 examples:
-                  - &a67
+                  - &a68
                     id: seat_42
                     name: Seat 42
                     customer_id: cus_123
@@ -19253,16 +18994,10 @@ paths:
                             price: null
                             expires_at: null
                     invoices: []
-              example: *a67
+              example: *a68
       x-speakeasy-name-override: update
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -19332,10 +19067,10 @@ paths:
                 - entity_id
               title: DeleteEntityParams
               examples:
-                - &a68
+                - &a69
                   customer_id: cus_123
                   entity_id: seat_42
-            example: *a68
+            example: *a69
       responses:
         "200":
           description: OK
@@ -19349,18 +19084,12 @@ paths:
                 required:
                   - success
                 examples:
-                  - &a69
+                  - &a70
                     success: true
-              example: *a69
+              example: *a70
       x-speakeasy-name-override: delete
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -19408,10 +19137,10 @@ paths:
                 - program_id
               title: CreateReferralCodeParams
               examples:
-                - &a70
+                - &a71
                   customer_id: cus_123
                   program_id: prog_123
-            example: *a70
+            example: *a71
       responses:
         "200":
           description: OK
@@ -19434,20 +19163,14 @@ paths:
                   - customer_id
                   - created_at
                 examples:
-                  - &a71
+                  - &a72
                     code: <string>
                     customer_id: <string>
                     created_at: 123
-              example: *a71
+              example: *a72
       x-speakeasy-name-override: createCode
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -19495,10 +19218,10 @@ paths:
                 - customer_id
               title: RedeemReferralCodeParams
               examples:
-                - &a72
+                - &a73
                   code: REF123
                   customer_id: cus_456
-            example: *a72
+            example: *a73
       responses:
         "200":
           description: OK
@@ -19521,20 +19244,14 @@ paths:
                   - customer_id
                   - reward_id
                 examples:
-                  - &a73
+                  - &a74
                     id: <string>
                     customer_id: <string>
                     reward_id: <string>
-              example: *a73
+              example: *a74
       x-speakeasy-name-override: redeemCode
       parameters:
-        - name: x-api-version
-          in: header
-          required: true
-          schema:
-            type: string
-            default: 2.2.0
-          x-speakeasy-globals-hidden: true
+        - *a5
       x-codeSamples:
         - lang: typescript
           label: Typescript (SDK)
@@ -19567,7 +19284,7 @@ x-speakeasy-globals:
       required: true
       schema:
         type: string
-        default: 2.2.0
+        default: 2.3.0
       x-speakeasy-globals-hidden: true
     - name: fail-open
       in: header

--- a/apps/docs/mintlify/snippets/dynamic-param-field.jsx
+++ b/apps/docs/mintlify/snippets/dynamic-param-field.jsx
@@ -1,5 +1,3 @@
-import { useEffect, useMemo, useState } from "react";
-
 /**
  * A wrapper around Mintlify's ParamField that dynamically switches
  * between snake_case and camelCase based on the selected code language.

--- a/apps/docs/mintlify/snippets/dynamic-response-example.jsx
+++ b/apps/docs/mintlify/snippets/dynamic-response-example.jsx
@@ -1,5 +1,3 @@
-import { useEffect, useMemo, useState } from "react";
-
 /**
  * A dynamic response example that shows JSON in the sidebar.
  * Displays two tabs (TypeScript/Response) and auto-switches based on selected language.

--- a/apps/docs/mintlify/snippets/dynamic-response-field.jsx
+++ b/apps/docs/mintlify/snippets/dynamic-response-field.jsx
@@ -1,5 +1,3 @@
-import { useEffect, useMemo, useState } from "react";
-
 /**
  * A wrapper around Mintlify's ResponseField that dynamically switches
  * between snake_case and camelCase based on the selected code language.

--- a/others/python-sdk/.speakeasy/code-samples.overlay.yaml
+++ b/others/python-sdk/.speakeasy/code-samples.overlay.yaml
@@ -13,7 +13,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -31,7 +31,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -51,7 +51,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -69,7 +69,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -87,7 +87,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -105,7 +105,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -123,7 +123,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -141,7 +141,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -176,7 +176,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -207,7 +207,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -225,7 +225,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -243,7 +243,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -274,7 +274,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -297,7 +297,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -315,7 +315,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -338,7 +338,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -356,7 +356,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -374,7 +374,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -392,11 +392,11 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
-                res = autumn.customers.list(request={})
+                res = autumn.customers.list(start_cursor="", limit=10)
 
                 # Handle response
                 print(res)
@@ -410,7 +410,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -428,7 +428,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -446,7 +446,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -464,7 +464,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -482,11 +482,11 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
-                res = autumn.entities.list(request={})
+                res = autumn.entities.list(start_cursor="", limit=10)
 
                 # Handle response
                 print(res)
@@ -500,7 +500,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -526,7 +526,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -544,11 +544,11 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
-                res = autumn.events.list(offset=0, limit=50, customer_id="cus_123")
+                res = autumn.events.list(start_cursor="", limit=50, customer_id="cus_123")
 
                 # Handle response
                 print(res)
@@ -562,7 +562,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -580,7 +580,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -598,7 +598,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -616,7 +616,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -634,7 +634,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -655,7 +655,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -681,7 +681,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -699,7 +699,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -717,7 +717,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -735,7 +735,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -756,7 +756,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 
@@ -774,7 +774,7 @@ actions:
 
 
             with Autumn(
-                x_api_version="2.2.0",
+                x_api_version="2.3.0",
                 secret_key="<YOUR_BEARER_TOKEN_HERE>",
             ) as autumn:
 

--- a/others/python-sdk/.speakeasy/gen.lock
+++ b/others/python-sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 05940b80-1ef8-40f4-9878-822fb2792070
 management:
-  docChecksum: 932df88c151e0ec14207c14a42226c15
-  docVersion: 2.2.0
+  docChecksum: a13fed7f9154860bf75393986b601705
+  docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.4.18
   configChecksum: 2263d20254e354a1792248274002f650
 persistentEdits:
-  generation_id: de3d7b31-df08-4ffc-a2e2-ad7ce75ec74b
-  pristine_commit_hash: fd8c83857ce67ece55ef5a223e90b5394804c9b7
-  pristine_tree_hash: 92a87692bee9941efe458e10e8a3996f54ccd6d1
+  generation_id: 13000448-81ca-4f34-8b88-cc3ff6e44172
+  pristine_commit_hash: 263928ab9a49664d811d3a0725b3b0bff6db327e
+  pristine_tree_hash: c6a92d30ffd915b1e2f0bcb6bc2fe2a3e018ce89
 features:
   python:
     additionalDependencies: 1.0.0
@@ -45,8 +45,8 @@ trackedFiles:
     pristine_git_object: 8d79f0abb72526f1fb34a4c03e5bba612c6ba2ae
   USAGE.md:
     id: 3aed33ce6e6f
-    last_write_checksum: sha1:56fbca3ffdf97dfd213c67aff08e329aae496d0f
-    pristine_git_object: 338e57de579fc8a219b6580798c5632db01380b2
+    last_write_checksum: sha1:d776c370bc736e3682169477ceb6ce139fe24d86
+    pristine_git_object: 69e9b3db23297366f991f0869a701a0b24f9b452
   docs/models/action.md:
     id: 3b583d6a609e
     last_write_checksum: sha1:098b94f92de64e0d8913334d0889fd85ebe460b6
@@ -1361,8 +1361,8 @@ trackedFiles:
     pristine_git_object: c1950ae7b75cbddefbb82acd0466f698520c81e3
   docs/models/eventslistparams.md:
     id: ab92b0ecc15c
-    last_write_checksum: sha1:5e6a8d722d79547d925198b7bab35f071c0fa1fe
-    pristine_git_object: 81ab707fd50986600be0a0bc1cf4f8af1e6b6eb9
+    last_write_checksum: sha1:94a3cd01e037761af88b5105b7061fa98f6512b6
+    pristine_git_object: 697198175854e321c902248cc725ad9bdafbb5ed
   docs/models/expirydurationtype.md:
     id: 7ba992bf53cc
     last_write_checksum: sha1:368f1d47012462b1ce9bd136fd0aa4a88cf419fb
@@ -1929,8 +1929,8 @@ trackedFiles:
     pristine_git_object: 196b6576bb0e6cd383dce7b9ca8809a5e516be6d
   docs/models/listcustomersparams.md:
     id: 8ac823390bd3
-    last_write_checksum: sha1:719e9f12cbcd82be36ab0e00332002ffe58f2dfa
-    pristine_git_object: 22499091dc914bb3b142af5727ce53f04ece6f1a
+    last_write_checksum: sha1:ee5fb1cef90fcbcbb7104ab28a3882ca930598eb
+    pristine_git_object: 2d22b90c77b474d406c1869a6c47e10cc109b514
   docs/models/listcustomersplan.md:
     id: 676e48e73f55
     last_write_checksum: sha1:d7d03d3d56264e691c90389b4ea7d94d66b90963
@@ -1961,8 +1961,8 @@ trackedFiles:
     pristine_git_object: b5a71cec323a5f010ec5393952655622d9957bf6
   docs/models/listcustomersresponse.md:
     id: 8bcc0ece3648
-    last_write_checksum: sha1:ea3bc6a1dec87761cce68202aea50e53ec061419
-    pristine_git_object: e51d209ca8ae108f5b18b5e418b9c94fde3a1191
+    last_write_checksum: sha1:bb231bcaa0609393f4b2c8f6d0d88057cb452d1c
+    pristine_git_object: 768c9f98a88555fae8dfbc3190041dc9c2caf3ca
   docs/models/listcustomersrevenuecat.md:
     id: 10d90016c4cd
     last_write_checksum: sha1:6f2f3a096c1128270aac1f472374dd996aacae0b
@@ -1985,8 +1985,8 @@ trackedFiles:
     pristine_git_object: f2257cb7235a82b97ba6a773a19a81345252e112
   docs/models/listcustomerssubscriptionstatus.md:
     id: f24b4a03e2ed
-    last_write_checksum: sha1:58115caac1e295f2d820402c1cf2db7b732dfa9d
-    pristine_git_object: 33fe11c96fdba7d466f2ae033f60ba3a370955c5
+    last_write_checksum: sha1:157530dabd0d28e5fd4a40b12d9a7b71a6addeea
+    pristine_git_object: 98b163a961fe45b25f8b94f59a92d5e7cb0e70dc
   docs/models/listcustomersthresholdtype.md:
     id: 891ad14c54c6
     last_write_checksum: sha1:504aac5244104ff09d4ebff1e830af82defc9bf9
@@ -2045,8 +2045,8 @@ trackedFiles:
     pristine_git_object: 0d6ca7bd4d0aff01cfbb4b2d81703523d24b1e6e
   docs/models/listentitiesparams.md:
     id: a98fa41dacb7
-    last_write_checksum: sha1:5c605039c907b42e10f1e8333f539ff2d6415c9c
-    pristine_git_object: c9bcfdec95553523717ec1c75fea47565c580856
+    last_write_checksum: sha1:92519d46339ac94f703fab562a52d26eb4b52cc1
+    pristine_git_object: 0fa5a5d8ee0d78889fb2049b2fe6c69632848b29
   docs/models/listentitiesplan.md:
     id: 35b85f6fd4b3
     last_write_checksum: sha1:fa8c2a8ef01dfe81b72c9103d38db67585ac55ae
@@ -2065,8 +2065,8 @@ trackedFiles:
     pristine_git_object: 6cc60dd796c7645d56e0b31bc85d79040261e519
   docs/models/listentitiesresponse.md:
     id: 795662eb1108
-    last_write_checksum: sha1:693193e2de204619f91348bf571691dc620f6ed6
-    pristine_git_object: 653ea83aacb56f39d9138566cd8b0bc7ea56aff1
+    last_write_checksum: sha1:898c1d9cb5e52991df0477c7ba8a73796d3a1844
+    pristine_git_object: f1b5599f926f0f17b49de1ca9c207010fc83afaf
   docs/models/listentitiesspendlimit.md:
     id: 3e35ba77a8ca
     last_write_checksum: sha1:7488d1c40d09b3ba994613980780646f4a572cdd
@@ -2125,8 +2125,8 @@ trackedFiles:
     pristine_git_object: 8fd9f92aef2315a6e9289700bbbc317dff8bc201
   docs/models/listeventsresponse.md:
     id: 150f903b0ed9
-    last_write_checksum: sha1:9eb8f98df1804fd7d9b0c1cedd5fad119992cb56
-    pristine_git_object: 0350b288fb5d4c93b021b448add0415bb9d66556
+    last_write_checksum: sha1:b82e8d94cf837a5dc4d066278853d0498c75d405
+    pristine_git_object: d0e11b78ece6784584fea25443b9549cd6b012c6
   docs/models/listfeaturescreditschema.md:
     id: bfa151aef980
     last_write_checksum: sha1:50f8d085ceaebbdd7e246a48eaaf185b49329d95
@@ -4109,40 +4109,40 @@ trackedFiles:
     pristine_git_object: 9632d9df66ca144a883a6a61092994f90b6b636c
   docs/sdks/autumn/README.md:
     id: d27c9292a1a3
-    last_write_checksum: sha1:fd96ce6718b4ade1cd4676d3a88bdd879e0dbafe
-    pristine_git_object: 8f377e35ef96f161e3d1899234b3d9d7576f3941
+    last_write_checksum: sha1:10fe85a3489ddeb4e769136e5a5d8199901ca6a8
+    pristine_git_object: 140a3ecb60eafa96438e9b8723a8ac35f688fbcd
   docs/sdks/balances/README.md:
     id: 6ca85866f00d
-    last_write_checksum: sha1:71ae48253fc0cba2f21f5aa8aa31170c5f6b446e
-    pristine_git_object: db2b13c3ee155b8d0740c164c952f2adb7413138
+    last_write_checksum: sha1:bcdf2e7c93426d2e3dbecda03331352bd88fc95a
+    pristine_git_object: 01aa27258dceaceafc0657bb3b8b1437c12919a6
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:4ae19aa53a8e85f4c606f2accf9f2431104014bf
-    pristine_git_object: 75a0f38995718815c8b9a761f127416e586edab0
+    last_write_checksum: sha1:dfba27127f0c8193a03aca5f3bbdf3f404f9bdd5
+    pristine_git_object: 2b1d25e67802c53a7e7e18cd14d4e695547b98b0
   docs/sdks/customers/README.md:
     id: 9332759cffc2
-    last_write_checksum: sha1:a242d24e05645c1d7e193a2de6b05cd0d75ec1ec
-    pristine_git_object: 629f6540f827518a16bdb4b97ce334ec4ceed8cb
+    last_write_checksum: sha1:3ba96b62f6a62480122a03a7f8c27c119eefade6
+    pristine_git_object: 45bb7e0da6bc397921f731c45f2a8bb8e1ecc664
   docs/sdks/entities/README.md:
     id: a140ac5181b9
-    last_write_checksum: sha1:70e5e30e50ef656d3877819f385d7c07d55116de
-    pristine_git_object: ac31c0445c4e24f84af187662a57ea740d14b024
+    last_write_checksum: sha1:ce657711d3d6ba38e92cd3d96964248dffafbabe
+    pristine_git_object: 51e73e75e6156f7471111069d2a84223089dd56e
   docs/sdks/events/README.md:
     id: cf45a4390b9b
-    last_write_checksum: sha1:cea99762b01b7bae01def1685a4ad7807a4d60dd
-    pristine_git_object: 428407a3e960acd6188d6241d16268fcb4868503
+    last_write_checksum: sha1:2291068c2b8ae415d71094b02d38cdac7ad83284
+    pristine_git_object: d5ead9109b17b6e015de5af749a240dadd440068
   docs/sdks/features/README.md:
     id: e885cfb7247b
-    last_write_checksum: sha1:ab8f4c6032ebaa6e2636c27c6a0c66138cb00a7d
-    pristine_git_object: f15f599301140e1f7af1a6e1c9462464b71a4437
+    last_write_checksum: sha1:7f8cc6ca8855001c309a48738fb12782b09d3cf1
+    pristine_git_object: e780c68e76247300ddcad095c859c1312e268eed
   docs/sdks/plans/README.md:
     id: 2d8c741fff57
-    last_write_checksum: sha1:19e53edc483ea98f9e427c9165f4d625c3ac7109
-    pristine_git_object: d13a6b26e488dbcbb08f1db69ff102a54dffcf78
+    last_write_checksum: sha1:a956c9b35832ad1b4b988220bbf133aa87c73301
+    pristine_git_object: 25a47ac0fdb8bc31110b3d96d2656bf744969f37
   docs/sdks/referrals/README.md:
     id: 50b71f597f20
-    last_write_checksum: sha1:583c44cd70208e8ea9e286b54a5b82f837c8a4be
-    pristine_git_object: 9a0dd0aec6d9b00b984510dfe6b8c12e43b60adf
+    last_write_checksum: sha1:de99a40759f0d5c8850f2f59613d20d646161c53
+    pristine_git_object: 72f6ca33937b57d77f1969e98a91c0f567893837
   py.typed:
     id: 258c3ed47ae4
     last_write_checksum: sha1:8efc425ffe830805ffcc0f3055871bdcdc542c60
@@ -4177,8 +4177,8 @@ trackedFiles:
     pristine_git_object: 3e604651c1eae73d815b276806e73b2f1334bb79
   src/autumn_sdk/_version.py:
     id: a98babfdf4fc
-    last_write_checksum: sha1:48d80ec79d1e2d4c26194db9db1ac7886acd76f1
-    pristine_git_object: 6fd40e5912793561523e90b1595f3300d62bf238
+    last_write_checksum: sha1:e9f37410254f0de534a9a04e67c8c736e38bf56d
+    pristine_git_object: 5876591b27e7f0ae36490c47c2893b48a3eaa8af
   src/autumn_sdk/balances.py:
     id: 0a15be654dad
     last_write_checksum: sha1:51d725f62f14d78037909fd4399d77a1291df149
@@ -4193,12 +4193,12 @@ trackedFiles:
     pristine_git_object: fac65762df83ced2a21a69d2d5b50a06f2ff0105
   src/autumn_sdk/customers.py:
     id: 5c5a0a07a433
-    last_write_checksum: sha1:9e122b366aaf67db8fbc4866c6173f0f57362cbb
-    pristine_git_object: 0f6c4580e9aeacd2441b8bc7bf8602f7e2451a70
+    last_write_checksum: sha1:bbdd432fc314a94a6ac5bd6335c8cf9474e02b66
+    pristine_git_object: aaf9171b48544d4e5039a9a210a67350bf2a8e71
   src/autumn_sdk/entities.py:
     id: 32ba2aa0874c
-    last_write_checksum: sha1:a314d4f2e26711b74a6be67b6d08e7fa24871213
-    pristine_git_object: 8fcca916bb052891a25cba998554e3a429a494e8
+    last_write_checksum: sha1:ced8d05bea86e3c180b1247bd3bbb6c72ed6c2f8
+    pristine_git_object: 8b05ef6046e2704c45a50c5149774c0aacaa552c
   src/autumn_sdk/errors/__init__.py:
     id: 242853123cf2
     last_write_checksum: sha1:1c4f4e0181a6598b531c2621340548b003df6e2a
@@ -4221,8 +4221,8 @@ trackedFiles:
     pristine_git_object: 1efa993593b78b8f93587adf8a12ce2efbb11002
   src/autumn_sdk/events.py:
     id: 3421eef7bbd5
-    last_write_checksum: sha1:5ede26c69706f2288a19d281f3695d3bd05d2b46
-    pristine_git_object: 8c9400ea6614688183791d4b49e8ba6d9b4e2fcc
+    last_write_checksum: sha1:0fb766e1ff058eb694f3e2eaadd06047f57223ad
+    pristine_git_object: b346cbffe1811393d45f0e89673cd2b27e64b27f
   src/autumn_sdk/features.py:
     id: 79d780190f74
     last_write_checksum: sha1:24f5dcce8bc1f0afc6f2dc0af6e2bc71ca1c1d8d
@@ -4237,48 +4237,48 @@ trackedFiles:
     pristine_git_object: 831468bf4b03022abfdccae15ce97d2739d92cde
   src/autumn_sdk/models/aggregateeventsop.py:
     id: 01321099f2a5
-    last_write_checksum: sha1:e8135648e39b731396565bcf59ec5a5cc400ae90
-    pristine_git_object: 898d3fdd6f7207730f04e9ca09bd19c3b3ae51d1
+    last_write_checksum: sha1:bbaf78080f665b38e531d2427c787e40ca0635a7
+    pristine_git_object: 3a4476749ea87675039e23243ed3865d3bdf57ca
   src/autumn_sdk/models/attachop.py:
     id: ebb59e06476c
-    last_write_checksum: sha1:a7f59812fa59058b5360c8af62ed0fc4a811cd47
-    pristine_git_object: fe27daebcf872612132a8500f274190b8b57fed5
+    last_write_checksum: sha1:f3258e635b6499464adf58005da5315a4e954e14
+    pristine_git_object: 1c74b555da5b64b178558d2a4fdc021724d2b3bc
   src/autumn_sdk/models/balance.py:
     id: a6354d7c4b97
     last_write_checksum: sha1:54a4422123d262666370d2e1238d990ef1dba324
     pristine_git_object: 10a5b2ae10d0daf7adc5e9f90de4d25665732a62
   src/autumn_sdk/models/billingupdateop.py:
     id: a2f17c75cfd3
-    last_write_checksum: sha1:b02b9483bc27f88bec0d3d3866735ca500929f34
-    pristine_git_object: 8a31641131897d8e8ab7b866b1a1bb14454f2d93
+    last_write_checksum: sha1:aade53f9ad5783e23c5141426ef05934d252a763
+    pristine_git_object: 25636ae22d123f0f378d41dc695dba42d18b4bee
   src/autumn_sdk/models/checkop.py:
     id: 31c2f84723c6
-    last_write_checksum: sha1:0dc2592b51e741677419a26ee6557815eeb33b03
-    pristine_git_object: 45a5f66396b8b0716c4eafa4a595817f3c6f680f
+    last_write_checksum: sha1:7cb0cbbf11f480372aa2c5a3466b07f78e301226
+    pristine_git_object: b165ecfba6d2d2d1ccf9a21029d6fa87db67b470
   src/autumn_sdk/models/createbalanceop.py:
     id: 27daf4da75bf
-    last_write_checksum: sha1:b6da2d7778cd4b98f0e6612810726512203eb1de
-    pristine_git_object: 29b8f2f3236a1fd875aac10ee13416ddecb62445
+    last_write_checksum: sha1:f034893074f11952de2b174c8f2991232e512858
+    pristine_git_object: 42d3636f3548ca45bcb5059f38f4a3d6762948f6
   src/autumn_sdk/models/createentityop.py:
     id: bf9521c0cfec
-    last_write_checksum: sha1:cb70cf946c37ffcc39c1cf128ff0fb2b4f880a03
-    pristine_git_object: 856605cbf8532734f7786ba40092082fb4f2f0d1
+    last_write_checksum: sha1:6a026ae9529f5ba00688fa306914ba058c9e9c05
+    pristine_git_object: 55fbc8631313633e7bdc82a707a11ab1dad04e1f
   src/autumn_sdk/models/createfeatureop.py:
     id: 68487033fbe5
-    last_write_checksum: sha1:7700b9041190ce954caa13d6981c0c1460e5ee20
-    pristine_git_object: 35a43e4dd6ea06d0ffbbde5ffaead959ce207632
+    last_write_checksum: sha1:c68f6e79a3dc3d3436d607fae75e4c4a958b7141
+    pristine_git_object: 3a3fa7e5caf97561ce5ea6f494941cb1ce64b67c
   src/autumn_sdk/models/createplanop.py:
     id: 077e6c7db2ad
-    last_write_checksum: sha1:0c61ef749d904298fb13666629dd8279e72dfff6
-    pristine_git_object: 83a58b0e78861300af0d4ddf3901e3474e2683d6
+    last_write_checksum: sha1:abd3f7dda2a80ddeeee92ec78efb394384f8db93
+    pristine_git_object: 1b6499a88233db6b079ec7add34d9726331f329d
   src/autumn_sdk/models/createreferralcodeop.py:
     id: 2f5f7b136c39
-    last_write_checksum: sha1:aee36f911153fc0dab9fd096dbb82d1083a61d28
-    pristine_git_object: cd3ad48900dab5fd4b07db41d62388e68a1818b2
+    last_write_checksum: sha1:9ef6a7e87ffd4cb0fb91f3592abb3b1ef51cb415
+    pristine_git_object: fea4d1bb3875848e66502705e4cb818233ec3f5a
   src/autumn_sdk/models/createscheduleop.py:
     id: afb0cf1cf7f2
-    last_write_checksum: sha1:b45fd72cb5e8c76c29f837a4da4afcf76c8e8bf2
-    pristine_git_object: 01b44eae27d95ceaca00b0b035202830305d99b4
+    last_write_checksum: sha1:435695ce987ee9e5393bb64ba84f479007f7cfd3
+    pristine_git_object: 97d115471f43fcbbc6c27f64112c0dd76dea3252
   src/autumn_sdk/models/customer.py:
     id: 8ed0174f7272
     last_write_checksum: sha1:b34d9296ba774e5a622b84a48ce38cdab983953c
@@ -4293,136 +4293,136 @@ trackedFiles:
     pristine_git_object: 6d020a0f8da88109f10c72fd81248a4d5194a31e
   src/autumn_sdk/models/deletebalanceop.py:
     id: 97d06f64852a
-    last_write_checksum: sha1:ba767e7c2cfe20f213abff1235768b6e789ef11b
-    pristine_git_object: d8b06d3c0000690d712dfeb7771a4c08d0c9932f
+    last_write_checksum: sha1:f8c0f83b5afa8636d3cb97e4c52ae472e55415a2
+    pristine_git_object: ba888a4d97ab8d8fb72e044756e574adf3f4335b
   src/autumn_sdk/models/deletecustomerop.py:
     id: dc7a1e2cc90b
-    last_write_checksum: sha1:8b345d4715c2fa291674b86287439e824cd479ce
-    pristine_git_object: f731ec176a58301941259ea8c4b36353703802bb
+    last_write_checksum: sha1:552184c914a58b499809d828293484a812015511
+    pristine_git_object: 9012d64fcd53fa2b0e9a3162814d0eab49d8ba33
   src/autumn_sdk/models/deleteentityop.py:
     id: f875e07e0401
-    last_write_checksum: sha1:a596e590cb293b64f97549972cb674f0ea6661c0
-    pristine_git_object: 994654d79145e1b31ccf1bb2400732e13060c11c
+    last_write_checksum: sha1:1ea6eb0899b768e16506aca2b4642b79b1a9cece
+    pristine_git_object: b83e92df7f07e812a2b742858f1057ea36f109b7
   src/autumn_sdk/models/deletefeatureop.py:
     id: 2cde77bc8684
-    last_write_checksum: sha1:eb0e3de24676ed9ca638050e753adcf77d9e9273
-    pristine_git_object: d16ff515bd2fd4ae2c67c7b3099b9bbc981e966d
+    last_write_checksum: sha1:bc4e0d34b684036d267adb46f3f5d568d89a895d
+    pristine_git_object: 73d6550e9d3d672e269f03d0123682e31081a4e5
   src/autumn_sdk/models/deleteplanop.py:
     id: 4dd8168b93d3
-    last_write_checksum: sha1:b66060053ba95103b6f9c21583c837aff5bf4f5b
-    pristine_git_object: 8399927609dfaba9ca603a77e3f85ada3861d2f2
+    last_write_checksum: sha1:13d5c802291fe3009fc2e75c417d9eaaa4a0e6f1
+    pristine_git_object: 7ceead5c6d6226a1e28dabb594031b4e7f223142
   src/autumn_sdk/models/finalizelockop.py:
     id: 8ae2484b0916
-    last_write_checksum: sha1:50898394734e6e9a366363ef64dd6ac917d61ad2
-    pristine_git_object: d7744bc3f223baddeed24f3e14315d9f6da0b84d
+    last_write_checksum: sha1:717296b4a61a55f90035cd12c89ae9cd2e88d577
+    pristine_git_object: 888b39cd8f29b10735aab2f44892813a41595f33
   src/autumn_sdk/models/getcustomerop.py:
     id: 266e08dde55d
-    last_write_checksum: sha1:26c01f348d7b5fa3d7416cd032f39c4e2fa40ef3
-    pristine_git_object: 8ce7e5cbc0aeb86645dad533bb80758be9e4fc5d
+    last_write_checksum: sha1:99d1a3e00f783dbeb7e90362549917fc6e892140
+    pristine_git_object: 2770ceced0327c6b2c38fa3fd91662bb5da786f9
   src/autumn_sdk/models/getentityop.py:
     id: 6a624594b41f
-    last_write_checksum: sha1:c269882e521ec211782e7ea02149157a2d09b5d5
-    pristine_git_object: 29cba6a2449a90f021a82911a730592d102ef992
+    last_write_checksum: sha1:3b71deedab3c21399d5d6afd4372dd31322afcc8
+    pristine_git_object: 2b8a05c98adc64b7f24d1078ec27d190a0138f2d
   src/autumn_sdk/models/getfeatureop.py:
     id: 72b158789497
-    last_write_checksum: sha1:89a9f44a1af9b36cf229f80000cae16054da17a5
-    pristine_git_object: 63aec0714ea5d7f98ffdb2d7125d0b9db6fe8537
+    last_write_checksum: sha1:dccbc8de6a2d4cc07a4045585f12d8649b9f4c0a
+    pristine_git_object: a3b6d982c56568f07fc5b226e4d836b62dc7d331
   src/autumn_sdk/models/getorcreatecustomerop.py:
     id: acfac0d7be14
-    last_write_checksum: sha1:9e7565db7d134b1c5925e4e4d18e26695b74e4f1
-    pristine_git_object: c929128d66a9269897320872bf8eefb7b64bd9e1
+    last_write_checksum: sha1:524b618ee1defe01311abb69aebedfa737015214
+    pristine_git_object: ecf53428c556a2515c44ee3bb7e31a2aab91f1f4
   src/autumn_sdk/models/getplanop.py:
     id: 590fb77ac88d
-    last_write_checksum: sha1:81ea83faee9199b1c02f72521ed5dff3c1da74c4
-    pristine_git_object: d08f2c9fc8056c6adb96024112c4aaade0ee5cb5
+    last_write_checksum: sha1:4b545b24018986ba9d93107df7840f39fb1f861c
+    pristine_git_object: e619e84014109d0ac73df596b4926a8f6dc92ee3
   src/autumn_sdk/models/internal/__init__.py:
     id: 2906fe7f2cde
     last_write_checksum: sha1:1905b58b74ecc52346d8f5c24ded2b6d6e1dad4a
     pristine_git_object: ceabb1b83cb7cc1e21e65639c69c30749d36f6e2
   src/autumn_sdk/models/internal/globals.py:
     id: 4e33eb99f463
-    last_write_checksum: sha1:68407c632e298626a027a6da8e5c87bfc34ce496
-    pristine_git_object: 857f87628bd168b87758ac04fc88a926255d7451
+    last_write_checksum: sha1:b12bb60e74b8678b0fd0543223c09cc3d77dcc8b
+    pristine_git_object: 2614675c993545d5df1e516d043649e50281c2a3
   src/autumn_sdk/models/listcustomersop.py:
     id: d7074740b8b0
-    last_write_checksum: sha1:927f6bd702f74d13fb90e93865b7c38f7ec6ea9d
-    pristine_git_object: 66eccd8ee4fddda461be05ee7516c5e591380464
+    last_write_checksum: sha1:a5d8ecb8aa876fbc13e45895238fdd4b8ef00262
+    pristine_git_object: efb7ae861ed3c85269dea269465c198119fe37fe
   src/autumn_sdk/models/listentitiesop.py:
     id: 918a05430967
-    last_write_checksum: sha1:8fa96fde2c49b269a489e2a7a44533f2d71f2ed4
-    pristine_git_object: 25e5f40817b1bf1d885ff7ee6b23db636c3e11be
+    last_write_checksum: sha1:dbcc46f4782eab84662ba8426cadecdae7473927
+    pristine_git_object: 7fe4e89b0d9c2a6cb6df185e6f0fc995687a4f97
   src/autumn_sdk/models/listeventsop.py:
     id: 751b0200d91d
-    last_write_checksum: sha1:d1fc02ee236167757b24b0ff5d07ef6c50ca8422
-    pristine_git_object: 2dee5460c65ef6cc4be4cd23b5d798ecf26274a7
+    last_write_checksum: sha1:a57b8d56c96c341e8572b4395c12209a62ff6b74
+    pristine_git_object: 86a98a1d2f3df5e7a53326e54a9ddb2883b711ed
   src/autumn_sdk/models/listfeaturesop.py:
     id: 95f88614bd8e
-    last_write_checksum: sha1:983c9bab14d984cdc250fd5822ca98dc373c3cae
-    pristine_git_object: 710a3e36719b112a82fa98903073bb090f72c2ec
+    last_write_checksum: sha1:3c2e2e44a81954ab08a70e7fa8dfbea30ab0aeb8
+    pristine_git_object: 8819d5dc8edea75b53ba1d465773b158eb95f310
   src/autumn_sdk/models/listplansop.py:
     id: fdf892c403f4
-    last_write_checksum: sha1:113ab9ebeee0eefbde8f8127c707c0e877ce44ce
-    pristine_git_object: eeb10aef025dba4e535b1b752707dba2b8c0cc44
+    last_write_checksum: sha1:eec171b45ca5d8b9e7d13e307c9125a0e6c92970
+    pristine_git_object: cc085894937b7e149381b51729063f03d39e4eb5
   src/autumn_sdk/models/multiattachop.py:
     id: dfdf7952c870
-    last_write_checksum: sha1:bc0ef7eee37a54bb0823e7270535ed079fff9113
-    pristine_git_object: 8cf4105bebefbcf73a641cc92f3bbf176fc1eba8
+    last_write_checksum: sha1:58d91eee19f9d021419ef6d98e15f65a435fdc8f
+    pristine_git_object: 98621cdbe47a5109f68dd5c1dce3127b1aa2545d
   src/autumn_sdk/models/opencustomerportalop.py:
     id: 004cc9a6466f
-    last_write_checksum: sha1:b190ddc8e45b3198fa12ae5f49deb9d8cac20a5e
-    pristine_git_object: 8383509aa89e0c11988baef8e424f5ae682d5c8e
+    last_write_checksum: sha1:e32037dcfea1c4bd953f749f74775b3d7d1d83c3
+    pristine_git_object: 79ac016f241d82916ccc1aab7c7e3a7e3fb9aef1
   src/autumn_sdk/models/plan.py:
     id: f85c4e07540d
     last_write_checksum: sha1:69a6d5e972a3d1d16bda1771940d66bbf403726d
     pristine_git_object: 99032117da3cc10b694f41fd0bc7a0c1f2bd7973
   src/autumn_sdk/models/previewattachop.py:
     id: 2b361be4bfa8
-    last_write_checksum: sha1:269b008a7f1899ba875a08bb44d37096d74b89c7
-    pristine_git_object: 4752cdb0c8e333a6407ffbb152463cce963fcada
+    last_write_checksum: sha1:19cfdad77a54a7419f28e9fc1f3cd81e1cf831db
+    pristine_git_object: d1b9ca8d15840e4ffb6a5804c3037bebbe188b8e
   src/autumn_sdk/models/previewmultiattachop.py:
     id: 963ffcd646a4
-    last_write_checksum: sha1:2095cb695b366c95cf32a25041b747596adc9cbd
-    pristine_git_object: 2540dad98d3028429071d41245b4e1db0a65371d
+    last_write_checksum: sha1:b8ff436f7435ce227a5426ae9fe5059e08cbef2b
+    pristine_git_object: 3a0561ab842ec6d09dda0e9bae06e6059c92e75a
   src/autumn_sdk/models/previewupdateop.py:
     id: 081d5f08508d
-    last_write_checksum: sha1:084d58dd000211d786551d314b08ff2ec7f3f180
-    pristine_git_object: 6c1ba3ccca01be177621b11ca4724fc658179434
+    last_write_checksum: sha1:dbf17616256e92fb18393f95bd536098ee4b6f7a
+    pristine_git_object: 346a1eb769186d700e50c3243fdbe09fea9ea251
   src/autumn_sdk/models/redeemreferralcodeop.py:
     id: 0abd7bfae718
-    last_write_checksum: sha1:df1248aa8876e069c8094cba0541acc4911db620
-    pristine_git_object: 2e67e9b952a5107efcb3d79f2d9b6b63c06b4030
+    last_write_checksum: sha1:b1a584450f1f79e796dd755a9305dc30a07ed601
+    pristine_git_object: 93b78a37bc7276b56d330f437e43eba7af4302c4
   src/autumn_sdk/models/security.py:
     id: 27d01b755fbe
     last_write_checksum: sha1:e5ac2e52ed9c2db46d4989c4744c230dd12bdf01
     pristine_git_object: aa686dd6f85ae1e27450392fcfe02527adfe8e61
   src/autumn_sdk/models/setuppaymentop.py:
     id: 603339ee67e3
-    last_write_checksum: sha1:67d270cd5abfb97b1225fd1fb90fdeb732772edd
-    pristine_git_object: dee5c4638d610b7dbad937804b7e9a30269d16cf
+    last_write_checksum: sha1:7a410d7b24326e3cf61fb1f1bf6871d0328cad18
+    pristine_git_object: 9c8c2e6b00f79e487e719904876c3ab2e88b31f4
   src/autumn_sdk/models/trackop.py:
     id: 2a744315e781
-    last_write_checksum: sha1:bf7bba4e903181d599be5be9c9fa55556be4b409
-    pristine_git_object: b6ba6867a53fc108da23705b39cb29ba6566f296
+    last_write_checksum: sha1:a03320b078d71050927407e1149770bf357bb7ae
+    pristine_git_object: 6a5c9d1796caf9aab48df3315196337c1c82d028
   src/autumn_sdk/models/updatebalanceop.py:
     id: cd80d90d4cae
-    last_write_checksum: sha1:7b6b881cc82b937e93cfd58f17d7f3d83bdb39f1
-    pristine_git_object: d69bad2bc308f31e4983cf5e2cd0639cedd9c9aa
+    last_write_checksum: sha1:729cd503f116f20564b7bccc79c60ac1011554f2
+    pristine_git_object: c0bbec7e538787d31d5eaebafa5c9033b6df9da3
   src/autumn_sdk/models/updatecustomerop.py:
     id: 28b9d5b59bae
-    last_write_checksum: sha1:3e8a1554ca804b5224f6610db19469d1f33baba7
-    pristine_git_object: 16ed7797c797ef1fd60c1de0c38770d30282c853
+    last_write_checksum: sha1:76c2569065030ec3f17314b057cec06d300aecd6
+    pristine_git_object: 63e06deec671e219be422630460b483fc31e16bd
   src/autumn_sdk/models/updateentityop.py:
     id: a49305af1e2e
-    last_write_checksum: sha1:ddd0da8cc96a40bf7ba51bfb060028b2b281d5e4
-    pristine_git_object: 9b6d1378b4defc1056a93eef6694159b5e91b326
+    last_write_checksum: sha1:448d0b049bedfd94fba404a9053da4f959200dcf
+    pristine_git_object: 80fe86883274d4bcd47b2f4f66d9a8286c98cdbe
   src/autumn_sdk/models/updatefeatureop.py:
     id: 2fdfed4aa2f2
-    last_write_checksum: sha1:67e6bcbdf14980e19787d10e0ab42485acff0862
-    pristine_git_object: 9507c8601dca2cefbc0b8b7d423a38a8272fe580
+    last_write_checksum: sha1:31b590aab5fd341dbf9d3ae8ec97f01fc6fe5090
+    pristine_git_object: 563058b5a7d4a5805ba9d5109c7383ecbecd3d1c
   src/autumn_sdk/models/updateplanop.py:
     id: 753ddf45ca40
-    last_write_checksum: sha1:8c4355ce9a7f7f5d7e59b95b9106d697c40a4048
-    pristine_git_object: 2bc28f5cdf9a47eabcd2536355c5fc431866e3a7
+    last_write_checksum: sha1:7806983a99cefbb6ed167afdf8f4401d7d7f802d
+    pristine_git_object: 9a4531386163eb8a82dd510b4db243541535d7dd
   src/autumn_sdk/plans.py:
     id: cf1ebabb687c
     last_write_checksum: sha1:8cca1565af6b67ab6947b016d0ab8f7a431fa824
@@ -4546,7 +4546,7 @@ examples:
     speakeasy-default-attach:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plan_id": "pro_plan", "redirect_mode": "if_required", "billing_cycle_anchor": "now"}
       responses:
@@ -4556,7 +4556,7 @@ examples:
     speakeasy-default-get-or-create-customer:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "name": "John Doe", "email": "john@example.com"}
       responses:
@@ -4566,17 +4566,17 @@ examples:
     speakeasy-default-list-customers:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
-        application/json: {"offset": 0, "limit": 10}
+        application/json: {"start_cursor": "", "limit": 10}
       responses:
         "200":
-          application/json: {"list": [{"id": "2ee25a41-0d81-4ad2-8451-ec1aadaefe58", "name": "Patrick", "email": "patrick@useautumn.com", "created_at": 2358.1, "fingerprint": null, "stripe_id": null, "env": "sandbox", "metadata": {}, "send_email_receipts": false, "billing_controls": {}, "subscriptions": [{"id": "<id>", "plan_id": "<id>", "auto_enable": true, "add_on": false, "status": "active", "past_due": true, "canceled_at": 1145.98, "expires_at": 4027.68, "trial_ends_at": 910.35, "started_at": 7325.71, "current_period_start": 406.39, "current_period_end": 2629.33, "quantity": 1}], "purchases": [], "balances": {"messages": {"feature_id": "<id>", "granted": 100, "remaining": 0, "usage": 100, "unlimited": false, "overage_allowed": false, "max_purchase": 4531.44, "next_reset_at": 1010.14, "breakdown": [{"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "<id>", "included_grant": 4967.46, "prepaid_grant": 6928.7, "remaining": 0, "usage": 100, "unlimited": false, "reset": {"interval": "month", "resets_at": 7938.58}, "price": null, "expires_at": 7264.51}]}}, "flags": {"advanced_workflows": {"id": "cus_ent_abc123", "plan_id": "pro_plan", "expires_at": null, "feature_id": "advanced_workflows"}}, "config": {"disable_pooled_balance": false}, "processors": {"stripe": {"id": "cus_U0BKxpq1mFhuJO"}}}], "has_more": false, "offset": 0, "limit": 10, "total": 1, "total_count": 100, "total_filtered_count": 42}
+          application/json: {"list": [{"id": "2ee25a41-0d81-4ad2-8451-ec1aadaefe58", "name": "Patrick", "email": "patrick@useautumn.com", "created_at": 2358.1, "fingerprint": null, "stripe_id": null, "env": "sandbox", "metadata": {}, "send_email_receipts": false, "billing_controls": {}, "subscriptions": [{"id": "<id>", "plan_id": "<id>", "auto_enable": true, "add_on": false, "status": "active", "past_due": true, "canceled_at": 1145.98, "expires_at": 4027.68, "trial_ends_at": 910.35, "started_at": 7325.71, "current_period_start": 406.39, "current_period_end": 2629.33, "quantity": 1}], "purchases": [], "balances": {"messages": {"feature_id": "<id>", "granted": 100, "remaining": 0, "usage": 100, "unlimited": false, "overage_allowed": false, "max_purchase": 4531.44, "next_reset_at": 1010.14, "breakdown": [{"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "<id>", "included_grant": 4967.46, "prepaid_grant": 6928.7, "remaining": 0, "usage": 100, "unlimited": false, "reset": {"interval": "month", "resets_at": 7938.58}, "price": null, "expires_at": 7264.51}]}}, "flags": {"advanced_workflows": {"id": "cus_ent_abc123", "plan_id": "pro_plan", "expires_at": null, "feature_id": "advanced_workflows"}}, "config": {"disable_pooled_balance": false}, "processors": {"stripe": {"id": "cus_U0BKxpq1mFhuJO"}}}], "next_cursor": null}
   updateCustomer:
     speakeasy-default-update-customer:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "name": "Jane Doe", "email": "jane@example.com"}
       responses:
@@ -4586,7 +4586,7 @@ examples:
     speakeasy-default-delete-customer:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "delete_in_stripe": false}
       responses:
@@ -4616,7 +4616,7 @@ examples:
     speakeasy-default-billing-update:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plan_id": "pro_plan", "feature_quantities": [{"feature_id": "seats", "quantity": 10}], "redirect_mode": "if_required", "billing_cycle_anchor": "now"}
       responses:
@@ -4686,7 +4686,7 @@ examples:
     speakeasy-default-list-plans:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {}
       responses:
@@ -4696,7 +4696,7 @@ examples:
     speakeasy-default-preview-attach:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plan_id": "pro_plan", "redirect_mode": "if_required", "billing_cycle_anchor": "now"}
       responses:
@@ -4726,7 +4726,7 @@ examples:
     speakeasy-default-setup-payment:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "success_url": "https://example.com/account/billing", "billing_cycle_anchor": "now"}
       responses:
@@ -4756,7 +4756,7 @@ examples:
     speakeasy-default-open-customer-portal:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "return_url": "https://useautumn.com"}
       responses:
@@ -4766,7 +4766,7 @@ examples:
     speakeasy-default-preview-update:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plan_id": "pro_plan", "feature_quantities": [{"feature_id": "seats", "quantity": 15}], "redirect_mode": "if_required", "billing_cycle_anchor": "now"}
       responses:
@@ -4776,7 +4776,7 @@ examples:
     speakeasy-default-create-balance:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "api_calls", "reset": {"interval": "month"}}
       responses:
@@ -4786,7 +4786,7 @@ examples:
     speakeasy-default-update-balance:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "api_calls", "remaining": 5}
       responses:
@@ -4796,7 +4796,7 @@ examples:
     speakeasy-default-check:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "messages"}
       responses:
@@ -4808,7 +4808,7 @@ examples:
     speakeasy-default-track:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "messages", "value": 1}
       responses:
@@ -4840,7 +4840,7 @@ examples:
     speakeasy-default-create-referral-code:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "program_id": "prog_123"}
       responses:
@@ -4850,7 +4850,7 @@ examples:
     speakeasy-default-redeem-referral-code:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"code": "REF123", "customer_id": "cus_456"}
       responses:
@@ -4860,7 +4860,7 @@ examples:
     speakeasy-default-create-entity:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"name": "Seat 42", "feature_id": "seats", "customer_id": "cus_123", "entity_id": "seat_42"}
       responses:
@@ -4870,7 +4870,7 @@ examples:
     speakeasy-default-get-entity:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"entity_id": "seat_42"}
       responses:
@@ -4880,7 +4880,7 @@ examples:
     speakeasy-default-delete-entity:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "entity_id": "seat_42"}
       responses:
@@ -4890,17 +4890,17 @@ examples:
     speakeasy-default-list-events:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
-        application/json: {"offset": 0, "limit": 50, "customer_id": "cus_123"}
+        application/json: {"start_cursor": "", "limit": 50, "customer_id": "cus_123"}
       responses:
         "200":
-          application/json: {"list": [{"id": "evt_36xpk2TmuQX5zVPPQ8tCtnR5Weg", "timestamp": 1765958215459, "feature_id": "credits", "customer_id": "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx", "value": 30, "properties": {}, "deductions": [{"balance_id": "cus_ent_3DdSDtFBlvDbjyUuJeUIbQlyN12", "feature_id": "credits", "plan_id": "pro", "reset": {"interval": "month", "resets_at": 1765958215459}, "value": 30}]}, {"id": "evt_36xmHxxjAkqxufDf9yHAPNfRrLM", "timestamp": 1765956512057, "feature_id": "credits", "customer_id": "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx", "value": 49, "properties": {}, "deductions": null}], "has_more": false, "offset": 0, "limit": 100, "total": 2}
+          application/json: {"list": [{"id": "evt_36xpk2TmuQX5zVPPQ8tCtnR5Weg", "timestamp": 1765958215459, "feature_id": "credits", "customer_id": "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx", "value": 30, "properties": {}, "deductions": [{"balance_id": "cus_ent_3DdSDtFBlvDbjyUuJeUIbQlyN12", "feature_id": "credits", "plan_id": "pro", "reset": {"interval": "month", "resets_at": 1765958215459}, "value": 30}]}, {"id": "evt_36xmHxxjAkqxufDf9yHAPNfRrLM", "timestamp": 1765956512057, "feature_id": "credits", "customer_id": "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx", "value": 49, "properties": {}, "deductions": null}], "next_cursor": "eyJ2IjowLCJpZCI6ImV2dF8zNnhtSHh4akFrcXh1ZkRmOXlIQVBOZlJyTE0iLCJ0IjoxNzY1OTU2NTEyMDU3fQ"}
   aggregateEvents:
     speakeasy-default-aggregate-events:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "api_calls", "range": "30d", "bin_size": "day"}
       responses:
@@ -4910,7 +4910,7 @@ examples:
     speakeasy-default-create-feature:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"name": "API Calls", "type": "metered", "consumable": true, "feature_id": "api-calls"}
       responses:
@@ -4920,7 +4920,7 @@ examples:
     speakeasy-default-get-feature:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"feature_id": "api-calls"}
       responses:
@@ -4930,7 +4930,7 @@ examples:
     speakeasy-default-list-features:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       responses:
         "200":
           application/json: {"list": [{"id": "api-calls", "name": "API Calls", "type": "metered", "consumable": true, "display": {"singular": "API call", "plural": "API calls"}, "archived": false}, {"id": "credits", "name": "Credits", "type": "credit_system", "consumable": true, "credit_schema": [{"metered_feature_id": "api-calls", "credit_cost": 1}, {"metered_feature_id": "image-generations", "credit_cost": 10}], "display": {"singular": "credit", "plural": "credits"}, "archived": false}]}
@@ -4938,7 +4938,7 @@ examples:
     speakeasy-default-update-feature:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"name": "API Requests", "display": {"singular": "API request", "plural": "API requests"}, "feature_id": "api-calls"}
       responses:
@@ -4948,7 +4948,7 @@ examples:
     speakeasy-default-delete-feature:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"feature_id": "old-feature"}
       responses:
@@ -4958,7 +4958,7 @@ examples:
     speakeasy-default-create-plan:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"plan_id": "free_plan", "group": "", "name": "Free", "add_on": false, "auto_enable": true, "items": [{"feature_id": "messages", "included": 100, "reset": {"interval": "month"}}], "create_in_stripe": true}
       responses:
@@ -4968,7 +4968,7 @@ examples:
     speakeasy-default-get-plan:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"plan_id": "pro_plan"}
       responses:
@@ -4978,7 +4978,7 @@ examples:
     speakeasy-default-update-plan:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"plan_id": "pro_plan", "group": "", "name": "Pro Plan (Updated)", "price": {"amount": 15, "interval": "month"}, "create_in_stripe": true, "archived": false}
       responses:
@@ -4988,7 +4988,7 @@ examples:
     speakeasy-default-delete-plan:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"plan_id": "unused_plan", "all_versions": false}
       responses:
@@ -5008,7 +5008,7 @@ examples:
     speakeasy-default-preview-multi-attach:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plans": [{"plan_id": "pro_plan"}, {"plan_id": "addon_seats", "feature_quantities": [{"feature_id": "seats", "quantity": 5}]}], "redirect_mode": "if_required"}
       responses:
@@ -5018,7 +5018,7 @@ examples:
     speakeasy-default-multi-attach:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plans": [{"plan_id": "pro_plan"}, {"plan_id": "addon_seats", "feature_quantities": [{"feature_id": "seats", "quantity": 5}]}], "redirect_mode": "if_required"}
       responses:
@@ -5028,7 +5028,7 @@ examples:
     speakeasy-default-delete-balance:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "api_calls"}
       responses:
@@ -5048,7 +5048,7 @@ examples:
     speakeasy-default-finalize-lock:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"lock_id": "lock_abc123", "action": "confirm"}
       responses:
@@ -5060,7 +5060,7 @@ examples:
     speakeasy-default-update-entity:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "entity_id": "seat_42", "billing_controls": {"spend_limits": [{"feature_id": "messages", "enabled": true, "overage_limit": 25}]}}
       responses:
@@ -5070,7 +5070,7 @@ examples:
     speakeasy-default-get-customer:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123"}
       responses:
@@ -5080,7 +5080,7 @@ examples:
     speakeasy-default-create-schedule:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "redirect_mode": "if_required", "billing_cycle_anchor": "now", "phases": [{"starts_at": 1735689600000, "plans": [{"plan_id": "trial_plan"}]}, {"starts_at": 1736899200000, "plans": [{"plan_id": "pro_plan"}]}]}
       responses:
@@ -5090,10 +5090,10 @@ examples:
     speakeasy-default-list-entities:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
-        application/json: {"offset": 0, "limit": 10}
+        application/json: {"start_cursor": "", "limit": 10}
       responses:
         "200":
-          application/json: {"list": [{"id": "seat_42", "name": "Seat 42", "customer_id": "cus_123", "feature_id": "seats", "created_at": 1771409161016, "env": "sandbox", "subscriptions": [{"id": "<id>", "plan_id": "pro_plan", "auto_enable": true, "add_on": false, "status": "active", "past_due": false, "canceled_at": null, "expires_at": null, "trial_ends_at": null, "started_at": 1771431921437, "current_period_start": 1771431921437, "current_period_end": 1771999921437, "quantity": 1}], "purchases": [], "balances": {"messages": {"feature_id": "messages", "granted": 100, "remaining": 72, "usage": 28, "unlimited": false, "overage_allowed": false, "max_purchase": null, "next_reset_at": 1773851121437, "breakdown": [{"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "pro_plan", "included_grant": 100, "prepaid_grant": 0, "remaining": 72, "usage": 28, "unlimited": false, "reset": {"interval": "month", "resets_at": 1773851121437}, "price": null, "expires_at": null}]}}, "flags": {"key": {"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "pro_plan", "expires_at": null, "feature_id": "dashboard"}}, "invoices": []}], "has_more": false, "offset": 0, "limit": 10, "total": 1, "total_count": 100, "total_filtered_count": 42}
+          application/json: {"list": [{"id": "seat_42", "name": "Seat 42", "customer_id": "cus_123", "feature_id": "seats", "created_at": 1771409161016, "env": "sandbox", "subscriptions": [{"id": "<id>", "plan_id": "pro_plan", "auto_enable": true, "add_on": false, "status": "active", "past_due": false, "canceled_at": null, "expires_at": null, "trial_ends_at": null, "started_at": 1771431921437, "current_period_start": 1771431921437, "current_period_end": 1771999921437, "quantity": 1}], "purchases": [], "balances": {"messages": {"feature_id": "messages", "granted": 100, "remaining": 72, "usage": 28, "unlimited": false, "overage_allowed": false, "max_purchase": null, "next_reset_at": 1773851121437, "breakdown": [{"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "pro_plan", "included_grant": 100, "prepaid_grant": 0, "remaining": 72, "usage": 28, "unlimited": false, "reset": {"interval": "month", "resets_at": 1773851121437}, "price": null, "expires_at": null}]}}, "flags": {"key": {"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "pro_plan", "expires_at": null, "feature_id": "dashboard"}}, "invoices": []}], "next_cursor": null}
 examplesVersion: 1.0.2

--- a/others/python-sdk/README.md
+++ b/others/python-sdk/README.md
@@ -122,7 +122,7 @@ from autumn_sdk import Autumn
 
 
 with Autumn(
-    x_api_version="2.2.0",
+    x_api_version="2.3.0",
     secret_key="<YOUR_BEARER_TOKEN_HERE>",
 ) as autumn:
 
@@ -144,7 +144,7 @@ from autumn_sdk import Autumn
 async def main():
 
     async with Autumn(
-        x_api_version="2.2.0",
+        x_api_version="2.3.0",
         secret_key="<YOUR_BEARER_TOKEN_HERE>",
     ) as autumn:
 
@@ -175,7 +175,7 @@ from autumn_sdk import Autumn
 
 with Autumn(
     secret_key="<YOUR_BEARER_TOKEN_HERE>",
-    x_api_version="2.2.0",
+    x_api_version="2.3.0",
 ) as autumn:
 
     res = autumn.check(customer_id="cus_123", feature_id="messages")
@@ -242,7 +242,7 @@ Use this as the primary entrypoint before billing operations so the customer rec
 * [get](docs/sdks/customers/README.md#get) - Fetches a customer by ID, optionally expanding related data such as invoices or entities.
 
 Use this when you know the customer exists or assert they exist without creating them.
-* [list](docs/sdks/customers/README.md#list) - Lists customers with pagination and optional filters.
+* [list](docs/sdks/customers/README.md#list) - Lists customers with cursor pagination and optional filters. Pass `start_cursor: ""` (or omit) for the first page; use `next_cursor` from a prior response for subsequent pages.
 * [update](docs/sdks/customers/README.md#update) - Updates an existing customer by ID.
 * [delete](docs/sdks/customers/README.md#delete) - Deletes a customer by ID.
 
@@ -315,7 +315,7 @@ from autumn_sdk.utils import BackoffStrategy, RetryConfig
 
 
 with Autumn(
-    x_api_version="2.2.0",
+    x_api_version="2.3.0",
     secret_key="<YOUR_BEARER_TOKEN_HERE>",
 ) as autumn:
 
@@ -335,7 +335,7 @@ from autumn_sdk.utils import BackoffStrategy, RetryConfig
 
 with Autumn(
     retry_config=RetryConfig("backoff", BackoffStrategy(1, 50, 1.1, 100), False),
-    x_api_version="2.2.0",
+    x_api_version="2.3.0",
     secret_key="<YOUR_BEARER_TOKEN_HERE>",
 ) as autumn:
 
@@ -366,7 +366,7 @@ from autumn_sdk import Autumn, errors
 
 
 with Autumn(
-    x_api_version="2.2.0",
+    x_api_version="2.3.0",
     secret_key="<YOUR_BEARER_TOKEN_HERE>",
 ) as autumn:
     res = None
@@ -420,7 +420,7 @@ from autumn_sdk import Autumn
 
 with Autumn(
     server_url="https://api.useautumn.com",
-    x_api_version="2.2.0",
+    x_api_version="2.3.0",
     secret_key="<YOUR_BEARER_TOKEN_HERE>",
 ) as autumn:
 
@@ -525,7 +525,7 @@ from autumn_sdk import Autumn
 def main():
 
     with Autumn(
-        x_api_version="2.2.0",
+        x_api_version="2.3.0",
         secret_key="<YOUR_BEARER_TOKEN_HERE>",
     ) as autumn:
         # Rest of application here...
@@ -535,7 +535,7 @@ def main():
 async def amain():
 
     async with Autumn(
-        x_api_version="2.2.0",
+        x_api_version="2.3.0",
         secret_key="<YOUR_BEARER_TOKEN_HERE>",
     ) as autumn:
         # Rest of application here...

--- a/others/python-sdk/USAGE.md
+++ b/others/python-sdk/USAGE.md
@@ -5,7 +5,7 @@ from autumn_sdk import Autumn
 
 
 with Autumn(
-    x_api_version="2.2.0",
+    x_api_version="2.3.0",
     secret_key="<YOUR_BEARER_TOKEN_HERE>",
 ) as autumn:
 
@@ -27,7 +27,7 @@ from autumn_sdk import Autumn
 async def main():
 
     async with Autumn(
-        x_api_version="2.2.0",
+        x_api_version="2.3.0",
         secret_key="<YOUR_BEARER_TOKEN_HERE>",
     ) as autumn:
 

--- a/others/python-sdk/src/autumn_sdk/_version.py
+++ b/others/python-sdk/src/autumn_sdk/_version.py
@@ -4,9 +4,9 @@ import importlib.metadata
 
 __title__: str = "autumn-sdk"
 __version__: str = "0.4.18"
-__openapi_doc_version__: str = "2.2.0"
+__openapi_doc_version__: str = "2.3.0"
 __gen_version__: str = "2.882.0"
-__user_agent__: str = "speakeasy-sdk/python 0.4.18 2.882.0 2.2.0 autumn-sdk"
+__user_agent__: str = "speakeasy-sdk/python 0.4.18 2.882.0 2.3.0 autumn-sdk"
 
 try:
     if __package__ is not None:

--- a/others/python-sdk/src/autumn_sdk/customers.py
+++ b/others/python-sdk/src/autumn_sdk/customers.py
@@ -3,9 +3,9 @@
 from .basesdk import BaseSDK
 from autumn_sdk import errors, models, utils
 from autumn_sdk._hooks import HookContext
-from autumn_sdk.types import BaseModel, Nullable, OptionalNullable, UNSET
+from autumn_sdk.types import Nullable, OptionalNullable, UNSET
 from autumn_sdk.utils.unmarshal_json_response import unmarshal_json_response
-from typing import Any, Dict, List, Mapping, Optional, Union, cast
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 
 class Customers(BaseSDK):
@@ -480,17 +480,29 @@ class Customers(BaseSDK):
     def list(
         self,
         *,
-        request: Optional[
-            Union[models.ListCustomersParams, models.ListCustomersParamsTypedDict]
+        start_cursor: Optional[str] = "",
+        limit: Optional[int] = 50,
+        plans: Optional[
+            Union[
+                List[models.ListCustomersPlan], List[models.ListCustomersPlanTypedDict]
+            ]
         ] = None,
+        subscription_status: Optional[models.ListCustomersSubscriptionStatus] = None,
+        search: Optional[str] = None,
+        processors: Optional[List[models.ListCustomersProcessor]] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
         http_headers: Optional[Mapping[str, str]] = None,
     ) -> models.ListCustomersResponse:
-        r"""Lists customers with pagination and optional filters.
+        r"""Lists customers with cursor pagination and optional filters. Pass `start_cursor: \"\"` (or omit) for the first page; use `next_cursor` from a prior response for subsequent pages.
 
-        :param request: The request object to send.
+        :param start_cursor: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
+        :param limit: Number of items to return. Default 50, hard ceiling 5000.
+        :param plans: Filter by plan ID and version. Returns customers with active subscriptions to this plan.
+        :param subscription_status: Filter by customer product status. Defaults to active and scheduled.
+        :param search: Search customers by id, name, or email.
+        :param processors: Filter by customer processor type (stripe, revenuecat, vercel).
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -506,9 +518,16 @@ class Customers(BaseSDK):
         else:
             base_url = self._get_url(base_url, url_variables)
 
-        if not isinstance(request, BaseModel):
-            request = utils.unmarshal(request, Optional[models.ListCustomersParams])
-        request = cast(Optional[models.ListCustomersParams], request)
+        request = models.ListCustomersParams(
+            start_cursor=start_cursor,
+            limit=limit,
+            plans=utils.get_pydantic_model(
+                plans, Optional[List[models.ListCustomersPlan]]
+            ),
+            subscription_status=subscription_status,
+            search=search,
+            processors=processors,
+        )
 
         req = self._build_request(
             method="POST",
@@ -516,7 +535,7 @@ class Customers(BaseSDK):
             base_url=base_url,
             url_variables=url_variables,
             request=request,
-            request_body_required=False,
+            request_body_required=True,
             request_has_path_params=False,
             request_has_query_params=True,
             user_agent_header="user-agent",
@@ -527,7 +546,7 @@ class Customers(BaseSDK):
             ),
             security=self.sdk_configuration.security,
             get_serialized_body=lambda: utils.serialize_request_body(
-                request, False, True, "json", Optional[models.ListCustomersParams]
+                request, False, False, "json", models.ListCustomersParams
             ),
             allow_empty_value=None,
             timeout_ms=timeout_ms,
@@ -572,17 +591,29 @@ class Customers(BaseSDK):
     async def list_async(
         self,
         *,
-        request: Optional[
-            Union[models.ListCustomersParams, models.ListCustomersParamsTypedDict]
+        start_cursor: Optional[str] = "",
+        limit: Optional[int] = 50,
+        plans: Optional[
+            Union[
+                List[models.ListCustomersPlan], List[models.ListCustomersPlanTypedDict]
+            ]
         ] = None,
+        subscription_status: Optional[models.ListCustomersSubscriptionStatus] = None,
+        search: Optional[str] = None,
+        processors: Optional[List[models.ListCustomersProcessor]] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
         http_headers: Optional[Mapping[str, str]] = None,
     ) -> models.ListCustomersResponse:
-        r"""Lists customers with pagination and optional filters.
+        r"""Lists customers with cursor pagination and optional filters. Pass `start_cursor: \"\"` (or omit) for the first page; use `next_cursor` from a prior response for subsequent pages.
 
-        :param request: The request object to send.
+        :param start_cursor: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
+        :param limit: Number of items to return. Default 50, hard ceiling 5000.
+        :param plans: Filter by plan ID and version. Returns customers with active subscriptions to this plan.
+        :param subscription_status: Filter by customer product status. Defaults to active and scheduled.
+        :param search: Search customers by id, name, or email.
+        :param processors: Filter by customer processor type (stripe, revenuecat, vercel).
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -598,9 +629,16 @@ class Customers(BaseSDK):
         else:
             base_url = self._get_url(base_url, url_variables)
 
-        if not isinstance(request, BaseModel):
-            request = utils.unmarshal(request, Optional[models.ListCustomersParams])
-        request = cast(Optional[models.ListCustomersParams], request)
+        request = models.ListCustomersParams(
+            start_cursor=start_cursor,
+            limit=limit,
+            plans=utils.get_pydantic_model(
+                plans, Optional[List[models.ListCustomersPlan]]
+            ),
+            subscription_status=subscription_status,
+            search=search,
+            processors=processors,
+        )
 
         req = self._build_request_async(
             method="POST",
@@ -608,7 +646,7 @@ class Customers(BaseSDK):
             base_url=base_url,
             url_variables=url_variables,
             request=request,
-            request_body_required=False,
+            request_body_required=True,
             request_has_path_params=False,
             request_has_query_params=True,
             user_agent_header="user-agent",
@@ -619,7 +657,7 @@ class Customers(BaseSDK):
             ),
             security=self.sdk_configuration.security,
             get_serialized_body=lambda: utils.serialize_request_body(
-                request, False, True, "json", Optional[models.ListCustomersParams]
+                request, False, False, "json", models.ListCustomersParams
             ),
             allow_empty_value=None,
             timeout_ms=timeout_ms,

--- a/others/python-sdk/src/autumn_sdk/entities.py
+++ b/others/python-sdk/src/autumn_sdk/entities.py
@@ -3,9 +3,9 @@
 from .basesdk import BaseSDK
 from autumn_sdk import errors, models, utils
 from autumn_sdk._hooks import HookContext
-from autumn_sdk.types import BaseModel, OptionalNullable, UNSET
+from autumn_sdk.types import OptionalNullable, UNSET
 from autumn_sdk.utils.unmarshal_json_response import unmarshal_json_response
-from typing import Mapping, Optional, Union, cast
+from typing import List, Mapping, Optional, Union
 
 
 class Entities(BaseSDK):
@@ -438,9 +438,14 @@ class Entities(BaseSDK):
     def list(
         self,
         *,
-        request: Optional[
-            Union[models.ListEntitiesParams, models.ListEntitiesParamsTypedDict]
+        start_cursor: Optional[str] = "",
+        limit: Optional[int] = 50,
+        plans: Optional[
+            Union[List[models.ListEntitiesPlan], List[models.ListEntitiesPlanTypedDict]]
         ] = None,
+        subscription_status: Optional[models.ListEntitiesSubscriptionStatus] = None,
+        search: Optional[str] = None,
+        processors: Optional[List[models.ListEntitiesProcessor]] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
@@ -450,7 +455,12 @@ class Entities(BaseSDK):
 
         Use this to page through entities globally, including filtering by plans inherited from parent customers or attached directly to entities.
 
-        :param request: The request object to send.
+        :param start_cursor: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
+        :param limit: Number of items to return. Default 50, hard ceiling 5000.
+        :param plans: Filter by plan ID and version. Returns entities with active subscriptions to this plan, including plans inherited from the parent customer.
+        :param subscription_status: Filter customer products used for entity hydration and plan matching. Defaults to active and scheduled.
+        :param search: Search entities by id or name.
+        :param processors: Filter by parent customer processor type (stripe, revenuecat, vercel).
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -466,9 +476,16 @@ class Entities(BaseSDK):
         else:
             base_url = self._get_url(base_url, url_variables)
 
-        if not isinstance(request, BaseModel):
-            request = utils.unmarshal(request, Optional[models.ListEntitiesParams])
-        request = cast(Optional[models.ListEntitiesParams], request)
+        request = models.ListEntitiesParams(
+            start_cursor=start_cursor,
+            limit=limit,
+            plans=utils.get_pydantic_model(
+                plans, Optional[List[models.ListEntitiesPlan]]
+            ),
+            subscription_status=subscription_status,
+            search=search,
+            processors=processors,
+        )
 
         req = self._build_request(
             method="POST",
@@ -476,7 +493,7 @@ class Entities(BaseSDK):
             base_url=base_url,
             url_variables=url_variables,
             request=request,
-            request_body_required=False,
+            request_body_required=True,
             request_has_path_params=False,
             request_has_query_params=True,
             user_agent_header="user-agent",
@@ -487,7 +504,7 @@ class Entities(BaseSDK):
             ),
             security=self.sdk_configuration.security,
             get_serialized_body=lambda: utils.serialize_request_body(
-                request, False, True, "json", Optional[models.ListEntitiesParams]
+                request, False, False, "json", models.ListEntitiesParams
             ),
             allow_empty_value=None,
             timeout_ms=timeout_ms,
@@ -532,9 +549,14 @@ class Entities(BaseSDK):
     async def list_async(
         self,
         *,
-        request: Optional[
-            Union[models.ListEntitiesParams, models.ListEntitiesParamsTypedDict]
+        start_cursor: Optional[str] = "",
+        limit: Optional[int] = 50,
+        plans: Optional[
+            Union[List[models.ListEntitiesPlan], List[models.ListEntitiesPlanTypedDict]]
         ] = None,
+        subscription_status: Optional[models.ListEntitiesSubscriptionStatus] = None,
+        search: Optional[str] = None,
+        processors: Optional[List[models.ListEntitiesProcessor]] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
@@ -544,7 +566,12 @@ class Entities(BaseSDK):
 
         Use this to page through entities globally, including filtering by plans inherited from parent customers or attached directly to entities.
 
-        :param request: The request object to send.
+        :param start_cursor: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
+        :param limit: Number of items to return. Default 50, hard ceiling 5000.
+        :param plans: Filter by plan ID and version. Returns entities with active subscriptions to this plan, including plans inherited from the parent customer.
+        :param subscription_status: Filter customer products used for entity hydration and plan matching. Defaults to active and scheduled.
+        :param search: Search entities by id or name.
+        :param processors: Filter by parent customer processor type (stripe, revenuecat, vercel).
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -560,9 +587,16 @@ class Entities(BaseSDK):
         else:
             base_url = self._get_url(base_url, url_variables)
 
-        if not isinstance(request, BaseModel):
-            request = utils.unmarshal(request, Optional[models.ListEntitiesParams])
-        request = cast(Optional[models.ListEntitiesParams], request)
+        request = models.ListEntitiesParams(
+            start_cursor=start_cursor,
+            limit=limit,
+            plans=utils.get_pydantic_model(
+                plans, Optional[List[models.ListEntitiesPlan]]
+            ),
+            subscription_status=subscription_status,
+            search=search,
+            processors=processors,
+        )
 
         req = self._build_request_async(
             method="POST",
@@ -570,7 +604,7 @@ class Entities(BaseSDK):
             base_url=base_url,
             url_variables=url_variables,
             request=request,
-            request_body_required=False,
+            request_body_required=True,
             request_has_path_params=False,
             request_has_query_params=True,
             user_agent_header="user-agent",
@@ -581,7 +615,7 @@ class Entities(BaseSDK):
             ),
             security=self.sdk_configuration.security,
             get_serialized_body=lambda: utils.serialize_request_body(
-                request, False, True, "json", Optional[models.ListEntitiesParams]
+                request, False, False, "json", models.ListEntitiesParams
             ),
             allow_empty_value=None,
             timeout_ms=timeout_ms,

--- a/others/python-sdk/src/autumn_sdk/events.py
+++ b/others/python-sdk/src/autumn_sdk/events.py
@@ -12,8 +12,8 @@ class Events(BaseSDK):
     def list(
         self,
         *,
-        offset: Optional[int] = 0,
-        limit: Optional[int] = 100,
+        start_cursor: Optional[str] = "",
+        limit: Optional[int] = 50,
         customer_id: Optional[str] = None,
         entity_id: Optional[str] = None,
         feature_id: Optional[
@@ -29,8 +29,8 @@ class Events(BaseSDK):
     ) -> models.ListEventsResponse:
         r"""List usage events for your organization. Filter by customer, feature, or time range.
 
-        :param offset: Number of items to skip
-        :param limit: Number of items to return. Default 100, max 1000.
+        :param start_cursor: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
+        :param limit: Number of items to return. Default 50, hard ceiling 5000.
         :param customer_id: Filter events by customer ID
         :param entity_id: Filter events by entity ID (e.g., per-seat or per-resource)
         :param feature_id: Filter by specific feature ID(s)
@@ -51,7 +51,7 @@ class Events(BaseSDK):
             base_url = self._get_url(base_url, url_variables)
 
         request = models.EventsListParams(
-            offset=offset,
+            start_cursor=start_cursor,
             limit=limit,
             customer_id=customer_id,
             entity_id=entity_id,
@@ -123,8 +123,8 @@ class Events(BaseSDK):
     async def list_async(
         self,
         *,
-        offset: Optional[int] = 0,
-        limit: Optional[int] = 100,
+        start_cursor: Optional[str] = "",
+        limit: Optional[int] = 50,
         customer_id: Optional[str] = None,
         entity_id: Optional[str] = None,
         feature_id: Optional[
@@ -140,8 +140,8 @@ class Events(BaseSDK):
     ) -> models.ListEventsResponse:
         r"""List usage events for your organization. Filter by customer, feature, or time range.
 
-        :param offset: Number of items to skip
-        :param limit: Number of items to return. Default 100, max 1000.
+        :param start_cursor: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
+        :param limit: Number of items to return. Default 50, hard ceiling 5000.
         :param customer_id: Filter events by customer ID
         :param entity_id: Filter events by entity ID (e.g., per-seat or per-resource)
         :param feature_id: Filter by specific feature ID(s)
@@ -162,7 +162,7 @@ class Events(BaseSDK):
             base_url = self._get_url(base_url, url_variables)
 
         request = models.EventsListParams(
-            offset=offset,
+            start_cursor=start_cursor,
             limit=limit,
             customer_id=customer_id,
             entity_id=entity_id,

--- a/others/python-sdk/src/autumn_sdk/models/aggregateeventsop.py
+++ b/others/python-sdk/src/autumn_sdk/models/aggregateeventsop.py
@@ -18,7 +18,7 @@ class AggregateEventsGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/attachop.py
+++ b/others/python-sdk/src/autumn_sdk/models/attachop.py
@@ -26,7 +26,7 @@ class AttachGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/billingupdateop.py
+++ b/others/python-sdk/src/autumn_sdk/models/billingupdateop.py
@@ -26,7 +26,7 @@ class BillingUpdateGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/checkop.py
+++ b/others/python-sdk/src/autumn_sdk/models/checkop.py
@@ -27,7 +27,7 @@ class CheckGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/createbalanceop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createbalanceop.py
@@ -24,7 +24,7 @@ class CreateBalanceGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/createentityop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createentityop.py
@@ -28,7 +28,7 @@ class CreateEntityGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/createfeatureop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createfeatureop.py
@@ -25,7 +25,7 @@ class CreateFeatureGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/createplanop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createplanop.py
@@ -25,7 +25,7 @@ class CreatePlanGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/createreferralcodeop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createreferralcodeop.py
@@ -18,7 +18,7 @@ class CreateReferralCodeGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/createscheduleop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createscheduleop.py
@@ -26,7 +26,7 @@ class CreateScheduleGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/deletebalanceop.py
+++ b/others/python-sdk/src/autumn_sdk/models/deletebalanceop.py
@@ -18,7 +18,7 @@ class DeleteBalanceGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/deletecustomerop.py
+++ b/others/python-sdk/src/autumn_sdk/models/deletecustomerop.py
@@ -18,7 +18,7 @@ class DeleteCustomerGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/deleteentityop.py
+++ b/others/python-sdk/src/autumn_sdk/models/deleteentityop.py
@@ -18,7 +18,7 @@ class DeleteEntityGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/deletefeatureop.py
+++ b/others/python-sdk/src/autumn_sdk/models/deletefeatureop.py
@@ -18,7 +18,7 @@ class DeleteFeatureGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/deleteplanop.py
+++ b/others/python-sdk/src/autumn_sdk/models/deleteplanop.py
@@ -18,7 +18,7 @@ class DeletePlanGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/finalizelockop.py
+++ b/others/python-sdk/src/autumn_sdk/models/finalizelockop.py
@@ -18,7 +18,7 @@ class FinalizeLockGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/getcustomerop.py
+++ b/others/python-sdk/src/autumn_sdk/models/getcustomerop.py
@@ -28,7 +28,7 @@ class GetCustomerGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/getentityop.py
+++ b/others/python-sdk/src/autumn_sdk/models/getentityop.py
@@ -27,7 +27,7 @@ class GetEntityGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/getfeatureop.py
+++ b/others/python-sdk/src/autumn_sdk/models/getfeatureop.py
@@ -25,7 +25,7 @@ class GetFeatureGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/getorcreatecustomerop.py
+++ b/others/python-sdk/src/autumn_sdk/models/getorcreatecustomerop.py
@@ -25,7 +25,7 @@ class GetOrCreateCustomerGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/getplanop.py
+++ b/others/python-sdk/src/autumn_sdk/models/getplanop.py
@@ -25,7 +25,7 @@ class GetPlanGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/internal/globals.py
+++ b/others/python-sdk/src/autumn_sdk/models/internal/globals.py
@@ -19,7 +19,7 @@ class Globals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     fail_open: Annotated[
         Optional[bool],

--- a/others/python-sdk/src/autumn_sdk/models/listcustomersop.py
+++ b/others/python-sdk/src/autumn_sdk/models/listcustomersop.py
@@ -27,7 +27,7 @@ class ListCustomersGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
@@ -77,7 +77,7 @@ ListCustomersSubscriptionStatus = Literal[
     "active",
     "scheduled",
 ]
-r"""Filter by customer product status. Defaults to active and scheduled"""
+r"""Filter by customer product status. Defaults to active and scheduled."""
 
 
 ListCustomersProcessor = Literal[
@@ -88,43 +88,50 @@ ListCustomersProcessor = Literal[
 
 
 class ListCustomersParamsTypedDict(TypedDict):
-    offset: NotRequired[int]
-    r"""Number of items to skip"""
+    start_cursor: NotRequired[str]
+    r"""Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages."""
     limit: NotRequired[int]
-    r"""Number of items to return. Default 10, max 1000."""
+    r"""Number of items to return. Default 50, hard ceiling 5000."""
     plans: NotRequired[List[ListCustomersPlanTypedDict]]
     r"""Filter by plan ID and version. Returns customers with active subscriptions to this plan."""
     subscription_status: NotRequired[ListCustomersSubscriptionStatus]
-    r"""Filter by customer product status. Defaults to active and scheduled"""
+    r"""Filter by customer product status. Defaults to active and scheduled."""
     search: NotRequired[str]
-    r"""Search customers by id, name, or email"""
+    r"""Search customers by id, name, or email."""
     processors: NotRequired[List[ListCustomersProcessor]]
-    r"""Filter by customer processor type (stripe, revenuecat, vercel)"""
+    r"""Filter by customer processor type (stripe, revenuecat, vercel)."""
 
 
 class ListCustomersParams(BaseModel):
-    offset: Optional[int] = 0
-    r"""Number of items to skip"""
+    start_cursor: Optional[str] = ""
+    r"""Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages."""
 
-    limit: Optional[int] = 10
-    r"""Number of items to return. Default 10, max 1000."""
+    limit: Optional[int] = 50
+    r"""Number of items to return. Default 50, hard ceiling 5000."""
 
     plans: Optional[List[ListCustomersPlan]] = None
     r"""Filter by plan ID and version. Returns customers with active subscriptions to this plan."""
 
     subscription_status: Optional[ListCustomersSubscriptionStatus] = None
-    r"""Filter by customer product status. Defaults to active and scheduled"""
+    r"""Filter by customer product status. Defaults to active and scheduled."""
 
     search: Optional[str] = None
-    r"""Search customers by id, name, or email"""
+    r"""Search customers by id, name, or email."""
 
     processors: Optional[List[ListCustomersProcessor]] = None
-    r"""Filter by customer processor type (stripe, revenuecat, vercel)"""
+    r"""Filter by customer processor type (stripe, revenuecat, vercel)."""
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = set(
-            ["offset", "limit", "plans", "subscription_status", "search", "processors"]
+            [
+                "start_cursor",
+                "limit",
+                "plans",
+                "subscription_status",
+                "search",
+                "processors",
+            ]
         )
         serialized = handler(self)
         m = {}
@@ -1094,41 +1101,30 @@ class ListCustomersResponseTypedDict(TypedDict):
     r"""OK"""
 
     list: List[ListCustomersListTypedDict]
-    r"""Array of items for current page"""
-    has_more: bool
-    r"""Whether more results exist after this page"""
-    offset: float
-    r"""Current offset position"""
-    limit: float
-    r"""Limit passed in the request"""
-    total: float
-    r"""Total number of items returned in the current page"""
-    total_count: float
-    r"""Total number of customers available in the current organization and environment"""
-    total_filtered_count: float
-    r"""Total number of customers matching the current filter before pagination is applied"""
+    r"""Items for current page."""
+    next_cursor: Nullable[str]
+    r"""Opaque cursor for the next page. Null when there are no more results."""
 
 
 class ListCustomersResponse(BaseModel):
     r"""OK"""
 
     list: List[ListCustomersList]
-    r"""Array of items for current page"""
+    r"""Items for current page."""
 
-    has_more: bool
-    r"""Whether more results exist after this page"""
+    next_cursor: Nullable[str]
+    r"""Opaque cursor for the next page. Null when there are no more results."""
 
-    offset: float
-    r"""Current offset position"""
+    @model_serializer(mode="wrap")
+    def serialize_model(self, handler):
+        serialized = handler(self)
+        m = {}
 
-    limit: float
-    r"""Limit passed in the request"""
+        for n, f in type(self).model_fields.items():
+            k = f.alias or n
+            val = serialized.get(k, serialized.get(n))
 
-    total: float
-    r"""Total number of items returned in the current page"""
+            if val != UNSET_SENTINEL:
+                m[k] = val
 
-    total_count: float
-    r"""Total number of customers available in the current organization and environment"""
-
-    total_filtered_count: float
-    r"""Total number of customers matching the current filter before pagination is applied"""
+        return m

--- a/others/python-sdk/src/autumn_sdk/models/listentitiesop.py
+++ b/others/python-sdk/src/autumn_sdk/models/listentitiesop.py
@@ -27,7 +27,7 @@ class ListEntitiesGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
@@ -88,10 +88,10 @@ ListEntitiesProcessor = Literal[
 
 
 class ListEntitiesParamsTypedDict(TypedDict):
-    offset: NotRequired[int]
-    r"""Number of items to skip"""
+    start_cursor: NotRequired[str]
+    r"""Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages."""
     limit: NotRequired[int]
-    r"""Number of items to return. Default 10, max 1000."""
+    r"""Number of items to return. Default 50, hard ceiling 5000."""
     plans: NotRequired[List[ListEntitiesPlanTypedDict]]
     r"""Filter by plan ID and version. Returns entities with active subscriptions to this plan, including plans inherited from the parent customer."""
     subscription_status: NotRequired[ListEntitiesSubscriptionStatus]
@@ -103,11 +103,11 @@ class ListEntitiesParamsTypedDict(TypedDict):
 
 
 class ListEntitiesParams(BaseModel):
-    offset: Optional[int] = 0
-    r"""Number of items to skip"""
+    start_cursor: Optional[str] = ""
+    r"""Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages."""
 
-    limit: Optional[int] = 10
-    r"""Number of items to return. Default 10, max 1000."""
+    limit: Optional[int] = 50
+    r"""Number of items to return. Default 50, hard ceiling 5000."""
 
     plans: Optional[List[ListEntitiesPlan]] = None
     r"""Filter by plan ID and version. Returns entities with active subscriptions to this plan, including plans inherited from the parent customer."""
@@ -124,7 +124,14 @@ class ListEntitiesParams(BaseModel):
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = set(
-            ["offset", "limit", "plans", "subscription_status", "search", "processors"]
+            [
+                "start_cursor",
+                "limit",
+                "plans",
+                "subscription_status",
+                "search",
+                "processors",
+            ]
         )
         serialized = handler(self)
         m = {}
@@ -842,41 +849,30 @@ class ListEntitiesResponseTypedDict(TypedDict):
     r"""OK"""
 
     list: List[ListEntitiesListTypedDict]
-    r"""Array of items for current page"""
-    has_more: bool
-    r"""Whether more results exist after this page"""
-    offset: float
-    r"""Current offset position"""
-    limit: float
-    r"""Limit passed in the request"""
-    total: float
-    r"""Total number of items returned in the current page"""
-    total_count: float
-    r"""Total number of entities available in the current organization and environment"""
-    total_filtered_count: float
-    r"""Total number of entities matching the current filter before pagination is applied"""
+    r"""Items for current page."""
+    next_cursor: Nullable[str]
+    r"""Opaque cursor for the next page. Null when there are no more results."""
 
 
 class ListEntitiesResponse(BaseModel):
     r"""OK"""
 
     list: List[ListEntitiesList]
-    r"""Array of items for current page"""
+    r"""Items for current page."""
 
-    has_more: bool
-    r"""Whether more results exist after this page"""
+    next_cursor: Nullable[str]
+    r"""Opaque cursor for the next page. Null when there are no more results."""
 
-    offset: float
-    r"""Current offset position"""
+    @model_serializer(mode="wrap")
+    def serialize_model(self, handler):
+        serialized = handler(self)
+        m = {}
 
-    limit: float
-    r"""Limit passed in the request"""
+        for n, f in type(self).model_fields.items():
+            k = f.alias or n
+            val = serialized.get(k, serialized.get(n))
 
-    total: float
-    r"""Total number of items returned in the current page"""
+            if val != UNSET_SENTINEL:
+                m[k] = val
 
-    total_count: float
-    r"""Total number of entities available in the current organization and environment"""
-
-    total_filtered_count: float
-    r"""Total number of entities matching the current filter before pagination is applied"""
+        return m

--- a/others/python-sdk/src/autumn_sdk/models/listeventsop.py
+++ b/others/python-sdk/src/autumn_sdk/models/listeventsop.py
@@ -18,7 +18,7 @@ class ListEventsGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
@@ -83,10 +83,10 @@ class ListEventsCustomRange(BaseModel):
 
 
 class EventsListParamsTypedDict(TypedDict):
-    offset: NotRequired[int]
-    r"""Number of items to skip"""
+    start_cursor: NotRequired[str]
+    r"""Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages."""
     limit: NotRequired[int]
-    r"""Number of items to return. Default 100, max 1000."""
+    r"""Number of items to return. Default 50, hard ceiling 5000."""
     customer_id: NotRequired[str]
     r"""Filter events by customer ID"""
     entity_id: NotRequired[str]
@@ -98,11 +98,11 @@ class EventsListParamsTypedDict(TypedDict):
 
 
 class EventsListParams(BaseModel):
-    offset: Optional[int] = 0
-    r"""Number of items to skip"""
+    start_cursor: Optional[str] = ""
+    r"""Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages."""
 
-    limit: Optional[int] = 100
-    r"""Number of items to return. Default 100, max 1000."""
+    limit: Optional[int] = 50
+    r"""Number of items to return. Default 50, hard ceiling 5000."""
 
     customer_id: Optional[str] = None
     r"""Filter events by customer ID"""
@@ -120,7 +120,7 @@ class EventsListParams(BaseModel):
     def serialize_model(self, handler):
         optional_fields = set(
             [
-                "offset",
+                "start_cursor",
                 "limit",
                 "customer_id",
                 "entity_id",
@@ -317,31 +317,30 @@ class ListEventsResponseTypedDict(TypedDict):
     r"""OK"""
 
     list: List[ListEventsListTypedDict]
-    r"""Array of items for current page"""
-    has_more: bool
-    r"""Whether more results exist after this page"""
-    offset: float
-    r"""Current offset position"""
-    limit: float
-    r"""Limit passed in the request"""
-    total: float
-    r"""Total number of items returned in the current page"""
+    r"""Items for current page."""
+    next_cursor: Nullable[str]
+    r"""Opaque cursor for the next page. Null when there are no more results."""
 
 
 class ListEventsResponse(BaseModel):
     r"""OK"""
 
     list: List[ListEventsList]
-    r"""Array of items for current page"""
+    r"""Items for current page."""
 
-    has_more: bool
-    r"""Whether more results exist after this page"""
+    next_cursor: Nullable[str]
+    r"""Opaque cursor for the next page. Null when there are no more results."""
 
-    offset: float
-    r"""Current offset position"""
+    @model_serializer(mode="wrap")
+    def serialize_model(self, handler):
+        serialized = handler(self)
+        m = {}
 
-    limit: float
-    r"""Limit passed in the request"""
+        for n, f in type(self).model_fields.items():
+            k = f.alias or n
+            val = serialized.get(k, serialized.get(n))
 
-    total: float
-    r"""Total number of items returned in the current page"""
+            if val != UNSET_SENTINEL:
+                m[k] = val
+
+        return m

--- a/others/python-sdk/src/autumn_sdk/models/listfeaturesop.py
+++ b/others/python-sdk/src/autumn_sdk/models/listfeaturesop.py
@@ -25,7 +25,7 @@ class ListFeaturesGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/listplansop.py
+++ b/others/python-sdk/src/autumn_sdk/models/listplansop.py
@@ -25,7 +25,7 @@ class ListPlansGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/multiattachop.py
+++ b/others/python-sdk/src/autumn_sdk/models/multiattachop.py
@@ -26,7 +26,7 @@ class MultiAttachGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/opencustomerportalop.py
+++ b/others/python-sdk/src/autumn_sdk/models/opencustomerportalop.py
@@ -18,7 +18,7 @@ class OpenCustomerPortalGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/previewattachop.py
+++ b/others/python-sdk/src/autumn_sdk/models/previewattachop.py
@@ -27,7 +27,7 @@ class PreviewAttachGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/previewmultiattachop.py
+++ b/others/python-sdk/src/autumn_sdk/models/previewmultiattachop.py
@@ -27,7 +27,7 @@ class PreviewMultiAttachGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/previewupdateop.py
+++ b/others/python-sdk/src/autumn_sdk/models/previewupdateop.py
@@ -27,7 +27,7 @@ class PreviewUpdateGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/redeemreferralcodeop.py
+++ b/others/python-sdk/src/autumn_sdk/models/redeemreferralcodeop.py
@@ -18,7 +18,7 @@ class RedeemReferralCodeGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/setuppaymentop.py
+++ b/others/python-sdk/src/autumn_sdk/models/setuppaymentop.py
@@ -25,7 +25,7 @@ class SetupPaymentGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/trackop.py
+++ b/others/python-sdk/src/autumn_sdk/models/trackop.py
@@ -20,7 +20,7 @@ class TrackGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/updatebalanceop.py
+++ b/others/python-sdk/src/autumn_sdk/models/updatebalanceop.py
@@ -18,7 +18,7 @@ class UpdateBalanceGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/updatecustomerop.py
+++ b/others/python-sdk/src/autumn_sdk/models/updatecustomerop.py
@@ -27,7 +27,7 @@ class UpdateCustomerGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/updateentityop.py
+++ b/others/python-sdk/src/autumn_sdk/models/updateentityop.py
@@ -27,7 +27,7 @@ class UpdateEntityGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/updatefeatureop.py
+++ b/others/python-sdk/src/autumn_sdk/models/updatefeatureop.py
@@ -25,7 +25,7 @@ class UpdateFeatureGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/others/python-sdk/src/autumn_sdk/models/updateplanop.py
+++ b/others/python-sdk/src/autumn_sdk/models/updateplanop.py
@@ -25,7 +25,7 @@ class UpdatePlanGlobals(BaseModel):
         Optional[str],
         pydantic.Field(alias="x-api-version"),
         FieldMetadata(header=HeaderMetadata(style="simple", explode=False)),
-    ] = "2.2.0"
+    ] = "2.3.0"
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):

--- a/packages/autumn-js/src/generated/listEventsSchemas.ts
+++ b/packages/autumn-js/src/generated/listEventsSchemas.ts
@@ -16,7 +16,7 @@ export const listEventsCustomRangeSchema = z.object({
 });
 
 export const eventsListParamsSchema = z.object({
-	offset: z.union([z.number(), z.undefined()]).optional(),
+	startCursor: z.union([z.string(), z.undefined()]).optional(),
 	limit: z.union([z.number(), z.undefined()]).optional(),
 	customerId: z.union([z.string(), z.undefined()]).optional(),
 	entityId: z.union([z.string(), z.undefined()]).optional(),
@@ -37,7 +37,7 @@ export const listEventsCustomRangeOutboundSchema = z.object({
 });
 
 export const eventsListParamsOutboundSchema = z.object({
-	offset: z.number(),
+	start_cursor: z.string(),
 	limit: z.number(),
 	customer_id: z.union([z.string(), z.undefined()]).optional(),
 	entity_id: z.union([z.string(), z.undefined()]).optional(),
@@ -84,8 +84,5 @@ export const listEventsListSchema = z.object({
 
 export const listEventsResponseSchema = z.object({
 	list: z.array(listEventsListSchema),
-	hasMore: z.boolean(),
-	offset: z.number(),
-	limit: z.number(),
-	total: z.number(),
+	nextCursor: z.string().nullable(),
 });

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -4,7 +4,7 @@ info:
 servers:
   - url: https://api.useautumn.com
     description: Production server
-openapi: 3.1.1
+openapi: 3.1.0
 components:
   schemas:
     CustomerId:
@@ -2714,8 +2714,8 @@ paths:
     post:
       operationId: listCustomers
       description: 'Lists customers with cursor pagination and optional filters. Pass
-        `cursor: ""` (or omit) for the first page; use `next_cursor` from a
-        prior response for subsequent pages.'
+        `start_cursor: ""` (or omit) for the first page; use `next_cursor` from
+        a prior response for subsequent pages.'
       tags:
         - customers
       requestBody:
@@ -2725,7 +2725,7 @@ paths:
             schema:
               type: object
               properties:
-                cursor:
+                start_cursor:
                   type: string
                   default: ""
                   description: Opaque pagination cursor. Empty string (default) requests the first
@@ -2774,7 +2774,7 @@ paths:
               title: ListCustomersParams
               examples:
                 - &a6
-                  cursor: ""
+                  start_cursor: ""
                   limit: 10
             example: *a6
       responses:
@@ -3428,17 +3428,6 @@ paths:
       x-speakeasy-name-override: list
       parameters:
         - *a5
-      x-speakeasy-pagination:
-        type: cursor
-        inputs:
-          - name: cursor
-            in: requestBody
-            type: cursor
-          - name: limit
-            in: requestBody
-            type: limit
-        outputs:
-          nextCursor: $.next_cursor
   /v1/customers.update:
     post:
       operationId: updateCustomer
@@ -15568,18 +15557,18 @@ paths:
             schema:
               type: object
               properties:
-                offset:
-                  type: integer
-                  minimum: 0
-                  maximum: 9007199254740991
-                  default: 0
-                  description: Number of items to skip
+                start_cursor:
+                  type: string
+                  default: ""
+                  description: Opaque pagination cursor. Empty string (default) requests the first
+                    page; use next_cursor from a prior response for subsequent
+                    pages.
                 limit:
                   type: integer
                   minimum: 1
-                  maximum: 1000
-                  default: 100
-                  description: Number of items to return. Default 100, max 1000.
+                  maximum: 5000
+                  default: 50
+                  description: Number of items to return. Default 50, hard ceiling 5000.
                 customer_id:
                   type: string
                   description: Filter events by customer ID
@@ -15609,9 +15598,11 @@ paths:
               title: EventsListParams
               examples:
                 - &a57
+                  start_cursor: ""
                   customer_id: cus_123
                   limit: 50
-                - feature_id: api_calls
+                - start_cursor: ""
+                  feature_id: api_calls
                   custom_range:
                     start: 1704067200000
                     end: 1706745600000
@@ -15729,25 +15720,16 @@ paths:
                         - value
                         - properties
                         - deductions
-                    description: Array of items for current page
-                  has_more:
-                    type: boolean
-                    description: Whether more results exist after this page
-                  offset:
-                    type: number
-                    description: Current offset position
-                  limit:
-                    type: number
-                    description: Limit passed in the request
-                  total:
-                    type: number
-                    description: Total number of items returned in the current page
+                    description: Items for current page.
+                  next_cursor:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Opaque cursor for the next page. Null when there are no more
+                      results.
                 required:
                   - list
-                  - has_more
-                  - offset
-                  - limit
-                  - total
+                  - next_cursor
                 examples:
                   - &a58
                     list:
@@ -15772,10 +15754,7 @@ paths:
                         value: 49
                         properties: {}
                         deductions: null
-                    total: 2
-                    has_more: false
-                    offset: 0
-                    limit: 100
+                    next_cursor: eyJ2IjowLCJpZCI6ImV2dF8zNnhtSHh4akFrcXh1ZkRmOXlIQVBOZlJyTE0iLCJ0IjoxNzY1OTU2NTEyMDU3fQ
               example: *a58
       x-speakeasy-name-override: list
       parameters:
@@ -17027,7 +17006,7 @@ paths:
             schema:
               type: object
               properties:
-                cursor:
+                start_cursor:
                   type: string
                   default: ""
                   description: Opaque pagination cursor. Empty string (default) requests the first
@@ -17078,7 +17057,7 @@ paths:
               title: ListEntitiesParams
               examples:
                 - &a65
-                  cursor: ""
+                  start_cursor: ""
                   limit: 10
                 - plans:
                     - id: pro_plan
@@ -17530,17 +17509,6 @@ paths:
       x-speakeasy-name-override: list
       parameters:
         - *a5
-      x-speakeasy-pagination:
-        type: cursor
-        inputs:
-          - name: cursor
-            in: requestBody
-            type: cursor
-          - name: limit
-            in: requestBody
-            type: limit
-        outputs:
-          nextCursor: $.next_cursor
   /v1/entities.update:
     post:
       operationId: updateEntity

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -4,7 +4,7 @@ info:
 servers:
   - url: https://api.useautumn.com
     description: Production server
-openapi: 3.1.1
+openapi: 3.1.0
 components:
   schemas:
     CustomerId:
@@ -2781,8 +2781,8 @@ paths:
     post:
       operationId: listCustomers
       description: 'Lists customers with cursor pagination and optional filters. Pass
-        `cursor: ""` (or omit) for the first page; use `next_cursor` from a
-        prior response for subsequent pages.'
+        `start_cursor: ""` (or omit) for the first page; use `next_cursor` from
+        a prior response for subsequent pages.'
       tags:
         - customers
       requestBody:
@@ -2792,7 +2792,7 @@ paths:
             schema:
               type: object
               properties:
-                cursor:
+                start_cursor:
                   type: string
                   default: ""
                   description: Opaque pagination cursor. Empty string (default) requests the first
@@ -2840,7 +2840,7 @@ paths:
                   description: Filter by customer processor type (stripe, revenuecat, vercel).
               title: ListCustomersParams
               examples:
-                - cursor: ""
+                - start_cursor: ""
                   limit: 10
       responses:
         "200":
@@ -3491,17 +3491,6 @@ paths:
       x-speakeasy-name-override: list
       parameters:
         - *a1
-      x-speakeasy-pagination:
-        type: cursor
-        inputs:
-          - name: cursor
-            in: requestBody
-            type: cursor
-          - name: limit
-            in: requestBody
-            type: limit
-        outputs:
-          nextCursor: $.next_cursor
   /v1/customers.update:
     post:
       operationId: updateCustomer
@@ -8680,7 +8669,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1778752127560,"plans":[{"planId":"trial_plan"}]},{"startsAt":1779961727560,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -16418,18 +16407,18 @@ paths:
             schema:
               type: object
               properties:
-                offset:
-                  type: integer
-                  minimum: 0
-                  maximum: 9007199254740991
-                  default: 0
-                  description: Number of items to skip
+                start_cursor:
+                  type: string
+                  default: ""
+                  description: Opaque pagination cursor. Empty string (default) requests the first
+                    page; use next_cursor from a prior response for subsequent
+                    pages.
                 limit:
                   type: integer
                   minimum: 1
-                  maximum: 1000
-                  default: 100
-                  description: Number of items to return. Default 100, max 1000.
+                  maximum: 5000
+                  default: 50
+                  description: Number of items to return. Default 50, hard ceiling 5000.
                 customer_id:
                   type: string
                   description: Filter events by customer ID
@@ -16458,9 +16447,11 @@ paths:
                   description: Filter events by time range
               title: EventsListParams
               examples:
-                - customer_id: cus_123
+                - start_cursor: ""
+                  customer_id: cus_123
                   limit: 50
-                - feature_id: api_calls
+                - start_cursor: ""
+                  feature_id: api_calls
                   custom_range:
                     start: 1704067200000
                     end: 1706745600000
@@ -16577,25 +16568,16 @@ paths:
                         - value
                         - properties
                         - deductions
-                    description: Array of items for current page
-                  has_more:
-                    type: boolean
-                    description: Whether more results exist after this page
-                  offset:
-                    type: number
-                    description: Current offset position
-                  limit:
-                    type: number
-                    description: Limit passed in the request
-                  total:
-                    type: number
-                    description: Total number of items returned in the current page
+                    description: Items for current page.
+                  next_cursor:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Opaque cursor for the next page. Null when there are no more
+                      results.
                 required:
                   - list
-                  - has_more
-                  - offset
-                  - limit
-                  - total
+                  - next_cursor
                 examples:
                   - list:
                       - id: evt_36xpk2TmuQX5zVPPQ8tCtnR5Weg
@@ -16619,10 +16601,7 @@ paths:
                         value: 49
                         properties: {}
                         deductions: null
-                    total: 2
-                    has_more: false
-                    offset: 0
-                    limit: 100
+                    next_cursor: eyJ2IjowLCJpZCI6ImV2dF8zNnhtSHh4akFrcXh1ZkRmOXlIQVBOZlJyTE0iLCJ0IjoxNzY1OTU2NTEyMDU3fQ
       x-speakeasy-name-override: list
       parameters:
         - *a1
@@ -17974,7 +17953,7 @@ paths:
             schema:
               type: object
               properties:
-                cursor:
+                start_cursor:
                   type: string
                   default: ""
                   description: Opaque pagination cursor. Empty string (default) requests the first
@@ -18024,7 +18003,7 @@ paths:
                     vercel).
               title: ListEntitiesParams
               examples:
-                - cursor: ""
+                - start_cursor: ""
                   limit: 10
                 - plans:
                     - id: pro_plan
@@ -18473,17 +18452,6 @@ paths:
       x-speakeasy-name-override: list
       parameters:
         - *a1
-      x-speakeasy-pagination:
-        type: cursor
-        inputs:
-          - name: cursor
-            in: requestBody
-            type: cursor
-          - name: limit
-            in: requestBody
-            type: limit
-        outputs:
-          nextCursor: $.next_cursor
   /v1/entities.update:
     post:
       operationId: updateEntity

--- a/packages/openapi/utils/apiReferenceGenerator/mergeMdx.ts
+++ b/packages/openapi/utils/apiReferenceGenerator/mergeMdx.ts
@@ -1,9 +1,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { ParsedOperation } from "./parseOpenApi.js";
 
-const IMPORTS = `import { DynamicParamField } from "/components/dynamic-param-field.jsx";
-import { DynamicResponseField } from "/components/dynamic-response-field.jsx";
-import { DynamicResponseExample } from "/components/dynamic-response-example.jsx";`;
+const IMPORTS = `import { DynamicParamField } from "/snippets/dynamic-param-field.jsx";
+import { DynamicResponseField } from "/snippets/dynamic-response-field.jsx";
+import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";`;
 
 /**
  * Merge manual MDX content with generated fields.

--- a/packages/openapi/v2.3/contracts/eventsContract.ts
+++ b/packages/openapi/v2.3/contracts/eventsContract.ts
@@ -4,11 +4,11 @@ import {
 	EVENTS_AGGREGATE_EXAMPLE_V1_GROUPED,
 	EventsAggregateResponseV1Schema,
 } from "@api/events/aggregate/eventsAggregateResponseV1.js";
-import { ApiEventsListParamsSchema } from "@api/events/list/eventsListParams.js";
+import { ApiEventsListV2_3ParamsSchema } from "@api/events/list/eventsListParamsV2_3.js";
 import {
-	ApiEventsListResponseSchema,
-	EVENTS_LIST_EXAMPLE,
-} from "@api/events/list/eventsListResponse.js";
+	EVENTS_LIST_V2_3_EXAMPLE,
+	ApiEventsListV2_3ResponseSchema,
+} from "@api/events/list/eventsListResponseV2_3.js";
 import { oc } from "@orpc/contract";
 
 export const eventsListContract = oc
@@ -25,14 +25,16 @@ export const eventsListContract = oc
 		}),
 	})
 	.input(
-		ApiEventsListParamsSchema.meta({
+		ApiEventsListV2_3ParamsSchema.meta({
 			title: "EventsListParams",
 			examples: [
 				{
+					start_cursor: "",
 					customer_id: "cus_123",
 					limit: 50,
 				},
 				{
+					start_cursor: "",
 					feature_id: "api_calls",
 					custom_range: {
 						start: 1704067200000,
@@ -43,8 +45,8 @@ export const eventsListContract = oc
 		}),
 	)
 	.output(
-		ApiEventsListResponseSchema.meta({
-			examples: [EVENTS_LIST_EXAMPLE],
+		ApiEventsListV2_3ResponseSchema.meta({
+			examples: [EVENTS_LIST_V2_3_EXAMPLE],
 		}),
 	);
 

--- a/packages/openapi/v2.3/openapi2.3.ts
+++ b/packages/openapi/v2.3/openapi2.3.ts
@@ -3,7 +3,7 @@ import { SuccessResponseSchema } from "@api/common/commonResponses.js";
 import {
 	ApiBalanceV1Schema,
 	ApiCustomerV5Schema,
-	ApiEventsListParamsSchema,
+	ApiEventsListV2_3ParamsSchema,
 	ApiPlanV1Schema,
 	AttachParamsV1Schema,
 	AttachPreviewResponseSchema,
@@ -75,7 +75,7 @@ async function generateOpenApiDocument(): Promise<Record<string, unknown>> {
 	registerInternalSchemas(CheckResponseV3Schema);
 	registerInternalSchemas(TrackResponseV3Schema);
 	registerInternalSchemas(CustomerDataSchema);
-	registerInternalSchemas(ApiEventsListParamsSchema);
+	registerInternalSchemas(ApiEventsListV2_3ParamsSchema);
 
 	const openApiDocument = (await generator.generate(v2_3ContractRouter, {
 		info: {
@@ -116,6 +116,9 @@ async function generateOpenApiDocument(): Promise<Record<string, unknown>> {
 			},
 		],
 	})) as Record<string, unknown>;
+
+	// Mintlify only supports OpenAPI 3.0 and 3.1.0; @orpc/openapi defaults to 3.1.1.
+	openApiDocument.openapi = "3.1.0";
 
 	applySpeakeasySettings({
 		openApiDocument,

--- a/packages/sdk/.speakeasy/code-samples.overlay.yaml
+++ b/packages/sdk/.speakeasy/code-samples.overlay.yaml
@@ -12,7 +12,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -35,7 +35,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -61,7 +61,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -84,7 +84,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -107,7 +107,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -131,7 +131,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -155,7 +155,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -178,7 +178,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -218,7 +218,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -254,7 +254,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -277,7 +277,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -300,7 +300,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -336,7 +336,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -365,7 +365,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -388,7 +388,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -417,7 +417,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -439,7 +439,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -461,7 +461,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -485,12 +485,14 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
             async function run() {
-              const result = await autumn.customers.list({});
+              const result = await autumn.customers.list({
+                limit: 10,
+              });
 
               console.log(result);
             }
@@ -505,7 +507,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -529,7 +531,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -554,7 +556,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -577,7 +579,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -599,12 +601,14 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
             async function run() {
-              const result = await autumn.entities.list({});
+              const result = await autumn.entities.list({
+                limit: 10,
+              });
 
               console.log(result);
             }
@@ -619,7 +623,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -651,7 +655,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -675,13 +679,12 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
             async function run() {
               const result = await autumn.events.list({
-                limit: 50,
                 customerId: "cus_123",
               });
 
@@ -698,7 +701,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -723,7 +726,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -745,7 +748,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -767,7 +770,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -787,7 +790,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -814,7 +817,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -847,7 +850,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -869,7 +872,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -891,7 +894,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -911,7 +914,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -938,7 +941,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 
@@ -961,7 +964,7 @@ actions:
             import { Autumn } from "@useautumn/sdk";
 
             const autumn = new Autumn({
-              xApiVersion: "2.2.0",
+              xApiVersion: "2.3.0",
               secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
             });
 

--- a/packages/sdk/.speakeasy/gen.lock
+++ b/packages/sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 7b300647-cd76-49e9-bf77-7d1bf5446d66
 management:
-  docChecksum: 97d07bb56e4025c6a4a5909d92279730
-  docVersion: 2.2.0
+  docChecksum: 2ef0aba76ee8815e90e9e79cbe09fe8f
+  docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.10.17
   configChecksum: bae45df54c836a79d656f78f967da99b
 persistentEdits:
-  generation_id: 7b6255c5-fef8-4b44-a956-0ce2590f6415
-  pristine_commit_hash: 73999c83a70cbe5b911f31604c01b40d957a4de7
-  pristine_tree_hash: d1f5c58596ed56f90455b242722bf9eef9e2c56e
+  generation_id: efd75abb-52b2-4a1e-ab1d-0a46c5f4fef9
+  pristine_commit_hash: 23fba30647d6c8563340bb6d7dacd63e1d41492f
+  pristine_tree_hash: 8915422a5d0df7d9d7c7132373b9c44c36dbb62e
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -56,16 +56,16 @@ trackedFiles:
     pristine_git_object: 670ac0a62d7e568c9d44a14f5deafb8442a255d8
   FUNCTIONS.md:
     id: 21b9df02aaeb
-    last_write_checksum: sha1:d35c281fe285c38f2f5afb32ee4e28f29f962d2b
-    pristine_git_object: e027f3d1846925cd697c120ddeaf0ac8bb11cabb
+    last_write_checksum: sha1:78f608eb146385ef6b4ec6d9b9377c267d2ba080
+    pristine_git_object: a50c2fc69cba3c6d35e34c3f3dc56409a17f9f27
   RUNTIMES.md:
     id: 620c490847b6
     last_write_checksum: sha1:e45b854f02c357cbcfdb8c3663000e8339e16505
     pristine_git_object: 27731c3b5ace66bedc454ed5acbe15075aacd3dc
   USAGE.md:
     id: 3aed33ce6e6f
-    last_write_checksum: sha1:bc07c552940c1ebe00fcc3ed2b6f0760536f4763
-    pristine_git_object: 3dd5ab73f6de2cb60e9e7729749e333df8c8974e
+    last_write_checksum: sha1:63b566b0e01d73254a2d7638f174cca661235b9d
+    pristine_git_object: ca31dfecda99574230d907832cad41afed90e9ac
   docs/lib/utils/retryconfig.md:
     id: 0ce9707cb848
     last_write_checksum: sha1:bc4454e196fcd219f5a78da690375a884f5ed07b
@@ -1384,8 +1384,8 @@ trackedFiles:
     pristine_git_object: 61a2cfeb1edc553ff1acd3e35709d8f17b3b7858
   docs/models/events-list-params.md:
     id: b743a4817767
-    last_write_checksum: sha1:5398e590e9563862ff7aea3056fd8f9218f17b6b
-    pristine_git_object: 032d2464b6ff1e4b2f1a35591a2014edf4ed21e6
+    last_write_checksum: sha1:a79fa81efd2c1c0f8bf076b7baf1e4e42e05b5f6
+    pristine_git_object: 9bb04cd122f0a031487eeda45b416e5978600241
   docs/models/expiry-duration-type.md:
     id: 3a927f275515
     last_write_checksum: sha1:19a85259a30b26567db272e409038d45136a35c8
@@ -1948,8 +1948,8 @@ trackedFiles:
     pristine_git_object: e3ad12e7ace38761dfa2673f72f213c7bc275ace
   docs/models/list-customers-params.md:
     id: 2a01311d59ad
-    last_write_checksum: sha1:189a65062891ac4a56519130714423d2a91d68d5
-    pristine_git_object: b0b76bdece84471bd9f70f45d560e4e1c6fb87e5
+    last_write_checksum: sha1:78e0b420b338634ea8cc63333c57f9153b0af507
+    pristine_git_object: 20ee8c94d7158c3bbe692026f5016779fe351b7b
   docs/models/list-customers-plan.md:
     id: 1dd1eb060144
     last_write_checksum: sha1:32c36fb64ec7f7463b72bf1b7cc8d94524288dd0
@@ -1980,8 +1980,8 @@ trackedFiles:
     pristine_git_object: fe03aa7b5c0cfbff67fb4d0885225349b46eaced
   docs/models/list-customers-response.md:
     id: a8afc03241c9
-    last_write_checksum: sha1:a56188ae7ae68d8f72b82533fa9e2d3b9dcb0252
-    pristine_git_object: 6fb8505a9493344695f390d391d012a05e9ff654
+    last_write_checksum: sha1:ef62f02095f81f3de105307007accb98ddc33e10
+    pristine_git_object: f20acebafeed4867684ad9d7324ccdccf9845345
   docs/models/list-customers-revenuecat.md:
     id: bf00bed8af84
     last_write_checksum: sha1:4997229789224aaae363f4dc1362709c5a378de1
@@ -2000,8 +2000,8 @@ trackedFiles:
     pristine_git_object: 3b72ceb1546d65c53809555eb63d99f194d58ae0
   docs/models/list-customers-subscription-status.md:
     id: 3f8df2a5cf7f
-    last_write_checksum: sha1:41d004c38432d196d1ef8d9a2a66304c2bf34e68
-    pristine_git_object: fcc1a6871b2f518cb3bcfeb88aa3cdc53523245b
+    last_write_checksum: sha1:f22b0c76e21b457ddd7bb4f96ca7737067591d24
+    pristine_git_object: 0754adcfb5e753a4f454c308dae87c3a7d4dc238
   docs/models/list-customers-subscription.md:
     id: e5c39bdff7de
     last_write_checksum: sha1:2149bab9fbc402075c6e6fad9227da4d934f6354
@@ -2064,8 +2064,8 @@ trackedFiles:
     pristine_git_object: 19202b44796241442484db1fee13164091c3497c
   docs/models/list-entities-params.md:
     id: 92aba00d96aa
-    last_write_checksum: sha1:1c14177f0301710354528c0352c09985ea54df90
-    pristine_git_object: dff3ddd29a18279833d8f304bdef8a1a1f1ab7f7
+    last_write_checksum: sha1:63f6d8d5c87aa3e9f30afa967d02c9d7f460bda0
+    pristine_git_object: 096d712b4791c84909b9f465f36f777c0d44b03f
   docs/models/list-entities-plan.md:
     id: 46b5b6920b73
     last_write_checksum: sha1:0a15106cb1bdb2cd03c181351dfd44dbe36a2643
@@ -2084,8 +2084,8 @@ trackedFiles:
     pristine_git_object: 675f11020b5bc609520c004bf7d5d5e86cf76d31
   docs/models/list-entities-response.md:
     id: bec7fb4bfa56
-    last_write_checksum: sha1:3402cd7390888921872e5c77f807bacac21214f2
-    pristine_git_object: 821d5532ecaa8dd54866a7ee6f4d3177c013b06c
+    last_write_checksum: sha1:414c794572db71a8102d9cf6cdf3e36ffe15e6e4
+    pristine_git_object: f63cbe5d12d908a15fc19c3cfb358d9ad9d1cd5d
   docs/models/list-entities-spend-limit.md:
     id: 9b3952cc7a05
     last_write_checksum: sha1:592be5bddb99b2865b0c193d15c7791f0e869a35
@@ -2144,8 +2144,8 @@ trackedFiles:
     pristine_git_object: 881a3fde529b19ecb516de2d98e4e9ef323ee80a
   docs/models/list-events-response.md:
     id: 1eec34e11f04
-    last_write_checksum: sha1:71e5783257df7c4df4c8e87cb9511fec5699c42b
-    pristine_git_object: 5ca8aec3f3eea564e1b1f4d970e9c8115596818f
+    last_write_checksum: sha1:e1bb33aff262ba95762b9ee52700457edc9a708a
+    pristine_git_object: 3bb2e569a523fc901e1e3040e87547065ecd088f
   docs/models/list-features-credit-schema.md:
     id: e173a5826e35
     last_write_checksum: sha1:74702d7084921deaba7824328acc98e7a9ece0ae
@@ -4124,40 +4124,40 @@ trackedFiles:
     pristine_git_object: a844f92b2baa6185834718690d34643de01d62b2
   docs/sdks/autumn/README.md:
     id: d27c9292a1a3
-    last_write_checksum: sha1:dbf426417232e3b9200f9a85e4bf31c5b5a79b22
-    pristine_git_object: a64774eb0ee7e0fd44118909be899cead2253cb5
+    last_write_checksum: sha1:4d49d2ee442e2d7ed8dede34951633a48546545b
+    pristine_git_object: c0965c3dba149c79dc016aab6adee2e1e4d32b2c
   docs/sdks/balances/README.md:
     id: 6ca85866f00d
-    last_write_checksum: sha1:a4e8baf562d105f12dec6e90ac7a38f8a2c8c5b4
-    pristine_git_object: a366694c3e2f4df91e7ae37aa212d8f07cb83c40
+    last_write_checksum: sha1:bd1e814fa0fa46eb24beefce2e585d9c8e4cb14a
+    pristine_git_object: 0ebe5146cd24c153cb9b7655e4f502c09f7d4abd
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:7d7afebd8840264cd7b82381d295f274954e894d
-    pristine_git_object: d65578a2e3601bc72fb5df7ca708c68ef019f679
+    last_write_checksum: sha1:d5505f30ec4893b1c194b7ac239feaaaa6bd73ea
+    pristine_git_object: a21c0795820fbf7b9b2d59a94ca14bf218656227
   docs/sdks/customers/README.md:
     id: 9332759cffc2
-    last_write_checksum: sha1:a5adadb2229238b387834d8a563881405499d4d5
-    pristine_git_object: dac9a751837589b868d7e95d50a73cc10fcd5fad
+    last_write_checksum: sha1:74cd5f6cf800e1d86b2c332fed3c3cd53f3eeb6b
+    pristine_git_object: 94228c7448e58f0dd1d53e5ae3be57b0aaae8ade
   docs/sdks/entities/README.md:
     id: a140ac5181b9
-    last_write_checksum: sha1:9d3a5edf7fe6e187f19f9f6d9a07f40d3ad53b38
-    pristine_git_object: 39ea43ec177cc2560e4ff157cba664fb5a20ffdb
+    last_write_checksum: sha1:9218d9c57b0f880056012a0058b6fcf22266809b
+    pristine_git_object: 660ee5a5ae602d5a59262df8be417b158b483b57
   docs/sdks/events/README.md:
     id: cf45a4390b9b
-    last_write_checksum: sha1:31c4754b0cbfea3c38dc4cf672b5015c9c869f36
-    pristine_git_object: 92842a2cc0f1f3092751b10428407d777bf1a183
+    last_write_checksum: sha1:45cecb8b22ef4a343e770296553fb77fa91f6a24
+    pristine_git_object: 1cc83472fe4220acda4c28e42b5425ed182b93d5
   docs/sdks/features/README.md:
     id: e885cfb7247b
-    last_write_checksum: sha1:df36a47412fa10a7d6fc33665542a7a1699f98db
-    pristine_git_object: d9f43c59f7c9f18e1ff1f6995e42ec7e75da49e4
+    last_write_checksum: sha1:88c210eae53f4461250167ffb7f9d393449e40e3
+    pristine_git_object: f8cb7e169f99bc7aaa0b6c3f50f1b2ff19b8d1eb
   docs/sdks/plans/README.md:
     id: 2d8c741fff57
-    last_write_checksum: sha1:2b61a17cf98e0c244bfaddc9b5b945d1ec778b12
-    pristine_git_object: 9aca7bb4d101682e58743d6fc70415dcc839c38b
+    last_write_checksum: sha1:57e57bb309355ca9bd404327d90d5ec43e26c6da
+    pristine_git_object: b74f515e33be0c7a50ffbdca8f70a015dde8bf06
   docs/sdks/referrals/README.md:
     id: 50b71f597f20
-    last_write_checksum: sha1:9a541f0191db895e4a8ea17c4b61c725ecc40972
-    pristine_git_object: 2e6c885f74a11db33b28d29be59a3660d670cb86
+    last_write_checksum: sha1:b10fdf64bd7d821c93d721f1ef481f045e046438
+    pristine_git_object: ae358ae6fbace6a9fffea13dac82023145fe5b17
   eslint.config.mjs:
     id: 461c8d07f6da
     last_write_checksum: sha1:9398f326377fe47f67af2df6eb6370750c0790b4
@@ -4172,8 +4172,8 @@ trackedFiles:
     pristine_git_object: 0928c2ed5c0c739a6fb22e31cdaf11d6bdec9dae
   examples/check.example.ts:
     id: af533e83342b
-    last_write_checksum: sha1:39f370d9c122f556462b2e157fad8c55fcd93ba2
-    pristine_git_object: 8548853c24f7fe1247ce1a36af015f7b695d3af5
+    last_write_checksum: sha1:1e52d8566e11b28e9acd207997a95c32d750d53e
+    pristine_git_object: b9004b0a94da3107a0a8b808f7ed14ede228e937
   examples/package.json:
     id: c1d7b0ec8e7e
     last_write_checksum: sha1:22cf1a48e1d9bc8ffc9e65280aeaa5600b54f659
@@ -4212,8 +4212,8 @@ trackedFiles:
     pristine_git_object: ccbecbd59533d8bf511f43ad4605756e2049da9a
   src/funcs/billing-create-schedule.ts:
     id: fd662bfcdc10
-    last_write_checksum: sha1:04c0a7d4c998f8f4a190443af5df360ff21a8ae9
-    pristine_git_object: dcaca142d7707aa6afe6326e402c7af8f9dec5d8
+    last_write_checksum: sha1:95f6e375d3f18364e872159aadba2826dab87e23
+    pristine_git_object: 80b8037f6e700d5935a56f767dac2336b9eb5eb0
   src/funcs/billing-multi-attach.ts:
     id: 67491e2d8249
     last_write_checksum: sha1:00ba80c1f98e7a8be29db0cf5a6957433f687861
@@ -4260,8 +4260,8 @@ trackedFiles:
     pristine_git_object: 34f37d67450d8635da7eb4004f440752db20d2d1
   src/funcs/customers-list.ts:
     id: 97f381c7d9f0
-    last_write_checksum: sha1:3961ba7301fc29f48c47e1a9d9794d3e2504c10d
-    pristine_git_object: fa376e28bcaa38ab7b13ef38171959a9ccc253cd
+    last_write_checksum: sha1:6d955abd6d11d6d7ae957e3f56ee22a96a112cff
+    pristine_git_object: 292324af091592f0818d20980beec1fdbd55e854
   src/funcs/customers-update.ts:
     id: 56f7739cc333
     last_write_checksum: sha1:ce5eef1a0aa802efc34e26011f98ec25005851ea
@@ -4280,8 +4280,8 @@ trackedFiles:
     pristine_git_object: ac3e07687390946e85825e6711f1b9f02f3195fd
   src/funcs/entities-list.ts:
     id: 589baf7729a5
-    last_write_checksum: sha1:ff50a8a15b8c6db846552beabcc140dbe6218d4b
-    pristine_git_object: 71091d629165448f9ee2c8761b312be718e0909c
+    last_write_checksum: sha1:96b615462da46c38d0d9f8160798733c11074a62
+    pristine_git_object: ec78a585695d94482aafe01de6f554e391c94365
   src/funcs/entities-update.ts:
     id: 45a3fa3d37e9
     last_write_checksum: sha1:9d094430bd69e5393225a4b16144ffdab3634f13
@@ -4368,8 +4368,8 @@ trackedFiles:
     pristine_git_object: 44be0eae8246521b230e8e711a88eff738fc015d
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:8c0fb8706617d5367106f95cdb3bf31afb95fccb
-    pristine_git_object: d325744a1b5af4a0af8f9ce4fe4b3ca46b1923c3
+    last_write_checksum: sha1:796e8eff5f98495ae539e34ae199859ed5ad9a4b
+    pristine_git_object: d5b0e5bda563f77be757fbb6efa31d6763ef32cf
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:1dd3e3fbb4550c4bf31f5ef997faff355d6f3250
@@ -4380,8 +4380,8 @@ trackedFiles:
     pristine_git_object: caeae5469fc8bd37da5aa7fd46d928eec5dc4b3a
   src/lib/env.ts:
     id: c52972a3b198
-    last_write_checksum: sha1:7be9d5a2ab2f9b49afeb7839777cb7c0d6ab257d
-    pristine_git_object: 33b268f7053f0e20095af4fb7535901be06ac33e
+    last_write_checksum: sha1:db8ae7ac703b7641782125df2b0571a81202d8d1
+    pristine_git_object: 9353771b57e326e8a8b40c7b39d80a9b40e36a37
   src/lib/files.ts:
     id: e5efa54fcb95
     last_write_checksum: sha1:795c14026405d547bfc47012f7ad9666e530fa7f
@@ -4544,16 +4544,16 @@ trackedFiles:
     pristine_git_object: d4e40a7bfc8ed390d86ddf93aed385ebd0df60e1
   src/models/list-customers-op.ts:
     id: b391692c8429
-    last_write_checksum: sha1:81d2e4964067a579ee4f9b55b4afd859b615e41a
-    pristine_git_object: 2d35eaa43087592387cbc194faff2ea40d9b969b
+    last_write_checksum: sha1:0b5806bf37d88bbad002d82bf404d5f3b8762593
+    pristine_git_object: 49c50334b82a7d58677307d3791be2ced19c8a06
   src/models/list-entities-op.ts:
     id: 4cbb69f4a0cd
-    last_write_checksum: sha1:b5ed7aaff1405547c7fa35582375db27df621516
-    pristine_git_object: 9158821d478a8c55df7166c588de3a5cc9cb723a
+    last_write_checksum: sha1:18424f0889282c5c4e62efabaac1a703c2a5dab0
+    pristine_git_object: 681ba8b7d889f2d04a7bba6f3f9bd1a16aa6ba27
   src/models/list-events-op.ts:
     id: 82a9f364bb21
-    last_write_checksum: sha1:36dcc9ead85e6efd715e1d6ea7b187717382c41d
-    pristine_git_object: 049cb8434c81408c26f6d621e5be3789535bb9bf
+    last_write_checksum: sha1:32c875df2a181a5aa651f4350a2a7114a8c92bd1
+    pristine_git_object: 6dcbe739854dac80f72b729ba19b1bfa08c0cc99
   src/models/list-features-op.ts:
     id: d9fcd707ca8f
     last_write_checksum: sha1:1b631462ea2042d3b2cf3db4c584d7538411667d
@@ -4636,16 +4636,16 @@ trackedFiles:
     pristine_git_object: 571de419ea3321d79acec4bddbb46b1580007115
   src/sdk/billing.ts:
     id: 10905058c4ad
-    last_write_checksum: sha1:706a4c4c73a8ed10f31a6923dd8a677c02fa39df
-    pristine_git_object: 901f9e5070ac44103c9099df126141d94efc4aa5
+    last_write_checksum: sha1:e59c12a907a253da7b983197fc5411ba1791157f
+    pristine_git_object: 647de145751dfcd88a9820b68253e2e2265f2b29
   src/sdk/customers.ts:
     id: d33e193e0c00
-    last_write_checksum: sha1:9a136aea44230b415c6d153b29c885b8c973b258
-    pristine_git_object: 3e9a67df405104ac6b1832a66bc1abf3e1efbf79
+    last_write_checksum: sha1:8d64f03efa17b4ef45a6d67a44d23e2943f1cd8b
+    pristine_git_object: 307ba52467887f429aac029db75944b5812fc502
   src/sdk/entities.ts:
     id: 71997b5f9b62
-    last_write_checksum: sha1:0ebff50a9212909395be29b69218ee90543636be
-    pristine_git_object: 195712afc95387658ac3f9a21312d181e80344bf
+    last_write_checksum: sha1:2b2f2ccb94c4a1799990766605cc381af00c6a44
+    pristine_git_object: 9f30b7a762a7771dc31428c9ea6d1c7ff8215fcc
   src/sdk/events.ts:
     id: c7d130088b17
     last_write_checksum: sha1:1dd099274cb75cb4ae46d01fa68ea13b53a79e1a
@@ -4994,7 +4994,7 @@ examples:
     speakeasy-default-get-or-create-customer:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "name": "John Doe", "email": "john@example.com"}
       responses:
@@ -5004,7 +5004,7 @@ examples:
     speakeasy-default-list-plans:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {}
       responses:
@@ -5014,7 +5014,7 @@ examples:
     speakeasy-default-attach:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plan_id": "pro_plan", "redirect_mode": "if_required", "billing_cycle_anchor": "now"}
       responses:
@@ -5042,17 +5042,17 @@ examples:
     speakeasy-default-list-customers:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
-        application/json: {"offset": 0, "limit": 10}
+        application/json: {"start_cursor": "", "limit": 10}
       responses:
         "200":
-          application/json: {"list": [{"id": "2ee25a41-0d81-4ad2-8451-ec1aadaefe58", "name": "Patrick", "email": "patrick@useautumn.com", "created_at": 2358.1, "fingerprint": null, "stripe_id": null, "env": "sandbox", "metadata": {}, "send_email_receipts": false, "billing_controls": {}, "subscriptions": [{"id": "<id>", "plan_id": "<id>", "auto_enable": true, "add_on": false, "status": "active", "past_due": true, "canceled_at": 1145.98, "expires_at": 4027.68, "trial_ends_at": 910.35, "started_at": 7325.71, "current_period_start": 406.39, "current_period_end": 2629.33, "quantity": 1}], "purchases": [], "balances": {"messages": {"feature_id": "<id>", "granted": 100, "remaining": 0, "usage": 100, "unlimited": false, "overage_allowed": false, "max_purchase": 4531.44, "next_reset_at": 1010.14, "breakdown": [{"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "<id>", "included_grant": 4967.46, "prepaid_grant": 6928.7, "remaining": 0, "usage": 100, "unlimited": false, "reset": {"interval": "month", "resets_at": 7938.58}, "price": null, "expires_at": 7264.51}]}}, "flags": {"advanced_workflows": {"id": "cus_ent_abc123", "plan_id": "pro_plan", "expires_at": null, "feature_id": "advanced_workflows"}}, "config": {"disable_pooled_balance": false}, "processors": {"stripe": {"id": "cus_U0BKxpq1mFhuJO"}}}], "has_more": false, "offset": 0, "limit": 10, "total": 1, "total_count": 100, "total_filtered_count": 42}
+          application/json: {"list": [{"id": "2ee25a41-0d81-4ad2-8451-ec1aadaefe58", "name": "Patrick", "email": "patrick@useautumn.com", "created_at": 2358.1, "fingerprint": null, "stripe_id": null, "env": "sandbox", "metadata": {}, "send_email_receipts": false, "billing_controls": {}, "subscriptions": [{"id": "<id>", "plan_id": "<id>", "auto_enable": true, "add_on": false, "status": "active", "past_due": true, "canceled_at": 1145.98, "expires_at": 4027.68, "trial_ends_at": 910.35, "started_at": 7325.71, "current_period_start": 406.39, "current_period_end": 2629.33, "quantity": 1}], "purchases": [], "balances": {"messages": {"feature_id": "<id>", "granted": 100, "remaining": 0, "usage": 100, "unlimited": false, "overage_allowed": false, "max_purchase": 4531.44, "next_reset_at": 1010.14, "breakdown": [{"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "<id>", "included_grant": 4967.46, "prepaid_grant": 6928.7, "remaining": 0, "usage": 100, "unlimited": false, "reset": {"interval": "month", "resets_at": 7938.58}, "price": null, "expires_at": 7264.51}]}}, "flags": {"advanced_workflows": {"id": "cus_ent_abc123", "plan_id": "pro_plan", "expires_at": null, "feature_id": "advanced_workflows"}}, "config": {"disable_pooled_balance": false}, "processors": {"stripe": {"id": "cus_U0BKxpq1mFhuJO"}}}], "next_cursor": null}
   updateCustomer:
     speakeasy-default-update-customer:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "name": "Jane Doe", "email": "jane@example.com"}
       responses:
@@ -5062,7 +5062,7 @@ examples:
     speakeasy-default-delete-customer:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "delete_in_stripe": false}
       responses:
@@ -5092,7 +5092,7 @@ examples:
     speakeasy-default-billing-update:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plan_id": "pro_plan", "feature_quantities": [{"feature_id": "seats", "quantity": 10}], "redirect_mode": "if_required", "billing_cycle_anchor": "now"}
       responses:
@@ -5162,7 +5162,7 @@ examples:
     speakeasy-default-preview-attach:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plan_id": "pro_plan", "redirect_mode": "if_required", "billing_cycle_anchor": "now"}
       responses:
@@ -5192,7 +5192,7 @@ examples:
     speakeasy-default-setup-payment:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "success_url": "https://example.com/account/billing", "billing_cycle_anchor": "now"}
       responses:
@@ -5222,7 +5222,7 @@ examples:
     speakeasy-default-open-customer-portal:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "return_url": "https://useautumn.com"}
       responses:
@@ -5232,7 +5232,7 @@ examples:
     speakeasy-default-preview-update:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plan_id": "pro_plan", "feature_quantities": [{"feature_id": "seats", "quantity": 15}], "redirect_mode": "if_required", "billing_cycle_anchor": "now"}
       responses:
@@ -5242,7 +5242,7 @@ examples:
     speakeasy-default-create-balance:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "api_calls", "reset": {"interval": "month"}}
       responses:
@@ -5252,7 +5252,7 @@ examples:
     speakeasy-default-update-balance:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "api_calls", "remaining": 5}
       responses:
@@ -5262,7 +5262,7 @@ examples:
     speakeasy-default-check:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "messages"}
       responses:
@@ -5274,7 +5274,7 @@ examples:
     speakeasy-default-track:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "messages", "value": 1}
       responses:
@@ -5306,7 +5306,7 @@ examples:
     speakeasy-default-create-referral-code:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "program_id": "prog_123"}
       responses:
@@ -5316,7 +5316,7 @@ examples:
     speakeasy-default-redeem-referral-code:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"code": "REF123", "customer_id": "cus_456"}
       responses:
@@ -5326,7 +5326,7 @@ examples:
     speakeasy-default-create-entity:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"name": "Seat 42", "feature_id": "seats", "customer_id": "cus_123", "entity_id": "seat_42"}
       responses:
@@ -5336,7 +5336,7 @@ examples:
     speakeasy-default-get-entity:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"entity_id": "seat_42"}
       responses:
@@ -5346,7 +5346,7 @@ examples:
     speakeasy-default-delete-entity:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "entity_id": "seat_42"}
       responses:
@@ -5356,17 +5356,17 @@ examples:
     speakeasy-default-list-events:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
-        application/json: {"offset": 0, "limit": 50, "customer_id": "cus_123"}
+        application/json: {"start_cursor": "", "limit": 50, "customer_id": "cus_123"}
       responses:
         "200":
-          application/json: {"list": [{"id": "evt_36xpk2TmuQX5zVPPQ8tCtnR5Weg", "timestamp": 1765958215459, "feature_id": "credits", "customer_id": "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx", "value": 30, "properties": {}, "deductions": [{"balance_id": "cus_ent_3DdSDtFBlvDbjyUuJeUIbQlyN12", "feature_id": "credits", "plan_id": "pro", "reset": {"interval": "month", "resets_at": 1765958215459}, "value": 30}]}, {"id": "evt_36xmHxxjAkqxufDf9yHAPNfRrLM", "timestamp": 1765956512057, "feature_id": "credits", "customer_id": "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx", "value": 49, "properties": {}, "deductions": null}], "has_more": false, "offset": 0, "limit": 100, "total": 2}
+          application/json: {"list": [{"id": "evt_36xpk2TmuQX5zVPPQ8tCtnR5Weg", "timestamp": 1765958215459, "feature_id": "credits", "customer_id": "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx", "value": 30, "properties": {}, "deductions": [{"balance_id": "cus_ent_3DdSDtFBlvDbjyUuJeUIbQlyN12", "feature_id": "credits", "plan_id": "pro", "reset": {"interval": "month", "resets_at": 1765958215459}, "value": 30}]}, {"id": "evt_36xmHxxjAkqxufDf9yHAPNfRrLM", "timestamp": 1765956512057, "feature_id": "credits", "customer_id": "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx", "value": 49, "properties": {}, "deductions": null}], "next_cursor": "eyJ2IjowLCJpZCI6ImV2dF8zNnhtSHh4akFrcXh1ZkRmOXlIQVBOZlJyTE0iLCJ0IjoxNzY1OTU2NTEyMDU3fQ"}
   aggregateEvents:
     speakeasy-default-aggregate-events:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "api_calls", "range": "30d", "bin_size": "day"}
       responses:
@@ -5376,7 +5376,7 @@ examples:
     speakeasy-default-create-feature:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"name": "API Calls", "type": "metered", "consumable": true, "feature_id": "api-calls"}
       responses:
@@ -5386,7 +5386,7 @@ examples:
     speakeasy-default-get-feature:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"feature_id": "api-calls"}
       responses:
@@ -5396,7 +5396,7 @@ examples:
     speakeasy-default-list-features:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       responses:
         "200":
           application/json: {"list": [{"id": "api-calls", "name": "API Calls", "type": "metered", "consumable": true, "display": {"singular": "API call", "plural": "API calls"}, "archived": false}, {"id": "credits", "name": "Credits", "type": "credit_system", "consumable": true, "credit_schema": [{"metered_feature_id": "api-calls", "credit_cost": 1}, {"metered_feature_id": "image-generations", "credit_cost": 10}], "display": {"singular": "credit", "plural": "credits"}, "archived": false}]}
@@ -5404,7 +5404,7 @@ examples:
     speakeasy-default-update-feature:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"name": "API Requests", "display": {"singular": "API request", "plural": "API requests"}, "feature_id": "api-calls"}
       responses:
@@ -5414,7 +5414,7 @@ examples:
     speakeasy-default-delete-feature:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"feature_id": "old-feature"}
       responses:
@@ -5424,7 +5424,7 @@ examples:
     speakeasy-default-create-plan:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"plan_id": "free_plan", "group": "", "name": "Free", "add_on": false, "auto_enable": true, "items": [{"feature_id": "messages", "included": 100, "reset": {"interval": "month"}}], "create_in_stripe": true}
       responses:
@@ -5434,7 +5434,7 @@ examples:
     speakeasy-default-get-plan:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"plan_id": "pro_plan"}
       responses:
@@ -5444,7 +5444,7 @@ examples:
     speakeasy-default-update-plan:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"plan_id": "pro_plan", "group": "", "name": "Pro Plan (Updated)", "price": {"amount": 15, "interval": "month"}, "create_in_stripe": true, "archived": false}
       responses:
@@ -5454,7 +5454,7 @@ examples:
     speakeasy-default-delete-plan:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"plan_id": "unused_plan", "all_versions": false}
       responses:
@@ -5474,7 +5474,7 @@ examples:
     speakeasy-default-preview-multi-attach:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plans": [{"plan_id": "pro_plan"}, {"plan_id": "addon_seats", "feature_quantities": [{"feature_id": "seats", "quantity": 5}]}], "redirect_mode": "if_required"}
       responses:
@@ -5484,7 +5484,7 @@ examples:
     speakeasy-default-multi-attach:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "plans": [{"plan_id": "pro_plan"}, {"plan_id": "addon_seats", "feature_quantities": [{"feature_id": "seats", "quantity": 5}]}], "redirect_mode": "if_required"}
       responses:
@@ -5494,7 +5494,7 @@ examples:
     speakeasy-default-delete-balance:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "feature_id": "api_calls"}
       responses:
@@ -5514,7 +5514,7 @@ examples:
     speakeasy-default-finalize-lock:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"lock_id": "lock_abc123", "action": "confirm"}
       responses:
@@ -5526,7 +5526,7 @@ examples:
     speakeasy-default-update-entity:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "entity_id": "seat_42", "billing_controls": {"spend_limits": [{"feature_id": "messages", "enabled": true, "overage_limit": 25}]}}
       responses:
@@ -5536,7 +5536,7 @@ examples:
     speakeasy-default-get-customer:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123"}
       responses:
@@ -5546,7 +5546,7 @@ examples:
     speakeasy-default-create-schedule:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
         application/json: {"customer_id": "cus_123", "redirect_mode": "if_required", "billing_cycle_anchor": "now", "phases": [{"starts_at": 1735689600000, "plans": [{"plan_id": "trial_plan"}]}, {"starts_at": 1736899200000, "plans": [{"plan_id": "pro_plan"}]}]}
       responses:
@@ -5556,10 +5556,10 @@ examples:
     speakeasy-default-list-entities:
       parameters:
         header:
-          x-api-version: "2.2.0"
+          x-api-version: "2.3.0"
       requestBody:
-        application/json: {"offset": 0, "limit": 10}
+        application/json: {"start_cursor": "", "limit": 10}
       responses:
         "200":
-          application/json: {"list": [{"id": "seat_42", "name": "Seat 42", "customer_id": "cus_123", "feature_id": "seats", "created_at": 1771409161016, "env": "sandbox", "subscriptions": [{"id": "<id>", "plan_id": "pro_plan", "auto_enable": true, "add_on": false, "status": "active", "past_due": false, "canceled_at": null, "expires_at": null, "trial_ends_at": null, "started_at": 1771431921437, "current_period_start": 1771431921437, "current_period_end": 1771999921437, "quantity": 1}], "purchases": [], "balances": {"messages": {"feature_id": "messages", "granted": 100, "remaining": 72, "usage": 28, "unlimited": false, "overage_allowed": false, "max_purchase": null, "next_reset_at": 1773851121437, "breakdown": [{"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "pro_plan", "included_grant": 100, "prepaid_grant": 0, "remaining": 72, "usage": 28, "unlimited": false, "reset": {"interval": "month", "resets_at": 1773851121437}, "price": null, "expires_at": null}]}}, "flags": {"key": {"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "pro_plan", "expires_at": null, "feature_id": "dashboard"}}, "invoices": []}], "has_more": false, "offset": 0, "limit": 10, "total": 1, "total_count": 100, "total_filtered_count": 42}
+          application/json: {"list": [{"id": "seat_42", "name": "Seat 42", "customer_id": "cus_123", "feature_id": "seats", "created_at": 1771409161016, "env": "sandbox", "subscriptions": [{"id": "<id>", "plan_id": "pro_plan", "auto_enable": true, "add_on": false, "status": "active", "past_due": false, "canceled_at": null, "expires_at": null, "trial_ends_at": null, "started_at": 1771431921437, "current_period_start": 1771431921437, "current_period_end": 1771999921437, "quantity": 1}], "purchases": [], "balances": {"messages": {"feature_id": "messages", "granted": 100, "remaining": 72, "usage": 28, "unlimited": false, "overage_allowed": false, "max_purchase": null, "next_reset_at": 1773851121437, "breakdown": [{"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "pro_plan", "included_grant": 100, "prepaid_grant": 0, "remaining": 72, "usage": 28, "unlimited": false, "reset": {"interval": "month", "resets_at": 1773851121437}, "price": null, "expires_at": null}]}}, "flags": {"key": {"id": "cus_ent_39qmLooixXLAqMywgXywjAz96rV", "plan_id": "pro_plan", "expires_at": null, "feature_id": "dashboard"}}, "invoices": []}], "next_cursor": null}
 examplesVersion: 1.0.2

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -1,10 +1,10 @@
 info:
   title: Autumn API
-  version: 2.2.0
+  version: 2.3.0
 servers:
   - url: https://api.useautumn.com
     description: Production server
-openapi: 3.1.1
+openapi: 3.1.0
 components:
   schemas:
     CustomerId:
@@ -1808,7 +1808,7 @@ paths:
           required: true
           schema:
             type: string
-            default: 2.2.0
+            default: 2.3.0
           x-speakeasy-globals-hidden: true
   /v1/customers.get:
     post:
@@ -2624,28 +2624,26 @@ paths:
   /v1/customers.list:
     post:
       operationId: listCustomers
-      description: Lists customers with pagination and optional filters.
+      description: 'Lists customers with cursor pagination and optional filters. Pass `start_cursor: ""` (or omit) for the first page; use `next_cursor` from a prior response for subsequent pages.'
       tags:
         - customers
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
               type: object
               properties:
-                offset:
-                  type: integer
-                  minimum: 0
-                  maximum: 9.007199254740991e+15
-                  default: 0
-                  description: Number of items to skip
+                start_cursor:
+                  type: string
+                  default: ""
+                  description: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
                 limit:
                   type: integer
                   minimum: 1
-                  maximum: 1000
-                  default: 10
-                  description: Number of items to return. Default 10, max 1000.
+                  maximum: 5000
+                  default: 50
+                  description: Number of items to return. Default 50, hard ceiling 5000.
                 plans:
                   type: array
                   items:
@@ -2665,10 +2663,10 @@ paths:
                     - active
                     - scheduled
                   type: string
-                  description: Filter by customer product status. Defaults to active and scheduled
+                  description: Filter by customer product status. Defaults to active and scheduled.
                 search:
                   type: string
-                  description: Search customers by id, name, or email
+                  description: Search customers by id, name, or email.
                 processors:
                   type: array
                   items:
@@ -2677,11 +2675,11 @@ paths:
                       - revenuecat
                       - vercel
                     type: string
-                  description: Filter by customer processor type (stripe, revenuecat, vercel)
+                  description: Filter by customer processor type (stripe, revenuecat, vercel).
               title: ListCustomersParams
               examples:
-                - limit: 10
-                  offset: 0
+                - start_cursor: ""
+                  limit: 10
       responses:
         "200":
           description: OK
@@ -3219,33 +3217,15 @@ paths:
                               feature_id: advanced_workflows
                           config:
                             disable_pooled_balance: false
-                    description: Array of items for current page
-                  has_more:
-                    type: boolean
-                    description: Whether more results exist after this page
-                  offset:
-                    type: number
-                    description: Current offset position
-                  limit:
-                    type: number
-                    description: Limit passed in the request
-                  total:
-                    type: number
-                    description: Total number of items returned in the current page
-                  total_count:
-                    type: number
-                    description: Total number of customers available in the current organization and environment
-                  total_filtered_count:
-                    type: number
-                    description: Total number of customers matching the current filter before pagination is applied
+                    description: Items for current page.
+                  next_cursor:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Opaque cursor for the next page. Null when there are no more results.
                 required:
                   - list
-                  - has_more
-                  - offset
-                  - limit
-                  - total
-                  - total_count
-                  - total_filtered_count
+                  - next_cursor
                 examples:
                   - list:
                       - id: 2ee25a41-0d81-4ad2-8451-ec1aadaefe58
@@ -3307,12 +3287,7 @@ paths:
                             feature_id: advanced_workflows
                         config:
                           disable_pooled_balance: false
-                    has_more: false
-                    offset: 0
-                    total: 1
-                    limit: 10
-                    total_count: 100
-                    total_filtered_count: 42
+                    next_cursor: null
       x-speakeasy-name-override: list
       parameters:
         - *a1
@@ -8037,7 +8012,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779094773453,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780304373453,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -15043,18 +15018,16 @@ paths:
             schema:
               type: object
               properties:
-                offset:
-                  type: integer
-                  minimum: 0
-                  maximum: 9.007199254740991e+15
-                  default: 0
-                  description: Number of items to skip
+                start_cursor:
+                  type: string
+                  default: ""
+                  description: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
                 limit:
                   type: integer
                   minimum: 1
-                  maximum: 1000
-                  default: 100
-                  description: Number of items to return. Default 100, max 1000.
+                  maximum: 5000
+                  default: 50
+                  description: Number of items to return. Default 50, hard ceiling 5000.
                 customer_id:
                   type: string
                   description: Filter events by customer ID
@@ -15083,9 +15056,11 @@ paths:
                   description: Filter events by time range
               title: EventsListParams
               examples:
-                - customer_id: cus_123
+                - start_cursor: ""
+                  customer_id: cus_123
                   limit: 50
-                - feature_id: api_calls
+                - start_cursor: ""
+                  feature_id: api_calls
                   custom_range:
                     start: 1704067200000
                     end: 1706745600000
@@ -15191,25 +15166,15 @@ paths:
                         - value
                         - properties
                         - deductions
-                    description: Array of items for current page
-                  has_more:
-                    type: boolean
-                    description: Whether more results exist after this page
-                  offset:
-                    type: number
-                    description: Current offset position
-                  limit:
-                    type: number
-                    description: Limit passed in the request
-                  total:
-                    type: number
-                    description: Total number of items returned in the current page
+                    description: Items for current page.
+                  next_cursor:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Opaque cursor for the next page. Null when there are no more results.
                 required:
                   - list
-                  - has_more
-                  - offset
-                  - limit
-                  - total
+                  - next_cursor
                 examples:
                   - list:
                       - id: evt_36xpk2TmuQX5zVPPQ8tCtnR5Weg
@@ -15233,10 +15198,7 @@ paths:
                         value: 49
                         properties: {}
                         deductions: null
-                    total: 2
-                    has_more: false
-                    offset: 0
-                    limit: 100
+                    next_cursor: eyJ2IjowLCJpZCI6ImV2dF8zNnhtSHh4akFrcXh1ZkRmOXlIQVBOZlJyTE0iLCJ0IjoxNzY1OTU2NTEyMDU3fQ
       x-speakeasy-name-override: list
       parameters:
         - *a1
@@ -16508,24 +16470,22 @@ paths:
       tags:
         - entities
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
               type: object
               properties:
-                offset:
-                  type: integer
-                  minimum: 0
-                  maximum: 9.007199254740991e+15
-                  default: 0
-                  description: Number of items to skip
+                start_cursor:
+                  type: string
+                  default: ""
+                  description: Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
                 limit:
                   type: integer
                   minimum: 1
-                  maximum: 1000
-                  default: 10
-                  description: Number of items to return. Default 10, max 1000.
+                  maximum: 5000
+                  default: 50
+                  description: Number of items to return. Default 50, hard ceiling 5000.
                 plans:
                   type: array
                   items:
@@ -16560,8 +16520,8 @@ paths:
                   description: Filter by parent customer processor type (stripe, revenuecat, vercel).
               title: ListEntitiesParams
               examples:
-                - limit: 10
-                  offset: 0
+                - start_cursor: ""
+                  limit: 10
                 - plans:
                     - id: pro_plan
       responses:
@@ -16930,33 +16890,15 @@ paths:
                         - purchases
                         - balances
                         - flags
-                    description: Array of items for current page
-                  has_more:
-                    type: boolean
-                    description: Whether more results exist after this page
-                  offset:
-                    type: number
-                    description: Current offset position
-                  limit:
-                    type: number
-                    description: Limit passed in the request
-                  total:
-                    type: number
-                    description: Total number of items returned in the current page
-                  total_count:
-                    type: number
-                    description: Total number of entities available in the current organization and environment
-                  total_filtered_count:
-                    type: number
-                    description: Total number of entities matching the current filter before pagination is applied
+                    description: Items for current page.
+                  next_cursor:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Opaque cursor for the next page. Null when there are no more results.
                 required:
                   - list
-                  - has_more
-                  - offset
-                  - limit
-                  - total
-                  - total_count
-                  - total_filtered_count
+                  - next_cursor
                 examples:
                   - list:
                       - id: seat_42
@@ -17003,12 +16945,7 @@ paths:
                                 price: null
                                 expires_at: null
                         invoices: []
-                    has_more: false
-                    offset: 0
-                    total: 1
-                    limit: 10
-                    total_count: 100
-                    total_filtered_count: 42
+                    next_cursor: null
       x-speakeasy-name-override: list
       parameters:
         - *a1
@@ -17715,7 +17652,7 @@ x-speakeasy-globals:
       required: true
       schema:
         type: string
-        default: 2.2.0
+        default: 2.3.0
       x-speakeasy-globals-hidden: true
     - name: fail-open
       in: header

--- a/packages/sdk/.speakeasy/workflow.lock
+++ b/packages/sdk/.speakeasy/workflow.lock
@@ -9,11 +9,11 @@ sources:
             - 2.2.0
     Autumn API Stripped:
         sourceNamespace: autumn-api-stripped
-        sourceRevisionDigest: sha256:4a5229356bd59114ab0416f0b4acbed7b70a2977a02ca9e779db1b546223eb7f
-        sourceBlobDigest: sha256:3fe7dec340e72b2b5e6ffea7ea017d4ccb62e8a7f2ec387ea33719dced575c3c
+        sourceRevisionDigest: sha256:77fa91848d845af89acfb71b0fc8ae93f2b6433eab1baabb1df5752d1bad2b8a
+        sourceBlobDigest: sha256:765145e79097f781f2838d142945c2f7c83eac030cf7d0b4f4e4d24c8a343e6b
         tags:
             - latest
-            - 2.2.0
+            - 2.3.0
 targets:
     autumn:
         source: Autumn API
@@ -25,10 +25,10 @@ targets:
     autumn-python:
         source: Autumn API Stripped
         sourceNamespace: autumn-api-stripped
-        sourceRevisionDigest: sha256:4a5229356bd59114ab0416f0b4acbed7b70a2977a02ca9e779db1b546223eb7f
-        sourceBlobDigest: sha256:3fe7dec340e72b2b5e6ffea7ea017d4ccb62e8a7f2ec387ea33719dced575c3c
+        sourceRevisionDigest: sha256:77fa91848d845af89acfb71b0fc8ae93f2b6433eab1baabb1df5752d1bad2b8a
+        sourceBlobDigest: sha256:765145e79097f781f2838d142945c2f7c83eac030cf7d0b4f4e4d24c8a343e6b
         codeSamplesNamespace: autumn-api-python-code-samples
-        codeSamplesRevisionDigest: sha256:67574df2aa1fb16b198206e27e22f29284831f669ca4d0dbce2081d695a1fca3
+        codeSamplesRevisionDigest: sha256:80bf351833a36e7fd65d6a69bb7c90a17445c3addefe3dc0e114df00f4506d2d
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.762.0

--- a/packages/sdk/FUNCTIONS.md
+++ b/packages/sdk/FUNCTIONS.md
@@ -25,7 +25,7 @@ import { check } from "@useautumn/sdk/funcs/check.js";
 // Use `AutumnCore` for best tree-shaking performance.
 // You can create one instance of it to use across an application.
 const autumn = new AutumnCore({
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
 });
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -89,7 +89,7 @@ For supported JavaScript runtimes, please consult [RUNTIMES.md](RUNTIMES.md).
 import { Autumn } from "@useautumn/sdk";
 
 const autumn = new Autumn({
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
 });
 
@@ -124,7 +124,7 @@ import { Autumn } from "@useautumn/sdk";
 
 const autumn = new Autumn({
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
 });
 
 async function run() {
@@ -271,7 +271,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779094773453,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780304373453,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.
@@ -492,7 +492,7 @@ const response = await client.get({ customerId: "cus_123", expand: ["invoices","
 
 @param customerId - ID of the customer to fetch
 @param expand - Expand related customer data like invoices or entities, or expand nested objects like balances.feature, flags.feature, subscriptions.plan, and purchases.plan. (optional)
-* [list](docs/sdks/customers/README.md#list) - Lists customers with pagination and optional filters.
+* [list](docs/sdks/customers/README.md#list) - Lists customers with cursor pagination and optional filters. Pass `start_cursor: ""` (or omit) for the first page; use `next_cursor` from a prior response for subsequent pages.
 * [update](docs/sdks/customers/README.md#update) - Updates an existing customer by ID.
 * [delete](docs/sdks/customers/README.md#delete) - Deletes a customer by ID.
 
@@ -782,7 +782,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779094773453,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780304373453,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.
@@ -1033,7 +1033,7 @@ const response = await client.getOrCreate({ customerId: "cus_123", name: "John D
 @param billingControls - Billing controls for the customer (auto top-ups, etc.) (optional)
 @param config - Miscellaneous configurations for the customer. (optional)
 @param expand - Fields to expand in the returned customer response, such as subscriptions.plan, purchases.plan, balances.feature, or flags.feature. (optional)
-- [`customersList`](docs/sdks/customers/README.md#list) - Lists customers with pagination and optional filters.
+- [`customersList`](docs/sdks/customers/README.md#list) - Lists customers with cursor pagination and optional filters. Pass `start_cursor: ""` (or omit) for the first page; use `next_cursor` from a prior response for subsequent pages.
 - [`customersUpdate`](docs/sdks/customers/README.md#update) - Updates an existing customer by ID.
 - [`entitiesCreate`](docs/sdks/entities/README.md#create) - Creates an entity for a customer and feature, then returns the entity with balances and subscriptions.
 
@@ -1266,7 +1266,7 @@ To change the default retry strategy for a single API call, simply provide a ret
 import { Autumn } from "@useautumn/sdk";
 
 const autumn = new Autumn({
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
 });
 
@@ -1309,7 +1309,7 @@ const autumn = new Autumn({
     },
     retryConnectionErrors: false,
   },
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
 });
 
@@ -1346,7 +1346,7 @@ import * as models from "@useautumn/sdk";
 import { Autumn } from "@useautumn/sdk";
 
 const autumn = new Autumn({
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
 });
 
@@ -1405,7 +1405,7 @@ import { Autumn } from "@useautumn/sdk";
 
 const autumn = new Autumn({
   serverURL: "https://api.useautumn.com",
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
 });
 

--- a/packages/sdk/USAGE.md
+++ b/packages/sdk/USAGE.md
@@ -3,7 +3,7 @@
 import { Autumn } from "@useautumn/sdk";
 
 const autumn = new Autumn({
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
 });
 

--- a/packages/sdk/examples/check.example.ts
+++ b/packages/sdk/examples/check.example.ts
@@ -14,7 +14,7 @@ dotenv.config();
 import { Autumn } from "@useautumn/sdk";
 
 const autumn = new Autumn({
-  xApiVersion: "2.2.0",
+  xApiVersion: "2.3.0",
   secretKey: process.env["AUTUMN_SECRET_KEY"] ?? "",
 });
 

--- a/packages/sdk/src/funcs/billing-create-schedule.ts
+++ b/packages/sdk/src/funcs/billing-create-schedule.ts
@@ -34,7 +34,7 @@ import { Result } from "../types/fp.js";
  * @example
  * ```typescript
  * // Schedule a transition from a trial plan to a paid plan
- * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779094773453,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780304373453,"plans":[{"planId":"pro_plan"}]}] });
+ * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
  * ```
  *
  * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/funcs/customers-list.ts
+++ b/packages/sdk/src/funcs/customers-list.ts
@@ -27,11 +27,11 @@ import { APICall, APIPromise } from "../types/async.js";
 import { Result } from "../types/fp.js";
 
 /**
- * Lists customers with pagination and optional filters.
+ * Lists customers with cursor pagination and optional filters. Pass `start_cursor: ""` (or omit) for the first page; use `next_cursor` from a prior response for subsequent pages.
  */
 export function customersList(
   client: AutumnCore,
-  request?: models.ListCustomersParams | undefined,
+  request: models.ListCustomersParams,
   options?: RequestOptions,
 ): APIPromise<
   Result<
@@ -55,7 +55,7 @@ export function customersList(
 
 async function $do(
   client: AutumnCore,
-  request?: models.ListCustomersParams | undefined,
+  request: models.ListCustomersParams,
   options?: RequestOptions,
 ): Promise<
   [
@@ -75,17 +75,14 @@ async function $do(
 > {
   const parsed = safeParse(
     request,
-    (value) =>
-      z.parse(z.optional(models.ListCustomersParams$outboundSchema), value),
+    (value) => z.parse(models.ListCustomersParams$outboundSchema, value),
     "Input validation failed",
   );
   if (!parsed.ok) {
     return [parsed, { status: "invalid" }];
   }
   const payload = parsed.value;
-  const body = payload === undefined
-    ? null
-    : encodeJSON("body", payload, { explode: true });
+  const body = encodeJSON("body", payload, { explode: true });
 
   const path = pathToFunc("/v1/customers.list")();
 

--- a/packages/sdk/src/funcs/entities-list.ts
+++ b/packages/sdk/src/funcs/entities-list.ts
@@ -54,7 +54,7 @@ import { Result } from "../types/fp.js";
  */
 export function entitiesList(
   client: AutumnCore,
-  request?: models.ListEntitiesParams | undefined,
+  request: models.ListEntitiesParams,
   options?: RequestOptions,
 ): APIPromise<
   Result<
@@ -78,7 +78,7 @@ export function entitiesList(
 
 async function $do(
   client: AutumnCore,
-  request?: models.ListEntitiesParams | undefined,
+  request: models.ListEntitiesParams,
   options?: RequestOptions,
 ): Promise<
   [
@@ -98,17 +98,14 @@ async function $do(
 > {
   const parsed = safeParse(
     request,
-    (value) =>
-      z.parse(z.optional(models.ListEntitiesParams$outboundSchema), value),
+    (value) => z.parse(models.ListEntitiesParams$outboundSchema, value),
     "Input validation failed",
   );
   if (!parsed.ok) {
     return [parsed, { status: "invalid" }];
   }
   const payload = parsed.value;
-  const body = payload === undefined
-    ? null
-    : encodeJSON("body", payload, { explode: true });
+  const body = encodeJSON("body", payload, { explode: true });
 
   const path = pathToFunc("/v1/entities.list")();
 

--- a/packages/sdk/src/lib/config.ts
+++ b/packages/sdk/src/lib/config.ts
@@ -70,8 +70,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 
 export const SDK_METADATA = {
   language: "typescript",
-  openapiDocVersion: "2.2.0",
+  openapiDocVersion: "2.3.0",
   sdkVersion: "0.10.17",
   genVersion: "2.882.0",
-  userAgent: "speakeasy-sdk/typescript 0.10.17 2.882.0 2.2.0 @useautumn/sdk",
+  userAgent: "speakeasy-sdk/typescript 0.10.17 2.882.0 2.3.0 @useautumn/sdk",
 } as const;

--- a/packages/sdk/src/lib/env.ts
+++ b/packages/sdk/src/lib/env.ts
@@ -25,7 +25,7 @@ export interface Env {
 export const envSchema: z.ZodMiniType<Env, unknown> = z.object({
   AUTUMN_SECRET_KEY: z.optional(z.string()),
 
-  AUTUMN_X_API_VERSION: z._default(z.string(), "2.2.0"),
+  AUTUMN_X_API_VERSION: z._default(z.string(), "2.3.0"),
   AUTUMN_FAIL_OPEN: z.pipe(
     z._default(z.enum(["true", "false"]), "true"),
     z.transform(v => v === "true"),

--- a/packages/sdk/src/models/list-customers-op.ts
+++ b/packages/sdk/src/models/list-customers-op.ts
@@ -24,14 +24,14 @@ export type ListCustomersPlan = {
 };
 
 /**
- * Filter by customer product status. Defaults to active and scheduled
+ * Filter by customer product status. Defaults to active and scheduled.
  */
 export const ListCustomersSubscriptionStatus = {
   Active: "active",
   Scheduled: "scheduled",
 } as const;
 /**
- * Filter by customer product status. Defaults to active and scheduled
+ * Filter by customer product status. Defaults to active and scheduled.
  */
 export type ListCustomersSubscriptionStatus = ClosedEnum<
   typeof ListCustomersSubscriptionStatus
@@ -46,11 +46,11 @@ export type ListCustomersProcessor = ClosedEnum<typeof ListCustomersProcessor>;
 
 export type ListCustomersParams = {
   /**
-   * Number of items to skip
+   * Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
    */
-  offset?: number | undefined;
+  startCursor?: string | undefined;
   /**
-   * Number of items to return. Default 10, max 1000.
+   * Number of items to return. Default 50, hard ceiling 5000.
    */
   limit?: number | undefined;
   /**
@@ -58,15 +58,15 @@ export type ListCustomersParams = {
    */
   plans?: Array<ListCustomersPlan> | undefined;
   /**
-   * Filter by customer product status. Defaults to active and scheduled
+   * Filter by customer product status. Defaults to active and scheduled.
    */
   subscriptionStatus?: ListCustomersSubscriptionStatus | undefined;
   /**
-   * Search customers by id, name, or email
+   * Search customers by id, name, or email.
    */
   search?: string | undefined;
   /**
-   * Filter by customer processor type (stripe, revenuecat, vercel)
+   * Filter by customer processor type (stripe, revenuecat, vercel).
    */
   processors?: Array<ListCustomersProcessor> | undefined;
 };
@@ -588,33 +588,13 @@ export type ListCustomersList = {
  */
 export type ListCustomersResponse = {
   /**
-   * Array of items for current page
+   * Items for current page.
    */
   list: Array<ListCustomersList>;
   /**
-   * Whether more results exist after this page
+   * Opaque cursor for the next page. Null when there are no more results.
    */
-  hasMore: boolean;
-  /**
-   * Current offset position
-   */
-  offset: number;
-  /**
-   * Limit passed in the request
-   */
-  limit: number;
-  /**
-   * Total number of items returned in the current page
-   */
-  total: number;
-  /**
-   * Total number of customers available in the current organization and environment
-   */
-  totalCount: number;
-  /**
-   * Total number of customers matching the current filter before pagination is applied
-   */
-  totalFilteredCount: number;
+  nextCursor: string | null;
 };
 
 /** @internal */
@@ -652,7 +632,7 @@ export const ListCustomersProcessor$outboundSchema: z.ZodMiniEnum<
 
 /** @internal */
 export type ListCustomersParams$Outbound = {
-  offset: number;
+  start_cursor: string;
   limit: number;
   plans?: Array<ListCustomersPlan$Outbound> | undefined;
   subscription_status?: string | undefined;
@@ -666,8 +646,8 @@ export const ListCustomersParams$outboundSchema: z.ZodMiniType<
   ListCustomersParams
 > = z.pipe(
   z.object({
-    offset: z._default(z.int(), 0),
-    limit: z._default(z.int(), 10),
+    startCursor: z._default(z.string(), ""),
+    limit: z._default(z.int(), 50),
     plans: z.optional(z.array(z.lazy(() => ListCustomersPlan$outboundSchema))),
     subscriptionStatus: z.optional(
       ListCustomersSubscriptionStatus$outboundSchema,
@@ -677,6 +657,7 @@ export const ListCustomersParams$outboundSchema: z.ZodMiniType<
   }),
   z.transform((v) => {
     return remap$(v, {
+      startCursor: "start_cursor",
       subscriptionStatus: "subscription_status",
     });
   }),
@@ -1314,18 +1295,11 @@ export const ListCustomersResponse$inboundSchema: z.ZodMiniType<
 > = z.pipe(
   z.object({
     list: z.array(z.lazy(() => ListCustomersList$inboundSchema)),
-    has_more: types.boolean(),
-    offset: types.number(),
-    limit: types.number(),
-    total: types.number(),
-    total_count: types.number(),
-    total_filtered_count: types.number(),
+    next_cursor: types.nullable(types.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
-      "has_more": "hasMore",
-      "total_count": "totalCount",
-      "total_filtered_count": "totalFilteredCount",
+      "next_cursor": "nextCursor",
     });
   }),
 );

--- a/packages/sdk/src/models/list-entities-op.ts
+++ b/packages/sdk/src/models/list-entities-op.ts
@@ -45,11 +45,11 @@ export type ListEntitiesProcessor = ClosedEnum<typeof ListEntitiesProcessor>;
 
 export type ListEntitiesParams = {
   /**
-   * Number of items to skip
+   * Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
    */
-  offset?: number | undefined;
+  startCursor?: string | undefined;
   /**
-   * Number of items to return. Default 10, max 1000.
+   * Number of items to return. Default 50, hard ceiling 5000.
    */
   limit?: number | undefined;
   /**
@@ -445,33 +445,13 @@ export type ListEntitiesList = {
  */
 export type ListEntitiesResponse = {
   /**
-   * Array of items for current page
+   * Items for current page.
    */
   list: Array<ListEntitiesList>;
   /**
-   * Whether more results exist after this page
+   * Opaque cursor for the next page. Null when there are no more results.
    */
-  hasMore: boolean;
-  /**
-   * Current offset position
-   */
-  offset: number;
-  /**
-   * Limit passed in the request
-   */
-  limit: number;
-  /**
-   * Total number of items returned in the current page
-   */
-  total: number;
-  /**
-   * Total number of entities available in the current organization and environment
-   */
-  totalCount: number;
-  /**
-   * Total number of entities matching the current filter before pagination is applied
-   */
-  totalFilteredCount: number;
+  nextCursor: string | null;
 };
 
 /** @internal */
@@ -509,7 +489,7 @@ export const ListEntitiesProcessor$outboundSchema: z.ZodMiniEnum<
 
 /** @internal */
 export type ListEntitiesParams$Outbound = {
-  offset: number;
+  start_cursor: string;
   limit: number;
   plans?: Array<ListEntitiesPlan$Outbound> | undefined;
   subscription_status?: string | undefined;
@@ -523,8 +503,8 @@ export const ListEntitiesParams$outboundSchema: z.ZodMiniType<
   ListEntitiesParams
 > = z.pipe(
   z.object({
-    offset: z._default(z.int(), 0),
-    limit: z._default(z.int(), 10),
+    startCursor: z._default(z.string(), ""),
+    limit: z._default(z.int(), 50),
     plans: z.optional(z.array(z.lazy(() => ListEntitiesPlan$outboundSchema))),
     subscriptionStatus: z.optional(
       ListEntitiesSubscriptionStatus$outboundSchema,
@@ -534,6 +514,7 @@ export const ListEntitiesParams$outboundSchema: z.ZodMiniType<
   }),
   z.transform((v) => {
     return remap$(v, {
+      startCursor: "start_cursor",
       subscriptionStatus: "subscription_status",
     });
   }),
@@ -977,18 +958,11 @@ export const ListEntitiesResponse$inboundSchema: z.ZodMiniType<
 > = z.pipe(
   z.object({
     list: z.array(z.lazy(() => ListEntitiesList$inboundSchema)),
-    has_more: types.boolean(),
-    offset: types.number(),
-    limit: types.number(),
-    total: types.number(),
-    total_count: types.number(),
-    total_filtered_count: types.number(),
+    next_cursor: types.nullable(types.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
-      "has_more": "hasMore",
-      "total_count": "totalCount",
-      "total_filtered_count": "totalFilteredCount",
+      "next_cursor": "nextCursor",
     });
   }),
 );

--- a/packages/sdk/src/models/list-events-op.ts
+++ b/packages/sdk/src/models/list-events-op.ts
@@ -37,11 +37,11 @@ export type ListEventsCustomRange = {
 
 export type EventsListParams = {
   /**
-   * Number of items to skip
+   * Opaque pagination cursor. Empty string (default) requests the first page; use next_cursor from a prior response for subsequent pages.
    */
-  offset?: number | undefined;
+  startCursor?: string | undefined;
   /**
-   * Number of items to return. Default 100, max 1000.
+   * Number of items to return. Default 50, hard ceiling 5000.
    */
   limit?: number | undefined;
   /**
@@ -154,25 +154,13 @@ export type ListEventsList = {
  */
 export type ListEventsResponse = {
   /**
-   * Array of items for current page
+   * Items for current page.
    */
   list: Array<ListEventsList>;
   /**
-   * Whether more results exist after this page
+   * Opaque cursor for the next page. Null when there are no more results.
    */
-  hasMore: boolean;
-  /**
-   * Current offset position
-   */
-  offset: number;
-  /**
-   * Limit passed in the request
-   */
-  limit: number;
-  /**
-   * Total number of items returned in the current page
-   */
-  total: number;
+  nextCursor: string | null;
 };
 
 /** @internal */
@@ -217,7 +205,7 @@ export function listEventsCustomRangeToJSON(
 
 /** @internal */
 export type EventsListParams$Outbound = {
-  offset: number;
+  start_cursor: string;
   limit: number;
   customer_id?: string | undefined;
   entity_id?: string | undefined;
@@ -231,8 +219,8 @@ export const EventsListParams$outboundSchema: z.ZodMiniType<
   EventsListParams
 > = z.pipe(
   z.object({
-    offset: z._default(z.int(), 0),
-    limit: z._default(z.int(), 100),
+    startCursor: z._default(z.string(), ""),
+    limit: z._default(z.int(), 50),
     customerId: z.optional(z.string()),
     entityId: z.optional(z.string()),
     featureId: z.optional(smartUnion([z.string(), z.array(z.string())])),
@@ -240,6 +228,7 @@ export const EventsListParams$outboundSchema: z.ZodMiniType<
   }),
   z.transform((v) => {
     return remap$(v, {
+      startCursor: "start_cursor",
       customerId: "customer_id",
       entityId: "entity_id",
       featureId: "feature_id",
@@ -377,14 +366,11 @@ export const ListEventsResponse$inboundSchema: z.ZodMiniType<
 > = z.pipe(
   z.object({
     list: z.array(z.lazy(() => ListEventsList$inboundSchema)),
-    has_more: types.boolean(),
-    offset: types.number(),
-    limit: types.number(),
-    total: types.number(),
+    next_cursor: types.nullable(types.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
-      "has_more": "hasMore",
+      "next_cursor": "nextCursor",
     });
   }),
 );

--- a/packages/sdk/src/sdk/billing.ts
+++ b/packages/sdk/src/sdk/billing.ts
@@ -86,7 +86,7 @@ export class Billing extends ClientSDK {
    * @example
    * ```typescript
    * // Schedule a transition from a trial plan to a paid plan
-   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779094773453,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780304373453,"plans":[{"planId":"pro_plan"}]}] });
+   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
    * ```
    *
    * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/sdk/customers.ts
+++ b/packages/sdk/src/sdk/customers.ts
@@ -79,10 +79,10 @@ export class Customers extends ClientSDK {
   }
 
   /**
-   * Lists customers with pagination and optional filters.
+   * Lists customers with cursor pagination and optional filters. Pass `start_cursor: ""` (or omit) for the first page; use `next_cursor` from a prior response for subsequent pages.
    */
   async list(
-    request?: models.ListCustomersParams | undefined,
+    request: models.ListCustomersParams,
     options?: RequestOptions,
   ): Promise<models.ListCustomersResponse> {
     return unwrapAsync(customersList(

--- a/packages/sdk/src/sdk/entities.ts
+++ b/packages/sdk/src/sdk/entities.ts
@@ -109,7 +109,7 @@ export class Entities extends ClientSDK {
    * @returns A paginated list of entity objects including their current subscriptions, purchases, balances, and flags.
    */
   async list(
-    request?: models.ListEntitiesParams | undefined,
+    request: models.ListEntitiesParams,
     options?: RequestOptions,
   ): Promise<models.ListEntitiesResponse> {
     return unwrapAsync(entitiesList(

--- a/shared/api/events/list/eventsListResponseV2_3.ts
+++ b/shared/api/events/list/eventsListResponseV2_3.ts
@@ -5,6 +5,42 @@ import { ApiEventsListItemSchema } from "./eventsListResponse.js";
 export const ApiEventsListV2_3ResponseSchema =
 	createCursorPaginatedResponseSchema(ApiEventsListItemSchema);
 
+export const EVENTS_LIST_V2_3_EXAMPLE = {
+	list: [
+		{
+			id: "evt_36xpk2TmuQX5zVPPQ8tCtnR5Weg",
+			timestamp: 1765958215459,
+			feature_id: "credits",
+			customer_id: "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx",
+			value: 30,
+			properties: {},
+			deductions: [
+				{
+					balance_id: "cus_ent_3DdSDtFBlvDbjyUuJeUIbQlyN12",
+					feature_id: "credits",
+					plan_id: "pro",
+					reset: {
+						interval: "month" as const,
+						resets_at: 1765958215459,
+					},
+					value: 30,
+				},
+			],
+		},
+		{
+			id: "evt_36xmHxxjAkqxufDf9yHAPNfRrLM",
+			timestamp: 1765956512057,
+			feature_id: "credits",
+			customer_id: "0pCIbS4AMAFDB1iBMNhARWZt2gDtVwQx",
+			value: 49,
+			properties: {},
+			deductions: null,
+		},
+	],
+	next_cursor:
+		"eyJ2IjowLCJpZCI6ImV2dF8zNnhtSHh4akFrcXh1ZkRmOXlIQVBOZlJyTE0iLCJ0IjoxNzY1OTU2NTEyMDU3fQ",
+};
+
 export type ApiEventsListV2_3Response = z.infer<
 	typeof ApiEventsListV2_3ResponseSchema
 >;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps API to v2.3 and switches list endpoints to cursor-based pagination. Updates docs, OpenAPI, and the Python `autumn-sdk` to use `start_cursor`/`next_cursor` with new defaults.

- **New Features**
  - Cursor-based pagination for `customers.list`, `entities.list`, and `events.list` using `start_cursor`; responses return `next_cursor`. Default `limit` is 50; max 5000.
  - Python `autumn-sdk` updated for v2.3 (`x_api_version="2.3.0"`), with new list method signatures and docs/snippets refreshed.
  - Docs fixed to import dynamic components from `/snippets/...`; OpenAPI version set to 2.3.0.

- **Migration**
  - Replace `offset` with `start_cursor` and iterate using `next_cursor`.
  - Review `limit` usage (defaults to 50; ceiling 5000).
  - Upgrade to the latest Python `autumn-sdk` and set `x_api_version="2.3.0"`.

<sup>Written for commit 4a84be33e4715d4eb818ebd03f53a00b632d8434. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1615?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

