### PR TITLE
cache v2 ramp admin config

### DIFF
--- a/server/src/cron.ts
+++ b/server/src/cron.ts
@@ -7,6 +7,7 @@ await warmupRegionalRedis();
 // Edge config modules self-register on import (cron reads redis-v2-cache
 // so resolveRedisV2 picks the right instance on each ctx build).
 await import("./internal/misc/redisV2Cache/redisV2CacheStore.js");
+await import("./internal/misc/cacheV2Ramp/cacheV2RampStore.js");
 const { logger } = await import("./external/logtail/logtailUtils.js");
 const { startAllEdgeConfigPolling } = await import(
 	"./internal/misc/edgeConfig/edgeConfigRegistry.js"

--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -6,6 +6,7 @@ export const ADMIN_CUSTOMER_BLOCK_CONFIG_KEY =
 export const ADMIN_ORG_LIMITS_CONFIG_KEY = "admin/org-limits-config.json";
 export const ADMIN_REDIS_V2_CACHE_CONFIG_KEY =
 	"admin/redis-v2-cache-config.json";
+export const ADMIN_CACHE_V2_RAMP_CONFIG_KEY = "admin/cache-v2-ramp-config.json";
 export const ADMIN_JOB_QUEUE_CONFIG_KEY = "admin/job-queue-config.json";
 export const ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY =
 	"admin/miscellaneous-edge-config.json";
@@ -48,6 +49,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "redis-v2-cache",
 			label: "V2 Redis Instance",
 			key: ADMIN_REDIS_V2_CACHE_CONFIG_KEY,
+		},
+		{
+			id: "cache-v2-ramp",
+			label: "Cache V2 Ramp",
+			key: ADMIN_CACHE_V2_RAMP_CONFIG_KEY,
 		},
 		{
 			id: "job-queues",

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -5,6 +5,7 @@ import {
 	isCacheV2RampActive,
 } from "@/internal/misc/cacheV2Ramp/index.js";
 import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
+import { redisV2 as redisV2Primary } from "./initRedisV2.js";
 import { getOrgRedis, type OrgWithRedisConfig } from "./orgRedisPool.js";
 import { resolveRedisV2 } from "./resolveRedisV2.js";
 
@@ -51,7 +52,7 @@ export const resolveCustomerRedisRouting = ({
 
 	return {
 		...routingInfo,
-		redis: resolveRedisV2({ orgId: org.id, customerId }),
+		redis: resolveRedisV2({ customerId }),
 	};
 };
 
@@ -119,7 +120,11 @@ export const getRedisTargetsForCustomer = ({
 	if (getActiveRedisV2Instance() === "dragonfly" && isCacheV2RampActive()) {
 		const destination = getRampDestinationRedis();
 		if (destination) {
-			redisTargets.push(destination, resolveRedisV2());
+			// Use redisV2Primary directly: at 100% ramp, resolveRedisV2() with no
+			// args still goes through isCacheV2RampEnabled (which returns true
+			// when migrationPercent >= 100 regardless of customerId), so it
+			// would return the destination — leaving primary out of the fan-out.
+			redisTargets.push(destination, redisV2Primary);
 		}
 	}
 	return [...new Set(redisTargets)];

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -1,5 +1,10 @@
 import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	getRampDestinationRedis,
+	isCacheV2RampActive,
+} from "@/internal/misc/cacheV2Ramp/index.js";
+import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
 import { getOrgRedis, type OrgWithRedisConfig } from "./orgRedisPool.js";
 import { resolveRedisV2 } from "./resolveRedisV2.js";
 
@@ -46,7 +51,7 @@ export const resolveCustomerRedisRouting = ({
 
 	return {
 		...routingInfo,
-		redis: resolveRedisV2(),
+		redis: resolveRedisV2({ orgId: org.id, customerId }),
 	};
 };
 
@@ -105,6 +110,20 @@ export const getRedisTargetsForCustomer = ({
 	const redisTargets = [currentRedis ?? resolveRedisV2()];
 	if (org.redis_config) {
 		redisTargets.push(resolveRedisV2(), getOrgRedis({ org }));
+	}
+	// During ramp, fan out to BOTH primary and destination. `currentRedis` may
+	// already be the destination (ramped customer) or the primary (non-ramped);
+	// without explicitly including both, the other cluster keeps stale entries
+	// until TTL. Gated on activeInstance === "dragonfly" so the upstash/redis
+	// kill switch disables the ramp fan-out.
+	if (
+		getActiveRedisV2Instance() === "dragonfly" &&
+		isCacheV2RampActive({ orgId: org.id })
+	) {
+		const destination = getRampDestinationRedis();
+		if (destination) {
+			redisTargets.push(destination, resolveRedisV2());
+		}
 	}
 	return [...new Set(redisTargets)];
 };

--- a/server/src/external/redis/customerRedisRouting.ts
+++ b/server/src/external/redis/customerRedisRouting.ts
@@ -116,10 +116,7 @@ export const getRedisTargetsForCustomer = ({
 	// without explicitly including both, the other cluster keeps stale entries
 	// until TTL. Gated on activeInstance === "dragonfly" so the upstash/redis
 	// kill switch disables the ramp fan-out.
-	if (
-		getActiveRedisV2Instance() === "dragonfly" &&
-		isCacheV2RampActive({ orgId: org.id })
-	) {
+	if (getActiveRedisV2Instance() === "dragonfly" && isCacheV2RampActive()) {
 		const destination = getRampDestinationRedis();
 		if (destination) {
 			redisTargets.push(destination, resolveRedisV2());

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -47,7 +47,7 @@ const createOrgRedisConnection = ({
 };
 
 export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
-	if (!org.redis_config) return resolveRedisV2();
+	if (!org.redis_config) return resolveRedisV2({ orgId: org.id });
 
 	const existing = pool.get(org.id);
 	if (existing) {
@@ -66,7 +66,7 @@ export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
 		if (error instanceof Error) {
 			logger.error(error);
 		}
-		return resolveRedisV2();
+		return resolveRedisV2({ orgId: org.id });
 	}
 
 	const instance = createOrgRedisConnection({

--- a/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
+++ b/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
@@ -5,6 +5,7 @@ import {
 	isCacheV2RampActive,
 } from "@/internal/misc/cacheV2Ramp/index.js";
 import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
+import { redisV2 as redisV2Primary } from "../initRedisV2.js";
 import { getOrgRedis } from "../orgRedisPool.js";
 import { resolveRedisV2 } from "../resolveRedisV2.js";
 
@@ -27,7 +28,10 @@ const withRampClustersIfActive = ({
 	if (!isCacheV2RampActive()) return candidates;
 	const destination = getRampDestinationRedis();
 	if (!destination) return candidates;
-	return [...candidates, destination, resolveRedisV2()];
+	// Use redisV2Primary directly: at 100% ramp, resolveRedisV2() with no
+	// args returns the destination (isCacheV2RampEnabled short-circuits to
+	// true when migrationPercent >= 100 regardless of customerId).
+	return [...candidates, destination, redisV2Primary];
 };
 
 export const getRedisV2LockReceiptCandidates = ({

--- a/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
+++ b/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
@@ -13,23 +13,18 @@ const dedupeRedisInstances = ({ candidates }: { candidates: Redis[] }) =>
 		(candidate, index) => candidates.indexOf(candidate) === index,
 	);
 
-/** Adds BOTH primary and ramp destination clients to the candidate list when
- *  the ramp is non-zero for this org. During ramp, lock/cleanup state may
- *  exist on EITHER cluster — scanning both prevents loss across boundary
- *  crossings.
+/** Adds BOTH primary and ramp destination to the candidate list when the ramp
+ *  is active. Lock/cleanup state may exist on EITHER cluster mid-ramp.
  *
  *  Gated on `activeInstance === "dragonfly"` so the upstash/redis kill switch
- *  disables ramp fan-out (when active is non-dragonfly, ramp traffic isn't
- *  routed to either cluster). */
+ *  also disables ramp fan-out. */
 const withRampClustersIfActive = ({
 	candidates,
-	orgId,
 }: {
 	candidates: Redis[];
-	orgId?: string;
 }): Redis[] => {
 	if (getActiveRedisV2Instance() !== "dragonfly") return candidates;
-	if (!isCacheV2RampActive({ orgId })) return candidates;
+	if (!isCacheV2RampActive()) return candidates;
 	const destination = getRampDestinationRedis();
 	if (!destination) return candidates;
 	return [...candidates, destination, resolveRedisV2()];
@@ -47,10 +42,7 @@ export const getRedisV2LockReceiptCandidates = ({
 	}
 
 	return dedupeRedisInstances({
-		candidates: withRampClustersIfActive({
-			candidates,
-			orgId: ctx.org.id,
-		}),
+		candidates: withRampClustersIfActive({ candidates }),
 	});
 };
 
@@ -66,9 +58,6 @@ export const getRedisV2OrgCleanupCandidates = ({
 	}
 
 	return dedupeRedisInstances({
-		candidates: withRampClustersIfActive({
-			candidates,
-			orgId: ctx.org.id,
-		}),
+		candidates: withRampClustersIfActive({ candidates }),
 	});
 };

--- a/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
+++ b/server/src/external/redis/orgRedisUtils/orgRedisMigrationUtils.ts
@@ -1,5 +1,10 @@
 import type { Redis } from "ioredis";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	getRampDestinationRedis,
+	isCacheV2RampActive,
+} from "@/internal/misc/cacheV2Ramp/index.js";
+import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
 import { getOrgRedis } from "../orgRedisPool.js";
 import { resolveRedisV2 } from "../resolveRedisV2.js";
 
@@ -7,6 +12,28 @@ const dedupeRedisInstances = ({ candidates }: { candidates: Redis[] }) =>
 	candidates.filter(
 		(candidate, index) => candidates.indexOf(candidate) === index,
 	);
+
+/** Adds BOTH primary and ramp destination clients to the candidate list when
+ *  the ramp is non-zero for this org. During ramp, lock/cleanup state may
+ *  exist on EITHER cluster — scanning both prevents loss across boundary
+ *  crossings.
+ *
+ *  Gated on `activeInstance === "dragonfly"` so the upstash/redis kill switch
+ *  disables ramp fan-out (when active is non-dragonfly, ramp traffic isn't
+ *  routed to either cluster). */
+const withRampClustersIfActive = ({
+	candidates,
+	orgId,
+}: {
+	candidates: Redis[];
+	orgId?: string;
+}): Redis[] => {
+	if (getActiveRedisV2Instance() !== "dragonfly") return candidates;
+	if (!isCacheV2RampActive({ orgId })) return candidates;
+	const destination = getRampDestinationRedis();
+	if (!destination) return candidates;
+	return [...candidates, destination, resolveRedisV2()];
+};
 
 export const getRedisV2LockReceiptCandidates = ({
 	ctx,
@@ -19,7 +46,12 @@ export const getRedisV2LockReceiptCandidates = ({
 		candidates.push(getOrgRedis({ org: ctx.org }), resolveRedisV2());
 	}
 
-	return dedupeRedisInstances({ candidates });
+	return dedupeRedisInstances({
+		candidates: withRampClustersIfActive({
+			candidates,
+			orgId: ctx.org.id,
+		}),
+	});
 };
 
 export const getRedisV2OrgCleanupCandidates = ({
@@ -33,5 +65,10 @@ export const getRedisV2OrgCleanupCandidates = ({
 		candidates.push(getOrgRedis({ org: ctx.org }));
 	}
 
-	return dedupeRedisInstances({ candidates });
+	return dedupeRedisInstances({
+		candidates: withRampClustersIfActive({
+			candidates,
+			orgId: ctx.org.id,
+		}),
+	});
 };

--- a/server/src/external/redis/resolveRedisV2.ts
+++ b/server/src/external/redis/resolveRedisV2.ts
@@ -1,5 +1,9 @@
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
+import {
+	getRampDestinationRedis,
+	isCacheV2RampEnabled,
+} from "@/internal/misc/cacheV2Ramp/index.js";
 import type { RedisV2InstanceName } from "@/internal/misc/redisV2Cache/redisV2CacheSchemas.js";
 import { getActiveRedisV2Instance } from "@/internal/misc/redisV2Cache/redisV2CacheStore.js";
 import {
@@ -8,11 +12,24 @@ import {
 } from "./initRedisV2.js";
 
 let lastLoggedInstance: RedisV2InstanceName | null = null;
+let publicRouteWarned = false;
 
-/** Returns the active V2 Redis instance, selected by the redis-v2-cache edge config.
+/** Returns the V2 Redis instance for this request.
+ *
+ *  Routing order:
+ *  1. If `redis-v2-cache` edge config selects a non-dragonfly instance
+ *     (`upstash`/`redis`), honor it — that's a global override / kill switch
+ *     and trumps the ramp.
+ *  2. Otherwise (active = dragonfly), if the ramp is enabled for this
+ *     customer/org AND a destination is configured → ramp destination client.
+ *  3. Otherwise → primary Dragonfly.
+ *
  *  Called by every ctx-building middleware/worker — request-path code reads
  *  ctx.redisV2 rather than calling this. */
-export const resolveRedisV2 = (): Redis => {
+export const resolveRedisV2 = (opts?: {
+	orgId?: string;
+	customerId?: string;
+}): Redis => {
 	const activeInstance = getActiveRedisV2Instance();
 
 	if (activeInstance !== lastLoggedInstance) {
@@ -22,7 +39,19 @@ export const resolveRedisV2 = (): Redis => {
 		lastLoggedInstance = activeInstance;
 	}
 
-	if (activeInstance === "dragonfly") return redisV2Primary;
+	if (activeInstance === "dragonfly") {
+		if (opts && isCacheV2RampEnabled(opts)) {
+			const destination = getRampDestinationRedis();
+			if (destination) return destination;
+			if (!publicRouteWarned) {
+				publicRouteWarned = true;
+				logger.warn(
+					"[resolveRedisV2] cache V2 ramp enabled but destination is not configured (or decryption failed); falling back to primary",
+				);
+			}
+		}
+		return redisV2Primary;
+	}
 
 	const alternate = getAlternateRedisV2Instance(activeInstance);
 	return alternate ?? redisV2Primary;

--- a/server/src/external/redis/resolveRedisV2.ts
+++ b/server/src/external/redis/resolveRedisV2.ts
@@ -26,10 +26,7 @@ let publicRouteWarned = false;
  *
  *  Called by every ctx-building middleware/worker — request-path code reads
  *  ctx.redisV2 rather than calling this. */
-export const resolveRedisV2 = (opts?: {
-	orgId?: string;
-	customerId?: string;
-}): Redis => {
+export const resolveRedisV2 = (opts?: { customerId?: string }): Redis => {
 	const activeInstance = getActiveRedisV2Instance();
 
 	if (activeInstance !== lastLoggedInstance) {

--- a/server/src/external/redis/resolveRedisV2.ts
+++ b/server/src/external/redis/resolveRedisV2.ts
@@ -40,7 +40,7 @@ export const resolveRedisV2 = (opts?: {
 	}
 
 	if (activeInstance === "dragonfly") {
-		if (opts && isCacheV2RampEnabled(opts)) {
+		if (isCacheV2RampEnabled({ customerId: opts?.customerId })) {
 			const destination = getRampDestinationRedis();
 			if (destination) return destination;
 			if (!publicRouteWarned) {

--- a/server/src/honoMiddlewares/baseMiddleware.ts
+++ b/server/src/honoMiddlewares/baseMiddleware.ts
@@ -1,10 +1,10 @@
 import {
-    ApiVersionClass,
-    AppEnv,
-    AuthType,
-    LATEST_VERSION,
-    type Organization,
-    tryCatch,
+	ApiVersionClass,
+	AppEnv,
+	AuthType,
+	LATEST_VERSION,
+	type Organization,
+	tryCatch,
 } from "@autumn/shared";
 import type { Context, Next } from "hono";
 import { db, dbGeneral } from "@/db/initDrizzle.js";
@@ -93,7 +93,7 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		db,
 		dbGeneral,
 		logger: childLogger,
-		redisV2: resolveRedisV2(),
+		redisV2: resolveRedisV2({ customerId }),
 
 		// Request info
 		id,
@@ -114,7 +114,9 @@ export const baseMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 
 		// Query params
 		expand: [],
-		skipCache: c.req.header("x-skip-cache") === "true" || c.req.query("skip_cache") === "true",
+		skipCache:
+			c.req.header("x-skip-cache") === "true" ||
+			c.req.query("skip_cache") === "true",
 
 		// Test params:
 		extraLogs: {},

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -26,6 +26,7 @@ import "./internal/misc/customerBlocks/customerBlockStore.js";
 import "./internal/misc/edgeConfig/orgLimitsStore.js";
 import "./internal/misc/stripeSync/stripeSyncStore.js";
 import "./internal/misc/redisV2Cache/redisV2CacheStore.js";
+import "./internal/misc/cacheV2Ramp/cacheV2RampStore.js";
 import "./internal/misc/jobQueues/jobQueueStore.js";
 // Side-effect: configures trigger.dev SDK to use TRIGGER_SERVER_SECRET_KEY.
 import "./trigger/configureTrigger.js";

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -1,12 +1,10 @@
 import { Hono } from "hono";
 import type { HonoEnv } from "../../honoUtils/HonoEnv";
 import {
-	handleDeleteAdminCacheV2RampDestination,
-	handleDeleteAdminCacheV2RampOrg,
+	handleDeleteAdminCacheV2Ramp,
 	handleGetAdminCacheV2Ramp,
-	handleUpdateAdminCacheV2RampOrg,
-	handleUpdateAdminCacheV2RampPercent,
-	handleUpsertAdminCacheV2RampDestination,
+	handleUpdateAdminCacheV2RampMigration,
+	handleUpsertAdminCacheV2Ramp,
 } from "./handleAdminCacheV2Ramp";
 import {
 	handleDeleteAdminOrgRedisConfig,
@@ -122,26 +120,12 @@ honoAdminRouter.put(
 	...handleUpsertAdminRedisV2CacheConfig,
 );
 honoAdminRouter.get("/cache-v2-ramp", ...handleGetAdminCacheV2Ramp);
-honoAdminRouter.put(
-	"/cache-v2-ramp/destination",
-	...handleUpsertAdminCacheV2RampDestination,
+honoAdminRouter.patch("/cache-v2-ramp", ...handleUpsertAdminCacheV2Ramp);
+honoAdminRouter.patch(
+	"/cache-v2-ramp/migration",
+	...handleUpdateAdminCacheV2RampMigration,
 );
-honoAdminRouter.delete(
-	"/cache-v2-ramp/destination",
-	...handleDeleteAdminCacheV2RampDestination,
-);
-honoAdminRouter.put(
-	"/cache-v2-ramp/percent",
-	...handleUpdateAdminCacheV2RampPercent,
-);
-honoAdminRouter.put(
-	"/cache-v2-ramp/orgs/:org_id",
-	...handleUpdateAdminCacheV2RampOrg,
-);
-honoAdminRouter.delete(
-	"/cache-v2-ramp/orgs/:org_id",
-	...handleDeleteAdminCacheV2RampOrg,
-);
+honoAdminRouter.delete("/cache-v2-ramp", ...handleDeleteAdminCacheV2Ramp);
 honoAdminRouter.get("/org-member", ...handleGetOrgMember);
 honoAdminRouter.get("/master-stripe-account", ...handleGetMasterStripeAccount);
 honoAdminRouter.get("/oauth-clients", ...handleListOAuthClients);

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -1,6 +1,14 @@
 import { Hono } from "hono";
 import type { HonoEnv } from "../../honoUtils/HonoEnv";
 import {
+	handleDeleteAdminCacheV2RampDestination,
+	handleDeleteAdminCacheV2RampOrg,
+	handleGetAdminCacheV2Ramp,
+	handleUpdateAdminCacheV2RampOrg,
+	handleUpdateAdminCacheV2RampPercent,
+	handleUpsertAdminCacheV2RampDestination,
+} from "./handleAdminCacheV2Ramp";
+import {
 	handleDeleteAdminOrgRedisConfig,
 	handleGetAdminOrgRedisConfig,
 	handleUpdateAdminOrgRedisMigration,
@@ -112,6 +120,27 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/redis-v2-cache-config",
 	...handleUpsertAdminRedisV2CacheConfig,
+);
+honoAdminRouter.get("/cache-v2-ramp", ...handleGetAdminCacheV2Ramp);
+honoAdminRouter.put(
+	"/cache-v2-ramp/destination",
+	...handleUpsertAdminCacheV2RampDestination,
+);
+honoAdminRouter.delete(
+	"/cache-v2-ramp/destination",
+	...handleDeleteAdminCacheV2RampDestination,
+);
+honoAdminRouter.put(
+	"/cache-v2-ramp/percent",
+	...handleUpdateAdminCacheV2RampPercent,
+);
+honoAdminRouter.put(
+	"/cache-v2-ramp/orgs/:org_id",
+	...handleUpdateAdminCacheV2RampOrg,
+);
+honoAdminRouter.delete(
+	"/cache-v2-ramp/orgs/:org_id",
+	...handleDeleteAdminCacheV2RampOrg,
 );
 honoAdminRouter.get("/org-member", ...handleGetOrgMember);
 honoAdminRouter.get("/master-stripe-account", ...handleGetMasterStripeAccount);

--- a/server/src/internal/admin/handleAdminCacheV2Ramp.ts
+++ b/server/src/internal/admin/handleAdminCacheV2Ramp.ts
@@ -78,22 +78,17 @@ export const handleUpsertAdminCacheV2Ramp = createRoute({
 			});
 		}
 
-		const current = getCacheV2RampConfig();
-		if (current && current.migrationPercent > 0) {
-			throw new RecaseError({
-				message: `Cannot update destination while migrationPercent is ${current.migrationPercent}%. Set it to 0 first.`,
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-
+		// Store enforces "refuse while migrationPercent > 0" atomically against
+		// fresh S3 state — no separate handler-level guard against the polled
+		// snapshot (which can lag in multi-instance deployments).
+		const wasConfigured = !!getCacheV2RampConfig();
 		await upsertCacheV2RampConnection({
 			connectionString: encryptData(connectionString),
 			url: redisUrl.host,
 		});
 
 		logger.info(
-			`[admin/handleUpsertAdminCacheV2Ramp] ${current ? "updated" : "created"}, url=${redisUrl.host}, actor=${actorString(ctx)}`,
+			`[admin/handleUpsertAdminCacheV2Ramp] ${wasConfigured ? "updated" : "created"}, url=${redisUrl.host}, actor=${actorString(ctx)}`,
 		);
 
 		return c.json({ success: true });
@@ -112,26 +107,22 @@ export const handleUpdateAdminCacheV2RampMigration = createRoute({
 		const { logger } = ctx;
 		const { migrationPercent } = c.req.valid("json");
 
-		const current = getCacheV2RampConfig();
-		if (!current) {
-			throw new RecaseError({
-				message:
-					"No cache V2 ramp config set. Configure destination first via PATCH /admin/cache-v2-ramp.",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-
+		// Snapshot the previous percent for logging only; the store enforces
+		// "config must exist" atomically against fresh S3 state.
+		const previousSnapshot = getCacheV2RampConfig();
 		await updateCacheV2RampMigrationPercent({ migrationPercent });
 
 		// Warm the destination client on first ramp-up so the first ramped
 		// requests don't pay the connect-handshake latency.
-		if (migrationPercent > 0 && current.migrationPercent === 0) {
+		if (
+			migrationPercent > 0 &&
+			(previousSnapshot?.migrationPercent ?? 0) === 0
+		) {
 			getRampDestinationRedis();
 		}
 
 		logger.info(
-			`[admin/handleUpdateAdminCacheV2RampMigration] ${current.migrationPercent}% -> ${migrationPercent}%, actor=${actorString(ctx)}`,
+			`[admin/handleUpdateAdminCacheV2RampMigration] ${previousSnapshot?.migrationPercent ?? 0}% -> ${migrationPercent}%, actor=${actorString(ctx)}`,
 		);
 
 		return c.json({ success: true });
@@ -147,16 +138,8 @@ export const handleDeleteAdminCacheV2Ramp = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { logger } = ctx;
-		const current = getCacheV2RampConfig();
-
-		if (current && current.migrationPercent > 0) {
-			throw new RecaseError({
-				message: `Cannot remove cache V2 ramp while migrationPercent is ${current.migrationPercent}%. Set it to 0 first.`,
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-
+		// Store enforces "refuse while migrationPercent > 0" atomically against
+		// fresh S3 state.
 		await removeCacheV2RampConfig();
 		closeRampDestinationClient();
 

--- a/server/src/internal/admin/handleAdminCacheV2Ramp.ts
+++ b/server/src/internal/admin/handleAdminCacheV2Ramp.ts
@@ -1,0 +1,248 @@
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	CacheV2RampInvariantError,
+	closeRampDestinationClient,
+	getCacheV2RampConfig,
+	removeCacheV2RampOrg,
+	updateCacheV2RampDestination,
+	updateCacheV2RampPercent,
+} from "@/internal/misc/cacheV2Ramp/index.js";
+import { encryptData } from "@/utils/encryptUtils.js";
+
+/** Wrap a store update that may throw `CacheV2RampInvariantError` and convert
+ *  invariant failures to HTTP 400. Anything else propagates as 500. */
+const runWithInvariantGuard = async <T>(fn: () => Promise<T>): Promise<T> => {
+	try {
+		return await fn();
+	} catch (error) {
+		if (error instanceof CacheV2RampInvariantError) {
+			throw new RecaseError({
+				message: error.message,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		throw error;
+	}
+};
+
+const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
+
+const orgIdParam = z.object({ org_id: z.string().min(1) });
+
+const actorString = (ctx: { user?: { email?: string }; userId?: string }) =>
+	ctx.user?.email ?? ctx.userId ?? "unknown";
+
+/**
+ * GET /admin/cache-v2-ramp
+ * Returns the current ramp config WITHOUT the encrypted connectionString —
+ * we never echo ciphertext back to the UI. URL (host:port), percent, org
+ * overrides, and timestamps are safe.
+ */
+export const handleGetAdminCacheV2Ramp = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const config = getCacheV2RampConfig();
+		return c.json({
+			destination: config.destination ? { url: config.destination.url } : null,
+			percent: config.percent,
+			previousPercent: config.previousPercent,
+			changedAt: config.changedAt,
+			orgs: config.orgs,
+		});
+	},
+});
+
+/**
+ * PUT /admin/cache-v2-ramp/destination  body: { connectionString }
+ * Accepts a PLAINTEXT redis:// or rediss:// connection string. Validates the
+ * scheme, extracts host:port for logging, encrypts the connection string,
+ * and persists. The plaintext never lands in S3.
+ */
+export const handleUpsertAdminCacheV2RampDestination = createRoute({
+	scopes: [Scopes.Superuser],
+	body: z.object({ connectionString: z.string().min(1) }),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { logger } = ctx;
+		const { connectionString: raw } = c.req.valid("json");
+		const connectionString = raw.trim();
+
+		let redisUrl: URL;
+		try {
+			redisUrl = new URL(connectionString);
+		} catch {
+			throw new RecaseError({
+				message: "Invalid connection string: could not parse URL",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		if (!REDIS_PROTOCOLS.has(redisUrl.protocol)) {
+			throw new RecaseError({
+				message: "Invalid connection string: expected redis:// or rediss://",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		if (!redisUrl.host) {
+			throw new RecaseError({
+				message: "Invalid connection string: missing host",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await runWithInvariantGuard(() =>
+			updateCacheV2RampDestination({
+				destination: {
+					connectionString: encryptData(connectionString),
+					url: redisUrl.host,
+				},
+			}),
+		);
+
+		logger.info(
+			`[admin/handleUpsertAdminCacheV2RampDestination] destination set, url=${redisUrl.host}, actor=${actorString(ctx)}`,
+		);
+
+		return c.json({ success: true });
+	},
+});
+
+/**
+ * DELETE /admin/cache-v2-ramp/destination
+ * Clears the destination. Refuses while percent > 0 to prevent yanking the
+ * rug from under in-flight ramped customers.
+ */
+export const handleDeleteAdminCacheV2RampDestination = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { logger } = ctx;
+		const config = getCacheV2RampConfig();
+
+		if (config.percent > 0) {
+			throw new RecaseError({
+				message: `Cannot clear destination while percent is ${config.percent}%. Set it to 0 first.`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		const activeOrgPercent = Object.entries(config.orgs).find(
+			([, entry]) => entry.percent > 0,
+		);
+		if (activeOrgPercent) {
+			throw new RecaseError({
+				message: `Cannot clear destination while org "${activeOrgPercent[0]}" has percent ${activeOrgPercent[1].percent}%. Set it to 0 first.`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await runWithInvariantGuard(() =>
+			updateCacheV2RampDestination({ destination: null }),
+		);
+		closeRampDestinationClient();
+
+		logger.info(
+			`[admin/handleDeleteAdminCacheV2RampDestination] destination cleared, actor=${actorString(ctx)}`,
+		);
+
+		return c.json({ success: true });
+	},
+});
+
+/**
+ * PUT /admin/cache-v2-ramp/percent  body: { percent }
+ * Updates the global ramp percent. Refuses to go above 0 unless a destination
+ * is configured (otherwise traffic would silently fall back to primary).
+ */
+export const handleUpdateAdminCacheV2RampPercent = createRoute({
+	scopes: [Scopes.Superuser],
+	body: z.object({ percent: z.number().int().min(0).max(100) }),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { logger } = ctx;
+		const { percent } = c.req.valid("json");
+		const config = getCacheV2RampConfig();
+
+		if (percent > 0 && !config.destination) {
+			throw new RecaseError({
+				message:
+					"Cannot ramp above 0% without a destination configured. Set destination first.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await runWithInvariantGuard(() => updateCacheV2RampPercent({ percent }));
+
+		logger.info(
+			`[admin/handleUpdateAdminCacheV2RampPercent] ${config.percent}% -> ${percent}%, actor=${actorString(ctx)}`,
+		);
+
+		return c.json({ success: true });
+	},
+});
+
+/**
+ * PUT /admin/cache-v2-ramp/orgs/:org_id  body: { percent }
+ * Sets a per-org override.
+ */
+export const handleUpdateAdminCacheV2RampOrg = createRoute({
+	scopes: [Scopes.Superuser],
+	params: orgIdParam,
+	body: z.object({ percent: z.number().int().min(0).max(100) }),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { logger } = ctx;
+		const { org_id: orgId } = c.req.param();
+		const { percent } = c.req.valid("json");
+		const config = getCacheV2RampConfig();
+
+		if (percent > 0 && !config.destination) {
+			throw new RecaseError({
+				message:
+					"Cannot set org override above 0% without a destination configured.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await runWithInvariantGuard(() =>
+			updateCacheV2RampPercent({ percent, orgId }),
+		);
+
+		const previous = config.orgs[orgId]?.percent ?? 0;
+		logger.info(
+			`[admin/handleUpdateAdminCacheV2RampOrg] org=${orgId}: ${previous}% -> ${percent}%, actor=${actorString(ctx)}`,
+		);
+
+		return c.json({ success: true });
+	},
+});
+
+/**
+ * DELETE /admin/cache-v2-ramp/orgs/:org_id
+ * Removes a per-org override (org falls back to the global percent).
+ */
+export const handleDeleteAdminCacheV2RampOrg = createRoute({
+	scopes: [Scopes.Superuser],
+	params: orgIdParam,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { logger } = ctx;
+		const { org_id: orgId } = c.req.param();
+
+		await removeCacheV2RampOrg({ orgId });
+
+		logger.info(
+			`[admin/handleDeleteAdminCacheV2RampOrg] org=${orgId} override removed, actor=${actorString(ctx)}`,
+		);
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/admin/handleAdminCacheV2Ramp.ts
+++ b/server/src/internal/admin/handleAdminCacheV2Ramp.ts
@@ -2,66 +2,49 @@ import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
 import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import {
-	CacheV2RampInvariantError,
 	closeRampDestinationClient,
 	getCacheV2RampConfig,
-	removeCacheV2RampOrg,
-	updateCacheV2RampDestination,
-	updateCacheV2RampPercent,
+	getRampDestinationRedis,
+	removeCacheV2RampConfig,
+	updateCacheV2RampMigrationPercent,
+	upsertCacheV2RampConnection,
 } from "@/internal/misc/cacheV2Ramp/index.js";
 import { encryptData } from "@/utils/encryptUtils.js";
 
-/** Wrap a store update that may throw `CacheV2RampInvariantError` and convert
- *  invariant failures to HTTP 400. Anything else propagates as 500. */
-const runWithInvariantGuard = async <T>(fn: () => Promise<T>): Promise<T> => {
-	try {
-		return await fn();
-	} catch (error) {
-		if (error instanceof CacheV2RampInvariantError) {
-			throw new RecaseError({
-				message: error.message,
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-		throw error;
-	}
-};
-
 const REDIS_PROTOCOLS = new Set(["redis:", "rediss:"]);
-
-const orgIdParam = z.object({ org_id: z.string().min(1) });
 
 const actorString = (ctx: { user?: { email?: string }; userId?: string }) =>
 	ctx.user?.email ?? ctx.userId ?? "unknown";
 
 /**
  * GET /admin/cache-v2-ramp
- * Returns the current ramp config WITHOUT the encrypted connectionString —
- * we never echo ciphertext back to the UI. URL (host:port), percent, org
- * overrides, and timestamps are safe.
+ * Returns the current ramp config in frontend-safe shape (host + percent only).
+ * Never echoes the encrypted connectionString.
  */
 export const handleGetAdminCacheV2Ramp = createRoute({
 	scopes: [Scopes.Superuser],
 	handler: async (c) => {
 		const config = getCacheV2RampConfig();
 		return c.json({
-			destination: config.destination ? { url: config.destination.url } : null,
-			percent: config.percent,
-			previousPercent: config.previousPercent,
-			changedAt: config.changedAt,
-			orgs: config.orgs,
+			cache_v2_ramp: config
+				? {
+						host: config.url,
+						migrationPercent: config.migrationPercent,
+						previousMigrationPercent: config.previousMigrationPercent,
+						migrationChangedAt: config.migrationChangedAt,
+					}
+				: null,
 		});
 	},
 });
 
 /**
- * PUT /admin/cache-v2-ramp/destination  body: { connectionString }
- * Accepts a PLAINTEXT redis:// or rediss:// connection string. Validates the
- * scheme, extracts host:port for logging, encrypts the connection string,
- * and persists. The plaintext never lands in S3.
+ * PATCH /admin/cache-v2-ramp  body: { connectionString }
+ * Upsert the destination. Accepts a PLAINTEXT redis:// or rediss:// URI;
+ * server validates the scheme, extracts host:port for logging, encrypts the
+ * connection string, and persists. Refuses while migrationPercent > 0.
  */
-export const handleUpsertAdminCacheV2RampDestination = createRoute({
+export const handleUpsertAdminCacheV2Ramp = createRoute({
 	scopes: [Scopes.Superuser],
 	body: z.object({ connectionString: z.string().min(1) }),
 	handler: async (c) => {
@@ -95,17 +78,22 @@ export const handleUpsertAdminCacheV2RampDestination = createRoute({
 			});
 		}
 
-		await runWithInvariantGuard(() =>
-			updateCacheV2RampDestination({
-				destination: {
-					connectionString: encryptData(connectionString),
-					url: redisUrl.host,
-				},
-			}),
-		);
+		const current = getCacheV2RampConfig();
+		if (current && current.migrationPercent > 0) {
+			throw new RecaseError({
+				message: `Cannot update destination while migrationPercent is ${current.migrationPercent}%. Set it to 0 first.`,
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await upsertCacheV2RampConnection({
+			connectionString: encryptData(connectionString),
+			url: redisUrl.host,
+		});
 
 		logger.info(
-			`[admin/handleUpsertAdminCacheV2RampDestination] destination set, url=${redisUrl.host}, actor=${actorString(ctx)}`,
+			`[admin/handleUpsertAdminCacheV2Ramp] ${current ? "updated" : "created"}, url=${redisUrl.host}, actor=${actorString(ctx)}`,
 		);
 
 		return c.json({ success: true });
@@ -113,134 +101,67 @@ export const handleUpsertAdminCacheV2RampDestination = createRoute({
 });
 
 /**
- * DELETE /admin/cache-v2-ramp/destination
- * Clears the destination. Refuses while percent > 0 to prevent yanking the
- * rug from under in-flight ramped customers.
+ * PATCH /admin/cache-v2-ramp/migration  body: { migrationPercent }
+ * Updates the percent. Stores previous value + timestamp.
  */
-export const handleDeleteAdminCacheV2RampDestination = createRoute({
+export const handleUpdateAdminCacheV2RampMigration = createRoute({
+	scopes: [Scopes.Superuser],
+	body: z.object({ migrationPercent: z.number().int().min(0).max(100) }),
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { logger } = ctx;
+		const { migrationPercent } = c.req.valid("json");
+
+		const current = getCacheV2RampConfig();
+		if (!current) {
+			throw new RecaseError({
+				message:
+					"No cache V2 ramp config set. Configure destination first via PATCH /admin/cache-v2-ramp.",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		await updateCacheV2RampMigrationPercent({ migrationPercent });
+
+		// Warm the destination client on first ramp-up so the first ramped
+		// requests don't pay the connect-handshake latency.
+		if (migrationPercent > 0 && current.migrationPercent === 0) {
+			getRampDestinationRedis();
+		}
+
+		logger.info(
+			`[admin/handleUpdateAdminCacheV2RampMigration] ${current.migrationPercent}% -> ${migrationPercent}%, actor=${actorString(ctx)}`,
+		);
+
+		return c.json({ success: true });
+	},
+});
+
+/**
+ * DELETE /admin/cache-v2-ramp
+ * Removes the cache V2 ramp config entirely. Refuses while migrationPercent > 0.
+ */
+export const handleDeleteAdminCacheV2Ramp = createRoute({
 	scopes: [Scopes.Superuser],
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { logger } = ctx;
-		const config = getCacheV2RampConfig();
+		const current = getCacheV2RampConfig();
 
-		if (config.percent > 0) {
+		if (current && current.migrationPercent > 0) {
 			throw new RecaseError({
-				message: `Cannot clear destination while percent is ${config.percent}%. Set it to 0 first.`,
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-		const activeOrgPercent = Object.entries(config.orgs).find(
-			([, entry]) => entry.percent > 0,
-		);
-		if (activeOrgPercent) {
-			throw new RecaseError({
-				message: `Cannot clear destination while org "${activeOrgPercent[0]}" has percent ${activeOrgPercent[1].percent}%. Set it to 0 first.`,
+				message: `Cannot remove cache V2 ramp while migrationPercent is ${current.migrationPercent}%. Set it to 0 first.`,
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});
 		}
 
-		await runWithInvariantGuard(() =>
-			updateCacheV2RampDestination({ destination: null }),
-		);
+		await removeCacheV2RampConfig();
 		closeRampDestinationClient();
 
 		logger.info(
-			`[admin/handleDeleteAdminCacheV2RampDestination] destination cleared, actor=${actorString(ctx)}`,
-		);
-
-		return c.json({ success: true });
-	},
-});
-
-/**
- * PUT /admin/cache-v2-ramp/percent  body: { percent }
- * Updates the global ramp percent. Refuses to go above 0 unless a destination
- * is configured (otherwise traffic would silently fall back to primary).
- */
-export const handleUpdateAdminCacheV2RampPercent = createRoute({
-	scopes: [Scopes.Superuser],
-	body: z.object({ percent: z.number().int().min(0).max(100) }),
-	handler: async (c) => {
-		const ctx = c.get("ctx");
-		const { logger } = ctx;
-		const { percent } = c.req.valid("json");
-		const config = getCacheV2RampConfig();
-
-		if (percent > 0 && !config.destination) {
-			throw new RecaseError({
-				message:
-					"Cannot ramp above 0% without a destination configured. Set destination first.",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-
-		await runWithInvariantGuard(() => updateCacheV2RampPercent({ percent }));
-
-		logger.info(
-			`[admin/handleUpdateAdminCacheV2RampPercent] ${config.percent}% -> ${percent}%, actor=${actorString(ctx)}`,
-		);
-
-		return c.json({ success: true });
-	},
-});
-
-/**
- * PUT /admin/cache-v2-ramp/orgs/:org_id  body: { percent }
- * Sets a per-org override.
- */
-export const handleUpdateAdminCacheV2RampOrg = createRoute({
-	scopes: [Scopes.Superuser],
-	params: orgIdParam,
-	body: z.object({ percent: z.number().int().min(0).max(100) }),
-	handler: async (c) => {
-		const ctx = c.get("ctx");
-		const { logger } = ctx;
-		const { org_id: orgId } = c.req.param();
-		const { percent } = c.req.valid("json");
-		const config = getCacheV2RampConfig();
-
-		if (percent > 0 && !config.destination) {
-			throw new RecaseError({
-				message:
-					"Cannot set org override above 0% without a destination configured.",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-
-		await runWithInvariantGuard(() =>
-			updateCacheV2RampPercent({ percent, orgId }),
-		);
-
-		const previous = config.orgs[orgId]?.percent ?? 0;
-		logger.info(
-			`[admin/handleUpdateAdminCacheV2RampOrg] org=${orgId}: ${previous}% -> ${percent}%, actor=${actorString(ctx)}`,
-		);
-
-		return c.json({ success: true });
-	},
-});
-
-/**
- * DELETE /admin/cache-v2-ramp/orgs/:org_id
- * Removes a per-org override (org falls back to the global percent).
- */
-export const handleDeleteAdminCacheV2RampOrg = createRoute({
-	scopes: [Scopes.Superuser],
-	params: orgIdParam,
-	handler: async (c) => {
-		const ctx = c.get("ctx");
-		const { logger } = ctx;
-		const { org_id: orgId } = c.req.param();
-
-		await removeCacheV2RampOrg({ orgId });
-
-		logger.info(
-			`[admin/handleDeleteAdminCacheV2RampOrg] org=${orgId} override removed, actor=${actorString(ctx)}`,
+			`[admin/handleDeleteAdminCacheV2Ramp] removed, actor=${actorString(ctx)}`,
 		);
 
 		return c.json({ success: true });

--- a/server/src/internal/customers/cusProducts/actions/expireOneOffCustomerProductResults.ts
+++ b/server/src/internal/customers/cusProducts/actions/expireOneOffCustomerProductResults.ts
@@ -49,7 +49,7 @@ export const expireOneOffCustomerProductResults = async ({
 			org: group.org,
 			env: group.env,
 			logger: ctx.logger,
-			redisV2: resolveRedisV2(),
+			redisV2: resolveRedisV2({ orgId: group.org.id }),
 		};
 
 		await batchUpdateCustomerProducts({

--- a/server/src/internal/customers/cusProducts/actions/expireOneOffCustomerProductResults.ts
+++ b/server/src/internal/customers/cusProducts/actions/expireOneOffCustomerProductResults.ts
@@ -49,7 +49,7 @@ export const expireOneOffCustomerProductResults = async ({
 			org: group.org,
 			env: group.env,
 			logger: ctx.logger,
-			redisV2: resolveRedisV2({ orgId: group.org.id }),
+			redisV2: resolveRedisV2(),
 		};
 
 		await batchUpdateCustomerProducts({

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampClient.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampClient.ts
@@ -26,12 +26,12 @@ let lastDecryptFailureKey: string | null = null;
  *  no destination is configured (ramp is dormant). */
 export const getRampDestinationRedis = (): Redis | null => {
 	const config = getCacheV2RampConfig();
-	if (!config.destination) {
+	if (!config) {
 		closeRampDestinationClient();
 		return null;
 	}
 
-	const { connectionString, url } = config.destination;
+	const { connectionString, url } = config;
 
 	if (
 		cached &&

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampClient.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampClient.ts
@@ -1,0 +1,130 @@
+import type { Redis } from "ioredis";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { getReachableDragonflyUrl } from "@/external/redis/getReachableDragonflyUrl.js";
+import {
+	createRedisConnection,
+	currentRegion,
+} from "@/external/redis/initRedis.js";
+import { REDIS_V2_COMMAND_TIMEOUT_MS } from "@/external/redis/initUtils/redisV2Config.js";
+import { decryptData } from "@/utils/encryptUtils.js";
+import { getCacheV2RampConfig } from "./cacheV2RampStore.js";
+
+type CachedClient = {
+	url: string;
+	connectionString: string;
+	instance: Redis;
+};
+let cached: CachedClient | null = null;
+let lastDecryptFailureKey: string | null = null;
+
+/** Returns the Redis client for the ramp destination configured in the edge config.
+ *
+ *  Lazy: creates the client on first call after the destination is set.
+ *  Hot-swappable: when the admin changes the URL OR rotates the encrypted
+ *  connection string (e.g. credential rotation on the same host), the next
+ *  call disconnects the old client and creates a new one. Returns null when
+ *  no destination is configured (ramp is dormant). */
+export const getRampDestinationRedis = (): Redis | null => {
+	const config = getCacheV2RampConfig();
+	if (!config.destination) {
+		closeRampDestinationClient();
+		return null;
+	}
+
+	const { connectionString, url } = config.destination;
+
+	if (
+		cached &&
+		cached.url === url &&
+		cached.connectionString === connectionString
+	) {
+		return cached.instance;
+	}
+
+	if (cached) {
+		const reason =
+			cached.url !== url
+				? `URL changed (${cached.url} -> ${url})`
+				: "credentials rotated";
+		logger.info(
+			`[cacheV2Ramp] destination ${reason}; disconnecting old client`,
+		);
+		try {
+			cached.instance.disconnect();
+		} catch (error) {
+			logger.warn(
+				`[cacheV2Ramp] failed to disconnect old destination client: ${error}`,
+			);
+		}
+		cached = null;
+	}
+
+	let decrypted: string;
+	try {
+		decrypted = decryptData(connectionString);
+	} catch (error) {
+		const failureKey = `${url}|${connectionString}`;
+		if (lastDecryptFailureKey !== failureKey) {
+			lastDecryptFailureKey = failureKey;
+			logger.error(
+				`[cacheV2Ramp] failed to decrypt destination connectionString for ${url}: ${error}. Ramp will route to primary until fixed.`,
+			);
+		}
+		return null;
+	}
+	lastDecryptFailureKey = null;
+
+	const reachable = getReachableDragonflyUrl(decrypted);
+	const instance = createRedisConnection({
+		cacheUrl: reachable,
+		region: `${currentRegion}:v2:ramp`,
+		supportsUpstashShebang: false,
+		commandTimeout: REDIS_V2_COMMAND_TIMEOUT_MS,
+	});
+
+	instance.on("error", (error) => {
+		logger.error(`[cacheV2Ramp] destination=${url}: ${error.message}`);
+	});
+
+	instance.on("ready", () => {
+		logger.info(`[cacheV2Ramp] destination=${url}: connected`);
+	});
+
+	cached = { url, connectionString, instance };
+	return instance;
+};
+
+/** Tear down the cached destination client. Safe to call multiple times. */
+export const closeRampDestinationClient = () => {
+	if (!cached) return;
+	try {
+		cached.instance.disconnect();
+	} catch (error) {
+		logger.warn(
+			`[cacheV2Ramp] failed to disconnect destination client during close: ${error}`,
+		);
+	}
+	cached = null;
+};
+
+/** Test-only: inject a Redis instance directly, bypassing the config + decryption. */
+export const _setRampDestinationClientForTesting = (
+	client: {
+		url: string;
+		connectionString: string;
+		instance: Redis;
+	} | null,
+) => {
+	if (
+		cached &&
+		(cached.url !== client?.url ||
+			cached.connectionString !== client?.connectionString)
+	) {
+		try {
+			cached.instance.disconnect();
+		} catch {
+			// best effort
+		}
+	}
+	cached = client;
+};

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampSchemas.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampSchemas.ts
@@ -1,34 +1,17 @@
 import { z } from "zod/v4";
-import { RolloutPercentSchema } from "@/internal/misc/rollouts/rolloutSchemas.js";
 
-/** Destination Redis the ramp targets. Stored in the edge config; admin-editable.
- *  `connectionString` is AES-256-CBC encrypted (same scheme as per-org redis_config).
- *  `url` is a plain host:port for logs/visibility — no scheme, no credentials.
- *  Schema rejects scheme/credentials so secrets never accidentally land in this
- *  field (which is logged + surfaced in Axiom). */
-export const RampDestinationSchema = z.object({
-	connectionString: z.string().min(1),
-	url: z
-		.string()
-		.min(1)
-		.refine(
-			(value) =>
-				!value.includes("://") && !value.includes("@") && !/\s/.test(value),
-			{
-				message:
-					"url must be a credential-free host:port (no scheme, no '@', no whitespace)",
-			},
-		),
-});
+/** Global cache V2 ramp config — mirrors per-org `redis_config` exactly.
+ *  `connectionString` is AES-256-CBC encrypted (same scheme as per-org).
+ *  `url` is a plain host:port for logs.
+ *  The whole config is `null` when no ramp is configured. */
+export const CacheV2RampConfigSchema = z
+	.object({
+		connectionString: z.string().min(1),
+		url: z.string().min(1),
+		migrationPercent: z.number().min(0).max(100).default(0),
+		previousMigrationPercent: z.number().min(0).max(100).default(0),
+		migrationChangedAt: z.number().default(0),
+	})
+	.nullable();
 
-export const CacheV2RampConfigSchema = z.object({
-	destination: RampDestinationSchema.nullable().default(null),
-	percent: z.number().min(0).max(100).default(0),
-	previousPercent: z.number().min(0).max(100).default(0),
-	changedAt: z.number().default(0),
-	orgs: z.record(z.string(), RolloutPercentSchema).default({}),
-});
-
-export type RampDestination = z.infer<typeof RampDestinationSchema>;
 export type CacheV2RampConfig = z.infer<typeof CacheV2RampConfigSchema>;
-export type CacheV2RampPercent = z.infer<typeof RolloutPercentSchema>;

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampSchemas.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampSchemas.ts
@@ -1,0 +1,34 @@
+import { z } from "zod/v4";
+import { RolloutPercentSchema } from "@/internal/misc/rollouts/rolloutSchemas.js";
+
+/** Destination Redis the ramp targets. Stored in the edge config; admin-editable.
+ *  `connectionString` is AES-256-CBC encrypted (same scheme as per-org redis_config).
+ *  `url` is a plain host:port for logs/visibility — no scheme, no credentials.
+ *  Schema rejects scheme/credentials so secrets never accidentally land in this
+ *  field (which is logged + surfaced in Axiom). */
+export const RampDestinationSchema = z.object({
+	connectionString: z.string().min(1),
+	url: z
+		.string()
+		.min(1)
+		.refine(
+			(value) =>
+				!value.includes("://") && !value.includes("@") && !/\s/.test(value),
+			{
+				message:
+					"url must be a credential-free host:port (no scheme, no '@', no whitespace)",
+			},
+		),
+});
+
+export const CacheV2RampConfigSchema = z.object({
+	destination: RampDestinationSchema.nullable().default(null),
+	percent: z.number().min(0).max(100).default(0),
+	previousPercent: z.number().min(0).max(100).default(0),
+	changedAt: z.number().default(0),
+	orgs: z.record(z.string(), RolloutPercentSchema).default({}),
+});
+
+export type RampDestination = z.infer<typeof RampDestinationSchema>;
+export type CacheV2RampConfig = z.infer<typeof CacheV2RampConfigSchema>;
+export type CacheV2RampPercent = z.infer<typeof RolloutPercentSchema>;

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampStore.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampStore.ts
@@ -1,4 +1,4 @@
-import { ms } from "@autumn/shared";
+import { ErrCode, ms, RecaseError } from "@autumn/shared";
 import { ADMIN_CACHE_V2_RAMP_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
 import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
 import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
@@ -21,7 +21,9 @@ export const getCacheV2RampConfig = (): CacheV2RampConfig => store.get();
 export const getCacheV2RampStatus = () => store.getStatus();
 
 /** Create-or-update the connection details. Preserves migration state if a
- *  config already exists; initializes with migrationPercent=0 otherwise. */
+ *  config already exists; initializes with migrationPercent=0 otherwise.
+ *  Invariant check (refuse while migrationPercent > 0) runs AFTER readFromSource
+ *  to avoid the multi-instance race where a handler's polled snapshot lags S3. */
 export const upsertCacheV2RampConnection = async ({
 	connectionString,
 	url,
@@ -30,6 +32,13 @@ export const upsertCacheV2RampConnection = async ({
 	url: string;
 }) => {
 	const current = await store.readFromSource();
+	if (current && current.migrationPercent > 0) {
+		throw new RecaseError({
+			message: `Cannot update destination while migrationPercent is ${current.migrationPercent}%. Set it to 0 first.`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
 	const now = Date.now();
 	const next: CacheV2RampConfig = current
 		? { ...current, connectionString, url }
@@ -50,9 +59,12 @@ export const updateCacheV2RampMigrationPercent = async ({
 }) => {
 	const current = await store.readFromSource();
 	if (!current) {
-		throw new Error(
-			"No cache V2 ramp config set. Configure destination first.",
-		);
+		throw new RecaseError({
+			message:
+				"No cache V2 ramp config set. Configure destination first via PATCH /admin/cache-v2-ramp.",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
 	}
 	await store.writeToSource({
 		config: {
@@ -65,6 +77,14 @@ export const updateCacheV2RampMigrationPercent = async ({
 };
 
 export const removeCacheV2RampConfig = async () => {
+	const current = await store.readFromSource();
+	if (current && current.migrationPercent > 0) {
+		throw new RecaseError({
+			message: `Cannot remove cache V2 ramp while migrationPercent is ${current.migrationPercent}%. Set it to 0 first.`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
 	await store.writeToSource({ config: null });
 };
 

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampStore.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampStore.ts
@@ -5,144 +5,70 @@ import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStor
 import {
 	type CacheV2RampConfig,
 	CacheV2RampConfigSchema,
-	type RampDestination,
 } from "./cacheV2RampSchemas.js";
-
-/** Thrown when a write would violate a cache-v2-ramp invariant. Read by admin
- *  handlers and translated to HTTP 400. Acts as a safety net against the race
- *  where a handler validates against its 10s-polled snapshot but the source
- *  state has already moved on. */
-export class CacheV2RampInvariantError extends Error {
-	constructor(message: string) {
-		super(message);
-		this.name = "CacheV2RampInvariantError";
-	}
-}
 
 const store = createEdgeConfigStore<CacheV2RampConfig>({
 	s3Key: ADMIN_CACHE_V2_RAMP_CONFIG_KEY,
 	schema: CacheV2RampConfigSchema,
-	defaultValue: () => ({
-		destination: null,
-		percent: 0,
-		previousPercent: 0,
-		changedAt: 0,
-		orgs: {},
-	}),
+	defaultValue: () => null,
 	pollIntervalMs: ms.seconds(10),
 });
 
 registerEdgeConfig({ store });
 
-const findActiveOrgOverride = (config: CacheV2RampConfig) =>
-	Object.entries(config.orgs).find(([, entry]) => entry.percent > 0);
-
-const assertHasDestination = (config: CacheV2RampConfig, action: string) => {
-	if (!config.destination) {
-		throw new CacheV2RampInvariantError(
-			`${action} requires a destination to be configured first`,
-		);
-	}
-};
-
-const assertNoActivePercent = (config: CacheV2RampConfig, action: string) => {
-	if (config.percent > 0) {
-		throw new CacheV2RampInvariantError(
-			`${action} blocked: global percent is ${config.percent}%. Set it to 0 first.`,
-		);
-	}
-	const activeOrg = findActiveOrgOverride(config);
-	if (activeOrg) {
-		throw new CacheV2RampInvariantError(
-			`${action} blocked: org "${activeOrg[0]}" has percent ${activeOrg[1].percent}%. Set it to 0 first.`,
-		);
-	}
-};
-
 export const getCacheV2RampConfig = (): CacheV2RampConfig => store.get();
 
 export const getCacheV2RampStatus = () => store.getStatus();
 
-export const updateCacheV2RampPercent = async ({
-	percent,
-	orgId,
+/** Create-or-update the connection details. Preserves migration state if a
+ *  config already exists; initializes with migrationPercent=0 otherwise. */
+export const upsertCacheV2RampConnection = async ({
+	connectionString,
+	url,
 }: {
-	percent: number;
-	orgId?: string;
+	connectionString: string;
+	url: string;
 }) => {
 	const current = await store.readFromSource();
 	const now = Date.now();
+	const next: CacheV2RampConfig = current
+		? { ...current, connectionString, url }
+		: {
+				connectionString,
+				url,
+				migrationPercent: 0,
+				previousMigrationPercent: 0,
+				migrationChangedAt: now,
+			};
+	await store.writeToSource({ config: next });
+};
 
-	if (percent > 0) {
-		assertHasDestination(
-			current,
-			`Setting ${orgId ? `org "${orgId}" override` : "global percent"} to ${percent}%`,
+export const updateCacheV2RampMigrationPercent = async ({
+	migrationPercent,
+}: {
+	migrationPercent: number;
+}) => {
+	const current = await store.readFromSource();
+	if (!current) {
+		throw new Error(
+			"No cache V2 ramp config set. Configure destination first.",
 		);
 	}
-
-	if (orgId) {
-		const existingOrg = current.orgs[orgId];
-		const nextOrgs = {
-			...current.orgs,
-			[orgId]: {
-				percent,
-				previousPercent: existingOrg?.percent ?? 0,
-				changedAt: now,
-			},
-		};
-		await store.writeToSource({ config: { ...current, orgs: nextOrgs } });
-		return;
-	}
-
 	await store.writeToSource({
 		config: {
 			...current,
-			percent,
-			previousPercent: current.percent,
-			changedAt: now,
+			previousMigrationPercent: current.migrationPercent,
+			migrationPercent,
+			migrationChangedAt: Date.now(),
 		},
 	});
 };
 
-export const removeCacheV2RampOrg = async ({ orgId }: { orgId: string }) => {
-	const current = await store.readFromSource();
-	if (!current.orgs[orgId]) return;
-	const { [orgId]: _removed, ...rest } = current.orgs;
-	await store.writeToSource({ config: { ...current, orgs: rest } });
-};
-
-/** Write the destination URL + encrypted connection string. Pass null to clear.
- *  Refuses to overwrite OR clear the destination while any percent is non-zero
- *  to avoid mid-ramp surprises (would invalidate the in-pool client / strand
- *  cache entries on the old cluster). */
-export const updateCacheV2RampDestination = async ({
-	destination,
-}: {
-	destination: RampDestination | null;
-}) => {
-	const current = await store.readFromSource();
-
-	if (destination === null) {
-		assertNoActivePercent(current, "Clearing destination");
-	} else if (current.destination) {
-		// Swapping to a new destination while traffic is being routed would
-		// strand cache entries on the old cluster and trip the disconnect race.
-		assertNoActivePercent(current, "Overwriting destination");
-	}
-
-	await store.writeToSource({ config: { ...current, destination } });
+export const removeCacheV2RampConfig = async () => {
+	await store.writeToSource({ config: null });
 };
 
 /** Test-only: override the in-memory config without writing to S3. */
-export const _setCacheV2RampConfigForTesting = (
-	config: Partial<CacheV2RampConfig>,
-) => {
-	store._setRuntimeConfigForTesting({
-		destination: null,
-		percent: 0,
-		previousPercent: 0,
-		changedAt: 0,
-		orgs: {},
-		...config,
-	});
+export const _setCacheV2RampConfigForTesting = (config: CacheV2RampConfig) => {
+	store._setRuntimeConfigForTesting(config);
 };

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampStore.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampStore.ts
@@ -1,0 +1,148 @@
+import { ms } from "@autumn/shared";
+import { ADMIN_CACHE_V2_RAMP_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type CacheV2RampConfig,
+	CacheV2RampConfigSchema,
+	type RampDestination,
+} from "./cacheV2RampSchemas.js";
+
+/** Thrown when a write would violate a cache-v2-ramp invariant. Read by admin
+ *  handlers and translated to HTTP 400. Acts as a safety net against the race
+ *  where a handler validates against its 10s-polled snapshot but the source
+ *  state has already moved on. */
+export class CacheV2RampInvariantError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CacheV2RampInvariantError";
+	}
+}
+
+const store = createEdgeConfigStore<CacheV2RampConfig>({
+	s3Key: ADMIN_CACHE_V2_RAMP_CONFIG_KEY,
+	schema: CacheV2RampConfigSchema,
+	defaultValue: () => ({
+		destination: null,
+		percent: 0,
+		previousPercent: 0,
+		changedAt: 0,
+		orgs: {},
+	}),
+	pollIntervalMs: ms.seconds(10),
+});
+
+registerEdgeConfig({ store });
+
+const findActiveOrgOverride = (config: CacheV2RampConfig) =>
+	Object.entries(config.orgs).find(([, entry]) => entry.percent > 0);
+
+const assertHasDestination = (config: CacheV2RampConfig, action: string) => {
+	if (!config.destination) {
+		throw new CacheV2RampInvariantError(
+			`${action} requires a destination to be configured first`,
+		);
+	}
+};
+
+const assertNoActivePercent = (config: CacheV2RampConfig, action: string) => {
+	if (config.percent > 0) {
+		throw new CacheV2RampInvariantError(
+			`${action} blocked: global percent is ${config.percent}%. Set it to 0 first.`,
+		);
+	}
+	const activeOrg = findActiveOrgOverride(config);
+	if (activeOrg) {
+		throw new CacheV2RampInvariantError(
+			`${action} blocked: org "${activeOrg[0]}" has percent ${activeOrg[1].percent}%. Set it to 0 first.`,
+		);
+	}
+};
+
+export const getCacheV2RampConfig = (): CacheV2RampConfig => store.get();
+
+export const getCacheV2RampStatus = () => store.getStatus();
+
+export const updateCacheV2RampPercent = async ({
+	percent,
+	orgId,
+}: {
+	percent: number;
+	orgId?: string;
+}) => {
+	const current = await store.readFromSource();
+	const now = Date.now();
+
+	if (percent > 0) {
+		assertHasDestination(
+			current,
+			`Setting ${orgId ? `org "${orgId}" override` : "global percent"} to ${percent}%`,
+		);
+	}
+
+	if (orgId) {
+		const existingOrg = current.orgs[orgId];
+		const nextOrgs = {
+			...current.orgs,
+			[orgId]: {
+				percent,
+				previousPercent: existingOrg?.percent ?? 0,
+				changedAt: now,
+			},
+		};
+		await store.writeToSource({ config: { ...current, orgs: nextOrgs } });
+		return;
+	}
+
+	await store.writeToSource({
+		config: {
+			...current,
+			percent,
+			previousPercent: current.percent,
+			changedAt: now,
+		},
+	});
+};
+
+export const removeCacheV2RampOrg = async ({ orgId }: { orgId: string }) => {
+	const current = await store.readFromSource();
+	if (!current.orgs[orgId]) return;
+	const { [orgId]: _removed, ...rest } = current.orgs;
+	await store.writeToSource({ config: { ...current, orgs: rest } });
+};
+
+/** Write the destination URL + encrypted connection string. Pass null to clear.
+ *  Refuses to overwrite OR clear the destination while any percent is non-zero
+ *  to avoid mid-ramp surprises (would invalidate the in-pool client / strand
+ *  cache entries on the old cluster). */
+export const updateCacheV2RampDestination = async ({
+	destination,
+}: {
+	destination: RampDestination | null;
+}) => {
+	const current = await store.readFromSource();
+
+	if (destination === null) {
+		assertNoActivePercent(current, "Clearing destination");
+	} else if (current.destination) {
+		// Swapping to a new destination while traffic is being routed would
+		// strand cache entries on the old cluster and trip the disconnect race.
+		assertNoActivePercent(current, "Overwriting destination");
+	}
+
+	await store.writeToSource({ config: { ...current, destination } });
+};
+
+/** Test-only: override the in-memory config without writing to S3. */
+export const _setCacheV2RampConfigForTesting = (
+	config: Partial<CacheV2RampConfig>,
+) => {
+	store._setRuntimeConfigForTesting({
+		destination: null,
+		percent: 0,
+		previousPercent: 0,
+		changedAt: 0,
+		orgs: {},
+		...config,
+	});
+};

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampUtils.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampUtils.ts
@@ -1,69 +1,25 @@
 import { getCustomerBucket } from "@/internal/misc/rollouts/rolloutUtils.js";
-import { type CacheV2RampPercent, getCacheV2RampConfig } from "./index.js";
+import { getCacheV2RampConfig } from "./cacheV2RampStore.js";
 
-const resolveCacheV2RampPercent = ({
-	orgId,
-}: {
-	orgId?: string;
-}): CacheV2RampPercent => {
-	const config = getCacheV2RampConfig();
-	if (orgId && config.orgs[orgId]) return config.orgs[orgId];
-	return {
-		percent: config.percent,
-		previousPercent: config.previousPercent,
-		changedAt: config.changedAt,
-	};
-};
-
-/** True when the given customer should be routed to the cache V2 ramp destination. */
+/** True when the given customer should be routed to the ramp destination. */
 export const isCacheV2RampEnabled = ({
-	orgId,
 	customerId,
 }: {
-	orgId?: string;
 	customerId?: string;
 }): boolean => {
-	const resolved = resolveCacheV2RampPercent({ orgId });
-	if (resolved.percent >= 100) return true;
-	if (resolved.percent <= 0) return false;
+	const config = getCacheV2RampConfig();
+	if (!config) return false;
+	if (config.migrationPercent >= 100) return true;
+	if (config.migrationPercent <= 0) return false;
 	if (!customerId) return false;
-
 	const bucket = getCustomerBucket({ customerId });
-	return bucket < resolved.percent;
+	return bucket < config.migrationPercent;
 };
 
-/** True when the cache V2 ramp is non-zero for the given org (or globally).
- *  Used by invalidation/lock-receipt code that needs to fan out to BOTH clusters
- *  during the ramp window, even when it doesn't know the customer. */
-export const isCacheV2RampActive = ({ orgId }: { orgId?: string }): boolean => {
-	const resolved = resolveCacheV2RampPercent({ orgId });
-	return resolved.percent > 0;
-};
-
-/** True when a cached entry should be treated as stale because the customer's
- *  bucket crossed the ramp boundary after the entry was written.
- *
- *  Mirrors `isSnapshotCacheStale` in rolloutUtils.ts. Use when reading from
- *  either V2 cluster — if the customer was on the OTHER cluster when the
- *  entry was written, and has since crossed back, the entry is stale. */
-export const isCacheV2RampCacheStale = ({
-	orgId,
-	customerId,
-	cachedAt,
-}: {
-	orgId?: string;
-	customerId?: string;
-	cachedAt?: number;
-}): boolean => {
-	const resolved = resolveCacheV2RampPercent({ orgId });
-	if (!resolved.changedAt) return false;
-	if (!customerId) return false;
-
-	const bucket = getCustomerBucket({ customerId });
-	const wasEnabled = bucket < resolved.previousPercent;
-	const isEnabled = bucket < resolved.percent;
-	if (wasEnabled === isEnabled) return false;
-
-	if (!cachedAt) return true;
-	return cachedAt < resolved.changedAt;
+/** True when migrationPercent > 0. Used by invalidation/lock-receipt code that
+ *  fans out to BOTH clusters during a ramp, even when it doesn't know the
+ *  customer. */
+export const isCacheV2RampActive = (): boolean => {
+	const config = getCacheV2RampConfig();
+	return !!config && config.migrationPercent > 0;
 };

--- a/server/src/internal/misc/cacheV2Ramp/cacheV2RampUtils.ts
+++ b/server/src/internal/misc/cacheV2Ramp/cacheV2RampUtils.ts
@@ -1,0 +1,69 @@
+import { getCustomerBucket } from "@/internal/misc/rollouts/rolloutUtils.js";
+import { type CacheV2RampPercent, getCacheV2RampConfig } from "./index.js";
+
+const resolveCacheV2RampPercent = ({
+	orgId,
+}: {
+	orgId?: string;
+}): CacheV2RampPercent => {
+	const config = getCacheV2RampConfig();
+	if (orgId && config.orgs[orgId]) return config.orgs[orgId];
+	return {
+		percent: config.percent,
+		previousPercent: config.previousPercent,
+		changedAt: config.changedAt,
+	};
+};
+
+/** True when the given customer should be routed to the cache V2 ramp destination. */
+export const isCacheV2RampEnabled = ({
+	orgId,
+	customerId,
+}: {
+	orgId?: string;
+	customerId?: string;
+}): boolean => {
+	const resolved = resolveCacheV2RampPercent({ orgId });
+	if (resolved.percent >= 100) return true;
+	if (resolved.percent <= 0) return false;
+	if (!customerId) return false;
+
+	const bucket = getCustomerBucket({ customerId });
+	return bucket < resolved.percent;
+};
+
+/** True when the cache V2 ramp is non-zero for the given org (or globally).
+ *  Used by invalidation/lock-receipt code that needs to fan out to BOTH clusters
+ *  during the ramp window, even when it doesn't know the customer. */
+export const isCacheV2RampActive = ({ orgId }: { orgId?: string }): boolean => {
+	const resolved = resolveCacheV2RampPercent({ orgId });
+	return resolved.percent > 0;
+};
+
+/** True when a cached entry should be treated as stale because the customer's
+ *  bucket crossed the ramp boundary after the entry was written.
+ *
+ *  Mirrors `isSnapshotCacheStale` in rolloutUtils.ts. Use when reading from
+ *  either V2 cluster — if the customer was on the OTHER cluster when the
+ *  entry was written, and has since crossed back, the entry is stale. */
+export const isCacheV2RampCacheStale = ({
+	orgId,
+	customerId,
+	cachedAt,
+}: {
+	orgId?: string;
+	customerId?: string;
+	cachedAt?: number;
+}): boolean => {
+	const resolved = resolveCacheV2RampPercent({ orgId });
+	if (!resolved.changedAt) return false;
+	if (!customerId) return false;
+
+	const bucket = getCustomerBucket({ customerId });
+	const wasEnabled = bucket < resolved.previousPercent;
+	const isEnabled = bucket < resolved.percent;
+	if (wasEnabled === isEnabled) return false;
+
+	if (!cachedAt) return true;
+	return cachedAt < resolved.changedAt;
+};

--- a/server/src/internal/misc/cacheV2Ramp/index.ts
+++ b/server/src/internal/misc/cacheV2Ramp/index.ts
@@ -6,21 +6,16 @@ export {
 export {
 	type CacheV2RampConfig,
 	CacheV2RampConfigSchema,
-	type CacheV2RampPercent,
-	type RampDestination,
-	RampDestinationSchema,
 } from "./cacheV2RampSchemas.js";
 export {
 	_setCacheV2RampConfigForTesting,
-	CacheV2RampInvariantError,
 	getCacheV2RampConfig,
 	getCacheV2RampStatus,
-	removeCacheV2RampOrg,
-	updateCacheV2RampDestination,
-	updateCacheV2RampPercent,
+	removeCacheV2RampConfig,
+	updateCacheV2RampMigrationPercent,
+	upsertCacheV2RampConnection,
 } from "./cacheV2RampStore.js";
 export {
 	isCacheV2RampActive,
-	isCacheV2RampCacheStale,
 	isCacheV2RampEnabled,
 } from "./cacheV2RampUtils.js";

--- a/server/src/internal/misc/cacheV2Ramp/index.ts
+++ b/server/src/internal/misc/cacheV2Ramp/index.ts
@@ -1,0 +1,26 @@
+export {
+	_setRampDestinationClientForTesting,
+	closeRampDestinationClient,
+	getRampDestinationRedis,
+} from "./cacheV2RampClient.js";
+export {
+	type CacheV2RampConfig,
+	CacheV2RampConfigSchema,
+	type CacheV2RampPercent,
+	type RampDestination,
+	RampDestinationSchema,
+} from "./cacheV2RampSchemas.js";
+export {
+	_setCacheV2RampConfigForTesting,
+	CacheV2RampInvariantError,
+	getCacheV2RampConfig,
+	getCacheV2RampStatus,
+	removeCacheV2RampOrg,
+	updateCacheV2RampDestination,
+	updateCacheV2RampPercent,
+} from "./cacheV2RampStore.js";
+export {
+	isCacheV2RampActive,
+	isCacheV2RampCacheStale,
+	isCacheV2RampEnabled,
+} from "./cacheV2RampUtils.js";

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -74,7 +74,7 @@ export const createWorkerContext = async ({
 		db,
 		dbGeneral: db,
 		logger: workerLogger,
-		redisV2: resolveRedisV2(),
+		redisV2: resolveRedisV2({ orgId: org.id, customerId }),
 
 		id: requestId || generateId("job"),
 		timestamp: Date.now(),

--- a/server/src/queue/createWorkerContext.ts
+++ b/server/src/queue/createWorkerContext.ts
@@ -74,7 +74,7 @@ export const createWorkerContext = async ({
 		db,
 		dbGeneral: db,
 		logger: workerLogger,
-		redisV2: resolveRedisV2({ orgId: org.id, customerId }),
+		redisV2: resolveRedisV2({ customerId }),
 
 		id: requestId || generateId("job"),
 		timestamp: Date.now(),

--- a/server/src/utils/workerUtils/createAutumnContext.ts
+++ b/server/src/utils/workerUtils/createAutumnContext.ts
@@ -59,7 +59,7 @@ export const createWorkerAutumnContext = async ({
 		db,
 		dbGeneral: db,
 		logger,
-		redisV2: resolveRedisV2({ orgId: org.id }),
+		redisV2: resolveRedisV2(),
 		expand: [],
 
 		id: workerId,

--- a/server/src/utils/workerUtils/createAutumnContext.ts
+++ b/server/src/utils/workerUtils/createAutumnContext.ts
@@ -59,7 +59,7 @@ export const createWorkerAutumnContext = async ({
 		db,
 		dbGeneral: db,
 		logger,
-		redisV2: resolveRedisV2(),
+		redisV2: resolveRedisV2({ orgId: org.id }),
 		expand: [],
 
 		id: workerId,

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -10,6 +10,7 @@ import {
 import "./internal/misc/requestBlocks/requestBlockStore.js";
 import "./internal/misc/rollouts/rolloutConfigStore.js";
 import "./internal/misc/redisV2Cache/redisV2CacheStore.js";
+import "./internal/misc/cacheV2Ramp/cacheV2RampStore.js";
 import "./internal/misc/jobQueues/jobQueueStore.js";
 
 // Number of worker processes (defaults to CPU cores)
@@ -104,11 +105,8 @@ if (cluster.isPrimary) {
 	const { primeRedisMonitor } = await import(
 		"./external/redis/initUtils/redisAvailability.js"
 	);
-	const {
-		primeRedisV2Monitor,
-		startRedisV2Monitor,
-		stopRedisV2Monitor,
-	} = await import("./external/redis/initUtils/redisV2Availability.js");
+	const { primeRedisV2Monitor, startRedisV2Monitor, stopRedisV2Monitor } =
+		await import("./external/redis/initUtils/redisV2Availability.js");
 	const { startRedisMonitor, stopRedisMonitor } = await import(
 		"./external/redis/initRedis.js"
 	);

--- a/server/tests/unit/redis/cache-v2-ramp.test.ts
+++ b/server/tests/unit/redis/cache-v2-ramp.test.ts
@@ -2,10 +2,26 @@ import { describe, expect, test } from "bun:test";
 import {
 	_setCacheV2RampConfigForTesting,
 	isCacheV2RampActive,
-	isCacheV2RampCacheStale,
 	isCacheV2RampEnabled,
 } from "@/internal/misc/cacheV2Ramp/index.js";
 import { getCustomerBucket } from "@/internal/misc/rollouts/rolloutUtils.js";
+
+const makeConfig = (
+	overrides: Partial<{
+		migrationPercent: number;
+		previousMigrationPercent: number;
+		migrationChangedAt: number;
+		url: string;
+		connectionString: string;
+	}> = {},
+) => ({
+	connectionString: "encrypted-blob",
+	url: "host.example.com:6379",
+	migrationPercent: 0,
+	previousMigrationPercent: 0,
+	migrationChangedAt: 0,
+	...overrides,
+});
 
 const findCustomerInBucketRange = ({
 	min,
@@ -23,66 +39,34 @@ const findCustomerInBucketRange = ({
 };
 
 describe("isCacheV2RampEnabled", () => {
+	test("returns false when no config is set", () => {
+		_setCacheV2RampConfigForTesting(null);
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(isCacheV2RampEnabled({ customerId })).toBe(false);
+	});
+
 	test("returns false at 0%", () => {
-		_setCacheV2RampConfigForTesting({ percent: 0 });
+		_setCacheV2RampConfigForTesting(makeConfig({ migrationPercent: 0 }));
 		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
 		expect(isCacheV2RampEnabled({ customerId })).toBe(false);
 	});
 
 	test("returns true at 100% even without customerId", () => {
-		_setCacheV2RampConfigForTesting({ percent: 100 });
+		_setCacheV2RampConfigForTesting(makeConfig({ migrationPercent: 100 }));
 		expect(isCacheV2RampEnabled({})).toBe(true);
 	});
 
 	test("returns false without customerId at fractional percent", () => {
-		_setCacheV2RampConfigForTesting({ percent: 50 });
+		_setCacheV2RampConfigForTesting(makeConfig({ migrationPercent: 50 }));
 		expect(isCacheV2RampEnabled({})).toBe(false);
 	});
 
-	test("routes customers in low buckets when percent=50", () => {
-		_setCacheV2RampConfigForTesting({ percent: 50 });
+	test("routes low-bucket customers when migrationPercent=50", () => {
+		_setCacheV2RampConfigForTesting(makeConfig({ migrationPercent: 50 }));
 		const low = findCustomerInBucketRange({ min: 0, max: 50 });
 		const high = findCustomerInBucketRange({ min: 50, max: 100 });
 		expect(isCacheV2RampEnabled({ customerId: low })).toBe(true);
 		expect(isCacheV2RampEnabled({ customerId: high })).toBe(false);
-	});
-
-	test("per-org override beats the global percent", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 0,
-			orgs: {
-				org_pinned_to_public: {
-					percent: 100,
-					previousPercent: 0,
-					changedAt: 0,
-				},
-			},
-		});
-		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
-		expect(
-			isCacheV2RampEnabled({ orgId: "org_pinned_to_public", customerId }),
-		).toBe(true);
-		expect(isCacheV2RampEnabled({ orgId: "other_org", customerId })).toBe(
-			false,
-		);
-	});
-
-	test("per-org override can keep an org on private during a global ramp", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 100,
-			orgs: {
-				org_pinned_to_private: {
-					percent: 0,
-					previousPercent: 0,
-					changedAt: 0,
-				},
-			},
-		});
-		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
-		expect(
-			isCacheV2RampEnabled({ orgId: "org_pinned_to_private", customerId }),
-		).toBe(false);
-		expect(isCacheV2RampEnabled({ orgId: "other_org", customerId })).toBe(true);
 	});
 
 	test("getCustomerBucket is deterministic", () => {
@@ -93,106 +77,18 @@ describe("isCacheV2RampEnabled", () => {
 });
 
 describe("isCacheV2RampActive", () => {
-	test("false when global percent is 0 and no org override", () => {
-		_setCacheV2RampConfigForTesting({ percent: 0 });
-		expect(isCacheV2RampActive({})).toBe(false);
-		expect(isCacheV2RampActive({ orgId: "any_org" })).toBe(false);
+	test("false when no config is set", () => {
+		_setCacheV2RampConfigForTesting(null);
+		expect(isCacheV2RampActive()).toBe(false);
 	});
 
-	test("true when global percent is non-zero", () => {
-		_setCacheV2RampConfigForTesting({ percent: 1 });
-		expect(isCacheV2RampActive({})).toBe(true);
+	test("false when migrationPercent is 0", () => {
+		_setCacheV2RampConfigForTesting(makeConfig({ migrationPercent: 0 }));
+		expect(isCacheV2RampActive()).toBe(false);
 	});
 
-	test("per-org override at non-zero activates even when global is 0", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 0,
-			orgs: {
-				org_active: { percent: 5, previousPercent: 0, changedAt: 1000 },
-			},
-		});
-		expect(isCacheV2RampActive({ orgId: "org_active" })).toBe(true);
-		expect(isCacheV2RampActive({ orgId: "other_org" })).toBe(false);
-	});
-
-	test("per-org override at zero deactivates even when global is non-zero", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 50,
-			orgs: {
-				org_pinned: { percent: 0, previousPercent: 0, changedAt: 1000 },
-			},
-		});
-		expect(isCacheV2RampActive({ orgId: "org_pinned" })).toBe(false);
-	});
-});
-
-describe("isCacheV2RampCacheStale", () => {
-	test("returns false when ramp has never changed", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 50,
-			previousPercent: 50,
-			changedAt: 0,
-		});
-		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
-		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 500 })).toBe(false);
-	});
-
-	test("forward ramp 0% -> 50%: bucket-crossing customer with stale cachedAt is stale", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 50,
-			previousPercent: 0,
-			changedAt: 1000,
-		});
-		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
-		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 500 })).toBe(true);
-	});
-
-	test("forward ramp 0% -> 50%: non-crossing customer is not stale", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 50,
-			previousPercent: 0,
-			changedAt: 1000,
-		});
-		const customerId = findCustomerInBucketRange({ min: 50, max: 100 });
-		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 500 })).toBe(false);
-	});
-
-	test("rollback 50% -> 0%: previously-on-public customer is stale on private", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 0,
-			previousPercent: 50,
-			changedAt: 1000,
-		});
-		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
-		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 500 })).toBe(true);
-	});
-
-	test("entries cached AFTER the changeover are not stale", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 50,
-			previousPercent: 0,
-			changedAt: 1000,
-		});
-		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
-		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 2000 })).toBe(false);
-	});
-
-	test("legacy entries without cachedAt are conservatively stale when bucket crossed", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 50,
-			previousPercent: 0,
-			changedAt: 1000,
-		});
-		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
-		expect(isCacheV2RampCacheStale({ customerId })).toBe(true);
-	});
-
-	test("returns false when no customerId is provided", () => {
-		_setCacheV2RampConfigForTesting({
-			percent: 50,
-			previousPercent: 0,
-			changedAt: 1000,
-		});
-		expect(isCacheV2RampCacheStale({ cachedAt: 500 })).toBe(false);
+	test("true when migrationPercent > 0", () => {
+		_setCacheV2RampConfigForTesting(makeConfig({ migrationPercent: 1 }));
+		expect(isCacheV2RampActive()).toBe(true);
 	});
 });

--- a/server/tests/unit/redis/cache-v2-ramp.test.ts
+++ b/server/tests/unit/redis/cache-v2-ramp.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import {
+	_setCacheV2RampConfigForTesting,
+	isCacheV2RampActive,
+	isCacheV2RampCacheStale,
+	isCacheV2RampEnabled,
+} from "@/internal/misc/cacheV2Ramp/index.js";
+import { getCustomerBucket } from "@/internal/misc/rollouts/rolloutUtils.js";
+
+const findCustomerInBucketRange = ({
+	min,
+	max,
+}: {
+	min: number;
+	max: number;
+}): string => {
+	for (let index = 0; index < 10_000; index++) {
+		const customerId = `cus_ramp_${index}`;
+		const bucket = getCustomerBucket({ customerId });
+		if (bucket >= min && bucket < max) return customerId;
+	}
+	throw new Error(`No customer found in bucket range [${min}, ${max})`);
+};
+
+describe("isCacheV2RampEnabled", () => {
+	test("returns false at 0%", () => {
+		_setCacheV2RampConfigForTesting({ percent: 0 });
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(isCacheV2RampEnabled({ customerId })).toBe(false);
+	});
+
+	test("returns true at 100% even without customerId", () => {
+		_setCacheV2RampConfigForTesting({ percent: 100 });
+		expect(isCacheV2RampEnabled({})).toBe(true);
+	});
+
+	test("returns false without customerId at fractional percent", () => {
+		_setCacheV2RampConfigForTesting({ percent: 50 });
+		expect(isCacheV2RampEnabled({})).toBe(false);
+	});
+
+	test("routes customers in low buckets when percent=50", () => {
+		_setCacheV2RampConfigForTesting({ percent: 50 });
+		const low = findCustomerInBucketRange({ min: 0, max: 50 });
+		const high = findCustomerInBucketRange({ min: 50, max: 100 });
+		expect(isCacheV2RampEnabled({ customerId: low })).toBe(true);
+		expect(isCacheV2RampEnabled({ customerId: high })).toBe(false);
+	});
+
+	test("per-org override beats the global percent", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 0,
+			orgs: {
+				org_pinned_to_public: {
+					percent: 100,
+					previousPercent: 0,
+					changedAt: 0,
+				},
+			},
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(
+			isCacheV2RampEnabled({ orgId: "org_pinned_to_public", customerId }),
+		).toBe(true);
+		expect(isCacheV2RampEnabled({ orgId: "other_org", customerId })).toBe(
+			false,
+		);
+	});
+
+	test("per-org override can keep an org on private during a global ramp", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 100,
+			orgs: {
+				org_pinned_to_private: {
+					percent: 0,
+					previousPercent: 0,
+					changedAt: 0,
+				},
+			},
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(
+			isCacheV2RampEnabled({ orgId: "org_pinned_to_private", customerId }),
+		).toBe(false);
+		expect(isCacheV2RampEnabled({ orgId: "other_org", customerId })).toBe(true);
+	});
+
+	test("getCustomerBucket is deterministic", () => {
+		expect(getCustomerBucket({ customerId: "cus_deterministic" })).toBe(
+			getCustomerBucket({ customerId: "cus_deterministic" }),
+		);
+	});
+});
+
+describe("isCacheV2RampActive", () => {
+	test("false when global percent is 0 and no org override", () => {
+		_setCacheV2RampConfigForTesting({ percent: 0 });
+		expect(isCacheV2RampActive({})).toBe(false);
+		expect(isCacheV2RampActive({ orgId: "any_org" })).toBe(false);
+	});
+
+	test("true when global percent is non-zero", () => {
+		_setCacheV2RampConfigForTesting({ percent: 1 });
+		expect(isCacheV2RampActive({})).toBe(true);
+	});
+
+	test("per-org override at non-zero activates even when global is 0", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 0,
+			orgs: {
+				org_active: { percent: 5, previousPercent: 0, changedAt: 1000 },
+			},
+		});
+		expect(isCacheV2RampActive({ orgId: "org_active" })).toBe(true);
+		expect(isCacheV2RampActive({ orgId: "other_org" })).toBe(false);
+	});
+
+	test("per-org override at zero deactivates even when global is non-zero", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 50,
+			orgs: {
+				org_pinned: { percent: 0, previousPercent: 0, changedAt: 1000 },
+			},
+		});
+		expect(isCacheV2RampActive({ orgId: "org_pinned" })).toBe(false);
+	});
+});
+
+describe("isCacheV2RampCacheStale", () => {
+	test("returns false when ramp has never changed", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 50,
+			previousPercent: 50,
+			changedAt: 0,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 100 });
+		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 500 })).toBe(false);
+	});
+
+	test("forward ramp 0% -> 50%: bucket-crossing customer with stale cachedAt is stale", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 500 })).toBe(true);
+	});
+
+	test("forward ramp 0% -> 50%: non-crossing customer is not stale", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 50, max: 100 });
+		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 500 })).toBe(false);
+	});
+
+	test("rollback 50% -> 0%: previously-on-public customer is stale on private", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 0,
+			previousPercent: 50,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 500 })).toBe(true);
+	});
+
+	test("entries cached AFTER the changeover are not stale", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+		expect(isCacheV2RampCacheStale({ customerId, cachedAt: 2000 })).toBe(false);
+	});
+
+	test("legacy entries without cachedAt are conservatively stale when bucket crossed", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		const customerId = findCustomerInBucketRange({ min: 0, max: 50 });
+		expect(isCacheV2RampCacheStale({ customerId })).toBe(true);
+	});
+
+	test("returns false when no customerId is provided", () => {
+		_setCacheV2RampConfigForTesting({
+			percent: 50,
+			previousPercent: 0,
+			changedAt: 1000,
+		});
+		expect(isCacheV2RampCacheStale({ cachedAt: 500 })).toBe(false);
+	});
+});

--- a/vite/src/views/admin/components/CacheV2RampDialog.tsx
+++ b/vite/src/views/admin/components/CacheV2RampDialog.tsx
@@ -1,0 +1,353 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { z } from "zod/v4";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+
+const CONFIRM_REMOVE_TEXT = "remove";
+const CONFIRM_HIGH_RAMP_TEXT = "ramp";
+const HIGH_RAMP_THRESHOLD = 25;
+
+const migrationPercentSchema = z
+	.string()
+	.trim()
+	.regex(/^\d+$/)
+	.transform(Number)
+	.pipe(z.number().int().min(0).max(100));
+
+type AdminCacheV2RampResponse = {
+	cache_v2_ramp: {
+		host: string;
+		migrationPercent: number;
+		previousMigrationPercent: number;
+		migrationChangedAt: number;
+	} | null;
+};
+
+export function CacheV2RampDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+
+	const [connectionString, setConnectionString] = useState("");
+	const [migrationInputDraft, setMigrationInputDraft] = useState<string | null>(
+		null,
+	);
+	const [removeConfirm, setRemoveConfirm] = useState("");
+	const [rampConfirm, setRampConfirm] = useState("");
+
+	const [saving, setSaving] = useState(false);
+	const [updatingMigration, setUpdatingMigration] = useState(false);
+	const [removing, setRemoving] = useState(false);
+
+	const { data, isLoading, isError, refetch } =
+		useQuery<AdminCacheV2RampResponse>({
+			queryKey: ["admin-cache-v2-ramp"],
+			queryFn: async () => {
+				const { data } =
+					await axiosInstance.get<AdminCacheV2RampResponse>(
+						"/admin/cache-v2-ramp",
+					);
+				return data;
+			},
+			enabled: open,
+		});
+
+	const cfg = data?.cache_v2_ramp ?? null;
+	const migrationInput =
+		migrationInputDraft ?? (cfg ? String(cfg.migrationPercent) : "");
+
+	useEffect(() => {
+		if (isError && !data) toast.error("Failed to load cache V2 ramp config");
+	}, [isError, data]);
+
+	useEffect(() => {
+		if (open) {
+			setConnectionString("");
+			setRemoveConfirm("");
+			setRampConfirm("");
+			setMigrationInputDraft(null);
+		}
+	}, [open]);
+
+	const refreshAfterMutation = async () => {
+		try {
+			await refetch();
+		} catch {
+			// non-fatal
+		}
+	};
+
+	const handleConnect = async () => {
+		if (!connectionString.trim()) return;
+		setSaving(true);
+		try {
+			await axiosInstance.patch("/admin/cache-v2-ramp", {
+				connectionString: connectionString.trim(),
+			});
+			setConnectionString("");
+			toast.success("Cache V2 ramp destination configured");
+			await refreshAfterMutation();
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to configure destination"));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const handleUpdateMigration = async () => {
+		const parsed = migrationPercentSchema.safeParse(migrationInput);
+		if (!parsed.success) {
+			toast.error("Migration percent must be an integer between 0 and 100");
+			return;
+		}
+		const percent = parsed.data;
+		const currentPercent = cfg?.migrationPercent ?? 0;
+
+		// High-ramp confirmation: large jumps OR crossing the threshold up.
+		const crossingThreshold =
+			percent >= HIGH_RAMP_THRESHOLD && currentPercent < HIGH_RAMP_THRESHOLD;
+		const bigJump = percent - currentPercent >= HIGH_RAMP_THRESHOLD;
+		if (
+			(crossingThreshold || bigJump) &&
+			rampConfirm !== CONFIRM_HIGH_RAMP_TEXT
+		) {
+			toast.error(
+				`Type "${CONFIRM_HIGH_RAMP_TEXT}" in the confirmation field to apply ${currentPercent}% → ${percent}%`,
+			);
+			return;
+		}
+
+		setUpdatingMigration(true);
+		try {
+			await axiosInstance.patch("/admin/cache-v2-ramp/migration", {
+				migrationPercent: percent,
+			});
+			toast.success(`Cache V2 ramp set to ${percent}%`);
+			setMigrationInputDraft(null);
+			setRampConfirm("");
+			await refreshAfterMutation();
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to update ramp percent"));
+		} finally {
+			setUpdatingMigration(false);
+		}
+	};
+
+	const handleRemove = async () => {
+		if (removeConfirm !== CONFIRM_REMOVE_TEXT) return;
+		setRemoving(true);
+		try {
+			await axiosInstance.delete("/admin/cache-v2-ramp");
+			setRemoveConfirm("");
+			toast.success("Cache V2 ramp config removed");
+			await refreshAfterMutation();
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to remove ramp config"));
+		} finally {
+			setRemoving(false);
+		}
+	};
+
+	const pendingPercent = (() => {
+		const parsed = migrationPercentSchema.safeParse(migrationInput);
+		return parsed.success ? parsed.data : null;
+	})();
+	const currentPercent = cfg?.migrationPercent ?? 0;
+	const requiresRampConfirm =
+		pendingPercent !== null &&
+		pendingPercent !== currentPercent &&
+		(pendingPercent - currentPercent >= HIGH_RAMP_THRESHOLD ||
+			(pendingPercent >= HIGH_RAMP_THRESHOLD &&
+				currentPercent < HIGH_RAMP_THRESHOLD));
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Cache V2 ramp</DialogTitle>
+					<DialogDescription>
+						Global percentage ramp routing customer cache traffic to a new V2
+						Redis destination. Changes propagate to all servers within ~10
+						seconds. Only active while the V2 instance is set to dragonfly.
+					</DialogDescription>
+				</DialogHeader>
+
+				{isLoading ? (
+					<div className="py-8 text-center text-tertiary-foreground text-sm">
+						Loading…
+					</div>
+				) : cfg ? (
+					<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-1">
+							<FormLabel>Destination host</FormLabel>
+							<Input
+								value={cfg.host}
+								readOnly
+								className="font-mono text-xs"
+							/>
+							<span className="text-subtle text-[11px]">
+								Connection string is encrypted at rest and never sent back to
+								the frontend. To rotate credentials, set ramp to 0% then
+								re-enter the full connection string below.
+							</span>
+						</div>
+
+						<div className="flex flex-col gap-1">
+							<FormLabel>Ramp percentage</FormLabel>
+							<div className="flex items-center gap-2">
+								<Input
+									type="number"
+									min={0}
+									max={100}
+									value={migrationInput}
+									onChange={(e) => setMigrationInputDraft(e.target.value)}
+									className="w-24 font-mono text-xs"
+								/>
+								<span className="text-tertiary-foreground text-xs">
+									% of customers routed to destination
+								</span>
+								<Button
+									onClick={handleUpdateMigration}
+									disabled={
+										updatingMigration ||
+										pendingPercent === null ||
+										pendingPercent === cfg.migrationPercent ||
+										(requiresRampConfirm &&
+											rampConfirm !== CONFIRM_HIGH_RAMP_TEXT)
+									}
+									size="sm"
+								>
+									{updatingMigration ? "Updating…" : "Update"}
+								</Button>
+							</div>
+							{cfg.previousMigrationPercent !== cfg.migrationPercent && (
+								<span className="text-subtle text-[11px]">
+									Previous: {cfg.previousMigrationPercent}% — changed{" "}
+									{new Date(cfg.migrationChangedAt).toLocaleString()}
+								</span>
+							)}
+							{requiresRampConfirm && (
+								<div className="mt-2 flex flex-col gap-1 rounded-md border border-amber-300 bg-amber-50 p-2">
+									<span className="text-[11px] text-amber-800">
+										High-impact change ({currentPercent}% → {pendingPercent}%).
+										Type <span className="font-mono">{CONFIRM_HIGH_RAMP_TEXT}</span>{" "}
+										to confirm.
+									</span>
+									<Input
+										value={rampConfirm}
+										onChange={(e) => setRampConfirm(e.target.value)}
+										placeholder={CONFIRM_HIGH_RAMP_TEXT}
+										className="text-xs"
+									/>
+								</div>
+							)}
+						</div>
+
+						<div className="flex flex-col gap-2 border-t border-stroke pt-4">
+							<FormLabel>Rotate / replace connection string</FormLabel>
+							<span className="text-subtle text-[11px]">
+								{cfg.migrationPercent > 0
+									? `Set ramp to 0% first (currently ${cfg.migrationPercent}%).`
+									: "Paste a new redis:// or rediss:// URI to replace the stored connection string. Host stays for logs only."}
+							</span>
+							<div className="flex items-center gap-2">
+								<Input
+									value={connectionString}
+									onChange={(e) => setConnectionString(e.target.value)}
+									placeholder="rediss://default:password@host:port"
+									disabled={cfg.migrationPercent > 0}
+									className="font-mono text-xs"
+								/>
+								<Button
+									onClick={handleConnect}
+									disabled={
+										saving ||
+										cfg.migrationPercent > 0 ||
+										!connectionString.trim()
+									}
+									size="sm"
+								>
+									{saving ? "Saving…" : "Replace"}
+								</Button>
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-2 border-t border-stroke pt-4">
+							<FormLabel>Remove ramp config</FormLabel>
+							<span className="text-subtle text-xs">
+								{cfg.migrationPercent > 0
+									? `Set ramp to 0% first (currently ${cfg.migrationPercent}%).`
+									: `Type "${CONFIRM_REMOVE_TEXT}" to confirm. This clears the destination and disconnects the client.`}
+							</span>
+							<div className="flex items-center gap-2">
+								<Input
+									value={removeConfirm}
+									onChange={(e) => setRemoveConfirm(e.target.value)}
+									placeholder={CONFIRM_REMOVE_TEXT}
+									disabled={cfg.migrationPercent > 0}
+									className="text-xs"
+								/>
+								<Button
+									variant="destructive"
+									size="sm"
+									onClick={handleRemove}
+									disabled={
+										removing ||
+										cfg.migrationPercent > 0 ||
+										removeConfirm !== CONFIRM_REMOVE_TEXT
+									}
+								>
+									{removing ? "Removing…" : "Remove"}
+								</Button>
+							</div>
+						</div>
+					</div>
+				) : (
+					<div className="flex flex-col gap-3">
+						<FormLabel>Destination connection string</FormLabel>
+						<Input
+							value={connectionString}
+							onChange={(e) => setConnectionString(e.target.value)}
+							placeholder="rediss://default:password@host:port"
+							className="font-mono text-xs"
+						/>
+						<span className="text-subtle text-[11px]">
+							Stored encrypted (AES-256-CBC). Frontend never sees the
+							connection string after save — only the host. Ramp starts at 0%
+							(no traffic routed) until you bump it.
+						</span>
+						<Button
+							onClick={handleConnect}
+							disabled={saving || !connectionString.trim()}
+						>
+							{saving ? "Saving…" : "Configure destination"}
+						</Button>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button variant="secondary" onClick={() => onOpenChange(false)}>
+						Close
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { Button } from "@/components/v2/buttons/Button";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { CacheV2RampDialog } from "./CacheV2RampDialog";
 import { CustomerBlockDialog } from "./CustomerBlockDialog";
 import { EdgeConfigDialog } from "./EdgeConfigDialog";
 import { FeatureFlagsDialog } from "./FeatureFlagsDialog";
@@ -32,6 +33,7 @@ export function EdgeConfigTab() {
 	const [jobQueuesOpen, setJobQueuesOpen] = useState(false);
 	const [stripeSyncOpen, setStripeSyncOpen] = useState(false);
 	const [redisV2CacheOpen, setRedisV2CacheOpen] = useState(false);
+	const [cacheV2RampOpen, setCacheV2RampOpen] = useState(false);
 	const [miscellaneousOpen, setMiscellaneousOpen] = useState(false);
 
 	const { data: source } = useQuery<EdgeConfigSource>({
@@ -229,6 +231,25 @@ export function EdgeConfigTab() {
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
 						<div className="text-sm font-medium text-foreground">
+							Cache V2 Ramp
+						</div>
+						<div className="text-xs text-tertiary-foreground">
+							Global percentage ramp routing customer cache traffic to a new V2
+							Redis destination. Only active while dragonfly is the V2 instance.
+						</div>
+					</div>
+					<Button
+						variant="primary"
+						size="sm"
+						onClick={() => setCacheV2RampOpen(true)}
+					>
+						Edit
+					</Button>
+				</div>
+
+				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
+					<div className="flex flex-col gap-0.5">
+						<div className="text-sm font-medium text-foreground">
 							Miscellaneous
 						</div>
 						<div className="text-xs text-tertiary-foreground">
@@ -281,6 +302,11 @@ export function EdgeConfigTab() {
 			<RedisV2CacheDialog
 				open={redisV2CacheOpen}
 				onOpenChange={setRedisV2CacheOpen}
+			/>
+
+			<CacheV2RampDialog
+				open={cacheV2RampOpen}
+				onOpenChange={setCacheV2RampOpen}
 			/>
 
 			<MiscellaneousEdgeConfigDialog


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a percent-based Cache V2 ramp to route selected customers to a new Redis V2 destination, controllable via admin endpoints, edge config, and a new admin UI. Includes safe fallbacks, per-request routing, and fan-out during ramp for a gradual, reversible rollout.

- New Features
  - Edge config: `admin/cache-v2-ramp-config.json` (10s polling); stores encrypted `connectionString`, `url`, `migrationPercent`, `previousMigrationPercent`, `migrationChangedAt`.
  - Admin API: GET `/admin/cache-v2-ramp`, PATCH `/admin/cache-v2-ramp`, PATCH `/admin/cache-v2-ramp/migration`, DELETE `/admin/cache-v2-ramp`.
  - Admin UI: Edge Config tab dialog to set the connection string, change `migrationPercent` (high-ramp confirm), and remove the config; shows host, previous percent, and last change.
  - Routing: `resolveRedisV2({ customerId })` sends ramped customers to the destination; otherwise primary. Honors `redis-v2-cache` kill switch (`upstash`/`redis` overrides ramp) and warns if ramp is enabled without a destination. Middleware/workers pass `customerId` for per-request routing.
  - Consistency during ramp: fan-out writes/invalidations and org lock/cleanup to both primary and destination when migration > 0; gated on active instance `dragonfly` so the kill switch disables fan-out.
  - Destination client: lazy, hot-swappable (decrypts creds, region tags, timeouts; uses reachable URL); logs errors; safe disconnect on config changes; pre-warmed on first ramp-up.
  - Integrated into cron/init/workers; unit tests for bucketing and ramp-active checks.

- Migration
  - Set destination: PATCH `/admin/cache-v2-ramp` with plaintext `redis://` or `rediss://` (validated and encrypted). Refused while `migrationPercent` > 0.
  - Ramp traffic: PATCH `/admin/cache-v2-ramp/migration` with 0–100; stores previous value + timestamp; first increase warms the destination client. At >0, fan-out happens automatically.
  - Change/remove destination: set `migrationPercent` to 0 first, then PATCH/DELETE; delete disconnects the client.
  - Emergency off: switch `redis-v2-cache` to `upstash`/`redis` to bypass ramp and disable fan-out.

<sup>Written for commit c3d0885596c2ace01494472f2b1ef71e73a00806. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1670?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

