### PR TITLE
fix: add tags to webhooks

### DIFF
--- a/server/src/external/svix/svixHelpers.ts
+++ b/server/src/external/svix/svixHelpers.ts
@@ -44,12 +44,14 @@ export const sendSvixEvent = async ({
 	data,
 	payloadFields,
 	idempotencyKey,
+	tags,
 }: {
 	ctx: AutumnContext;
 	eventType: string;
 	data: unknown;
 	payloadFields?: { id?: string; occurred_at?: number };
 	idempotencyKey?: string;
+	tags?: string[];
 }) => {
 	if (!process.env.SVIX_API_KEY) return;
 
@@ -71,6 +73,7 @@ export const sendSvixEvent = async ({
 					...payloadFields,
 					data,
 				},
+				...(tags && tags.length > 0 ? { tags } : {}),
 			},
 			idempotencyKey ? { idempotencyKey } : undefined,
 		);

--- a/server/src/internal/analytics/handlers/handleProductsUpdated.ts
+++ b/server/src/internal/analytics/handlers/handleProductsUpdated.ts
@@ -15,6 +15,7 @@ import {
 	type EntityLegacyData,
 	type FullCusProduct,
 	type FullProduct,
+	fullCustomerToTags,
 	type Organization,
 	type PlanLegacyData,
 } from "@autumn/shared";
@@ -203,5 +204,6 @@ export const handleProductsUpdated = async ({
 			entity,
 			updated_product: versionedPlan,
 		},
+		tags: fullCustomerToTags({ fullCustomer: fullCus }),
 	});
 };

--- a/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
+++ b/server/src/internal/balances/trackWebhooks/checkLimitReached.ts
@@ -4,6 +4,7 @@ import {
 	apiBalanceToAllowed,
 	type Feature,
 	type FullCustomer,
+	fullCustomerToTags,
 	WebhookEventType,
 } from "@autumn/shared";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
@@ -79,6 +80,7 @@ const checkLimitForSubject = async ({
 	if (!oldResult.allowed || newResult.allowed) return;
 
 	const customerId = newFullCus.id || newFullCus.internal_id;
+	const tags = fullCustomerToTags({ fullCustomer: newFullCus });
 
 	await sendSvixEvent({
 		ctx,
@@ -89,6 +91,7 @@ const checkLimitForSubject = async ({
 			limit_type: newResult.limitType ?? "included",
 			...(entityId && { entity_id: entityId }),
 		},
+		tags,
 	});
 
 	ctx.logger.info(

--- a/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
+++ b/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
@@ -4,6 +4,7 @@ import {
 	type Feature,
 	type FullCustomer,
 	fullCustomerToCustomerEntitlements,
+	fullCustomerToTags,
 	getApiBalance,
 	WebhookEventType,
 } from "@autumn/shared";
@@ -151,6 +152,8 @@ const processAlerts = async ({
 			minuteBucket,
 		].join(":");
 
+		const tags = fullCustomerToTags({ fullCustomer: newFullCus });
+
 		await sendSvixEvent({
 			ctx,
 			eventType: WebhookEventType.BalancesUsageAlertTriggered,
@@ -165,6 +168,7 @@ const processAlerts = async ({
 					threshold_type: alert.threshold_type,
 				},
 			},
+			tags,
 		});
 
 		ctx.logger.info(

--- a/server/src/internal/balances/trackWebhooks/handleThresholdReached.ts
+++ b/server/src/internal/balances/trackWebhooks/handleThresholdReached.ts
@@ -10,6 +10,7 @@ import {
 	dbToApiFeatureV1,
 	type Feature,
 	type FullCustomer,
+	fullCustomerToTags,
 	WebhookEventType,
 } from "@autumn/shared";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
@@ -99,6 +100,7 @@ const handleAllowanceUsed = async ({
 					targetVersion: ctx.apiVersion,
 				}),
 			},
+			tags: fullCustomerToTags({ fullCustomer: newFullCus }),
 		});
 	}
 };
@@ -172,6 +174,7 @@ export const handleThresholdReached = async ({
 						targetVersion: ctx.apiVersion,
 					}),
 				},
