### PR TITLE
Revert "Revert "Tinybird reads cutover us east""

### DIFF
--- a/scripts/setup/AGENT_README.md
+++ b/scripts/setup/AGENT_README.md
@@ -58,7 +58,7 @@ Set these in the process environment before running `bun dev:agent` and they wil
 | PostgreSQL | 5432 | Database: `autumn`, user: `postgres`, password: `postgres` |
 | Redis Stack | 6379 | Used for `CACHE_URL` and `CACHE_URL_US_EAST` (RedisJSON required) |
 | ElasticMQ | 9324 | Local SQS replacement, queue: `autumn.fifo` |
-| ClickHouse | 8123 | Used for `TINYBIRD_CLICKHOUSE_URL` |
+| ClickHouse | 8123 | Used for `TINYBIRD_US_EAST_CLICKHOUSE_URL` |
 | Server | 8080 | Autumn API server |
 | Vite | 3000 | Frontend dev server |
 | Checkout | 3001 | Checkout app dev server |

--- a/scripts/setup/writeAgentEnv.ts
+++ b/scripts/setup/writeAgentEnv.ts
@@ -67,7 +67,7 @@ AWS_ACCESS_KEY_ID=x
 AWS_SECRET_ACCESS_KEY=x
 
 # ClickHouse (local)
-TINYBIRD_CLICKHOUSE_URL=http://localhost:8123
+TINYBIRD_US_EAST_CLICKHOUSE_URL=http://localhost:8123
 
 # App URLs
 BETTER_AUTH_URL=http://localhost:${serverPort}

--- a/server/src/external/tinybird/initClickhouse.ts
+++ b/server/src/external/tinybird/initClickhouse.ts
@@ -3,8 +3,8 @@ import { type ClickHouseClient, createClient } from "@clickhouse/client";
 // ClickHouse URL is different from API URL
 // API: https://api.europe-west2.gcp.tinybird.co
 // ClickHouse: https://europe-west2.gcp.clickhouse.tinybird.co
-const TINYBIRD_CLICKHOUSE_URL = process.env.TINYBIRD_CLICKHOUSE_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
+const TINYBIRD_CLICKHOUSE_URL = process.env.TINYBIRD_US_EAST_CLICKHOUSE_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
 
 // Debug logging
 if (TINYBIRD_CLICKHOUSE_URL && TINYBIRD_TOKEN) {

--- a/server/src/external/tinybird/initTinybirdV2.ts
+++ b/server/src/external/tinybird/initTinybirdV2.ts
@@ -1,19 +1,19 @@
 import { createTinybirdApi } from "@tinybirdco/sdk";
 
-const TINYBIRD_US_EAST_API_URL = process.env.TINYBIRD_US_EAST_API_URL;
-const TINYBIRD_US_EAST_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
+// Dual-write safety net during the us-east cutover. Reads the legacy
+// us-west env vars; delete with the dual-write logic in `sendEvents.ts`
+// once us-east is stable.
+const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
 
-/** Secondary Tinybird API client (us-east region) for dual-write during migration. */
-export const tinybirdUsEastApi =
-	TINYBIRD_US_EAST_API_URL && TINYBIRD_US_EAST_TOKEN
-		? createTinybirdApi({
-				baseUrl: TINYBIRD_US_EAST_API_URL,
-				token: TINYBIRD_US_EAST_TOKEN,
-			})
+/** Secondary Tinybird API client for dual-write during region cutover. */
+export const tinybirdSecondaryApi =
+	TINYBIRD_API_URL && TINYBIRD_TOKEN
+		? createTinybirdApi({ baseUrl: TINYBIRD_API_URL, token: TINYBIRD_TOKEN })
 		: null;
 
-if (tinybirdUsEastApi) {
+if (tinybirdSecondaryApi) {
 	console.log(
-		`[Tinybird] us-east dual-write configured with URL: ${TINYBIRD_US_EAST_API_URL}`,
+		`[Tinybird] secondary dual-write configured with URL: ${TINYBIRD_API_URL}`,
 	);
 }

--- a/server/src/external/tinybird/sendEvents/sendEvents.ts
+++ b/server/src/external/tinybird/sendEvents/sendEvents.ts
@@ -3,7 +3,7 @@ import type { EventInsert } from "@autumn/shared";
 import * as Sentry from "@sentry/bun";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { tinybirdIngest } from "../initTinybird.js";
-import { tinybirdUsEastApi } from "../initTinybirdV2.js";
+import { tinybirdSecondaryApi } from "../initTinybirdV2.js";
 import { isTinybirdConfigured } from "../tinybirdUtils.js";
 import { mapToTinybirdEvent } from "./mapEvent.js";
 
@@ -35,7 +35,7 @@ export const sendEventsToTinybird = async ({
 
 	const tinybirdEvents = events.map(mapToTinybirdEvent);
 
-	const reportFailure = (error: unknown, region: "primary" | "us-east") => {
+	const reportFailure = (error: unknown, region: "primary" | "secondary") => {
 		const errorId = generateErrorId();
 		const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -81,24 +81,21 @@ export const sendEventsToTinybird = async ({
 		})
 		.catch((error: unknown) => reportFailure(error, "primary"));
 
-	const usEastWrite = tinybirdUsEastApi
-		? tinybirdUsEastApi
+	const secondaryWrite = tinybirdSecondaryApi
+		? tinybirdSecondaryApi
 				.ingestBatch("events", tinybirdEvents)
 				.then((result) => {
-					logger?.info(
-						`Sent ${events.length} events to Tinybird (us-east)`,
-						{
-							data: {
-								region: "us-east",
-								eventCount: events.length,
-								successfulRows: result?.successful_rows,
-								quarantinedRows: result?.quarantined_rows,
-							},
+					logger?.info(`Sent ${events.length} events to Tinybird (secondary)`, {
+						data: {
+							region: "secondary",
+							eventCount: events.length,
+							successfulRows: result?.successful_rows,
+							quarantinedRows: result?.quarantined_rows,
 						},
-					);
+					});
 				})
-				.catch((error: unknown) => reportFailure(error, "us-east"))
+				.catch((error: unknown) => reportFailure(error, "secondary"))
 		: Promise.resolve();
 
-	await Promise.all([primaryWrite, usEastWrite]);
+	await Promise.all([primaryWrite, secondaryWrite]);
 };

--- a/server/src/external/tinybird/tinybirdUtils.ts
+++ b/server/src/external/tinybird/tinybirdUtils.ts
@@ -1,8 +1,8 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 
-const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
+const TINYBIRD_API_URL = process.env.TINYBIRD_US_EAST_API_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
 
 export type TinybirdConfig = {
 	baseUrl: string;


### PR DESCRIPTION
Reverts useautumn/autumn#1606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make us-east the primary Tinybird region for reads/writes and keep a secondary client for dual-write to the legacy region. Updates env vars and local setup to use `TINYBIRD_US_EAST_*` for primary; legacy `TINYBIRD_*` vars power the secondary client.

- **Migration**
  - Set `TINYBIRD_US_EAST_API_URL` and `TINYBIRD_US_EAST_TOKEN` for the primary client.
  - Replace `TINYBIRD_CLICKHOUSE_URL` with `TINYBIRD_US_EAST_CLICKHOUSE_URL` (local: `http://localhost:8123`).
  - Keep `TINYBIRD_API_URL` and `TINYBIRD_TOKEN` if you want secondary dual-write enabled.

<sup>Written for commit 17e3c734f92dc3afbabe7c3c1ddfcba6dc6e16e7. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1654?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

