### PR TITLE
fix: 🐛 redis hard coded to us west

### DIFF
--- a/server/src/external/redis/initUtils/redisConfig.ts
+++ b/server/src/external/redis/initUtils/redisConfig.ts
@@ -6,7 +6,7 @@ const REGION_US_WEST_2 = "us-west-2";
 const ALL_REGIONS = [REGION_US_EAST_2, REGION_US_WEST_2] as const;
 
 // Current region this instance is running in
-export const currentRegion = process.env.AWS_REGION || REGION_US_WEST_2;
+export const currentRegion = process.env.AWS_REGION || REGION_US_EAST_2;
 
 export const cacheBackupUrl = process.env.CACHE_BACKUP_URL?.trim();
 
@@ -35,4 +35,4 @@ export const getCacheUrlForRegion = ({ region }: { region: string }) => {
 	return regionToCacheUrl[region];
 };
 
-export const PRIMARY_REGION = REGION_US_WEST_2;
+export const PRIMARY_REGION = REGION_US_EAST_2;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Redis region defaults by switching the fallback and PRIMARY_REGION from us-west-2 to us-east-2. We now respect AWS_REGION when set and fall back to us-east-2, ensuring cache routing matches the new primary region.

<sup>Written for commit a2db97752f5e2d840159fac61daedf171ae3f8f4. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1650?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a hard-coded region default in the Redis configuration, where both the `currentRegion` fallback and `PRIMARY_REGION` constant were incorrectly pointing to `us-west-2` instead of `us-east-2`.

- **[Bug fix]** Changed the `currentRegion` environment variable fallback from `REGION_US_WEST_2` to `REGION_US_EAST_2`, so instances without `AWS_REGION` set default to the correct primary region.
- **[Bug fix]** Changed `PRIMARY_REGION` constant from `REGION_US_WEST_2` to `REGION_US_EAST_2` to match the intended primary deployment region.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a focused two-line correction with no new logic introduced.

The change corrects two constants that were pointing to the wrong AWS region. The fallback chain in `primaryCacheUrl` still resolves correctly after the fix, and no new code paths are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/redisConfig.ts | Fixes hard-coded US West 2 defaults for `currentRegion` fallback and `PRIMARY_REGION` to use US East 2 instead. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 redis hard coded to us west"](https://github.com/useautumn/autumn/commit/a2db97752f5e2d840159fac61daedf171ae3f8f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33039340)</sub>

<!-- /greptile_comment -->