### PR TITLE
chore: api

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "autumn",

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -8669,7 +8669,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779276876159,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780486476159,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/.speakeasy/gen.lock
+++ b/packages/sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 7b300647-cd76-49e9-bf77-7d1bf5446d66
 management:
-  docChecksum: 2ef0aba76ee8815e90e9e79cbe09fe8f
+  docChecksum: 6a1df89023761bd23eb5bf8211d8dd0a
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.10.17
   configChecksum: bae45df54c836a79d656f78f967da99b
 persistentEdits:
-  generation_id: efd75abb-52b2-4a1e-ab1d-0a46c5f4fef9
-  pristine_commit_hash: 23fba30647d6c8563340bb6d7dacd63e1d41492f
-  pristine_tree_hash: 8915422a5d0df7d9d7c7132373b9c44c36dbb62e
+  generation_id: 67efec9a-201b-450e-881f-78d2efc51aa0
+  pristine_commit_hash: 60f5c6ce051819a686a353ef7f1b2d881e22ae6e
+  pristine_tree_hash: ec100e572dccea6f162c8316680fa32165355b4c
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -4132,8 +4132,8 @@ trackedFiles:
     pristine_git_object: 0ebe5146cd24c153cb9b7655e4f502c09f7d4abd
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:d5505f30ec4893b1c194b7ac239feaaaa6bd73ea
-    pristine_git_object: a21c0795820fbf7b9b2d59a94ca14bf218656227
+    last_write_checksum: sha1:f99f9f655f28f922737553ecfc752465f9044a83
+    pristine_git_object: 06b795d127cff402311aaf3494bd20f4ef0226fb
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:74cd5f6cf800e1d86b2c332fed3c3cd53f3eeb6b
@@ -4212,8 +4212,8 @@ trackedFiles:
     pristine_git_object: ccbecbd59533d8bf511f43ad4605756e2049da9a
   src/funcs/billing-create-schedule.ts:
     id: fd662bfcdc10
-    last_write_checksum: sha1:95f6e375d3f18364e872159aadba2826dab87e23
-    pristine_git_object: 80b8037f6e700d5935a56f767dac2336b9eb5eb0
+    last_write_checksum: sha1:323271d99100628ad90cc49e2c74b13e92158308
+    pristine_git_object: 96cfa89c175dd7b85a68ff3882396383c92294a4
   src/funcs/billing-multi-attach.ts:
     id: 67491e2d8249
     last_write_checksum: sha1:00ba80c1f98e7a8be29db0cf5a6957433f687861
@@ -4636,8 +4636,8 @@ trackedFiles:
     pristine_git_object: 571de419ea3321d79acec4bddbb46b1580007115
   src/sdk/billing.ts:
     id: 10905058c4ad
-    last_write_checksum: sha1:e59c12a907a253da7b983197fc5411ba1791157f
-    pristine_git_object: 647de145751dfcd88a9820b68253e2e2265f2b29
+    last_write_checksum: sha1:4080b34a74e8093303a96536651d6690e95fb129
+    pristine_git_object: 43cf308037de1f5b98b98f57ec3cff9161dc3d26
   src/sdk/customers.ts:
     id: d33e193e0c00
     last_write_checksum: sha1:8d64f03efa17b4ef45a6d67a44d23e2943f1cd8b

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -8012,7 +8012,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779276876159,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780486476159,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/.speakeasy/workflow.lock
+++ b/packages/sdk/.speakeasy/workflow.lock
@@ -2,11 +2,11 @@ speakeasyVersion: 1.762.0
 sources:
     Autumn API:
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:e86135c413edb7e63d472f7cc2d3288655855fcfed349c4aaa8979b6bf95a571
-        sourceBlobDigest: sha256:29d462702a2326b6f735960eb0f9771abb9a88d7ac493d04819af37a79f7d7cb
+        sourceRevisionDigest: sha256:87da9052ce935078ff9e3d67172dba092df81d9e225acebdd75d8034da120ef4
+        sourceBlobDigest: sha256:4d8c2a7bc31fa854597bf2ad563afc7325f2a7fc4f90d9f088ab8ab6a6ae7a24
         tags:
             - latest
-            - 2.2.0
+            - 2.3.0
     Autumn API Stripped:
         sourceNamespace: autumn-api-stripped
         sourceRevisionDigest: sha256:77fa91848d845af89acfb71b0fc8ae93f2b6433eab1baabb1df5752d1bad2b8a
