### PR TITLE
Charlie/apperance

### DIFF
--- a/vite/src/components/v2/sheet-overlay/SheetOverlay.tsx
+++ b/vite/src/components/v2/sheet-overlay/SheetOverlay.tsx
@@ -83,6 +83,7 @@ export function SheetOverlay({ inline = false }: { inline?: boolean }) {
 					initial={{ opacity: 0 }}
 					animate={{ opacity: 1 }}
 					exit={{ opacity: 0 }}
+					data-slot="sheet-overlay"
 					className="absolute inset-0 bg-white/70 dark:bg-black/70"
 					style={{ zIndex: 40 }}
 					onMouseDown={handleMouseDown}

--- a/vite/src/contexts/ThemeProvider.tsx
+++ b/vite/src/contexts/ThemeProvider.tsx
@@ -2,27 +2,33 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 
-type Theme = "light" | "dark" | "system";
+type ThemeMode = "light" | "dark" | "system";
+type ThemePreset = "modern" | "classic";
 
 interface ThemeContextType {
-	theme: Theme;
-	setTheme: (theme: Theme) => void;
+	mode: ThemeMode;
+	setMode: (mode: ThemeMode) => void;
+	preset: ThemePreset;
+	setPreset: (preset: ThemePreset) => void;
 	isDark: boolean;
+	/** @deprecated Use `mode` instead */
+	theme: ThemeMode;
+	/** @deprecated Use `setMode` instead */
+	setTheme: (mode: ThemeMode) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-	const [theme, setTheme] = useLocalStorage<Theme>("theme", "system");
+	const [mode, setMode] = useLocalStorage<ThemeMode>("theme", "system");
+	const [preset, setPreset] = useLocalStorage<ThemePreset>("theme-preset", "classic");
 	const [isDark, setIsDark] = useState(false);
 
 	useEffect(() => {
 		const root = document.documentElement;
-
-		// Remove both classes first
 		root.classList.remove("light", "dark");
 
-		if (theme === "system") {
+		if (mode === "system") {
 			const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
 				.matches
 				? "dark"
@@ -30,14 +36,19 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 			root.classList.add(systemTheme);
 			setIsDark(systemTheme === "dark");
 		} else {
-			root.classList.add(theme);
-			setIsDark(theme === "dark");
+			root.classList.add(mode);
+			setIsDark(mode === "dark");
 		}
-	}, [theme]);
+	}, [mode]);
 
-	// Listen for system theme changes
 	useEffect(() => {
-		if (theme !== "system") return;
+		const root = document.documentElement;
+		root.classList.remove("preset-classic", "preset-modern");
+		root.classList.add(`preset-${preset}`);
+	}, [preset]);
+
+	useEffect(() => {
+		if (mode !== "system") return;
 
 		const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 		const handleChange = (e: MediaQueryListEvent) => {
@@ -49,15 +60,25 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
 		mediaQuery.addEventListener("change", handleChange);
 		return () => mediaQuery.removeEventListener("change", handleChange);
-	}, [theme]);
+	}, [mode]);
 