+				tags: fullCustomerToTags({ fullCustomer: newFullCus }),
 			});
 			ctx.logger.info(
 				"Sent Svix event for threshold reached (type: limit_reached)",

--- a/server/src/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.ts
+++ b/server/src/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.ts
@@ -20,6 +20,7 @@ import {
 	type EntityLegacyData,
 	enrichFullCustomerWithEntity,
 	findCustomerProductById,
+	fullCustomerToTags,
 	type PlanLegacyData,
 } from "@autumn/shared";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
@@ -138,6 +139,8 @@ export const sendProductsUpdated = async ({
 		`[sendProductsUpdated] Sending webhook for customer ${customerId}, product ${fullProduct.name}, scenario: ${scenario}`,
 	);
 
+	const tags = fullCustomerToTags({ fullCustomer });
+
 	await sendSvixEvent({
 		ctx,
 		eventType: "customer.products.updated",
@@ -147,5 +150,6 @@ export const sendProductsUpdated = async ({
 			entity,
 			updated_product: versionedPlan,
 		},
+		tags,
 	});
 };

--- a/server/tests/integration/billing/autumn-webhooks/svix-message-tags.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/svix-message-tags.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration tests for Svix message tags on customer.products.updated webhooks.
+ *
+ * Tag format: "customer_id.<id>" and "entity_id.<id>".
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - sendSvixEvent({ ..., tags?: string[] }): tags optional, forwarded to MessageIn.tags.
+ *   New behaviors:
+ *     - sendProductsUpdated workflow, customer-level attach:
+ *         outgoing svix message has tag "customer_id.<id>", no entity_id tag.
+ *     - sendProductsUpdated workflow, entity-level attach:
+ *         outgoing svix message has tags including BOTH
+ *         "customer_id.<id>" AND "entity_id.<id>".
+ *   Side effects:
+ *     - MessageOut.tags contains the expected entries (verified by fetching
+ *       the message by its svix-id header from the delivered webhook).
+ *
+ * Pre-impl red: messages exist but tags are null/absent on MessageOut.tags.
+ * Post-impl green: MessageOut.tags contains the expected entries.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import type { ApiCustomerV3, ApiEntityV0, ApiProduct } from "@autumn/shared";
+import chalk from "chalk";
+import { Svix } from "svix";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+type CustomerProductsUpdatedPayload = {
+	type: string;
+	data: {
+		scenario: string;
+		customer: ApiCustomerV3;
+		updated_product: ApiProduct;
+		entity?: ApiEntityV0;
+	};
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SVIX SETUP (shared across all tests)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+let appId: string;
+let svix: Svix;
+
+beforeAll(async () => {
+	appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["customer.products.updated"],
+	});
+	playToken = webhook.playToken;
+
+	const apiKey = process.env.SVIX_API_KEY;
+	if (!apiKey) throw new Error("SVIX_API_KEY required for tag tests");
+	svix = new Svix(apiKey);
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CUSTOMER-LEVEL: customer_id tag only
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("svix tags: customer.products.updated (customer-level) has customer_id tag")}`,
+	async () => {
+		const customerId = "webhook-tags-customer-only";
+
+		const pro = products.pro({
+			id: "pro-tags-customer",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", skipWebhooks: true }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		// Confirm the webhook reached Svix (via Play delivery) and grab the svix-id
+		// header so we can fetch the underlying message to inspect tags.
+		const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+			token: playToken,
+			predicate: (payload) =>
+				payload.type === "customer.products.updated" &&
+				payload.data?.customer?.id === customerId,
+			timeoutMs: 20000,
+		});
+		expect(result).not.toBeNull();
+
+		const svixId = result!.event.headers["svix-id"];
+		expect(svixId).toBeDefined();
+
+		// ── Contract assertion 1: MessageOut.tags contains customer_id tag ───────
+		const message = await svix.message.get(appId, svixId);
+		const customerTag = `customer_id.${customerId}`;
+		expect(message.tags).toContain(customerTag);
+
+		// ── Contract assertion 2: no entity_id tag for customer-level event ──────
+		expect(
+			message.tags?.some((t) => t.startsWith("entity_id.")),
+		).toBe(false);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ENTITY-LEVEL: customer_id AND entity_id tags
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("svix tags: customer.products.updated (entity-level) has customer_id AND entity_id tags")}`,
+	async () => {
+		const customerId = "webhook-tags-entity";
+
+		const pro = products.pro({
+			id: "pro-tags-entity",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", skipWebhooks: true }),
+				s.products({ list: [pro] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [s.attach({ productId: pro.id, entityIndex: 0 })],
+		});
+		const entityId = entities[0].id;
+
+		// Confirm the webhook reached Svix and grab the svix-id header.
+		const result = await waitForWebhook<CustomerProductsUpdatedPayload>({
+			token: playToken,
+			predicate: (payload) =>
+				payload.type === "customer.products.updated" &&
+				payload.data?.customer?.id === customerId &&
+				payload.data?.entity?.id === entityId,
+			timeoutMs: 20000,
+		});
+		expect(result).not.toBeNull();
+
+		const svixId = result!.event.headers["svix-id"];
+		expect(svixId).toBeDefined();
+
+		// ── Contract assertion: tags include BOTH customer_id and entity_id ──────
+		const message = await svix.message.get(appId, svixId);
+		const customerTag = `customer_id.${customerId}`;
+		const entityTag = `entity_id.${entityId}`;
+		expect(message.tags).toContain(customerTag);
+		expect(message.tags).toContain(entityTag);
+	},
+);

--- a/shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts
+++ b/shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts
@@ -1,0 +1,15 @@
+import type { FullCustomer } from "@models/cusModels/fullCusModel.js";
+
+// Svix tag chars must match [a-zA-Z0-9\-_.], so we separate key/value with `.`
+// instead of `:` (rejected with HTTP 422 at message creation).
+export const fullCustomerToTags = ({
+	fullCustomer,
+}: {
+	fullCustomer: FullCustomer;
+}): string[] => {
+	const customerId = fullCustomer.id ?? fullCustomer.internal_id;
+	const tags = [`customer_id.${customerId}`];
+	const entityId = fullCustomer.entity?.id;
+	if (entityId) tags.push(`entity_id.${entityId}`);
+	return tags;
+};

--- a/shared/utils/cusUtils/index.ts
+++ b/shared/utils/cusUtils/index.ts
@@ -7,4 +7,5 @@ export * from "./fullCusUtils/enrichFullCustomer";
 export * from "./fullCusUtils/fullCustomerToCustomerEntitlements";
 export * from "./fullCusUtils/fullCustomerToOverageAllowed";
 export * from "./fullCusUtils/fullCustomerToSpendLimit";
+export * from "./fullCusUtils/fullCustomerToTags";
 export * from "./fullCusUtils/getCusStripeSubCount";


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Svix message tags to outgoing webhooks so consumers can filter by customer and entity. Tags use "customer_id.<id>" and "entity_id.<id>" and are now attached to products and balance/limit events.

- **New Features**
  - Updated sendSvixEvent to accept optional tags and forward them to Svix.
  - Added fullCustomerToTags to generate valid tags from a FullCustomer.
  - Attached tags to: customer.products.updated, balances.usage_alert_triggered, balances.limit_reached, and balances.threshold_reached.
  - Added integration tests to verify tags on customer.products.updated for customer- and entity-level deliveries.

<sup>Written for commit 1c44088b7c74f29724151a637f3adf0d419d37d9. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1617?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR attaches Svix message tags (`customer_id.<id>` and optionally `entity_id.<id>`) to outgoing webhooks so consumers can filter deliveries by customer or entity without parsing payload bodies.

- **Bug fixes / Improvements**: New `fullCustomerToTags` shared utility generates the tag list from a `FullCustomer`; five `sendSvixEvent` call sites (`handleProductsUpdated`, `checkLimitReached`, `checkUsageAlerts`, `handleThresholdReached`, `sendProductsUpdated`) are updated to pass those tags.
- **Improvements**: `sendSvixEvent` in `svixHelpers.ts` gains an optional `tags?: string[]` parameter that is conditionally spread into the Svix `MessageIn` object.
- **Improvements**: Integration tests validate that `customer.products.updated` messages carry the expected tags at both customer-level and entity-level attach scenarios.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core tag-attachment logic is correct and well-tested, with minor gaps in coverage and entity fallback behaviour.

The change is additive and isolated — existing webhook payloads are unchanged, tags are optional in both the new API and the Svix contract. The two notable gaps are: `sendAutoTopupSucceededWebhook` was not updated so the `billing.auto_topup.succeeded` event will be delivered without customer tags, and `entity.id` has no `internal_id` fallback unlike the customer path, meaning entity-level events silently drop the `entity_id` tag when no user-provided entity ID exists. Neither breaks existing behaviour, but both leave the tagging feature incomplete for a subset of events.

`shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts` (entity fallback logic) and `server/src/internal/balances/autoTopUp/webhooks/sendAutoTopupSucceededWebhook.ts` (missing tag wiring).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts | New utility that derives Svix tags from a FullCustomer; customer ID always present via fallback but entity ID has no fallback to internal_id, potentially omitting the tag for entities without a user-provided id. |
| server/src/external/svix/svixHelpers.ts | Adds optional `tags` parameter to `sendSvixEvent` and conditionally spreads it into the MessageIn object; implementation is correct. |
| server/src/internal/balances/autoTopUp/webhooks/sendAutoTopupSucceededWebhook.ts | Not changed in this PR but is the only remaining sendSvixEvent call site without customer tags; billing.auto_topup.succeeded events will be delivered untagged. |
| server/tests/integration/billing/autumn-webhooks/svix-message-tags.test.ts | New integration tests covering customer-level and entity-level customer.products.updated webhooks; validates tag presence on MessageOut via Svix API. |
| server/src/internal/balances/trackWebhooks/checkLimitReached.ts | Correctly computes tags from newFullCus and passes them to sendSvixEvent. |
| server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts | Correctly computes tags from newFullCus and passes them to sendSvixEvent. |
| server/src/internal/balances/trackWebhooks/handleThresholdReached.ts | Tags added inline at both threshold-reached and allowance-used send sites. |
| server/src/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.ts | Tags derived from fullCustomer and forwarded to sendSvixEvent; change is straightforward. |
| server/src/internal/analytics/handlers/handleProductsUpdated.ts | Tags derived from fullCus and forwarded; consistent with other updated sites. |
| shared/utils/cusUtils/index.ts | Re-exports the new fullCustomerToTags utility from the shared package index. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Webhook trigger site] --> B[fullCustomerToTags]
    B --> C{entity present?}
    C -- Yes, entity.id set --> D["tags: [customer_id.X, entity_id.Y]"]
    C -- Yes, entity.id null --> E["tags: [customer_id.X]"]
    C -- No entity --> F["tags: [customer_id.X]"]
    D --> G[sendSvixEvent]
    E --> G
    F --> G
    G --> H{tags present?}
    H -- Yes --> I[MessageIn with tags]
    H -- No --> J[MessageIn without tags]
    I --> K[Svix API]
    J --> K
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
shared/utils/cusUtils/fullCusUtils/fullCustomerToTags.ts:12-13
**Entity tag silently absent when `entity.id` is null**

`Customer.id` falls back to `internal_id` so a `customer_id` tag is always emitted. `Entity.id` is also typed as `string | null` (same pattern), but there is no fallback to `entity.internal_id` here. An entity-level webhook (e.g. threshold-reached or limit-reached) will silently produce no `entity_id` tag when the entity was created without a user-provided `id`, even though `entity.internal_id` is always present.

```suggestion
	const entityId =
		fullCustomer.entity?.id ?? fullCustomer.entity?.internal_id;
	if (entityId) tags.push(`entity_id.${entityId}`);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/add-tags-to..."](https://github.com/useautumn/autumn/commit/1cf621d6ef82e85fffa81fc9b1ac11b71ddf2297) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32801166)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->