### PR TITLE
chore: fix revert trial issue

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts
@@ -91,6 +91,13 @@ export const computeCustomPlanNewCustomerProduct = ({
 				: {}),
 
 			...(params.status ? { status: params.status } : {}),
+
+			onTrialEnd:
+				trialContext?.onEnd ??
+				currentCustomerProduct.on_trial_end ??
+				undefined,
+			previousCustomerProductId:
+				currentCustomerProduct.previous_customer_product_id ?? undefined,
 		},
 	});
 

--- a/server/tests/integration/billing/update-subscription/free-trial/update-revert-trial-cancel.test.ts
+++ b/server/tests/integration/billing/update-subscription/free-trial/update-revert-trial-cancel.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Update Revert Trial Then Cancel — Regression Test
+ *
+ * Reproduces the bug where extending a revert trial via billing.update
+ * (customize.free_trial) creates a new customer product that loses the
+ * on_trial_end and previous_customer_product_id fields. When the extended
+ * trial is then cancelled immediately, the revert logic doesn't fire and
+ * the previous plan stays permanently Paused.
+ *
+ * Bug timeline (mintlify / 69f0ecf77c72f1de7b555ba1):
+ * 1. Attach Pro (Yearly) — Active paid plan
+ * 2. Attach Enterprise trial with on_end: "revert" — Pro paused, Enterprise active
+ * 3. billing.update extends Enterprise trial (customize.free_trial with on_end: revert)
+ * 4. billing.update cancel_immediately Enterprise — Pro stays Paused (BUG)
+ *
+ * Root cause: computeCustomPlanNewCustomerProduct does not carry over
+ * on_trial_end / previous_customer_product_id from the old customer product.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ALL_STATUSES,
+	type AttachParamsV1Input,
+	CusProductStatus,
+	FreeTrialDuration,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Extend revert trial then cancel — previous plan should be restored
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(
+	`${chalk.yellowBright("update-revert-trial-cancel 1: extend revert trial then cancel immediately — previous plan restored")}`,
+	async () => {
+		const customerId = "update-revert-trial-cancel-basic";
+
+		const proMessages = items.monthlyMessages({ includedUsage: 500 });
+		const pro = products.pro({ id: "pro", items: [proMessages] });
+
+		const enterpriseMessages = items.monthlyMessages({ includedUsage: 2000 });
+		const enterprisePrice = items.monthlyPrice({ price: 50 });
+		const enterprise = products.base({
+			id: "enterprise",
+			items: [enterpriseMessages, enterprisePrice],
+		});
+
+		const { autumnV2, autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, enterprise] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		// Step 1: Attach enterprise with revert trial (2 days)
+		await autumnV2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: enterprise.id,
+			redirect_mode: "if_required",
+			customize: {
+				free_trial: {
+					duration_length: 2,
+					duration_type: FreeTrialDuration.Day,
+					card_required: false,
+					on_end: "revert",
+				},
+			},
+		});
+
+		// Verify: enterprise active with revert, pro paused
+		const afterAttach = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+
+		const trialCp = afterAttach.customer_products.find(
+			(cp) => cp.product_id === enterprise.id,
+		);
+		const pausedCp = afterAttach.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		);
+
+		expect(trialCp).toBeDefined();
+		expect(trialCp!.status).toBe(CusProductStatus.Active);
+		expect(trialCp!.on_trial_end).toBe("revert");
+		expect(trialCp!.previous_customer_product_id).toBe(pausedCp!.id);
+		expect(pausedCp).toBeDefined();
+		expect(pausedCp!.status).toBe(CusProductStatus.Paused);
+
+		// Step 2: Extend the trial to 104 days via billing.update (customize.free_trial)
+		await autumnV2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			subscription_id: trialCp!.id,
+			customize: {
+				free_trial: {
+					duration_length: 104,
+					duration_type: FreeTrialDuration.Day,
+					on_end: "revert",
+					card_required: false,
+				},
+			},
+		});
+
+		// Verify: the replacement enterprise cusProduct still has on_trial_end + previous link
+		const afterUpdate = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+
+		const updatedTrialCp = afterUpdate.customer_products.find(
+			(cp) =>
+				cp.product_id === enterprise.id &&
+				cp.status === CusProductStatus.Active,
+		);
+
+		expect(updatedTrialCp).toBeDefined();
+		expect(updatedTrialCp!.on_trial_end).toBe("revert");
+		expect(updatedTrialCp!.previous_customer_product_id).toBe(pausedCp!.id);
+
+		// Step 3: Cancel enterprise immediately
+		await autumnV1.subscriptions.update(
+			{
+				customer_id: customerId,
+				product_id: enterprise.id,
+				cancel_action: "cancel_immediately" as const,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Verify: pro should be restored to Active, enterprise expired
+		const afterCancel = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+
+		const cancelledEnterprise = afterCancel.customer_products.find(
+			(cp) =>
+				cp.product_id === enterprise.id &&
+				cp.status === CusProductStatus.Expired,
+		);
+		const restoredPro = afterCancel.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		);
+
+		expect(cancelledEnterprise).toBeDefined();
+		expect(restoredPro).toBeDefined();
+		expect(restoredPro!.status).toBe(CusProductStatus.Active);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Extend revert trial then cancel — no default product created
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(
+	`${chalk.yellowBright("update-revert-trial-cancel 2: extend revert trial then cancel — default product NOT created")}`,
+	async () => {
+		const customerId = "update-revert-trial-cancel-no-default";
+
+		const freeMessages = items.monthlyMessages({ includedUsage: 100 });
+		const free = products.base({
+			id: "free",
+			isDefault: true,
+			items: [freeMessages],
+		});
+
+		const proMessages = items.monthlyMessages({ includedUsage: 500 });
+		const pro = products.pro({ id: "pro", items: [proMessages] });
+
+		const enterpriseMessages = items.monthlyMessages({ includedUsage: 2000 });
+		const enterprisePrice = items.monthlyPrice({ price: 50 });
+		const enterprise = products.base({
+			id: "enterprise",
+			items: [enterpriseMessages, enterprisePrice],
+		});
+
+		const { autumnV2, autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro, enterprise] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		// Step 1: Attach enterprise with revert trial
+		await autumnV2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: enterprise.id,
+			redirect_mode: "if_required",
+			customize: {
+				free_trial: {
+					duration_length: 2,
+					duration_type: FreeTrialDuration.Day,
+					card_required: false,
+					on_end: "revert",
+				},
+			},
+		});
+
+		// Get the trial cusProduct ID for the update call
+		const afterAttach = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+
+		const trialCp = afterAttach.customer_products.find(
+			(cp) => cp.product_id === enterprise.id,
+		);
+		expect(trialCp).toBeDefined();
+
+		// Step 2: Extend the trial
+		await autumnV2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			subscription_id: trialCp!.id,
+			customize: {
+				free_trial: {
+					duration_length: 30,
+					duration_type: FreeTrialDuration.Day,
+					on_end: "revert",
+					card_required: false,
+				},
+			},
+		});
+
+		// Step 3: Cancel enterprise immediately
+		await autumnV1.subscriptions.update(
+			{
+				customer_id: customerId,
+				product_id: enterprise.id,
+				cancel_action: "cancel_immediately" as const,
+			},
+			{ timeout: 2000 },
+		);
+
+		// Verify: pro restored, enterprise expired, NO free default created
+		const afterCancel = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			inStatuses: ALL_STATUSES,
+		});
+
+		const restoredPro = afterCancel.customer_products.find(
+			(cp) => cp.product_id === pro.id,
+		);
+		const cancelledEnterprise = afterCancel.customer_products.find(
+			(cp) =>
+				cp.product_id === enterprise.id &&
+				cp.status === CusProductStatus.Expired,
+		);
+		const freeDefault = afterCancel.customer_products.find(
+			(cp) =>
+				cp.product_id === free.id && cp.status === CusProductStatus.Active,
+		);
+
+		expect(cancelledEnterprise).toBeDefined();
+		expect(restoredPro).toBeDefined();
+		expect(restoredPro!.status).toBe(CusProductStatus.Active);
+
+		// The bug: without the fix, a free default IS created instead of reverting
+		expect(freeDefault).toBeUndefined();
+	},
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes revert-trial behavior when an extended free trial is cancelled immediately. The previous plan now restores correctly instead of staying paused or creating a default plan.

