### PR TITLE
fix: list events type

### DIFF
--- a/packages/autumn-js/src/react/hooks/useListEvents.ts
+++ b/packages/autumn-js/src/react/hooks/useListEvents.ts
@@ -18,13 +18,33 @@ export const useListEvents = (params: UseListEventsParams = {}) => {
 	const {
 		queryOptions,
 		limit: passedLimit,
+		startCursor: passedStartCursor,
 		customRange,
 		...restParams
 	} = params;
 
 	const limit = passedLimit ?? 100;
-	const [page, setPage] = useState(0);
-	const offset = page * limit;
+	const initialStartCursor = passedStartCursor ?? "";
+	const paginationKey = JSON.stringify({
+		...restParams,
+		customRange,
+		limit,
+		initialStartCursor,
+	});
+	const [paginationState, setPaginationState] = useState({
+		key: paginationKey,
+		page: 0,
+		startCursors: [initialStartCursor],
+	});
+	const pagination =
+		paginationState.key === paginationKey
+			? paginationState
+			: {
+					key: paginationKey,
+					page: 0,
+					startCursors: [initialStartCursor],
+				};
+	const startCursor = pagination.startCursors[pagination.page] ?? initialStartCursor;
 
 	const startDate = customRange?.start
 		? new Date(customRange.start).toISOString().slice(0, 13)
@@ -39,41 +59,83 @@ export const useListEvents = (params: UseListEventsParams = {}) => {
 			"events",
 			"list",
 			restParams.featureId,
+			restParams.entityId,
 			startDate,
 			endDate,
-			offset,
+			startCursor,
 			limit,
 		],
 		queryFn: () =>
 			client.listEvents({
 				...restParams,
 				customRange,
-				offset,
+				startCursor,
 				limit,
 			}),
 		...queryOptions,
 	});
 
