### PR TITLE
fix: increase connection pooling

### DIFF
--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -99,12 +99,14 @@ const isProd = process.env.NODE_ENV === "production";
 
 export const { db: dbCritical, client: clientCritical } = initDrizzle({
 	name: "critical",
-	maxConnections: 15,
+	maxConnections: isProd ? 100 : 10,
 	connectTimeout: isProd ? 2 : 30,
 	databaseUrl: process.env.DATABASE_CRITICAL_URL,
 	poolConfig: {
 		application_name: "autumn-critical",
 		query_timeout: isProd ? 2_000 : 30_000,
+		// Keep 10 warm conns to avoid TLS-handshake stampedes on bursty traffic.
+		min: 10,
 	},
 });
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase Postgres connection pooling for the critical DB and keep a warm pool to smooth burst traffic. This reduces connection churn and lowers latency in production.

- **Bug Fixes**
  - Raised maxConnections to 100 in production (10 in development).
  - Set pool min to 10 to keep warm connections and avoid TLS-handshake stampedes.

<sup>Written for commit d3ac2da7783988bf86aad35eecbbbe00963b0964. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1678?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Increases the `dbCritical` connection pool ceiling from a fixed 15 to 100 in production (10 in dev) and adds a 10-connection warm floor to the critical pool to reduce TLS-handshake latency spikes under bursty load.

- **[Improvements]** `maxConnections` for `dbCritical` now scales with environment (`isProd ? 100 : 10`), giving production significantly more headroom under load.
- **[Improvements]** `min: 10` is added to the critical pool's config so 10 connections are kept warm, avoiding cold-start TLS overhead during traffic bursts.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the production path is correct and the only concern is that `min` equals `max` in dev, keeping all 10 connections permanently warm locally.

The production configuration is straightforward and correct — `max = 100`, `min = 10` is a valid and intentional warm-pool setup. The only issue is that the hardcoded `min: 10` matches `maxConnections` (also 10) in development, so local pools will hold all connections open rather than idling down.

No files require special attention; the change is isolated to the `dbCritical` pool configuration in `server/src/db/initDrizzle.ts`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/initDrizzle.ts | Raises `dbCritical` max connections from 15 to 100 in production and adds a `min: 10` warm-connection floor; `min` is hardcoded and equals `max` (10) in dev, keeping all connections permanently open locally. |
| ai | Submodule pointer bump — no reviewable code change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/db/initDrizzle.ts:108-109
In development, `maxConnections` is `10` and `min` is also hardcoded to `10`, so `min === max`. Every dev environment will permanently hold all 10 connections open from the moment the pool is created, which is heavier than necessary locally. Scaling `min` with the environment keeps the warm-connection intent in production while leaving dev lightweight.

```suggestion
		// Keep 10 warm conns to avoid TLS-handshake stampedes on bursty traffic.
		min: isProd ? 10 : 2,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: increase connection pooling"](https://github.com/useautumn/autumn/commit/d3ac2da7783988bf86aad35eecbbbe00963b0964) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33269263)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->