### PR TITLE
fix: shadow flags

### DIFF
--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -1,10 +1,10 @@
 import {
-	ApiVersionClass,
-	AppEnv,
-	AuthType,
-	LATEST_VERSION,
-	type Organization,
-	tryCatch,
+    ApiVersionClass,
+    AppEnv,
+    AuthType,
+    LATEST_VERSION,
+    type Organization,
+    tryCatch,
 } from "@autumn/shared";
 import type { Context, Next } from "hono";
 import { db, dbGeneral } from "@/db/initDrizzle.js";
@@ -114,7 +114,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 
 		// Query params
 		expand: [],
-		skipCache: c.req.header("x-skip-cache") === "true",
+		skipCache: c.req.header("x-skip-cache") === "true" || c.req.query("skip_cache") === "true",
 
 		// Test params:
 		extraLogs: {},

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
@@ -1,7 +1,7 @@
 import {
-	CustomerNotFoundError,
-	EntityNotFoundError,
-	type FullSubject,
+    CustomerNotFoundError,
+    EntityNotFoundError,
+    type FullSubject,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
@@ -24,6 +24,7 @@ export const getOrSetCachedFullSubject = async ({
 	const useRedis = !skipCache;
 
 	let fetchedSubjectViewEpoch = 0;
+
 
 	if (useRedis) {
 		// The pipeline inside getCachedFullSubject already fetches + refreshes

--- a/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
+++ b/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
@@ -3,6 +3,7 @@ import {
 	type AggregatedFeatureBalance,
 	type AggregatedSubjectFlag,
 	type Customer,
+	CusProductStatus,
 	type DbCustomerEntitlement,
 	type DbCustomerPrice,
 	type DbFreeTrial,
@@ -140,6 +141,24 @@ export const subjectQueryRowToNormalized = ({
 		);
 	};
 
+	// `flags` is keyed by feature_id (one slot per feature), but a customer
+	// can have multiple cus_ents for the same boolean — e.g. an active
+	// cus_product, a scheduled next-cycle cus_product, and loose extras
+	// from a prior plan. We prefer the most "currently effective" source so
+	// the API surfaces the right plan_id (and so a Scheduled flag doesn't
+	// land in `flags`, get routed to a Scheduled cus_product, and then be
+	// dropped downstream by orgToInStatuses).
+	const flagPriorityByFeatureId: Record<string, number> = {};
+	const getFlagPriority = (cusEnt: DbCustomerEntitlement): number => {
+		if (!cusEnt.customer_product_id) return 2;
+		const owningCusProduct = customerProductsById.get(
+			cusEnt.customer_product_id,
+		);
+		if (owningCusProduct?.status === CusProductStatus.Active) return 0;
+		if (owningCusProduct?.status === CusProductStatus.PastDue) return 1;
+		return 3;
+	};
+
 	const partitionCustomerEntitlement = (
 		customerEntitlement: DbCustomerEntitlement,
 	) => {
@@ -149,6 +168,13 @@ export const subjectQueryRowToNormalized = ({
 		if (!catalogEntitlement) return;
 
 		if (catalogEntitlement.feature.type === FeatureType.Boolean) {
+			const newPriority = getFlagPriority(customerEntitlement);
+			const existingPriority =
+				flagPriorityByFeatureId[catalogEntitlement.feature.id];
+			if (existingPriority !== undefined && existingPriority <= newPriority) {
+				return;
+			}
+			flagPriorityByFeatureId[catalogEntitlement.feature.id] = newPriority;
 			flags[catalogEntitlement.feature.id] = {
 				featureId: catalogEntitlement.feature.id,
 				internalFeatureId: customerEntitlement.internal_feature_id,

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -26,6 +26,8 @@ export const getApiEntityByRollout = async ({
 			source,
 		});
 
+		
+
 		return getApiEntityV2({
 			ctx,
 			fullSubject,

--- a/server/tests/integration/billing/attach/scheduled-switch/scheduled-switch-entity-boolean-flags.test.ts
+++ b/server/tests/integration/billing/attach/scheduled-switch/scheduled-switch-entity-boolean-flags.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Scheduled Switch Entity Boolean Flag Tests (Attach V2)
+ *
+ * Regression coverage for a bug where boolean flags from the active
+ * customer product disappeared from entities.get when:
+ *   - the same feature also had a cus_ent on a scheduled (next-cycle)
+ *     cus_product, or
+ *   - the entity had a loose entity-bound boolean entitlement (e.g. from
+ *     a prior plan migration) for the same feature.
+ *
+ * The repro path:
+ *   1. subjectQueryRowToNormalized.partitionCustomerEntitlement writes
+ *      `flags[feature_id] = {…}` keyed by feature — last-write-wins.
+ *   2. RELEVANT_STATUSES in the SQL CTE includes Scheduled, so scheduled
+ *      cus_ents land in row.customer_entitlements alongside the active ones.
+ *   3. When the scheduled (or loose-extra) cus_ent gets written last, it
+ *      overwrites the active cus_product's flag.
+ *   4. normalizedToFullSubject routes the flag into the scheduled
+ *      cus_product's customer_entitlements; fullSubjectToCustomerEntitlements
+ *      then drops it because orgToInStatuses excludes Scheduled.
+ *
+ * Production hit: org=mintlify customer=685d19f71cc6af2881ae2f0c
+ * entity=68a1e19cabf9f5b161674ce7 — AI_CHAT and other booleans on the
+ * active enterprise cus_product silently missing from entities.get.
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiEntityV2, ApiEntityV2Schema } from "@autumn/shared";
+import chalk from "chalk";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Scheduled upgrade cus_product must not shadow active flag
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright(
+		"scheduled-switch boolean flags 1: scheduled upgrade cus_product must NOT shadow active cus_product's boolean flag",
+	)}`,
+	async () => {
+		const customerId = "sched-switch-bool-flags-scheduled";
+
+		const pro = products.pro({
+			id: "bool-flags-sched-pro",
+			items: [items.dashboard(), items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "bool-flags-sched-premium",
+			items: [items.dashboard(), items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id, entityIndex: 0 }),
+				s.billing.attach({
+					productId: premium.id,
+					entityIndex: 0,
+					planSchedule: "end_of_cycle",
+				}),
+			],
+		});
+
+		const entityId = entities[0].id;
+
+		const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entityId,
+			{ keepInternalFields: true },
+		);
+		ApiEntityV2Schema.parse(entity);
+
+		expect(entity.flags[TestFeature.Dashboard]).toBeDefined();
+		expect(entity.flags[TestFeature.Dashboard]).toMatchObject({
+			feature_id: TestFeature.Dashboard,
+			plan_id: pro.id,
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Loose entity-bound extra must not shadow active flag
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright(
+		"scheduled-switch boolean flags 2: loose entity-bound extra must NOT shadow active cus_product's boolean flag",
+	)}`,
+	async () => {
+		const customerId = "sched-switch-bool-flags-loose";
+
+		const customerProd = products.pro({
+			id: "bool-flags-loose-pro",
+			items: [items.dashboard(), items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2, autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [customerProd] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [],
+		});
+
+		const entityId = entities[0].id;
+
+		// Pre-existing loose entity-bound Dashboard cus_ent (mimics the
+		// cus_ent_3AUV9* leftovers Mintlify carried over from their prior plan).
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			entity_id: entityId,
+			feature_id: TestFeature.Dashboard,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: customerProd.id,
+			redirect_mode: "if_required",
+		});
+
+		const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entityId,
+			{ keepInternalFields: true },
+		);
+		ApiEntityV2Schema.parse(entity);
+
+		expect(entity.flags[TestFeature.Dashboard]).toBeDefined();
+		expect(entity.flags[TestFeature.Dashboard]).toMatchObject({
+			feature_id: TestFeature.Dashboard,
+			plan_id: customerProd.id,
+		});
+	},
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes boolean flag shadowing so entities.get always returns the active plan’s flags with the correct plan_id. Also adds a `skip_cache=true` query param to bypass cache when needed.

- **Bug Fixes**
  - Prevent scheduled or loose entitlements from overwriting active boolean flags by prioritizing sources per feature in `subjectQueryRowToNormalized` (Active > PastDue > loose > Scheduled).
  - Added regression tests for scheduled upgrade and loose-flag scenarios; middleware now also respects `skip_cache=true` alongside `x-skip-cache: true`.

<sup>Written for commit 62ffb58cdd532cdb4fedcba1d607def5bf4126ca. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1632?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where boolean feature flags from an active customer product were silently dropped when the same feature also had a customer entitlement on a scheduled (next-cycle) or loose-extra customer product. The root cause was a last-write-wins assignment in `subjectQueryRowToNormalized`, combined with the SQL CTE including Scheduled entitlements alongside Active ones.

- **Bug fixes**: `subjectQueryRowToNormalized` now uses a priority-ranked selection for boolean flags (Active=0, PastDue=1, loose extra=2, Scheduled/other=3), so the most \"currently effective\" source always wins regardless of iteration order.
- **Improvements**: `skipCache` in `baseMiddleware` is extended to also accept a `?skip_cache=true` query parameter, making cache bypass accessible without custom HTTP header support.
- **Improvements**: A new integration test (`scheduled-switch-entity-boolean-flags.test.ts`) covers both regression scenarios with a documented production hit reference.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the boolean flag priority fix is well-reasoned and covered by new integration tests, with only a minor concern about the query-param cache bypass.

The core change in `subjectQueryRowToNormalized` correctly resolves a last-write-wins race between Active and Scheduled entitlements using a clear priority scheme, and the new tests exercise both repro paths. The only open question is whether exposing `skip_cache` as a query param could be misused for sustained DB load by authenticated callers.

`baseMiddleware.ts` deserves a second look regarding the new `skip_cache` query param and whether rate-limiting or scope-restriction is appropriate before the feature is publicly documented.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts | Core fix: adds priority-based selection for boolean flags to prevent Scheduled/loose-extra cus_ents from shadowing Active cus_product flags (Active=0, PastDue=1, loose=2, others=3). Logic is correct and handles all orderings of iteration. |
| server/src/honoMiddlewares/baseMiddleware.ts | Adds `skip_cache` query param as alternative to the `x-skip-cache` header; exposes cache bypass to any authenticated API caller without requiring custom header support. |
| server/tests/integration/billing/attach/scheduled-switch/scheduled-switch-entity-boolean-flags.test.ts | New regression test covering both bug scenarios: scheduled-upgrade shadowing and loose-extra shadowing. Tests are concurrent and well-documented with a production hit reference. |
| server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts | Whitespace-only change (added blank line); no functional modifications. |
| server/src/internal/entities/actions/getApiEntityByRollout.ts | Whitespace-only change (added blank lines); no functional modifications. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[partitionCustomerEntitlement called] --> B{Feature type Boolean?}
    B -- No --> M[Push to meteredCustomerEntitlements]
    B -- Yes --> C[getFlagPriority]
    C --> D{cusEnt has customer_product_id?}
    D -- No --> P2[priority = 2 loose extra]
    D -- Yes --> E{owning cus_product status}
    E -- Active --> P0[priority = 0]
    E -- PastDue --> P1[priority = 1]
    E -- other Scheduled/Expired/etc --> P3[priority = 3]
    P0 & P1 & P2 & P3 --> F{existingPriority defined AND existing <= new?}
    F -- Yes --> G[Skip - existing is better or equal]
    F -- No --> H[Write flag + update flagPriorityByFeatureId]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/honoMiddlewares/baseMiddleware.ts:117
**Cache bypass exposed via query param**

The new `skip_cache` query param lets any authenticated caller force a database read on every request simply by appending `?skip_cache=true` to a URL. Unlike a custom header (which requires deliberate SDK configuration), a query param is trivially passed in browser URLs, shared links, and simple `fetch` calls. An authenticated user who discovers this knob could drive sustained DB load by including it in high-frequency polling requests.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: shadow flags"](https://github.com/useautumn/autumn/commit/62ffb58cdd532cdb4fedcba1d607def5bf4126ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32869348)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->