### PR TITLE
chore: add org config to ui

### DIFF
--- a/server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts
+++ b/server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts
@@ -1,0 +1,37 @@
+import { OrgConfigSchema, type OrgConfig, Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { clearOrgCache } from "../orgUtils/clearOrgCache.js";
+import { sql } from "drizzle-orm";
+import { z } from "zod/v4";
+
+const validKeys = new Set(Object.keys(OrgConfigSchema.shape));
+const bodySchema = z.record(z.string(), z.boolean());
+
+export const handleUpdateOrgConfig = createRoute({
+	scopes: [Scopes.Organisation.Write],
+	body: bodySchema,
+	handler: async (c) => {
+		const { db, org } = c.get("ctx");
+		const raw = c.req.valid("json");
+
+		const updates = Object.fromEntries(
+			Object.entries(raw).filter(([k]) => validKeys.has(k)),
+		) as Partial<OrgConfig>;
+
+		if (Object.keys(updates).length === 0) {
+			return c.json({ success: true, config: OrgConfigSchema.parse(org.config) });
+		}
+
+		const rows = await db.execute<{ config: OrgConfig }>(
+			sql`UPDATE organizations
+				SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify(updates)}::jsonb
+				WHERE id = ${org.id}
+				RETURNING config`,
+		);
+
+		await clearOrgCache({ db, orgId: org.id });
+
+		const config = (rows as unknown as { config: OrgConfig }[])[0]?.config;
+		return c.json({ success: true, config: OrgConfigSchema.parse(config ?? {}) });
+	},
+});

--- a/server/src/internal/orgs/orgRouter.ts
+++ b/server/src/internal/orgs/orgRouter.ts
@@ -18,6 +18,7 @@ import {
 	handleUpsertRevenueCatConfig,
 } from "./handlers/handleRevenueCatConfig.js";
 import { handleUpdateOrg } from "./handlers/handleUpdateOrg.js";
+import { handleUpdateOrgConfig } from "./handlers/handleUpdateOrgConfig.js";
 import {
 	handleGetVercelSink,
 	handleUpsertVercelConfig,
@@ -34,6 +35,7 @@ export const internalOrgRouter = new Hono<HonoEnv>();
 
 internalOrgRouter.get("", ...handleGetOrg);
 internalOrgRouter.delete("", ...handleDeleteOrg);
+internalOrgRouter.patch("/config", ...handleUpdateOrgConfig);
 internalOrgRouter.get("/members", ...handleGetOrgMembers);
 internalOrgRouter.post("/remove-member", ...handleRemoveMember);
 internalOrgRouter.get("/upload_url", ...handleGetUploadUrl);
@@ -51,6 +53,7 @@ honoOrgRouter.get("/me", (c) => {
 	});
 });
 honoOrgRouter.patch("", ...handleUpdateOrg);
+honoOrgRouter.patch("/config", ...handleUpdateOrgConfig);
 honoOrgRouter.get("/stripe", ...handleGetStripeAccount);
 honoOrgRouter.delete("/stripe", ...handleDeleteStripe);
 honoOrgRouter.post("/stripe", ...handleConnectStripe);

