### PR TITLE
Change copy on website

### DIFF
--- a/apps/website/app/constant.tsx
+++ b/apps/website/app/constant.tsx
@@ -1201,10 +1201,16 @@ export const faqData = [
 			"Yes. Autumn works with Stripe—it handles the billing logic that Stripe doesn't. You keep your Stripe account, your customer relationships, and your payment data. Autumn sits between your app and Stripe, managing webhooks, usage limits, and state.\n\nYou're never locked in. Your subscriptions live in Stripe.",
 	},
 	{
+		id: 7,
+		question: "Do I need to call Autumn before every action?",
+		answer:
+			"For latency-sensitive operations, you may not want to make an `autumn.check()` network call before every action. \n\n Instead, you can either cache the Autumn customer data on your end, or use our single `customer.products.updated` webhook to replicate the Autumn state into your own system.",
+	},
+	{
 		id: 2,
 		question: "What if Autumn goes down? Will my app go down?",
 		answer:
-			"We run on redundant infrastructure and high availability is our priority. However, not being able to reach Autumn does not mean that your app will go down. Our SDKs default to fail open and fail fast, meaning that in a worst case scenario, some users may get temporary additional access.\n\nWe can work with you to reconcile usage tracking and balances afterward if needed.",
+			"We run on redundant infrastructure and high availability is our priority. However, not being able to reach Autumn does not mean that your app will go down. Our app and SDKs default to fail open and fail fast, meaning that in a worst case scenario, some users may get temporary additional access.\n\nWe can work with you to reconcile usage tracking and balances afterward if needed.",
 	},
 	{
 		id: 3,
@@ -1216,11 +1222,11 @@ export const faqData = [
 		id: 4,
 		question: "What if I need to move off Autumn? Am I locked in?",
 		answer:
-			"Autumn is open source. You can self-host anytime, or export all your data. Your Stripe subscriptions, customers and payment details remain yours. Moving off Autumn is simply a case of building what you would have built in-house without Autumn (but this has never happened, touch wood!). ",
+			"Autumn is open source. You can self-host anytime, or export all your data. Your Stripe subscriptions, customers and payment details remain yours. Moving off Autumn is simply a case of building what you would have built in-house anyway (but this has never happened, touch wood!). \n\n You can even do this gradually: first by replicating customer state into your own system via our webhooks, then making a full transition after.",
 	},
 	{
 		id: 5,
-		question: "How long would it take to go live?",
+		question: "Can you do the implementation for us?",
 		answer:
 			"If you're setting up payments for the first time, most teams go live in under an hour. Migrating from an existing billing system typically takes 1–2 weeks, depending on complexity.\n\n For Series A+ companies, we provide a forward deployed service to work with your team, dual-write to your internal system and Autumn, then smoothly migrate over. Minimal work needed on your part.",
 	},
@@ -1230,67 +1236,61 @@ export const faqData = [
 		answer:
 			"Yes. Autumn supports 10,000+ events per second per end customer. We've processed millions of billing events daily for AI companies at scale. If you have specific requirements, reach out—we'll walk through our architecture.",
 	},
-	{
-		id: 7,
-		question: "What if I can't use `check()`?",
-		answer:
-			"Latency-sensitive customers may not be able to use `check()` in real-time. In these cases, you can cache the Autumn customer data on your end, or use our single `customer.products.updated` webhook to replicate the Autumn state into your own system.",
-	},
 ];
 
 export const featuresData = [
 	{
-		title: "Usage Ledgers",
+		title: "Real-time balances",
 		description:
 			"Recurring, one-time and rollover credit balances. Stack balances across plans and topups. Deduct from soonest expiry first.",
 		Icon: IconWebhooks,
 	},
 	{
-		title: "Payment Logic",
-		description:
-			"Checkouts, upgrades, downgrades, add-ons, proration, 3DS, edge cases, webhooks: all handled in a single API call.",
-		Icon: IconWebhooks,
-	},
-	{
-		title: "Custom Plans",
-		description:
-			"Create one-off deals for enterprise customers. Unique pricing, features, and limits without touching code.",
-		Icon: IconPlans,
-	},
-	{
-		title: "Usage Analytics",
-		description:
-			"Fast timeseries charts and event logs out of the box. Powered by ClickHouse.",
-		Icon: IconAnalytics,
-	},
-	{
-		title: "Team Billing",
-		description:
-			"Grant plans and features to entities under an organization. Create pools of credits, or assign to users directly.",
-		Icon: IconTeam,
-	},
-	{
-		title: "Auto Top-ups",
-		description:
-			"Let users refill credits when balance runs low. Configure thresholds and amounts. Fully automated.",
-		Icon: IconTopUp,
-	},
-	{
-		title: "Pricing Versioning",
+		title: "Instant pricing changes",
 		description:
 			"Change your pricing model without breaking existing customers. Grandfather old plans or migrate users gradually. No database or Stripe migrations.",
 		Icon: IconVersioning,
 	},
 	{
-		title: "Alerts and Spend Limits",
+		title: "Custom contracts",
+		description:
+			"Create one-off deals for enterprise customers. Unique pricing, features, and limits without touching code.",
+		Icon: IconPlans,
+	},
+	{
+		title: "Usage history",
+		description:
+			"Fast timeseries charts and event logs out of the box. Powered by ClickHouse.",
+		Icon: IconAnalytics,
+	},
+	{
+		title: "Organization billing",
+		description:
+			"Grant plans and features to entities under an organization. Create pools of credits, or assign to users directly.",
+		Icon: IconTeam,
+	},
+	{
+		title: "Auto top-ups",
+		description:
+			"Let users refill credits when balance runs low. Configure thresholds and amounts. Fully automated.",
+		Icon: IconTopUp,
+	},
+	{
+		title: "Alerts and spend limits",
 		description:
 			"Give customers governance over their usage. Configure alerts, limits and overage per customer.",
 		Icon: IconReact,
 	},
 	{
-		title: "Coupons and Referrals",
+		title: "Payment logic",
 		description:
-			"Built-in referral system with rewards, tracking, and attribution. Launch referral programs in minutes.",
+			"Checkouts, upgrades, downgrades, add-ons, proration, 3DS, edge cases, webhooks: all handled in a single API call.",
+		Icon: IconWebhooks,
+	},
+	{
+		title: "Coupons and referrals",
+		description:
+			"Grant expiring coupon credit grants to customers. Launch referral programs in minutes.",
 		Icon: IconReferral,
 	},
 ];

