### PR TITLE
fix: connection pooling

### DIFF
--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -40,7 +40,7 @@ const normalizeDbExecute = <
 
 /** Creates a Drizzle pool with the given configuration. */
 export const initDrizzle = ({
-	maxConnections = isProd ? 70 : 10,
+	maxConnections = isProd ? 100 : 10,
 	replica = false,
 	connectTimeout = 5,
 	databaseUrl,
@@ -99,7 +99,7 @@ const isProd = process.env.NODE_ENV === "production";
 
 export const { db: dbCritical, client: clientCritical } = initDrizzle({
 	name: "critical",
-	maxConnections: 15,
+	maxConnections: isProd ? 100 : 10,
 	connectTimeout: isProd ? 2 : 30,
 	databaseUrl: process.env.DATABASE_CRITICAL_URL,
 	poolConfig: {
@@ -120,7 +120,7 @@ const replicaResult = process.env.DATABASE_REPLICA_URL
 	? initDrizzle({
 			name: "replica",
 			replica: true,
-			maxConnections: 15,
+			maxConnections: 100,
 			connectTimeout: null,
 		})
 	: null;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increased Postgres connection pool limits to 100 in production to prevent connection starvation under load. Applies to default, critical, and replica pools.

- **Bug Fixes**
  - Default `initDrizzle` `maxConnections`: 70 → 100 in prod.
  - `dbCritical`: now `isProd ? 100 : 10` (was 15).
  - Replica: `maxConnections` set to 100; timeouts unchanged.

- **Dependencies**
  - Updated `ai` submodule pointer.

<sup>Written for commit dd608f5a16d908d3913d810efbe1294ab3a8135f. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1677?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR raises connection pool sizes across all three database pools to address connection exhaustion. The `dbCritical` pool was the most constrained (hardcoded at 15) and is the likely source of the issue being fixed.

- **[Bug fixes]** `dbCritical` pool limit raised from 15 → `isProd ? 100 : 10`, with an `isProd` guard added to distinguish prod from dev — the previous hardcoded 15 was shared across all environments.
- **[Improvements]** `initDrizzle` default `maxConnections` raised from 70 → 100 in prod; replica pool raised from 15 → 100.
- **[Improvements]** `ai` submodule pointer updated.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are limited to pool size configuration with no logic alterations.

The critical pool going from 15 to 100 connections in production is a large jump. The aggregate connection budget is now 300 per process (general + critical + replica), and the replica pool hardcodes 100 regardless of environment — both worth verifying against the upstream Postgres/PgBouncer limits before deploying at scale.

server/src/db/initDrizzle.ts — specifically the aggregate connection count and the replica pool's lack of an `isProd` guard.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/db/initDrizzle.ts | Increases pool sizes for critical (15→100), general default (70→100), and replica (15→100) pools. Adds `isProd` guard to critical pool, but replica remains hardcoded at 100 without env awareness. |
| ai | Git submodule pointer update only; no reviewable source changes. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Server Process] --> B[dbGeneral\nmax: 100 prod / 10 dev]
    A --> C[dbCritical\nmax: 100 prod / 10 dev]
    A --> D{DATABASE_REPLICA_URL?}
    D -- Yes --> E[dbReplica\nmax: 100 always]
    D -- No --> F[null]
    B --> G[(PostgreSQL / PgBouncer)]
    C --> G
    E --> G
    G --> H[Total per process\n200-300 connections in prod]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/db/initDrizzle.ts`, line 119-126 ([link](https://github.com/useautumn/autumn/blob/dd608f5a16d908d3913d810efbe1294ab3a8135f/server/src/db/initDrizzle.ts#L119-L126)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Replica pool ignores `isProd` for `maxConnections`**

   The replica pool is the only one that doesn't apply the `isProd ? 100 : 10` guard added to the other pools. If `DATABASE_REPLICA_URL` is ever configured in a dev or staging environment, the replica pool will open up to 100 connections instead of the 10 that other pools are capped at in non-prod. The other two pool call-sites (critical and the `initDrizzle` default) both gate on `isProd`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/db/initDrizzle.ts
   Line: 119-126

   Comment:
   **Replica pool ignores `isProd` for `maxConnections`**

   The replica pool is the only one that doesn't apply the `isProd ? 100 : 10` guard added to the other pools. If `DATABASE_REPLICA_URL` is ever configured in a dev or staging environment, the replica pool will open up to 100 connections instead of the 10 that other pools are capped at in non-prod. The other two pool call-sites (critical and the `initDrizzle` default) both gate on `isProd`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/db/initDrizzle.ts`, line 100-128 ([link](https://github.com/useautumn/autumn/blob/dd608f5a16d908d3913d810efbe1294ab3a8135f/server/src/db/initDrizzle.ts#L100-L128)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Aggregate connection budget now 300 per process**

   Each of the three pools (`dbGeneral`, `dbCritical`, `dbReplica`) is now sized at 100 connections, totalling 300 per server process. Multiplied by replica/horizontal-scale instance count, this can easily saturate Postgres's `max_connections` (or a PgBouncer pool limit). Before this PR the critical and replica pools were each capped at 15. Worth confirming that the upstream connection limit (Postgres or pooler) has headroom for `300 × instance_count` before rolling out to production.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/db/initDrizzle.ts
   Line: 100-128

   Comment:
   **Aggregate connection budget now 300 per process**

   Each of the three pools (`dbGeneral`, `dbCritical`, `dbReplica`) is now sized at 100 connections, totalling 300 per server process. Multiplied by replica/horizontal-scale instance count, this can easily saturate Postgres's `max_connections` (or a PgBouncer pool limit). Before this PR the critical and replica pools were each capped at 15. Worth confirming that the upstream connection limit (Postgres or pooler) has headroom for `300 × instance_count` before rolling out to production.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/db/initDrizzle.ts:119-126
**Replica pool ignores `isProd` for `maxConnections`**

The replica pool is the only one that doesn't apply the `isProd ? 100 : 10` guard added to the other pools. If `DATABASE_REPLICA_URL` is ever configured in a dev or staging environment, the replica pool will open up to 100 connections instead of the 10 that other pools are capped at in non-prod. The other two pool call-sites (critical and the `initDrizzle` default) both gate on `isProd`.

### Issue 2 of 2
server/src/db/initDrizzle.ts:100-128
**Aggregate connection budget now 300 per process**

Each of the three pools (`dbGeneral`, `dbCritical`, `dbReplica`) is now sized at 100 connections, totalling 300 per server process. Multiplied by replica/horizontal-scale instance count, this can easily saturate Postgres's `max_connections` (or a PgBouncer pool limit). Before this PR the critical and replica pools were each capped at 15. Worth confirming that the upstream connection limit (Postgres or pooler) has headroom for `300 × instance_count` before rolling out to production.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: connection pooling"](https://github.com/useautumn/autumn/commit/dd608f5a16d908d3913d810efbe1294ab3a8135f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33248711)</sub>

<!-- /greptile_comment -->