### PR TITLE
typecheck fix

### DIFF
--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -47,7 +47,7 @@ const createOrgRedisConnection = ({
 };
 
 export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
-	if (!org.redis_config) return resolveRedisV2({ orgId: org.id });
+	if (!org.redis_config) return resolveRedisV2();
 
 	const existing = pool.get(org.id);
 	if (existing) {
@@ -66,7 +66,7 @@ export const getOrgRedis = ({ org }: { org: OrgWithRedisConfig }): Redis => {
 		if (error instanceof Error) {
 			logger.error(error);
 		}
-		return resolveRedisV2({ orgId: org.id });
+		return resolveRedisV2();
 	}
 
 	const instance = createOrgRedisConnection({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix typecheck by calling `resolveRedisV2()` without `orgId` in `getOrgRedis`. Prevents TS errors and uses the default Redis client when org config is missing or connection creation fails.

<sup>Written for commit 0ac40ffea97c78b5cada8de69b72c34f038163dc. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1672?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

