### PR TITLE
Charlie/fix custom items delete

### DIFF
--- a/vite/src/components/forms/shared/plan-items/CollapsedBooleanItems.tsx
+++ b/vite/src/components/forms/shared/plan-items/CollapsedBooleanItems.tsx
@@ -7,6 +7,7 @@ import {
 	AccordionTrigger,
 } from "@/components/ui/accordion";
 import { LAYOUT_TRANSITION } from "@/components/v2/sheets/SharedSheetComponents";
+import { getItemId } from "@/utils/product/productItemUtils";
 import { motion } from "motion/react";
 
 interface CollapsedBooleanItemsProps {
@@ -41,15 +42,15 @@ export function CollapsedBooleanItems({
 				</AccordionTrigger>
 				<AccordionContent className="pb-1.5 pt-1.5 px-0">
 					<div className="flex flex-col gap-1.5">
-						{items.map((item, index) => (
-							<motion.div
-								key={item.feature_id ?? index}
-								layout="position"
-								transition={{ layout: LAYOUT_TRANSITION }}
-							>
-								{renderItem(item, index)}
-							</motion.div>
-						))}
+					{items.map((item, index) => (
+						<motion.div
+							key={getItemId({ item, itemIndex: index })}
+							layout="position"
+							transition={{ layout: LAYOUT_TRANSITION }}
+						>
+							{renderItem(item, index)}
+						</motion.div>
+					))}
 					</div>
 				</AccordionContent>
 			</AccordionItem>

--- a/vite/src/utils/product/productItemUtils.ts
+++ b/vite/src/utils/product/productItemUtils.ts
@@ -107,13 +107,13 @@ export const getItemId = ({
 	item: ProductItem;
 	itemIndex: number;
 }) => {
+	if (item.entitlement_id) return `ent-${item.entitlement_id}`;
+	if (item.price_id) return `price-${item.price_id}`;
 	if (item.feature_id) {
 		return item.entity_feature_id
 			? `feature-${item.feature_id}-${item.entity_feature_id}`
 			: `feature-${item.feature_id}`;
 	}
-	if (item.entitlement_id) return `ent-${item.entitlement_id}`;
-	if (item.price_id) return `price-${item.price_id}`;
 	return `item-${itemIndex}`;
 };
 

--- a/vite/src/utils/product/productItemUtils.ts
+++ b/vite/src/utils/product/productItemUtils.ts
@@ -107,7 +107,13 @@ export const getItemId = ({
 	item: ProductItem;
 	itemIndex: number;
 }) => {
-	// || item.entitlement_id || item.price_id;
+	if (item.feature_id) {
+		return item.entity_feature_id
+			? `feature-${item.feature_id}-${item.entity_feature_id}`
+			: `feature-${item.feature_id}`;
+	}
+	if (item.entitlement_id) return `ent-${item.entitlement_id}`;
+	if (item.price_id) return `price-${item.price_id}`;
 	return `item-${itemIndex}`;
 };
 

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureList.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureList.tsx
@@ -96,7 +96,7 @@ export const PlanFeatureList = ({
 		const itemIndex = product.items?.indexOf(item) ?? -1;
 		return (
 			<PlanFeatureRow
-				key={item.entitlement_id || item.price_id || itemIndex}
+				key={getItemId({ item, itemIndex })}
 				item={item}
 				index={itemIndex}
 				onDelete={handleDelete}

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -34,7 +34,7 @@ interface PlanFeatureRowProps {
 
 export const PlanFeatureRow = ({
 	item: itemProp,
-	onDelete: _onDelete,
+	onDelete,
 	index,
 	readOnly = false,
 	prepaidQuantity,
@@ -42,7 +42,7 @@ export const PlanFeatureRow = ({
 	const { org } = useOrg();
 	const { features } = useFeaturesQuery();
 	const { setItem } = useProductItemContext();
-	const { product, setProduct } = useProduct();
+	const { product } = useProduct();
 	const { itemId, setSheet } = useSheet();
 	const isOnboarding = useOnboardingStore((s) => s.isOnboarding);
 	const playgroundMode = useOnboardingStore((s) => s.playgroundMode);
@@ -92,12 +92,8 @@ export const PlanFeatureRow = ({
 	};
 
 	const handleDeleteRow = () => {
-		const newItems = product.items?.filter((i) => i !== item) || [];
-
-		setProduct({ ...product, items: newItems });
-
-		if (isSelected) {
-			setSheet({ type: "edit-plan" });
+		if (onDelete) {
+			onDelete(item);
 		}
 	};
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes deletion of custom plan items by using stable item IDs for React keys and routing deletes through the parent. Prevents ghost rows and keeps selection state in sync in the plan editor.

- **Bug Fixes**
  - Added `getItemId` to build stable IDs from `feature_id` (+ `entity_feature_id`), `entitlement_id`, or `price_id`, with index fallback.
  - Switched list keys in `CollapsedBooleanItems` and `PlanFeatureList` to use `getItemId`.
  - `PlanFeatureRow` now delegates delete via `onDelete` instead of mutating product state directly.

<sup>Written for commit 5ee6eeb3a5fc799b0548698c9465a2982a164322. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1629?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes deletion of custom plan items by lifting the delete logic from `PlanFeatureRow` up to `PlanFeatureList`, and simultaneously implements stable React key generation via the now-complete `getItemId` utility.

- **Bug fixes** — `PlanFeatureRow.handleDeleteRow` previously called `setProduct` directly with its own filtered list; this was fragile because the component owned the item reference but not the full list context. The fix delegates to the `onDelete` callback already wired through props, so `PlanFeatureList` performs the single authoritative `filter` + `setSheet` reset.
- **Improvements** — `getItemId` now returns a deterministic, stable key (`ent-*`, `price-*`, `feature-*[-entity]`) instead of always falling back to `item-${index}`, making React reconciliation more reliable across list mutations.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused refactor of delete ownership and key generation with no new state management complexity.

The deletion path is now cleanly owned by PlanFeatureList, which holds the product state. productV2ToFeatureItems/sortPlanItems preserve object references (Array.filter/sort), so the reference-equality filter in handleDelete works correctly. getItemId's priority order (entitlement_id → price_id → feature_id → index) is sensible and consistent with how items are identified elsewhere in the codebase.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/utils/product/productItemUtils.ts | Implements stable React key generation in getItemId, prioritizing entitlement_id > price_id > feature_id (+entity) > index fallback. |
| vite/src/views/products/plan/components/plan-card/PlanFeatureList.tsx | Lifts delete logic from PlanFeatureRow into PlanFeatureList.handleDelete; updates key prop to use getItemId for consistent key generation. |
| vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx | Removes inline delete logic (setProduct call + sheet reset); delegates delete to onDelete callback passed from PlanFeatureList. |
| vite/src/components/forms/shared/plan-items/CollapsedBooleanItems.tsx | Replaces feature_id ?? index key with getItemId for consistency; minor indentation adjustment with no behavioural impact. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant PlanFeatureRow
    participant PlanFeatureList
    participant ProductState

    User->>PlanFeatureRow: clicks trash icon
    PlanFeatureRow->>PlanFeatureRow: handleDeleteRow()
    PlanFeatureRow->>PlanFeatureList: onDelete(item)
    PlanFeatureList->>ProductState: "product.items.filter(i !== item)"
    PlanFeatureList->>ProductState: "setProduct({ ...product, items: newItems })"
    PlanFeatureList->>PlanFeatureList: "getItemId(item) === activeItemId?"
    alt selected item was deleted
        PlanFeatureList->>ProductState: "setSheet({ type: "edit-plan" })"
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix delete custom item issue"](https://github.com/useautumn/autumn/commit/5ee6eeb3a5fc799b0548698c9465a2982a164322) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32854617)</sub>

<!-- /greptile_comment -->