### PR TITLE
feat(customers): 🎸 route getFull through cursor query via edge config

### DIFF
--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -7,6 +7,8 @@ export const ADMIN_ORG_LIMITS_CONFIG_KEY = "admin/org-limits-config.json";
 export const ADMIN_REDIS_V2_CACHE_CONFIG_KEY =
 	"admin/redis-v2-cache-config.json";
 export const ADMIN_JOB_QUEUE_CONFIG_KEY = "admin/job-queue-config.json";
+export const ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY =
+	"admin/miscellaneous-edge-config.json";
 export const BLUE_GREEN_ACTIVE_SLOT_KEY = "admin/blue-green-active-slot.json";
 export const BLUE_GREEN_CRON_ACTIVE_SLOT_KEY =
 	"admin/blue-green-cron-active-slot.json";
@@ -51,6 +53,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "job-queues",
 			label: "Job Queues",
 			key: ADMIN_JOB_QUEUE_CONFIG_KEY,
+		},
+		{
+			id: "miscellaneous",
+			label: "Miscellaneous",
+			key: ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY,
 		},
 		{
 			id: "stripe-sync",

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -1,19 +1,20 @@
 import { Hono } from "hono";
 import type { HonoEnv } from "../../honoUtils/HonoEnv";
-import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
-import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSources";
-import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsConfig";
-import { handleGetAdminJobQueueConfig } from "./handleGetAdminJobQueueConfig";
-import { handleGetAdminOrgLimitsConfig } from "./handleGetAdminOrgLimitsConfig";
 import {
 	handleDeleteAdminOrgRedisConfig,
 	handleGetAdminOrgRedisConfig,
 	handleUpdateAdminOrgRedisMigration,
 	handleUpsertAdminOrgRedisConfig,
 } from "./handleAdminOrgRedisConfig";
+import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
+import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSources";
+import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsConfig";
+import { handleGetAdminJobQueueConfig } from "./handleGetAdminJobQueueConfig";
+import { handleGetAdminMiscellaneousEdgeConfig } from "./handleGetAdminMiscellaneousEdgeConfig";
+import { handleGetAdminOrgLimitsConfig } from "./handleGetAdminOrgLimitsConfig";
 import { handleGetAdminOrgRequestBlock } from "./handleGetAdminOrgRequestBlock";
-import { handleGetAdminRequestBlockConfig } from "./handleGetAdminRequestBlockConfig";
 import { handleGetAdminRedisV2CacheConfig } from "./handleGetAdminRedisV2CacheConfig";
+import { handleGetAdminRequestBlockConfig } from "./handleGetAdminRequestBlockConfig";
 import { handleGetAdminStripeSyncConfig } from "./handleGetAdminStripeSyncConfig";
 
 import { handleGetInvoiceLineItems } from "./handleGetInvoiceLineItems";
@@ -25,10 +26,11 @@ import { handleListOAuthClients } from "./handleListOAuthClients";
 import { handleUpsertAdminCustomerBlockConfig } from "./handleUpsertAdminCustomerBlockConfig";
 import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureFlagsConfig";
 import { handleUpsertAdminJobQueueConfig } from "./handleUpsertAdminJobQueueConfig";
+import { handleUpsertAdminMiscellaneousEdgeConfig } from "./handleUpsertAdminMiscellaneousEdgeConfig";
 import { handleUpsertAdminOrgLimitsConfig } from "./handleUpsertAdminOrgLimitsConfig";
 import { handleUpsertAdminOrgRequestBlock } from "./handleUpsertAdminOrgRequestBlock";
-import { handleUpsertAdminRequestBlockConfig } from "./handleUpsertAdminRequestBlockConfig";
 import { handleUpsertAdminRedisV2CacheConfig } from "./handleUpsertAdminRedisV2CacheConfig";
+import { handleUpsertAdminRequestBlockConfig } from "./handleUpsertAdminRequestBlockConfig";
 import { handleUpsertAdminStripeSyncConfig } from "./handleUpsertAdminStripeSyncConfig";
 import { handleDeleteRollout } from "./rollouts/handleDeleteRollout";
 import { handleDeleteRolloutOrg } from "./rollouts/handleDeleteRolloutOrg";
@@ -77,6 +79,14 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/feature-flags-config",
 	...handleUpsertAdminFeatureFlagsConfig,
+);
+honoAdminRouter.get(
+	"/miscellaneous-edge-config",
+	...handleGetAdminMiscellaneousEdgeConfig,
+);
+honoAdminRouter.put(
+	"/miscellaneous-edge-config",
+	...handleUpsertAdminMiscellaneousEdgeConfig,
 );
 honoAdminRouter.get(
 	"/customer-block-config",

--- a/server/src/internal/admin/handleGetAdminMiscellaneousEdgeConfig.ts
+++ b/server/src/internal/admin/handleGetAdminMiscellaneousEdgeConfig.ts
@@ -1,0 +1,22 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getMiscellaneousEdgeConfigFromSource,
+	getRuntimeMiscellaneousEdgeConfigStatus,
+} from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
+
+export const handleGetAdminMiscellaneousEdgeConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const status = getRuntimeMiscellaneousEdgeConfigStatus();
+		const config = await getMiscellaneousEdgeConfigFromSource();
+
+		return c.json({
+			...config,
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminMiscellaneousEdgeConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminMiscellaneousEdgeConfig.ts
@@ -1,0 +1,16 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { MiscellaneousEdgeConfigSchema } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.js";
+import { updateFullMiscellaneousEdgeConfig } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
+
+export const handleUpsertAdminMiscellaneousEdgeConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	body: MiscellaneousEdgeConfigSchema,
+	handler: async (c) => {
+		const body = c.req.valid("json");
+
+		await updateFullMiscellaneousEdgeConfig({ config: body });
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -107,11 +107,15 @@ export class CusService {
 					orgSlug: org.slug,
 				});
 
-				const useFlatModel = isOnNewFlatCusModel({
-					orgId,
-					env,
-					customerId: idOrInternalId,
-				});
+				const useFlatModel =
+					isOnNewFlatCusModel({
+						orgId,
+						env,
+						customerId: idOrInternalId,
+					}) &&
+					!withTrialsUsed &&
+					!withEvents &&
+					!entityId;
 
 				const query = useFlatModel
 					? getCursorPaginatedFullCusQuery({

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -39,12 +39,18 @@ import {
 	getOrgCusProductLimit,
 	getOrgEntitiesLimit,
 } from "../misc/edgeConfig/orgLimitsStore.js";
+import { isOnNewFlatCusModel } from "../misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { resetCustomerEntitlements } from "./actions/resetCustomerEntitlements/resetCustomerEntitlements.js";
+import { getCursorPaginatedFullCusQuery } from "./cursorPaginatedFullCusQuery.js";
 import {
 	ACTIVE_STATUSES,
 	RELEVANT_STATUSES,
 } from "./cusProducts/CusProductService.js";
 import { getFullCusQuery, hasCustomerListFilters } from "./getFullCusQuery.js";
+import {
+	type FlattenedCustomerRow,
+	reassembleFlattenedCustomer,
+} from "./reassembleFlattenedCustomer/index.js";
 
 // const tracer = trace.getTracer("express");
 
@@ -101,20 +107,40 @@ export class CusService {
 					orgSlug: org.slug,
 				});
 
-				const query = getFullCusQuery({
-					idOrInternalId,
+				const useFlatModel = isOnNewFlatCusModel({
 					orgId,
 					env,
-					inStatuses,
-					includeInvoices,
-					withEntities,
-					withTrialsUsed,
-					withSubs,
-					withEvents,
-					entityId,
-					cusProductLimit,
-					entitiesLimit,
+					customerId: idOrInternalId,
 				});
+
+				const query = useFlatModel
+					? getCursorPaginatedFullCusQuery({
+							orgId,
+							env,
+							inStatuses,
+							withSubs,
+							withEntities,
+							includeInvoices,
+							entitiesLimit,
+							invoicesLimit: 10,
+							limit: 1,
+							customerId: idOrInternalId,
+							cusProductLimit,
+						})
+					: getFullCusQuery({
+							idOrInternalId,
+							orgId,
+							env,
+							inStatuses,
+							includeInvoices,
+							withEntities,
+							withTrialsUsed,
+							withSubs,
+							withEvents,
+							entityId,
+							cusProductLimit,
+							entitiesLimit,
+						});
 
 				if (explain) {
 					const explainQuery = sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) ${query}`;
@@ -122,36 +148,68 @@ export class CusService {
 					return result as unknown as FullCustomer;
 				}
 
+				const tSqlStart = performance.now();
 				const { result, usedReplica } = await executeWithHealthTracking({
 					db,
 					query,
 					useReplica: ctx.testOptions?.useReplica,
 				});
+				const sqlMs = performance.now() - tSqlStart;
 
-				if (!result || result.length === 0) {
-					if (allowNotFound) {
-						return null as unknown as FullCustomer;
+				ctx.logger.info(
+					`[CusService.getFull] path=${useFlatModel ? "flat" : "legacy"} orgId=${orgId} customer=${idOrInternalId} sqlMs=${sqlMs.toFixed(0)}`,
+				);
+
+				let fullCus: FullCustomer;
+				if (useFlatModel) {
+					const flat = (result?.[0] ?? {
+						customers: [],
+						customer_products: [],
+						customer_entitlements: [],
+						extra_customer_entitlements: [],
+						customer_prices: [],
+						entitlements: [],
+						rollovers: [],
+						replaceables: [],
+						free_trials: [],
+						subscriptions: [],
+					}) as unknown as FlattenedCustomerRow;
+					const reassembled = reassembleFlattenedCustomer(flat);
+					if (reassembled.length === 0) {
+						if (allowNotFound) {
+							return null as unknown as FullCustomer;
+						}
+						throw new CustomerNotFoundError({
+							customerId: idOrInternalId,
+						});
+					}
+					fullCus = reassembled[0];
+				} else {
+					if (!result || result.length === 0) {
+						if (allowNotFound) {
+							return null as unknown as FullCustomer;
+						}
+
+						throw new CustomerNotFoundError({
+							customerId: idOrInternalId,
+						});
 					}
 
-					throw new CustomerNotFoundError({
-						customerId: idOrInternalId,
-					});
+					const data = result[0];
+					data.created_at = Number(data.created_at);
+
+					for (const product of data.customer_products as FullCusProduct[]) {
+						if (!product.customer_prices) {
+							product.customer_prices = [];
+						}
+
+						if (!product.customer_entitlements) {
+							product.customer_entitlements = [];
+						}
+					}
+
+					fullCus = data as FullCustomer;
 				}
-
-				const data = result[0];
-				data.created_at = Number(data.created_at);
-
-				for (const product of data.customer_products as FullCusProduct[]) {
-					if (!product.customer_prices) {
-						product.customer_prices = [];
-					}
-
-					if (!product.customer_entitlements) {
-						product.customer_entitlements = [];
-					}
-				}
-
-				const fullCus = data as FullCustomer;
 
 				// if (orgId === "org_2x5sJDcxhpVDjyUSqs4khaaNnxq") {
 				// 	fullCus.customer_products = (

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -30,6 +30,7 @@ export type CursorPaginatedFullCusQueryArgs = {
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
 	cusProductLimit: number;
+	customerId?: string;
 };
 
 /**
@@ -56,6 +57,7 @@ export const getCursorPaginatedFullCusQuery = ({
 	noneFilter,
 	productVersionFilters,
 	cusProductLimit,
+	customerId,
 }: CursorPaginatedFullCusQueryArgs) => {
 	const cpStatusFilter = inStatuses?.length
 		? sql`AND cp.status = ANY(ARRAY[${sql.join(
@@ -137,13 +139,12 @@ export const getCursorPaginatedFullCusQuery = ({
 				c.id,
 				c.created_at,
 				row_to_json(c) AS row_json
-			FROM customers c
-			WHERE c.org_id = ${orgId}
-				AND c.env = ${env}
-				${customerListFilterSql}
-				${cursorPredicate}
-			ORDER BY c.created_at DESC, c.id DESC
-			LIMIT ${fetchLimit}
+		FROM customers c
+		WHERE c.org_id = ${orgId}
+			AND c.env = ${env}
+			${customerId ? sql`AND (c.id = ${customerId} OR c.internal_id = ${customerId})` : sql`${customerListFilterSql}${cursorPredicate}`}
+		ORDER BY c.created_at DESC, c.id DESC
+		LIMIT ${fetchLimit}
 		),
 		cp_ranked_raw AS MATERIALIZED (
 			SELECT

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
@@ -1,0 +1,9 @@
+import { z } from "zod/v4";
+
+export const MiscellaneousEdgeConfigSchema = z.object({
+	newFlatCusModel: z.array(z.string()).default([]),
+});
+
+export type MiscellaneousEdgeConfig = z.infer<
+	typeof MiscellaneousEdgeConfigSchema
+>;

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
@@ -1,0 +1,54 @@
+import type { AppEnv } from "@autumn/shared";
+import { ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type MiscellaneousEdgeConfig,
+	MiscellaneousEdgeConfigSchema,
+} from "./miscellaneousEdgeConfigSchemas.js";
+
+const store = createEdgeConfigStore<MiscellaneousEdgeConfig>({
+	s3Key: ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY,
+	schema: MiscellaneousEdgeConfigSchema,
+	defaultValue: () => MiscellaneousEdgeConfigSchema.parse({}),
+});
+
+registerEdgeConfig({ store });
+
+export const getRuntimeMiscellaneousEdgeConfigStatus = () => store.getStatus();
+
+export const getRuntimeMiscellaneousEdgeConfig = (): MiscellaneousEdgeConfig =>
+	store.get();
+
+export const isOnNewFlatCusModel = ({
+	orgId,
+	env,
+	customerId,
+}: {
+	orgId: string;
+	env: AppEnv;
+	customerId: string;
+}): boolean => {
+	const config = store.get();
+	const key = `${orgId}:${env}:${customerId}`;
+	return config.newFlatCusModel.includes(key);
+};
+
+export const getMiscellaneousEdgeConfigFromSource =
+	async (): Promise<MiscellaneousEdgeConfig> => store.readFromSource();
+
+export const updateFullMiscellaneousEdgeConfig = async ({
+	config,
+}: {
+	config: MiscellaneousEdgeConfig;
+}): Promise<void> => {
+	await store.writeToSource({ config });
+};
+
+export const _setMiscellaneousEdgeConfigForTesting = ({
+	config,
+}: {
+	config: MiscellaneousEdgeConfig;
+}): void => {
+	store._setRuntimeConfigForTesting(config);
+};

--- a/server/tests/integration/scopes/scope-403.test.ts
+++ b/server/tests/integration/scopes/scope-403.test.ts
@@ -99,6 +99,33 @@ const ROUTES = [
 		isWebhookExempt: false,
 	},
 	{
+		handlerName: "handleGetAdminMiscellaneousEdgeConfig",
+		handlerFile: "src/internal/admin/handleGetAdminMiscellaneousEdgeConfig.ts",
+		method: "GET",
+		path: "/admin/miscellaneous-edge-config",
+		style: "REST",
+		group: "admin",
+		mountChain: ["", "admin", "/miscellaneous-edge-config"],
+		sourceRouterFile: "src/internal/admin/adminRouter.ts",
+		routeKind: "createRoute",
+		needsScopes: true,
+		isWebhookExempt: false,
+	},
+	{
+		handlerName: "handleUpsertAdminMiscellaneousEdgeConfig",
+		handlerFile:
+			"src/internal/admin/handleUpsertAdminMiscellaneousEdgeConfig.ts",
+		method: "PUT",
+		path: "/admin/miscellaneous-edge-config",
+		style: "REST",
+		group: "admin",
+		mountChain: ["", "admin", "/miscellaneous-edge-config"],
+		sourceRouterFile: "src/internal/admin/adminRouter.ts",
+		routeKind: "createRoute",
+		needsScopes: true,
+		isWebhookExempt: false,
+	},
+	{
 		handlerName: "handleGetInvoiceLineItems",
 		handlerFile: "src/internal/admin/handleGetInvoiceLineItems.ts",
 		method: "POST",
@@ -3664,6 +3691,20 @@ const SCOPE_DECISIONS: Record<
 		shape: "array",
 		decidedAt: "2026-04-24T15:14:53.392Z",
 	},
+	"GET|/admin/miscellaneous-edge-config|handleGetAdminMiscellaneousEdgeConfig":
+		{
+			decision: "decided",
+			scopes: ["superuser"],
+			shape: "array",
+			decidedAt: "2026-05-19T16:00:00.000Z",
+		},
+	"PUT|/admin/miscellaneous-edge-config|handleUpsertAdminMiscellaneousEdgeConfig":
+		{
+			decision: "decided",
+			scopes: ["superuser"],
+			shape: "array",
+			decidedAt: "2026-05-19T16:00:00.000Z",
+		},
 	"POST|/admin/invoice-line-items|handleGetInvoiceLineItems": {
 		decision: "decided",
 		scopes: ["superuser"],

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -6,6 +6,7 @@ import { CustomerBlockDialog } from "./CustomerBlockDialog";
 import { EdgeConfigDialog } from "./EdgeConfigDialog";
 import { FeatureFlagsDialog } from "./FeatureFlagsDialog";
 import { JobQueuesDialog } from "./JobQueuesDialog";
+import { MiscellaneousEdgeConfigDialog } from "./MiscellaneousEdgeConfigDialog";
 import { OrgLimitsDialog } from "./OrgLimitsDialog";
 import { RawEdgeConfigDialog } from "./RawEdgeConfigDialog";
 import { RedisV2CacheDialog } from "./RedisV2CacheDialog";
@@ -31,6 +32,7 @@ export function EdgeConfigTab() {
 	const [jobQueuesOpen, setJobQueuesOpen] = useState(false);
 	const [stripeSyncOpen, setStripeSyncOpen] = useState(false);
 	const [redisV2CacheOpen, setRedisV2CacheOpen] = useState(false);
+	const [miscellaneousOpen, setMiscellaneousOpen] = useState(false);
 
 	const { data: source } = useQuery<EdgeConfigSource>({
 		queryKey: ["admin-edge-config-sources"],
@@ -72,7 +74,9 @@ export function EdgeConfigTab() {
 										className="min-w-0 text-xs text-muted-foreground"
 										title={config.key}
 									>
-										<span className="text-tertiary-foreground">{config.label}:</span>{" "}
+										<span className="text-tertiary-foreground">
+											{config.label}:
+										</span>{" "}
 										<span className="font-mono">{config.key}</span>
 									</span>
 								))}
@@ -85,7 +89,9 @@ export function EdgeConfigTab() {
 			<div className="rounded-lg border border-border overflow-hidden">
 				<div className="flex items-center justify-between p-4 border-b border-border">
 					<div className="flex flex-col gap-0.5">
-						<div className="text-sm font-medium text-foreground">Feature Flags</div>
+						<div className="text-sm font-medium text-foreground">
+							Feature Flags
+						</div>
 						<div className="text-xs text-tertiary-foreground">
 							Toggle maintenance modes and feature gates globally.
 						</div>
@@ -101,7 +107,9 @@ export function EdgeConfigTab() {
 
 				<div className="flex items-center justify-between p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
-						<div className="text-sm font-medium text-foreground">Request Blocking</div>
+						<div className="text-sm font-medium text-foreground">
+							Request Blocking
+						</div>
 						<div className="text-xs text-tertiary-foreground">
 							Block /v1 API requests org-wide or by endpoint pattern.
 						</div>
@@ -126,7 +134,9 @@ export function EdgeConfigTab() {
 
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
-						<div className="text-sm font-medium text-foreground">Customer Blocking</div>
+						<div className="text-sm font-medium text-foreground">
+							Customer Blocking
+						</div>
 						<div className="text-xs text-tertiary-foreground">
 							Block a specific org, environment, and customer combination after
 							customer ID resolution.
@@ -143,7 +153,9 @@ export function EdgeConfigTab() {
 
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
-						<div className="text-sm font-medium text-foreground">Org Limits</div>
+						<div className="text-sm font-medium text-foreground">
+							Org Limits
+						</div>
 						<div className="text-xs text-tertiary-foreground">
 							Per-org overrides for max customer products returned in queries
 							(default 15).
@@ -160,7 +172,9 @@ export function EdgeConfigTab() {
 
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
-						<div className="text-sm font-medium text-foreground">Job Queues</div>
+						<div className="text-sm font-medium text-foreground">
+							Job Queues
+						</div>
 						<div className="text-xs text-tertiary-foreground">
 							Pause or resume worker consumption for shared and dedicated SQS
 							queues.
@@ -177,7 +191,9 @@ export function EdgeConfigTab() {
 
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
-						<div className="text-sm font-medium text-foreground">Stripe Sync</div>
+						<div className="text-sm font-medium text-foreground">
+							Stripe Sync
+						</div>
 						<div className="text-xs text-tertiary-foreground">
 							Enable Stripe webhook event syncing to the sync DB per org.
 						</div>
@@ -193,7 +209,9 @@ export function EdgeConfigTab() {
 
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
-						<div className="text-sm font-medium text-foreground">V2 Redis Instance</div>
+						<div className="text-sm font-medium text-foreground">
+							V2 Redis Instance
+						</div>
 						<div className="text-xs text-tertiary-foreground">
 							Switch the active V2 Redis between upstash, redis, and dragonfly
 							at runtime.
@@ -203,6 +221,25 @@ export function EdgeConfigTab() {
 						variant="primary"
 						size="sm"
 						onClick={() => setRedisV2CacheOpen(true)}
+					>
+						Edit
+					</Button>
+				</div>
+
+				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
+					<div className="flex flex-col gap-0.5">
+						<div className="text-sm font-medium text-foreground">
+							Miscellaneous
+						</div>
+						<div className="text-xs text-tertiary-foreground">
+							Catch-all rollout switches. Includes the new flat customer-model
+							allowlist for the faster set-based getFull query.
+						</div>
+					</div>
+					<Button
+						variant="primary"
+						size="sm"
+						onClick={() => setMiscellaneousOpen(true)}
 					>
 						Edit
 					</Button>
@@ -234,10 +271,7 @@ export function EdgeConfigTab() {
 
 			<OrgLimitsDialog open={orgLimitsOpen} onOpenChange={setOrgLimitsOpen} />
 
-			<JobQueuesDialog
-				open={jobQueuesOpen}
-				onOpenChange={setJobQueuesOpen}
-			/>
+			<JobQueuesDialog open={jobQueuesOpen} onOpenChange={setJobQueuesOpen} />
 
 			<StripeSyncDialog
 				open={stripeSyncOpen}
@@ -247,6 +281,11 @@ export function EdgeConfigTab() {
 			<RedisV2CacheDialog
 				open={redisV2CacheOpen}
 				onOpenChange={setRedisV2CacheOpen}
+			/>
+
+			<MiscellaneousEdgeConfigDialog
+				open={miscellaneousOpen}
+				onOpenChange={setMiscellaneousOpen}
 			/>
 		</div>
 	);

--- a/vite/src/views/admin/components/MiscellaneousEdgeConfigDialog.tsx
+++ b/vite/src/views/admin/components/MiscellaneousEdgeConfigDialog.tsx
@@ -1,0 +1,335 @@
+import Editor from "@monaco-editor/react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/v2/badges/Badge";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+
+type MiscellaneousEdgeConfig = {
+	newFlatCusModel: string[];
+	configHealthy: boolean;
+	configConfigured: boolean;
+	lastSuccessAt: string | null;
+	error: string | null;
+};
+
+const DEFAULT_CONFIG: MiscellaneousEdgeConfig = {
+	newFlatCusModel: [],
+	configHealthy: false,
+	configConfigured: false,
+	lastSuccessAt: null,
+	error: null,
+};
+
+export function MiscellaneousEdgeConfigDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const [loading, setLoading] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [config, setConfig] = useState<MiscellaneousEdgeConfig>(DEFAULT_CONFIG);
+	const [jsonText, setJsonText] = useState("");
+	const [jsonError, setJsonError] = useState<string | null>(null);
+	const [syncSource, setSyncSource] = useState<"form" | "json">("form");
+
+	const [newEntry, setNewEntry] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+
+		let cancelled = false;
+		setLoading(true);
+
+		void axiosInstance
+			.get<MiscellaneousEdgeConfig>("/admin/miscellaneous-edge-config")
+			.then(({ data }) => {
+				if (cancelled) return;
+				const merged: MiscellaneousEdgeConfig = {
+					...DEFAULT_CONFIG,
+					...data,
+					newFlatCusModel: data.newFlatCusModel ?? [],
+				};
+				setConfig(merged);
+				const {
+					configHealthy: _h,
+					configConfigured: _c,
+					lastSuccessAt: _l,
+					error: _e,
+					...flagsOnly
+				} = merged;
+				setJsonText(JSON.stringify(flagsOnly, null, 2));
+				setSyncSource("form");
+			})
+			.catch((error) => {
+				if (!cancelled)
+					toast.error(
+						getBackendErr(error, "Failed to load miscellaneous edge config"),
+					);
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [axiosInstance, open]);
+
+	useEffect(() => {
+		if (syncSource !== "form") return;
+		const {
+			configHealthy: _h,
+			configConfigured: _c,
+			lastSuccessAt: _l,
+			error: _e,
+			...flagsOnly
+		} = config;
+		setJsonText(JSON.stringify(flagsOnly, null, 2));
+		setJsonError(null);
+	}, [config, syncSource]);
+
+	const handleJsonChange = (value: string | undefined) => {
+		const text = value ?? "";
+		setJsonText(text);
+		setSyncSource("json");
+		try {
+			const parsed = JSON.parse(text) as Partial<MiscellaneousEdgeConfig>;
+			setConfig((prev) => ({
+				...prev,
+				newFlatCusModel: parsed.newFlatCusModel ?? prev.newFlatCusModel,
+			}));
+			setJsonError(null);
+		} catch {
+			setJsonError("Invalid JSON");
+		}
+	};
+
+	const handleSave = async () => {
+		if (jsonError) {
+			toast.error("Fix JSON errors before saving");
+			return;
+		}
+
+		let payload: unknown;
+		try {
+			payload = JSON.parse(jsonText);
+		} catch {
+			toast.error("Invalid JSON");
+			return;
+		}
+
+		setSaving(true);
+		try {
+			await axiosInstance.put("/admin/miscellaneous-edge-config", payload);
+			toast.success("Miscellaneous edge config saved");
+			onOpenChange(false);
+		} catch (error) {
+			toast.error(
+				getBackendErr(error, "Failed to save miscellaneous edge config"),
+			);
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const addEntry = () => {
+		const entry = newEntry.trim();
+		if (!entry) return;
+		if (config.newFlatCusModel.includes(entry)) {
+			toast.error("Entry already exists");
+			return;
+		}
+
+		setSyncSource("form");
+		setConfig((prev) => ({
+			...prev,
+			newFlatCusModel: [...prev.newFlatCusModel, entry],
+		}));
+		setNewEntry("");
+	};
+
+	const removeEntry = (entry: string) => {
+		setSyncSource("form");
+		setConfig((prev) => ({
+			...prev,
+			newFlatCusModel: prev.newFlatCusModel.filter((e) => e !== entry),
+		}));
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-4xl bg-card">
+				<DialogHeader>
+					<DialogTitle>Miscellaneous Edge Config</DialogTitle>
+					<DialogDescription>
+						Catch-all config for one-off rollout switches. Changes propagate to
+						all servers within 30 seconds.
+					</DialogDescription>
+				</DialogHeader>
+
+				{loading ? (
+					<div className="py-8 text-sm text-tertiary-foreground text-center">
+						Loading...
+					</div>
+				) : (
+					<div className="grid grid-cols-[300px_1fr] gap-6">
+						<div className="flex flex-col gap-4">
+							<div className="text-xs font-medium text-tertiary-foreground uppercase tracking-wide">
+								New Flat Cus Model
+							</div>
+							<div className="text-[11px] text-tertiary-foreground -mt-2">
+								Allowlist of{" "}
+								<span className="font-mono">orgId:env:customerId</span> keys
+								that opt into the new set-based{" "}
+								<span className="font-mono">getFull</span> query path.
+							</div>
+							<div className="rounded-lg border border-border p-3 flex flex-col gap-2">
+								{config.newFlatCusModel.length === 0 && (
+									<div className="text-xs text-tertiary-foreground italic">
+										No entries
+									</div>
+								)}
+								{config.newFlatCusModel.map((entry) => (
+									<div
+										key={entry}
+										className="flex items-center justify-between gap-2"
+									>
+										<div className="min-w-0 flex-1">
+											<div className="text-xs font-mono text-foreground truncate">
+												{entry}
+											</div>
+										</div>
+										<button
+											type="button"
+											onClick={() => removeEntry(entry)}
+											className="shrink-0 text-tertiary-foreground hover:text-red-500 transition-colors"
+										>
+											<svg
+												width="14"
+												height="14"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="currentColor"
+												strokeWidth="2"
+												role="img"
+												aria-label="Remove entry"
+											>
+												<title>Remove entry</title>
+												<path d="M18 6L6 18M6 6l12 12" />
+											</svg>
+										</button>
+									</div>
+								))}
+								<div className="flex flex-col gap-2 pt-2 border-t border-border">
+									<input
+										type="text"
+										placeholder="orgId:env:customerId"
+										value={newEntry}
+										onChange={(e) => setNewEntry(e.target.value)}
+										onKeyDown={(e) => {
+											if (e.key === "Enter") {
+												e.preventDefault();
+												addEntry();
+											}
+										}}
+										className="w-full px-2 py-1 text-xs rounded border border-border bg-input text-foreground placeholder:text-tertiary-foreground focus:outline-none focus:ring-1 focus:ring-ring font-mono"
+									/>
+									<Button
+										variant="secondary"
+										size="sm"
+										onClick={addEntry}
+										disabled={!newEntry.trim()}
+									>
+										Add
+									</Button>
+								</div>
+							</div>
+
+							<div className="rounded-lg border border-border p-3 text-xs text-tertiary-foreground">
+								<div className="mb-2 flex items-center gap-2">
+									<Badge
+										variant="muted"
+										className={
+											config.configHealthy
+												? "bg-emerald-50 text-emerald-700 border-emerald-200"
+												: "bg-amber-50 text-amber-700 border-amber-200"
+										}
+									>
+										{config.configHealthy
+											? "Config healthy"
+											: "Config unavailable"}
+									</Badge>
+									{config.lastSuccessAt && (
+										<span>
+											Last refresh:{" "}
+											{new Date(config.lastSuccessAt).toLocaleString()}
+										</span>
+									)}
+								</div>
+								<div>
+									{config.configConfigured === false
+										? "S3 miscellaneous edge config is not configured."
+										: config.error || "Config updates within 30s of saving."}
+								</div>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-2">
+							<div className="text-xs font-medium text-tertiary-foreground uppercase tracking-wide">
+								Raw JSON
+							</div>
+							<div className="rounded-md border border-border overflow-hidden h-[300px]">
+								<Editor
+									height="100%"
+									language="json"
+									value={jsonText}
+									onChange={handleJsonChange}
+									options={{
+										minimap: { enabled: false },
+										scrollBeyondLastLine: false,
+										fontSize: 13,
+										tabSize: 2,
+										wordWrap: "on",
+										formatOnPaste: true,
+										formatOnType: true,
+									}}
+									theme="vs-dark"
+								/>
+							</div>
+							{jsonError && (
+								<div className="text-xs text-red-500">{jsonError}</div>
+							)}
+						</div>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button variant="secondary" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						onClick={handleSave}
+						isLoading={saving}
+						disabled={loading || !!jsonError}
+					>
+						Save
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
Adds miscellaneousEdgeConfig store with newFlatCusModel allowlist. When
orgId:env:customerId matches, CusService.getFull routes through the
set-based getCursorPaginatedFullCusQuery instead of the legacy LATERAL
query. Benchmarks show ~44x speedup (891ms to 20ms) for high-cardinality
customers. Includes admin GET/PUT routes and a Miscellaneous tab dialog
in the admin UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes customer getFull to the flat, cursor-based query for allowlisted customers via a new edge config, delivering ~44x faster reads on high-cardinality customers. Falls back to the legacy path when trials, events, or entity filters are requested.

- New Features
  - Add `miscellaneousEdgeConfig` store with `newFlatCusModel` allowlist (`orgId:env:customerId`).
  - Route `CusService.getFull` to `getCursorPaginatedFullCusQuery` when allowlisted and no `withTrialsUsed`, `withEvents`, or `entityId` flags; otherwise use legacy. Reassemble flat rows to `FullCustomer`.
  - Expose admin GET/PUT `/admin/miscellaneous-edge-config` (Superuser) and persist at `admin/miscellaneous-edge-config.json`.
  - Add “Miscellaneous” admin UI dialog to edit the allowlist and view config health.
  - Update cursor query to accept `customerId` filtering and fetch a single record; log query path and SQL latency.
  - Extend scope tests to cover the new routes.

<sup>Written for commit 765c3193c7d55eec0533add67e9a654f2f0a0981. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1626?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a feature-flagged fast path for `CusService.getFull`: when an `orgId:env:customerId` key is present in a new `newFlatCusModel` allowlist (stored in S3 and surfaced via an admin UI dialog), the legacy `LATERAL`-based query is replaced by the existing set-based `getCursorPaginatedFullCusQuery`. The switch is controlled at runtime with no deploy needed and includes superuser-only admin GET/PUT endpoints for managing the allowlist.

- **[Improvements]** Routes `getFull` through the faster cursor-paginated set-based query for allowlisted customers, with a claimed ~44× speedup for high-cardinality customers (891 ms → 20 ms).
- **[API changes]** Adds `GET /admin/miscellaneous-edge-config` and `PUT /admin/miscellaneous-edge-config` superuser endpoints plus a new "Miscellaneous" tab in the admin edge-config UI.
- **[Improvements]** Logs the query path (`flat` vs `legacy`) and SQL latency on every `getFull` call for observability.
</details>


<h3>Confidence Score: 3/5</h3>

The routing logic is sound and the allowlist gives fine-grained control, but the flat path silently caps invoice results at 10 while the legacy path returns all invoices — a meaningful behavioral difference for any allowlisted customer with a larger invoice history.

The invoice truncation in the flat path is the main concern: invoicesLimit: 10 is hardcoded in the getCursorPaginatedFullCusQuery call inside getFull, whereas buildInvoicesCTE in the legacy path has no LIMIT and returns the full invoice set. Customers on the new path who call GET /customers/:id?expand=invoices and have more than 10 invoices will receive silently incomplete data. The rest of the plumbing — admin routes, schema validation, scope decisions, UI dialog — is clean and consistent with how other edge configs are handled in the repo.

server/src/internal/customers/CusService.ts — specifically the hardcoded invoicesLimit in the flat-model branch

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/CusService.ts | Adds flat-model branch to getFull; hardcodes invoicesLimit to 10 while the legacy path returns all invoices, silently truncating data for allowlisted customers |
| server/src/internal/customers/cursorPaginatedFullCusQuery.ts | Adds optional customerId filter that bypasses cursor/list filters; SQL logic is correct for single-customer lookups |
| server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts | New edge config store for the newFlatCusModel allowlist; uses Array.includes() O(n) for membership checks which may become a concern at scale |
| server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts | New Zod schema for MiscellaneousEdgeConfig; straightforward and correct |
| server/src/internal/admin/handleGetAdminMiscellaneousEdgeConfig.ts | New admin GET handler for the miscellaneous edge config; superuser-scoped, clean implementation |
| server/src/internal/admin/handleUpsertAdminMiscellaneousEdgeConfig.ts | New admin PUT handler; validates body against schema before writing to S3, superuser-scoped |
| vite/src/views/admin/components/MiscellaneousEdgeConfigDialog.tsx | New admin dialog for the allowlist; dual form/JSON editor with cancellation safety, looks correct |
| vite/src/views/admin/components/EdgeConfigTab.tsx | Adds Miscellaneous section to the EdgeConfigTab and wires up the new dialog; reformatting only for other sections |
| server/src/internal/admin/adminRouter.ts | Registers the two new miscellaneous-edge-config routes; import reordering only, no logic change |
| server/src/external/aws/s3/adminS3Config.ts | Adds new S3 key constant and edge config source entry for the miscellaneous config |
| server/tests/integration/scopes/scope-403.test.ts | Adds scope decisions for both new routes; correctly requires superuser for both GET and PUT |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CusService.getFull(idOrInternalId)"] --> B["isOnNewFlatCusModel\n(orgId:env:customerId)"]
    B -->|"key in newFlatCusModel\narray (S3 edge config)"| C["getCursorPaginatedFullCusQuery\n(set-based, invoicesLimit=10)"]
    B -->|"key NOT in allowlist"| D["getFullCusQuery\n(legacy LATERAL, all invoices)"]
    C --> E["executeWithHealthTracking"]
    D --> E
    E --> F{useFlatModel?}
    F -->|yes| G["reassembleFlattenedCustomer\n(flat row → FullCustomer[])"]
    F -->|no| H["result[0] → FullCustomer\n(normalize created_at, fix arrays)"]
    G --> I["Return FullCustomer"]
    H --> I

    style C fill:#d4edda,stroke:#28a745
    style D fill:#fff3cd,stroke:#ffc107
    style G fill:#d4edda,stroke:#28a745
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts`, line 389-391 ([link](https://github.com/useautumn/autumn/blob/c0152d859ca03c3963c9d5d946fc7ea6d8d1eb6c/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts#L389-L391)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **O(n) allowlist lookup on every `getFull` call**

   `config.newFlatCusModel.includes(key)` performs a linear scan of the entire allowlist array on every `getFull` invocation. Because the config is polled from S3 on a ~30 s interval and rebuilt from scratch each time, there is no persistent `Set` — the array is searched fresh for every request. Once this allowlist grows beyond a trivial size, or when `getFull` is called in tight loops (e.g. batch migrations), this accumulates into measurable overhead. Converting `newFlatCusModel` to a `Set<string>` at read time (once, inside `store.get()` or as a derived cache) would give O(1) membership checks.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
   Line: 389-391

   Comment:
   **O(n) allowlist lookup on every `getFull` call**

   `config.newFlatCusModel.includes(key)` performs a linear scan of the entire allowlist array on every `getFull` invocation. Because the config is polled from S3 on a ~30 s interval and rebuilt from scratch each time, there is no persistent `Set` — the array is searched fresh for every request. Once this allowlist grows beyond a trivial size, or when `getFull` is called in tight loops (e.g. batch migrations), this accumulates into measurable overhead. Converting `newFlatCusModel` to a `Set<string>` at read time (once, inside `store.get()` or as a derived cache) would give O(1) membership checks.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/customers/CusService.ts:125
**Hardcoded `invoicesLimit: 10` truncates invoice data**

The flat model path hard-caps invoice results at 10, but the legacy `getFullCusQuery` path returns **all** invoices (no `LIMIT` in `buildInvoicesCTE`). Any customer on the `newFlatCusModel` allowlist who requests `expand=invoices` and has more than 10 invoices will silently receive truncated data — the same response shape but fewer rows than the legacy path would return.

### Issue 2 of 2
server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts:389-391
**O(n) allowlist lookup on every `getFull` call**

`config.newFlatCusModel.includes(key)` performs a linear scan of the entire allowlist array on every `getFull` invocation. Because the config is polled from S3 on a ~30 s interval and rebuilt from scratch each time, there is no persistent `Set` — the array is searched fresh for every request. Once this allowlist grows beyond a trivial size, or when `getFull` is called in tight loops (e.g. batch migrations), this accumulates into measurable overhead. Converting `newFlatCusModel` to a `Set<string>` at read time (once, inside `store.get()` or as a derived cache) would give O(1) membership checks.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(customers): 🎸 route getFull throug..."](https://github.com/useautumn/autumn/commit/c0152d859ca03c3963c9d5d946fc7ea6d8d1eb6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32844634)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->