### PR TITLE
Fix: analytics tooltip for plan_id grouping

### DIFF
--- a/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
@@ -1,5 +1,5 @@
-import { memo, startTransition, useCallback, useMemo, useState } from "react";
-import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
+import { memo, startTransition, useCallback, useMemo, useRef, useState } from "react";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
 import { cn } from "@/lib/utils";
 import { useAnalyticsContext } from "./AnalyticsContext";
@@ -22,7 +22,6 @@ interface ChartSeriesConfig {
 
 const MAX_TOOLTIP_ITEMS = 5;
 const CHART_STYLE = { cursor: "default" } as const;
-const TRANSPARENT_CURSOR = { fill: "transparent", strokeWidth: 0 } as const;
 const X_TICK = { fontSize: 11, fill: "#666" } as const;
 const Y_TICK = {
 	fontSize: 11,
@@ -62,21 +61,26 @@ export const EventsBarChart = memo(function EventsBarChart({
 }) {
 	const { selectedInterval } = useAnalyticsContext();
 	const [hoveredKey, setHoveredKey] = useState<string | null>(null);
-	const [activeIndex, setActiveIndex] = useState<number | null>(null);
+	const [activeRow, setActiveRow] = useState<Row | null>(null);
+	const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
 
 	const handleBarMouseEnter = useCallback(
-		(dataKey: string) => (_data: unknown, index: number) =>
+		(dataKey: string) => (entry: any) =>
 			startTransition(() => {
 				setHoveredKey(dataKey);
-				setActiveIndex(index);
+				setActiveRow(entry?.payload ?? null);
 			}),
 		[],
 	);
+	const handleMouseMove = useCallback((e: React.MouseEvent) => {
+		const rect = containerRef.current?.getBoundingClientRect();
+		if (rect) setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+	}, []);
 	const handleChartMouseLeave = useCallback(() => {
-		startTransition(() => {
-			setHoveredKey(null);
-			setActiveIndex(null);
-		});
+		setHoveredKey(null);
+		setActiveRow(null);
+		setMousePos(null);
 	}, []);
 
 	const formatXAxis = useCallback(
@@ -98,59 +102,36 @@ export const EventsBarChart = memo(function EventsBarChart({
 		return config;
 	}, [chartConfig]);
 
-	const tooltipContent = useCallback(
-		({ active }: { active?: boolean }) => {
-			if (!active || activeIndex == null) return null;
-			const row = data.data[activeIndex];
-			if (!row) return null;
-			const period = String(row.period);
-
-			// Build items from our tracked index, not Recharts' payload
-			const allItems = chartConfig
-				.map((s) => ({ dataKey: s.yKey, value: Number(row[s.yKey] ?? 0), color: s.fill }))
-				.filter((i) => i.value !== 0);
-			const items = hoveredKey
-				? allItems.filter((i) => i.dataKey === hoveredKey)
-				: allItems.sort((a, b) => b.value - a.value);
-			if (!items.length) return null;
-
-			const visible = items.slice(0, MAX_TOOLTIP_ITEMS);
-			const overflow = items.length - visible.length;
-			const overflowSum = overflow > 0
-				? items.slice(MAX_TOOLTIP_ITEMS).reduce((s, i) => s + i.value, 0)
-				: 0;
-			return (
-				<div className="bg-popover text-popover-foreground grid min-w-[8rem] items-start gap-1.5 rounded-lg px-2.5 py-1.5 text-xs shadow-md ring-1 ring-foreground/10">
-					<div className="font-medium">{formatXAxis(period)}</div>
-					<div className="grid gap-1">
-						{visible.map((item) => (
-							<TooltipItem
-								key={item.dataKey}
-								item={item}
-								label={rechartsConfig[item.dataKey]?.label as string ?? item.dataKey}
-							/>
-						))}
-						{overflow > 0 && (
-							<div className="flex items-center gap-2 text-muted-foreground">
-								<span className="h-2.5 w-2.5 shrink-0" />
-								<span className="flex-1">+{overflow} more</span>
-								<span className="tabular-nums">{overflowSum.toLocaleString()}</span>
-							</div>
-						)}
-					</div>
-				</div>
-			);
-		},
-		[activeIndex, hoveredKey, data.data, chartConfig, formatXAxis, rechartsConfig],
-	);
+	const tooltipData = useMemo(() => {
+		if (!activeRow) return null;
+		const allItems = chartConfig
+			.map((s) => ({ dataKey: s.yKey, value: Number(activeRow[s.yKey] ?? 0), color: s.fill }))
+			.filter((i) => i.value !== 0);
+		const items = hoveredKey
+			? allItems.filter((i) => i.dataKey === hoveredKey)
+			: allItems.sort((a, b) => b.value - a.value);
+		if (!items.length) return null;
+		return { period: String(activeRow.period), items };
+	}, [activeRow, hoveredKey, chartConfig]);
 
 	const barHandlers = useMemo(
 		() => chartConfig.map((series) => handleBarMouseEnter(series.yKey)),
 		[chartConfig, handleBarMouseEnter],
 	);
 
+	const visible = tooltipData?.items.slice(0, MAX_TOOLTIP_ITEMS) ?? [];
+	const overflow = (tooltipData?.items.length ?? 0) - visible.length;
+	const overflowSum = overflow > 0
+		? tooltipData!.items.slice(MAX_TOOLTIP_ITEMS).reduce((s, i) => s + i.value, 0)
+		: 0;
+
 	return (
-		<div className="h-full w-full">
+		<div
+			ref={containerRef}
+			className="h-full w-full relative"
+			onMouseMove={handleMouseMove}
+			onMouseLeave={handleChartMouseLeave}
+		>
 			<ChartContainer
 				config={rechartsConfig}
 				className={cn(
@@ -166,7 +147,6 @@ export const EventsBarChart = memo(function EventsBarChart({
 					barCategoryGap="10%"
 					style={CHART_STYLE}
 					throttleDelay="raf"
-					onMouseLeave={handleChartMouseLeave}
 				>
 					<CartesianGrid
 						vertical={false}
@@ -192,11 +172,6 @@ export const EventsBarChart = memo(function EventsBarChart({
 						tick={Y_TICK}
 						tickFormatter={formatCompactNumber}
 					/>
-					<Tooltip
-						cursor={TRANSPARENT_CURSOR}
-						isAnimationActive={false}
-						content={tooltipContent}
-					/>
 					{chartConfig.map((series, si) => (
 						<Bar
 							key={series.yKey}
@@ -210,6 +185,35 @@ export const EventsBarChart = memo(function EventsBarChart({
 					))}
 				</BarChart>
 			</ChartContainer>
+			{tooltipData && mousePos && (
+				<div
+					className="pointer-events-none absolute z-50 bg-popover text-popover-foreground grid min-w-[8rem] items-start gap-1.5 rounded-lg px-2.5 py-1.5 text-xs shadow-md ring-1 ring-foreground/10"
+					style={{
+						top: mousePos.y - 12,
+						...((containerRef.current?.offsetWidth ?? 0) - mousePos.x < 200
+							? { right: (containerRef.current?.offsetWidth ?? 0) - mousePos.x + 12 }
+							: { left: mousePos.x + 12 }),
+					}}
+				>
+					<div className="font-medium">{formatXAxis(tooltipData.period)}</div>
+					<div className="grid gap-1">
+						{visible.map((item) => (
+							<TooltipItem
+								key={item.dataKey}
+								item={item}
+								label={rechartsConfig[item.dataKey]?.label as string ?? item.dataKey}
+							/>
+						))}
+						{overflow > 0 && (
+							<div className="flex items-center gap-2 text-muted-foreground">
+								<span className="h-2.5 w-2.5 shrink-0" />
+								<span className="flex-1">+{overflow} more</span>
+								<span className="tabular-nums">{overflowSum.toLocaleString()}</span>
+							</div>
+						)}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 });


### PR DESCRIPTION
## Summary
- Replace Recharts `<Tooltip>` with a custom overlay that works reliably for all grouping types (plan_id, customer_id, etc.)
- Store the hovered bar's actual data row via `entry.payload` instead of looking up by index
- Flip tooltip direction when near the right edge to prevent overflow

Cherry-pick of 5a8563832 from `charlie/frontend-cleanups`.

## Test plan
- [ ] Verify tooltip appears when hovering bars with plan_id grouping
- [ ] Verify tooltip shows correct date and values for the hovered bar
- [ ] Verify tooltip flips to the left near the right edge of the chart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the `recharts` Tooltip with a custom overlay to fix incorrect values when grouping by plan_id and other keys. Tooltips now use the hovered bar’s data and stay within the chart.

- **Bug Fixes**
  - Read hovered row via `entry.payload` instead of index lookup to show correct date and totals.
  - Track mouse position and render an absolute overlay; flip left near the right edge to avoid overflow.
  - Remove `Tooltip` usage and transparent cursor; attach hover handlers to each `Bar` and reset on leave.

<sup>Written for commit 1a0914043046a86ba428e75a3c6c8c7952a98f1e. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1624?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the Recharts built-in `<Tooltip>` with a custom absolutely-positioned overlay in `AnalyticsGraph.tsx` to fix tooltip rendering for `plan_id` (and other non-index-based) groupings. The root cause was that the old implementation looked up rows by numeric index, which became unreliable when grouping keys like `plan_id` were used; the fix stores the hovered row directly from `entry.payload`.

- **Bug fixes**: Switches from index-based row lookup to `entry.payload` capture in `handleBarMouseEnter`, ensuring the correct data row is always shown regardless of grouping type.
- **Improvements**: Removes the Recharts `<Tooltip>` component in favour of a mouse-tracked overlay div that positions itself relative to the cursor and flips direction near the right edge to prevent overflow.
- **Improvements**: `handleChartMouseLeave` is promoted to the outer wrapper `div` (and `mousePos` state is cleared on leave), ensuring tooltip cleanup happens reliably across the full chart area.
</details>

<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped to the analytics tooltip overlay and has no server-side or data-mutation impact; safe to merge with the minor positioning edge case noted.

The core fix — reading entry.payload instead of indexing into data.data — is correct and directly addresses the broken tooltip. The only issues found are minor: derived values (visible, overflow, overflowSum) are recomputed on every mouse-move render rather than being included in the memoized computation, and the tooltip top position can go slightly negative when the cursor is within 12px of the chart's top edge. Neither affects correctness of the displayed data.

vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx — specifically the custom tooltip positioning logic and the inline derived-value computations.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx | Replaces Recharts built-in Tooltip with a custom absolutely-positioned overlay; switches from index-based row lookup to direct entry.payload capture; adds edge-flip positioning logic. Two minor issues: derived tooltip values are recomputed inline on every mouse-move render, and tooltip top position can go negative near the chart's top edge. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User moves mouse over outer div] --> B[handleMouseMove setMousePos x,y]
    B --> C{Cursor over a Bar?}
    C -- Yes --> D[Bar.onMouseEnter fires handleBarMouseEnter]
    D --> E[setHoveredKey + setActiveRow from entry.payload]
    C -- No --> F[mousePos updates, activeRow unchanged]
    E --> G{tooltipData useMemo}
    F --> G
    G -- activeRow is null --> H[tooltipData = null]
    G -- activeRow non-null --> I[Build items from chartConfig filter/sort by hoveredKey]
    I --> J{items.length > 0?}
    J -- No --> H
    J -- Yes --> K[tooltipData = period + items]
    K --> L{tooltipData AND mousePos?}
    H --> M[Tooltip hidden]
    L -- Yes --> N[Render overlay div flip left or right if near edge]
    L -- No --> M
    A --> O[User leaves outer div]
    O --> P[handleChartMouseLeave clears all state]
    P --> M
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx:122-126
**Derived tooltip values computed on every mouse-move render**

`visible`, `overflow`, and `overflowSum` are derived from `tooltipData` but computed inline in the render body rather than inside the memoized `tooltipData` computation. Because `handleMouseMove` calls `setMousePos` on every `mousemove` event, the component re-renders continuously while the cursor moves. `tooltipData` itself is correctly memoized and won't recompute, but these slice/reduce operations run again on each re-render even though `tooltipData` hasn't changed. Moving them inside the `tooltipData` `useMemo` (or a second memo gated on it) avoids the unnecessary work and keeps the tooltip-building logic in one place.

### Issue 2 of 2
vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx:189-193
**Tooltip can render above the container when cursor is near the top edge**

When `mousePos.y` is less than 12, `top: mousePos.y - 12` becomes negative, pushing the tooltip above the container boundary. Since the container is `relative` but has no `overflow: hidden`, the tooltip floats above the chart and may be partially obscured by adjacent UI. Clamping the value prevents the overflow.

```suggestion
				<div
					className="pointer-events-none absolute z-50 bg-popover text-popover-foreground grid min-w-[8rem] items-start gap-1.5 rounded-lg px-2.5 py-1.5 text-xs shadow-md ring-1 ring-foreground/10"
					style={{
						top: Math.max(0, mousePos.y - 12),
						...((containerRef.current?.offsetWidth ?? 0) - mousePos.x < 200
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: replace Recharts Tooltip with custo..."](https://github.com/useautumn/autumn/commit/1a0914043046a86ba428e75a3c6c8c7952a98f1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32834920)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->