### PR TITLE
fix: noop plan patch

### DIFF
--- a/server/src/internal/billing/v2/setup/patch/handleCustomizeNoopItems.ts
+++ b/server/src/internal/billing/v2/setup/patch/handleCustomizeNoopItems.ts
@@ -1,0 +1,56 @@
+import {
+	type CreatePlanItemParamsV1,
+	type CustomizePlanV1,
+	type Feature,
+	findCustomerEntitlementByFeature,
+	findFeatureById,
+	type FullCusProduct,
+	isBooleanFeature,
+} from "@autumn/shared";
+
+const isNoopAddItem = ({
+	item,
+	targetCustomerProduct,
+	features,
+}: {
+	item: CreatePlanItemParamsV1;
+	targetCustomerProduct: FullCusProduct;
+	features: Feature[];
+}): boolean => {
+	const feature = findFeatureById({
+		features,
+		featureId: item.feature_id,
+	});
+
+	if (!feature || !isBooleanFeature({ feature })) return false;
+
+	return Boolean(
+		findCustomerEntitlementByFeature({
+			cusEnts: targetCustomerProduct.customer_entitlements,
+			feature,
+		}),
+	);
+};
+
+export const handleCustomizeNoopItems = ({
+	customize,
+	targetCustomerProduct,
+	features,
+}: {
+	customize: CustomizePlanV1;
+	targetCustomerProduct: FullCusProduct;
+	features: Feature[];
+}): {
+	addItems: CreatePlanItemParamsV1[];
+} => {
+	const addItems = (customize.add_items ?? []).filter(
+		(item) =>
+			!isNoopAddItem({
+				item,
+				targetCustomerProduct,
+				features,
+			}),
+	);
+
+	return { addItems };
+};

--- a/server/src/internal/billing/v2/setup/patch/index.ts
+++ b/server/src/internal/billing/v2/setup/patch/index.ts
@@ -1,4 +1,5 @@
 export * from "./handleCustomizeAddItems";
 export * from "./handleCustomizeDeleteItems";
+export * from "./handleCustomizeNoopItems";
 export * from "./setupPatchContext";
 export * from "./types";

--- a/server/src/internal/billing/v2/setup/patch/setupPatchContext.ts
+++ b/server/src/internal/billing/v2/setup/patch/setupPatchContext.ts
@@ -12,6 +12,7 @@ import { duplicateCustomerProduct } from "@/internal/billing/v2/utils/initFullCu
 import { generateId } from "@/utils/genUtils";
 import { handleCustomizeAddItems } from "./handleCustomizeAddItems";
 import { handleCustomizeDeleteItems } from "./handleCustomizeDeleteItems";
+import { handleCustomizeNoopItems } from "./handleCustomizeNoopItems";
 import { handleCustomizePrice } from "./handleCustomizePrice";
 import type { ReusePricesAndEntitlements } from "./types";
 
@@ -137,10 +138,16 @@ export const setupPatchContext = ({
 		reusePricesAndEntitlements,
 	});
 
+	const { addItems: nonNoopAddItems } = handleCustomizeNoopItems({
+		customize: params.customize,
+		targetCustomerProduct: finalCustomerProduct,
+		features: ctx.features,
+	});
+
 	const { prices: customItemPrices, entitlements: customEntitlements } =
 		handleCustomizeAddItems({
 			ctx,
-			customize: params.customize,
+			customize: { ...params.customize, add_items: nonNoopAddItems },
 			fullProduct: patchFullProduct,
 			reusePricesAndEntitlements,
 		});