-	const hasMore = query.data?.hasMore ?? false;
-	const hasPrevious = page > 0;
+	const hasMore = query.data?.nextCursor !== null && query.data?.nextCursor !== undefined;
+	const hasPrevious = pagination.page > 0;
 
 	const nextPage = useCallback(() => {
 		if (!hasMore) return;
-		setPage((currentPage) => currentPage + 1);
-	}, [hasMore]);
+		setPaginationState((current) => {
+			const activeState =
+				current.key === paginationKey
+					? current
+					: {
+							key: paginationKey,
+							page: 0,
+							startCursors: [initialStartCursor],
+						};
+			const startCursors = activeState.startCursors.slice(
+				0,
+				activeState.page + 1,
+			);
+			startCursors[activeState.page + 1] = query.data?.nextCursor ?? "";
+
+			return {
+				key: paginationKey,
+				page: activeState.page + 1,
+				startCursors,
+			};
+		});
+	}, [hasMore, initialStartCursor, paginationKey, query.data?.nextCursor]);
 
 	const prevPage = useCallback(() => {
 		if (!hasPrevious) return;
-		setPage((currentPage) => currentPage - 1);
-	}, [hasPrevious]);
+		setPaginationState((current) => {
+			const activeState = current.key === paginationKey ? current : pagination;
+
+			return {
+				...activeState,
+				page: Math.max(0, activeState.page - 1),
+			};
+		});
+	}, [hasPrevious, pagination, paginationKey]);
 
 	const goToPage = useCallback(({ pageNum }: { pageNum: number }) => {
-		setPage(Math.max(0, pageNum));
-	}, []);
+		setPaginationState((current) => {
+			const activeState = current.key === paginationKey ? current : pagination;
+
+			return {
+				...activeState,
+				page: Math.max(
+					0,
+					Math.min(pageNum, activeState.startCursors.length - 1),
+				),
+			};
+		});
+	}, [pagination, paginationKey]);
 
 	const resetPagination = useCallback(() => {
-		setPage(0);
-	}, []);
+		setPaginationState({
+			key: paginationKey,
+			page: 0,
+			startCursors: [initialStartCursor],
+		});
+	}, [initialStartCursor, paginationKey]);
 
 	return useMemo(
 		() => ({
@@ -81,7 +143,7 @@ export const useListEvents = (params: UseListEventsParams = {}) => {
 			list: query.data?.list,
 			hasMore,
 			hasPrevious,
-			page,
+			page: pagination.page,
 			nextPage,
 			prevPage,
 			goToPage,
@@ -91,7 +153,7 @@ export const useListEvents = (params: UseListEventsParams = {}) => {
 			query,
 			hasMore,
 			hasPrevious,
-			page,
+			pagination.page,
 			nextPage,
 			prevPage,
 			goToPage,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches `useListEvents` to cursor-based pagination and fixes pagination state so it resets correctly when params change. Aligns `hasMore` and navigation with `nextCursor` and adds `entityId` to the query key to avoid cache collisions.

- **Bug Fixes**
  - Replaced offset/page with `startCursor`/`nextCursor`; tracks per-page cursors for next/prev/goTo.
  - Adds a params-derived pagination key to reset state on input changes; supports an initial `startCursor`.
  - Includes `entityId` in the query key and computes `hasMore` from `nextCursor`.

<sup>Written for commit 5b8295db10ca1bacf2f03bf8e2bb7a07e960fc67. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1633?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates the `useListEvents` hook from offset-based pagination to cursor-based pagination to align with the API's `nextCursor` response field, and extracts `startCursor` from params so it is no longer accidentally forwarded as a raw query parameter.

- **[Bug fixes]** Replaces `offset`/`hasMore` with `startCursor`/`nextCursor` pagination; the `startCursors` array accumulates cursors as the user pages forward, enabling correct back-navigation.
- **[Bug fixes]** Adds `restParams.entityId` to the React Query cache key, which was previously missing and would cause different entities to share the same cached result.
- **[Improvements]** Introduces `paginationKey` derived from all non-cursor params so that pagination state resets lazily (without an extra `setState` call) whenever the query parameters change.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with one logic fix recommended before wider use.

The cursor-based rewrite and the entityId cache-key fix are both correct. The one concern is that nextPage reads query.data?.nextCursor from the render closure after the hasMore guard rather than capturing it before entering the state updater. A rapid double-tap can enqueue two updaters that both see the same cursor, causing page 2 to load the same data as page 1. The fix is a one-liner, so the change is otherwise solid.

packages/autumn-js/src/react/hooks/useListEvents.ts — the nextPage callback's state updater.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/autumn-js/src/react/hooks/useListEvents.ts | Cursor-based pagination replaces offset-based; entityId added to cache key; minor concern around reading query.data?.nextCursor from closure inside a setState updater. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as UI Component
    participant Hook as useListEvents
    participant RQ as React Query
    participant API as Autumn API

    UI->>Hook: render (params)
    Hook->>Hook: compute paginationKey
    Hook->>Hook: derive pagination (reset if key changed)
    Hook->>Hook: "startCursor = startCursors[page]"
    Hook->>RQ: useQuery([..., startCursor, limit])
    RQ->>API: "listEvents({ startCursor, limit })"
    API-->>RQ: "{ list, nextCursor }"
    RQ-->>Hook: query.data
    Hook->>Hook: "hasMore = nextCursor !== null"

    UI->>Hook: nextPage()
    Hook->>Hook: capture nextCursor from query.data
    Hook->>Hook: setPaginationState(page+1, push cursor)
    Hook->>RQ: invalidate / new queryKey
    RQ->>API: "listEvents({ startCursor: nextCursor })"
    API-->>RQ: "{ list, nextCursor: nextCursor2 }"

    UI->>Hook: prevPage()
    Hook->>Hook: setPaginationState(page-1)
    Hook->>RQ: useQuery with startCursors[page-1]
    RQ-->>Hook: cached or fresh response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/autumn-js/src/react/hooks/useListEvents.ts:81-104
Inside a `setPaginationState` updater the `query.data?.nextCursor` value is read from the outer render closure rather than from a stable source. Because `hasMore` is checked *before* calling `setPaginationState`, a rapid double-tap on "next page" can enqueue two updaters while both still see the same closure value of `nextCursor` (the cursor for the *current* page). The second updater would then store the same cursor at index `page + 2`, making page 2 load identical data to page 1. Capturing the cursor value before entering the updater keeps the logic self-contained and makes the intent clear.

```suggestion
	const nextPage = useCallback(() => {
		if (!hasMore) return;
		const nextCursor = query.data?.nextCursor ?? "";
		setPaginationState((current) => {
			const activeState =
				current.key === paginationKey
					? current
					: {
							key: paginationKey,
							page: 0,
							startCursors: [initialStartCursor],
						};
			const startCursors = activeState.startCursors.slice(
				0,
				activeState.page + 1,
			);
			startCursors[activeState.page + 1] = nextCursor;

			return {
				key: paginationKey,
				page: activeState.page + 1,
				startCursors,
			};
		});
	}, [hasMore, initialStartCursor, paginationKey, query.data?.nextCursor]);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: list events hook"](https://github.com/useautumn/autumn/commit/5b8295db10ca1bacf2f03bf8e2bb7a07e960fc67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32871665)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->