- **Bug Fixes**
  - In `computeCustomPlanNewCustomerProduct`, preserve `onTrialEnd` (from trial context or existing record) and `previousCustomerProductId` when replacing the trial customer product.
  - Added regression tests that extend a revert trial and then cancel to verify the original plan is restored and no default product is created.

<sup>Written for commit aa8c70475a56b5516cb528214b98eff21a18db35. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1635?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression in the revert-trial flow where extending an active revert trial via `billing.update` would silently drop `on_trial_end` and `previous_customer_product_id` from the newly created customer product. Cancelling the extended trial would then fail to restore the previously-paused plan.

- **Bug fix** — `computeCustomPlanNewCustomerProduct` now carries `on_trial_end` (with `trialContext?.onEnd` taking priority) and `previous_customer_product_id` from the current customer product into the replacement record, preserving the revert-trial chain.
- **Improvements** — Two regression integration tests cover the fix: one verifies the paused plan is restored after cancel, and a second confirms no spurious default-product attachment occurs when revert fires.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a targeted two-field carry-over with a clear regression test covering both the restore and no-default-product paths.

The core fix is minimal and well-reasoned: onTrialEnd correctly prioritises trialContext.onEnd before falling back to the current record's value, and previousCustomerProductId is always safe to forward since it is null on all non-revert-trial products. The integration tests reproduce the exact bug scenario end-to-end. The only nit is a redundant ?? undefined expression that has no runtime impact.

