### PR TITLE
Main

### DIFF
--- a/packages/autumn-js/src/react/hooks/useListEvents.ts
+++ b/packages/autumn-js/src/react/hooks/useListEvents.ts
@@ -18,13 +18,33 @@ export const useListEvents = (params: UseListEventsParams = {}) => {
 	const {
 		queryOptions,
 		limit: passedLimit,
+		startCursor: passedStartCursor,
 		customRange,
 		...restParams
 	} = params;
 
 	const limit = passedLimit ?? 100;
-	const [page, setPage] = useState(0);
-	const offset = page * limit;
+	const initialStartCursor = passedStartCursor ?? "";
+	const paginationKey = JSON.stringify({
+		...restParams,
+		customRange,
+		limit,
+		initialStartCursor,
+	});
+	const [paginationState, setPaginationState] = useState({
+		key: paginationKey,
+		page: 0,
+		startCursors: [initialStartCursor],
+	});
+	const pagination =
+		paginationState.key === paginationKey
+			? paginationState
+			: {
+					key: paginationKey,
+					page: 0,
+					startCursors: [initialStartCursor],
+				};
+	const startCursor = pagination.startCursors[pagination.page] ?? initialStartCursor;
 
 	const startDate = customRange?.start
 		? new Date(customRange.start).toISOString().slice(0, 13)
@@ -39,41 +59,83 @@ export const useListEvents = (params: UseListEventsParams = {}) => {
 			"events",
 			"list",
 			restParams.featureId,
+			restParams.entityId,
 			startDate,
 			endDate,
-			offset,
+			startCursor,
 			limit,
 		],
 		queryFn: () =>
 			client.listEvents({
 				...restParams,
 				customRange,
-				offset,
+				startCursor,
 				limit,
 			}),
 		...queryOptions,
 	});
 
