### PR TITLE
feat: 🎸 worlds best theem

### DIFF
--- a/vite/src/contexts/ThemeProvider.tsx
+++ b/vite/src/contexts/ThemeProvider.tsx
@@ -3,7 +3,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 
 type ThemeMode = "light" | "dark" | "system";
-type ThemePreset = "modern" | "classic";
+export type ThemePreset = "modern" | "classic" | "cursed";
 
 interface ThemeContextType {
 	mode: ThemeMode;
@@ -40,7 +40,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
 	useEffect(() => {
 		const root = document.documentElement;
-		root.classList.remove("preset-classic", "preset-modern");
+		root.classList.remove("preset-classic", "preset-modern", "preset-cursed");
 		root.classList.add(`preset-${preset}`);
 	}, [preset]);
 

--- a/vite/src/index.css
+++ b/vite/src/index.css
@@ -3,6 +3,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Rubik+Glitch&family=Nabla&family=Noto+Sans+Cuneiform&display=swap");
 
 @import "tailwindcss";
 @import "tailwind-scrollbar-hide/v4";
@@ -203,6 +204,46 @@ html {
 .preset-modern.dark [data-slot="sheet-overlay"],
 .preset-modern.dark [data-slot="dialog-overlay"] {
 	background-color: rgb(0 0 0 / 0.6) !important;
+}
+
+/* Cursed preset — admin-only joke. Eldritch space font + hideous palette. */
+.preset-cursed {
+	font-family: "Rubik Glitch", "Nabla", "Noto Sans Cuneiform", "Comic Sans MS", cursive !important;
+	background-color: #ff00aa;
+	--background: #ff00aa;
+	--outer-background: #00ff88;
+	--foreground: #ffff00;
+	--muted-foreground: #00ffff;
+	--tertiary-foreground: #ff8800;
+	--primary: #00ff00;
+	--primary-foreground: #ff00ff;
+	--active-primary: #ffff00;
+	--hover-primary: #00ffff;
+	--interactive-secondary: #ff66cc;
+	--interactive-secondary-hover: #ccff00;
+	--card: #00ddff;
+	--border: #ff0000;
+	--input: #ff0000;
+	--input-background: #ffff00;
+	--muted: #ff66cc;
+	--destructive: #00ff00;
+	letter-spacing: 0.05em;
+}
+
+.preset-cursed.dark {
+	background-color: #2a0033;
+	--background: #2a0033;
+	--outer-background: #003322;
+	--foreground: #00ff88;
+	--muted-foreground: #ff66cc;
+	--card: #330044;
+	--border: #ff00ff;
+	--interactive-secondary: #220033;
+	--interactive-secondary-hover: #441166;
+}
+
+.preset-cursed * {
+	font-family: inherit !important;
 }
 
 @theme inline {

--- a/vite/src/views/settings/sections/AppearanceSection.tsx
+++ b/vite/src/views/settings/sections/AppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { Leaf, Monitor, Moon, Sun } from "lucide-react";
+import { Leaf, Monitor, Moon, Skull, Sun } from "lucide-react";
 import {
 	Card,
 	CardContent,
@@ -8,6 +8,7 @@ import {
 } from "@/components/v2/cards/Card";
 import { useTheme } from "@/contexts/ThemeProvider";
 import { cn } from "@/lib/utils";
+import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { SettingsSection } from "../SettingsSection";
 
 interface PreviewColors {
@@ -52,6 +53,14 @@ const PRESET_OPTIONS = [
 		light: { bg: "bg-white", sidebar: "bg-[#fafaf9]", card: "bg-[#f7f7f7]", line: "bg-[#e5e5e5]", header: "bg-[#fafaf9]", dot: "bg-[#d1d1d1]" },
 		dark: { bg: "bg-[#0a0a0a]", sidebar: "bg-[#000000]", card: "bg-[#0f0f0f]", line: "bg-[#1a1a1a]", header: "bg-[#0f0f0f]", dot: "bg-[#2a2a2a]" },
 	},
+	{
+		id: "cursed",
+		label: "Cursed",
+		description: "A̸ ̷g̶r̴e̵a̷t̸ ̶T̵a̴n̶v̷i̴r̸ ̵A̶h̷m̴e̸d̵ ̷s̶p̴e̵c̷i̸a̶l̴",
+		icon: <Skull className="size-5 text-muted-foreground" />,
+		light: { bg: "bg-[#ff00aa]", sidebar: "bg-[#00ff88]", card: "bg-[#00ddff]", line: "bg-[#ff0000]", header: "bg-[#ffff00]", dot: "bg-[#ff8800]" },
+		dark: { bg: "bg-[#2a0033]", sidebar: "bg-[#003322]", card: "bg-[#330044]", line: "bg-[#ff00ff]", header: "bg-[#441166]", dot: "bg-[#00ff88]" },
+	},
 ] as const;
 
 const tc = "transition-colors duration-200";
@@ -95,6 +104,10 @@ const systemPrefersDark = () =>
 
 export const AppearanceSection = () => {
 	const { mode, setMode, preset, setPreset, isDark } = useTheme();
+	const { isAdmin } = useAdmin();
+	const presetOptions = PRESET_OPTIONS.filter(
+		(p) => p.id !== "cursed" || isAdmin,
+	);
 
 	return (
 		<SettingsSection
@@ -135,19 +148,20 @@ export const AppearanceSection = () => {
 				</CardHeader>
 				<CardContent>
 					<div className="grid grid-cols-2 gap-3">
-						{PRESET_OPTIONS.map((option) => {
+						{presetOptions.map((option) => {
 							const isActive = preset === option.id;
 							return (
 								<button
 									key={option.id}
 									type="button"
 									onClick={() => setPreset(option.id)}
-									className={cn(
-										"flex flex-col gap-2.5 rounded-lg border p-2.5 transition-all duration-200 cursor-pointer text-left",
-										isActive
-											? "border-primary ring-2 ring-primary/20 ring-offset-1 ring-offset-background"
-											: "border-border hover:border-muted-foreground/30",
-									)}
+								className={cn(
+									"flex flex-col gap-2.5 rounded-lg border p-2.5 transition-all duration-200 cursor-pointer text-left",
+									option.id === "cursed" && "col-span-2",
+									isActive
+										? "border-primary ring-2 ring-primary/20 ring-offset-1 ring-offset-background"
+										: "border-border hover:border-muted-foreground/30",
+								)}
 								>
 									<ThemePreview colors={isDark ? option.dark : option.light} height="h-[80px]" />
 									<div className="flex items-center gap-2.5 px-0.5">


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an admin‑only “Cursed” theme preset with a loud color palette and glitch fonts. Updates theme context and Appearance settings; non‑admins won’t see the option.

- **New Features**
  - Added `cursed` preset to `ThemePreset` and root class toggling (`preset-cursed`) in the theme provider.
  - Introduced light/dark CSS tokens for `cursed` and imported new fonts (“Rubik Glitch”, “Nabla”, “Noto Sans Cuneiform”); enforce font inheritance under `.preset-cursed`.
  - Updated Appearance settings to show the “Cursed” option with a skull icon only for admins via `useAdmin`, and make it span two columns in the grid.

<sup>Written for commit 35a22ffa3e20e9209f1a9fc8f5043c218f5ca9ec. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1679?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Review completed and submitted via the greptile-review MCP tools.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; admin-only cosmetic feature with no data or auth impact.

All findings are non-blocking style and minor logic observations.

vite/src/index.css and vite/src/views/settings/sections/AppearanceSection.tsx

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 worlds best theem"](https://github.com/useautumn/autumn/commit/35a22ffa3e20e9209f1a9fc8f5043c218f5ca9ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33283582)</sub>

<!-- /greptile_comment -->