### PR TITLE
fix: attach tax rate id

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@better-auth/cli": "^1.4.21",
-        "@biomejs/biome": "^2.2.7",
+        "@biomejs/biome": "2.2.2",
         "@trigger.dev/build": "4.4.6",
         "@types/node": "^24.9.1",
         "concurrently": "^9.2.1",
@@ -937,23 +937,23 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.2.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.2.2", "@biomejs/cli-darwin-x64": "2.2.2", "@biomejs/cli-linux-arm64": "2.2.2", "@biomejs/cli-linux-arm64-musl": "2.2.2", "@biomejs/cli-linux-x64": "2.2.2", "@biomejs/cli-linux-x64-musl": "2.2.2", "@biomejs/cli-win32-arm64": "2.2.2", "@biomejs/cli-win32-x64": "2.2.2" }, "bin": { "biome": "bin/biome" } }, "sha512-j1omAiQWCkhuLgwpMKisNKnsM6W8Xtt1l0WZmqY/dFj8QPNkIoTvk4tSsi40FaAAkBE1PU0AFG2RWFBWenAn+w=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6ePfbCeCPryWu0CXlzsWNZgVz/kBEvHiPyNpmViSt6A2eoDf4kXs3YnwQPzGjy8oBgQulrHcLnJL0nkCh80mlQ=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tn4JmVO+rXsbRslml7FvKaNrlgUeJot++FkvYIhl1OkslVCofAtS35MPlBMhXgKWF9RNr9cwHanrPTUUXcYGag=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-JfrK3gdmWWTh2J5tq/rcWCOsImVyzUnOS2fkjhiYKCQ+v8PqM+du5cfB7G1kXas+7KQeKSWALv18iQqdtIMvzw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-/MhYg+Bd6renn6i1ylGFL5snYUn/Ct7zoGVKhxnro3bwekiZYE8Kl39BSb0MeuqM+72sThkQv4TnNubU9njQRw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Ogb+77edO5LEP/xbNicACOWVLt8mgC+E1wmpUakr+O4nKwLt9vXe74YNuT3T1dUBxC/SnrVmlzZFC7kQJEfquQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ZCLXcZvjZKSiRY/cFANKg+z6Fhsf9MHOzj+NrDQcM+LbqYRT97LyCLWy2AS+W2vP+i89RyRM+kbGpUzbRTYWig=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 

--- a/package.json
+++ b/package.json
@@ -107,11 +107,9 @@
 		"migrate-functions:prod": "infisical run --env=prod --recursive -- bun scripts/migrations/migrate-functions.ts",
 		"validate-schema": "infisical run --env=prod --recursive -- bun scripts/migrations/validate-schema.ts",
 		"validate-shebangs": "infisical run --env=prod --recursive -- bun scripts/migrations/validate-fullsubject-shebangs.ts",
-
 		"tb": "bun scripts/tinybird/index.ts",
 		"tb:prod": "bun scripts/tinybird/index.ts prod",
 		"tb:prod-legacy": "bun scripts/tinybird/index.ts prod-legacy",
-
 		"trigger:deploy": "bunx trigger.dev deploy",
 		"setupci": "node scripts/setup/setupci.js",
 		"replicate": "bun scripts/db/replicate.ts",