--- a/server/src/internal/orgs/orgUtils.ts
+++ b/server/src/internal/orgs/orgUtils.ts
@@ -4,6 +4,7 @@ import {
 	type FrontendOrg,
 	type Organization,
 	type OrgConfig,
+	OrgConfigSchema,
 	organizations,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
@@ -265,6 +266,7 @@ export const createOrgResponse = ({
 		live_pkey: org.live_pkey,
 		onboarded: org.onboarded ?? true,
 		deployed: org.deployed ?? true,
+		config: OrgConfigSchema.parse(org.config || {}),
 		redis_config: org.redis_config
 			? {
 					host: org.redis_config.url,
@@ -283,7 +285,7 @@ const getOrgAndFeatures = async ({ req }: { req: any }) => {
 	return { org, features };
 };
 
-const updateOrgConfig = async ({
+export const updateOrgConfig = async ({
 	db,
 	org,
 	config,

--- a/server/tests/integration/org-config/update-org-config.test.ts
+++ b/server/tests/integration/org-config/update-org-config.test.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "bun:test";
+import { type OrgConfig, OrgConfigSchema, organizations } from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq, sql } from "drizzle-orm";
+
+test.concurrent(
+	`${chalk.yellowBright("org config: sequential updates preserve previous fields")}`,
+	async () => {
+		const { ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+
+		const { db, org } = ctx;
+
+		// Reset config to known empty state
+		await db
+			.update(organizations)
+			.set({ config: {} as OrgConfig })
+			.where(eq(organizations.id, org.id));
+
+		// First update: set cancel_on_past_due via atomic jsonb merge
+		await db.execute(
+			sql`UPDATE organizations
+				SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify({ cancel_on_past_due: true })}::jsonb
+				WHERE id = ${org.id}`,
+		);
+
+		// Second update: set automatic_tax via atomic jsonb merge
+		await db.execute(
+			sql`UPDATE organizations
+				SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify({ automatic_tax: true })}::jsonb
+				WHERE id = ${org.id}`,
+		);
+
+		// Read final state
+		const [final] = await db
+			.select({ config: organizations.config })
+			.from(organizations)
+			.where(eq(organizations.id, org.id))
+			.limit(1);
+
+		const parsed = OrgConfigSchema.parse(final?.config ?? {});
+
+		expect(parsed.cancel_on_past_due).toBe(true);
+		expect(parsed.automatic_tax).toBe(true);
+		expect(parsed.include_past_due).toBe(true); // default
+
+		// Restore
+		await db
+			.update(organizations)
+			.set({ config: org.config })
+			.where(eq(organizations.id, org.id));
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("org config: concurrent updates do not overwrite each other")}`,
+	async () => {
+		const { ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+
+		const { db, org } = ctx;
+
+		// Reset config
+		await db
+			.update(organizations)
+			.set({ config: {} as OrgConfig })
+			.where(eq(organizations.id, org.id));
+
+		// Fire 5 updates concurrently — each sets a different field
+		await Promise.all([
+			db.execute(
+				sql`UPDATE organizations
+					SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify({ cancel_on_past_due: true })}::jsonb
+					WHERE id = ${org.id}`,
+			),
+			db.execute(
+				sql`UPDATE organizations
+					SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify({ automatic_tax: true })}::jsonb
+					WHERE id = ${org.id}`,
+			),
+			db.execute(
+				sql`UPDATE organizations
+					SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify({ anchor_start_of_month: true })}::jsonb
+					WHERE id = ${org.id}`,
+			),
+			db.execute(
+				sql`UPDATE organizations
+					SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify({ disable_stripe_writes: true })}::jsonb
+					WHERE id = ${org.id}`,
+			),
+			db.execute(
+				sql`UPDATE organizations
+					SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify({ invoice_memos: true })}::jsonb
+					WHERE id = ${org.id}`,
+			),
+		]);
+
+		// All 5 fields should be true
+		const [final] = await db
+			.select({ config: organizations.config })
+			.from(organizations)
+			.where(eq(organizations.id, org.id))
+			.limit(1);
+
+		const parsed = OrgConfigSchema.parse(final?.config ?? {});
+
+		expect(parsed.cancel_on_past_due).toBe(true);
+		expect(parsed.automatic_tax).toBe(true);
+		expect(parsed.anchor_start_of_month).toBe(true);
+		expect(parsed.disable_stripe_writes).toBe(true);
+		expect(parsed.invoice_memos).toBe(true);
+
+		// Restore
+		await db
+			.update(organizations)
+			.set({ config: org.config })
+			.where(eq(organizations.id, org.id));
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("org config: toggling off preserves other fields")}`,
+	async () => {
+		const { ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+
+		const { db, org } = ctx;
+
+		// Set two fields on
+		await db.execute(
+			sql`UPDATE organizations
+				SET config = ${JSON.stringify({ automatic_tax: true, void_invoices_on_subscription_deletion: true })}::jsonb
+				WHERE id = ${org.id}`,
+		);
+
+		// Toggle one off
+		await db.execute(
+			sql`UPDATE organizations
+				SET config = COALESCE(config, '{}'::jsonb) || ${JSON.stringify({ automatic_tax: false })}::jsonb
+				WHERE id = ${org.id}`,
+		);
+
+		const [result] = await db
+			.select({ config: organizations.config })
+			.from(organizations)
+			.where(eq(organizations.id, org.id))
+			.limit(1);
+
+		const parsed = OrgConfigSchema.parse(result?.config ?? {});
+
+		expect(parsed.automatic_tax).toBe(false);
+		expect(parsed.void_invoices_on_subscription_deletion).toBe(true);
+
+		// Restore
+		await db
+			.update(organizations)
+			.set({ config: org.config })
+			.where(eq(organizations.id, org.id));
+	},
+);

--- a/shared/models/orgModels/frontendOrg.ts
+++ b/shared/models/orgModels/frontendOrg.ts
@@ -1,4 +1,5 @@
 import { VercelMarketplaceMode } from "@models/genModels/processorSchemas";
+import { OrgConfigSchema } from "./orgConfig";
 import { z } from "zod/v4";
 
 export const FrontendOrgSchema = z.object({
@@ -24,6 +25,7 @@ export const FrontendOrgSchema = z.object({
 	through_master: z.boolean(),
 	onboarded: z.boolean(),
 	deployed: z.boolean(),
+	config: OrgConfigSchema,
 	redis_config: z
 		.object({
 			host: z.string(),

--- a/vite/src/contexts/ThemeProvider.tsx
+++ b/vite/src/contexts/ThemeProvider.tsx
@@ -11,35 +11,32 @@ interface ThemeContextType {
 	preset: ThemePreset;
 	setPreset: (preset: ThemePreset) => void;
 	isDark: boolean;
-	/** @deprecated Use `mode` instead */
+	/** @deprecated Use `mode` */
 	theme: ThemeMode;
-	/** @deprecated Use `setMode` instead */
+	/** @deprecated Use `setMode` */
 	setTheme: (mode: ThemeMode) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+function resolveSystemTheme(): "light" | "dark" {
+	return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyMode(mode: ThemeMode): boolean {
+	const root = document.documentElement;
+	root.classList.remove("light", "dark");
+	const resolved = mode === "system" ? resolveSystemTheme() : mode;
+	root.classList.add(resolved);
+	return resolved === "dark";
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
 	const [mode, setMode] = useLocalStorage<ThemeMode>("theme", "system");
 	const [preset, setPreset] = useLocalStorage<ThemePreset>("theme-preset", "classic");
-	const [isDark, setIsDark] = useState(false);
+	const [isDark, setIsDark] = useState(() => applyMode(mode));
 
-	useEffect(() => {
-		const root = document.documentElement;
-		root.classList.remove("light", "dark");
-
-		if (mode === "system") {
-			const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-				.matches
-				? "dark"
-				: "light";
-			root.classList.add(systemTheme);
-			setIsDark(systemTheme === "dark");
-		} else {
-			root.classList.add(mode);
-			setIsDark(mode === "dark");
-		}
-	}, [mode]);
+	useEffect(() => setIsDark(applyMode(mode)), [mode]);
 
 	useEffect(() => {
 		const root = document.documentElement;
@@ -49,17 +46,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
 	useEffect(() => {
 		if (mode !== "system") return;
-
-		const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-		const handleChange = (e: MediaQueryListEvent) => {
-			const root = document.documentElement;
-			root.classList.remove("light", "dark");
-			root.classList.add(e.matches ? "dark" : "light");
-			setIsDark(e.matches);
-		};
-
-		mediaQuery.addEventListener("change", handleChange);
-		return () => mediaQuery.removeEventListener("change", handleChange);
+		const mq = window.matchMedia("(prefers-color-scheme: dark)");
+		const onChange = () => setIsDark(applyMode("system"));
+		mq.addEventListener("change", onChange);
+		return () => mq.removeEventListener("change", onChange);
 	}, [mode]);
 
 	useHotkeys("t", () => setMode(isDark ? "light" : "dark"), {
@@ -69,15 +59,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
 	return (
 		<ThemeContext.Provider
-			value={{
-				mode,
-				setMode,
-				preset,
-				setPreset,
-				isDark,
-				theme: mode,
-				setTheme: setMode,
-			}}
+			value={{ mode, setMode, preset, setPreset, isDark, theme: mode, setTheme: setMode }}
 		>
 			{children}
 		</ThemeContext.Provider>
@@ -86,8 +68,6 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
 export function useTheme() {
 	const context = useContext(ThemeContext);
-	if (context === undefined) {
-		throw new Error("useTheme must be used within a ThemeProvider");
-	}
+	if (!context) throw new Error("useTheme must be used within a ThemeProvider");
 	return context;
 }

--- a/vite/src/views/settings/SettingsView.tsx
+++ b/vite/src/views/settings/SettingsView.tsx
@@ -1,5 +1,6 @@
 import {
 	BuildingIcon,
+	CreditCardIcon,
 	PaletteIcon,
 	ShieldCheckIcon,
 	UserIcon,
@@ -13,8 +14,9 @@ import { OrganizationSection } from "./sections/OrganizationSection";
 import { MembersSection } from "./sections/MembersSection";
 import { AuthorizedAppsSection } from "./sections/AuthorizedAppsSection";
 import { AppearanceSection } from "./sections/AppearanceSection";
+import { BillingSettingsSection } from "./sections/BillingSettingsSection";
 
-type SettingsTab = "account" | "organization" | "members" | "apps" | "appearance";
+type SettingsTab = "account" | "organization" | "members" | "billing" | "appearance" | "apps";
 
 interface SettingsNavItem {
 	readonly id: SettingsTab;
@@ -35,6 +37,11 @@ const SETTINGS_TABS: readonly SettingsNavItem[] = [
 		icon: <UsersIcon className="size-4" />,
 	},
 	{
+		id: "billing",
+		label: "Billing",
+		icon: <CreditCardIcon className="size-4" />,
+	},
+	{
 		id: "appearance",
 		label: "Appearance",
 		icon: <PaletteIcon className="size-4" />,
@@ -50,8 +57,9 @@ const SECTION_MAP: Record<SettingsTab, React.ComponentType> = {
 	account: AccountSection,
 	organization: OrganizationSection,
 	members: MembersSection,
-	apps: AuthorizedAppsSection,
+	billing: BillingSettingsSection,
 	appearance: AppearanceSection,
+	apps: AuthorizedAppsSection,
 };
 
 export const SettingsView = () => {

--- a/vite/src/views/settings/sections/AppearanceSection.tsx
+++ b/vite/src/views/settings/sections/AppearanceSection.tsx
@@ -19,32 +19,20 @@ interface PreviewColors {
 	readonly dot: string;
 }
 
-const PREVIEW_LIGHT: PreviewColors = {
-	bg: "bg-white",
-	sidebar: "bg-[#f5f5f4]",
-	card: "bg-[#fafaf9]",
-	line: "bg-[#e5e5e5]",
-	header: "bg-[#f5f5f4]",
-	dot: "bg-[#d1d1d1]",
+const LIGHT: PreviewColors = {
+	bg: "bg-white", sidebar: "bg-[#f5f5f4]", card: "bg-[#fafaf9]",
+	line: "bg-[#e5e5e5]", header: "bg-[#f5f5f4]", dot: "bg-[#d1d1d1]",
 };
 
-const PREVIEW_DARK: PreviewColors = {
-	bg: "bg-[#0a0a0a]",
-	sidebar: "bg-[#000000]",
-	card: "bg-[#0f0f0f]",
-	line: "bg-[#1e1e1e]",
-	header: "bg-[#111111]",
-	dot: "bg-[#333333]",
+const DARK: PreviewColors = {
+	bg: "bg-[#0a0a0a]", sidebar: "bg-[#000000]", card: "bg-[#0f0f0f]",
+	line: "bg-[#1e1e1e]", header: "bg-[#111111]", dot: "bg-[#333333]",
 };
-
-const systemPrefersDark =
-	typeof window !== "undefined" &&
-	window.matchMedia("(prefers-color-scheme: dark)").matches;
 
 const MODE_OPTIONS = [
-	{ id: "light", label: "Light", icon: <Sun className="size-4" />, preview: PREVIEW_LIGHT },
-	{ id: "dark", label: "Dark", icon: <Moon className="size-4" />, preview: PREVIEW_DARK },
-	{ id: "system", label: "System", icon: <Monitor className="size-4" />, preview: systemPrefersDark ? PREVIEW_DARK : PREVIEW_LIGHT },
+	{ id: "light", label: "Light", icon: <Sun className="size-4" /> },
+	{ id: "dark", label: "Dark", icon: <Moon className="size-4" /> },
+	{ id: "system", label: "System", icon: <Monitor className="size-4" /> },
 ] as const;
 
 const PRESET_OPTIONS = [
@@ -66,28 +54,30 @@ const PRESET_OPTIONS = [
 	},
 ] as const;
 
+const tc = "transition-colors duration-200";
+
 function ThemePreview({ colors, height = "h-[72px]" }: { colors: PreviewColors; height?: string }) {
 	return (
-		<div className={cn("rounded-md border overflow-hidden transition-colors duration-200", height, colors.bg)}>
+		<div className={cn("rounded-md border overflow-hidden", tc, height, colors.bg)}>
 			<div className="flex h-full">
-				<div className={cn("w-[22%] h-full flex flex-col transition-colors duration-200", colors.sidebar)}>
+				<div className={cn("w-[22%] h-full flex flex-col", tc, colors.sidebar)}>
 					<div className="p-1.5 flex items-center gap-1">
-						<div className={cn("size-2 rounded-full transition-colors duration-200", colors.dot)} />
+						<div className={cn("size-2 rounded-full", tc, colors.dot)} />
 					</div>
 					<div className="flex flex-col gap-1 px-1.5">
-						<div className={cn("h-1 w-full rounded-sm transition-colors duration-200", colors.line)} />
-						<div className={cn("h-1 w-3/4 rounded-sm transition-colors duration-200", colors.line)} />
-						<div className={cn("h-1 w-4/5 rounded-sm transition-colors duration-200", colors.line)} />
+						<div className={cn("h-1 w-full rounded-sm", tc, colors.line)} />
+						<div className={cn("h-1 w-3/4 rounded-sm", tc, colors.line)} />
+						<div className={cn("h-1 w-4/5 rounded-sm", tc, colors.line)} />
 					</div>
 				</div>
-				<div className="flex-1 flex flex-col transition-colors duration-200">
-					<div className={cn("h-4 border-b border-transparent flex items-center px-2 transition-colors duration-200", colors.header)}>
-						<div className={cn("h-1 w-8 rounded-sm transition-colors duration-200", colors.line)} />
+				<div className={cn("flex-1 flex flex-col", tc)}>
+					<div className={cn("h-4 border-b border-transparent flex items-center px-2", tc, colors.header)}>
+						<div className={cn("h-1 w-8 rounded-sm", tc, colors.line)} />
 					</div>
 					<div className="flex-1 p-2 flex flex-col gap-1.5">
-						<div className={cn("h-3 w-3/4 rounded transition-colors duration-200", colors.card)} />
-						<div className={cn("h-1.5 w-1/2 rounded-sm transition-colors duration-200", colors.line)} />
-						<div className={cn("h-1.5 w-2/3 rounded-sm transition-colors duration-200", colors.line)} />
+						<div className={cn("h-3 w-3/4 rounded", tc, colors.card)} />
+						<div className={cn("h-1.5 w-1/2 rounded-sm", tc, colors.line)} />
+						<div className={cn("h-1.5 w-2/3 rounded-sm", tc, colors.line)} />
 					</div>
 				</div>
 			</div>
@@ -95,8 +85,13 @@ function ThemePreview({ colors, height = "h-[72px]" }: { colors: PreviewColors; 
 	);
 }
 
+function resolvePresetLabel(label: string | { light: string; dark: string }, isDark: boolean): string {
+	return typeof label === "string" ? label : isDark ? label.dark : label.light;
+}
+
 export const AppearanceSection = () => {
 	const { mode, setMode, preset, setPreset, isDark } = useTheme();
+	const modePreview = isDark ? DARK : LIGHT;
 
 	return (
 		<SettingsSection
@@ -118,7 +113,9 @@ export const AppearanceSection = () => {
 									: "border-border hover:border-muted-foreground/30",
 							)}
 						>
-							<ThemePreview colors={option.preview} />
+							<ThemePreview
+								colors={option.id === "light" ? LIGHT : option.id === "dark" ? DARK : modePreview}
+							/>
 							<div className="flex items-center gap-1.5 px-0.5">
 								{option.icon}
 								<span className="text-sm font-medium">{option.label}</span>
@@ -131,18 +128,12 @@ export const AppearanceSection = () => {
 			<Card className="shadow-none bg-interactive-secondary">
 				<CardHeader>
 					<CardTitle>Theme</CardTitle>
-					<CardDescription>
-						Select a visual style for the dashboard
-					</CardDescription>
+					<CardDescription>Select a visual style for the dashboard</CardDescription>
 				</CardHeader>
 				<CardContent>
 					<div className="grid grid-cols-2 gap-3">
 						{PRESET_OPTIONS.map((option) => {
 							const isActive = preset === option.id;
-							const colors = isDark ? option.dark : option.light;
-							const label = typeof option.label === "string"
-								? option.label
-								: isDark ? option.label.dark : option.label.light;
 							return (
 								<button
 									key={option.id}
@@ -155,14 +146,14 @@ export const AppearanceSection = () => {
 											: "border-border hover:border-muted-foreground/30",
 									)}
 								>
-									<ThemePreview colors={colors} height="h-[80px]" />
+									<ThemePreview colors={isDark ? option.dark : option.light} height="h-[80px]" />
 									<div className="flex items-center gap-2.5 px-0.5">
 										{option.icon}
 										<div className="flex flex-col gap-0.5">
-											<span className="text-sm font-medium">{label}</span>
-											<span className="text-xs text-muted-foreground">
-												{option.description}
+											<span className="text-sm font-medium">
+												{resolvePresetLabel(option.label, isDark)}
 											</span>
+											<span className="text-xs text-muted-foreground">{option.description}</span>
 										</div>
 									</div>
 								</button>

--- a/vite/src/views/settings/sections/AppearanceSection.tsx
+++ b/vite/src/views/settings/sections/AppearanceSection.tsx
@@ -89,9 +89,12 @@ function resolvePresetLabel(label: string | { light: string; dark: string }, isD
 	return typeof label === "string" ? label : isDark ? label.dark : label.light;
 }
 
+const systemPrefersDark = () =>
+	typeof window !== "undefined" &&
+	window.matchMedia("(prefers-color-scheme: dark)").matches;
+
 export const AppearanceSection = () => {
 	const { mode, setMode, preset, setPreset, isDark } = useTheme();
-	const modePreview = isDark ? DARK : LIGHT;
 
 	return (
 		<SettingsSection
@@ -114,7 +117,7 @@ export const AppearanceSection = () => {
 							)}
 						>
 							<ThemePreview
-								colors={option.id === "light" ? LIGHT : option.id === "dark" ? DARK : modePreview}
+								colors={option.id === "light" ? LIGHT : option.id === "dark" ? DARK : systemPrefersDark() ? DARK : LIGHT}
 							/>
 							<div className="flex items-center gap-1.5 px-0.5">
 								{option.icon}

--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -1,0 +1,91 @@
+import type { FrontendOrg, OrgConfig } from "@autumn/shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { useOrg } from "@/hooks/common/useOrg";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useEnv } from "@/utils/envUtils";
+import { SettingsSection } from "../SettingsSection";
+
+const BILLING_TOGGLES = [
+	{ key: "anchor_start_of_month", label: "Anchor billing to start of month", description: "Billing cycles start on the 1st of each month" },
+	{ key: "cancel_on_past_due", label: "Cancel on past due", description: "Automatically cancel subscriptions when payment is past due" },
+	{ key: "reverse_deduction_order", label: "Reverse deduction order", description: "Deduct from newest balance first instead of oldest" },
+	{ key: "include_past_due", label: "Include past due", description: "Include past-due subscriptions when checking entitlements" },
+	{ key: "invoice_memos", label: "Invoice memos", description: "Include line-item memos on Stripe invoices" },
+	{ key: "entity_product", label: "Entity products", description: "Enable entity-level product assignments" },
+	{ key: "void_invoices_on_subscription_deletion", label: "Void invoices on cancellation", description: "Void open invoices when a subscription is deleted" },
+	{ key: "default_applies_to_entities", label: "Default plan applies to entities", description: "The default plan is applied at entity level" },
+	{ key: "disable_stripe_writes", label: "Disable Stripe writes", description: "Prevent Autumn from writing to Stripe (read-only mode)" },
+	{ key: "automatic_tax", label: "Automatic tax", description: "Enable Stripe Tax for automatic tax calculation" },
+] as const satisfies readonly { key: keyof OrgConfig; label: string; description: string }[];
+
+const REFETCH_DELAY_MS = 1000;
+
+export const BillingSettingsSection = () => {
+	const { org } = useOrg();
+	const axiosInstance = useAxiosInstance();
+	const queryClient = useQueryClient();
+	const env = useEnv();
+	const queryKey = ["org", env];
+	const refetchTimer = useRef<ReturnType<typeof setTimeout>>();
+
+	useEffect(() => () => clearTimeout(refetchTimer.current), []);
+
+	const { mutate } = useMutation({
+		mutationFn: async (updates: Partial<OrgConfig>) => {
+			const { data } = await axiosInstance.patch("/organization/config", updates);
+			return data as { config: OrgConfig };
+		},
+		onMutate: async (updates) => {
+			clearTimeout(refetchTimer.current);
+			await queryClient.cancelQueries({ queryKey });
+			queryClient.setQueryData<FrontendOrg>(queryKey, (old) =>
+				old ? { ...old, config: { ...old.config, ...updates } } : old,
+			);
+		},
+		onSuccess: (data) => {
+			queryClient.setQueryData<FrontendOrg>(queryKey, (old) =>
+				old ? { ...old, config: data.config } : old,
+			);
+		},
+		onError: () => {
+			toast.error("Failed to update billing settings");
+			queryClient.invalidateQueries({ queryKey });
+		},
+		onSettled: () => {
+			clearTimeout(refetchTimer.current);
+			refetchTimer.current = setTimeout(
+				() => queryClient.invalidateQueries({ queryKey }),
+				REFETCH_DELAY_MS,
+			);
+		},
+	});
+
+	if (!org) return null;
+
+	const config = org.config ?? {};
+
+	return (
+		<SettingsSection
+			title="Billing"
+			description="Configure how billing and subscriptions behave"
+		>
+			<div className="flex flex-col divide-y divide-border rounded-lg border bg-interactive-secondary px-4">
+				{BILLING_TOGGLES.map(({ key, label, description }) => (
+					<div key={key} className="flex items-center justify-between gap-4 py-3.5">
+						<div className="flex flex-col gap-0.5">
+							<span className="text-sm font-medium">{label}</span>
+							<span className="text-xs text-muted-foreground">{description}</span>
+						</div>
+						<Switch
+							checked={!!config[key]}
+							onCheckedChange={(val) => mutate({ [key]: val })}
+						/>
+					</div>
+				))}
+			</div>
+		</SettingsSection>
+	);
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds organization config support end-to-end with a new Billing settings UI, so org admins can toggle billing behaviors directly. Also improves theme handling to respect system theme on first paint and live changes, and cleans up the Appearance preview.

- **New Features**
  - Server: `PATCH /organization/config` atomically merges boolean updates into `organizations.config` (JSONB), validates keys with `OrgConfigSchema` (`zod`), and clears org cache.
  - Routes: Exposed on both internal and public org routers; `createOrgResponse` now returns parsed `config`.
  - Models: `FrontendOrg` includes typed `config`.
  - UI: New “Billing” tab with toggles for key flags (e.g., `automatic_tax`, `cancel_on_past_due`, `disable_stripe_writes`), using optimistic updates with `@tanstack/react-query` and a short delayed refetch.
  - Tests: Integration tests ensure sequential, concurrent, and toggle-off updates preserve existing fields.

- **Refactors**
  - Theme: Applies mode on initial render to prevent theme flicker and listens to system changes; simplified helpers and state in `ThemeProvider`.
  - Appearance: Simplified preview rendering and preset labeling; smaller, clearer code while preserving behavior.

<sup>Written for commit b1e8c26e17529bce5a2b9419adcaa9a76b2a329d. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1673?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires org configuration into the settings UI, adding a new **Billing** settings tab backed by a `PATCH /organization/config` endpoint that atomically merges individual boolean flags into the org's `config` JSONB column.

- **[Improvements]** New `handleUpdateOrgConfig` handler validates the request body against `OrgConfigSchema` keys, performs an atomic jsonb merge via raw SQL (`COALESCE(config, '{}') || …`), and clears the org cache — with integration tests covering sequential, concurrent, and toggle-off scenarios.
- **[Improvements]** `BillingSettingsSection` provides a toggle UI for 10 org config flags using React Query optimistic updates; `FrontendOrgSchema` and `createOrgResponse` are extended to include the parsed `config` field.
- **[Improvements]** `ThemeProvider` is refactored to apply the theme during `useState` lazy initialisation (eliminating a flash-of-wrong-theme on first render) and `AppearanceSection` removes a stale module-level `systemPrefersDark` snapshot in favour of the live `isDark` value from context.
</details>

<h3>Confidence Score: 3/5</h3>

The server-side changes are solid, but the billing UI leaves toggle controls in the wrong state whenever a config update fails.

The optimistic update in BillingSettingsSection does not snapshot the previous cache value in onMutate, so the onError handler can only schedule a background refetch rather than immediately restoring the previous state. This means any failed toggle will appear stuck in the new position until the re-fetch completes — a visible, reproducible UX defect on every API error.

vite/src/views/settings/sections/BillingSettingsSection.tsx — the onMutate/onError pair needs a rollback snapshot.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/settings/sections/BillingSettingsSection.tsx | New settings UI with optimistic updates for org config toggles; missing rollback snapshot in onMutate means error path leaves the UI in the wrong state until a background refetch resolves. |
| server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts | New PATCH /config endpoint; whitelist-filters request body against OrgConfigSchema keys, then performs an atomic jsonb merge via raw SQL. Consistent with existing db.execute patterns in the codebase. |
| server/tests/integration/org-config/update-org-config.test.ts | Integration tests covering sequential updates, concurrent jsonb merges, and toggle-off scenarios for org config. |
| shared/models/orgModels/frontendOrg.ts | Adds the OrgConfig field to the FrontendOrgSchema so the config is included in the typed frontend org object. |
| server/src/internal/orgs/orgUtils.ts | Adds config field (parsed through OrgConfigSchema for defaults) to the org response and exports updateOrgConfig for use by the new handler. |
| vite/src/contexts/ThemeProvider.tsx | Refactor: extracts applyMode/resolveSystemTheme helpers, applies theme during initial useState lazy-init to eliminate a flash-of-wrong-theme on first render. |
| vite/src/views/settings/SettingsView.tsx | Adds a Billing tab to the settings navigation wired to the new BillingSettingsSection component. |
| vite/src/views/settings/sections/AppearanceSection.tsx | Minor refactor: renames preview constants, extracts tc/resolvePresetLabel helpers, removes static systemPrefersDark check, and compresses inline styles. |
| server/src/internal/orgs/orgRouter.ts | Registers the new PATCH /config route on both the internal and hono org routers. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as BillingSettingsSection
    participant RQ as React Query Cache
    participant API as PATCH /organization/config
    participant DB as PostgreSQL (organizations)
    participant Cache as Org Cache (Redis)

    UI->>RQ: onMutate — cancelQueries + optimistic setQueryData
    UI->>API: "PATCH { [key]: boolean }"
    API->>API: filter keys against OrgConfigSchema.shape
    API->>DB: "UPDATE … SET config = COALESCE(config,'{}') || updates::jsonb RETURNING config"
    DB-->>API: updated config row
    API->>Cache: clearOrgCache(orgId)
    API-->>UI: "{ success: true, config }"
    UI->>RQ: onSuccess — setQueryData with server config
    UI->>RQ: onSettled — schedule invalidateQueries after 1 s
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/settings/sections/BillingSettingsSection.tsx:41-56
Missing optimistic-update rollback on error. `onMutate` applies an optimistic toggle change but doesn't return the previous snapshot. When `onError` fires it calls `invalidateQueries`, which marks the query stale and triggers a background refetch — but until that refetch resolves the UI shows the wrong toggle state. A user will see the toggle sit in the incorrect position for ~1 network round-trip, and if the refetch itself is slow or the component is re-mounted before it completes they may never see the correction.

```suggestion
		onMutate: async (updates) => {
			clearTimeout(refetchTimer.current);
			await queryClient.cancelQueries({ queryKey });
			const previousOrg = queryClient.getQueryData<FrontendOrg>(queryKey);
			queryClient.setQueryData<FrontendOrg>(queryKey, (old) =>
				old ? { ...old, config: { ...old.config, ...updates } } : old,
			);
			return { previousOrg };
		},
		onSuccess: (data) => {
			queryClient.setQueryData<FrontendOrg>(queryKey, (old) =>
				old ? { ...old, config: data.config } : old,
			);
		},
		onError: (_err, _updates, context) => {
			toast.error("Failed to update billing settings");
			if (context?.previousOrg) {
				queryClient.setQueryData(queryKey, context.previousOrg);
			} else {
				queryClient.invalidateQueries({ queryKey });
			}
		},
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add org config to ui"](https://github.com/useautumn/autumn/commit/d4a703bcd4f9e5fd5364a9bda43451f388c35363) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33090967)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->