### PR TITLE
Add missing lottie-web dependency to website

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -19,6 +19,7 @@
 		"gray-matter": "^4.0.3",
 		"gsap": "^3.15.0",
 		"lottie-react": "^2.4.1",
+		"lottie-web": "^5.13.0",
 		"motion": "^12.38.0",
 		"next": "16.2.4",
 		"ngrok": "^5.0.0-beta.2",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "autumn",
@@ -122,6 +121,7 @@
         "gray-matter": "^4.0.3",
         "gsap": "^3.15.0",
         "lottie-react": "^2.4.1",
+        "lottie-web": "^5.13.0",
         "motion": "^12.38.0",
         "next": "16.2.4",
         "ngrok": "^5.0.0-beta.2",


### PR DESCRIPTION
## Summary
- Add `lottie-web` to `apps/website/package.json` — required by `solution-animation.tsx` but was missing, causing a Turbopack build failure

## Test plan
- [ ] Verify website builds successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing `lottie-web` dependency to `apps/website`, required by `solution-animation.tsx`, to fix Turbopack build failures. Restores successful website builds.

<sup>Written for commit 72db2a12d6161ccc911981b229f7be9dd511d8d5. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1639?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `lottie-web` as an explicit dependency in `apps/website/package.json` to fix a Turbopack build failure. The package was already being used directly in `solution-animation.tsx` but was only available as a transitive dependency of `lottie-react`, which Turbopack does not allow.

- **[Bug fix]** Added `lottie-web@^5.13.0` to `apps/website/package.json` — the package is directly imported in `solution-animation.tsx` but was missing from the manifest, causing a Turbopack build failure.
- **[Improvements]** The `bun.lock` `configVersion` field was removed as part of regenerating the lockfile with `bun install`, which is a benign format update.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds a single missing explicit dependency that was already present in the lockfile as a transitive package.

The change is minimal and correct: `lottie-web` is directly imported in `solution-animation.tsx` and the lockfile already contained the resolved package via `lottie-react`. Making it explicit unblocks the Turbopack build without touching any application logic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/package.json | Adds `lottie-web@^5.13.0` as an explicit dependency; correctly reflects the direct import in `solution-animation.tsx`. |
| bun.lock | Lockfile updated to reflect the new explicit `lottie-web` dependency; `configVersion` field removed as a benign bun lockfile format change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[solution-animation.tsx] -->|import lottie from| B[lottie-web]
    A -->|import gsap from| C[gsap]
    D[lottie-react] -->|transitive dep| B
    E[apps/website/package.json] -->|explicit dep added| B
    E -->|explicit dep| D
    E -->|explicit dep| C
```
</details>

<sub>Reviews (1): Last reviewed commit: ["add missing lottie-web dependency to web..."](https://github.com/useautumn/autumn/commit/72db2a12d6161ccc911981b229f7be9dd511d8d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32991883)</sub>

<!-- /greptile_comment -->