### PR TITLE
add whitelisted fullsubject cache warmer

### DIFF
--- a/server/src/honoMiddlewares/refreshCacheMiddleware.ts
+++ b/server/src/honoMiddlewares/refreshCacheMiddleware.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { warmFullSubjectCache } from "@/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { getRefreshCacheRouteConfig } from "./refreshCacheConfigs.js";
 
@@ -34,6 +35,12 @@ export const refreshCacheMiddleware = async (
 		customerId: ctx.customerId,
 		entityId: ctx.entityId,
 		ctx,
+		source: "refreshCacheMiddleware",
+	});
+
+	warmFullSubjectCache({
+		ctx,
+		customerId: ctx.customerId,
 		source: "refreshCacheMiddleware",
 	});
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -14,6 +14,7 @@ const warmEnqueueFailedCounter = meter.createCounter(
 
 const WARM_CACHE_CUSTOMER_IDS = new Set<string>([
 	"64138004cce3c9e82a7083d9",
+	"cache-warmer-feature-test-cus",
 ]);
 
 export const shouldWarmCache = (customerId: string | undefined): boolean => {

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -1,0 +1,141 @@
+import { metrics } from "@opentelemetry/api";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { buildFullSubjectViewEpochKey } from "../builders/buildFullSubjectViewEpochKey.js";
+import { setCachedFullSubject } from "./setCachedFullSubject/setCachedFullSubject.js";
+
+const meter = metrics.getMeter("autumn-server");
+const warmStartedCounter = meter.createCounter("autumn.cache.warm.started", {
+	description: "FullSubject cache warm attempts initiated",
+});
+const warmCompletedCounter = meter.createCounter(
+	"autumn.cache.warm.completed",
+	{ description: "FullSubject cache warms that wrote a value" },
+);
+const warmSkippedCounter = meter.createCounter("autumn.cache.warm.skipped", {
+	description:
+		"FullSubject cache warms skipped (already running, missing data, etc.)",
+});
+const warmFailedCounter = meter.createCounter("autumn.cache.warm.failed", {
+	description: "FullSubject cache warms that threw",
+});
+
+const inflight = new Map<string, Promise<void>>();
+
+const parseAllowlist = (): Set<string> => {
+	const raw = process.env.WARM_CACHE_CUSTOMER_IDS ?? "";
+	return new Set(
+		raw
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean),
+	);
+};
+
+let allowlist: Set<string> | null = null;
+const getAllowlist = (): Set<string> => {
+	if (allowlist === null) allowlist = parseAllowlist();
+	return allowlist;
+};
+
+export const shouldWarmCache = (customerId: string | undefined): boolean => {
+	if (!customerId) return false;
+	return getAllowlist().has(customerId);
+};
+
+const readCurrentEpoch = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+}): Promise<number> => {
+	const { org, env, redisV2 } = ctx;
+	const epochKey = buildFullSubjectViewEpochKey({
+		orgId: org.id,
+		env,
+		customerId,
+	});
+	const raw = await runRedisOp({
+		operation: () => redisV2.get(epochKey),
+		source: "warmFullSubjectCache:readEpoch",
+		redisInstance: redisV2,
+	});
+	if (raw === null || raw === undefined) return 0;
+	const parsed = Number.parseInt(String(raw), 10);
+	return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+/**
+ * Eagerly re-populate the customer-level FullSubject cache after invalidation.
+ * Fire-and-forget — never blocks the caller, never throws.
+ *
+ * Gated by `WARM_CACHE_CUSTOMER_IDS` env var to limit blast radius. Uses an
+ * in-process single-flight Map so a write burst against the same customer
+ * doesn't fan out into N concurrent hydrations. The underlying Lua write
+ * is conditional on `fetchedSubjectViewEpoch`, so a racing invalidate is
+ * safe: the warm becomes a no-op when its epoch is stale.
+ *
+ * Scope: customer-level subject only. Entity-level keys are NOT re-warmed
+ * (one warm per entity would itself be a storm). Reads for individual
+ * entities still hydrate on miss.
+ */
+export const warmFullSubjectCache = ({
+	ctx,
+	customerId,
+	source,
+}: {
+	ctx: AutumnContext;
+	customerId: string | undefined;
+	source?: string;
+}): void => {
+	if (!shouldWarmCache(customerId)) return;
+	const id = customerId as string;
+	// Scope single-flight to (org, env, customer) so two orgs sharing an
+	// upstream customer id don't suppress each other's warms.
+	const inflightKey = `${ctx.org.id}:${ctx.env}:${id}`;
+
+	if (inflight.has(inflightKey)) {
+		warmSkippedCounter.add(1, { reason: "already_running" });
+		return;
+	}
+
+	warmStartedCounter.add(1, { source: source ?? "unknown" });
+
+	const promise = (async () => {
+		try {
+			const epoch = await readCurrentEpoch({ ctx, customerId: id });
+			const normalizedResult = await getFullSubjectNormalized({
+				ctx,
+				customerId: id,
+			});
+			if (!normalizedResult) {
+				warmSkippedCounter.add(1, { reason: "no_data" });
+				return;
+			}
+			const writeResult = await setCachedFullSubject({
+				ctx,
+				normalized: normalizedResult.normalized,
+				fetchedSubjectViewEpoch: epoch,
+			});
+			if (writeResult === "OK") {
+				warmCompletedCounter.add(1, { source: source ?? "unknown" });
+			} else {
+				// STALE_WRITE / CACHE_EXISTS / FAILED — Lua bailed; no value written.
+				warmSkippedCounter.add(1, { reason: writeResult.toLowerCase() });
+			}
+		} catch (error) {
+			warmFailedCounter.add(1, { source: source ?? "unknown" });
+			ctx.logger.warn(
+				`[warmFullSubjectCache] customer=${id} source=${source} error=${error}`,
+			);
+		} finally {
+			// Inside the try/catch scope so a throw from the metric or logger
+			// above doesn't escape as an unhandled rejection.
+			inflight.delete(inflightKey);
+		}
+	})();
+
+	inflight.set(inflightKey, promise);
+};

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -1,7 +1,7 @@
 import { metrics } from "@opentelemetry/api";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
-import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import { buildFullSubjectViewEpochKey } from "../builders/buildFullSubjectViewEpochKey.js";
 import { setCachedFullSubject } from "./setCachedFullSubject/setCachedFullSubject.js";
 
@@ -18,30 +18,18 @@ const warmSkippedCounter = meter.createCounter("autumn.cache.warm.skipped", {
 		"FullSubject cache warms skipped (already running, missing data, etc.)",
 });
 const warmFailedCounter = meter.createCounter("autumn.cache.warm.failed", {
-	description: "FullSubject cache warms that threw",
+	description: "FullSubject cache warms that threw or failed to write",
 });
 
 const inflight = new Map<string, Promise<void>>();
 
-const parseAllowlist = (): Set<string> => {
-	const raw = process.env.WARM_CACHE_CUSTOMER_IDS ?? "";
-	return new Set(
-		raw
-			.split(",")
-			.map((s) => s.trim())
-			.filter(Boolean),
-	);
-};
-
-let allowlist: Set<string> | null = null;
-const getAllowlist = (): Set<string> => {
-	if (allowlist === null) allowlist = parseAllowlist();
-	return allowlist;
-};
+const WARM_CACHE_CUSTOMER_IDS = new Set<string>([
+	"64138004cce3c9e82a7083d9",
+]);
 
 export const shouldWarmCache = (customerId: string | undefined): boolean => {
 	if (!customerId) return false;
-	return getAllowlist().has(customerId);
+	return WARM_CACHE_CUSTOMER_IDS.has(customerId);
 };
 
 const readCurrentEpoch = async ({
@@ -75,14 +63,15 @@ export const warmFullSubjectCache = ({
 	ctx: AutumnContext;
 	customerId: string | undefined;
 	source?: string;
-}): void => {
-	if (!shouldWarmCache(customerId)) return;
+}): Promise<void> | undefined => {
+	if (!shouldWarmCache(customerId)) return undefined;
 	const id = customerId as string;
 	const inflightKey = `${ctx.org.id}:${ctx.env}:${id}`;
 
-	if (inflight.has(inflightKey)) {
+	const existingPromise = inflight.get(inflightKey);
+	if (existingPromise) {
 		warmSkippedCounter.add(1, { reason: "already_running" });
-		return;
+		return existingPromise;
 	}
 
 	warmStartedCounter.add(1, { source: source ?? "unknown" });
@@ -105,11 +94,22 @@ export const warmFullSubjectCache = ({
 			});
 			if (writeResult === "OK") {
 				warmCompletedCounter.add(1, { source: source ?? "unknown" });
+			} else if (writeResult === "FAILED") {
+				warmFailedCounter.add(1, {
+					source: source ?? "unknown",
+					reason: "write_failed",
+				});
+				ctx.logger.error(
+					`[warmFullSubjectCache] Cache warm write FAILED for customer=${id} source=${source}`,
+				);
 			} else {
 				warmSkippedCounter.add(1, { reason: writeResult.toLowerCase() });
 			}
 		} catch (error) {
-			warmFailedCounter.add(1, { source: source ?? "unknown" });
+			warmFailedCounter.add(1, {
+				source: source ?? "unknown",
+				reason: "exception",
+			});
 			ctx.logger.warn(
 				`[warmFullSubjectCache] customer=${id} source=${source} error=${error}`,
 			);
@@ -119,4 +119,5 @@ export const warmFullSubjectCache = ({
 	})();
 
 	inflight.set(inflightKey, promise);
+	return promise;
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -1,27 +1,16 @@
 import { metrics } from "@opentelemetry/api";
-import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
-import { buildFullSubjectViewEpochKey } from "../builders/buildFullSubjectViewEpochKey.js";
-import { setCachedFullSubject } from "./setCachedFullSubject/setCachedFullSubject.js";
+import { warmFullSubjectCacheTask } from "@/trigger/cache/warmFullSubjectCacheTask.js";
 
 const meter = metrics.getMeter("autumn-server");
-const warmStartedCounter = meter.createCounter("autumn.cache.warm.started", {
-	description: "FullSubject cache warm attempts initiated",
-});
-const warmCompletedCounter = meter.createCounter(
-	"autumn.cache.warm.completed",
-	{ description: "FullSubject cache warms that wrote a value" },
+const warmEnqueuedCounter = meter.createCounter(
+	"autumn.cache.warm.enqueued",
+	{ description: "FullSubject cache warm enqueues" },
 );
-const warmSkippedCounter = meter.createCounter("autumn.cache.warm.skipped", {
-	description:
-		"FullSubject cache warms skipped (already running, missing data, etc.)",
-});
-const warmFailedCounter = meter.createCounter("autumn.cache.warm.failed", {
-	description: "FullSubject cache warms that threw or failed to write",
-});
-
-const inflight = new Map<string, Promise<void>>();
+const warmEnqueueFailedCounter = meter.createCounter(
+	"autumn.cache.warm.enqueue_failed",
+	{ description: "FullSubject cache warm enqueue failures" },
+);
 
 const WARM_CACHE_CUSTOMER_IDS = new Set<string>([
 	"64138004cce3c9e82a7083d9",
@@ -32,29 +21,6 @@ export const shouldWarmCache = (customerId: string | undefined): boolean => {
 	return WARM_CACHE_CUSTOMER_IDS.has(customerId);
 };
 
-const readCurrentEpoch = async ({
-	ctx,
-	customerId,
-}: {
-	ctx: AutumnContext;
-	customerId: string;
-}): Promise<number> => {
-	const { org, env, redisV2 } = ctx;
-	const epochKey = buildFullSubjectViewEpochKey({
-		orgId: org.id,
-		env,
-		customerId,
-	});
-	const raw = await runRedisOp({
-		operation: () => redisV2.get(epochKey),
-		source: "warmFullSubjectCache:readEpoch",
-		redisInstance: redisV2,
-	});
-	if (raw === null || raw === undefined) return 0;
-	const parsed = Number.parseInt(String(raw), 10);
-	return Number.isNaN(parsed) ? 0 : parsed;
-};
-
 export const warmFullSubjectCache = ({
 	ctx,
 	customerId,
@@ -63,61 +29,29 @@ export const warmFullSubjectCache = ({
 	ctx: AutumnContext;
 	customerId: string | undefined;
 	source?: string;
-}): Promise<void> | undefined => {
-	if (!shouldWarmCache(customerId)) return undefined;
+}): void => {
+	if (!shouldWarmCache(customerId)) return;
 	const id = customerId as string;
-	const inflightKey = `${ctx.org.id}:${ctx.env}:${id}`;
 
-	const existingPromise = inflight.get(inflightKey);
-	if (existingPromise) {
-		warmSkippedCounter.add(1, { reason: "already_running" });
-		return existingPromise;
-	}
-
-	warmStartedCounter.add(1, { source: source ?? "unknown" });
-
-	const promise = (async () => {
-		try {
-			const epoch = await readCurrentEpoch({ ctx, customerId: id });
-			const normalizedResult = await getFullSubjectNormalized({
-				ctx,
+	void warmFullSubjectCacheTask
+		.trigger(
+			{
+				orgId: ctx.org.id,
+				env: ctx.env,
 				customerId: id,
-			});
-			if (!normalizedResult) {
-				warmSkippedCounter.add(1, { reason: "no_data" });
-				return;
-			}
-			const writeResult = await setCachedFullSubject({
-				ctx,
-				normalized: normalizedResult.normalized,
-				fetchedSubjectViewEpoch: epoch,
-			});
-			if (writeResult === "OK") {
-				warmCompletedCounter.add(1, { source: source ?? "unknown" });
-			} else if (writeResult === "FAILED") {
-				warmFailedCounter.add(1, {
-					source: source ?? "unknown",
-					reason: "write_failed",
-				});
-				ctx.logger.error(
-					`[warmFullSubjectCache] Cache warm write FAILED for customer=${id} source=${source}`,
-				);
-			} else {
-				warmSkippedCounter.add(1, { reason: writeResult.toLowerCase() });
-			}
-		} catch (error) {
-			warmFailedCounter.add(1, {
-				source: source ?? "unknown",
-				reason: "exception",
-			});
+				source,
+			},
+			{
+				concurrencyKey: `${ctx.org.id}:${ctx.env}:${id}`,
+			},
+		)
+		.then(() => {
+			warmEnqueuedCounter.add(1, { source: source ?? "unknown" });
+		})
+		.catch((error) => {
+			warmEnqueueFailedCounter.add(1, { source: source ?? "unknown" });
 			ctx.logger.warn(
-				`[warmFullSubjectCache] customer=${id} source=${source} error=${error}`,
+				`[warmFullSubjectCache] enqueue failed customer=${id} source=${source} error=${error}`,
 			);
-		} finally {
-			inflight.delete(inflightKey);
-		}
-	})();
-
-	inflight.set(inflightKey, promise);
-	return promise;
+		});
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -67,20 +67,6 @@ const readCurrentEpoch = async ({
 	return Number.isNaN(parsed) ? 0 : parsed;
 };
 
-/**
- * Eagerly re-populate the customer-level FullSubject cache after invalidation.
- * Fire-and-forget — never blocks the caller, never throws.
- *
- * Gated by `WARM_CACHE_CUSTOMER_IDS` env var to limit blast radius. Uses an
- * in-process single-flight Map so a write burst against the same customer
- * doesn't fan out into N concurrent hydrations. The underlying Lua write
- * is conditional on `fetchedSubjectViewEpoch`, so a racing invalidate is
- * safe: the warm becomes a no-op when its epoch is stale.
- *
- * Scope: customer-level subject only. Entity-level keys are NOT re-warmed
- * (one warm per entity would itself be a storm). Reads for individual
- * entities still hydrate on miss.
- */
 export const warmFullSubjectCache = ({
 	ctx,
 	customerId,
@@ -92,8 +78,6 @@ export const warmFullSubjectCache = ({
 }): void => {
 	if (!shouldWarmCache(customerId)) return;
 	const id = customerId as string;
-	// Scope single-flight to (org, env, customer) so two orgs sharing an
-	// upstream customer id don't suppress each other's warms.
 	const inflightKey = `${ctx.org.id}:${ctx.env}:${id}`;
 
 	if (inflight.has(inflightKey)) {
@@ -122,7 +106,6 @@ export const warmFullSubjectCache = ({
 			if (writeResult === "OK") {
 				warmCompletedCounter.add(1, { source: source ?? "unknown" });
 			} else {
-				// STALE_WRITE / CACHE_EXISTS / FAILED — Lua bailed; no value written.
 				warmSkippedCounter.add(1, { reason: writeResult.toLowerCase() });
 			}
 		} catch (error) {
@@ -131,8 +114,6 @@ export const warmFullSubjectCache = ({
 				`[warmFullSubjectCache] customer=${id} source=${source} error=${error}`,
 			);
 		} finally {
-			// Inside the try/catch scope so a throw from the metric or logger
-			// above doesn't escape as an unhandled rejection.
 			inflight.delete(inflightKey);
 		}
 	})();

--- a/server/src/trigger/cache/warmFullSubjectCacheTask.ts
+++ b/server/src/trigger/cache/warmFullSubjectCacheTask.ts
@@ -1,14 +1,12 @@
 import { AppEnv } from "@autumn/shared";
-import { task } from "@trigger.dev/sdk/v3";
 import { metrics } from "@opentelemetry/api";
+import { task } from "@trigger.dev/sdk/v3";
 import { z } from "zod/v4";
 import { warmupRegionalRedis } from "@/external/redis/initUtils/redisWarmup.js";
-import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
-import { buildFullSubjectViewEpochKey } from "@/internal/customers/cache/fullSubject/builders/buildFullSubjectViewEpochKey.js";
-import { setCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.js";
-import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
-import { CusService } from "@/internal/customers/CusService.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
 import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
 
 const meter = metrics.getMeter("autumn-server");
@@ -34,7 +32,103 @@ const PayloadSchema = z.object({
 
 export type WarmFullSubjectCachePayload = z.infer<typeof PayloadSchema>;
 
-const ENTITY_BATCH_SIZE = 10;
+const ENTITY_BATCH_SIZE = 25;
+const BATCH_PAUSE_MS = 100;
+
+export type WarmFullSubjectResult = {
+	warmed_customer: number;
+	warmed_entities: number;
+	total_entities: number;
+};
+
+export const runWarmFullSubjectCache = async ({
+	ctx,
+	customerId,
+	source,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	source?: string;
+}): Promise<WarmFullSubjectResult> => {
+	const customer = await CusService.get({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		idOrInternalId: customerId,
+	});
+	if (!customer) {
+		warmSkippedCounter.add(1, { reason: "customer_not_found" });
+		ctx.logger.warn(
+			`warm-full-subject-cache: customer not found id=${customerId}`,
+		);
+		return { warmed_customer: 0, warmed_entities: 0, total_entities: 0 };
+	}
+
+	let warmedCustomer = 0;
+	try {
+		await getOrSetCachedFullSubject({
+			ctx,
+			customerId,
+			source: source ?? "warm-full-subject-cache",
+		});
+		warmCustomerCounter.add(1, { source: source ?? "unknown" });
+		warmedCustomer = 1;
+	} catch (error) {
+		warmFailedCounter.add(1, { reason: "customer_hydrate" });
+		ctx.logger.warn(
+			`warm-full-subject-cache: customer-level warm failed customer=${customerId} error=${error}`,
+		);
+	}
+
+	const entities = await EntityService.list({
+		db: ctx.db,
+		internalCustomerId: customer.internal_id,
+		isDeleted: false,
+	});
+
+	let warmedEntities = 0;
+	for (let i = 0; i < entities.length; i += ENTITY_BATCH_SIZE) {
+		const batch = entities.slice(i, i + ENTITY_BATCH_SIZE);
+		const results = await Promise.allSettled(
+			batch.map(async (entity) => {
+				const entityId = entity.id ?? entity.internal_id;
+				if (!entityId) return false;
+				await getOrSetCachedFullSubject({
+					ctx,
+					customerId,
+					entityId,
+					source: source ?? "warm-full-subject-cache",
+				});
+				return true;
+			}),
+		);
+		for (const r of results) {
+			if (r.status === "fulfilled" && r.value === true) warmedEntities++;
+			else if (r.status === "rejected") {
+				warmFailedCounter.add(1, { reason: "entity_hydrate" });
+			} else {
+				warmSkippedCounter.add(1, { reason: "entity_write_skipped" });
+			}
+		}
+
+		// Pace successive batches so DB+Redis don't see a burst when a
+		// customer has many entities.
+		if (i + ENTITY_BATCH_SIZE < entities.length) {
+			await new Promise((resolve) => setTimeout(resolve, BATCH_PAUSE_MS));
+		}
+	}
+
+	warmEntityCounter.add(warmedEntities, { source: source ?? "unknown" });
+	ctx.logger.info(
+		`warm-full-subject-cache: customer=${customerId} warmed_customer=${warmedCustomer} warmed_entities=${warmedEntities}/${entities.length} source=${source}`,
+	);
+
+	return {
+		warmed_customer: warmedCustomer,
+		warmed_entities: warmedEntities,
+		total_entities: entities.length,
+	};
+};
 
 export const warmFullSubjectCacheTask = task({
 	id: "warm-full-subject-cache",
@@ -55,107 +149,6 @@ export const warmFullSubjectCacheTask = task({
 			}),
 		);
 
-		const customer = await CusService.get({
-			db: ctx.db,
-			orgId: ctx.org.id,
-			env: ctx.env,
-			idOrInternalId: customerId,
-		});
-		if (!customer) {
-			warmSkippedCounter.add(1, { reason: "customer_not_found" });
-			logger.warn(
-				`warm-full-subject-cache: customer not found id=${customerId}`,
-			);
-			return { warmed_customer: 0, warmed_entities: 0 };
-		}
-
-		const epochKey = buildFullSubjectViewEpochKey({
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId,
-		});
-		const epochRaw = await runRedisOp({
-			operation: () => ctx.redisV2.get(epochKey),
-			source: "warm-full-subject-cache:read-epoch",
-			redisInstance: ctx.redisV2,
-		});
-		const parsed = epochRaw == null ? 0 : Number.parseInt(String(epochRaw), 10);
-		const epoch = Number.isNaN(parsed) ? 0 : parsed;
-
-		let warmedCustomer = 0;
-		try {
-			const customerSubject = await getFullSubjectNormalized({
-				ctx,
-				customerId,
-			});
-			if (customerSubject) {
-				const result = await setCachedFullSubject({
-					ctx,
-					normalized: customerSubject.normalized,
-					fetchedSubjectViewEpoch: epoch,
-				});
-				if (result === "OK") {
-					warmCustomerCounter.add(1, { source: source ?? "unknown" });
-					warmedCustomer = 1;
-				} else {
-					warmSkippedCounter.add(1, { reason: result.toLowerCase() });
-				}
-			} else {
-				warmSkippedCounter.add(1, { reason: "no_customer_data" });
-			}
-		} catch (error) {
-			warmFailedCounter.add(1, { reason: "customer_hydrate" });
-			logger.warn(
-				`warm-full-subject-cache: customer-level warm failed customer=${customerId} error=${error}`,
-			);
-		}
-
-		const entities = await EntityService.list({
-			db: ctx.db,
-			internalCustomerId: customer.internal_id,
-			isDeleted: false,
-		});
-
-		let warmedEntities = 0;
-		for (let i = 0; i < entities.length; i += ENTITY_BATCH_SIZE) {
-			const batch = entities.slice(i, i + ENTITY_BATCH_SIZE);
-			const results = await Promise.allSettled(
-				batch.map(async (entity) => {
-					const entityId = entity.id ?? entity.internal_id;
-					if (!entityId) return false;
-					const entitySubject = await getFullSubjectNormalized({
-						ctx,
-						customerId,
-						entityId,
-					});
-					if (!entitySubject) return false;
-					const result = await setCachedFullSubject({
-						ctx,
-						normalized: entitySubject.normalized,
-						fetchedSubjectViewEpoch: epoch,
-					});
-					return result === "OK";
-				}),
-			);
-			for (const r of results) {
-				if (r.status === "fulfilled" && r.value === true) warmedEntities++;
-				else if (r.status === "rejected") {
-					warmFailedCounter.add(1, { reason: "entity_hydrate" });
-				} else {
-					warmSkippedCounter.add(1, { reason: "entity_write_skipped" });
-				}
-			}
-		}
-
-		warmEntityCounter.add(warmedEntities, { source: source ?? "unknown" });
-		logger.info(
-			`warm-full-subject-cache: customer=${customerId} warmed_customer=${warmedCustomer} warmed_entities=${warmedEntities}/${entities.length} source=${source}`,
-		);
-
-		return {
-			warmed_customer: warmedCustomer,
-			warmed_entities: warmedEntities,
-			total_entities: entities.length,
-		};
+		return runWarmFullSubjectCache({ ctx, customerId, source });
 	},
 });

--- a/server/src/trigger/cache/warmFullSubjectCacheTask.ts
+++ b/server/src/trigger/cache/warmFullSubjectCacheTask.ts
@@ -1,0 +1,161 @@
+import { AppEnv } from "@autumn/shared";
+import { task } from "@trigger.dev/sdk/v3";
+import { metrics } from "@opentelemetry/api";
+import { z } from "zod/v4";
+import { warmupRegionalRedis } from "@/external/redis/initUtils/redisWarmup.js";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { buildFullSubjectViewEpochKey } from "@/internal/customers/cache/fullSubject/builders/buildFullSubjectViewEpochKey.js";
+import { setCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.js";
+import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { EntityService } from "@/internal/api/entities/EntityService.js";
+import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
+
+const meter = metrics.getMeter("autumn-server");
+const warmCustomerCounter = meter.createCounter("autumn.cache.warm.customer", {
+	description: "Customer-level FullSubject warms",
+});
+const warmEntityCounter = meter.createCounter("autumn.cache.warm.entity", {
+	description: "Entity-level FullSubject warms",
+});
+const warmSkippedCounter = meter.createCounter("autumn.cache.warm.skipped", {
+	description: "FullSubject warms skipped",
+});
+const warmFailedCounter = meter.createCounter("autumn.cache.warm.failed", {
+	description: "FullSubject warm failures",
+});
+
+const PayloadSchema = z.object({
+	orgId: z.string(),
+	env: z.enum(AppEnv),
+	customerId: z.string(),
+	source: z.string().optional(),
+});
+
+export type WarmFullSubjectCachePayload = z.infer<typeof PayloadSchema>;
+
+const ENTITY_BATCH_SIZE = 10;
+
+export const warmFullSubjectCacheTask = task({
+	id: "warm-full-subject-cache",
+	maxDuration: 120,
+	run: async (raw: unknown, { ctx: triggerCtx }) => {
+		const { orgId, env, customerId, source } = PayloadSchema.parse(raw);
+
+		const { ctx, logger } = await createTriggerContext({
+			orgId,
+			env,
+			triggerCtx,
+			customerId,
+		});
+
+		await warmupRegionalRedis().catch((error) =>
+			logger.warn("warm-full-subject-cache: redis warmup failed", {
+				data: { error: error instanceof Error ? error.message : String(error) },
+			}),
+		);
+
+		const customer = await CusService.get({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: customerId,
+		});
+		if (!customer) {
+			warmSkippedCounter.add(1, { reason: "customer_not_found" });
+			logger.warn(
+				`warm-full-subject-cache: customer not found id=${customerId}`,
+			);
+			return { warmed_customer: 0, warmed_entities: 0 };
+		}
+
+		const epochKey = buildFullSubjectViewEpochKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+		});
+		const epochRaw = await runRedisOp({
+			operation: () => ctx.redisV2.get(epochKey),
+			source: "warm-full-subject-cache:read-epoch",
+			redisInstance: ctx.redisV2,
+		});
+		const parsed = epochRaw == null ? 0 : Number.parseInt(String(epochRaw), 10);
+		const epoch = Number.isNaN(parsed) ? 0 : parsed;
+
+		let warmedCustomer = 0;
+		try {
+			const customerSubject = await getFullSubjectNormalized({
+				ctx,
+				customerId,
+			});
+			if (customerSubject) {
+				const result = await setCachedFullSubject({
+					ctx,
+					normalized: customerSubject.normalized,
+					fetchedSubjectViewEpoch: epoch,
+				});
+				if (result === "OK") {
+					warmCustomerCounter.add(1, { source: source ?? "unknown" });
+					warmedCustomer = 1;
+				} else {
+					warmSkippedCounter.add(1, { reason: result.toLowerCase() });
+				}
+			} else {
+				warmSkippedCounter.add(1, { reason: "no_customer_data" });
+			}
+		} catch (error) {
+			warmFailedCounter.add(1, { reason: "customer_hydrate" });
+			logger.warn(
+				`warm-full-subject-cache: customer-level warm failed customer=${customerId} error=${error}`,
+			);
+		}
+
+		const entities = await EntityService.list({
+			db: ctx.db,
+			internalCustomerId: customer.internal_id,
+			isDeleted: false,
+		});
+
+		let warmedEntities = 0;
+		for (let i = 0; i < entities.length; i += ENTITY_BATCH_SIZE) {
+			const batch = entities.slice(i, i + ENTITY_BATCH_SIZE);
+			const results = await Promise.allSettled(
+				batch.map(async (entity) => {
+					const entityId = entity.id ?? entity.internal_id;
+					if (!entityId) return false;
+					const entitySubject = await getFullSubjectNormalized({
+						ctx,
+						customerId,
+						entityId,
+					});
+					if (!entitySubject) return false;
+					const result = await setCachedFullSubject({
+						ctx,
+						normalized: entitySubject.normalized,
+						fetchedSubjectViewEpoch: epoch,
+					});
+					return result === "OK";
+				}),
+			);
+			for (const r of results) {
+				if (r.status === "fulfilled" && r.value === true) warmedEntities++;
+				else if (r.status === "rejected") {
+					warmFailedCounter.add(1, { reason: "entity_hydrate" });
+				} else {
+					warmSkippedCounter.add(1, { reason: "entity_write_skipped" });
+				}
+			}
+		}
+
+		warmEntityCounter.add(warmedEntities, { source: source ?? "unknown" });
+		logger.info(
+			`warm-full-subject-cache: customer=${customerId} warmed_customer=${warmedCustomer} warmed_entities=${warmedEntities}/${entities.length} source=${source}`,
+		);
+
+		return {
+			warmed_customer: warmedCustomer,
+			warmed_entities: warmedEntities,
+			total_entities: entities.length,
+		};
+	},
+});

--- a/server/tests/integration/db/full-subject-cache/cache-warmer-warms-customer-and-entities.test.ts
+++ b/server/tests/integration/db/full-subject-cache/cache-warmer-warms-customer-and-entities.test.ts
@@ -1,0 +1,158 @@
+/**
+ * TDD test for cache warmer happy path.
+ *
+ * Contract under test:
+ *   Allowlist:
+ *     - "cache-warmer-feature-test-cus" is on WARM_CACHE_CUSTOMER_IDS so
+ *       attempts to warm this customer are NOT short-circuited.
+ *   New behaviors:
+ *     - runWarmFullSubjectCache({ ctx, customerId }) populates the
+ *       FullSubject cache for the customer AND every entity owned by
+ *       the customer, given a previously-invalidated cache.
+ *     - Returns { warmed_customer: 1, warmed_entities: N, total_entities: N }
+ *       when both the customer and all N entities hydrate cleanly.
+ *     - Between entity batches the warmer pauses BATCH_PAUSE_MS so a
+ *       large entity fan-out does not burst DB+Redis. (Asserted
+ *       indirectly via the total entity count, not on timing.)
+ *   Side effects:
+ *     - Redis key at buildFullSubjectKey({ customerId }) is populated.
+ *     - Redis key at buildFullSubjectKey({ customerId, entityId }) is
+ *       populated for each of the customer's 5 entities.
+ *
+ * Pre-impl red: this file did not exist; the warmer body lived inside
+ *   the trigger.dev task wrapper and could not be invoked directly.
+ * Post-impl green: runWarmFullSubjectCache is exported from
+ *   warmFullSubjectCacheTask.ts and writes the expected Redis keys.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import {
+	buildFullSubjectKey,
+	getCachedFullSubject,
+	invalidateCachedFullSubject,
+} from "@/internal/customers/cache/fullSubject/index.js";
+import { runWarmFullSubjectCache } from "@/trigger/cache/warmFullSubjectCacheTask.js";
+
+test(
+	`${chalk.yellowBright("cache warmer: hydrates customer + every entity after invalidation")}`,
+	async () => {
+		// Must match the entry added to WARM_CACHE_CUSTOMER_IDS in
+		// server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts.
+		const customerId = "cache-warmer-feature-test-cus";
+
+		const free = products.base({
+			id: "warm-free",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const pro = products.pro({
+			id: "warm-pro",
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+
+		const { ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.deleteCustomer({ customerId }),
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+				s.entities({ count: 5, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.attach({ productId: free.id, entityIndex: 0 }),
+				s.attach({ productId: free.id, entityIndex: 1 }),
+				s.attach({ productId: free.id, entityIndex: 2 }),
+				s.attach({ productId: free.id, entityIndex: 3 }),
+				s.attach({ productId: free.id, entityIndex: 4 }),
+				s.attach({ productId: pro.id }),
+			],
+		});
+
+		expect(entities).toHaveLength(5);
+
+		// Start from a clean cache so the warm's effects are unambiguous.
+		// The attach above does this via refreshCacheMiddleware, but a
+		// concurrent read could have re-populated the entry; force it.
+		await invalidateCachedFullSubject({
+			ctx,
+			customerId,
+			source: "integration-test:cache-warmer",
+		});
+		for (const entity of entities) {
+			await invalidateCachedFullSubject({
+				ctx,
+				customerId,
+				entityId: entity.id,
+				source: "integration-test:cache-warmer",
+			});
+		}
+
+		// ── Pre-condition: cache is empty for customer + all 5 entities ──────────
+		const customerCachePre = await getCachedFullSubject({
+			ctx,
+			customerId,
+			source: "integration-test:cache-warmer-pre",
+		});
+		expect(customerCachePre.fullSubject).toBeUndefined();
+
+		for (const entity of entities) {
+			const entityCachePre = await getCachedFullSubject({
+				ctx,
+				customerId,
+				entityId: entity.id,
+				source: "integration-test:cache-warmer-pre",
+			});
+			expect(entityCachePre.fullSubject).toBeUndefined();
+		}
+
+		// ── Behavior under test: warm the cache ──────────────────────────────────
+		const result = await runWarmFullSubjectCache({
+			ctx,
+			customerId,
+			source: "integration-test",
+		});
+
+		// ── Contract assertion 1: return value reflects what was warmed ──────────
+		expect(result.warmed_customer).toBe(1);
+		expect(result.total_entities).toBe(5);
+		expect(result.warmed_entities).toBe(5);
+
+		// ── Contract assertion 2: customer-level cache key is populated ──────────
+		const customerCachePost = await getCachedFullSubject({
+			ctx,
+			customerId,
+			source: "integration-test:cache-warmer-post",
+		});
+		expect(customerCachePost.fullSubject).toBeDefined();
+
+		const customerSubjectKey = buildFullSubjectKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+		});
+		expect(await ctx.redisV2.exists(customerSubjectKey)).toBe(1);
+
+		// ── Contract assertion 3: each entity cache key is populated ─────────────
+		for (const entity of entities) {
+			const entityCachePost = await getCachedFullSubject({
+				ctx,
+				customerId,
+				entityId: entity.id,
+				source: "integration-test:cache-warmer-post",
+			});
+			expect(entityCachePost.fullSubject).toBeDefined();
+
+			const entitySubjectKey = buildFullSubjectKey({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId,
+				entityId: entity.id,
+			});
+			expect(await ctx.redisV2.exists(entitySubjectKey)).toBe(1);
+		}
+	},
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a whitelisted FullSubject cache warmer enqueued from `refreshCacheMiddleware` to prefill customer and entity cache and reduce cold misses. Runs as a non-blocking background `@trigger.dev/sdk/v3` task; pilot targets one hardcoded customer.

- **New Features**
  - Enqueues warm job only for allowlisted `customerId`; de-duped per org/env/customer via `concurrencyKey`.
  - Warms customer and all entities via `getOrSetCachedFullSubject` in 25-size batches with a brief pause; performs regional Redis warmup first.
  - Metrics: enqueue `enqueued`/`enqueue_failed`; task counts warmed customer/entities, skipped, and failures via `@opentelemetry/api`.
  - Skips when not allowlisted or customer missing; logs and continues on per-entity failures.

<sup>Written for commit 7f5901dc8d8e9836b188a4e3d86cea03b1158131. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1680?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

