### PR TITLE
fix: increase db connections

### DIFF
--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -39,7 +39,7 @@ const normalizeDbExecute = <
 
 /** Creates a Drizzle pool with the given configuration. */
 export const initDrizzle = ({
-	maxConnections = 10,
+	maxConnections = 20,
 	replica = false,
 	connectTimeout = 5,
 	databaseUrl,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increased the default DB pool size in `initDrizzle` from 10 to 20 to handle higher concurrency and reduce request queueing/timeouts.

<sup>Written for commit ee887f428e8349fc4964c44e9a188950e5b91761. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1625?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Increases the default connection pool size for the general Drizzle pool from 10 to 20, and bumps the `ai` submodule pointer.

- **[Bug fixes]** `initDrizzle` default `maxConnections` raised from 10 → 20, raising the ceiling for `dbGeneral` (the pool used by all standard endpoints). Explicit overrides for `dbCritical` (5) and `dbReplica` (5) are unchanged.
- **[Improvements]** `ai` submodule updated to a newer commit.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single-line default value change with no logic impact.

The only server-side change is raising the default pool size for dbGeneral from 10 to 20. The explicit overrides on dbCritical and dbReplica are untouched, so this affects exactly one pool. The change is minimal, intentional, and carries no correctness risk beyond the operational assumption that the database server can accommodate the additional connections.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/initDrizzle.ts | Default maxConnections bumped from 10 to 20, affecting only the dbGeneral pool (dbCritical and dbReplica use explicit values of 5). |
| ai | ai submodule pointer advanced to a new commit; no server-side logic changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: increase db connections"](https://github.com/useautumn/autumn/commit/ee887f428e8349fc4964c44e9a188950e5b91761) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32834954)</sub>

<!-- /greptile_comment -->