@@ -159,7 +157,7 @@
 	},
 	"devDependencies": {
 		"@better-auth/cli": "^1.4.21",
-		"@biomejs/biome": "^2.2.7",
+		"@biomejs/biome": "2.2.2",
 		"@trigger.dev/build": "4.4.6",
 		"@types/node": "^24.9.1",
 		"concurrently": "^9.2.1",

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -299,6 +299,7 @@ export const setupAttachBillingContext = async ({
 			params.success_url ?? orgToReturnUrl({ org: ctx.org, env: ctx.env }),
 		checkoutSessionParams: params.checkout_session_params,
 		userMetadata: params.metadata,
+		taxRateId: params.tax_rate_id,
 
 		externalId: params.subscription_id,
 

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
@@ -42,10 +42,18 @@ export const buildStripeCheckoutSessionAction = ({
 		? "payment"
 		: "subscription";
 
-	// 3. Build line_items from recurring items and one-off items
+	// Payment-mode checkout has no top-level default_tax_rates, so one-off items take per-line tax_rates.
+	const taxRateId = billingContext.taxRateId;
+	const applyTaxRateToLineItem = (
+		item: Stripe.Checkout.SessionCreateParams.LineItem,
+	): Stripe.Checkout.SessionCreateParams.LineItem =>
+		taxRateId ? { ...item, tax_rates: [taxRateId] } : item;
+
 	const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = [
 		...recurringLineItems.filter((item) => item.quantity !== 0),
-		...oneOffLineItems.filter((item) => item.quantity !== 0),
+		...oneOffLineItems
+			.filter((item) => item.quantity !== 0)
+			.map(applyTaxRateToLineItem),
 	];
 
 	// 4. Trial handling (only for subscription mode)
@@ -66,6 +74,7 @@ export const buildStripeCheckoutSessionAction = ({
 							end_behavior: { missing_payment_method: "cancel" },
 						},
 					}),
+					...(taxRateId && { default_tax_rates: [taxRateId] }),
 					metadata: buildAutumnSubscriptionMetadata({
 						actionSource: billingContext.actionSource,
 					}),

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -51,6 +51,10 @@ export const executeStripeSubscriptionOperation = async ({
 	const wantsAutoTax =
 		!!ctx.org.config.automatic_tax && !billingContext.invoiceMode;
 
+	const taxRateParams = billingContext.taxRateId
+		? { default_tax_rates: [billingContext.taxRateId] }
+		: {};
+
 	switch (subscriptionAction.type) {
 		case "update": {
 			let stripeSubscription = billingContext.stripeSubscription;
@@ -99,6 +103,7 @@ export const executeStripeSubscriptionOperation = async ({
 					...(updateWillCreateInvoice ? invoiceModeParams : {}),
 					...(autumnMeta && { metadata: autumnMeta }),
 					...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
+					...taxRateParams,
 					expand: ["latest_invoice"],
 				},
 			);
@@ -110,6 +115,7 @@ export const executeStripeSubscriptionOperation = async ({
 				...fallbackPaymentMethodParams,
 				...(autumnMeta && { metadata: autumnMeta }),
 				...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
+				...taxRateParams,
 
 				billing_mode: { type: "flexible" },
 

--- a/server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-pro.test.ts
+++ b/server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-pro.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Pass an explicit Stripe tax rate ID (`tax_rate_id`) through
+ * `/v1/billing.attach` and assert that:
+ *   - The created Stripe subscription carries it in `default_tax_rates`.
+ *   - The first invoice applies the 10% rate on top of pro's $20 base.
+ */
+
+import { expect, test } from "bun:test";
+import { getStripeSubscription } from "@tests/integration/billing/utils/stripeSubscriptionUtils.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+
+const subTaxRateIds = (sub: Stripe.Subscription): string[] =>
+	(sub.default_tax_rates ?? []).map((rate) =>
+		typeof rate === "string" ? rate : rate.id,
+	);
+
+test.concurrent(
+	`${chalk.yellowBright("attach-tax-rate-id (v2 /v1/billing.attach): pro $20/mo + explicit 10% tax_rate_id = $22 invoice")}`,
+	async () => {
+		const customerId = "attach-tax-rate-pro";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "Test Tax",
+			percentage: 10,
+			inclusive: false,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: proProd.id,
+			tax_rate_id: taxRate.id,
+		});
+
+		const { stripeCli, subscription } = await getStripeSubscription({
+			customerId,
+		});
+
+		expect(subTaxRateIds(subscription)).toContain(taxRate.id);
+
+		const latestInvoiceId =
+			typeof subscription.latest_invoice === "string"
+				? subscription.latest_invoice
+				: (subscription.latest_invoice as Stripe.Invoice).id!;
+		const invoice = await stripeCli.invoices.retrieve(latestInvoiceId);
+
+		expect(invoice.subtotal).toBe(2000);
+		expect(invoice.total).toBe(2200);
+		expect(invoice.total - invoice.subtotal).toBe(200);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("attach-tax-rate-id (v2): tax_rate_id set on pro persists through upgrade to premium")}`,
+	async () => {
+		const customerId = "attach-tax-rate-pro-then-premium";
+		const proProd = products.pro({ id: "pro", items: [] });
+		const premiumProd = products.premium({ id: "premium", items: [] });
+
+		const { ctx, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [proProd, premiumProd] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "Test Tax",
+			percentage: 10,
+			inclusive: false,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: proProd.id,
+			tax_rate_id: taxRate.id,
+		});
+
+		const afterAttach = await getStripeSubscription({ customerId });
+		expect(subTaxRateIds(afterAttach.subscription)).toContain(taxRate.id);
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: premiumProd.id,
+		});
+
+		const afterUpgrade = await getStripeSubscription({ customerId });
+		expect(subTaxRateIds(afterUpgrade.subscription)).toContain(taxRate.id);
+	},
+);

--- a/shared/api/billing/attachV2/attachParamsV0.ts
+++ b/shared/api/billing/attachV2/attachParamsV0.ts
@@ -35,6 +35,8 @@ export const ExtAttachParamsV0Schema = BillingParamsBaseV0Schema.extend({
 	// For importing an existing subscription...?
 	processor_subscription_id: z.string().optional(),
 	no_billing_changes: z.boolean().optional(),
+
+	tax_rate_id: z.string().optional(),
 });
 
 export const AttachParamsV0Schema = ExtAttachParamsV0Schema.extend({

--- a/shared/api/billing/attachV2/attachParamsV1.ts
+++ b/shared/api/billing/attachV2/attachParamsV1.ts
@@ -95,6 +95,11 @@ export const AttachParamsV1Schema = BillingParamsBaseV1Schema.extend({
 		description:
 			"If true, the customer's plan is activated immediately even when payment is deferred (invoice mode) or pending (Stripe checkout). For Stripe checkout, the customer_product is inserted before the customer completes the hosted form.",
 	}),
+
+	tax_rate_id: z.string().optional().meta({
+		description:
+			"Stripe tax rate ID (txr_...) to apply as the default tax rate on the created subscription, invoice, or checkout session line items.",
+	}),
 });
 
 export type AttachParamsV1 = z.infer<typeof AttachParamsV1Schema>;

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -86,6 +86,7 @@ export interface BillingContext {
 	successUrl?: string;
 	checkoutSessionParams?: Record<string, unknown>;
 	userMetadata?: Record<string, string>;
+	taxRateId?: string;
 
 	skipBillingChanges?: boolean;
 	dryRunStripe?: boolean;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Attach now accepts `tax_rate_id` and applies it in Stripe checkout and subscription flows. This fixes missing tax on one‑off items and ensures the rate persists through plan upgrades.

- **Bug Fixes**
  - Add `tax_rate_id` to attach V0/V1 params and thread it through the billing context.
  - Stripe Checkout: set `default_tax_rates` in subscription mode; set per-line `tax_rates` in payment mode.
  - Subscription operations: apply `default_tax_rates` on create and update.
  - Integration tests: verify pro $20 + 10% = $22 and that the rate persists after upgrading to premium.

- **Dependencies**
  - Pin `@biomejs/biome` to `2.2.2` (dev).

<sup>Written for commit 4268c652b0ae018cb327cf219ebfcc6abb9c4f80. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1641?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds support for passing an explicit Stripe tax rate ID (`tax_rate_id`) through the `/v1/billing.attach` endpoint, propagating it as `default_tax_rates` on created/updated subscriptions and checkout sessions, with per-line-item `tax_rates` applied to one-off items in payment-mode checkout.

- **[API changes]** New optional `tax_rate_id` field added to both `AttachParamsV0` and `AttachParamsV1` schemas and threaded into `BillingContext`.
- **[Bug fixes]** `default_tax_rates` is now applied to Stripe subscriptions (create & update paths) and checkout sessions (`subscription_data` for recurring items, per-line-item for one-off items).
- **[Improvements]** Two integration tests verify that the tax rate appears on the created subscription invoice and that it persists through an upgrade when not explicitly re-supplied.
</details>


<h3>Confidence Score: 3/5</h3>

Any organisation that has automatic tax enabled at the org level AND whose callers pass tax_rate_id will receive a Stripe API error on every attach call — both the subscription path and the checkout session path send conflicting tax parameters simultaneously.

Both executeStripeSubscriptionOperation and buildStripeCheckoutSessionAction can emit automatic_tax enabled and default_tax_rates in the same Stripe request. Stripe rejects that combination, so the tax_rate_id feature is broken for any org with automatic_tax configured, covering the subscription create, update, and checkout session paths at once.

executeStripeSubscriptionOperation.ts and buildStripeCheckoutSessionAction.ts both need a guard to skip automatic_tax when taxRateId is present.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts | Adds taxRateParams to both create and update subscription paths; automatic_tax and default_tax_rates can both be sent to Stripe simultaneously when an org has automatic_tax enabled and a caller passes tax_rate_id. |
| server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts | Applies tax_rate_id to subscription_data.default_tax_rates and per-line-item tax_rates for one-off items; same automatic_tax conflict present when org has automatic_tax configured. |
| shared/api/billing/attachV2/attachParamsV1.ts | Adds optional tax_rate_id field with a clear description to the V1 attach schema. |
| server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts | Threads params.tax_rate_id through to BillingContext as taxRateId. |
| server/tests/integration/billing/tax/attach-tax-rates/attach-tax-rate-id-pro.test.ts | New integration tests covering initial attach with tax_rate_id and persistence through an upgrade; second test relies on Stripe implicitly preserving default_tax_rates across subscription updates. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AttachEndpoint
    participant BillingContext
    participant StripeOps

    Client->>AttachEndpoint: "POST /v1/billing.attach { tax_rate_id }"
    AttachEndpoint->>BillingContext: setupAttachBillingContext()
    BillingContext-->>AttachEndpoint: "BillingContext { taxRateId }"

    alt Stripe Checkout
        AttachEndpoint->>StripeOps: buildStripeCheckoutSessionAction()
        Note over StripeOps: subscription_data.default_tax_rates or lineItem.tax_rates
        StripeOps-->>Client: Stripe Checkout URL
    else Direct subscription
        AttachEndpoint->>StripeOps: executeStripeSubscriptionOperation()
        Note over StripeOps: default_tax_rates applied on create/update
        StripeOps-->>AttachEndpoint: Stripe Subscription
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts`, line 49-56 ([link](https://github.com/useautumn/autumn/blob/3d9d2198256391fd64eecf56061cbf3b641a3f18/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts#L49-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> Stripe rejects subscription create/update requests that include both `automatic_tax: { enabled: true }` and `default_tax_rates`. When an organisation has `automatic_tax` configured and a caller also supplies `tax_rate_id`, both fields land in the same API call, causing a Stripe error such as "You cannot set default_tax_rates while automatic_tax is enabled."

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
   Line: 49-56

   Comment:
   Stripe rejects subscription create/update requests that include both `automatic_tax: { enabled: true }` and `default_tax_rates`. When an organisation has `automatic_tax` configured and a caller also supplies `tax_rate_id`, both fields land in the same API call, causing a Stripe error such as "You cannot set default_tax_rates while automatic_tax is enabled."

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts`, line 89-99 ([link](https://github.com/useautumn/autumn/blob/3d9d2198256391fd64eecf56061cbf3b641a3f18/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts#L89-L99)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> Same conflict as in `executeStripeSubscriptionOperation`: when `org.config.automatic_tax` is set and `taxRateId` is also present, the resulting checkout session params will contain both `automatic_tax: { enabled: true }` (from `autumnAutoTax`) and `subscription_data.default_tax_rates`, which Stripe rejects.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts
   Line: 89-99

   Comment:
   Same conflict as in `executeStripeSubscriptionOperation`: when `org.config.automatic_tax` is set and `taxRateId` is also present, the resulting checkout session params will contain both `automatic_tax: { enabled: true }` (from `autumnAutoTax`) and `subscription_data.default_tax_rates`, which Stripe rejects.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts:49-56
Stripe rejects subscription create/update requests that include both `automatic_tax: { enabled: true }` and `default_tax_rates`. When an organisation has `automatic_tax` configured and a caller also supplies `tax_rate_id`, both fields land in the same API call, causing a Stripe error such as "You cannot set default_tax_rates while automatic_tax is enabled."

```suggestion
	// Skip auto_tax in invoice mode: send_invoice has no address-collection
	// UI so Stripe Tax rejects.
	// Also skip auto_tax when an explicit tax_rate_id is provided — Stripe
	// does not allow default_tax_rates and automatic_tax on the same subscription.
	const wantsAutoTax =
		!!ctx.org.config.automatic_tax &&
		!billingContext.invoiceMode &&
		!billingContext.taxRateId;

	const taxRateParams = billingContext.taxRateId
		? { default_tax_rates: [billingContext.taxRateId] }
		: {};
```

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeCheckoutSessionAction.ts:89-99
Same conflict as in `executeStripeSubscriptionOperation`: when `org.config.automatic_tax` is set and `taxRateId` is also present, the resulting checkout session params will contain both `automatic_tax: { enabled: true }` (from `autumnAutoTax`) and `subscription_data.default_tax_rates`, which Stripe rejects.

```suggestion
	// 7. Build params. Tax policy is baked in here (not at execute time) so
	// the action object is self-describing in logs/EXTRA_LOGS.
	// Skip automatic_tax when an explicit tax_rate_id is supplied — Stripe
	// does not allow both on the same checkout session / subscription_data.
	const autumnAutoTax: Partial<Stripe.Checkout.SessionCreateParams> =
		org.config.automatic_tax && !taxRateId
			? {
					automatic_tax: { enabled: true },
					billing_address_collection: "required",
					customer_update: { address: "auto", name: "auto" },
					tax_id_collection: { enabled: true },
				}
			: {};
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/attach-tax-..."](https://github.com/useautumn/autumn/commit/3d9d2198256391fd64eecf56061cbf3b641a3f18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33001938)</sub>

<!-- /greptile_comment -->