@@ -18,10 +18,10 @@ targets:
     autumn:
         source: Autumn API
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:e86135c413edb7e63d472f7cc2d3288655855fcfed349c4aaa8979b6bf95a571
-        sourceBlobDigest: sha256:29d462702a2326b6f735960eb0f9771abb9a88d7ac493d04819af37a79f7d7cb
+        sourceRevisionDigest: sha256:87da9052ce935078ff9e3d67172dba092df81d9e225acebdd75d8034da120ef4
+        sourceBlobDigest: sha256:4d8c2a7bc31fa854597bf2ad563afc7325f2a7fc4f90d9f088ab8ab6a6ae7a24
         codeSamplesNamespace: autumn-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:97c2a86cbf5db2f317e55614b6cd9851570bb5e5eec5120f0d6c21b46a3a3095
+        codeSamplesRevisionDigest: sha256:222311f143e62954bf39614f69eeb55aeeada6161e8ee102e96c9ac1e1335c0d
     autumn-python:
         source: Autumn API Stripped
         sourceNamespace: autumn-api-stripped

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -271,7 +271,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779276876159,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780486476159,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.
@@ -782,7 +782,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779276876159,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780486476159,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/funcs/billing-create-schedule.ts
+++ b/packages/sdk/src/funcs/billing-create-schedule.ts
@@ -34,7 +34,7 @@ import { Result } from "../types/fp.js";
  * @example
  * ```typescript
  * // Schedule a transition from a trial plan to a paid plan
- * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
+ * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779276876159,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780486476159,"plans":[{"planId":"pro_plan"}]}] });
  * ```
  *
  * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/sdk/billing.ts
+++ b/packages/sdk/src/sdk/billing.ts
@@ -86,7 +86,7 @@ export class Billing extends ClientSDK {
    * @example
    * ```typescript
    * // Schedule a transition from a trial plan to a paid plan
-   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779185921682,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780395521682,"plans":[{"planId":"pro_plan"}]}] });
+   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779276876159,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780486476159,"plans":[{"planId":"pro_plan"}]}] });
    * ```
    *
    * @param customerId - The ID of the customer to create the schedule for.


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Regenerated the SDK and OpenAPI artifacts to Autumn API 2.3.0 and refreshed the billing.createSchedule examples. Updated docs and lockfiles; no runtime or API surface changes.

<sup>Written for commit d5edd472dbe4cec47e9d712a4ad0a34b2466b11f. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1642?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR regenerates the Autumn TypeScript SDK via Speakeasy, bumping the API source from version `2.2.0` to `2.3.0` with refreshed example timestamps across all doc surfaces.

- **[API changes]** `workflow.lock` version tag bumped from `2.2.0` to `2.3.0`; all Speakeasy digest hashes and generation IDs updated to reflect the new spec revision.
- **[Improvements]** Example `startsAt` timestamps in the `billing.createSchedule` code samples refreshed to future-dated values across `openapi.yml`, `out.openapi.yaml`, `README.md`, `billing-create-schedule.ts`, and `billing.ts`.
- **[Improvements]** `bun.lock` gains a `configVersion: 0` field reflecting an updated lockfile format.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely generated output with no logic changes.

All changes are auto-generated by Speakeasy: timestamp updates in code-sample strings, refreshed digest hashes, and a lockfile format field. No business logic, API signatures, or runtime behaviour is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/sdk/.speakeasy/workflow.lock | API source version tag bumped from `2.2.0` to `2.3.0`; digest hashes updated accordingly. |
| packages/sdk/src/funcs/billing-create-schedule.ts | Example `startsAt` timestamps refreshed to more recent future values; no logic changes. |
| packages/sdk/src/sdk/billing.ts | Example `startsAt` timestamps refreshed; no logic or signature changes. |
| packages/openapi/openapi.yml | Same timestamp refresh in the `createSchedule` code sample within the OpenAPI spec. |
| packages/sdk/README.md | Two occurrences of the example timestamps updated to match the regenerated SDK docs. |
| packages/sdk/.speakeasy/gen.lock | Checksums and generation IDs regenerated to reflect the updated source spec. |
| bun.lock | Added `configVersion: 0` field; routine lockfile format update. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OpenAPI Spec v2.3.0\nopenapi.yml] -->|Speakeasy generates| B[out.openapi.yaml]
    B --> C[SDK source\nbilling-create-schedule.ts\nbilling.ts]
    B --> D[SDK docs\nREADME.md]
    B --> E[Lock files\ngen.lock / workflow.lock]
    C & D & E -->|Published| F[packages/sdk v0.10.17]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: updated API"](https://github.com/useautumn/autumn/commit/d5edd472dbe4cec47e9d712a4ad0a34b2466b11f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33002433)</sub>

<!-- /greptile_comment -->