No files require special attention; the single-line source change is self-contained and the test file exercises the full cancel-revert path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts | Adds `onTrialEnd` and `previousCustomerProductId` carry-over to the new customer product init options, fixing lost revert-trial state on extension. Minor: `?? undefined` at the end of the `onTrialEnd` expression is redundant. |
| server/tests/integration/billing/update-subscription/free-trial/update-revert-trial-cancel.test.ts | New integration test file reproducing the full revert-trial-extend-then-cancel scenario with two complementary cases; well-structured and covers the exact bug being fixed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Customer
    participant API as billing.update
    participant Compute as computeCustomPlanNewCustomerProduct
    participant DB as Database

    C->>API: attach Enterprise (revert trial, 2 days)
    API->>DB: "Enterprise CusProduct {on_trial_end: revert, previous_cus_prod_id: Pro.id}"
    DB-->>C: Enterprise Active, Pro Paused

    C->>API: billing.update extend trial to 104 days
    API->>Compute: compute new CusProduct
    Note over Compute: BEFORE fix: on_trial_end and previous_cus_prod_id lost
    Note over Compute: AFTER fix: carry over trialContext.onEnd ?? current.on_trial_end and current.previous_customer_product_id
    Compute->>DB: "New Enterprise CusProduct {on_trial_end: revert, previous_cus_prod_id: Pro.id}"

    C->>API: cancel Enterprise immediately
    API->>DB: "Read on_trial_end = revert, previous_cus_prod_id = Pro.id"
    API->>DB: Expire Enterprise, Restore Pro to Active
    DB-->>C: Pro Active
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts:95-98
The trailing `?? undefined` in the `onTrialEnd` assignment is redundant — if `currentCustomerProduct.on_trial_end` is `null`, the nullish coalescing already produces `undefined`, which `initCustomerProduct` handles the same way via `onTrialEnd ?? null`.

```suggestion
			onTrialEnd:
				trialContext?.onEnd ??
				currentCustomerProduct.on_trial_end ??
				null,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix revert trial issue"](https://github.com/useautumn/autumn/commit/aa8c70475a56b5516cb528214b98eff21a18db35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32874061)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->