### PR TITLE
fix: webhook race condition

### DIFF
--- a/server/src/honoMiddlewares/routeHandler.ts
+++ b/server/src/honoMiddlewares/routeHandler.ts
@@ -125,6 +125,7 @@ export function createRoute<
 	versionedQuery?: Query extends ZodType ? VersionedSchemas<Query> : never;
 	params?: Params;
 	resource?: AffectedResource;
+	/** Be VERY careful — wraps the ENTIRE handler in a txn; bad for handlers that call Stripe (writes aren't visible until response returns). */
 	withTx?: boolean;
 	handler?: (
 		c: ValidatedContext<HonoEnv, Body, Query, Params>,

--- a/server/src/internal/balances/finalizeLock/runRedisFinalizeLockV2.ts
+++ b/server/src/internal/balances/finalizeLock/runRedisFinalizeLockV2.ts
@@ -47,7 +47,7 @@ export const runRedisFinalizeLockV2 = async ({
 	const rolloverIds = Object.keys(rolloverUpdates);
 
 	if (modifiedCusEntIds.length > 0 || rolloverIds.length > 0) {
-		ctx.logger.info(`[QUEUE SYNC V4] (${receipt.customer_id})`);
+
 		globalSyncBatchingManagerV3.addSyncItem({
 			customerId: receipt.customer_id,
 			orgId: ctx.org.id,

--- a/server/src/internal/balances/track/v3/runRedisTrackV3.ts
+++ b/server/src/internal/balances/track/v3/runRedisTrackV3.ts
@@ -1,21 +1,21 @@
 import type {
-	FullSubject,
-	TrackDeduction,
-	TrackParams,
-	TrackResponseV3,
+    FullSubject,
+    TrackDeduction,
+    TrackParams,
+    TrackResponseV3,
 } from "@autumn/shared";
 import { tryCatch } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { globalEventBatchingManager } from "@/internal/balances/events/EventBatchingManager.js";
 import { resolveInternalProductIdForEvent } from "@/internal/balances/events/resolveInternalProductIdForEvent.js";
 import {
-	buildEventInfo,
-	initEvent,
+    buildEventInfo,
+    initEvent,
 } from "@/internal/balances/events/initEvent.js";
 import {
-	deductionToTrackResponseV2,
-	executeRedisDeductionV2,
-	projectMutationLogsToTrackDeductionsV2,
+    deductionToTrackResponseV2,
+    executeRedisDeductionV2,
+    projectMutationLogsToTrackDeductionsV2,
 } from "@/internal/balances/utils/deductionV2/index.js";
 import { globalSyncBatchingManagerV3 } from "@/internal/balances/utils/sync/SyncBatchingManagerV3.js";
 import type { FeatureDeduction } from "../../utils/types/featureDeduction.js";
@@ -40,7 +40,7 @@ const queueSyncItem = ({
 
 	if (cusEntIds.length === 0 && rolloverIds.length === 0) return;
 
-	ctx.logger.info(`[QUEUE SYNC V4] (${body.customer_id})`);
+
 	globalSyncBatchingManagerV3.addSyncItem({
 		customerId: body.customer_id,
 		orgId: ctx.org.id,

--- a/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
@@ -297,7 +297,7 @@ export class SyncBatchingManagerV3 {
 				messageDeduplicationId,
 			});
 
-			logger.info(
+			logger.debug(
 				`[SyncV4] Queued sync for ${context.customerId}, ${cusEntIds.length} entitlements, ${rolloverIds.length} rollovers`,
 			);
 		} catch (error) {

--- a/server/src/internal/billing/v2/handlers/handleCreateSchedule.ts
+++ b/server/src/internal/billing/v2/handlers/handleCreateSchedule.ts
@@ -1,7 +1,7 @@
 import {
-	CreateScheduleParamsV0Schema,
-	type CreateScheduleResponse,
-	Scopes,
+    CreateScheduleParamsV0Schema,
+    type CreateScheduleResponse,
+    Scopes,
 } from "@autumn/shared";
 import { billingActions } from "@/internal/billing/v2/actions";
 import { buildBillingLockKey } from "@/internal/billing/v2/utils/billingLock/buildBillingLockKey";
@@ -11,7 +11,7 @@ import { createRoute } from "../../../../honoMiddlewares/routeHandler";
 export const handleCreateSchedule = createRoute({
 	scopes: [Scopes.Billing.Write],
 	body: CreateScheduleParamsV0Schema,
-	withTx: true,
+
 	lock:
 		process.env.NODE_ENV !== "development"
 			? {

--- a/server/src/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.ts
+++ b/server/src/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.ts
@@ -19,13 +19,13 @@ import {
 	cusProductToProduct,
 	type EntityLegacyData,
 	enrichFullCustomerWithEntity,
-	findCustomerProductById,
 	fullCustomerToTags,
 	type PlanLegacyData,
 } from "@autumn/shared";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
 import { getApiCustomerBase } from "@/internal/customers/cusUtils/apiCusUtils/getApiCustomerBase.js";
 import { getApiEntityBase } from "@/internal/entities/entityUtils/apiEntityUtils/getApiEntityBase.js";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
@@ -41,19 +41,21 @@ export const sendProductsUpdated = async ({
 	const { features, logger } = ctx;
 	const { customerProductId, scenario, customerId } = payload;
 
-	// Fetch FullCustomer
-	const fullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: customerId ?? "",
-		withEntities: true,
-		withSubs: true,
-		allowNotFound: true,
-	});
-
-	const customerProduct = findCustomerProductById({
-		fullCustomer,
-		customerProductId,
-	});
+	// Fetch cusProduct directly by ID — CusService.getFull filters by
+	// RELEVANT_STATUSES and applies a per-org cusProduct limit, so a cusProduct
+	// that transitioned to Expired (cancel/downgrade, or replaced by a
+	// subsequent create_schedule) between enqueue and worker pickup would be
+	// dropped before findCustomerProductById sees it.
+	const [fullCustomer, customerProduct] = await Promise.all([
+		CusService.getFull({
+			ctx,
+			idOrInternalId: customerId ?? "",
+			withEntities: true,
+			withSubs: true,
+			allowNotFound: true,
+		}),
+		CusProductService.getFull({ db: ctx.db, id: customerProductId }),
+	]);
 
 	if (!fullCustomer) {
 		logger.warn(`[sendProductsUpdated] Customer ${customerId ?? ""} not found`);

--- a/server/src/internal/customers/cusProducts/CusProductService.ts
+++ b/server/src/internal/customers/cusProducts/CusProductService.ts
@@ -184,7 +184,10 @@ export class CusProductService {
 	static async getFull({ db, id }: { db: DrizzleCli; id: string }) {
 		const data = await db.query.customerProducts.findFirst({
 			where: eq(customerProducts.id, id),
-			with: getFullCusProdRelations(),
+			with: {
+				product: true,
+				...getFullCusProdRelations(),
+			},
 		});
 
 		return data as FullCusProduct | undefined;

--- a/server/tests/integration/billing/autumn-webhooks/create-schedule-webhook.test.ts
+++ b/server/tests/integration/billing/autumn-webhooks/create-schedule-webhook.test.ts
@@ -1,0 +1,120 @@
+/**
+ * TDD test for the mintlify webhook miss: billing.create_schedule INSERTS an
+ * active immediate-phase customer product and queues sendProductsUpdated for
+ * it. The worker must then deliver a customer.products.updated webhook for
+ * that newly-inserted active cusProduct.
+ *
+ * Real-world repro: req.id Root=1-6a0ba974-03e2b83621e4e34101d66c61 (mintlify
+ * org GG6tnmO7cHb40PNhwYBTZtxQdeL74NHF, 2026-05-19T00:06:14Z):
+ *   00:06:18.102 INFO  [billingPlanToSendProductsUpdated] Queued webhook for
+ *                       Enterprise, scenario: upgrade
+ *   00:06:18.125 WARN  [sendProductsUpdated] Customer product
+ *                       cus_prod_3Dv4NvFlTFWBQXeIgELByDbl3lw not found
+ * The inserted active cusProduct was lost between enqueue and worker pickup.
+ *
+ * Red-failure mode (current behavior):
+ *  - waitForWebhook returns null after 20s; no customer.products.updated event
+ *    is delivered for the immediate-phase plan inserted by createSchedule.
+ *
+ * Green-success criteria (after fix):
+ *  - The customer.products.updated webhook is delivered with the immediate
+ *    phase plan_id in updated_product.id.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type ApiProduct,
+	type CreateScheduleParamsV0Input,
+	ms,
+} from "@autumn/shared";
+import chalk from "chalk";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+type CustomerProductsUpdatedPayload = {
+	type: string;
+	data: {
+		scenario: string;
+		customer: ApiCustomerV3;
+		updated_product: ApiProduct;
+	};
+};
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	const appId = getTestSvixAppId({ svixConfig: ctx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["customer.products.updated"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+});
+
+test(
+	`${chalk.yellowBright("sendProductsUpdated: multi-phase create_schedule fires webhook for inserted active cusProduct")}`,
+	async () => {
+		const customerId = "create-schedule-webhook-multiphase";
+
+		const pro = products.pro({
+			id: "pro-create-schedule-webhook",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "premium-create-schedule-webhook",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
+		});
+
+		const now = Date.now();
+
+		// Mirror mintlify's actual call pattern: multi-phase schedule —
+		// immediate active plan (pro) + future scheduled plan (premium).
+		// This produces a cusProduct with scheduled_ids populated, exactly
+		// like cus_prod_3Dv4NvFlTFWBQXeIgELByDbl3lw in prod.
+		const response = await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{ starts_at: now, plans: [{ plan_id: pro.id }] },
+				{ starts_at: now + ms.days(30), plans: [{ plan_id: premium.id }] },
+			],
+		} satisfies CreateScheduleParamsV0Input);
+		expect(response.status).toBe("created");
+
+		// The immediate-phase pro cusProduct must deliver its
+		// customer.products.updated webhook.
+		const proWebhook = await waitForWebhook<CustomerProductsUpdatedPayload>({
+			token: playToken,
+			predicate: (payload) =>
+				payload.type === "customer.products.updated" &&
+				payload.data?.customer?.id === customerId &&
+				payload.data?.updated_product?.id === pro.id,
+			timeoutMs: 20_000,
+		});
+
+		expect(proWebhook).not.toBeNull();
+		expect(proWebhook!.payload.data.updated_product.id).toBe(pro.id);
+	},
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race that caused some `customer.products.updated` webhooks to be missed after multi‑phase `billing.create_schedule`. We now commit writes immediately and fetch the new customer product by ID so the worker always builds the payload.

- **Bug Fixes**
  - `sendProductsUpdated`: fetch cusProduct by ID via `CusProductService.getFull` (no status/limit filters); runs in parallel with `CusService.getFull` to avoid drops if status changes between enqueue and worker pickup.
  - `CusProductService.getFull`: include `product` relation so `cusProductToProduct` has data.
  - `handleCreateSchedule`: remove `withTx` so writes are visible immediately; added a warning comment on `withTx` in `createRoute`.
  - Logging: remove noisy `[QUEUE SYNC V4]` info logs; downgrade `[SyncV4]` queue logs to `debug`.
  - Tests: add integration test reproducing the Mintlify multi‑phase schedule and verifying the immediate‑phase plan triggers `customer.products.updated`.

<sup>Written for commit 21c168d3dba64049e75736b38bf2e8a5baab6c98. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1620?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a webhook delivery race condition in `billing.create_schedule` where the queue worker could pick up a `sendProductsUpdated` job before the wrapping database transaction committed, making the newly-inserted `customerProduct` invisible to the worker. A second, related bug caused `Expired` customer products (status-filtered out by `CusService.getFull`) to be silently dropped even when the status change happened after the job was enqueued.

- **[Bug fixes]** Removed `withTx: true` from `handleCreateSchedule` so all DB writes are committed before `billingPlanToSendProductsUpdated` enqueues the webhook job, eliminating the transaction-visibility window.
- **[Bug fixes]** Replaced `CusService.getFull` + `findCustomerProductById` in `sendProductsUpdated` with a direct `CusProductService.getFull` call by ID, bypassing the `RELEVANT_STATUSES` filter that could silently drop records that transitioned to `Expired` between enqueue and worker pickup.
- **[Bug fixes / Improvements]** Added `product: true` to `CusProductService.getFull`'s Drizzle relations (previously missing, causing `cusProductToProduct` to spread `undefined`); added a prominent warning comment on the `withTx` option; and downgraded a noisy sync-queue `info` log to `debug`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are tightly scoped to the webhook delivery path and directly address a confirmed production incident.

All three code sites (transaction removal, direct ID fetch, product relation fix) are internally consistent and address the same root-cause chain. The new integration test directly reproduces the production failure scenario. No other callers of CusProductService.getFull exist, so the added product: true relation has no unintended blast radius.

No files require special attention — the core changes to handleCreateSchedule.ts and sendProductsUpdated.ts are straightforward and well-documented.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/handlers/handleCreateSchedule.ts | Removed `withTx: true` — the root cause of the race condition. DB writes now commit immediately so the queue worker always sees them. |
| server/src/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.ts | Replaced CusService.getFull+findCustomerProductById with a direct CusProductService.getFull call; runs both fetches in parallel via Promise.all. Fixes silent webhook miss for Expired-status cusProducts. |
| server/src/internal/customers/cusProducts/CusProductService.ts | Added `product: true` to getFull's Drizzle relations; previously the relation was missing, meaning cusProductToProduct spread an undefined object. No other callers of getFull exist. |
| server/src/honoMiddlewares/routeHandler.ts | Added a warning JSDoc comment to the `withTx` option documenting why it must not be used for handlers that call Stripe. No logic change. |
| server/tests/integration/billing/autumn-webhooks/create-schedule-webhook.test.ts | New integration test verifying that a multi-phase create_schedule delivers a customer.products.updated webhook for the immediately-active plan. Directly reproduces the mintlify production incident. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as handleCreateSchedule
    participant DB as Database
    participant Queue as SQS/Queue
    participant Worker as sendProductsUpdated Worker

    Note over Handler,DB: Before fix (withTx: true)
    Client->>Handler: POST /billing/create-schedule
    Handler->>DB: BEGIN TRANSACTION
    Handler->>DB: INSERT customerProduct
    Handler->>Queue: enqueue sendProductsUpdated job
    Worker->>DB: CusService.getFull (filtered by RELEVANT_STATUSES)
    Note over Worker,DB: ❌ cusProduct invisible (txn not committed yet)
    Worker-->>Worker: warn "Customer product not found" — no webhook sent
    Handler->>DB: COMMIT TRANSACTION

    Note over Handler,DB: After fix (no withTx)
    Client->>Handler: POST /billing/create-schedule
    Handler->>DB: INSERT customerProduct (immediate commit)
    Handler->>Queue: enqueue sendProductsUpdated job
    Worker->>DB: CusProductService.getFull by ID (no status filter)
    Note over Worker,DB: ✅ cusProduct found directly by ID
    Worker->>DB: CusService.getFull (customer context)
    Worker-->>Client: customer.products.updated webhook delivered
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/webhook-rac..."](https://github.com/useautumn/autumn/commit/21c168d3dba64049e75736b38bf2e8a5baab6c98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32813710)</sub>

<!-- /greptile_comment -->