### PR TITLE
fix: missing cusProduct

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/findTargetCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/findTargetCustomerProduct.ts
@@ -15,6 +15,8 @@ import {
 	RecaseError,
 	type UpdateSubscriptionV1Params,
 } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 
 /**
  * Assigns a numeric priority to a customer product for auto-resolution.
@@ -129,13 +131,15 @@ const buildNotFoundMessage = ({
 };
 
 /** Finds the target customer product for an updateSubscription call, or throws. */
-export const findTargetCustomerProduct = ({
+export const findTargetCustomerProduct = async ({
+	ctx,
 	params,
 	fullCustomer,
 }: {
+	ctx: AutumnContext;
 	params: UpdateSubscriptionV1Params;
 	fullCustomer: FullCustomer;
-}): FullCusProduct => {
+}): Promise<FullCusProduct> => {
 	const internalEntityId = fullCustomer.entity?.internal_id;
 
 	const candidates = fullCustomer.customer_products.filter((cp) => {
@@ -145,16 +149,26 @@ export const findTargetCustomerProduct = ({
 
 	const target = resolveTargetCustomerProduct({ params, candidates });
 
-	if (!target) {
-		throw new RecaseError({
-			message: buildNotFoundMessage({
-				params,
-				customerId: fullCustomer.id ?? "",
-			}),
-			code: ErrCode.CusProductNotFound,
-			statusCode: 404,
+	if (target) return target;
+
+	// Explicit id provided but filtered out (e.g. entity-scoped cusProduct
+	// looked up without entity context). Resolve directly from the DB.
+	if (params.customer_product_id) {
+		const fallback = await CusProductService.getFull({
+			db: ctx.db,
+			id: params.customer_product_id,
 		});
+		if (fallback && fallback.internal_customer_id === fullCustomer.internal_id) {
+			return fallback;
+		}
 	}
 
-	return target;
+	throw new RecaseError({
+		message: buildNotFoundMessage({
+			params,
+			customerId: fullCustomer.id ?? "",
+		}),
+		code: ErrCode.CusProductNotFound,
+		statusCode: 404,
+	});
 };

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/findTargetCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/findTargetCustomerProduct.ts
@@ -157,8 +157,12 @@ export const findTargetCustomerProduct = async ({
 		const fallback = await CusProductService.getFull({
 			db: ctx.db,
 			id: params.customer_product_id,
+			inStatuses: RELEVANT_STATUSES,
 		});
-		if (fallback && fallback.internal_customer_id === fullCustomer.internal_id) {
+		if (
+			fallback &&
+			fallback.internal_customer_id === fullCustomer.internal_id
+		) {
 			return fallback;
 		}
 	}

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts
@@ -43,7 +43,8 @@ export const setupUpdateSubscriptionProductContext = async ({
 		};
 	}
 
-	const targetCustomerProduct = findTargetCustomerProduct({
+	const targetCustomerProduct = await findTargetCustomerProduct({
+		ctx,
 		params,
 		fullCustomer,
 	});

--- a/server/src/internal/customers/cusProducts/CusProductService.ts
+++ b/server/src/internal/customers/cusProducts/CusProductService.ts
@@ -181,9 +181,20 @@ export class CusProductService {
 		return cusProducts as FullCusProduct[];
 	}
 
-	static async getFull({ db, id }: { db: DrizzleCli; id: string }) {
+	static async getFull({
+		db,
+		id,
+		inStatuses,
+	}: {
+		db: DrizzleCli;
+		id: string;
+		inStatuses?: CusProductStatus[];
+	}) {
 		const data = await db.query.customerProducts.findFirst({
-			where: eq(customerProducts.id, id),
+			where: and(
+				eq(customerProducts.id, id),
+				inStatuses ? inArray(customerProducts.status, inStatuses) : undefined,
+			),
 			with: {
 				product: true,
 				...getFullCusProdRelations(),

--- a/server/tests/integration/billing/update-subscription/cancel/immediately/cancel-entity-product-by-id.test.ts
+++ b/server/tests/integration/billing/update-subscription/cancel/immediately/cancel-entity-product-by-id.test.ts
@@ -1,0 +1,78 @@
+/**
+ * TDD test for: cancelling an entity-scoped customer product by customer_product_id
+ * fails when the request omits entity_id (e.g. dashboard cancel flow).
+ *
+ * Red-failure mode (current):
+ *  - findTargetCustomerProduct filters fullCustomer.customer_products by
+ *    isCusProductOnEntity using fullCustomer.entity?.internal_id. With no
+ *    entity_id in params, internalEntityId is undefined → entity-scoped
+ *    cusProducts get filtered out → throws CusProductNotFound even though
+ *    the explicit customer_product_id matches a real row.
+ *
+ * Green-success criteria (after fix):
+ *  - When an explicit customer_product_id is provided and the candidate
+ *    list doesn't contain it, fall back to CusProductService.getFull and
+ *    return the row directly.
+ */
+
+import { expect, test } from "bun:test";
+import { CusProductStatus } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService";
+
+test(
+	`${chalk.yellowBright("cancel by id: resolves entity-scoped cusProduct even without entity context")}`,
+	async () => {
+		const customerId = "cancel-entity-product-by-id";
+
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [messagesItem, priceItem],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.entities({ count: 1, featureId: "users" }),
+			],
+			actions: [s.attach({ productId: pro.id, entityIndex: 0 })],
+		});
+
+		const fullCustomerBefore = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+
+		const entityPro = fullCustomerBefore.customer_products.find(
+			(cp) =>
+				cp.product.id === pro.id &&
+				cp.internal_entity_id &&
+				cp.status === CusProductStatus.Active,
+		);
+		expect(entityPro).toBeDefined();
+
+		// Mirrors the dashboard cancel: customer_product_id passed without entity_id.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			customer_product_id: entityPro!.id,
+			cancel_action: "cancel_immediately" as const,
+		});
+
+		const fullCustomerAfter = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const activeEntityPro = fullCustomerAfter.customer_products.find(
+			(cp) =>
+				cp.id === entityPro!.id && cp.status === CusProductStatus.Active,
+		);
+		expect(activeEntityPro).toBeUndefined();
+	},
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes customer product resolution when canceling or updating by `customer_product_id` without `entity_id`. Adds a status-scoped DB fallback to resolve entity-scoped products and prevent false 404s or mutations of inactive subscriptions.

- **Bug Fixes**
  - `findTargetCustomerProduct` now falls back to `CusProductService.getFull` filtered by `RELEVANT_STATUSES` and validates ownership; `getFull` gained an optional `inStatuses` filter.
  - Made `findTargetCustomerProduct` async and pass `ctx` from `setupUpdateSubscriptionProductContext`.
  - Added an integration test to confirm cancel-by-id works for entity-scoped products without entity context.

<sup>Written for commit fdc7fd47809b5cc798a5072da8bbfb9961b82030. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1681?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where cancelling an entity-scoped customer product by `customer_product_id` (without providing `entity_id`) would throw `CusProductNotFound` because the candidate list filtered out entity-scoped products when no entity context was present in the request.

- **Bug fixes**: `findTargetCustomerProduct` is made `async` and gains a DB fallback: when an explicit `customer_product_id` is provided but not found in the filtered candidate list, it fetches the record directly from the DB and validates ownership before returning it.
- **Bug fixes**: A new integration test covers the exact regression — cancelling an entity-scoped product from the dashboard (which omits `entity_id`) now succeeds instead of throwing a 404.
</details>

<h3>Confidence Score: 3/5</h3>

The DB fallback correctly validates ownership but skips the status filter, meaning a cancelled subscription could be returned and mutated.

The fallback DB lookup in `findTargetCustomerProduct` skips the `RELEVANT_STATUSES` filter that the primary candidate path enforces, meaning a caller could mutate an already-cancelled subscription by passing its ID.

findTargetCustomerProduct.ts — specifically the fallback return block at lines 161-163.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/setup/findTargetCustomerProduct.ts | Adds an async DB fallback for entity-scoped cusProducts when the candidate list misses them; the fallback omits the RELEVANT_STATUSES check that guards the primary path. |
| server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionProductContext.ts | Minimal change: adds `await` and passes `ctx` through to the now-async `findTargetCustomerProduct`; no logic changed. |
| server/tests/integration/billing/update-subscription/cancel/immediately/cancel-entity-product-by-id.test.ts | New integration test covering the exact regression: cancelling an entity-scoped product by ID when entity_id is omitted from the request. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[findTargetCustomerProduct called] --> B[Filter customer_products by RELEVANT_STATUSES + entity context]
    B --> C[resolveTargetCustomerProduct on candidates]
    C --> D{target found?}
    D -- Yes --> E[Return target]
    D -- No --> F{customer_product_id provided?}
    F -- No --> G[Throw CusProductNotFound]
    F -- Yes --> H[CusProductService.getFull from DB]
    H --> I{fallback found AND ownership matches?}
    I -- No --> G
    I -- Yes --> J[Return fallback]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/actions/updateSubscription/setup/findTargetCustomerProduct.ts:161-163
The DB fallback does not check whether the retrieved `cusProduct` has a relevant status. The primary candidate list is deliberately filtered to `RELEVANT_STATUSES` (Active, PastDue, Scheduled), but `CusProductService.getFull` fetches any row by ID regardless of status. A caller who supplies a `customer_product_id` that belongs to an already-cancelled subscription will bypass that filter and receive the cancelled product back, allowing downstream mutation of an inactive subscription.

```suggestion
		if (
			fallback &&
			fallback.internal_customer_id === fullCustomer.internal_id &&
			RELEVANT_STATUSES.includes(fallback.status)
		) {
			return fallback;
		}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/missing-cus..."](https://github.com/useautumn/autumn/commit/c3877da27b09dd79ae0d5afecd207d12cd62d3a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33314982)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->