-	useHotkeys("t", () => setTheme(isDark ? "light" : "dark"), {
+	useHotkeys("t", () => setMode(isDark ? "light" : "dark"), {
 		enabled: import.meta.env.DEV,
 		enableOnFormTags: false,
 	});
 
 	return (
-		<ThemeContext.Provider value={{ theme, setTheme, isDark }}>
+		<ThemeContext.Provider
+			value={{
+				mode,
+				setMode,
+				preset,
+				setPreset,
+				isDark,
+				theme: mode,
+				setTheme: setMode,
+			}}
+		>
 			{children}
 		</ThemeContext.Provider>
 	);

--- a/vite/src/index.css
+++ b/vite/src/index.css
@@ -179,6 +179,32 @@ html {
 	color-scheme: dark;
 }
 
+/* Midnight preset — deeper contrast */
+.preset-modern {
+	background-color: #ffffff;
+	--background: #ffffff;
+	--outer-background: #fafaf9;
+	--card: #fafaf9;
+}
+
+.preset-modern.dark {
+	--background: #0a0a0a;
+	--outer-background: #000000;
+	--interactive-secondary: #141414;
+	--interactive-secondary-hover: #1e1e1e;
+	--active-primary: #1e1e1e;
+	--input-background: #111111;
+	--muted: #111111;
+	--card: #050505;
+	--border: #1e1e1e;
+	--chart-grid-stroke: #1a1a1a;
+}
+
+.preset-modern.dark [data-slot="sheet-overlay"],
+.preset-modern.dark [data-slot="dialog-overlay"] {
+	background-color: rgb(0 0 0 / 0.6) !important;
+}
+
 @theme inline {
 	/* CUSTOM STUFF */
 	--color-tertiary-foreground: var(--tertiary-foreground);

--- a/vite/src/styles/custom.css
+++ b/vite/src/styles/custom.css
@@ -179,5 +179,5 @@
 /* Override Shiki background color in dark mode */
 .dark .shiki,
 .dark .shiki pre {
-	background-color: #161616 !important;
+	background-color: var(--background) !important;
 }

--- a/vite/src/views/main-sidebar/MainSidebar.tsx
+++ b/vite/src/views/main-sidebar/MainSidebar.tsx
@@ -6,6 +6,7 @@ import {
 	CoinVerticalIcon,
 	CubeIcon,
 	DatabaseIcon,
+	GearIcon,
 	UsersIcon,
 	LegoIcon,
 	OptionIcon,
@@ -230,17 +231,23 @@ export const MainSidebar = ({
 							title="Analytics"
 							env={env}
 						/>
-						{canSeeDev && (
-							<CollapsibleNavGroup
-								value="dev"
-								icon={<TerminalWindowIcon size={16} weight="fill" />}
-								title="Developer"
-								env={env}
-								isOpen={devGroupOpen}
-								onToggle={() => setDevGroupOpen((prev) => !prev)}
-								subTabs={buildDevSubTabs({ flags, isAdmin })}
-							/>
-						)}
+					{canSeeDev && (
+						<CollapsibleNavGroup
+							value="dev"
+							icon={<TerminalWindowIcon size={16} weight="fill" />}
+							title="Developer"
+							env={env}
+							isOpen={devGroupOpen}
+							onToggle={() => setDevGroupOpen((prev) => !prev)}
+							subTabs={buildDevSubTabs({ flags, isAdmin })}
+						/>
+					)}
+					<NavButton
+						value="settings"
+						icon={<GearIcon size={16} weight="fill" />}
+						title="Settings"
+						env={env}
+					/>
 					</div>
 				</div>
 

--- a/vite/src/views/main-sidebar/SidebarBottom.tsx
+++ b/vite/src/views/main-sidebar/SidebarBottom.tsx
@@ -11,7 +11,6 @@ import { useSidebarContext } from "./SidebarContext";
 export default function SidebarBottom() {
 	const env = useEnv();
 	const { expanded } = useSidebarContext();
-	// const { user, isLoaded } = useUser();
 
 	return (
 		<div className="">

--- a/vite/src/views/main-sidebar/components/OrgDropdown.tsx
+++ b/vite/src/views/main-sidebar/components/OrgDropdown.tsx
@@ -5,7 +5,6 @@ import {
 	Moon,
 	PanelRight,
 	Plus,
-	Settings,
 	Sun,
 } from "lucide-react";
 import { useState } from "react";
@@ -47,7 +46,7 @@ import { LogOutItem } from "./LogOutItem";
 export const OrgDropdown = () => {
 	const { org, isLoading, error } = useOrg();
 	const { expanded, setExpanded } = useSidebarContext();
-	const { theme, setTheme } = useTheme();
+	const { mode, setMode } = useTheme();
 	const navigate = useNavigate();
 
 	const { data: orgsData } = useListOrganizations();
@@ -137,23 +136,47 @@ export const OrgDropdown = () => {
 					</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					<DropdownMenuGroup>
-						<DropdownMenuItem
-							onClick={() => {
-								navigateTo("/settings", navigate);
-								setDropdownOpen(false);
-							}}
-						>
-							<div className="flex justify-between w-full items-center gap-2 text-muted-foreground">
-								<span>Settings</span>
-								<Settings size={14} />
-							</div>
-						</DropdownMenuItem>
 						<DropdownMenuItem onClick={() => setDialogType("create")}>
 							<div className="flex justify-between w-full items-center gap-2 text-muted-foreground">
 								<span>Create Organization</span>
 								<Plus size={14} />
 							</div>
 						</DropdownMenuItem>
+						<DropdownMenuSub>
+							<DropdownMenuSubTrigger className="text-muted-foreground">
+								<div className="flex justify-between w-full items-center gap-2">
+									<span>Theme</span>
+									{mode === "light" && <Sun size={14} />}
+									{mode === "dark" && <Moon size={14} />}
+									{mode === "system" && <Monitor size={14} />}
+								</div>
+							</DropdownMenuSubTrigger>
+							<DropdownMenuPortal>
+								<DropdownMenuSubContent className="w-36">
+									<DropdownMenuItem
+										onClick={() => setMode("light")}
+										className="flex justify-between items-center"
+									>
+										<span className="text-muted-foreground">Light</span>
+										<Sun size={14} />
+									</DropdownMenuItem>
+									<DropdownMenuItem
+										onClick={() => setMode("dark")}
+										className="flex justify-between items-center"
+									>
+										<span className="text-muted-foreground">Dark</span>
+										<Moon size={14} />
+									</DropdownMenuItem>
+									<DropdownMenuItem
+										onClick={() => setMode("system")}
+										className="flex justify-between items-center"
+									>
+										<span className="text-muted-foreground">System</span>
+										<Monitor size={14} />
+									</DropdownMenuItem>
+								</DropdownMenuSubContent>
+							</DropdownMenuPortal>
+						</DropdownMenuSub>
 						{!expanded && (
 							<DropdownMenuItem
 								onClick={() => {
@@ -167,41 +190,6 @@ export const OrgDropdown = () => {
 								</div>
 							</DropdownMenuItem>
 						)}
-						<DropdownMenuSub>
-							<DropdownMenuSubTrigger className="text-muted-foreground">
-								<div className="flex justify-between w-full items-center gap-2">
-									<span>Theme</span>
-									{theme === "light" && <Sun size={14} />}
-									{theme === "dark" && <Moon size={14} />}
-									{theme === "system" && <Monitor size={14} />}
-								</div>
-							</DropdownMenuSubTrigger>
-							<DropdownMenuPortal>
-								<DropdownMenuSubContent className="w-36">
-									<DropdownMenuItem
-										onClick={() => setTheme("light")}
-										className="flex justify-between items-center"
-									>
-										<span className="text-muted-foreground">Light</span>
-										<Sun size={14} />
-									</DropdownMenuItem>
-									<DropdownMenuItem
-										onClick={() => setTheme("dark")}
-										className="flex justify-between items-center"
-									>
-										<span className="text-muted-foreground">Dark</span>
-										<Moon size={14} />
-									</DropdownMenuItem>
-									<DropdownMenuItem
-										onClick={() => setTheme("system")}
-										className="flex justify-between items-center"
-									>
-										<span className="text-muted-foreground">System</span>
-										<Monitor size={14} />
-									</DropdownMenuItem>
-								</DropdownMenuSubContent>
-							</DropdownMenuPortal>
-						</DropdownMenuSub>
 						{orgs && orgs.length > 0 && (
 							<>
 								<DropdownMenuSeparator />

--- a/vite/src/views/settings/SettingsView.tsx
+++ b/vite/src/views/settings/SettingsView.tsx
@@ -1,5 +1,6 @@
 import {
 	BuildingIcon,
+	PaletteIcon,
 	ShieldCheckIcon,
 	UserIcon,
 	UsersIcon,
@@ -11,8 +12,9 @@ import { AccountSection } from "./sections/AccountSection";
 import { OrganizationSection } from "./sections/OrganizationSection";
 import { MembersSection } from "./sections/MembersSection";
 import { AuthorizedAppsSection } from "./sections/AuthorizedAppsSection";
+import { AppearanceSection } from "./sections/AppearanceSection";
 
-type SettingsTab = "account" | "organization" | "members" | "apps";
+type SettingsTab = "account" | "organization" | "members" | "apps" | "appearance";
 
 interface SettingsNavItem {
 	readonly id: SettingsTab;
@@ -33,6 +35,11 @@ const SETTINGS_TABS: readonly SettingsNavItem[] = [
 		icon: <UsersIcon className="size-4" />,
 	},
 	{
+		id: "appearance",
+		label: "Appearance",
+		icon: <PaletteIcon className="size-4" />,
+	},
+	{
 		id: "apps",
 		label: "Authorized Apps",
 		icon: <ShieldCheckIcon className="size-4" />,
@@ -44,6 +51,7 @@ const SECTION_MAP: Record<SettingsTab, React.ComponentType> = {
 	organization: OrganizationSection,
 	members: MembersSection,
 	apps: AuthorizedAppsSection,
+	appearance: AppearanceSection,
 };
 
 export const SettingsView = () => {

--- a/vite/src/views/settings/sections/AppearanceSection.tsx
+++ b/vite/src/views/settings/sections/AppearanceSection.tsx
@@ -1,0 +1,176 @@
+import { Leaf, Monitor, Moon, Sun } from "lucide-react";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/v2/cards/Card";
+import { useTheme } from "@/contexts/ThemeProvider";
+import { cn } from "@/lib/utils";
+import { SettingsSection } from "../SettingsSection";
+
+interface PreviewColors {
+	readonly bg: string;
+	readonly sidebar: string;
+	readonly card: string;
+	readonly line: string;
+	readonly header: string;
+	readonly dot: string;
+}
+
+const PREVIEW_LIGHT: PreviewColors = {
+	bg: "bg-white",
+	sidebar: "bg-[#f5f5f4]",
+	card: "bg-[#fafaf9]",
+	line: "bg-[#e5e5e5]",
+	header: "bg-[#f5f5f4]",
+	dot: "bg-[#d1d1d1]",
+};
+
+const PREVIEW_DARK: PreviewColors = {
+	bg: "bg-[#0a0a0a]",
+	sidebar: "bg-[#000000]",
+	card: "bg-[#0f0f0f]",
+	line: "bg-[#1e1e1e]",
+	header: "bg-[#111111]",
+	dot: "bg-[#333333]",
+};
+
+const systemPrefersDark =
+	typeof window !== "undefined" &&
+	window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+const MODE_OPTIONS = [
+	{ id: "light", label: "Light", icon: <Sun className="size-4" />, preview: PREVIEW_LIGHT },
+	{ id: "dark", label: "Dark", icon: <Moon className="size-4" />, preview: PREVIEW_DARK },
+	{ id: "system", label: "System", icon: <Monitor className="size-4" />, preview: systemPrefersDark ? PREVIEW_DARK : PREVIEW_LIGHT },
+] as const;
+
+const PRESET_OPTIONS = [
+	{
+		id: "classic",
+		label: "Classic",
+		description: "The original Autumn look",
+		icon: <Leaf className="size-5 text-muted-foreground" />,
+		light: { bg: "bg-[#fafaf9]", sidebar: "bg-[#F5F5F4]", card: "bg-[#f8f8f7]", line: "bg-[#e5e5e5]", header: "bg-[#F5F5F4]", dot: "bg-[#d1d1d1]" },
+		dark: { bg: "bg-[#161616]", sidebar: "bg-[#121212]", card: "bg-[#1a1a1a]", line: "bg-[#2c2c2c]", header: "bg-[#1a1a1a]", dot: "bg-[#3a3a3a]" },
+	},
+	{
+		id: "modern",
+		label: { light: "Noon", dark: "Midnight" },
+		description: "Deeper contrast, sharper feel",
+		icon: <Moon className="size-5 text-muted-foreground" />,
+		light: { bg: "bg-white", sidebar: "bg-[#fafaf9]", card: "bg-[#f7f7f7]", line: "bg-[#e5e5e5]", header: "bg-[#fafaf9]", dot: "bg-[#d1d1d1]" },
+		dark: { bg: "bg-[#0a0a0a]", sidebar: "bg-[#000000]", card: "bg-[#0f0f0f]", line: "bg-[#1a1a1a]", header: "bg-[#0f0f0f]", dot: "bg-[#2a2a2a]" },
+	},
+] as const;
+
+function ThemePreview({ colors, height = "h-[72px]" }: { colors: PreviewColors; height?: string }) {
+	return (
+		<div className={cn("rounded-md border overflow-hidden transition-colors duration-200", height, colors.bg)}>
+			<div className="flex h-full">
+				<div className={cn("w-[22%] h-full flex flex-col transition-colors duration-200", colors.sidebar)}>
+					<div className="p-1.5 flex items-center gap-1">
+						<div className={cn("size-2 rounded-full transition-colors duration-200", colors.dot)} />
+					</div>
+					<div className="flex flex-col gap-1 px-1.5">
+						<div className={cn("h-1 w-full rounded-sm transition-colors duration-200", colors.line)} />
+						<div className={cn("h-1 w-3/4 rounded-sm transition-colors duration-200", colors.line)} />
+						<div className={cn("h-1 w-4/5 rounded-sm transition-colors duration-200", colors.line)} />
+					</div>
+				</div>
+				<div className="flex-1 flex flex-col transition-colors duration-200">
+					<div className={cn("h-4 border-b border-transparent flex items-center px-2 transition-colors duration-200", colors.header)}>
+						<div className={cn("h-1 w-8 rounded-sm transition-colors duration-200", colors.line)} />
+					</div>
+					<div className="flex-1 p-2 flex flex-col gap-1.5">
+						<div className={cn("h-3 w-3/4 rounded transition-colors duration-200", colors.card)} />
+						<div className={cn("h-1.5 w-1/2 rounded-sm transition-colors duration-200", colors.line)} />
+						<div className={cn("h-1.5 w-2/3 rounded-sm transition-colors duration-200", colors.line)} />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export const AppearanceSection = () => {
+	const { mode, setMode, preset, setPreset, isDark } = useTheme();
+
+	return (
+		<SettingsSection
+			title="Appearance"
+			description="Customize how the dashboard looks and feels"
+		>
+			<div className="flex flex-col gap-2">
+				<p className="text-sm font-medium text-foreground">Mode</p>
+				<div className="grid grid-cols-3 gap-3">
+					{MODE_OPTIONS.map((option) => (
+						<button
+							key={option.id}
+							type="button"
+							onClick={() => setMode(option.id)}
+							className={cn(
+								"flex flex-col gap-2 rounded-lg border p-2 transition-colors cursor-pointer text-left",
+								mode === option.id
+									? "border-primary bg-active-primary"
+									: "border-border hover:border-muted-foreground/30",
+							)}
+						>
+							<ThemePreview colors={option.preview} />
+							<div className="flex items-center gap-1.5 px-0.5">
+								{option.icon}
+								<span className="text-sm font-medium">{option.label}</span>
+							</div>
+						</button>
+					))}
+				</div>
+			</div>
+
+			<Card className="shadow-none bg-interactive-secondary">
+				<CardHeader>
+					<CardTitle>Theme</CardTitle>
+					<CardDescription>
+						Select a visual style for the dashboard
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<div className="grid grid-cols-2 gap-3">
+						{PRESET_OPTIONS.map((option) => {
+							const isActive = preset === option.id;
+							const colors = isDark ? option.dark : option.light;
+							const label = typeof option.label === "string"
+								? option.label
+								: isDark ? option.label.dark : option.label.light;
+							return (
+								<button
+									key={option.id}
+									type="button"
+									onClick={() => setPreset(option.id)}
+									className={cn(
+										"flex flex-col gap-2.5 rounded-lg border p-2.5 transition-all duration-200 cursor-pointer text-left",
+										isActive
+											? "border-primary ring-2 ring-primary/20 ring-offset-1 ring-offset-background"
+											: "border-border hover:border-muted-foreground/30",
+									)}
+								>
+									<ThemePreview colors={colors} height="h-[80px]" />
+									<div className="flex items-center gap-2.5 px-0.5">
+										{option.icon}
+										<div className="flex flex-col gap-0.5">
+											<span className="text-sm font-medium">{label}</span>
+											<span className="text-xs text-muted-foreground">
+												{option.description}
+											</span>
+										</div>
+									</div>
+								</button>
+							);
+						})}
+					</div>
+				</CardContent>
+			</Card>
+		</SettingsSection>
+	);
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Appearance settings with Light/Dark/System modes and Classic/Modern presets, and moves Settings to the main sidebar. Also introduces `bun pw` to run local dev against production Infisical env safely.

- New Features
  - Settings > Appearance: pick mode (Light/Dark/System) and theme preset (Classic/Modern) with live previews; values persist.
  - ThemeProvider: adds `mode` and `preset` with `preset-*` classes on `<html>`; keeps `theme`/`setTheme` as deprecated aliases.
  - Modern preset styles: deeper contrast in dark; targeted overlay styling via `data-slot` on sheet/dialog; code blocks now use `var(--background)` in dark mode.
  - Sidebar: adds a Settings nav button; removes Settings from the org dropdown; Theme menu in the dropdown now uses `mode`; reorders “Open Sidebar” below the Theme submenu.
  - Dev tooling: `bun pw`, `bun pw identify`, `bun pw restore` to run worktrees against prod Infisical secrets while keeping SQS local.

- Bug Fixes
  - `scripts/preload-env.ts` skips `.env.local` when `PW_MODE=1` so prod secrets aren’t overridden.
  - Disables Google emulate in pw runs to prevent dev fallback against the prod DB.

<sup>Written for commit e16bfe90bed6a3f1d9e5efd5604dbbb63fbc1336. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1669?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an Appearance settings section that lets users pick a light/dark/system mode and a visual preset ("Classic" or "Modern/Midnight"), backed by a `ThemeProvider` refactor that renames `theme`→`mode` with deprecated aliases for backward compatibility. It also introduces a `bun pw` developer script that runs the dev server against prod Infisical secrets by skipping `.env.local` overrides.

- **[Improvements]** New Appearance settings tab with mode picker and two visual presets (`classic` / `modern`), driven by CSS classes on `<html>` and persisted to localStorage.
- **[Improvements]** `ThemeProvider` extended with `preset` state; `theme`/`setTheme` kept as `@deprecated` aliases so existing callers don't break.
- **[Improvements]** New `bun pw` / `bun pw:identify` scripts for testing against the production database without dev `.env.local` files leaking in via `PW_MODE=1` guard in `preload-env.ts`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are isolated to UI theming and a developer tooling script with no server-side or data-layer impact.

The `systemPrefersDark` value is captured once at module load in `AppearanceSection.tsx`, so the "System" preview thumbnail will show stale colours if the OS preference changes mid-session. Everything else — the `ThemeProvider` refactor, preset CSS classes, and the `bun pw` script — looks correct and well-guarded.

vite/src/views/settings/sections/AppearanceSection.tsx — the stale system-preference snapshot; vite/src/views/main-sidebar/MainSidebar.tsx — the indentation inconsistency introduced during the refactor.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/settings/sections/AppearanceSection.tsx | New Appearance settings section with mode (light/dark/system) and preset (classic/modern) pickers; `systemPrefersDark` is captured at module load time, so the System-mode preview thumbnail can show the wrong colours after a system preference change mid-session. |
| vite/src/contexts/ThemeProvider.tsx | Adds `preset` state (persisted to localStorage as `theme-preset`) and applies it as a CSS class; renames `theme`/`setTheme` to `mode`/`setMode` with backward-compat deprecated aliases. Logic is correct. |
| vite/src/index.css | Adds `.preset-modern` and `.preset-modern.dark` CSS variable overrides, plus overlay selectors for sheet/dialog using `data-slot` attributes; straightforward CSS addition. |
| vite/src/views/main-sidebar/MainSidebar.tsx | Adds a Settings nav button to the sidebar and moves the Developer group block; the two new/moved blocks are indented one level less than the surrounding nav buttons, creating an inconsistency. |
| scripts/pw/index.ts | New developer script that starts the dev server with prod Infisical secrets; correctly guards against stale `.env.local` overrides via `PW_MODE=1`. |
| scripts/preload-env.ts | Wraps the `.env.local` loading logic in a `PW_MODE !== "1"` guard so `bun pw` (prod env) doesn't have dev overrides bleed in. |
| vite/src/views/settings/SettingsView.tsx | Adds an Appearance tab to the settings nav and maps it to the new AppearanceSection component. |
| vite/src/components/v2/sheet-overlay/SheetOverlay.tsx | Adds `data-slot="sheet-overlay"` attribute to the overlay motion div so the new `.preset-modern.dark` CSS rule can target it. |
| vite/src/styles/custom.css | Replaces hardcoded `#161616` Shiki background with `var(--background)` so dark-mode code blocks respect the active preset's background colour. |
| vite/src/views/main-sidebar/components/OrgDropdown.tsx | Switches from deprecated `theme`/`setTheme` to `mode`/`setMode`, removes the Settings item (moved to sidebar), and reorders the Open Sidebar item below the Theme sub-menu. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    LS[(localStorage)] -->|theme key| mode
    LS -->|theme-preset key| preset

    mode -->|useEffect| MC{mode == system?}
    MC -->|yes| MQ[window.matchMedia]
    MQ --> DarkClass[add dark class to html]
    MQ --> LightClass[add light class to html]
    MC -->|no| Direct[add mode class directly]

    preset -->|useEffect| PC[swap preset-classic or preset-modern class on html]

    DarkClass & LightClass & Direct --> ThemeVars[dark/light CSS variables applied]
    PC --> PresetVars[preset-modern CSS overrides applied]
    ThemeVars & PresetVars --> UI[Rendered UI]

    AppearanceSection -->|setMode| mode
    AppearanceSection -->|setPreset| preset
    OrgDropdown -->|setMode| mode
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/settings/sections/AppearanceSection.tsx:40-48
The `systemPrefersDark` value is computed once at module load and frozen into `MODE_OPTIONS` as a constant. If the user changes their OS theme preference while the app is open, the "System" preview thumbnail will display the wrong colours until a full page reload. Since `AppearanceSection` already has access to `isDark` from the context (which is updated reactively), the preview can simply derive its colours at render time instead.

```suggestion
const MODE_OPTIONS = [
	{ id: "light", label: "Light", icon: <Sun className="size-4" />, preview: PREVIEW_LIGHT },
	{ id: "dark", label: "Dark", icon: <Moon className="size-4" />, preview: PREVIEW_DARK },
	{ id: "system", label: "System", icon: <Monitor className="size-4" />, preview: null },
] as const;
```

### Issue 2 of 2
vite/src/views/main-sidebar/MainSidebar.tsx:234-250
Indentation inconsistency after the refactor — the `{canSeeDev && ...}` block and the new `<NavButton value="settings">` sit one level shallower than the surrounding `<NavButton>` siblings (e.g., the `analytics` button above them), while the closing `</div>` remains at the original deeper level. This is cosmetic but will cause noisy diffs in future PRs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add apperance"](https://github.com/useautumn/autumn/commit/b97919fb24d26f325cd9eab25c5fc62447144107) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33080270)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->