-	const hasMore = query.data?.hasMore ?? false;
-	const hasPrevious = page > 0;
+	const hasMore = query.data?.nextCursor !== null && query.data?.nextCursor !== undefined;
+	const hasPrevious = pagination.page > 0;
 
 	const nextPage = useCallback(() => {
 		if (!hasMore) return;
-		setPage((currentPage) => currentPage + 1);
-	}, [hasMore]);
+		setPaginationState((current) => {
+			const activeState =
+				current.key === paginationKey
+					? current
+					: {
+							key: paginationKey,
+							page: 0,
+							startCursors: [initialStartCursor],
+						};
+			const startCursors = activeState.startCursors.slice(
+				0,
+				activeState.page + 1,
+			);
+			startCursors[activeState.page + 1] = query.data?.nextCursor ?? "";
+
+			return {
+				key: paginationKey,
+				page: activeState.page + 1,
+				startCursors,
+			};
+		});
+	}, [hasMore, initialStartCursor, paginationKey, query.data?.nextCursor]);
 
 	const prevPage = useCallback(() => {
 		if (!hasPrevious) return;
-		setPage((currentPage) => currentPage - 1);
-	}, [hasPrevious]);
+		setPaginationState((current) => {
+			const activeState = current.key === paginationKey ? current : pagination;
+
+			return {
+				...activeState,
+				page: Math.max(0, activeState.page - 1),
+			};
+		});
+	}, [hasPrevious, pagination, paginationKey]);
 
 	const goToPage = useCallback(({ pageNum }: { pageNum: number }) => {
-		setPage(Math.max(0, pageNum));
-	}, []);
+		setPaginationState((current) => {
+			const activeState = current.key === paginationKey ? current : pagination;
+
+			return {
+				...activeState,
+				page: Math.max(
+					0,
+					Math.min(pageNum, activeState.startCursors.length - 1),
+				),
+			};
+		});
+	}, [pagination, paginationKey]);
 
 	const resetPagination = useCallback(() => {
-		setPage(0);
-	}, []);
+		setPaginationState({
+			key: paginationKey,
+			page: 0,
+			startCursors: [initialStartCursor],
+		});
+	}, [initialStartCursor, paginationKey]);
 
 	return useMemo(
 		() => ({
@@ -81,7 +143,7 @@ export const useListEvents = (params: UseListEventsParams = {}) => {
 			list: query.data?.list,
 			hasMore,
 			hasPrevious,
-			page,
+			page: pagination.page,
 			nextPage,
 			prevPage,
 			goToPage,
@@ -91,7 +153,7 @@ export const useListEvents = (params: UseListEventsParams = {}) => {
 			query,
 			hasMore,
 			hasPrevious,
-			page,
+			pagination.page,
 			nextPage,
 			prevPage,
 			goToPage,

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -1,10 +1,10 @@
 import {
-	ApiVersionClass,
-	AppEnv,
-	AuthType,
-	LATEST_VERSION,
-	type Organization,
-	tryCatch,
+    ApiVersionClass,
+    AppEnv,
+    AuthType,
+    LATEST_VERSION,
+    type Organization,
+    tryCatch,
 } from "@autumn/shared";
 import type { Context, Next } from "hono";
 import { db, dbGeneral } from "@/db/initDrizzle.js";
@@ -114,7 +114,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 
 		// Query params
 		expand: [],
-		skipCache: c.req.header("x-skip-cache") === "true",
+		skipCache: c.req.header("x-skip-cache") === "true" || c.req.query("skip_cache") === "true",
 
 		// Test params:
 		extraLogs: {},

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
@@ -1,7 +1,7 @@
 import {
-	CustomerNotFoundError,
-	EntityNotFoundError,
-	type FullSubject,
+    CustomerNotFoundError,
+    EntityNotFoundError,
+    type FullSubject,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
@@ -24,6 +24,7 @@ export const getOrSetCachedFullSubject = async ({
 	const useRedis = !skipCache;
 
 	let fetchedSubjectViewEpoch = 0;
+
 
 	if (useRedis) {
 		// The pipeline inside getCachedFullSubject already fetches + refreshes

--- a/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
+++ b/server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts
@@ -3,6 +3,7 @@ import {
 	type AggregatedFeatureBalance,
 	type AggregatedSubjectFlag,
 	type Customer,
+	CusProductStatus,
 	type DbCustomerEntitlement,
 	type DbCustomerPrice,
 	type DbFreeTrial,
@@ -140,6 +141,24 @@ export const subjectQueryRowToNormalized = ({
 		);
 	};
 
+	// `flags` is keyed by feature_id (one slot per feature), but a customer
+	// can have multiple cus_ents for the same boolean — e.g. an active
+	// cus_product, a scheduled next-cycle cus_product, and loose extras
+	// from a prior plan. We prefer the most "currently effective" source so
+	// the API surfaces the right plan_id (and so a Scheduled flag doesn't
+	// land in `flags`, get routed to a Scheduled cus_product, and then be
+	// dropped downstream by orgToInStatuses).
+	const flagPriorityByFeatureId: Record<string, number> = {};
+	const getFlagPriority = (cusEnt: DbCustomerEntitlement): number => {
+		if (!cusEnt.customer_product_id) return 2;
+		const owningCusProduct = customerProductsById.get(
+			cusEnt.customer_product_id,
+		);
+		if (owningCusProduct?.status === CusProductStatus.Active) return 0;
+		if (owningCusProduct?.status === CusProductStatus.PastDue) return 1;
+		return 3;
+	};
+
 	const partitionCustomerEntitlement = (
 		customerEntitlement: DbCustomerEntitlement,
 	) => {
@@ -149,6 +168,13 @@ export const subjectQueryRowToNormalized = ({
 		if (!catalogEntitlement) return;
 
 		if (catalogEntitlement.feature.type === FeatureType.Boolean) {
+			const newPriority = getFlagPriority(customerEntitlement);
+			const existingPriority =
+				flagPriorityByFeatureId[catalogEntitlement.feature.id];
+			if (existingPriority !== undefined && existingPriority <= newPriority) {
+				return;
+			}
+			flagPriorityByFeatureId[catalogEntitlement.feature.id] = newPriority;
 			flags[catalogEntitlement.feature.id] = {
 				featureId: catalogEntitlement.feature.id,
 				internalFeatureId: customerEntitlement.internal_feature_id,

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -26,6 +26,8 @@ export const getApiEntityByRollout = async ({
 			source,
 		});
 
+		
+
 		return getApiEntityV2({
 			ctx,
 			fullSubject,

--- a/server/tests/integration/billing/attach/scheduled-switch/scheduled-switch-entity-boolean-flags.test.ts
+++ b/server/tests/integration/billing/attach/scheduled-switch/scheduled-switch-entity-boolean-flags.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Scheduled Switch Entity Boolean Flag Tests (Attach V2)
+ *
+ * Regression coverage for a bug where boolean flags from the active
+ * customer product disappeared from entities.get when:
+ *   - the same feature also had a cus_ent on a scheduled (next-cycle)
+ *     cus_product, or
+ *   - the entity had a loose entity-bound boolean entitlement (e.g. from
+ *     a prior plan migration) for the same feature.
+ *
+ * The repro path:
+ *   1. subjectQueryRowToNormalized.partitionCustomerEntitlement writes
+ *      `flags[feature_id] = {…}` keyed by feature — last-write-wins.
+ *   2. RELEVANT_STATUSES in the SQL CTE includes Scheduled, so scheduled
+ *      cus_ents land in row.customer_entitlements alongside the active ones.
+ *   3. When the scheduled (or loose-extra) cus_ent gets written last, it
+ *      overwrites the active cus_product's flag.
+ *   4. normalizedToFullSubject routes the flag into the scheduled
+ *      cus_product's customer_entitlements; fullSubjectToCustomerEntitlements
+ *      then drops it because orgToInStatuses excludes Scheduled.
+ *
+ * Production hit: org=mintlify customer=685d19f71cc6af2881ae2f0c
+ * entity=68a1e19cabf9f5b161674ce7 — AI_CHAT and other booleans on the
+ * active enterprise cus_product silently missing from entities.get.
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiEntityV2, ApiEntityV2Schema } from "@autumn/shared";
+import chalk from "chalk";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Scheduled upgrade cus_product must not shadow active flag
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright(
+		"scheduled-switch boolean flags 1: scheduled upgrade cus_product must NOT shadow active cus_product's boolean flag",
+	)}`,
+	async () => {
+		const customerId = "sched-switch-bool-flags-scheduled";
+
+		const pro = products.pro({
+			id: "bool-flags-sched-pro",
+			items: [items.dashboard(), items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "bool-flags-sched-premium",
+			items: [items.dashboard(), items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id, entityIndex: 0 }),
+				s.billing.attach({
+					productId: premium.id,
+					entityIndex: 0,
+					planSchedule: "end_of_cycle",
+				}),
+			],
+		});
+
+		const entityId = entities[0].id;
+
+		const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entityId,
+			{ keepInternalFields: true },
+		);
+		ApiEntityV2Schema.parse(entity);
+
+		expect(entity.flags[TestFeature.Dashboard]).toBeDefined();
+		expect(entity.flags[TestFeature.Dashboard]).toMatchObject({
+			feature_id: TestFeature.Dashboard,
+			plan_id: pro.id,
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Loose entity-bound extra must not shadow active flag
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright(
+		"scheduled-switch boolean flags 2: loose entity-bound extra must NOT shadow active cus_product's boolean flag",
+	)}`,
+	async () => {
+		const customerId = "sched-switch-bool-flags-loose";
+
+		const customerProd = products.pro({
+			id: "bool-flags-loose-pro",
+			items: [items.dashboard(), items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2, autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [customerProd] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [],
+		});
+
+		const entityId = entities[0].id;
+
+		// Pre-existing loose entity-bound Dashboard cus_ent (mimics the
+		// cus_ent_3AUV9* leftovers Mintlify carried over from their prior plan).
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			entity_id: entityId,
+			feature_id: TestFeature.Dashboard,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: customerProd.id,
+			redirect_mode: "if_required",
+		});
+
+		const entity = await autumnV2_2.entities.get<ApiEntityV2>(
+			customerId,
+			entityId,
+			{ keepInternalFields: true },
+		);
+		ApiEntityV2Schema.parse(entity);
+
+		expect(entity.flags[TestFeature.Dashboard]).toBeDefined();
+		expect(entity.flags[TestFeature.Dashboard]).toMatchObject({
+			feature_id: TestFeature.Dashboard,
+			plan_id: customerProd.id,
+		});
+	},
+);

--- a/vite/src/components/forms/shared/plan-items/CollapsedBooleanItems.tsx
+++ b/vite/src/components/forms/shared/plan-items/CollapsedBooleanItems.tsx
@@ -7,6 +7,7 @@ import {
 	AccordionTrigger,
 } from "@/components/ui/accordion";
 import { LAYOUT_TRANSITION } from "@/components/v2/sheets/SharedSheetComponents";
+import { getItemId } from "@/utils/product/productItemUtils";
 import { motion } from "motion/react";
 
 interface CollapsedBooleanItemsProps {
@@ -41,15 +42,15 @@ export function CollapsedBooleanItems({
 				</AccordionTrigger>
 				<AccordionContent className="pb-1.5 pt-1.5 px-0">
 					<div className="flex flex-col gap-1.5">
-						{items.map((item, index) => (
-							<motion.div
-								key={item.feature_id ?? index}
-								layout="position"
-								transition={{ layout: LAYOUT_TRANSITION }}
-							>
-								{renderItem(item, index)}
-							</motion.div>
-						))}
+					{items.map((item, index) => (
+						<motion.div
+							key={getItemId({ item, itemIndex: index })}
+							layout="position"
+							transition={{ layout: LAYOUT_TRANSITION }}
+						>
+							{renderItem(item, index)}
+						</motion.div>
+					))}
 					</div>
 				</AccordionContent>
 			</AccordionItem>

--- a/vite/src/utils/product/productItemUtils.ts
+++ b/vite/src/utils/product/productItemUtils.ts
@@ -107,13 +107,13 @@ export const getItemId = ({
 	item: ProductItem;
 	itemIndex: number;
 }) => {
+	if (item.entitlement_id) return `ent-${item.entitlement_id}`;
+	if (item.price_id) return `price-${item.price_id}`;
 	if (item.feature_id) {
 		return item.entity_feature_id
 			? `feature-${item.feature_id}-${item.entity_feature_id}`
 			: `feature-${item.feature_id}`;
 	}
-	if (item.entitlement_id) return `ent-${item.entitlement_id}`;
-	if (item.price_id) return `price-${item.price_id}`;
 	return `item-${itemIndex}`;
 };
 

--- a/vite/src/utils/product/productItemUtils.ts
+++ b/vite/src/utils/product/productItemUtils.ts
@@ -107,7 +107,13 @@ export const getItemId = ({
 	item: ProductItem;
 	itemIndex: number;
 }) => {
-	// || item.entitlement_id || item.price_id;
+	if (item.feature_id) {
+		return item.entity_feature_id
+			? `feature-${item.feature_id}-${item.entity_feature_id}`
+			: `feature-${item.feature_id}`;
+	}
+	if (item.entitlement_id) return `ent-${item.entitlement_id}`;
+	if (item.price_id) return `price-${item.price_id}`;
 	return `item-${itemIndex}`;
 };
 

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureList.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureList.tsx
@@ -96,7 +96,7 @@ export const PlanFeatureList = ({
 		const itemIndex = product.items?.indexOf(item) ?? -1;
 		return (
 			<PlanFeatureRow
-				key={item.entitlement_id || item.price_id || itemIndex}
+				key={getItemId({ item, itemIndex })}
 				item={item}
 				index={itemIndex}
 				onDelete={handleDelete}

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -34,7 +34,7 @@ interface PlanFeatureRowProps {
 
 export const PlanFeatureRow = ({
 	item: itemProp,
-	onDelete: _onDelete,
+	onDelete,
 	index,
 	readOnly = false,
 	prepaidQuantity,
@@ -42,7 +42,7 @@ export const PlanFeatureRow = ({
 	const { org } = useOrg();
 	const { features } = useFeaturesQuery();
 	const { setItem } = useProductItemContext();
-	const { product, setProduct } = useProduct();
+	const { product } = useProduct();
 	const { itemId, setSheet } = useSheet();
 	const isOnboarding = useOnboardingStore((s) => s.isOnboarding);
 	const playgroundMode = useOnboardingStore((s) => s.playgroundMode);
@@ -92,12 +92,8 @@ export const PlanFeatureRow = ({
 	};
 
 	const handleDeleteRow = () => {
-		const newItems = product.items?.filter((i) => i !== item) || [];
-
-		setProduct({ ...product, items: newItems });
-
-		if (isSelected) {
-			setSheet({ type: "edit-plan" });
+		if (onDelete) {
+			onDelete(item);
 		}
 	};
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing boolean flags in entity responses when scheduled switches or loose extras were present. Also moves events to cursor-based pagination, stabilizes plan item keys to prevent ghost rows, and adds a `skip_cache` query flag.

- **Bug Fixes**
  - Entities: boolean flags now prioritize Active > Past Due > Scheduled/loose, so `entities.get` returns the correct `plan_id` and flags don’t disappear. Regression tests cover scheduled switch and loose extra cases.
  - Events: `useListEvents` now uses cursor pagination with `startCursor`, maintains per-page cursors for back/forward, and computes `hasMore` from `nextCursor`.
  - UI: plan item keys use `getItemId` (feature/entity_feature/price/entitlement) to prevent ghost items; row delete is handled by the parent.
  - API: base middleware accepts `skip_cache=true` (in addition to `x-skip-cache: true`) to bypass cache.

<sup>Written for commit d753b6d6a77f2e00f99b8a00a220853da979fa06. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1634?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers a targeted bug fix that prevents a scheduled or loose-extra boolean entitlement from silently overwriting an active product's flag in `subjectQueryRowToNormalized`, accompanied by cursor-based pagination in `useListEvents`, a `skip_cache` query-param shortcut for cache bypass, and several UI clean-ups around React key stability and delete-logic delegation.

- **[Bug fixes]** `subjectQueryRowToNormalized` now assigns a priority score (Active=0, PastDue=1, no-product=2, other=3) to each boolean entitlement and keeps only the highest-priority flag per feature, fixing the production regression where AI_CHAT and other flags silently disappeared from `entities.get` when a scheduled upgrade was pending.
- **[Improvements]** `useListEvents` replaces offset pagination with cursor-based pagination, storing a `startCursors` history array for backwards navigation and keying cache queries on `startCursor` and `entityId`.
- **[Improvements]** `getItemId` now returns stable, meaningful React keys using `entitlement_id → price_id → feature_id` before falling back to an index, used across `PlanFeatureList`, `CollapsedBooleanItems`, and `PlanFeatureRow`; delete logic is also lifted from `PlanFeatureRow` into the parent list to keep row components stateless.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core boolean-flag bug fix is correct and well-covered by new integration tests, and the UI/pagination changes are self-contained improvements.

The boolean-flag priority fix directly addresses a confirmed production regression, is well-reasoned, and the new tests cover both the scheduled-upgrade and loose-extra scenarios. The cursor-based pagination logic in `useListEvents` is functionally correct but includes `pagination` (a derived, unstable object reference) in `useCallback` dependency arrays, causing unnecessary callback recreation during param-change windows. The `skip_cache` query param makes cache bypass URL-visible, which is worth revisiting before broader rollout.

`packages/autumn-js/src/react/hooks/useListEvents.ts` and `server/src/honoMiddlewares/baseMiddleware.ts` warrant a second look.

<details open><summary><h3>Security Review</h3></summary>

- **Cache-bypass exposure** (`server/src/honoMiddlewares/baseMiddleware.ts`): `skip_cache=true` as a URL query parameter makes the cache-bypass toggle visible in server access logs, CDN logs, browser history, and `Referer` headers. Any authenticated caller who discovers the parameter can force direct DB hits on every request, increasing database load. The prior `x-skip-cache` header approach avoided URL-level visibility.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/repos/getFullSubject/subjectQueryRowToNormalized.ts | Adds flag-priority logic so Active cus_product's boolean flag is never overwritten by a Scheduled or loose-extra entitlement; fix is correct and well-tested |
| packages/autumn-js/src/react/hooks/useListEvents.ts | Migrates from offset-based to cursor-based pagination; logic is sound but `pagination` object in `useCallback` deps causes unnecessary callback recreation during key-mismatch renders |
| server/src/honoMiddlewares/baseMiddleware.ts | Adds `skip_cache` query-param support alongside the existing `x-skip-cache` header; flag now appears in URL-visible locations (logs, CDN, browser history) |
| vite/src/utils/product/productItemUtils.ts | Implements `getItemId` with stable, meaningful IDs using `entitlement_id`, `price_id`, and `feature_id` priority before falling back to index |
| vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx | Refactors delete logic to delegate to `onDelete` callback instead of directly mutating product state; sheet-close on selected-item delete is correctly preserved in the parent |
| server/tests/integration/billing/attach/scheduled-switch/scheduled-switch-entity-boolean-flags.test.ts | New integration tests covering both scheduled-upgrade and loose-extra scenarios for the boolean flag priority bug fix |
| vite/src/views/products/plan/components/plan-card/PlanFeatureList.tsx | Switches React key to `getItemId` for stable key generation; `handleDelete` correctly moves sheet-close logic from row to list |
| vite/src/components/forms/shared/plan-items/CollapsedBooleanItems.tsx | Uses `getItemId` for motion.div keys (feature_id-based for booleans) instead of index; minor indentation change |
| server/src/internal/entities/actions/getApiEntityByRollout.ts | Whitespace-only change; no logic modified |
| server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts | Whitespace-only change (extra blank line); no logic modified |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[subjectQueryRowToNormalized] --> B{For each DbCustomerEntitlement}
    B --> C{Feature type = Boolean?}
    C -- No --> D[Push to meteredCustomerEntitlements]
    C -- Yes --> E[getFlagPriority]
    E --> F{customer_product_id?}
    F -- No --> G[Priority 2: loose extra]
    F -- Yes --> H{owning cus_product status}
    H -- Active --> I[Priority 0]
    H -- PastDue --> J[Priority 1]
    H -- Other/Scheduled --> K[Priority 3]
    G & I & J & K --> L{existingPriority <= newPriority?}
    L -- Yes --> M[Skip: existing wins]
    L -- No --> N[Update flags map with this entitlement]
    N --> O[flagPriorityByFeatureId updated]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/autumn-js/src/react/hooks/useListEvents.ts:39-46
**`pagination` object reference changes on every render, defeating `useCallback`**

When `paginationState.key !== paginationKey` (params changed but no pagination action taken yet), the local `pagination` variable is a freshly-created reset object on every render. Both `prevPage` (line 116) and `goToPage` (line 130) include `pagination` in their `useCallback` dependency arrays, so React recreates those callbacks on every render during that window — passing new function references to child components and causing unnecessary re-renders. Deriving the reset value from refs or stabilising the object reference would avoid this.

### Issue 2 of 3
packages/autumn-js/src/react/hooks/useListEvents.ts:118-130
**`goToPage` silently clamps to already-visited pages**

`Math.min(pageNum, activeState.startCursors.length - 1)` caps navigation at the last visited page. If a caller passes `pageNum: 5` but only pages 0–2 have been visited, the hook silently lands on page 2 with no error or feedback. The returned `page` value in the hook's output is the only way a caller can detect this, and there is no indication that cursor-based pagination requires sequential access. At minimum, a comment here would help users of this hook avoid confusion.

### Issue 3 of 3
server/src/honoMiddlewares/baseMiddleware.ts:117
**`skip_cache` query param is URL-visible and logged**

The `x-skip-cache` header was set in a non-URL location intentionally. Exposing the same toggle as a query parameter (`skip_cache=true`) means the bypass flag appears in server access logs, browser history, CDN/proxy logs, and referrer headers. Any authenticated caller who knows about this parameter can force a cache-miss on every request, increasing database load. If the intent is testing convenience, consider restricting this param to non-production environments or specific IP ranges.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1633 from useautumn/..."](https://github.com/useautumn/autumn/commit/d753b6d6a77f2e00f99b8a00a220853da979fa06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32873994)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->