### PR TITLE
Frontend cleanups: analytics, sidebar, empty states

### DIFF
--- a/vite/src/app/OnboardingLayout.tsx
+++ b/vite/src/app/OnboardingLayout.tsx
@@ -34,7 +34,7 @@ export function OnboardingLayout() {
 				)}
 				includeCredentials={true}
 			>
-				<div className="w-screen h-screen flex items-center justify-center bg-stone-100">
+				<div className="w-screen h-screen flex items-center justify-center bg-background">
 					<LoadingScreen />
 				</div>
 			</AutumnProvider>
@@ -56,7 +56,7 @@ export function OnboardingLayout() {
 			includeCredentials={true}
 		>
 			<NuqsAdapter>
-				<main className="w-screen h-screen bg-stone-100">
+				<main className="w-screen h-screen bg-background">
 					<CustomToaster />
 					<Outlet />
 				</main>

--- a/vite/src/components/ai-elements/prompt-input.tsx
+++ b/vite/src/components/ai-elements/prompt-input.tsx
@@ -48,12 +48,6 @@ import {
 	HoverCardContent,
 	HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import {
-	InputGroup,
-	InputGroupAddon,
-	InputGroupButton,
-	InputGroupTextarea,
-} from "@/components/v2/inputs/InputGroup";
 import { Button } from "@/components/v2/buttons/Button";
 import {
 	DropdownMenu,
@@ -301,7 +295,7 @@ export function PromptInputAttachment({
 			<HoverCardTrigger asChild>
 				<div
 					className={cn(
-						"group relative flex h-8 cursor-pointer select-none items-center gap-1.5 rouplaceholder:text-md border border-border px-1.5 font-medium text-sm transition-all hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+						"group relative flex h-8 cursor-pointer select-none items-center gap-1.5 rounded-md border border-border px-1.5 font-medium text-sm transition-all hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
 						className,
 					)}
 					key={data.id}
@@ -344,7 +338,7 @@ export function PromptInputAttachment({
 			<PromptInputHoverCardContent className="w-auto p-2">
 				<div className="w-auto space-y-3">
 					{isImage && (
-						<div className="flex max-h-96 w-96 items-center justify-center overflow-hidden rouplaceholder:text-md border">
+						<div className="flex max-h-96 w-96 items-center justify-center overflow-hidden rounded-md border">
 							<img
 								alt={filename || "attachment preview"}
 								className="max-h-full max-w-full object-contain"
@@ -789,9 +783,20 @@ export const PromptInput = ({
 				ref={formRef}
 				{...props}
 			>
-				<InputGroup className="overflow-hidden border-border/60 rounded-2xl dark:border-white/15 bg-interactive-secondary/70">
+				<div
+					data-slot="prompt-input"
+					className="group/input-group relative flex w-full flex-col overflow-hidden rounded-2xl border border-border/60 dark:border-white/15 bg-interactive-secondary/70 shadow-md outline-none cursor-text input-state-focus-within"
+					onClick={(e) => {
+						if ((e.target as HTMLElement).closest("button")) return;
+						const el = e.currentTarget.querySelector("input, textarea") as
+							| HTMLInputElement
+							| HTMLTextAreaElement
+							| null;
+						el?.focus();
+					}}
+				>
 					{children}
-				</InputGroup>
+				</div>
 			</form>
 		</>
 	);
@@ -814,9 +819,7 @@ export const PromptInputBody = ({
 	<div className={cn("contents", className)} {...props} />
 );
 
-export type PromptInputTextareaProps = ComponentProps<
-	typeof InputGroupTextarea
->;
+export type PromptInputTextareaProps = ComponentProps<"textarea">;
 
 export const PromptInputTextarea = ({
 	onChange,
@@ -901,9 +904,10 @@ export const PromptInputTextarea = ({
 			};
 
 	return (
-		<InputGroupTextarea
+		<textarea
+			data-slot="input-group-control"
 			className={cn(
-				"field-sizing-content max-h-48 min-h-16 placeholder:text-subtle",
+				"field-sizing-content max-h-48 min-h-16 w-full flex-1 resize-none bg-transparent py-3 px-3 text-sm text-foreground outline-none placeholder:text-subtle placeholder:select-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
 				className,
 			)}
 			name="message"
@@ -918,34 +922,32 @@ export const PromptInputTextarea = ({
 	);
 };
 
-export type PromptInputHeaderProps = Omit<
-	ComponentProps<typeof InputGroupAddon>,
-	"align"
->;
+export type PromptInputHeaderProps = HTMLAttributes<HTMLDivElement>;
 
 export const PromptInputHeader = ({
 	className,
 	...props
 }: PromptInputHeaderProps) => (
-	<InputGroupAddon
-		align="block-end"
-		className={cn("order-first flex-wrap gap-1", className)}
+	<div
+		className={cn(
+			"order-first flex w-full items-center justify-start gap-2 px-3 pt-3 flex-wrap",
+			className,
+		)}
 		{...props}
 	/>
 );
 
-export type PromptInputFooterProps = Omit<
-	ComponentProps<typeof InputGroupAddon>,
-	"align"
->;
+export type PromptInputFooterProps = HTMLAttributes<HTMLDivElement>;
 
 export const PromptInputFooter = ({
 	className,
 	...props
 }: PromptInputFooterProps) => (
-	<InputGroupAddon
-		align="block-end"
-		className={cn("justify-between gap-1", className)}
+	<div
+		className={cn(
+			"flex w-full items-center justify-between gap-1 px-3 pb-3",
+			className,
+		)}
 		{...props}
 	/>
 );
@@ -959,27 +961,22 @@ export const PromptInputTools = ({
 	<div className={cn("flex items-center gap-1", className)} {...props} />
 );
 
-export type PromptInputButtonProps = ComponentProps<typeof InputGroupButton>;
+export type PromptInputButtonProps = ComponentProps<typeof Button>;
 
 export const PromptInputButton = ({
 	variant = "skeleton",
 	className,
-	size,
+	size = "icon",
 	...props
-}: PromptInputButtonProps) => {
-	const newSize =
-		size ?? (Children.count(props.children) > 1 ? "sm" : "icon-sm");
-
-	return (
-		<InputGroupButton
-			className={cn(className)}
-			size={newSize}
-			type="button"
-			variant={variant}
-			{...props}
-		/>
-	);
-};
+}: PromptInputButtonProps) => (
+	<Button
+		type="button"
+		variant={variant}
+		size={size}
+		className={cn("shadow-none", className)}
+		{...props}
+	/>
+);
 
 export type PromptInputActionMenuProps = ComponentProps<typeof DropdownMenu>;
 export const PromptInputActionMenu = (props: PromptInputActionMenuProps) => (
@@ -1023,14 +1020,14 @@ export const PromptInputActionMenuItem = ({
 // Note: Actions that perform side-effects (like opening a file dialog)
 // are provided in opt-in modules (e.g., prompt-input-attachments).
 
-export type PromptInputSubmitProps = ComponentProps<typeof InputGroupButton> & {
+export type PromptInputSubmitProps = ComponentProps<typeof Button> & {
 	status?: ChatStatus;
 };
 
 export const PromptInputSubmit = ({
 	className,
 	variant = "primary",
-	size = "icon-sm",
+	size = "icon",
 	status,
 	children,
 	...props
@@ -1046,16 +1043,16 @@ export const PromptInputSubmit = ({
 	}
 
 	return (
-		<InputGroupButton
+		<Button
 			aria-label="Submit"
-			className={cn(className)}
-			size={size}
 			type="submit"
 			variant={variant}
+			size={size}
+			className={cn("shadow-none", className)}
 			{...props}
 		>
 			{children ?? Icon}
-		</InputGroupButton>
+		</Button>
 	);
 };
 

--- a/vite/src/components/general/table-components/ToolbarButton.tsx
+++ b/vite/src/components/general/table-components/ToolbarButton.tsx
@@ -11,7 +11,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ButtonProps>(
 				variant="skeleton"
 				size="icon"
 				className={cn(
-					"rounded-lg !h-5 !w-5 p-0 transition-all duration-100 hover:bg-stone-50",
+					"rounded-lg !h-5 !w-5 p-0 transition-all duration-100",
 					props?.className,
 				)}
 				{...props}

--- a/vite/src/components/general/table/table-content-virtualized.tsx
+++ b/vite/src/components/general/table/table-content-virtualized.tsx
@@ -83,11 +83,14 @@ export function TableContentVirtualized({
 		scrollContainer,
 	};
 
+	const isFlexFill = virtualization?.containerHeight === "100%";
+
 	return (
 		<TableContext.Provider value={contextWithRef}>
 			<div
 				className={cn(
 					"rounded-lg border relative z-50 min-w-0 overflow-hidden",
+					isFlexFill && "h-full flex flex-col",
 					!rows.length &&
 						"border-dashed bg-interactive-secondary dark:bg-transparent",
 					className,
@@ -97,10 +100,9 @@ export function TableContentVirtualized({
 					<div className="bg-white/60 dark:bg-black/60 absolute pointer-events-none rounded-lg -inset-[1px] z-70" />
 				)}
 
-			{/* Fixed header table - scrolls horizontally in sync with body */}
 				<div
 					ref={headerRef}
-					className="overflow-x-auto overflow-y-hidden scrollbar-none"
+					className="overflow-x-auto overflow-y-hidden scrollbar-none shrink-0"
 					style={{ scrollbarWidth: "none" }}
 				>
 					<div
@@ -110,7 +112,6 @@ export function TableContentVirtualized({
 							paddingRight: scrollbarWidth,
 						}}
 					>
-						{/* Column visibility toggle - only render if not in toolbar */}
 						{enableColumnVisibility && !columnVisibilityInToolbar && (
 							<div
 								className={cn(
@@ -130,17 +131,20 @@ export function TableContentVirtualized({
 					</div>
 				</div>
 
-				{/* Scroll container for body only - key forces remount when columns change */}
 				<div
 					key={visibleColumnKey}
 					ref={setScrollContainer}
 					onScroll={handleScroll}
-					className="w-full overflow-auto"
+					className={cn(
+						"w-full overflow-auto",
+						isFlexFill && "flex-1 min-h-0",
+					)}
 					style={{
-						minHeight,
-						maxHeight: virtualization?.containerHeight
-							? `calc(${virtualization.containerHeight} - ${headerHeight}px)`
-							: undefined,
+						minHeight: isFlexFill ? undefined : minHeight,
+						maxHeight:
+							!isFlexFill && virtualization?.containerHeight
+								? `calc(${virtualization.containerHeight} - ${headerHeight}px)`
+								: undefined,
 						willChange: "scroll-position",
 					}}
 				>
@@ -149,7 +153,6 @@ export function TableContentVirtualized({
 						flexibleTableColumns={flexibleTableColumns}
 						style={{ minWidth: `${totalWidth}px` }}
 					>
-						{/* Clone children with key to force remount when columns change */}
 						{React.Children.map(children, (child) =>
 							React.isValidElement(child)
 								? React.cloneElement(child, { key: visibleColumnKey })

--- a/vite/src/components/v2/badges/Badge.tsx
+++ b/vite/src/components/v2/badges/Badge.tsx
@@ -17,7 +17,7 @@ const badgeVariants = cva(
 				default:
 					"border-transparent bg-zinc-900 text-zinc-50 shadow hover:bg-zinc-900/80 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-50/80",
 
-				muted: "bg-muted border border-transparent",
+				muted: "bg-muted border border-border/50",
 				green: "bg-green-500/10 text-green-500 border-transparent",
 			},
 			size: {

--- a/vite/src/components/v2/sheets/Sheet.tsx
+++ b/vite/src/components/v2/sheets/Sheet.tsx
@@ -59,7 +59,7 @@ function SheetPortal({
 	container?: HTMLElement | null;
 }) {
 	const resolvedContainer =
-		container ?? document.querySelector("[data-main-content]");
+		container ?? document.querySelector("[data-main-content]") ?? document.body;
 	return (
 		<SheetPrimitive.Portal
 			data-slot="sheet-portal"

--- a/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
@@ -22,6 +22,7 @@ interface ChartSeriesConfig {
 
 const MAX_TOOLTIP_ITEMS = 5;
 const CHART_STYLE = { cursor: "default" } as const;
+const TRANSPARENT_CURSOR = { fill: "transparent", strokeWidth: 0 } as const;
 const X_TICK = { fontSize: 11, fill: "#666" } as const;
 const Y_TICK = {
 	fontSize: 11,
@@ -61,16 +62,22 @@ export const EventsBarChart = memo(function EventsBarChart({
 }) {
 	const { selectedInterval } = useAnalyticsContext();
 	const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+	const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
 	const handleBarMouseEnter = useCallback(
-		(dataKey: string) => () =>
-			startTransition(() => setHoveredKey(dataKey)),
+		(dataKey: string) => (_data: unknown, index: number) =>
+			startTransition(() => {
+				setHoveredKey(dataKey);
+				setActiveIndex(index);
+			}),
 		[],
 	);
-	const handleBarMouseLeave = useCallback(
-		() => startTransition(() => setHoveredKey(null)),
-		[],
-	);
+	const handleChartMouseLeave = useCallback(() => {
+		startTransition(() => {
+			setHoveredKey(null);
+			setActiveIndex(null);
+		});
+	}, []);
 
 	const formatXAxis = useCallback(
 		(value: string): string => {
@@ -92,26 +99,35 @@ export const EventsBarChart = memo(function EventsBarChart({
 	}, [chartConfig]);
 
 	const tooltipContent = useCallback(
-		({ active, payload, label }: { active?: boolean; payload?: any[]; label?: string | number }) => {
-			if (!active || !payload?.length) return null;
+		({ active }: { active?: boolean }) => {
+			if (!active || activeIndex == null) return null;
+			const row = data.data[activeIndex];
+			if (!row) return null;
+			const period = String(row.period);
+
+			// Build items from our tracked index, not Recharts' payload
+			const allItems = chartConfig
+				.map((s) => ({ dataKey: s.yKey, value: Number(row[s.yKey] ?? 0), color: s.fill }))
+				.filter((i) => i.value !== 0);
 			const items = hoveredKey
-				? payload.filter((p: any) => String(p.dataKey) === hoveredKey && Number(p.value) !== 0)
-				: [...payload].filter((p: any) => Number(p.value) !== 0).sort((a: any, b: any) => (b.value as number) - (a.value as number));
+				? allItems.filter((i) => i.dataKey === hoveredKey)
+				: allItems.sort((a, b) => b.value - a.value);
 			if (!items.length) return null;
+
 			const visible = items.slice(0, MAX_TOOLTIP_ITEMS);
 			const overflow = items.length - visible.length;
 			const overflowSum = overflow > 0
-				? items.slice(MAX_TOOLTIP_ITEMS).reduce((s: number, p: any) => s + Number(p.value), 0)
+				? items.slice(MAX_TOOLTIP_ITEMS).reduce((s, i) => s + i.value, 0)
 				: 0;
 			return (
 				<div className="bg-popover text-popover-foreground grid min-w-[8rem] items-start gap-1.5 rounded-lg px-2.5 py-1.5 text-xs shadow-md ring-1 ring-foreground/10">
-					<div className="font-medium">{formatXAxis(String(label))}</div>
+					<div className="font-medium">{formatXAxis(period)}</div>
 					<div className="grid gap-1">
-						{visible.map((item: any) => (
+						{visible.map((item) => (
 							<TooltipItem
-								key={String(item.dataKey)}
+								key={item.dataKey}
 								item={item}
-								label={rechartsConfig[String(item.dataKey)]?.label as string ?? String(item.dataKey)}
+								label={rechartsConfig[item.dataKey]?.label as string ?? item.dataKey}
 							/>
 						))}
 						{overflow > 0 && (
@@ -125,16 +141,12 @@ export const EventsBarChart = memo(function EventsBarChart({
 				</div>
 			);
 		},
-		[hoveredKey, formatXAxis, rechartsConfig],
+		[activeIndex, hoveredKey, data.data, chartConfig, formatXAxis, rechartsConfig],
 	);
 
 	const barHandlers = useMemo(
-		() =>
-			chartConfig.map((series) => ({
-				onMouseEnter: handleBarMouseEnter(series.yKey),
-				onMouseLeave: handleBarMouseLeave,
-			})),
-		[chartConfig, handleBarMouseEnter, handleBarMouseLeave],
+		() => chartConfig.map((series) => handleBarMouseEnter(series.yKey)),
+		[chartConfig, handleBarMouseEnter],
 	);
 
 	return (
@@ -154,6 +166,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 					barCategoryGap="10%"
 					style={CHART_STYLE}
 					throttleDelay="raf"
+					onMouseLeave={handleChartMouseLeave}
 				>
 					<CartesianGrid
 						vertical={false}
@@ -180,7 +193,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 						tickFormatter={formatCompactNumber}
 					/>
 					<Tooltip
-						cursor={false}
+						cursor={TRANSPARENT_CURSOR}
 						isAnimationActive={false}
 						content={tooltipContent}
 					/>
@@ -192,8 +205,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 							fill={series.fill}
 							activeBar={false}
 							style={CHART_STYLE}
-							onMouseEnter={barHandlers[si].onMouseEnter}
-							onMouseLeave={barHandlers[si].onMouseLeave}
+							onMouseEnter={barHandlers[si]}
 						/>
 					))}
 				</BarChart>

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -22,6 +22,7 @@ import { extractPropertyKeys } from "./utils/extractPropertyKeys";
 import {
 	generateChartConfig,
 	transformGroupedData,
+	trimToTopSeries,
 } from "./utils/transformGroupedChartData";
 
 export const AnalyticsView = () => {
@@ -140,30 +141,44 @@ export const AnalyticsView = () => {
 			};
 		}
 
-		// Transform data for grouped display (pivots rows into columns per group)
+		// 1. Drop raw rows where every feature column is zero — cuts ~95%
+		//    of rows before the pivot so it runs on hundreds, not thousands.
+		const groupCol =
+			groupBy === "customer_id" || groupBy === "entity_id" || groupBy === "plan_id"
+				? groupBy
+				: groupBy ? `properties.${groupBy}` : null;
+		const skipKeys = new Set(["period", groupCol].filter(Boolean) as string[]);
+		const nonZeroData = filteredEvents.data.filter(
+			(row: Record<string, string | number>) => {
+				for (const key in row) {
+					if (skipKeys.has(key)) continue;
+					if (Number(row[key]) !== 0) return true;
+				}
+				return false;
+			},
+		);
+		const nonZeroEvents = nonZeroData.length === filteredEvents.data.length
+			? filteredEvents
+			: { ...filteredEvents, data: nonZeroData, rows: nonZeroData.length };
+
+		// 2. Pivot into one column per group×feature
 		const transformed = transformGroupedData({
-			events: filteredEvents,
+			events: nonZeroEvents,
 			groupBy,
 		});
 
-		const nonEmptyData = transformed.data.filter((row) => {
-			for (const key in row) {
-				if (key === "period") continue;
-				if (Number(row[key]) !== 0) return true;
-			}
-			return false;
-		});
-		const trimmed = { ...transformed, data: nonEmptyData, rows: nonEmptyData.length };
+		// 3. Keep only top 30 series by volume so Recharts renders ≤30 <Bar>s
+		const trimmed = trimToTopSeries({ events: transformed, maxSeries: 30 });
 
 		const config = generateChartConfig({
-				events: trimmed,
-				features,
-				groupBy,
-				originalColors: colors,
-				entityNames,
-				customerNames,
-				planNames,
-			});
+			events: trimmed,
+			features,
+			groupBy,
+			originalColors: colors,
+			entityNames,
+			customerNames,
+			planNames,
+		});
 
 		return { chartData: trimmed, chartConfig: config };
 	}, [events, features, groupBy, groupFilter, planDeselected, entityNames, customerNames, planNames]);
@@ -315,7 +330,7 @@ export const AnalyticsView = () => {
 
 	return (
 		<AnalyticsContext.Provider value={contextValue}>
-			<PageContainer className="text-sm">
+			<PageContainer className="text-sm h-full overflow-hidden">
 				<OnboardingGuide />
 				{showRevenueMetrics && <RevenueMetricsSection />}
 				<div className="pb-6 shrink-0">
@@ -326,11 +341,12 @@ export const AnalyticsView = () => {
 						</div>
 						<QueryTopbar />
 					</div>
+				<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1] overflow-hidden">
 					{queryLoading && (
-						<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1] animate-pulse" />
+						<div className="flex-1 animate-pulse" />
 					)}
 					{!queryLoading && chartData && chartData.data.length > 0 && (
-						<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1]">
+						<>
 							<ChartLegend
 								entries={legendEntries}
 								showLabels={!!groupBy || legendEntries.length <= 3}
@@ -341,24 +357,30 @@ export const AnalyticsView = () => {
 									chartConfig={chartConfig}
 								/>
 							</div>
-						</div>
+						</>
 					)}
 					{!queryLoading && (!chartData || chartData.data.length === 0) && (
-						<div className="flex-1 px-10 pt-6">
-							<p className="text-tertiary-foreground text-sm">
-								No events found. Please widen your filters.{" "}
+						<div className="flex-1 flex flex-col items-center justify-center gap-2">
+							<ChartBarIcon size={28} weight="duotone" className="text-muted-foreground/50" />
+							<p className="text-muted-foreground text-sm">
 								{eventNames.length === 0
-									? "Try to select some events in the dropdown above."
-									: ""}
+									? "Start sending events to view usage data."
+									: "No events found for these filters."}
 							</p>
 						</div>
 					)}
 				</div>
+				</div>
 
-				<div className="flex-1 min-h-[400px] pb-8">
+				<div className="flex-1 min-h-[200px] pb-2">
 					<EventsTable
 						data={rawEvents?.data ?? []}
 						isLoading={rawQueryLoading}
+						emptyMessage={
+							eventNames.length === 0
+								? "Start sending events to view usage data."
+								: "No events found for these filters."
+						}
 					/>
 				</div>
 			</PageContainer>

--- a/vite/src/views/customers/customer/analytics/components/EventsTable.tsx
+++ b/vite/src/views/customers/customer/analytics/components/EventsTable.tsx
@@ -40,9 +40,13 @@ const PLACEHOLDER_ROWS: IRow[] = Array.from({ length: 15 }, (_, i) => ({
 export const EventsTable = memo(function EventsTable({
 	data,
 	isLoading = false,
+	emptyMessage = "No events to display.",
+	className,
 }: {
 	data: IRow[];
 	isLoading?: boolean;
+	emptyMessage?: string;
+	className?: string;
 }) {
 	const [selectedEvent, setSelectedEvent] = useState<IRow | null>(null);
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -65,75 +69,86 @@ export const EventsTable = memo(function EventsTable({
 				setIsDialogOpen(true);
 			};
 
+	const isEmpty = !isLoading && data.length === 0;
+
 	return (
-		<>
-			<div className="flex items-center justify-between pb-4 h-10">
+		<div className={cn("h-full flex flex-col", className)}>
+			<div className="flex items-center justify-between pb-4 h-10 shrink-0">
 				<div className="text-tertiary-foreground text-md flex gap-2 items-center">
 					<DatabaseIcon size={16} weight="fill" className="text-subtle" />
 					Events
 				</div>
-				<div className="flex items-center gap-2">
-					<Select
-						value={pageSize.toString()}
-						onValueChange={(value) => {
-							table.setPageSize(Number(value));
-							table.setPageIndex(0);
-						}}
-						disabled={isDisabled}
-					>
-						<SelectTrigger className="h-7 w-fit px-2 text-xs">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							{PAGE_SIZE_OPTIONS.map((size) => (
-								<SelectItem key={size} value={size.toString()}>
-									{size}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-					<IconButton
-						variant="secondary"
-						size="default"
-						icon={<CaretLeftIcon size={12} weight="bold" />}
-						onClick={() => table.previousPage()}
-						disabled={!canGoPrev || isDisabled}
-						className={cn((!canGoPrev || isDisabled) && "pointer-events-none opacity-50")}
-					/>
-					<span className="text-muted-foreground text-xs font-medium">
-						{isLoading ? "–" : `${currentPage} / ${Math.max(totalPages, 1)}`}
-					</span>
-					<IconButton
-						variant="secondary"
-						size="default"
-						icon={<CaretRightIcon size={12} weight="bold" />}
-						onClick={() => table.nextPage()}
-						disabled={!canGoNext || isDisabled}
-						className={cn((!canGoNext || isDisabled) && "pointer-events-none opacity-50")}
-					/>
-				</div>
+				{!isEmpty && (
+					<div className="flex items-center gap-2">
+						<Select
+							value={pageSize.toString()}
+							onValueChange={(value) => {
+								table.setPageSize(Number(value));
+								table.setPageIndex(0);
+							}}
+							disabled={isDisabled}
+						>
+							<SelectTrigger className="h-7 w-fit px-2 text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{PAGE_SIZE_OPTIONS.map((size) => (
+									<SelectItem key={size} value={size.toString()}>
+										{size}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<IconButton
+							variant="secondary"
+							size="default"
+							icon={<CaretLeftIcon size={12} weight="bold" />}
+							onClick={() => table.previousPage()}
+							disabled={!canGoPrev || isDisabled}
+							className={cn((!canGoPrev || isDisabled) && "pointer-events-none opacity-50")}
+						/>
+						<span className="text-muted-foreground text-xs font-medium">
+							{isLoading ? "–" : `${currentPage} / ${Math.max(totalPages, 1)}`}
+						</span>
+						<IconButton
+							variant="secondary"
+							size="default"
+							icon={<CaretRightIcon size={12} weight="bold" />}
+							onClick={() => table.nextPage()}
+							disabled={!canGoNext || isDisabled}
+							className={cn((!canGoNext || isDisabled) && "pointer-events-none opacity-50")}
+						/>
+					</div>
+				)}
 			</div>
-			<Table.Provider
-				config={{
-					table,
-					numberOfColumns: activeColumns.length,
-					isLoading: false,
-					enableSorting: !isLoading,
-					onRowClick: handleRowClick,
-					rowClassName: "h-8",
-					flexibleTableColumns: true,
-					virtualization: {
-						containerHeight: "calc(100vh - 700px)",
-						rowHeight: 32,
-					},
-				}}
-			>
-				<Table.Container>
-					<Table.VirtualizedContent>
-						<Table.VirtualizedBody />
-					</Table.VirtualizedContent>
-				</Table.Container>
-			</Table.Provider>
+			{isEmpty ? (
+				<div className="flex flex-col items-center justify-center gap-2 rounded-lg border bg-interactive-secondary min-h-[200px]">
+					<DatabaseIcon size={28} weight="duotone" className="text-muted-foreground/50" />
+					<p className="text-muted-foreground text-sm">{emptyMessage}</p>
+				</div>
+			) : (
+				<Table.Provider
+					config={{
+						table,
+						numberOfColumns: activeColumns.length,
+						isLoading: false,
+						enableSorting: !isLoading,
+						onRowClick: handleRowClick,
+						rowClassName: "h-8",
+						flexibleTableColumns: true,
+						virtualization: {
+							containerHeight: "100%",
+							rowHeight: 32,
+						},
+					}}
+				>
+					<Table.Container className="flex-1 min-h-0">
+						<Table.VirtualizedContent className="h-full">
+							<Table.VirtualizedBody />
+						</Table.VirtualizedContent>
+					</Table.Container>
+				</Table.Provider>
+			)}
 			{selectedEvent && (
 				<RowClickDialog
 					event={selectedEvent}
@@ -141,6 +156,6 @@ export const EventsTable = memo(function EventsTable({
 					setIsOpen={setIsDialogOpen}
 				/>
 			)}
-		</>
+		</div>
 	);
 });

--- a/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectFeatureDropdown.tsx
@@ -76,14 +76,16 @@ export const SelectFeatureDropdown = () => {
 	const currentEventNames =
 		searchParams.get("event_names")?.split(",").filter(Boolean) || [];
 
-	// Build event options from useEventNames data, enriched with feature info
+	// Build event options from useEventNames data, keeping only those linked to a feature
 	const eventOptions: EventOption[] = useMemo(() => {
-		return eventNamesData.map((item) => ({
-			eventName: item.event_name,
-			eventCount: item.event_count,
-			linkedFeatures: getFeaturesForEventName(item.event_name, features),
-			selected: currentEventNames.includes(item.event_name),
-		}));
+		return eventNamesData
+			.map((item) => ({
+				eventName: item.event_name,
+				eventCount: item.event_count,
+				linkedFeatures: getFeaturesForEventName(item.event_name, features),
+				selected: currentEventNames.includes(item.event_name),
+			}))
+			.filter((option) => option.linkedFeatures.length > 0);
 	}, [eventNamesData, features, currentEventNames]);
 
 	// Filter options based on search (search both event name and feature ids)

--- a/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SelectGroupByDropdown.tsx
@@ -11,6 +11,7 @@ import { Checkbox } from "@/components/v2/checkboxes/Checkbox";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
+	DropdownMenuGroup,
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
@@ -338,11 +339,12 @@ export const SelectGroupByDropdown = ({
 							</>
 						)}
 
-					{currentGroupBy &&
-						currentGroupBy !== "plan_id" &&
-						availableGroupValues.length > 0 && (
-							<>
-								<DropdownMenuSeparator />
+				{currentGroupBy &&
+					currentGroupBy !== "plan_id" &&
+					availableGroupValues.length > 0 && (
+						<>
+							<DropdownMenuSeparator />
+							<DropdownMenuGroup>
 								<DropdownMenuLabel className="text-xs text-subtle font-normal">
 									Filter by value
 								</DropdownMenuLabel>
@@ -381,8 +383,9 @@ export const SelectGroupByDropdown = ({
 										</DropdownMenuItem>
 									);
 								})}
-							</>
-						)}
+							</DropdownMenuGroup>
+						</>
+					)}
 				</div>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -1,4 +1,4 @@
-import { ErrCode } from "@autumn/shared";
+import { ErrCode, FeatureType } from "@autumn/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useSearchParams } from "react-router";
@@ -47,10 +47,21 @@ export const useAnalyticsData = ({
 			: `properties.${groupBy}`
 		: undefined;
 
+	const featureLinkedEventNames = useMemo(() => {
+		if (!featuresData?.length) return cachedEventNames;
+		return cachedEventNames.filter((e) =>
+			featuresData.some(
+				(f) =>
+					(f.type === FeatureType.Metered || f.type === FeatureType.CreditSystem) &&
+					(f.event_names?.includes(e.event_name) || f.id === e.event_name),
+			),
+		);
+	}, [cachedEventNames, featuresData]);
+
 	const selectedEventNames =
 		eventNames || featureIds
 			? [...(eventNames || []), ...(featureIds || [])]
-			: cachedEventNames.slice(0, 3).map((e) => e.event_name);
+			: featureLinkedEventNames.slice(0, 3).map((e) => e.event_name);
 
 	const postBody = {
 		customer_id: customerId || undefined,

--- a/vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts
+++ b/vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts
@@ -68,6 +68,50 @@ function getFeatureName({
 }
 
 /**
+ * Keeps only the top-N series by total volume and orders them so the
+ * largest renders last (top of a stacked bar chart).
+ */
+export function trimToTopSeries({
+	events,
+	maxSeries,
+}: {
+	events: EventsData;
+	maxSeries: number;
+}): EventsData {
+	const seriesCols = events.meta
+		.filter((m) => m.name !== "period")
+		.map((m) => m.name);
+
+	const totals = new Map<string, number>();
+	for (const col of seriesCols) totals.set(col, 0);
+	for (const row of events.data) {
+		for (const col of seriesCols) {
+			totals.set(col, (totals.get(col) ?? 0) + Number(row[col] ?? 0));
+		}
+	}
+
+	// Sorted ascending so the largest series is last → top of stack
+	const sorted = [...totals.entries()]
+		.sort((a, b) => a[1] - b[1]);
+	const kept = sorted.length > maxSeries
+		? sorted.slice(-maxSeries)
+		: sorted;
+	const orderedCols = kept.map(([col]) => col);
+
+	const meta = [
+		{ name: "period" },
+		...orderedCols.map((name) => ({ name })),
+	];
+	const data = events.data.map((row) => {
+		const slim: EventRow = { period: row.period };
+		for (const col of orderedCols) slim[col] = row[col] ?? 0;
+		return slim;
+	});
+
+	return { meta, rows: data.length, data };
+}
+
+/**
  * Transforms grouped data from backend format to chart-ready format.
  *
  * Backend returns (when group_by is used):

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -37,7 +37,7 @@ export function CustomerListTable({
 	const env = useEnv();
 
 	const tableContainerHeight =
-		env === AppEnv.Sandbox ? "calc(100vh - 174px)" : "calc(100vh - 134px)";
+		env === AppEnv.Sandbox ? "calc(100vh - 230px)" : "calc(100vh - 190px)";
 
 	const { features } = useFeaturesQuery();
 	const { products } = useProductsQuery();

--- a/vite/src/views/main-sidebar/MainSidebar.tsx
+++ b/vite/src/views/main-sidebar/MainSidebar.tsx
@@ -6,7 +6,7 @@ import {
 	CoinVerticalIcon,
 	CubeIcon,
 	DatabaseIcon,
-	IdentificationCardIcon,
+	UsersIcon,
 	LegoIcon,
 	OptionIcon,
 	TerminalWindowIcon,
@@ -206,7 +206,7 @@ export const MainSidebar = ({
 									{
 										title: "All Customers",
 										value: "customers",
-										icon: <IdentificationCardIcon size={16} weight="fill" />,
+										icon: <UsersIcon size={16} weight="fill" />,
 									},
 									{
 										title: "Migrations",

--- a/vite/src/views/main-sidebar/components/AuthorizedApps.tsx
+++ b/vite/src/views/main-sidebar/components/AuthorizedApps.tsx
@@ -1,9 +1,11 @@
 import { groupAndFormatScopes } from "@autumn/shared";
-import { Calendar, Key, Shield, Trash2 } from "lucide-react";
+import { EllipsisVertical, Key, Shield, TrashIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { TableCell, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/v2/badges/Badge";
 import { Button } from "@/components/v2/buttons/Button";
+import { IconButton } from "@/components/v2/buttons/IconButton";
 import {
 	Dialog,
 	DialogContent,
@@ -12,60 +14,91 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/v2/dialogs/Dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/v2/dropdowns/DropdownMenu";
 import { getBackendErr } from "@/utils/genUtils";
+import { formatDateStr } from "@/utils/formatUtils/formatDateUtils";
+import {
+	SETTINGS_ROW_CLASS,
+	SettingsTable,
+} from "@/views/settings/SettingsTable";
 
 interface OAuthConsent {
-	id: string;
-	clientId: string;
-	scopes: string[];
-	referenceId: string | null;
-	createdAt: string;
-	updatedAt: string;
+	readonly id: string;
+	readonly clientId: string;
+	readonly scopes: string[];
+	readonly referenceId: string | null;
+	readonly createdAt: string;
+	readonly updatedAt: string;
 }
 
 interface ClientInfo {
-	client_id: string;
-	name: string;
+	readonly client_id: string;
+	readonly name: string;
 }
 
 interface ApiKeyPreview {
-	prefix: string;
-	name: string;
-	env: string;
+	readonly prefix: string;
+	readonly name: string;
+	readonly env: string;
 }
 
-// Helper to render scope badges
-function renderScopeBadges(scopes: string[]): JSX.Element {
-	const grouped = groupAndFormatScopes(scopes);
+const COLUMNS = [
+	{ label: "Application", width: "20%" },
+	{ label: "Permissions", width: "50%" },
+	{ label: "Authorized", width: "25%" },
+] as const;
 
-	if (grouped.length === 0) {
-		return (
-			<span className="text-sm text-muted-foreground">No permissions</span>
-		);
-	}
+const ConsentRowToolbar = ({
+	consentId,
+	clientName,
+	onRevoke,
+}: {
+	readonly consentId: string;
+	readonly clientName: string;
+	readonly onRevoke: (consentId: string, clientName: string) => void;
+}) => {
+	const [open, setOpen] = useState(false);
 
 	return (
-		<div className="flex flex-wrap gap-1.5">
-			{grouped.map((permission) => (
-				<Badge
-					key={permission.resource}
-					variant="secondary"
-					className="text-xs"
+		<DropdownMenu open={open} onOpenChange={setOpen}>
+			<DropdownMenuTrigger asChild>
+				<IconButton
+					variant="skeleton"
+					size="icon"
+					iconOrientation="center"
+					icon={<EllipsisVertical />}
+					className="!h-5 !w-5 rounded-lg hover:bg-interactive-secondary-hover"
+				/>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="z-[200]">
+				<DropdownMenuItem
+					variant="destructive"
+					className="flex justify-between"
+					onClick={() => {
+						onRevoke(consentId, clientName);
+						setOpen(false);
+					}}
 				>
-					{permission.resourceName}: {permission.actions.join(", ")}
-				</Badge>
-			))}
-		</div>
+					<div className="flex justify-between items-center w-full gap-4">
+						<span>Revoke</span>
+						<TrashIcon size={12} />
+					</div>
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
-}
+};
 
 export const AuthorizedApps = () => {
 	const [consents, setConsents] = useState<OAuthConsent[]>([]);
 	const [clientNames, setClientNames] = useState<Record<string, string>>({});
 	const [isLoading, setIsLoading] = useState(true);
 	const [revokingId, setRevokingId] = useState<string | null>(null);
-
-	// Revoke confirmation dialog state
 	const [revokeDialogOpen, setRevokeDialogOpen] = useState(false);
 	const [revokeTarget, setRevokeTarget] = useState<{
 		consentId: string;
@@ -77,25 +110,18 @@ export const AuthorizedApps = () => {
 	const fetchConsents = async () => {
 		setIsLoading(true);
 		try {
-			// Use our new org-level consent endpoint
 			const response = await fetch(
 				`${import.meta.env.VITE_BACKEND_URL}/consents`,
-				{
-					credentials: "include",
-				},
+				{ credentials: "include" },
 			);
-
 			if (!response.ok) {
 				const error = await response.json().catch(() => ({}));
 				toast.error(error.message || "Failed to fetch authorized apps");
 				return;
 			}
-
 			const data = await response.json();
 			const consentList = (data.consents as OAuthConsent[]) || [];
 			setConsents(consentList);
-
-			// Fetch client names for each consent
 			const names: Record<string, string> = {};
 			await Promise.all(
 				consentList.map(async (consent) => {
@@ -131,22 +157,17 @@ export const AuthorizedApps = () => {
 		setRevokeDialogOpen(true);
 		setLoadingApiKeys(true);
 		setLinkedApiKeys([]);
-
-		// Fetch API keys linked to this consent
 		try {
 			const response = await fetch(
 				`${import.meta.env.VITE_BACKEND_URL}/consents/${consentId}/api-keys`,
-				{
-					credentials: "include",
-				},
+				{ credentials: "include" },
 			);
-
 			if (response.ok) {
 				const data = await response.json();
 				setLinkedApiKeys(data.apiKeys || []);
 			}
 		} catch {
-			// If we can't fetch API keys, just show the basic dialog
+			// Silent — dialog still usable without API key preview
 		} finally {
 			setLoadingApiKeys(false);
 		}
@@ -154,23 +175,17 @@ export const AuthorizedApps = () => {
 
 	const handleConfirmRevoke = async () => {
 		if (!revokeTarget) return;
-
 		setRevokingId(revokeTarget.consentId);
 		try {
 			const response = await fetch(
 				`${import.meta.env.VITE_BACKEND_URL}/consents/${revokeTarget.consentId}`,
-				{
-					method: "DELETE",
-					credentials: "include",
-				},
+				{ method: "DELETE", credentials: "include" },
 			);
-
 			if (!response.ok) {
 				const error = await response.json().catch(() => ({}));
 				toast.error(error.message || "Failed to revoke access");
 				return;
 			}
-
 			const result = await response.json();
 			toast.success(
 				`Access revoked for ${revokeTarget.clientName}${result.deletedApiKeys > 0 ? ` (${result.deletedApiKeys} API key${result.deletedApiKeys > 1 ? "s" : ""} deleted)` : ""}`,
@@ -186,81 +201,70 @@ export const AuthorizedApps = () => {
 		}
 	};
 
-	const formatDate = (dateString: string) => {
-		return new Date(dateString).toLocaleDateString("en-US", {
-			year: "numeric",
-			month: "short",
-			day: "numeric",
-		});
-	};
+	if (isLoading) return null;
+
+	if (consents.length === 0) {
+		return (
+			<div className="rounded-lg shadow-card border bg-interactive-secondary px-4 py-12 text-center">
+				<Shield className="size-8 mx-auto mb-3 text-subtle" />
+				<p className="text-sm text-tertiary-foreground">
+					No applications have been authorized
+				</p>
+				<p className="text-xs text-subtle mt-1">
+					When you authorize an app to access this organization, it will appear
+					here
+				</p>
+			</div>
+		);
+	}
 
 	return (
-		<div className="flex flex-col">
-			<div className="border border-border rounded-xl overflow-hidden">
-				<div className="divide-y divide-border">
-					{isLoading ? (
-						<div className="px-4 py-12 text-center text-sm text-tertiary-foreground">
-							<span className="shimmer">Loading authorized apps...</span>
-						</div>
-					) : consents.length === 0 ? (
-						<div className="px-4 py-12 text-center">
-							<Shield className="w-8 h-8 mx-auto mb-3 text-subtle" />
-							<p className="text-sm text-tertiary-foreground">
-								No applications have been authorized
-							</p>
-							<p className="text-xs text-subtle mt-1">
-								When you authorize an app to access this organization, it will
-								appear here
-							</p>
-						</div>
-					) : (
-						consents.map((consent) => (
-							<div
-								key={consent.id}
-								className="px-4 py-4 flex items-start justify-between gap-4"
-							>
-								<div className="flex-1 min-w-0">
-									<div className="flex items-center gap-2">
-										<p className="text-sm font-medium text-foreground">
-											{clientNames[consent.clientId] || "Loading..."}
-										</p>
-									</div>
-
-									{/* Scopes - Grouped by Resource */}
-									<div className="mt-2">
-										{renderScopeBadges(consent.scopes)}
-									</div>
-
-									{/* Date */}
-									<div className="flex items-center gap-1 mt-2 text-xs text-tertiary-foreground">
-										<Calendar className="w-3 h-3" />
-										<span>Authorized on {formatDate(consent.createdAt)}</span>
-									</div>
+		<>
+			<SettingsTable columns={COLUMNS}>
+				{consents.map((consent) => {
+					const grouped = groupAndFormatScopes(consent.scopes);
+					const name = clientNames[consent.clientId] || "Loading...";
+					return (
+						<TableRow key={consent.id} className={SETTINGS_ROW_CLASS}>
+							<TableCell className="pl-4 text-foreground font-medium">
+								{name}
+							</TableCell>
+							<TableCell>
+								<div className="flex flex-wrap gap-1">
+									{grouped.length === 0 ? (
+										<span className="text-xs text-tertiary-foreground">
+											No permissions
+										</span>
+									) : (
+										grouped.map((p) => (
+											<Badge
+												key={p.resource}
+												variant="muted"
+												size="sm"
+											>
+												{p.resourceName}: {p.actions.join(", ")}
+											</Badge>
+										))
+									)}
 								</div>
+							</TableCell>
+							<TableCell className="text-tertiary-foreground text-xs">
+								{formatDateStr(consent.createdAt)}
+							</TableCell>
+							<TableCell className="pr-2">
+								<div className="flex justify-end">
+									<ConsentRowToolbar
+										consentId={consent.id}
+										clientName={name}
+										onRevoke={handleRevokeClick}
+									/>
+								</div>
+							</TableCell>
+						</TableRow>
+					);
+				})}
+			</SettingsTable>
 
-								{/* Revoke Button */}
-								<Button
-									variant="secondary"
-									size="sm"
-									onClick={() =>
-										handleRevokeClick(
-											consent.id,
-											clientNames[consent.clientId] || "this app",
-										)
-									}
-									disabled={revokingId === consent.id}
-									className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-950/30"
-								>
-									<Trash2 className="w-3.5 h-3.5 mr-1.5" />
-									{revokingId === consent.id ? "Revoking..." : "Revoke"}
-								</Button>
-							</div>
-						))
-					)}
-				</div>
-			</div>
-
-			{/* Revoke Confirmation Dialog */}
 			<Dialog open={revokeDialogOpen} onOpenChange={setRevokeDialogOpen}>
 				<DialogContent>
 					<DialogHeader>
@@ -273,8 +277,6 @@ export const AuthorizedApps = () => {
 							? This app will no longer be able to access your organization.
 						</DialogDescription>
 					</DialogHeader>
-
-					{/* Show linked API keys that will be deleted */}
 					{loadingApiKeys ? (
 						<div className="py-3 text-sm text-tertiary-foreground">
 							Checking for linked API keys...
@@ -282,7 +284,7 @@ export const AuthorizedApps = () => {
 					) : linkedApiKeys.length > 0 ? (
 						<div className="py-2">
 							<div className="flex items-center gap-2 text-sm font-medium text-amber-600 dark:text-amber-400 mb-2">
-								<Key className="w-4 h-4" />
+								<Key className="size-4" />
 								<span>The following API keys will also be deleted:</span>
 							</div>
 							<div className="space-y-1.5 bg-input/50 dark:bg-input/30 rounded-md p-3">
@@ -295,7 +297,9 @@ export const AuthorizedApps = () => {
 											{key.prefix}...
 										</code>
 										<div className="flex items-center gap-2">
-											<span className="text-tertiary-foreground text-xs">{key.name}</span>
+											<span className="text-tertiary-foreground text-xs">
+												{key.name}
+											</span>
 											<span
 												className={`text-xs px-1.5 py-0.5 rounded ${
 													key.env === "live"
@@ -311,7 +315,6 @@ export const AuthorizedApps = () => {
 							</div>
 						</div>
 					) : null}
-
 					<DialogFooter>
 						<Button
 							variant="secondary"
@@ -329,6 +332,6 @@ export const AuthorizedApps = () => {
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
-		</div>
+		</>
 	);
 };

--- a/vite/src/views/main-sidebar/components/OrgDropdown.tsx
+++ b/vite/src/views/main-sidebar/components/OrgDropdown.tsx
@@ -78,7 +78,7 @@ export const OrgDropdown = () => {
 	if (!org || error) return null;
 
 	return (
-		<div className={cn("flex px-3")}>
+		<div className={cn("flex", expanded ? "px-3" : "px-2")}>
 			<CreateNewOrg dialogType={dialogType} setDialogType={setDialogType} />
 
 			<DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
@@ -94,8 +94,10 @@ export const OrgDropdown = () => {
 					<DropdownMenuTrigger asChild>
 						<Button
 							className={cn(
-								"bg-transparent! shimmer-hover p-0.5 gap-2 rounded-md justify-start items-center transition-all duration-200 cursor-pointer",
-								expanded ? "h-7 min-w-28" : "h-7 w-7 p-0.5",
+								"bg-transparent! gap-2 rounded-md items-center transition-all duration-200 cursor-pointer",
+								expanded
+									? "h-7 min-w-28 p-0.5 justify-start shimmer-hover"
+									: "h-7 w-full px-2 justify-center hover:bg-transparent",
 							)}
 							variant="skeleton"
 						>

--- a/vite/src/views/main-sidebar/org-dropdown/components/OrgLogo.tsx
+++ b/vite/src/views/main-sidebar/org-dropdown/components/OrgLogo.tsx
@@ -6,7 +6,7 @@ export const OrgLogo = ({ org }: { org: FrontendOrg }) => {
 	return (
 		<div
 			className={cn(
-				"rounded-md overflow-hidden flex items-center justify-center scale-100 translate-x-px bg-zinc-200 w-5 h-5 min-w-5 min-h-5",
+				"rounded-md overflow-hidden flex items-center justify-center w-5 h-5 min-w-5 min-h-5",
 			)}
 		>
 			{/* {org.logo ? (

--- a/vite/src/views/products/features/feature-list/FeatureListMenuButton.tsx
+++ b/vite/src/views/products/features/feature-list/FeatureListMenuButton.tsx
@@ -18,7 +18,7 @@ export function FeatureListMenuButton() {
 			<DropdownMenuTrigger asChild>
 				<IconButton
 					icon={<EllipsisVertical />}
-					variant="secondary"
+					variant="skeleton"
 					size="default"
 					iconOrientation="center"
 					className="h-7!"

--- a/vite/src/views/products/products/components/product-list/ProductListMenuButton.tsx
+++ b/vite/src/views/products/products/components/product-list/ProductListMenuButton.tsx
@@ -18,7 +18,7 @@ export function ProductListMenuButton() {
 			<DropdownMenuTrigger asChild>
 				<IconButton
 					icon={<EllipsisVertical />}
-					variant="secondary"
+					variant="skeleton"
 					size="default"
 					iconOrientation="center"
 					className="!h-7"


### PR DESCRIPTION
## Summary
Cherry-pick of frontend cleanups onto main.

- Optimize analytics chart performance: filter zero rows before pivot, trim to top 30 series, order bars by volume
- Fix Recharts tooltip showing wrong date by bypassing internal index computation
- Clean up analytics empty states with icons and contextual messages
- Fix sidebar org logo centering and hover styling when collapsed
- Match "All Customers" sidebar icon to page header
- Remove light hover background from table toolbar buttons

## Test plan
- [ ] Verify analytics chart loads and tooltips show correct date on all segments
- [ ] Verify empty states render correctly for both chart and table
- [ ] Verify collapsed sidebar icons are centered
- [ ] Verify three-dots menu in tables shows no background on hover

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized analytics charts and polished UI across analytics, tables, and the sidebar for a faster, clearer experience. This includes major chart performance gains, a correct tooltip date, friendlier empty states, and tidier navigation.

- New Features
  - Analytics: Faster charts by filtering zero rows before pivot and trimming to the top 30 series; improved empty states for charts and the Events table; virtualization now fills available height.
  - Authorized apps: Rebuilt list into a settings table with grouped permission badges, authorized date, and a row menu to revoke access; revoke dialog previews linked API keys to be deleted.

- Bug Fixes
  - Chart tooltip now shows the correct period (derived from the active bar index) and uses a transparent cursor to avoid misleading highlights.
  - Sidebar polish: centered org logo when collapsed and updated “All Customers” to the `Users` icon.
  - UI consistency: removed toolbar hover backgrounds; improved muted `Badge` border; `Sheet` portal falls back to `document.body`; unified onboarding background (`bg-background`); prompt input uses native textarea/buttons for reliable focus and spacing; virtualized tables handle 100% height without overflow; adjusted customer list heights; feature/product menu buttons use the `skeleton` variant.

<sup>Written for commit e4a1bc5d5ffad96c6addaec6dcc708f533440d99. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1619?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR cherry-picks a set of frontend cleanups covering analytics performance, tooltip correctness, empty states, sidebar layout, and table styling.

- **[Improvements]** Analytics pipeline now pre-filters zero rows before the pivot, trims to top 30 series via `trimToTopSeries`, and orders bars by volume for cleaner stacked-bar rendering.
- **[Bug fixes]** Recharts tooltip date mismatch fixed by tracking `activeIndex` in React state (via `onMouseEnter` on each `Bar`) rather than relying on Recharts' internal `label` computation; chart and events-table empty states replaced with contextual icons and messages.
- **[Improvements]** Sidebar org logo centering corrected for collapsed state; \"All Customers\" icon swapped to `UsersIcon`; table toolbar three-dots buttons switched to `skeleton` variant; `PromptInput` compound components inlined with equivalent plain HTML elements.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are UI-only with no server-side or data-model impact.

The analytics refactor is well-structured. trimToTopSeries can leave all-zero period rows when activity falls entirely in trimmed series, and the groupCol mapping in AnalyticsView duplicates logic in transformGroupedData creating drift risk. Both are low-impact in practice.

transformGroupedChartData.ts and AnalyticsView.tsx in the analytics utilities.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx | Tooltip refactored to track activeIndex via onMouseEnter state instead of relying on Recharts' internal label, fixing the wrong-date bug. |
| vite/src/views/customers/customer/analytics/AnalyticsView.tsx | Adds pre-pivot zero-row filter, wires in trimToTopSeries (top 30), and improves empty states. The groupBy column resolution is duplicated from transformGroupedData.ts and could drift. |
| vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts | New trimToTopSeries utility correctly keeps top-N columns by total volume. After trimming, all-zero period rows for trimmed-only activity are not removed, leaving potential ghost x-axis entries when >30 series. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | Default event selection now filtered to feature-linked events only (Metered/CreditSystem). Falls back to all cachedEventNames when featuresData is empty, which is correct. |
| vite/src/views/customers/customer/analytics/components/EventsTable.tsx | Adds emptyMessage prop, hides pagination when empty, shows contextual empty state, and switches to containerHeight=100% flex layout. |
| vite/src/views/main-sidebar/components/AuthorizedApps.tsx | UI refactored from bespoke card layout to SettingsTable. revokingId still protects the confirm button in the dialog. |
| vite/src/components/general/table/table-content-virtualized.tsx | Adds isFlexFill mode when containerHeight is 100%, switching from explicit max-height calc to flex-based height fill. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts:94-99
**Ghost bars after trimming to top series**

`trimToTopSeries` removes columns but keeps all period rows. If a period's activity falls entirely in the trimmed (non-top-30) series, that period's row becomes all-zeros after trimming. The chart will render it as invisible zero-height bars, but the period label will still appear on the x-axis as an empty gap. A post-trim row filter — like the previous post-pivot filter — would prevent these phantom entries. This only surfaces when there are more than 30 distinct series, but it's a behavioral difference from the old code where all series were kept.

### Issue 2 of 2
vite/src/views/customers/customer/analytics/AnalyticsView.tsx:146-149
**Duplicated `groupBy` → column-name mapping**

This `groupCol` resolution (line 146–149) is the same mapping already in `transformGroupedData.ts` (`groupByColumn`). If the logic ever diverges — say a new special-cased column is added to `transformGroupedData` but not here — `skipKeys` would be wrong: either the groupBy column gets treated as a feature column (falsely satisfying the non-zero check) or a feature column gets skipped. Extracting this into a shared helper would eliminate the drift risk.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: frontend cleanup"](https://github.com/useautumn/autumn/commit/e4a1bc5d5ffad96c6addaec6dcc708f533440d99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32811027)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->