### PR TITLE
chore: add confirmation to billing settings

### DIFF
--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -83,6 +83,7 @@ export const BillingSettingsSection = () => {
 						<Switch
 							checked={!!displayConfig[key]}
 							onCheckedChange={(val) => handleToggle(key, val)}
+							disabled={isPending}
 						/>
 					</div>
 				))}

--- a/vite/src/views/settings/sections/BillingSettingsSection.tsx
+++ b/vite/src/views/settings/sections/BillingSettingsSection.tsx
@@ -1,15 +1,15 @@
 import type { FrontendOrg, OrgConfig } from "@autumn/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/v2/buttons/Button";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useEnv } from "@/utils/envUtils";
 import { SettingsSection } from "../SettingsSection";
 
 const BILLING_TOGGLES = [
-	{ key: "anchor_start_of_month", label: "Anchor billing to start of month", description: "Billing cycles start on the 1st of each month" },
 	{ key: "cancel_on_past_due", label: "Cancel on past due", description: "Automatically cancel subscriptions when payment is past due" },
 	{ key: "reverse_deduction_order", label: "Reverse deduction order", description: "Deduct from newest balance first instead of oldest" },
 	{ key: "include_past_due", label: "Include past due", description: "Include past-due subscriptions when checking entitlements" },
@@ -21,51 +21,52 @@ const BILLING_TOGGLES = [
 	{ key: "automatic_tax", label: "Automatic tax", description: "Enable Stripe Tax for automatic tax calculation" },
 ] as const satisfies readonly { key: keyof OrgConfig; label: string; description: string }[];
 
-const REFETCH_DELAY_MS = 1000;
-
 export const BillingSettingsSection = () => {
 	const { org } = useOrg();
 	const axiosInstance = useAxiosInstance();
 	const queryClient = useQueryClient();
 	const env = useEnv();
 	const queryKey = ["org", env];
-	const refetchTimer = useRef<ReturnType<typeof setTimeout>>();
+	const [pending, setPending] = useState<Partial<OrgConfig>>({});
 
-	useEffect(() => () => clearTimeout(refetchTimer.current), []);
+	const serverConfig = org?.config ?? {};
+	const displayConfig = { ...serverConfig, ...pending };
+	const isDirty = Object.keys(pending).length > 0;
 
-	const { mutate } = useMutation({
+	const { mutate, isPending } = useMutation({
 		mutationFn: async (updates: Partial<OrgConfig>) => {
 			const { data } = await axiosInstance.patch("/organization/config", updates);
 			return data as { config: OrgConfig };
 		},
-		onMutate: async (updates) => {
-			clearTimeout(refetchTimer.current);
-			await queryClient.cancelQueries({ queryKey });
-			queryClient.setQueryData<FrontendOrg>(queryKey, (old) =>
-				old ? { ...old, config: { ...old.config, ...updates } } : old,
-			);
-		},
 		onSuccess: (data) => {
+			setPending({});
 			queryClient.setQueryData<FrontendOrg>(queryKey, (old) =>
 				old ? { ...old, config: data.config } : old,
 			);
+			toast.success("Billing settings saved");
 		},
 		onError: () => {
 			toast.error("Failed to update billing settings");
 			queryClient.invalidateQueries({ queryKey });
 		},
-		onSettled: () => {
-			clearTimeout(refetchTimer.current);
-			refetchTimer.current = setTimeout(
-				() => queryClient.invalidateQueries({ queryKey }),
-				REFETCH_DELAY_MS,
-			);
-		},
 	});
 
-	if (!org) return null;
+	const handleToggle = (key: keyof OrgConfig, value: boolean) => {
+		setPending((prev) => {
+			const next = { ...prev, [key]: value };
+			if (serverConfig[key] === value) {
+				delete next[key];
+			}
+			return next;
+		});
+	};
 
-	const config = org.config ?? {};
+	const handleSave = () => {
+		if (!isDirty || isPending) return;
+		mutate(pending);
+	};
+
+	if (!org) return null;
 
 	return (
 		<SettingsSection
@@ -80,12 +81,21 @@ export const BillingSettingsSection = () => {
 							<span className="text-xs text-muted-foreground">{description}</span>
 						</div>
 						<Switch
-							checked={!!config[key]}
-							onCheckedChange={(val) => mutate({ [key]: val })}
+							checked={!!displayConfig[key]}
+							onCheckedChange={(val) => handleToggle(key, val)}
 						/>
 					</div>
 				))}
 			</div>
+			<Button
+				variant="primary"
+				onClick={handleSave}
+				disabled={!isDirty}
+				isLoading={isPending}
+				className="w-full"
+			>
+				Save Changes
+			</Button>
 		</SettingsSection>
 	);
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a confirmation step to Billing settings so changes only save when the user clicks Save Changes. Switches are disabled during save to prevent lost changes.

- **New Features**
  - Added a Save Changes button with loading and disabled states.
  - Hold edits in a local pending state; UI reflects pending vs. server values.
  - Disable switches while saving to prevent in-flight edits from being lost.
  - Show success and error toasts on save.

- **Refactors**
  - Replaced optimistic updates and refetch timer with explicit save; update cache on success and invalidate on error.
  - Switched from `useRef`/`useEffect` to `useState`.
  - Removed the "Anchor billing to start of month" toggle.

<sup>Written for commit f5b9ab61cdfc4ed4cae02c8bacf777b2eb380b14. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1674?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the immediate-save-on-toggle behavior in `BillingSettingsSection` with a batched "Save Changes" flow, and removes the `anchor_start_of_month` toggle entry.

- **[Improvements]** Switches now accumulate into local `pending` state; a "Save Changes" button submits all changes in a single `PATCH` request, replacing the previous optimistic per-toggle mutation with a refetch timer.
- **[Improvements]** Removed `anchor_start_of_month` from the toggle list and dropped the optimistic-update / `onMutate` / `onSettled` mutation callbacks in favour of a simpler success/error pair.
</details>

<h3>Confidence Score: 3/5</h3>

The batched-save refactor is clean overall, but the switches remain interactive while a save is in flight, which can cause the user's most recent toggle changes to be silently discarded.

The save flow correctly guards the button and clears pending state on success, but Switch components lack a disabled={isPending} prop. Any toggle a user makes between clicking Save and the response arriving will be erased by setPending({}) in onSuccess with no indication to the user.

vite/src/views/settings/sections/BillingSettingsSection.tsx — the switch disabled-during-save guard is missing

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/settings/sections/BillingSettingsSection.tsx | Refactored from optimistic per-toggle saves to a batched "Save Changes" flow; switches are not disabled while the mutation is in progress, allowing in-flight toggle changes to be silently discarded on success. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant UI as BillingSettingsSection
    participant State as pending (useState)
    participant API as PATCH /organization/config
    participant Cache as React Query Cache

    User->>UI: Toggle switch
    UI->>State: "setPending({ [key]: value })"
    Note over State: If value == serverConfig[key],<br/>key is removed from pending

    User->>UI: Click "Save Changes"
    UI->>API: mutate(pending)
    API-->>UI: "onSuccess({ config })"
    UI->>State: "setPending({})"
    UI->>Cache: setQueryData (update org config)
    UI-->>User: toast "Billing settings saved"

    alt Request fails
        API-->>UI: onError
        UI->>Cache: invalidateQueries (refetch)
        UI-->>User: toast "Failed to update billing settings"
        Note over State: pending is retained so user can retry
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/settings/sections/BillingSettingsSection.tsx:83-86
**Silent loss of in-flight toggle changes**

When `isPending` is true and the user flips additional switches, those changes accumulate in `pending`. When `onSuccess` fires it calls `setPending({})`, which wipes **all** pending state including any toggles the user made after clicking "Save". Those newer changes are silently discarded with no feedback. Disabling the switches during the mutation prevents this.

```suggestion
						<Switch
							checked={!!displayConfig[key]}
							onCheckedChange={(val) => handleToggle(key, val)}
							disabled={isPending}
						/>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add confirmation to billing setti..."](https://github.com/useautumn/autumn/commit/febb25be901a7ed7d509d2ad4a98366c68403f40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33094013)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->