--- a/server/tests/integration/billing/update-subscription/custom-plan-patch/patch-update-items-noop-boolean.test.ts
+++ b/server/tests/integration/billing/update-subscription/custom-plan-patch/patch-update-items-noop-boolean.test.ts
@@ -1,0 +1,175 @@
+/**
+ * TDD coverage for the boolean-feature noop path in patch-style add_items.
+ *
+ * Contract under test:
+ *   Behavior:
+ *     - customize.add_items containing a boolean feature_id whose target customer
+ *       product ALREADY has a customer_entitlement for that feature is a noop —
+ *       no second customer_entitlement row is inserted.
+ *   Side effects:
+ *     - cus_product retains exactly 1 customer_entitlement for that feature.
+ *     - flags[feature_id] still present and still tied to the same plan_id.
+ *     - update call succeeds; preview total = 0 for a pure noop.
+ *   Negative control:
+ *     - Adding a boolean feature NOT already on the cus_product creates exactly
+ *       1 customer_entitlement (normal add path is unaffected by the filter).
+ *
+ * Pre-impl red: without handleCustomizeNoopItems, handleCustomizeAddItems builds
+ * a fresh Entitlement for the boolean feature; applyCustomerProductItemsPatch
+ * appends it alongside the existing one, leaving 2 cusEnts for the same feature.
+ * Post-impl green: the noop filter drops the duplicate add_item before it reaches
+ * the add-items handler, so the cusEnt count stays at 1.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	customers,
+	CusProductStatus,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+
+const countDashboardCusEnts = async ({
+	ctx,
+	customerId,
+	productId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	productId: string;
+}): Promise<number> => {
+	const dbCustomer = await ctx.db.query.customers.findFirst({
+		where: eq(customers.id, customerId),
+	});
+	expect(dbCustomer).toBeDefined();
+
+	const cusProducts = await CusProductService.list({
+		db: ctx.db,
+		internalCustomerId: dbCustomer!.internal_id,
+		inStatuses: [CusProductStatus.Active, CusProductStatus.PastDue],
+	});
+
+	const cusProduct = cusProducts.find(
+		(cp) => cp.product?.id === productId && cp.status === CusProductStatus.Active,
+	);
+	expect(cusProduct).toBeDefined();
+
+	return cusProduct!.customer_entitlements.filter(
+		(cusEnt) => cusEnt.entitlement.feature_id === TestFeature.Dashboard,
+	).length;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("patch noop boolean: re-adding existing boolean alongside a real add does not duplicate")}`,
+	async () => {
+		const customerId = "patch-noop-boolean-existing";
+		const pro = products.pro({ items: [items.dashboard()] });
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		// ── Sanity: start with exactly 1 Dashboard cusEnt ──────────────
+		expect(
+			await countDashboardCusEnts({ ctx, customerId, productId: pro.id }),
+		).toBe(1);
+
+		const updateParams: UpdateSubscriptionV1ParamsInput = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: {
+				add_items: [
+					itemsV2.dashboard(),
+					itemsV2.monthlyWords({ included: 150 }),
+				],
+			},
+		};
+
+		// ── Contract: update succeeds (noop dashboard + real words add) ─
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>(
+			updateParams,
+		);
+
+		// ── Contract: flag still present, tied to pro ──────────────────
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [pro.id] });
+		expectFlagCorrect({
+			customer,
+			featureId: TestFeature.Dashboard,
+			planId: pro.id,
+		});
+
+		// ── Contract: noop produced no duplicate cusEnt row ────────────
+		// Pre-fix: this would be 2 (handleCustomizeAddItems built a fresh
+		//   Entitlement for Dashboard; applyCustomerProductItemsPatch tacked
+		//   it on alongside the existing one).
+		// Post-fix: handleCustomizeNoopItems drops the duplicate add_item
+		//   before it reaches the add handler.
+		expect(
+			await countDashboardCusEnts({ ctx, customerId, productId: pro.id }),
+		).toBe(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("patch noop boolean: adding a new boolean feature still inserts exactly once")}`,
+	async () => {
+		const customerId = "patch-noop-boolean-new";
+		const pro = products.pro({ items: [] });
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		// ── Sanity: start with 0 Dashboard cusEnts ─────────────────────
+		expect(
+			await countDashboardCusEnts({ ctx, customerId, productId: pro.id }),
+		).toBe(0);
+
+		const updateParams: UpdateSubscriptionV1ParamsInput = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: {
+				add_items: [itemsV2.dashboard()],
+			},
+		};
+
+		await autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>(
+			updateParams,
+		);
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [pro.id] });
+		expectFlagCorrect({
+			customer,
+			featureId: TestFeature.Dashboard,
+			planId: pro.id,
+		});
+
+		// ── Contract: filter must not block legitimate adds ────────────
+		expect(
+			await countDashboardCusEnts({ ctx, customerId, productId: pro.id }),
+		).toBe(1);
+	},
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Treat re-adding an existing boolean feature in `customize.add_items` as a no-op to prevent duplicate `customer_entitlements`. This fixes duplicate boolean entitlements during plan patch updates and keeps flags stable.

- **Bug Fixes**
  - Added `handleCustomizeNoopItems` to filter boolean `add_items` already entitled on the target customer product (uses `findFeatureById`, `isBooleanFeature`, `findCustomerEntitlementByFeature` from `@autumn/shared`).
  - Integrated the filter in `setupPatchContext` before `handleCustomizeAddItems`, ensuring only real additions are processed.
  - Added integration tests to verify no duplicates on re-add and that legitimate boolean adds still insert exactly once.

<sup>Written for commit 6eb2197a2ecc1994d5b7f3832449f35cfe52dc4b. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1628?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where re-submitting a boolean feature that is already attached to a customer product via `customize.add_items` would create a duplicate `customer_entitlement` row instead of being treated as a no-op.

- **[Bug fixes]** Adds `handleCustomizeNoopItems`, which filters out `add_items` entries for boolean features that already have a corresponding `customer_entitlement` on the target customer product before they reach `handleCustomizeAddItems`.
- **[Improvements]** Integrates the noop filter into `setupPatchContext` between the delete-items pass and the add-items pass, so same-request delete-then-re-add of a boolean feature is still correctly handled (delete removes the entitlement first, so the re-add is not mistaken for a noop).
- **[Improvements]** Adds integration tests covering the duplicate-prevention contract and a negative control verifying that adding a genuinely new boolean feature still inserts exactly one entitlement.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small, well-tested, and the mutation ordering in setupPatchContext ensures delete-then-re-add of the same boolean feature still works correctly.

The noop filter is narrow (boolean features only), the integration point in setupPatchContext is positioned correctly after the delete pass and before the add pass, and the two integration tests cover both the duplicate-prevention contract and the legitimate new-add path. No existing paths are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/setup/patch/handleCustomizeNoopItems.ts | New file implementing the noop filter for boolean add_items — logic is correct and well-scoped. |
| server/src/internal/billing/v2/setup/patch/setupPatchContext.ts | Inserts the noop filter between delete-items and add-items passes; ordering is correct since deleteCustomerProductItems mutates finalCustomerProduct before the noop check runs. |
| server/src/internal/billing/v2/setup/patch/index.ts | Adds the new export — trivial barrel change. |
| server/tests/integration/billing/update-subscription/custom-plan-patch/patch-update-items-noop-boolean.test.ts | Well-structured integration tests with positive and negative controls; covers the pre-fix duplicate scenario and the unaffected new-add path. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[setupPatchContext called] --> B[Create finalCustomerProduct\nclone or duplicate]
    B --> C[handleCustomizeDeleteItems\nmutates finalCustomerProduct,\nremoving deleted entitlements]
    C --> D[cusProductToProduct\nderive patchFullProduct]
    D --> E[handleCustomizePrice\napply price overrides]
    E --> F[handleCustomizeNoopItems\nfilter add_items]
    F --> G{Is item a boolean feature\nalready in finalCustomerProduct\ncustomer_entitlements?}
    G -->|Yes — noop| H[Drop the add_item]
    G -->|No| I[Keep the add_item]
    H --> J[nonNoopAddItems]
    I --> J
    J --> K[handleCustomizeAddItems\nbuilds new prices and entitlements\nfor remaining items only]
    K --> L[Return PatchContext]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["no op a plan patch"](https://github.com/useautumn/autumn/commit/6eb2197a2ecc1994d5b7f3832449f35cfe52dc4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32850495)</sub>

<!-- /greptile_comment -->