--- a/apps/website/components/hero.tsx
+++ b/apps/website/components/hero.tsx
@@ -149,12 +149,9 @@ export default function Hero() {
 							<p className="hero-reveal lg:opacity-0 tracking-[-2%] w-full max-w-xs sm:max-w-[480px] md:max-w-xl text-[#FFFFFF99] md:text-[16px] text-[14px] font-light leading-5 font-sans">
 								Your {" "}
 								<span className="text-white font-light">
-									 single source of truth
+									 real-time source of truth
 								</span>{" "}
-								for usage-based, PLG and sales-led monetization. Replace your {" "}
-								<span className="text-white font-light">
-								usage limits, credit ledger and Stripe billing logic
-								</span>{" "}
+								for usage-based, PLG and sales-led monetization. Replace your usage limits, credit ledger and Stripe billing logic
 								with a flexible control plane.
 							</p>
 							

--- a/apps/website/components/hero.tsx
+++ b/apps/website/components/hero.tsx
@@ -142,17 +142,22 @@ export default function Hero() {
 						<div className="flex flex-col gap-6 w-full px-0 lg:px-0">
 							<h1 className="hero-reveal lg:opacity-0 text-[44px] md:text-[56px] w-full max-w-sm sm:max-w-[480px] md:max-w-xl leading-[44px] tracking-[-5%] md:leading-14 font-sans">
 								<span className="text-[#FFFFFF99] font-normal">
-									Drop-in credits and billing for
+									The revenue runtime for
 								</span>{" "}
-								<span className="text-white block md:inline">AI agents</span>
+								<span className="text-white block md:inline"> AI companies</span>
 							</h1>
 							<p className="hero-reveal lg:opacity-0 tracking-[-2%] w-full max-w-xs sm:max-w-[480px] md:max-w-xl text-[#FFFFFF99] md:text-[16px] text-[14px] font-light leading-5 font-sans">
-								Stop rebuilding usage limits, credit ledgers and payment logic.{" "}
+								Your {" "}
 								<span className="text-white font-light">
-									Autumn is the customer database
+									 single source of truth
 								</span>{" "}
-								that scales from your first user to your largest contract.
+								for usage-based, PLG and sales-led monetization. Replace your {" "}
+								<span className="text-white font-light">
+								usage limits, credit ledger and Stripe billing logic
+								</span>{" "}
+								with a flexible control plane.
 							</p>
+							
 						</div>
 					</div>
 					{/*

--- a/apps/website/components/problem.tsx
+++ b/apps/website/components/problem.tsx
@@ -43,7 +43,7 @@ export default function Problem() {
 							</span>
 						</h2>
 						<p className="text-[#888888] font-light text-[16px] md:text-[18px] xl:text-[16px] tracking-[-2%] leading-[20px] mb-8 xl:mb-10 max-w-sm md:max-w-lg xl:max-w-sm text-center xl:text-left">
-							AI billing is harder to maintain than seat-based. Managing payments, balances and entitlements
+							AI billing is harder than seat-based. Managing payments, balances and entitlements
 							across pricing and product changes becomes messy quickly.
 							<span className="text-white">
 								{" "}

--- a/apps/website/components/problem.tsx
+++ b/apps/website/components/problem.tsx
@@ -36,18 +36,18 @@ export default function Problem() {
 					<div className="flex flex-col mb-2 gap-3 pl-[28px] xl:pl-[90px] pr-6 xl:pr-8 pt-14 sm:pt-16 xl:pt-16 items-center xl:items-start">
 						<h2 className="font-normal tracking-[-4%] leading-[32px] xl:leading-[40px] mb-2 xl:mb-4 text-center xl:text-left">
 							<span className="block text-[#686868] text-[30px] md:text-[36px] xl:text-[40px]">
-								Say goodbye to the 
+								Say goodbye to your 
 							</span>
 							<span className="block text-white text-[30px] md:text-[36px] xl:text-[40px]">
-								old way of billing.
+								vibecoded infra.
 							</span>
 						</h2>
 						<p className="text-[#888888] font-light text-[16px] md:text-[18px] xl:text-[16px] tracking-[-2%] leading-[20px] mb-8 xl:mb-10 max-w-sm md:max-w-lg xl:max-w-sm text-center xl:text-left">
-							Maintaining payment logic, customer balances and feature access
-							across pricing and product changes is months of work.
+							AI billing is harder to maintain than seat-based. Managing payments, balances and entitlements
+							across pricing and product changes becomes messy quickly.
 							<span className="text-white">
 								{" "}
-								Autumn replaces all the billing code you're building yourself.
+								Autumn decouples your billing logic from code.
 							</span>
 						</p>
 					</div>

--- a/apps/website/components/production-scale.tsx
+++ b/apps/website/components/production-scale.tsx
@@ -61,7 +61,7 @@ const cards = [
 	{
 		bg: "#A175FF",
 		icon: "/images/production/uptime2.svg",
-		metric: "1 Billion +",
+		metric: "> 5 billion",
 		label: "Monthly events",
 		description:
 			"Autumn handles billions of billing events monthly for some of your favorite apps.",
@@ -70,7 +70,7 @@ const cards = [
 	{
 		bg: "#FFE8FA",
 		icon: "/images/production/latency.svg",
-		metric: "<50ms",
+		metric: "< 50ms",
 		label: "US latency",
 		description:
 			"Every billing check resolves in under 50ms. Your users never wait for a gate.",

--- a/apps/website/components/solution.tsx
+++ b/apps/website/components/solution.tsx
@@ -48,14 +48,14 @@ export default function Solution() {
 				{/* Heading */}
 				<div className="text-center mb-16 lg:mb-4 flex flex-col items-center">
 					<h2 className="text-[30px] leading-[30px] md:text-[40px] md:leading-[40px] font-normal tracking-tight mb-6">
-						<span className="text-[#A3A3A3]">Replace it all with </span>
-						<span className="text-white">Autumn</span>
+						<span className="text-[#A3A3A3]">Your app's </span>
+						<span className="text-white">customer record</span>
 					</h2>
 					<p className="text-[#A3A3A3] text-[14px] md:text-[16px] sm:text-base max-w-2xl mx-auto font-light leading-[20px] tracking-[-2%]">
-						Autumn is a database purpose-built for billing state. Configure your
+						Autumn is a database purpose-built for real-time monetization. Configure your
 						pricing
 						<br className="hidden sm:block" />
-						in the dashboard.{" "}
+						in the dashboard or CLI.{" "}
 						<span className="text-white">
 							Three API calls handle everything else.
 						</span>


### PR DESCRIPTION
## Summary
- Update website copy across hero, problem, solution, and production-scale sections
- Refresh constants and messaging in `apps/website/`

## Test plan
- [ ] Verify website renders correctly with updated copy

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated website copy across the hero, problem, solution, features, FAQ, and production-scale sections to sharpen positioning and clarify behavior. Adds an FAQ on `autumn.check()` for latency-sensitive paths, updates the hero to “The revenue runtime for AI companies,” refines fail-open and lock-in answers (incl. gradual migration), revises feature titles/descriptions, and updates scale metrics to > 5 billion monthly events and < 50 ms US latency.

<sup>Written for commit f09070e85932c1826be0b29757cb6772894c2102. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1638?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refreshes marketing copy across five website files — hero tagline, problem/solution sections, production-scale metrics, FAQ entries, and feature card titles — with no structural or logic changes to components.

- **[Improvements]** Hero headline updated to "The revenue runtime for AI companies", problem section reframed around AI billing complexity, and production-scale monthly events bumped to "> 5 billion".
- **[Improvements]** FAQ restructured: the "What if I can't use `check()`?" entry replaced with a clearer "Do I need to call Autumn before every action?", and the lock-in answer extended with a gradual migration note.
- **[Bug fixes]** FAQ id 5 question was renamed to "Can you do the implementation for us?" but its answer still leads with time-to-go-live content from the old "How long would it take to go live?" question, causing a visible question/answer mismatch on the site.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the FAQ question/answer mismatch — the rest are pure copy refreshes with no functional impact.

FAQ id 5's question was updated to "Can you do the implementation for us?" but its answer still opens by describing time-to-go-live, which is the answer to the old question. This leaves a confusing, mismatched FAQ entry visible to all website visitors until corrected.

apps/website/app/constant.tsx — specifically the FAQ id 5 answer block around line 1231.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/app/constant.tsx | FAQ and features copy updated; question for id 5 was changed to "Can you do the implementation for us?" but the existing answer (which answered "How long would it take to go live?") was not updated to match. |
| apps/website/components/hero.tsx | Hero tagline and description refreshed; minor leading whitespace in a <span> text node and inconsistent indentation on the second highlighted span. |
| apps/website/components/problem.tsx | Problem-section heading and body copy updated to AI billing framing; no structural or logic issues. |
| apps/website/components/production-scale.tsx | Metric updated from "1 Billion +" to "> 5 billion" and latency label spacing normalized; straightforward copy change. |
| apps/website/components/solution.tsx | Solution section heading and description updated to "customer record" and "real-time monetization" framing; no issues found. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Website Pages] --> B[hero.tsx]
    A --> C[problem.tsx]
    A --> D[solution.tsx]
    A --> E[production-scale.tsx]
    A --> F[constant.tsx]

    B --> B1["Tagline: 'The revenue runtime for AI companies'"]
    B --> B2["Desc: single source of truth / control plane"]

    C --> C1["Heading: 'Say goodbye to your vibecoded infra'"]
    C --> C2["Body: AI billing complexity framing"]

    D --> D1["Heading: 'Your app's customer record'"]
    D --> D2["Desc: real-time monetization + CLI"]

    E --> E1["Metric: > 5 billion monthly events"]
    E --> E2["Latency: < 50ms (spacing normalized)"]

    F --> F1["FAQ: new Q7 — 'Do I need to call Autumn before every action?'"]
    F --> F2["FAQ: id5 question changed ⚠️ answer not updated"]
    F --> F3["featuresData: titles + descriptions refreshed"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/website/app/constant.tsx:1228-1232
**FAQ answer doesn't match the new question**

The question was changed to "Can you do the implementation for us?" but the answer opens with "If you're setting up payments for the first time, most teams go live in under an hour" — that directly answers the old question ("How long would it take to go live?"), not the new one. A visitor asking if Autumn can do the implementation would expect a yes/no and the forward-deployed-service details; the time-to-go-live sentences are a non-sequitur here and will confuse readers.

### Issue 2 of 2
apps/website/components/hero.tsx:152-157
**Leading space and inconsistent indentation in hero paragraph**

Line 152 has a stray leading space — ` single source of truth` — that will render as a visible gap before the highlighted text. Lines 156–157 (`usage limits, credit ledger and Stripe billing logic`) are also indented at the same level as the containing `<span>` tag rather than one level deeper, unlike the first `<span>` on lines 151–153.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["change copy on website"](https://github.com/useautumn/autumn/commit/1463e56746d9a81f6a47f5dc248cff175b3cafff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32987334)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->