### PR TITLE
Runtime-configurable cluster cutover

### DIFF
--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -7,6 +7,7 @@ await warmupRegionalRedis();
 // Edge config modules self-register on import (cron reads redis-v2-cache
 // so resolveRedisV2 picks the right instance on each ctx build).
 await import("./internal/misc/redisV2Cache/redisV2CacheStore.js");
+await import("./internal/misc/dragonflyRamp/dragonflyRampStore.js");
 const { logger } = await import("./external/logtail/logtailUtils.js");
 const { startAllEdgeConfigPolling } = await import(
 	"./internal/misc/edgeConfig/edgeConfigRegistry.js"

--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -6,6 +6,8 @@ export const ADMIN_CUSTOMER_BLOCK_CONFIG_KEY =
 export const ADMIN_ORG_LIMITS_CONFIG_KEY = "admin/org-limits-config.json";
 export const ADMIN_REDIS_V2_CACHE_CONFIG_KEY =
 	"admin/redis-v2-cache-config.json";
+export const ADMIN_DRAGONFLY_RAMP_CONFIG_KEY =
+	"admin/dragonfly-ramp-config.json";
 export const ADMIN_JOB_QUEUE_CONFIG_KEY = "admin/job-queue-config.json";
 export const ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY =
 	"admin/miscellaneous-edge-config.json";
@@ -48,6 +50,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "redis-v2-cache",
 			label: "V2 Redis Instance",
 			key: ADMIN_REDIS_V2_CACHE_CONFIG_KEY,
+		},
+		{
+			id: "dragonfly-ramp",
+			label: "Dragonfly Public Ramp",
+			key: ADMIN_DRAGONFLY_RAMP_CONFIG_KEY,
 		},
 		{
 			id: "job-queues",

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -4,6 +4,7 @@ import {
 	getRampDestinationRedis,
 	isDragonflyRampActive,
 } from "@/internal/misc/dragonflyRamp/index.js";
+import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
 import { getOrgRedis, type OrgWithRedisConfig } from "./orgRedisPool.js";
 import { resolveRedisV2 } from "./resolveRedisV2.js";
 
@@ -110,12 +111,19 @@ export const getRedisTargetsForCustomer = ({
 	if (org.redis_config) {
 		redisTargets.push(resolveRedisV2(), getOrgRedis({ org }));
 	}
-	// Fan out invalidations to the ramp destination when the ramp is non-zero —
-	// without this, ramped customers can read stale entries from whichever
-	// cluster invalidation skipped.
-	if (isDragonflyRampActive({ orgId: org.id })) {
+	// During ramp, fan out to BOTH primary and destination. `currentRedis` may
+	// already be the destination (ramped customer) or the primary (non-ramped);
+	// without explicitly including both, the other cluster keeps stale entries
+	// until TTL. Gated on activeInstance === "dragonfly" so the upstash/redis
+	// kill switch disables the ramp fan-out.
+	if (
+		getActiveRedisV2Instance() === "dragonfly" &&
+		isDragonflyRampActive({ orgId: org.id })
+	) {
 		const destination = getRampDestinationRedis();
-		if (destination) redisTargets.push(destination);
+		if (destination) {
+			redisTargets.push(destination, resolveRedisV2());
+		}
 	}
 	return [...new Set(redisTargets)];
 };

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -1,5 +1,9 @@
 import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	getRampDestinationRedis,
+	isDragonflyRampActive,
+} from "@/internal/misc/dragonflyRamp/index.js";
 import { getOrgRedis, type OrgWithRedisConfig } from "./orgRedisPool.js";
 import { resolveRedisV2 } from "./resolveRedisV2.js";
 
@@ -46,7 +50,7 @@ export const resolveCustomerRedisRouting = ({
 
 	return {
 		...routingInfo,
-		redis: resolveRedisV2(),
+		redis: resolveRedisV2({ orgId: org.id, customerId }),
 	};
 };
 
@@ -105,6 +109,13 @@ export const getRedisTargetsForCustomer = ({
 	const redisTargets = [currentRedis ?? resolveRedisV2()];
 	if (org.redis_config) {
 		redisTargets.push(resolveRedisV2(), getOrgRedis({ org }));
+	}
+	// Fan out invalidations to the ramp destination when the ramp is non-zero —
+	// without this, ramped customers can read stale entries from whichever
+	// cluster invalidation skipped.
+	if (isDragonflyRampActive({ orgId: org.id })) {
+		const destination = getRampDestinationRedis();
+		if (destination) redisTargets.push(destination);
 	}
 	return [...new Set(redisTargets)];
 };

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -47,7 +47,7 @@ const createOrgRedisConnection = ({
 };
 
 export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
-	if (!org.redis_config) return resolveRedisV2();
+	if (!org.redis_config) return resolveRedisV2({ orgId: org.id });
 
 	const existing = pool.get(org.id);
 	if (existing) {
@@ -66,7 +66,7 @@ export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
 		if (error instanceof Error) {
 			logger.error(error);
 		}
-		return resolveRedisV2();
+		return resolveRedisV2({ orgId: org.id });
 	}
 
 	const instance = createOrgRedisConnection({

--- a/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
+++ b/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
@@ -1,5 +1,9 @@
 import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	getRampDestinationRedis,
+	isDragonflyRampActive,
+} from "@/internal/misc/dragonflyRamp/index.js";
 import { getOrgRedis } from "../orgRedisPool.js";
 import { resolveRedisV2 } from "../resolveRedisV2.js";
 
@@ -7,6 +11,22 @@ const dedupeRedisInstances = ({ candidates }: { candidates: Redis[] }) =>
 	candidates.filter(
 		(candidate, index) => candidates.indexOf(candidate) === index,
 	);
+
+/** Adds the ramp destination client to the candidate list when the ramp is
+ *  non-zero for this org. During ramp, locks/cleanup state may exist on EITHER
+ *  cluster — scanning both prevents loss across boundary crossings. */
+const withRampDestinationIfActive = ({
+	candidates,
+	orgId,
+}: {
+	candidates: Redis[];
+	orgId?: string;
+}): Redis[] => {
+	if (!isDragonflyRampActive({ orgId })) return candidates;
+	const destination = getRampDestinationRedis();
+	if (!destination) return candidates;
+	return [...candidates, destination];
+};
 
 export const getRedisV2LockReceiptCandidates = ({
 	ctx,
@@ -19,7 +39,12 @@ export const getRedisV2LockReceiptCandidates = ({
 		candidates.push(getOrgRedis({ org: ctx.org }), resolveRedisV2());
 	}
 
-	return dedupeRedisInstances({ candidates });
+	return dedupeRedisInstances({
+		candidates: withRampDestinationIfActive({
+			candidates,
+			orgId: ctx.org.id,
+		}),
+	});
 };
 
 export const getRedisV2OrgCleanupCandidates = ({
@@ -33,5 +58,10 @@ export const getRedisV2OrgCleanupCandidates = ({
 		candidates.push(getOrgRedis({ org: ctx.org }));
 	}
 
-	return dedupeRedisInstances({ candidates });
+	return dedupeRedisInstances({
+		candidates: withRampDestinationIfActive({
+			candidates,
+			orgId: ctx.org.id,
+		}),
+	});
 };

--- a/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
+++ b/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
@@ -4,6 +4,7 @@ import {
 	getRampDestinationRedis,
 	isDragonflyRampActive,
 } from "@/internal/misc/dragonflyRamp/index.js";
+import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
 import { getOrgRedis } from "../orgRedisPool.js";
 import { resolveRedisV2 } from "../resolveRedisV2.js";
 
@@ -12,20 +13,26 @@ const dedupeRedisInstances = ({ candidates }: { candidates: Redis[] }) =>
 		(candidate, index) => candidates.indexOf(candidate) === index,
 	);
 
-/** Adds the ramp destination client to the candidate list when the ramp is
- *  non-zero for this org. During ramp, locks/cleanup state may exist on EITHER
- *  cluster — scanning both prevents loss across boundary crossings. */
-const withRampDestinationIfActive = ({
+/** Adds BOTH primary and ramp destination clients to the candidate list when
+ *  the ramp is non-zero for this org. During ramp, lock/cleanup state may
+ *  exist on EITHER cluster — scanning both prevents loss across boundary
+ *  crossings.
+ *
+ *  Gated on `activeInstance === "dragonfly"` so the upstash/redis kill switch
+ *  disables ramp fan-out (when active is non-dragonfly, ramp traffic isn't
+ *  routed to either cluster). */
+const withRampClustersIfActive = ({
 	candidates,
 	orgId,
 }: {
 	candidates: Redis[];
 	orgId?: string;
 }): Redis[] => {
+	if (getActiveRedisV2Instance() !== "dragonfly") return candidates;
 	if (!isDragonflyRampActive({ orgId })) return candidates;
 	const destination = getRampDestinationRedis();
 	if (!destination) return candidates;
-	return [...candidates, destination];
+	return [...candidates, destination, resolveRedisV2()];
 };
 
 export const getRedisV2LockReceiptCandidates = ({
@@ -40,7 +47,7 @@ export const getRedisV2LockReceiptCandidates = ({
 	}
 
 	return dedupeRedisInstances({
-		candidates: withRampDestinationIfActive({
+		candidates: withRampClustersIfActive({
 			candidates,
 			orgId: ctx.org.id,
 		}),
@@ -59,7 +66,7 @@ export const getRedisV2OrgCleanupCandidates = ({
 	}
 
 	return dedupeRedisInstances({
-		candidates: withRampDestinationIfActive({
+		candidates: withRampClustersIfActive({
 			candidates,
 			orgId: ctx.org.id,
 		}),

--- a/server/src/external/redis/resolveRedisV2.ts
+++ b/server/src/external/redis/resolveRedisV2.ts
@@ -1,5 +1,9 @@
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
+import {
+	getRampDestinationRedis,
+	isDragonflyPublicEnabled,
+} from "@/internal/misc/dragonflyRamp/index.js";
 import type { RedisV2InstanceName } from "@/internal/misc/redisV2Cache/redisV2CacheSchemas.js";
 import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
 import {
@@ -8,11 +12,24 @@ import {
 } from "./initRedisV2.js";
 
 let lastLoggedInstance: RedisV2InstanceName | null = null;
+let publicRouteWarned = false;
 
-/** Returns the active V2 Redis instance, selected by the redis-v2-cache edge config.
+/** Returns the V2 Redis instance for this request.
+ *
+ *  Routing order:
+ *  1. If `redis-v2-cache` edge config selects a non-dragonfly instance
+ *     (`upstash`/`redis`), honor it — that's a global override / kill switch
+ *     and trumps the ramp.
+ *  2. Otherwise (active = dragonfly), if the ramp is enabled for this
+ *     customer/org AND a destination is configured → ramp destination client.
+ *  3. Otherwise → primary Dragonfly.
+ *
  *  Called by every ctx-building middleware/worker — request-path code reads
  *  ctx.redisV2 rather than calling this. */
-export const resolveRedisV2 = (): Redis => {
+export const resolveRedisV2 = (opts?: {
+	orgId?: string;
+	customerId?: string;
+}): Redis => {
 	const activeInstance = getActiveRedisV2Instance();
 
 	if (activeInstance !== lastLoggedInstance) {
@@ -22,7 +39,19 @@ export const resolveRedisV2 = (): Redis => {
 		lastLoggedInstance = activeInstance;
 	}
 
-	if (activeInstance === "dragonfly") return redisV2Primary;
+	if (activeInstance === "dragonfly") {
+		if (opts && isDragonflyPublicEnabled(opts)) {
+			const destination = getRampDestinationRedis();
+			if (destination) return destination;
+			if (!publicRouteWarned) {
+				publicRouteWarned = true;
+				logger.warn(
+					"[resolveRedisV2] dragonfly ramp enabled but destination is not configured (or decryption failed); falling back to primary",
+				);
+			}
+		}
+		return redisV2Primary;
+	}
 
 	const alternate = getAlternateRedisV2Instance(activeInstance);
 	return alternate ?? redisV2Primary;

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -1,10 +1,10 @@
 import {
-    ApiVersionClass,
-    AppEnv,
-    AuthType,
-    LATEST_VERSION,
-    type Organization,
-    tryCatch,
+	ApiVersionClass,
+	AppEnv,
+	AuthType,
+	LATEST_VERSION,
+	type Organization,
+	tryCatch,
 } from "@autumn/shared";
 import type { Context, Next } from "hono";
 import { db, dbGeneral } from "@/db/initDrizzle.js";
@@ -93,7 +93,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		db,
 		dbGeneral,
 		logger: childLogger,
-		redisV2: resolveRedisV2(),
+		redisV2: resolveRedisV2({ customerId }),
 
 		// Request info
 		id,
@@ -114,7 +114,9 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 
 		// Query params
 		expand: [],
-		skipCache: c.req.header("x-skip-cache") === "true" || c.req.query("skip_cache") === "true",
+		skipCache:
+			c.req.header("x-skip-cache") === "true" ||
+			c.req.query("skip_cache") === "true",
 
 		// Test params:
 		extraLogs: {},

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -26,6 +26,7 @@ import "./internal/misc/customerBlocks/customerBlockStore.js";
 import "./internal/misc/edgeConfig/orgLimitsStore.js";
 import "./internal/misc/stripeSync/stripeSyncStore.js";
 import "./internal/misc/redisV2Cache/redisV2CacheStore.js";
+import "./internal/misc/dragonflyRamp/dragonflyRampStore.js";
 import "./internal/misc/jobQueues/jobQueueStore.js";
 // Side-effect: configures trigger.dev SDK to use TRIGGER_SERVER_SECRET_KEY.
 import "./trigger/configureTrigger.js";

--- a/server/src/internal/customers/cusProducts/actions/expireOneOffCustomerProductResults.ts
+++ b/server/src/internal/customers/cusProducts/actions/expireOneOffCustomerProductResults.ts
@@ -49,7 +49,7 @@ export const expireOneOffCustomerProductResults = async ({
 			org: group.org,
 			env: group.env,
 			logger: ctx.logger,
-			redisV2: resolveRedisV2(),
+			redisV2: resolveRedisV2({ orgId: group.org.id }),
 		};
 
 		await batchUpdateCustomerProducts({

--- a/server/src/internal/misc/dragonflyRamp/dragonflyRampClient.ts
+++ b/server/src/internal/misc/dragonflyRamp/dragonflyRampClient.ts
@@ -47,16 +47,15 @@ export const getRampDestinationRedis = (): Redis | null => {
 				? `URL changed (${cached.url} -> ${url})`
 				: "credentials rotated";
 		logger.info(
-			`[dragonflyRamp] destination ${reason}; gracefully closing old client`,
+			`[dragonflyRamp] destination ${reason}; disconnecting old client`,
 		);
-		// quit() lets in-flight commands complete before closing the socket,
-		// avoiding "Connection is closed" errors on requests that still hold a
-		// reference to this client via ctx.redisV2.
-		cached.instance.quit().catch((error) => {
+		try {
+			cached.instance.disconnect();
+		} catch (error) {
 			logger.warn(
-				`[dragonflyRamp] error during old destination client quit: ${error}`,
+				`[dragonflyRamp] failed to disconnect old destination client: ${error}`,
 			);
-		});
+		}
 		cached = null;
 	}
 
@@ -95,16 +94,16 @@ export const getRampDestinationRedis = (): Redis | null => {
 	return instance;
 };
 
-/** Tear down the cached destination client. Safe to call multiple times.
- *  Uses quit() so in-flight commands held by ctx.redisV2 references can
- *  complete before the socket closes. */
+/** Tear down the cached destination client. Safe to call multiple times. */
 export const closeRampDestinationClient = () => {
 	if (!cached) return;
-	cached.instance.quit().catch((error) => {
+	try {
+		cached.instance.disconnect();
+	} catch (error) {
 		logger.warn(
-			`[dragonflyRamp] error during destination client close: ${error}`,
+			`[dragonflyRamp] failed to disconnect destination client during close: ${error}`,
 		);
-	});
+	}
 	cached = null;
 };
 
@@ -121,9 +120,11 @@ export const _setRampDestinationClientForTesting = (
 		(cached.url !== client?.url ||
 			cached.connectionString !== client?.connectionString)
 	) {
-		cached.instance.quit().catch(() => {
+		try {
+			cached.instance.disconnect();
+		} catch {
 			// best effort
-		});
+		}
 	}
 	cached = client;
 };

--- a/server/src/internal/misc/dragonflyRamp/dragonflyRampClient.ts
+++ b/server/src/internal/misc/dragonflyRamp/dragonflyRampClient.ts
@@ -47,15 +47,16 @@ export const getRampDestinationRedis = (): Redis | null => {
 				? `URL changed (${cached.url} -> ${url})`
 				: "credentials rotated";
 		logger.info(
-			`[dragonflyRamp] destination ${reason}; disconnecting old client`,
+			`[dragonflyRamp] destination ${reason}; gracefully closing old client`,
 		);
-		try {
-			cached.instance.disconnect();
-		} catch (error) {
+		// quit() lets in-flight commands complete before closing the socket,
+		// avoiding "Connection is closed" errors on requests that still hold a
+		// reference to this client via ctx.redisV2.
+		cached.instance.quit().catch((error) => {
 			logger.warn(
-				`[dragonflyRamp] failed to disconnect old destination client: ${error}`,
+				`[dragonflyRamp] error during old destination client quit: ${error}`,
 			);
-		}
+		});
 		cached = null;
 	}
 
@@ -94,16 +95,16 @@ export const getRampDestinationRedis = (): Redis | null => {
 	return instance;
 };
 
-/** Tear down the cached destination client. Safe to call multiple times. */
+/** Tear down the cached destination client. Safe to call multiple times.
+ *  Uses quit() so in-flight commands held by ctx.redisV2 references can
+ *  complete before the socket closes. */
 export const closeRampDestinationClient = () => {
 	if (!cached) return;
-	try {
-		cached.instance.disconnect();
-	} catch (error) {
+	cached.instance.quit().catch((error) => {
 		logger.warn(
-			`[dragonflyRamp] failed to disconnect destination client during close: ${error}`,
+			`[dragonflyRamp] error during destination client close: ${error}`,
 		);
-	}
+	});
 	cached = null;
 };
 
@@ -120,11 +121,9 @@ export const _setRampDestinationClientForTesting = (
 		(cached.url !== client?.url ||
 			cached.connectionString !== client?.connectionString)
 	) {
-		try {
-			cached.instance.disconnect();
-		} catch {
+		cached.instance.quit().catch(() => {
 			// best effort
-		}
+		});
 	}
 	cached = client;
 };

--- a/server/src/internal/misc/dragonflyRamp/dragonflyRampClient.ts
+++ b/server/src/internal/misc/dragonflyRamp/dragonflyRampClient.ts
@@ -1,0 +1,106 @@
+import type { Redis } from "ioredis";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { getReachableDragonflyUrl } from "@/external/redis/getReachableDragonflyUrl.js";
+import {
+	createRedisConnection,
+	currentRegion,
+} from "@/external/redis/initRedis.js";
+import { REDIS_V2_COMMAND_TIMEOUT_MS } from "@/external/redis/initUtils/redisV2Config.js";
+import { decryptData } from "@/utils/encryptUtils.js";
+import { getDragonflyRampConfig } from "./dragonflyRampStore.js";
+
+type CachedClient = { url: string; instance: Redis };
+let cached: CachedClient | null = null;
+let lastDecryptFailureUrl: string | null = null;
+
+/** Returns the Redis client for the ramp destination configured in the edge config.
+ *
+ *  Lazy: creates the client on first call after the destination URL is set.
+ *  Hot-swappable: when the admin changes the destination URL, the next call
+ *  disconnects the old client and creates a new one keyed on the new URL.
+ *  Returns null when no destination is configured (ramp is dormant). */
+export const getRampDestinationRedis = (): Redis | null => {
+	const config = getDragonflyRampConfig();
+	if (!config.destination) {
+		closeRampDestinationClient();
+		return null;
+	}
+
+	const { connectionString, url } = config.destination;
+
+	if (cached && cached.url === url) return cached.instance;
+
+	if (cached) {
+		logger.info(
+			`[dragonflyRamp] destination URL changed (${cached.url} -> ${url}); disconnecting old client`,
+		);
+		try {
+			cached.instance.disconnect();
+		} catch (error) {
+			logger.warn(
+				`[dragonflyRamp] failed to disconnect old destination client: ${error}`,
+			);
+		}
+		cached = null;
+	}
+
+	let decrypted: string;
+	try {
+		decrypted = decryptData(connectionString);
+	} catch (error) {
+		if (lastDecryptFailureUrl !== url) {
+			lastDecryptFailureUrl = url;
+			logger.error(
+				`[dragonflyRamp] failed to decrypt destination connectionString for ${url}: ${error}. Ramp will route to primary until fixed.`,
+			);
+		}
+		return null;
+	}
+	lastDecryptFailureUrl = null;
+
+	const reachable = getReachableDragonflyUrl(decrypted);
+	const instance = createRedisConnection({
+		cacheUrl: reachable,
+		region: `${currentRegion}:v2:ramp`,
+		supportsUpstashShebang: false,
+		commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
+	});
+
+	instance.on("error", (error) => {
+		logger.error(`[dragonflyRamp] destination=${url}: ${error.message}`);
+	});
+
+	instance.on("ready", () => {
+		logger.info(`[dragonflyRamp] destination=${url}: connected`);
+	});
+
+	cached = { url, instance };
+	return instance;
+};
+
+/** Tear down the cached destination client. Safe to call multiple times. */
+export const closeRampDestinationClient = () => {
+	if (!cached) return;
+	try {
+		cached.instance.disconnect();
+	} catch (error) {
+		logger.warn(
+			`[dragonflyRamp] failed to disconnect destination client during close: ${error}`,
+		);
+	}
+	cached = null;
+};
+
+/** Test-only: inject a Redis instance directly, bypassing the config + decryption. */
+export const _setRampDestinationClientForTesting = (
+	client: { url: string; instance: Redis } | null,
+) => {
+	if (cached && cached.url !== client?.url) {
+		try {
+			cached.instance.disconnect();
+		} catch {
+			// best effort
+		}
+	}
+	cached = client;
+};

--- a/server/src/internal/misc/dragonflyRamp/dragonflyRampClient.ts
+++ b/server/src/internal/misc/dragonflyRamp/dragonflyRampClient.ts
@@ -9,16 +9,21 @@ import { REDIS_V2_COMMAND_TIMEOUT_MS } from "@/external/redis/initUtils/redisV2C
 import { decryptData } from "@/utils/encryptUtils.js";
 import { getDragonflyRampConfig } from "./dragonflyRampStore.js";
 
-type CachedClient = { url: string; instance: Redis };
+type CachedClient = {
+	url: string;
+	connectionString: string;
+	instance: Redis;
+};
 let cached: CachedClient | null = null;
-let lastDecryptFailureUrl: string | null = null;
+let lastDecryptFailureKey: string | null = null;
 
 /** Returns the Redis client for the ramp destination configured in the edge config.
  *
- *  Lazy: creates the client on first call after the destination URL is set.
- *  Hot-swappable: when the admin changes the destination URL, the next call
- *  disconnects the old client and creates a new one keyed on the new URL.
- *  Returns null when no destination is configured (ramp is dormant). */
+ *  Lazy: creates the client on first call after the destination is set.
+ *  Hot-swappable: when the admin changes the URL OR rotates the encrypted
+ *  connection string (e.g. credential rotation on the same host), the next
+ *  call disconnects the old client and creates a new one. Returns null when
+ *  no destination is configured (ramp is dormant). */
 export const getRampDestinationRedis = (): Redis | null => {
 	const config = getDragonflyRampConfig();
 	if (!config.destination) {
@@ -28,11 +33,21 @@ export const getRampDestinationRedis = (): Redis | null => {
 
 	const { connectionString, url } = config.destination;
 
-	if (cached && cached.url === url) return cached.instance;
+	if (
+		cached &&
+		cached.url === url &&
+		cached.connectionString === connectionString
+	) {
+		return cached.instance;
+	}
 
 	if (cached) {
+		const reason =
+			cached.url !== url
+				? `URL changed (${cached.url} -> ${url})`
+				: "credentials rotated";
 		logger.info(
-			`[dragonflyRamp] destination URL changed (${cached.url} -> ${url}); disconnecting old client`,
+			`[dragonflyRamp] destination ${reason}; disconnecting old client`,
 		);
 		try {
 			cached.instance.disconnect();
@@ -48,15 +63,16 @@ export const getRampDestinationRedis = (): Redis | null => {
 	try {
 		decrypted = decryptData(connectionString);
 	} catch (error) {
-		if (lastDecryptFailureUrl !== url) {
-			lastDecryptFailureUrl = url;
+		const failureKey = `${url}|${connectionString}`;
+		if (lastDecryptFailureKey !== failureKey) {
+			lastDecryptFailureKey = failureKey;
 			logger.error(
 				`[dragonflyRamp] failed to decrypt destination connectionString for ${url}: ${error}. Ramp will route to primary until fixed.`,
 			);
 		}
 		return null;
 	}
-	lastDecryptFailureUrl = null;
+	lastDecryptFailureKey = null;
 
 	const reachable = getReachableDragonflyUrl(decrypted);
 	const instance = createRedisConnection({
@@ -74,7 +90,7 @@ export const getRampDestinationRedis = (): Redis | null => {
 		logger.info(`[dragonflyRamp] destination=${url}: connected`);
 	});
 
-	cached = { url, instance };
+	cached = { url, connectionString, instance };
 	return instance;
 };
 
@@ -93,9 +109,17 @@ export const closeRampDestinationClient = () => {
 
 /** Test-only: inject a Redis instance directly, bypassing the config + decryption. */
 export const _setRampDestinationClientForTesting = (
-	client: { url: string; instance: Redis } | null,
+	client: {
+		url: string;
+		connectionString: string;
+		instance: Redis;
+	} | null,
 ) => {
-	if (cached && cached.url !== client?.url) {
+	if (
+		cached &&
+		(cached.url !== client?.url ||
+			cached.connectionString !== client?.connectionString)
+	) {
 		try {
 			cached.instance.disconnect();
 		} catch {

--- a/server/src/internal/misc/dragonflyRamp/dragonflyRampSchemas.ts
+++ b/server/src/internal/misc/dragonflyRamp/dragonflyRampSchemas.ts
@@ -1,0 +1,22 @@
+import { z } from "zod/v4";
+import { RolloutPercentSchema } from "@/internal/misc/rollouts/rolloutSchemas.js";
+
+/** Destination Redis the ramp targets. Stored in the edge config; admin-editable.
+ *  `connectionString` is AES-256-CBC encrypted (same scheme as per-org redis_config).
+ *  `url` is a plain host:port for logs/visibility — no credentials. */
+export const RampDestinationSchema = z.object({
+	connectionString: z.string().min(1),
+	url: z.string().min(1),
+});
+
+export const DragonflyRampConfigSchema = z.object({
+	destination: RampDestinationSchema.nullable().default(null),
+	percent: z.number().min(0).max(100).default(0),
+	previousPercent: z.number().min(0).max(100).default(0),
+	changedAt: z.number().default(0),
+	orgs: z.record(z.string(), RolloutPercentSchema).default({}),
+});
+
+export type RampDestination = z.infer<typeof RampDestinationSchema>;
+export type DragonflyRampConfig = z.infer<typeof DragonflyRampConfigSchema>;
+export type DragonflyRampPercent = z.infer<typeof RolloutPercentSchema>;

--- a/server/src/internal/misc/dragonflyRamp/dragonflyRampSchemas.ts
+++ b/server/src/internal/misc/dragonflyRamp/dragonflyRampSchemas.ts
@@ -3,10 +3,22 @@ import { RolloutPercentSchema } from "@/internal/misc/rollouts/rolloutSchemas.js
 
 /** Destination Redis the ramp targets. Stored in the edge config; admin-editable.
  *  `connectionString` is AES-256-CBC encrypted (same scheme as per-org redis_config).
- *  `url` is a plain host:port for logs/visibility — no credentials. */
+ *  `url` is a plain host:port for logs/visibility — no scheme, no credentials.
+ *  Schema rejects scheme/credentials so secrets never accidentally land in this
+ *  field (which is logged + surfaced in Axiom). */
 export const RampDestinationSchema = z.object({
 	connectionString: z.string().min(1),
-	url: z.string().min(1),
+	url: z
+		.string()
+		.min(1)
+		.refine(
+			(value) =>
+				!value.includes("://") && !value.includes("@") && !/\s/.test(value),
+			{
+				message:
+					"url must be a credential-free host:port (no scheme, no '@', no whitespace)",
+			},
+		),
 });
 
 export const DragonflyRampConfigSchema = z.object({

--- a/server/src/internal/misc/dragonflyRamp/dragonflyRampStore.ts
+++ b/server/src/internal/misc/dragonflyRamp/dragonflyRampStore.ts
@@ -1,0 +1,93 @@
+import { ms } from "@autumn/shared";
+import { ADMIN_DRAGONFLY_RAMP_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type DragonflyRampConfig,
+	DragonflyRampConfigSchema,
+	type RampDestination,
+} from "./dragonflyRampSchemas.js";
+
+const store = createEdgeConfigStore<DragonflyRampConfig>({
+	s3Key: ADMIN_DRAGONFLY_RAMP_CONFIG_KEY,
+	schema: DragonflyRampConfigSchema,
+	defaultValue: () => ({
+		destination: null,
+		percent: 0,
+		previousPercent: 0,
+		changedAt: 0,
+		orgs: {},
+	}),
+	pollIntervalMs: ms.seconds(10),
+});
+
+registerEdgeConfig({ store });
+
+export const getDragonflyRampConfig = (): DragonflyRampConfig => store.get();
+
+export const getDragonflyRampStatus = () => store.getStatus();
+
+export const updateDragonflyRampPercent = async ({
+	percent,
+	orgId,
+}: {
+	percent: number;
+	orgId?: string;
+}) => {
+	const current = await store.readFromSource();
+	const now = Date.now();
+
+	if (orgId) {
+		const existingOrg = current.orgs[orgId];
+		const nextOrgs = {
+			...current.orgs,
+			[orgId]: {
+				percent,
+				previousPercent: existingOrg?.percent ?? 0,
+				changedAt: now,
+			},
+		};
+		await store.writeToSource({ config: { ...current, orgs: nextOrgs } });
+		return;
+	}
+
+	await store.writeToSource({
+		config: {
+			...current,
+			percent,
+			previousPercent: current.percent,
+			changedAt: now,
+		},
+	});
+};
+
+export const removeDragonflyRampOrg = async ({ orgId }: { orgId: string }) => {
+	const current = await store.readFromSource();
+	if (!current.orgs[orgId]) return;
+	const { [orgId]: _removed, ...rest } = current.orgs;
+	await store.writeToSource({ config: { ...current, orgs: rest } });
+};
+
+/** Write the destination URL + encrypted connection string. Pass null to clear. */
+export const updateDragonflyRampDestination = async ({
+	destination,
+}: {
+	destination: RampDestination | null;
+}) => {
+	const current = await store.readFromSource();
+	await store.writeToSource({ config: { ...current, destination } });
+};
+
+/** Test-only: override the in-memory config without writing to S3. */
+export const _setDragonflyRampConfigForTesting = (
+	config: Partial<DragonflyRampConfig>,
+) => {
+	store._setRuntimeConfigForTesting({
+		destination: null,
+		percent: 0,
+		previousPercent: 0,
+		changedAt: 0,
+		orgs: {},
+		...config,
+	});
+};

--- a/server/src/internal/misc/dragonflyRamp/dragonflyRampUtils.ts
+++ b/server/src/internal/misc/dragonflyRamp/dragonflyRampUtils.ts
@@ -1,0 +1,73 @@
+import { getCustomerBucket } from "@/internal/misc/rollouts/rolloutUtils.js";
+import { type DragonflyRampPercent, getDragonflyRampConfig } from "./index.js";
+
+const resolveDragonflyRampPercent = ({
+	orgId,
+}: {
+	orgId?: string;
+}): DragonflyRampPercent => {
+	const config = getDragonflyRampConfig();
+	if (orgId && config.orgs[orgId]) return config.orgs[orgId];
+	return {
+		percent: config.percent,
+		previousPercent: config.previousPercent,
+		changedAt: config.changedAt,
+	};
+};
+
+/** True when the given customer should be routed to the public Dragonfly URL. */
+export const isDragonflyPublicEnabled = ({
+	orgId,
+	customerId,
+}: {
+	orgId?: string;
+	customerId?: string;
+}): boolean => {
+	const resolved = resolveDragonflyRampPercent({ orgId });
+	if (resolved.percent >= 100) return true;
+	if (resolved.percent <= 0) return false;
+	if (!customerId) return false;
+
+	const bucket = getCustomerBucket({ customerId });
+	return bucket < resolved.percent;
+};
+
+/** True when the dragonfly public-ramp is non-zero for the given org (or globally).
+ *  Used by invalidation/lock-receipt code that needs to fan out to BOTH clusters
+ *  during the ramp window, even when it doesn't know the customer. */
+export const isDragonflyRampActive = ({
+	orgId,
+}: {
+	orgId?: string;
+}): boolean => {
+	const resolved = resolveDragonflyRampPercent({ orgId });
+	return resolved.percent > 0;
+};
+
+/** True when a cached entry should be treated as stale because the customer's
+ *  bucket crossed the ramp boundary after the entry was written.
+ *
+ *  Mirrors `isSnapshotCacheStale` in rolloutUtils.ts. Use when reading from
+ *  either Dragonfly cluster — if the customer was on the OTHER cluster when
+ *  the entry was written, and has since crossed back, the entry is stale. */
+export const isDragonflyRampCacheStale = ({
+	orgId,
+	customerId,
+	cachedAt,
+}: {
+	orgId?: string;
+	customerId?: string;
+	cachedAt?: number;
+}): boolean => {
+	const resolved = resolveDragonflyRampPercent({ orgId });
+	if (!resolved.changedAt) return false;
+	if (!customerId) return false;
+
+	const bucket = getCustomerBucket({ customerId });
+	const wasEnabled = bucket < resolved.previousPercent;
+	const isEnabled = bucket < resolved.percent;
+	if (wasEnabled === isEnabled) return false;
+
+	if (!cachedAt) return true;
+	return cachedAt < resolved.changedAt;
+};

--- a/server/src/internal/misc/dragonflyRamp/index.ts
+++ b/server/src/internal/misc/dragonflyRamp/index.ts
@@ -1,0 +1,25 @@
+export {
+	_setRampDestinationClientForTesting,
+	closeRampDestinationClient,
+	getRampDestinationRedis,
+} from "./dragonflyRampClient.js";
+export {
+	type DragonflyRampConfig,
+	DragonflyRampConfigSchema,
+	type DragonflyRampPercent,
+	type RampDestination,
+	RampDestinationSchema,
+} from "./dragonflyRampSchemas.js";
+export {
+	_setDragonflyRampConfigForTesting,
+	getDragonflyRampConfig,
+	getDragonflyRampStatus,
+	removeDragonflyRampOrg,
+	updateDragonflyRampDestination,
+	updateDragonflyRampPercent,
+} from "./dragonflyRampStore.js";
+export {
+	isDragonflyPublicEnabled,
+	isDragonflyRampActive,
+	isDragonflyRampCacheStale,
+} from "./dragonflyRampUtils.js";

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -74,7 +74,7 @@ export const createWorkerContext = async ({
 		db,
 		dbGeneral: db,
 		logger: workerLogger,
-		redisV2: resolveRedisV2(),
+		redisV2: resolveRedisV2({ orgId: org.id, customerId }),
 
 		id: requestId || generateId("job"),
 		timestamp: Date.now(),

--- a/server/src/utils/workerUtils/createAutumnContext.ts
+++ b/server/src/utils/workerUtils/createAutumnContext.ts
@@ -59,7 +59,7 @@ export const createWorkerAutumnContext = async ({
 		db,
 		dbGeneral: db,
 		logger,
-		redisV2: resolveRedisV2(),
+		redisV2: resolveRedisV2({ orgId: org.id }),
 		expand: [],
 
 		id: workerId,

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -10,6 +10,7 @@ import {
 import "./internal/misc/requestBlocks/requestBlockStore.js";
 import "./internal/misc/rollouts/rolloutConfigStore.js";
 import "./internal/misc/redisV2Cache/redisV2CacheStore.js";
+import "./internal/misc/dragonflyRamp/dragonflyRampStore.js";
 import "./internal/misc/jobQueues/jobQueueStore.js";
 
 // Number of worker processes (defaults to CPU cores)
@@ -104,11 +105,8 @@ if (cluster.isPrimary) {
 	const { primeRedisMonitor } = await import(
 		"./external/redis/initUtils/redisAvailability.js"
 	);
-	const {
-		primeRedisV2Monitor,
-		startRedisV2Monitor,
-		stopRedisV2Monitor,
-	} = await import("./external/redis/initUtils/redisV2Availability.js");
+	const { primeRedisV2Monitor, startRedisV2Monitor, stopRedisV2Monitor } =
+		await import("./external/redis/initUtils/redisV2Availability.js");
 	const { startRedisMonitor, stopRedisMonitor } = await import(
 		"./external/redis/initRedis.js"
 	);

--- a/server/tests/unit/redis/dragonfly-ramp.test.ts
+++ b/server/tests/unit/redis/dragonfly-ramp.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import {
+	_setDragonflyRampConfigForTesting,
+	isDragonflyPublicEnabled,
+	isDragonflyRampActive,
+	isDragonflyRampCacheStale,
+} from "@/internal/misc/dragonflyRamp/index.js";
+import { getCustomerBucket } from "@/internal/misc/rollouts/rolloutUtils.js";
+
+const findCustomerInBucketRange = ({
+	min,
+	max,
+}: {
+	min: number;
+	max: number;
+}): string => {
+	for (let index = 0; index < 10_000; index++) {
+		const customerId = `cus_ramp_${index}`;
+		const bucket = getCustomerBucket({ customerId });
+		if (bucket >= min && bucket < max) return customerId;
+	}
+	throw new Error(`No customer found in bucket range [${min}, ${max})`);
+};
+
+describe("isDragonflyPublicEnabled", () => {
+	test("returns false at 0%", () => {
+		_setDragonflyRampConfigForTesting({ percent: 0 });
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(isDragonflyPublicEnabled({ customerId })).toBe(false);
+	});
+
+	test("returns true at 100% even without customerId", () => {
+		_setDragonflyRampConfigForTesting({ percent: 100 });
+		expect(isDragonflyPublicEnabled({})).toBe(true);
+	});
+
+	test("returns false without customerId at fractional percent", () => {
+		_setDragonflyRampConfigForTesting({ percent: 50 });
+		expect(isDragonflyPublicEnabled({})).toBe(false);
+	});
+
+	test("routes customers in low buckets when percent=50", () => {
+		_setDragonflyRampConfigForTesting({ percent: 50 });
+		const low = findCustomerInBucketRange({ min: 0, max: 50 });
+		const high = findCustomerInBucketRange({ min: 50, max: 100 });
+		expect(isDragonflyPublicEnabled({ customerId: low })).toBe(true);
+		expect(isDragonflyPublicEnabled({ customerId: high })).toBe(false);
+	});
+
+	test("per-org override beats the global percent", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 0,
+			orgs: {
+				org_pinned_to_public: {
+					percent: 100,
+					previousPercent: 0,
+					changedAt: 0,
+				},
+			},
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(
+			isDragonflyPublicEnabled({ orgId: "org_pinned_to_public", customerId }),
+		).toBe(true);
+		expect(isDragonflyPublicEnabled({ orgId: "other_org", customerId })).toBe(
+			false,
+		);
+	});
+
+	test("per-org override can keep an org on private during a global ramp", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 100,
+			orgs: {
+				org_pinned_to_private: {
+					percent: 0,
+					previousPercent: 0,
+					changedAt: 0,
+				},
+			},
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(
+			isDragonflyPublicEnabled({ orgId: "org_pinned_to_private", customerId }),
+		).toBe(false);
+		expect(isDragonflyPublicEnabled({ orgId: "other_org", customerId })).toBe(
+			true,
+		);
+	});
+
+	test("getCustomerBucket is deterministic", () => {
+		expect(getCustomerBucket({ customerId: "cus_deterministic" })).toBe(
+			getCustomerBucket({ customerId: "cus_deterministic" }),
+		);
+	});
+});
+
+describe("isDragonflyRampActive", () => {
+	test("false when global percent is 0 and no org override", () => {
+		_setDragonflyRampConfigForTesting({ percent: 0 });
+		expect(isDragonflyRampActive({})).toBe(false);
+		expect(isDragonflyRampActive({ orgId: "any_org" })).toBe(false);
+	});
+
+	test("true when global percent is non-zero", () => {
+		_setDragonflyRampConfigForTesting({ percent: 1 });
+		expect(isDragonflyRampActive({})).toBe(true);
+	});
+
+	test("per-org override at non-zero activates even when global is 0", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 0,
+			orgs: {
+				org_active: { percent: 5, previousPercent: 0, changedAt: 1000 },
+			},
+		});
+		expect(isDragonflyRampActive({ orgId: "org_active" })).toBe(true);
+		expect(isDragonflyRampActive({ orgId: "other_org" })).toBe(false);
+	});
+
+	test("per-org override at zero deactivates even when global is non-zero", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 50,
+			orgs: {
+				org_pinned: { percent: 0, previousPercent: 0, changedAt: 1000 },
+			},
+		});
+		expect(isDragonflyRampActive({ orgId: "org_pinned" })).toBe(false);
+	});
+});
+
+describe("isDragonflyRampCacheStale", () => {
+	test("returns false when ramp has never changed", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 50,
+			previousPercent: 50,
+			changedAt: 0,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(isDragonflyRampCacheStale({ customerId, cachedAt: 500 })).toBe(
+			false,
+		);
+	});
+
+	test("forward ramp 0% -> 50%: bucket-crossing customer with stale cachedAt is stale", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+		expect(isDragonflyRampCacheStale({ customerId, cachedAt: 500 })).toBe(true);
+	});
+
+	test("forward ramp 0% -> 50%: non-crossing customer is not stale", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 50, max: 100 });
+		expect(isDragonflyRampCacheStale({ customerId, cachedAt: 500 })).toBe(
+			false,
+		);
+	});
+
+	test("rollback 50% -> 0%: previously-on-public customer is stale on private", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 0,
+			previousPercent: 50,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+		expect(isDragonflyRampCacheStale({ customerId, cachedAt: 500 })).toBe(true);
+	});
+
+	test("entries cached AFTER the changeover are not stale", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+		expect(isDragonflyRampCacheStale({ customerId, cachedAt: 2000 })).toBe(
+			false,
+		);
+	});
+
+	test("legacy entries without cachedAt are conservatively stale when bucket crossed", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+		expect(isDragonflyRampCacheStale({ customerId })).toBe(true);
+	});
+
+	test("returns false when no customerId is provided", () => {
+		_setDragonflyRampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		expect(isDragonflyRampCacheStale({ cachedAt: 500 })).toBe(false);
+	});
+});


### PR DESCRIPTION
Adds a percent-based traffic ramp that gradually shifts shared V2 Redis between the current primary Dragonfly and an admin-configured destination URL. Lets us drain the active cluster before tier upgrades, scheduled maintenance, or future provider migrations — all without redeploying.

How it works:
- New S3 edge config admin/dragonfly-ramp-config.json (10s poll) with global percent + per-org overrides, plus an admin-editable destination { connectionString (AES-256-CBC encrypted), url } — same encryption scheme as per-org redis_config
- resolveRedisV2({ orgId, customerId }) checks the ramp and returns the dynamically-pooled destination client when the customer's bucket lands under percent (Bun.hash(customerId) % 100)
- Gated on redis-v2-cache activeInstance === "dragonfly" so the existing upstash/redis kill switch still trumps the ramp
- Per-org redis_config orgs bypass the ramp entirely (they have their own dedicated cluster)

Coverage during ramp:
- getRedisV2LockReceiptCandidates + getRedisV2OrgCleanupCandidates fan out to both primary + destination so finalize doesn't miss receipts after boundary crossings
- getRedisTargetsForCustomer includes destination so invalidations don't leave stale entries on the alternate cluster
- updateDragonflyRampPercent / updateDragonflyRampDestination / removeDragonflyRampOrg all readFromSource() before merge to avoid clobbering concurrent admin edits
- Destination client pool detects URL change and disconnects old client before creating a new one (matches orgRedisPool pattern)
- Decryption failure on the destination connectionString is non-fatal — ramp routes back to primary with a one-time error log

Available helpers:
- isDragonflyPublicEnabled({ orgId, customerId })
- isDragonflyRampActive({ orgId })
- isDragonflyRampCacheStale({ orgId, customerId, cachedAt }) — helper is in place but not yet wired into FullSubject/FullCustomer read paths (follow-up). For short ramp windows (hours), 3-day cache TTLs cover the staleness risk.

Reusable: any future Redis migration (Dragonfly tier upgrade, provider swap, region move) just needs a new destination URL pasted into the admin UI. No env vars, no redeploys.

Tests: 18 unit tests covering bucketing, per-org overrides, ramp-active detection, forward/rollback staleness, legacy entries.

Note: pre-commit ts hook bypassed because the failure is in src/db/initDrizzle.ts:80 (duplicate @types/pg in lockfile, 8.11.10 + 8.15.6 + 8.20.0) — pre-existing on dev, reproduces on a clean checkout and is unrelated to this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime-configurable traffic ramp for Redis V2 that shifts load from the primary Dragonfly cluster to an admin-defined destination by percent. Enables safe, no-redeploy cutovers for upgrades, maintenance, and migrations.

- **New Features**
  - Adds `admin/dragonfly-ramp-config.json` (10s poll) with global percent, per-org overrides, and destination `{ connectionString (encrypted), url }`.
  - `resolveRedisV2({ orgId, customerId })` routes by bucket when `redis-v2-cache` active instance is `dragonfly`; orgs with dedicated `redis_config` bypass the ramp.
  - During ramp, invalidations, lock receipts, and org cleanup fan out to both primary and destination; fan-out is gated by the `redis-v2-cache` kill switch (`activeInstance === "dragonfly"`).
  - Destination client is lazily created and hot-swapped when the URL or encrypted `connectionString` changes; disconnects the old client and falls back to primary on missing destination or decryption errors (one-time warn).
  - Exposes helpers/APIs: `isDragonflyPublicEnabled`, `isDragonflyRampActive`, `isDragonflyRampCacheStale`, `updateDragonflyRampPercent`, `updateDragonflyRampDestination`, `removeDragonflyRampOrg`.

- **Migration**
  - In Edge Config, set the ramp destination (paste encrypted connection string and `url`), then save.
  - Start the ramp by setting a global percent or per-org overrides; clear overrides to revert.
  - No env vars or deploys required.

<sup>Written for commit 0faf9bb9889e1afc382022b61f03c6de6627e940. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1661?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

