### PR TITLE
cache warmer pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Autumn
 
-![Autumn](assets/github_hero.png)
+<img width="1983" height="793" alt="image" src="https://github.com/user-attachments/assets/f2b6271d-19af-4b16-be73-b55a3303b7f1" />
+
 
 [![Discord](https://img.shields.io/badge/Join%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/53emPtY9tA)
 [![Follow](https://img.shields.io/twitter/follow/autumnpricing?style=social)](https://x.com/autumnpricing)

--- a/apps/docs/mintlify/documentation/webhooks.mdx
+++ b/apps/docs/mintlify/documentation/webhooks.mdx
@@ -7,10 +7,6 @@ With Autumn, you don't need webhooks for managing billing — subscription state
 
 However, webhooks can still be useful for specific use cases where you want to trigger actions in your own systems.
 
-<Note>
-Webhooks are currently in beta. Please reach out to us on [Discord](https://discord.gg/STqxY92zuS) or email us at support@useautumn.com to enable webhooks for your account.
-</Note>
-
 ## Use Cases
 
 While Autumn handles billing complexity for you, webhooks are helpful for:
@@ -22,43 +18,116 @@ While Autumn handles billing complexity for you, webhooks are helpful for:
 
 ## Available Events
 
-### customer.products.updated
+### billing.updated
 
-Fired when a customer's product or plan changes. The `scenario` field indicates what type of change occurred.
+Fired whenever a customer's plans change — new subscriptions, upgrades, downgrades, etc. Each event carries a `plan_changes` array describing exactly what happened to each affected plan.
 
-| Scenario | Description |
-|----------|-------------|
-| `new` | Customer subscribed to a new product |
-| `upgrade` | Customer upgraded to a higher-tier plan |
-| `downgrade` | Customer downgraded to a lower-tier plan |
-| `renew` | Subscription renewed for another billing period |
-| `cancel` | Subscription was canceled |
-| `expired` | Subscription has expired |
-| `past_due` | Payment is past due |
-| `scheduled` | A plan change has been scheduled |
+| Action | Description |
+|--------|-------------|
+| `activated` | A plan is now active on the customer (newly attached, or a previously scheduled plan reached its start date) |
+| `scheduled` | A plan has been queued to start at a future date |
+| `updated` | A plan's state changed in place (cancellation set or cleared, `past_due` flipped, items added or removed) |
+| `expired` | A plan ended and is no longer in effect |
 
-**Example payload:**
+Each entry also includes the `subscription` (or `purchase` for one-off products) after the change, and `previous_attributes` holding the prior values of any fields that were updated. For instance, if a plan was canceled at period end:
 
 ```json expandable
 {
-  "type": "customer.products.updated",
+  "action": "updated",
+  "subscription": {
+    "plan_id": "pro",
+    "status": "active",
+    "past_due": false,
+    "started_at": 1759248000000,
+    "canceled_at": 1761840000000,
+    "expires_at": 1764432000000,
+    "trial_ends_at": null,
+    "current_period_start": 1761840000000,
+    "current_period_end": 1764432000000
+  },
+  "previous_attributes": {
+    "canceled_at": null,
+    "expires_at": null
+  },
+  "item_changes": []
+}
+```
+
+The top-level `tags` array surfaces optional reason tags describing why the event fired:
+
+| Tag | When |
+|-----|------|
+| `trial_ended` | A trial just ended (Stripe subscription transition or the trial-expiry cron) |
+| `phase_changed` | A Stripe subscription schedule phase advanced |
+
+**Example payload (upgrade from `free` to `pro`):**
+
+```json expandable
+{
+  "type": "billing.updated",
   "data": {
-    "scenario": "new",
-    "customer": {
-      "id": "user_123",
-      "name": "John Doe",
-      "email": "john@example.com",
-      "balances": { ... },
-      "subscriptions": [ ... ]
-    },
-    "updated_product": {
-      "id": "pro_plan",
-      "name": "Pro Plan",
-      "features": [ ... ]
-    }
+    "object": "billing.updated",
+    "customer_id": "user_123",
+    "plan_changes": [
+      {
+        "action": "activated",
+        "subscription": {
+          "plan_id": "pro",
+          "status": "active",
+          "past_due": false,
+          "started_at": 1761840000000,
+          "canceled_at": null,
+          "expires_at": null,
+          "trial_ends_at": null,
+          "current_period_start": 1761840000000,
+          "current_period_end": 1764432000000
+        },
+        "previous_attributes": null,
+        "item_changes": []
+      },
+      {
+        "action": "expired",
+        "subscription": {
+          "plan_id": "free",
+          "status": "expired",
+          "past_due": false,
+          "started_at": 1759248000000,
+          "canceled_at": 1761840000000,
+          "expires_at": 1761840000000,
+          "trial_ends_at": null,
+          "current_period_start": null,
+          "current_period_end": null
+        },
+        "previous_attributes": { "status": "active" },
+        "item_changes": []
+      }
+    ],
+    "tags": []
   }
 }
 ```
+
+For entity-scoped events, the payload will also include an `entity_id`:
+
+```json expandable
+{
+  "type": "billing.updated",
+  "data": {
+    "object": "billing.updated",
+    "customer_id": "user_123",
+    "entity_id": "team_456",
+    "plan_changes": [ ... ],
+    "tags": []
+  }
+}
+```
+
+**Common patterns:**
+
+- **Sync Autumn state back to your DB** — listen for every `billing.updated` and persist each `plan_changes` entry's `subscription` snapshot keyed by `customer_id` (+ `entity_id` if set).
+- **Notify on upgrades** — filter for entries with `action: "activated"`. For "upgrade from previous plan" specifically, pair it with an `action: "expired"` entry on the same event.
+- **Detect cancellations** — filter for entries where `previous_attributes.canceled_at === null` (a cancellation was just set) or `previous_attributes.canceled_at` is a number (an uncancel).
+- **Trial-end emails** — filter for `tags.includes("trial_ended")`.
 
 ### balances.limit_reached
 
@@ -183,7 +252,7 @@ Fired when a customer crosses a configured usage alert threshold. Usage alerts l
 
 ## Setup
 
-Once webhooks are enabled for your account, you can configure your webhook endpoints in the Autumn dashboard:
+Configure your webhook endpoints in the Autumn dashboard:
 
 <Steps>
   <Step title="Navigate to Developer Settings">

--- a/server/src/honoMiddlewares/refreshCacheMiddleware.ts
+++ b/server/src/honoMiddlewares/refreshCacheMiddleware.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { warmFullSubjectCache } from "@/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import { getRefreshCacheRouteConfig } from "./refreshCacheConfigs.js";
 
@@ -34,6 +35,12 @@ export const refreshCacheMiddleware = async (
 		customerId: ctx.customerId,
 		entityId: ctx.entityId,
 		ctx,
+		source: "refreshCacheMiddleware",
+	});
+
+	warmFullSubjectCache({
+		ctx,
+		customerId: ctx.customerId,
 		source: "refreshCacheMiddleware",
 	});
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -14,6 +14,7 @@ const warmEnqueueFailedCounter = meter.createCounter(
 
 const WARM_CACHE_CUSTOMER_IDS = new Set<string>([
 	"64138004cce3c9e82a7083d9",
+	"cache-warmer-feature-test-cus",
 ]);
 
 export const shouldWarmCache = (customerId: string | undefined): boolean => {

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -1,0 +1,141 @@
+import { metrics } from "@opentelemetry/api";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { buildFullSubjectViewEpochKey } from "../builders/buildFullSubjectViewEpochKey.js";
+import { setCachedFullSubject } from "./setCachedFullSubject/setCachedFullSubject.js";
+
+const meter = metrics.getMeter("autumn-server");
+const warmStartedCounter = meter.createCounter("autumn.cache.warm.started", {
+	description: "FullSubject cache warm attempts initiated",
+});
+const warmCompletedCounter = meter.createCounter(
+	"autumn.cache.warm.completed",
+	{ description: "FullSubject cache warms that wrote a value" },
+);
+const warmSkippedCounter = meter.createCounter("autumn.cache.warm.skipped", {
+	description:
+		"FullSubject cache warms skipped (already running, missing data, etc.)",
+});
+const warmFailedCounter = meter.createCounter("autumn.cache.warm.failed", {
+	description: "FullSubject cache warms that threw",
+});
+
+const inflight = new Map<string, Promise<void>>();
+
+const parseAllowlist = (): Set<string> => {
+	const raw = process.env.WARM_CACHE_CUSTOMER_IDS ?? "";
+	return new Set(
+		raw
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean),
+	);
+};
+
+let allowlist: Set<string> | null = null;
+const getAllowlist = (): Set<string> => {
+	if (allowlist === null) allowlist = parseAllowlist();
+	return allowlist;
+};
+
+export const shouldWarmCache = (customerId: string | undefined): boolean => {
+	if (!customerId) return false;
+	return getAllowlist().has(customerId);
+};
+
+const readCurrentEpoch = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+}): Promise<number> => {
+	const { org, env, redisV2 } = ctx;
+	const epochKey = buildFullSubjectViewEpochKey({
+		orgId: org.id,
+		env,
+		customerId,
+	});
+	const raw = await runRedisOp({
+		operation: () => redisV2.get(epochKey),
+		source: "warmFullSubjectCache:readEpoch",
+		redisInstance: redisV2,
+	});
+	if (raw === null || raw === undefined) return 0;
+	const parsed = Number.parseInt(String(raw), 10);
+	return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+/**
+ * Eagerly re-populate the customer-level FullSubject cache after invalidation.
+ * Fire-and-forget — never blocks the caller, never throws.
+ *
+ * Gated by `WARM_CACHE_CUSTOMER_IDS` env var to limit blast radius. Uses an
+ * in-process single-flight Map so a write burst against the same customer
+ * doesn't fan out into N concurrent hydrations. The underlying Lua write
+ * is conditional on `fetchedSubjectViewEpoch`, so a racing invalidate is
+ * safe: the warm becomes a no-op when its epoch is stale.
+ *
+ * Scope: customer-level subject only. Entity-level keys are NOT re-warmed
+ * (one warm per entity would itself be a storm). Reads for individual
+ * entities still hydrate on miss.
+ */
+export const warmFullSubjectCache = ({
+	ctx,
+	customerId,
+	source,
+}: {
+	ctx: AutumnContext;
+	customerId: string | undefined;
+	source?: string;
+}): void => {
+	if (!shouldWarmCache(customerId)) return;
+	const id = customerId as string;
+	// Scope single-flight to (org, env, customer) so two orgs sharing an
+	// upstream customer id don't suppress each other's warms.
+	const inflightKey = `${ctx.org.id}:${ctx.env}:${id}`;
+
+	if (inflight.has(inflightKey)) {
+		warmSkippedCounter.add(1, { reason: "already_running" });
+		return;
+	}
+
+	warmStartedCounter.add(1, { source: source ?? "unknown" });
+
+	const promise = (async () => {
+		try {
+			const epoch = await readCurrentEpoch({ ctx, customerId: id });
+			const normalizedResult = await getFullSubjectNormalized({
+				ctx,
+				customerId: id,
+			});
+			if (!normalizedResult) {
+				warmSkippedCounter.add(1, { reason: "no_data" });
+				return;
+			}
+			const writeResult = await setCachedFullSubject({
+				ctx,
+				normalized: normalizedResult.normalized,
+				fetchedSubjectViewEpoch: epoch,
+			});
+			if (writeResult === "OK") {
+				warmCompletedCounter.add(1, { source: source ?? "unknown" });
+			} else {
+				// STALE_WRITE / CACHE_EXISTS / FAILED — Lua bailed; no value written.
+				warmSkippedCounter.add(1, { reason: writeResult.toLowerCase() });
+			}
+		} catch (error) {
+			warmFailedCounter.add(1, { source: source ?? "unknown" });
+			ctx.logger.warn(
+				`[warmFullSubjectCache] customer=${id} source=${source} error=${error}`,
+			);
+		} finally {
+			// Inside the try/catch scope so a throw from the metric or logger
+			// above doesn't escape as an unhandled rejection.
+			inflight.delete(inflightKey);
+		}
+	})();
+
+	inflight.set(inflightKey, promise);
+};

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -1,7 +1,7 @@
 import { metrics } from "@opentelemetry/api";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
-import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import { buildFullSubjectViewEpochKey } from "../builders/buildFullSubjectViewEpochKey.js";
 import { setCachedFullSubject } from "./setCachedFullSubject/setCachedFullSubject.js";
 
@@ -18,30 +18,18 @@ const warmSkippedCounter = meter.createCounter("autumn.cache.warm.skipped", {
 		"FullSubject cache warms skipped (already running, missing data, etc.)",
 });
 const warmFailedCounter = meter.createCounter("autumn.cache.warm.failed", {
-	description: "FullSubject cache warms that threw",
+	description: "FullSubject cache warms that threw or failed to write",
 });
 
 const inflight = new Map<string, Promise<void>>();
 
-const parseAllowlist = (): Set<string> => {
-	const raw = process.env.WARM_CACHE_CUSTOMER_IDS ?? "";
-	return new Set(
-		raw
-			.split(",")
-			.map((s) => s.trim())
-			.filter(Boolean),
-	);
-};
-
-let allowlist: Set<string> | null = null;
-const getAllowlist = (): Set<string> => {
-	if (allowlist === null) allowlist = parseAllowlist();
-	return allowlist;
-};
+const WARM_CACHE_CUSTOMER_IDS = new Set<string>([
+	"64138004cce3c9e82a7083d9",
+]);
 
 export const shouldWarmCache = (customerId: string | undefined): boolean => {
 	if (!customerId) return false;
-	return getAllowlist().has(customerId);
+	return WARM_CACHE_CUSTOMER_IDS.has(customerId);
 };
 
 const readCurrentEpoch = async ({
@@ -75,14 +63,15 @@ export const warmFullSubjectCache = ({
 	ctx: AutumnContext;
 	customerId: string | undefined;
 	source?: string;
-}): void => {
-	if (!shouldWarmCache(customerId)) return;
+}): Promise<void> | undefined => {
+	if (!shouldWarmCache(customerId)) return undefined;
 	const id = customerId as string;
 	const inflightKey = `${ctx.org.id}:${ctx.env}:${id}`;
 
-	if (inflight.has(inflightKey)) {
+	const existingPromise = inflight.get(inflightKey);
+	if (existingPromise) {
 		warmSkippedCounter.add(1, { reason: "already_running" });
-		return;
+		return existingPromise;
 	}
 
 	warmStartedCounter.add(1, { source: source ?? "unknown" });
@@ -105,11 +94,22 @@ export const warmFullSubjectCache = ({
 			});
 			if (writeResult === "OK") {
 				warmCompletedCounter.add(1, { source: source ?? "unknown" });
+			} else if (writeResult === "FAILED") {
+				warmFailedCounter.add(1, {
+					source: source ?? "unknown",
+					reason: "write_failed",
+				});
+				ctx.logger.error(
+					`[warmFullSubjectCache] Cache warm write FAILED for customer=${id} source=${source}`,
+				);
 			} else {
 				warmSkippedCounter.add(1, { reason: writeResult.toLowerCase() });
 			}
 		} catch (error) {
-			warmFailedCounter.add(1, { source: source ?? "unknown" });
+			warmFailedCounter.add(1, {
+				source: source ?? "unknown",
+				reason: "exception",
+			});
 			ctx.logger.warn(
 				`[warmFullSubjectCache] customer=${id} source=${source} error=${error}`,
 			);
@@ -119,4 +119,5 @@ export const warmFullSubjectCache = ({
 	})();
 
 	inflight.set(inflightKey, promise);
+	return promise;
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -1,27 +1,16 @@
 import { metrics } from "@opentelemetry/api";
-import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
-import { buildFullSubjectViewEpochKey } from "../builders/buildFullSubjectViewEpochKey.js";
-import { setCachedFullSubject } from "./setCachedFullSubject/setCachedFullSubject.js";
+import { warmFullSubjectCacheTask } from "@/trigger/cache/warmFullSubjectCacheTask.js";
 
 const meter = metrics.getMeter("autumn-server");
-const warmStartedCounter = meter.createCounter("autumn.cache.warm.started", {
-	description: "FullSubject cache warm attempts initiated",
-});
-const warmCompletedCounter = meter.createCounter(
-	"autumn.cache.warm.completed",
-	{ description: "FullSubject cache warms that wrote a value" },
+const warmEnqueuedCounter = meter.createCounter(
+	"autumn.cache.warm.enqueued",
+	{ description: "FullSubject cache warm enqueues" },
 );
-const warmSkippedCounter = meter.createCounter("autumn.cache.warm.skipped", {
-	description:
-		"FullSubject cache warms skipped (already running, missing data, etc.)",
-});
-const warmFailedCounter = meter.createCounter("autumn.cache.warm.failed", {
-	description: "FullSubject cache warms that threw or failed to write",
-});
-
-const inflight = new Map<string, Promise<void>>();
+const warmEnqueueFailedCounter = meter.createCounter(
+	"autumn.cache.warm.enqueue_failed",
+	{ description: "FullSubject cache warm enqueue failures" },
+);
 
 const WARM_CACHE_CUSTOMER_IDS = new Set<string>([
 	"64138004cce3c9e82a7083d9",
@@ -32,29 +21,6 @@ export const shouldWarmCache = (customerId: string | undefined): boolean => {
 	return WARM_CACHE_CUSTOMER_IDS.has(customerId);
 };
 
-const readCurrentEpoch = async ({
-	ctx,
-	customerId,
-}: {
-	ctx: AutumnContext;
-	customerId: string;
-}): Promise<number> => {
-	const { org, env, redisV2 } = ctx;
-	const epochKey = buildFullSubjectViewEpochKey({
-		orgId: org.id,
-		env,
-		customerId,
-	});
-	const raw = await runRedisOp({
-		operation: () => redisV2.get(epochKey),
-		source: "warmFullSubjectCache:readEpoch",
-		redisInstance: redisV2,
-	});
-	if (raw === null || raw === undefined) return 0;
-	const parsed = Number.parseInt(String(raw), 10);
-	return Number.isNaN(parsed) ? 0 : parsed;
-};
-
 export const warmFullSubjectCache = ({
 	ctx,
 	customerId,
@@ -63,61 +29,29 @@ export const warmFullSubjectCache = ({
 	ctx: AutumnContext;
 	customerId: string | undefined;
 	source?: string;
-}): Promise<void> | undefined => {
-	if (!shouldWarmCache(customerId)) return undefined;
+}): void => {
+	if (!shouldWarmCache(customerId)) return;
 	const id = customerId as string;
-	const inflightKey = `${ctx.org.id}:${ctx.env}:${id}`;
 
-	const existingPromise = inflight.get(inflightKey);
-	if (existingPromise) {
-		warmSkippedCounter.add(1, { reason: "already_running" });
-		return existingPromise;
-	}
-
-	warmStartedCounter.add(1, { source: source ?? "unknown" });
-
-	const promise = (async () => {
-		try {
-			const epoch = await readCurrentEpoch({ ctx, customerId: id });
-			const normalizedResult = await getFullSubjectNormalized({
-				ctx,
+	void warmFullSubjectCacheTask
+		.trigger(
+			{
+				orgId: ctx.org.id,
+				env: ctx.env,
 				customerId: id,
-			});
-			if (!normalizedResult) {
-				warmSkippedCounter.add(1, { reason: "no_data" });
-				return;
-			}
-			const writeResult = await setCachedFullSubject({
-				ctx,
-				normalized: normalizedResult.normalized,
-				fetchedSubjectViewEpoch: epoch,
-			});
-			if (writeResult === "OK") {
-				warmCompletedCounter.add(1, { source: source ?? "unknown" });
-			} else if (writeResult === "FAILED") {
-				warmFailedCounter.add(1, {
-					source: source ?? "unknown",
-					reason: "write_failed",
-				});
-				ctx.logger.error(
-					`[warmFullSubjectCache] Cache warm write FAILED for customer=${id} source=${source}`,
-				);
-			} else {
-				warmSkippedCounter.add(1, { reason: writeResult.toLowerCase() });
-			}
-		} catch (error) {
-			warmFailedCounter.add(1, {
-				source: source ?? "unknown",
-				reason: "exception",
-			});
+				source,
+			},
+			{
+				concurrencyKey: `${ctx.org.id}:${ctx.env}:${id}`,
+			},
+		)
+		.then(() => {
+			warmEnqueuedCounter.add(1, { source: source ?? "unknown" });
+		})
+		.catch((error) => {
+			warmEnqueueFailedCounter.add(1, { source: source ?? "unknown" });
 			ctx.logger.warn(
-				`[warmFullSubjectCache] customer=${id} source=${source} error=${error}`,
+				`[warmFullSubjectCache] enqueue failed customer=${id} source=${source} error=${error}`,
 			);
-		} finally {
-			inflight.delete(inflightKey);
-		}
-	})();
-
-	inflight.set(inflightKey, promise);
-	return promise;
+		});
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts
@@ -67,20 +67,6 @@ const readCurrentEpoch = async ({
 	return Number.isNaN(parsed) ? 0 : parsed;
 };
 
-/**
- * Eagerly re-populate the customer-level FullSubject cache after invalidation.
- * Fire-and-forget — never blocks the caller, never throws.
- *
- * Gated by `WARM_CACHE_CUSTOMER_IDS` env var to limit blast radius. Uses an
- * in-process single-flight Map so a write burst against the same customer
- * doesn't fan out into N concurrent hydrations. The underlying Lua write
- * is conditional on `fetchedSubjectViewEpoch`, so a racing invalidate is
- * safe: the warm becomes a no-op when its epoch is stale.
- *
- * Scope: customer-level subject only. Entity-level keys are NOT re-warmed
- * (one warm per entity would itself be a storm). Reads for individual
- * entities still hydrate on miss.
- */
 export const warmFullSubjectCache = ({
 	ctx,
 	customerId,
@@ -92,8 +78,6 @@ export const warmFullSubjectCache = ({
 }): void => {
 	if (!shouldWarmCache(customerId)) return;
 	const id = customerId as string;
-	// Scope single-flight to (org, env, customer) so two orgs sharing an
-	// upstream customer id don't suppress each other's warms.
 	const inflightKey = `${ctx.org.id}:${ctx.env}:${id}`;
 
 	if (inflight.has(inflightKey)) {
@@ -122,7 +106,6 @@ export const warmFullSubjectCache = ({
 			if (writeResult === "OK") {
 				warmCompletedCounter.add(1, { source: source ?? "unknown" });
 			} else {
-				// STALE_WRITE / CACHE_EXISTS / FAILED — Lua bailed; no value written.
 				warmSkippedCounter.add(1, { reason: writeResult.toLowerCase() });
 			}
 		} catch (error) {
@@ -131,8 +114,6 @@ export const warmFullSubjectCache = ({
 				`[warmFullSubjectCache] customer=${id} source=${source} error=${error}`,
 			);
 		} finally {
-			// Inside the try/catch scope so a throw from the metric or logger
-			// above doesn't escape as an unhandled rejection.
 			inflight.delete(inflightKey);
 		}
 	})();

--- a/server/src/trigger/cache/warmFullSubjectCacheTask.ts
+++ b/server/src/trigger/cache/warmFullSubjectCacheTask.ts
@@ -1,14 +1,12 @@
 import { AppEnv } from "@autumn/shared";
-import { task } from "@trigger.dev/sdk/v3";
 import { metrics } from "@opentelemetry/api";
+import { task } from "@trigger.dev/sdk/v3";
 import { z } from "zod/v4";
 import { warmupRegionalRedis } from "@/external/redis/initUtils/redisWarmup.js";
-import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
-import { buildFullSubjectViewEpochKey } from "@/internal/customers/cache/fullSubject/builders/buildFullSubjectViewEpochKey.js";
-import { setCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.js";
-import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
-import { CusService } from "@/internal/customers/CusService.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
 import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
 
 const meter = metrics.getMeter("autumn-server");
@@ -34,7 +32,103 @@ const PayloadSchema = z.object({
 
 export type WarmFullSubjectCachePayload = z.infer<typeof PayloadSchema>;
 
-const ENTITY_BATCH_SIZE = 10;
+const ENTITY_BATCH_SIZE = 25;
+const BATCH_PAUSE_MS = 100;
+
+export type WarmFullSubjectResult = {
+	warmed_customer: number;
+	warmed_entities: number;
+	total_entities: number;
+};
+
+export const runWarmFullSubjectCache = async ({
+	ctx,
+	customerId,
+	source,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	source?: string;
+}): Promise<WarmFullSubjectResult> => {
+	const customer = await CusService.get({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		idOrInternalId: customerId,
+	});
+	if (!customer) {
+		warmSkippedCounter.add(1, { reason: "customer_not_found" });
+		ctx.logger.warn(
+			`warm-full-subject-cache: customer not found id=${customerId}`,
+		);
+		return { warmed_customer: 0, warmed_entities: 0, total_entities: 0 };
+	}
+
+	let warmedCustomer = 0;
+	try {
+		await getOrSetCachedFullSubject({
+			ctx,
+			customerId,
+			source: source ?? "warm-full-subject-cache",
+		});
+		warmCustomerCounter.add(1, { source: source ?? "unknown" });
+		warmedCustomer = 1;
+	} catch (error) {
+		warmFailedCounter.add(1, { reason: "customer_hydrate" });
+		ctx.logger.warn(
+			`warm-full-subject-cache: customer-level warm failed customer=${customerId} error=${error}`,
+		);
+	}
+
+	const entities = await EntityService.list({
+		db: ctx.db,
+		internalCustomerId: customer.internal_id,
+		isDeleted: false,
+	});
+
+	let warmedEntities = 0;
+	for (let i = 0; i < entities.length; i += ENTITY_BATCH_SIZE) {
+		const batch = entities.slice(i, i + ENTITY_BATCH_SIZE);
+		const results = await Promise.allSettled(
+			batch.map(async (entity) => {
+				const entityId = entity.id ?? entity.internal_id;
+				if (!entityId) return false;
+				await getOrSetCachedFullSubject({
+					ctx,
+					customerId,
+					entityId,
+					source: source ?? "warm-full-subject-cache",
+				});
+				return true;
+			}),
+		);
+		for (const r of results) {
+			if (r.status === "fulfilled" && r.value === true) warmedEntities++;
+			else if (r.status === "rejected") {
+				warmFailedCounter.add(1, { reason: "entity_hydrate" });
+			} else {
+				warmSkippedCounter.add(1, { reason: "entity_write_skipped" });
+			}
+		}
+
+		// Pace successive batches so DB+Redis don't see a burst when a
+		// customer has many entities.
+		if (i + ENTITY_BATCH_SIZE < entities.length) {
+			await new Promise((resolve) => setTimeout(resolve, BATCH_PAUSE_MS));
+		}
+	}
+
+	warmEntityCounter.add(warmedEntities, { source: source ?? "unknown" });
+	ctx.logger.info(
+		`warm-full-subject-cache: customer=${customerId} warmed_customer=${warmedCustomer} warmed_entities=${warmedEntities}/${entities.length} source=${source}`,
+	);
+
+	return {
+		warmed_customer: warmedCustomer,
+		warmed_entities: warmedEntities,
+		total_entities: entities.length,
+	};
+};
 
 export const warmFullSubjectCacheTask = task({
 	id: "warm-full-subject-cache",
@@ -55,107 +149,6 @@ export const warmFullSubjectCacheTask = task({
 			}),
 		);
 
-		const customer = await CusService.get({
-			db: ctx.db,
-			orgId: ctx.org.id,
-			env: ctx.env,
-			idOrInternalId: customerId,
-		});
-		if (!customer) {
-			warmSkippedCounter.add(1, { reason: "customer_not_found" });
-			logger.warn(
-				`warm-full-subject-cache: customer not found id=${customerId}`,
-			);
-			return { warmed_customer: 0, warmed_entities: 0 };
-		}
-
-		const epochKey = buildFullSubjectViewEpochKey({
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId,
-		});
-		const epochRaw = await runRedisOp({
-			operation: () => ctx.redisV2.get(epochKey),
-			source: "warm-full-subject-cache:read-epoch",
-			redisInstance: ctx.redisV2,
-		});
-		const parsed = epochRaw == null ? 0 : Number.parseInt(String(epochRaw), 10);
-		const epoch = Number.isNaN(parsed) ? 0 : parsed;
-
-		let warmedCustomer = 0;
-		try {
-			const customerSubject = await getFullSubjectNormalized({
-				ctx,
-				customerId,
-			});
-			if (customerSubject) {
-				const result = await setCachedFullSubject({
-					ctx,
-					normalized: customerSubject.normalized,
-					fetchedSubjectViewEpoch: epoch,
-				});
-				if (result === "OK") {
-					warmCustomerCounter.add(1, { source: source ?? "unknown" });
-					warmedCustomer = 1;
-				} else {
-					warmSkippedCounter.add(1, { reason: result.toLowerCase() });
-				}
-			} else {
-				warmSkippedCounter.add(1, { reason: "no_customer_data" });
-			}
-		} catch (error) {
-			warmFailedCounter.add(1, { reason: "customer_hydrate" });
-			logger.warn(
-				`warm-full-subject-cache: customer-level warm failed customer=${customerId} error=${error}`,
-			);
-		}
-
-		const entities = await EntityService.list({
-			db: ctx.db,
-			internalCustomerId: customer.internal_id,
-			isDeleted: false,
-		});
-
-		let warmedEntities = 0;
-		for (let i = 0; i < entities.length; i += ENTITY_BATCH_SIZE) {
-			const batch = entities.slice(i, i + ENTITY_BATCH_SIZE);
-			const results = await Promise.allSettled(
-				batch.map(async (entity) => {
-					const entityId = entity.id ?? entity.internal_id;
-					if (!entityId) return false;
-					const entitySubject = await getFullSubjectNormalized({
-						ctx,
-						customerId,
-						entityId,
-					});
-					if (!entitySubject) return false;
-					const result = await setCachedFullSubject({
-						ctx,
-						normalized: entitySubject.normalized,
-						fetchedSubjectViewEpoch: epoch,
-					});
-					return result === "OK";
-				}),
-			);
-			for (const r of results) {
-				if (r.status === "fulfilled" && r.value === true) warmedEntities++;
-				else if (r.status === "rejected") {
-					warmFailedCounter.add(1, { reason: "entity_hydrate" });
-				} else {
-					warmSkippedCounter.add(1, { reason: "entity_write_skipped" });
-				}
-			}
-		}
-
-		warmEntityCounter.add(warmedEntities, { source: source ?? "unknown" });
-		logger.info(
-			`warm-full-subject-cache: customer=${customerId} warmed_customer=${warmedCustomer} warmed_entities=${warmedEntities}/${entities.length} source=${source}`,
-		);
-
-		return {
-			warmed_customer: warmedCustomer,
-			warmed_entities: warmedEntities,
-			total_entities: entities.length,
-		};
+		return runWarmFullSubjectCache({ ctx, customerId, source });
 	},
 });

--- a/server/src/trigger/cache/warmFullSubjectCacheTask.ts
+++ b/server/src/trigger/cache/warmFullSubjectCacheTask.ts
@@ -1,0 +1,161 @@
+import { AppEnv } from "@autumn/shared";
+import { task } from "@trigger.dev/sdk/v3";
+import { metrics } from "@opentelemetry/api";
+import { z } from "zod/v4";
+import { warmupRegionalRedis } from "@/external/redis/initUtils/redisWarmup.js";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { buildFullSubjectViewEpochKey } from "@/internal/customers/cache/fullSubject/builders/buildFullSubjectViewEpochKey.js";
+import { setCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/setCachedFullSubject/setCachedFullSubject.js";
+import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { EntityService } from "@/internal/api/entities/EntityService.js";
+import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
+
+const meter = metrics.getMeter("autumn-server");
+const warmCustomerCounter = meter.createCounter("autumn.cache.warm.customer", {
+	description: "Customer-level FullSubject warms",
+});
+const warmEntityCounter = meter.createCounter("autumn.cache.warm.entity", {
+	description: "Entity-level FullSubject warms",
+});
+const warmSkippedCounter = meter.createCounter("autumn.cache.warm.skipped", {
+	description: "FullSubject warms skipped",
+});
+const warmFailedCounter = meter.createCounter("autumn.cache.warm.failed", {
+	description: "FullSubject warm failures",
+});
+
+const PayloadSchema = z.object({
+	orgId: z.string(),
+	env: z.enum(AppEnv),
+	customerId: z.string(),
+	source: z.string().optional(),
+});
+
+export type WarmFullSubjectCachePayload = z.infer<typeof PayloadSchema>;
+
+const ENTITY_BATCH_SIZE = 10;
+
+export const warmFullSubjectCacheTask = task({
+	id: "warm-full-subject-cache",
+	maxDuration: 120,
+	run: async (raw: unknown, { ctx: triggerCtx }) => {
+		const { orgId, env, customerId, source } = PayloadSchema.parse(raw);
+
+		const { ctx, logger } = await createTriggerContext({
+			orgId,
+			env,
+			triggerCtx,
+			customerId,
+		});
+
+		await warmupRegionalRedis().catch((error) =>
+			logger.warn("warm-full-subject-cache: redis warmup failed", {
+				data: { error: error instanceof Error ? error.message : String(error) },
+			}),
+		);
+
+		const customer = await CusService.get({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: customerId,
+		});
+		if (!customer) {
+			warmSkippedCounter.add(1, { reason: "customer_not_found" });
+			logger.warn(
+				`warm-full-subject-cache: customer not found id=${customerId}`,
+			);
+			return { warmed_customer: 0, warmed_entities: 0 };
+		}
+
+		const epochKey = buildFullSubjectViewEpochKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+		});
+		const epochRaw = await runRedisOp({
+			operation: () => ctx.redisV2.get(epochKey),
+			source: "warm-full-subject-cache:read-epoch",
+			redisInstance: ctx.redisV2,
+		});
+		const parsed = epochRaw == null ? 0 : Number.parseInt(String(epochRaw), 10);
+		const epoch = Number.isNaN(parsed) ? 0 : parsed;
+
+		let warmedCustomer = 0;
+		try {
+			const customerSubject = await getFullSubjectNormalized({
+				ctx,
+				customerId,
+			});
+			if (customerSubject) {
+				const result = await setCachedFullSubject({
+					ctx,
+					normalized: customerSubject.normalized,
+					fetchedSubjectViewEpoch: epoch,
+				});
+				if (result === "OK") {
+					warmCustomerCounter.add(1, { source: source ?? "unknown" });
+					warmedCustomer = 1;
+				} else {
+					warmSkippedCounter.add(1, { reason: result.toLowerCase() });
+				}
+			} else {
+				warmSkippedCounter.add(1, { reason: "no_customer_data" });
+			}
+		} catch (error) {
+			warmFailedCounter.add(1, { reason: "customer_hydrate" });
+			logger.warn(
+				`warm-full-subject-cache: customer-level warm failed customer=${customerId} error=${error}`,
+			);
+		}
+
+		const entities = await EntityService.list({
+			db: ctx.db,
+			internalCustomerId: customer.internal_id,
+			isDeleted: false,
+		});
+
+		let warmedEntities = 0;
+		for (let i = 0; i < entities.length; i += ENTITY_BATCH_SIZE) {
+			const batch = entities.slice(i, i + ENTITY_BATCH_SIZE);
+			const results = await Promise.allSettled(
+				batch.map(async (entity) => {
+					const entityId = entity.id ?? entity.internal_id;
+					if (!entityId) return false;
+					const entitySubject = await getFullSubjectNormalized({
+						ctx,
+						customerId,
+						entityId,
+					});
+					if (!entitySubject) return false;
+					const result = await setCachedFullSubject({
+						ctx,
+						normalized: entitySubject.normalized,
+						fetchedSubjectViewEpoch: epoch,
+					});
+					return result === "OK";
+				}),
+			);
+			for (const r of results) {
+				if (r.status === "fulfilled" && r.value === true) warmedEntities++;
+				else if (r.status === "rejected") {
+					warmFailedCounter.add(1, { reason: "entity_hydrate" });
+				} else {
+					warmSkippedCounter.add(1, { reason: "entity_write_skipped" });
+				}
+			}
+		}
+
+		warmEntityCounter.add(warmedEntities, { source: source ?? "unknown" });
+		logger.info(
+			`warm-full-subject-cache: customer=${customerId} warmed_customer=${warmedCustomer} warmed_entities=${warmedEntities}/${entities.length} source=${source}`,
+		);
+
+		return {
+			warmed_customer: warmedCustomer,
+			warmed_entities: warmedEntities,
+			total_entities: entities.length,
+		};
+	},
+});

--- a/server/tests/integration/db/full-subject-cache/cache-warmer-warms-customer-and-entities.test.ts
+++ b/server/tests/integration/db/full-subject-cache/cache-warmer-warms-customer-and-entities.test.ts
@@ -1,0 +1,158 @@
+/**
+ * TDD test for cache warmer happy path.
+ *
+ * Contract under test:
+ *   Allowlist:
+ *     - "cache-warmer-feature-test-cus" is on WARM_CACHE_CUSTOMER_IDS so
+ *       attempts to warm this customer are NOT short-circuited.
+ *   New behaviors:
+ *     - runWarmFullSubjectCache({ ctx, customerId }) populates the
+ *       FullSubject cache for the customer AND every entity owned by
+ *       the customer, given a previously-invalidated cache.
+ *     - Returns { warmed_customer: 1, warmed_entities: N, total_entities: N }
+ *       when both the customer and all N entities hydrate cleanly.
+ *     - Between entity batches the warmer pauses BATCH_PAUSE_MS so a
+ *       large entity fan-out does not burst DB+Redis. (Asserted
+ *       indirectly via the total entity count, not on timing.)
+ *   Side effects:
+ *     - Redis key at buildFullSubjectKey({ customerId }) is populated.
+ *     - Redis key at buildFullSubjectKey({ customerId, entityId }) is
+ *       populated for each of the customer's 5 entities.
+ *
+ * Pre-impl red: this file did not exist; the warmer body lived inside
+ *   the trigger.dev task wrapper and could not be invoked directly.
+ * Post-impl green: runWarmFullSubjectCache is exported from
+ *   warmFullSubjectCacheTask.ts and writes the expected Redis keys.
+ */
+
+import { expect, test } from "bun:test";
+import chalk from "chalk";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import {
+	buildFullSubjectKey,
+	getCachedFullSubject,
+	invalidateCachedFullSubject,
+} from "@/internal/customers/cache/fullSubject/index.js";
+import { runWarmFullSubjectCache } from "@/trigger/cache/warmFullSubjectCacheTask.js";
+
+test(
+	`${chalk.yellowBright("cache warmer: hydrates customer + every entity after invalidation")}`,
+	async () => {
+		// Must match the entry added to WARM_CACHE_CUSTOMER_IDS in
+		// server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts.
+		const customerId = "cache-warmer-feature-test-cus";
+
+		const free = products.base({
+			id: "warm-free",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+		const pro = products.pro({
+			id: "warm-pro",
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+
+		const { ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.deleteCustomer({ customerId }),
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+				s.entities({ count: 5, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.attach({ productId: free.id, entityIndex: 0 }),
+				s.attach({ productId: free.id, entityIndex: 1 }),
+				s.attach({ productId: free.id, entityIndex: 2 }),
+				s.attach({ productId: free.id, entityIndex: 3 }),
+				s.attach({ productId: free.id, entityIndex: 4 }),
+				s.attach({ productId: pro.id }),
+			],
+		});
+
+		expect(entities).toHaveLength(5);
+
+		// Start from a clean cache so the warm's effects are unambiguous.
+		// The attach above does this via refreshCacheMiddleware, but a
+		// concurrent read could have re-populated the entry; force it.
+		await invalidateCachedFullSubject({
+			ctx,
+			customerId,
+			source: "integration-test:cache-warmer",
+		});
+		for (const entity of entities) {
+			await invalidateCachedFullSubject({
+				ctx,
+				customerId,
+				entityId: entity.id,
+				source: "integration-test:cache-warmer",
+			});
+		}
+
+		// ── Pre-condition: cache is empty for customer + all 5 entities ──────────
+		const customerCachePre = await getCachedFullSubject({
+			ctx,
+			customerId,
+			source: "integration-test:cache-warmer-pre",
+		});
+		expect(customerCachePre.fullSubject).toBeUndefined();
+
+		for (const entity of entities) {
+			const entityCachePre = await getCachedFullSubject({
+				ctx,
+				customerId,
+				entityId: entity.id,
+				source: "integration-test:cache-warmer-pre",
+			});
+			expect(entityCachePre.fullSubject).toBeUndefined();
+		}
+
+		// ── Behavior under test: warm the cache ──────────────────────────────────
+		const result = await runWarmFullSubjectCache({
+			ctx,
+			customerId,
+			source: "integration-test",
+		});
+
+		// ── Contract assertion 1: return value reflects what was warmed ──────────
+		expect(result.warmed_customer).toBe(1);
+		expect(result.total_entities).toBe(5);
+		expect(result.warmed_entities).toBe(5);
+
+		// ── Contract assertion 2: customer-level cache key is populated ──────────
+		const customerCachePost = await getCachedFullSubject({
+			ctx,
+			customerId,
+			source: "integration-test:cache-warmer-post",
+		});
+		expect(customerCachePost.fullSubject).toBeDefined();
+
+		const customerSubjectKey = buildFullSubjectKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId,
+		});
+		expect(await ctx.redisV2.exists(customerSubjectKey)).toBe(1);
+
+		// ── Contract assertion 3: each entity cache key is populated ─────────────
+		for (const entity of entities) {
+			const entityCachePost = await getCachedFullSubject({
+				ctx,
+				customerId,
+				entityId: entity.id,
+				source: "integration-test:cache-warmer-post",
+			});
+			expect(entityCachePost.fullSubject).toBeDefined();
+
+			const entitySubjectKey = buildFullSubjectKey({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				customerId,
+				entityId: entity.id,
+			});
+			expect(await ctx.redisV2.exists(entitySubjectKey)).toBe(1);
+		}
+	},
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a pilot background cache warmer that pre-populates FullSubject cache for allowlisted customers after invalidation. Also updates webhook docs to the new `billing.updated` event and refreshes the README image.

- **New Features**
  - Adds `warmFullSubjectCacheTask` using `@trigger.dev/sdk` to warm the customer and all entities in small batches with pacing; guarded by `shouldWarmCache` (allowlist) and keyed concurrency.
  - `refreshCacheMiddleware` now enqueues `warmFullSubjectCache` after `deleteCachedFullCustomer`, so warms happen right after invalidation.
  - Telemetry counters added via `@opentelemetry/api`; regional Redis warmup runs before hydration.
  - Exposes `runWarmFullSubjectCache` for direct invocation; new integration test verifies the customer + entity caches are populated.
  - Docs: rewrote webhooks to use `billing.updated` with clear examples and tags; removed the beta note; minor README image update.

<sup>Written for commit 7f5901dc8d8e9836b188a4e3d86cea03b1158131. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1682?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a cache-warmer pilot for the `FullSubject` cache. After each cache invalidation in `refreshCacheMiddleware`, a trigger.dev background task is enqueued (fire-and-forget, gated behind a two-entry allowlist) to proactively re-populate the customer-level and entity-level Redis keys before the next read arrives.

- **Improvements**: New `warmFullSubjectCacheTask` warms the customer entry and all non-deleted entity entries in batches of 25 with a 100 ms inter-batch pause; `concurrencyKey` prevents overlapping runs for the same subject. OpenTelemetry counters track enqueue successes, enqueue failures, warms, skips, and hydration errors.
- **API changes**: Webhook docs rename `customer.products.updated` to `billing.updated`, expand the payload with `plan_changes`, `previous_attributes`, and `tags`, and graduate webhooks out of beta.
</details>

<h3>Confidence Score: 4/5</h3>

The core warm path is fire-and-forget, gated behind a two-entry allowlist, and idempotent by design — safe to merge for the pilot.

The warmer logic is sound: batched entity hydration, proper error isolation via Promise.allSettled, and a concurrencyKey preventing overlapping trigger.dev runs. The hard-coded production customer ID and the entity-ID fallback are non-critical for the pilot scope but worth addressing before a broader rollout.

warmFullSubjectCache.ts contains a raw production customer ID that should move to config, and warmFullSubjectCacheTask.ts has the entity-ID fallback worth reviewing before the allowlist expands.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/refreshCacheMiddleware.ts | Adds a fire-and-forget `warmFullSubjectCache` call after `deleteCachedFullCustomer`; only runs when `routeConfig` and `ctx.customerId` are both set, so the existing guard is respected. |
| server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts | New helper that gates cache warm on a hard-coded Set of customer IDs. Contains a raw production customer ID that should ideally be moved to config/env. Uses concurrencyKey to prevent parallel trigger.dev tasks for the same subject. |
| server/src/trigger/cache/warmFullSubjectCacheTask.ts | New trigger.dev task that warms customer-level and entity-level FullSubject caches in batches. The `entity.id ?? entity.internal_id` fallback (line 94) may warm an unreachable Redis key when an entity lacks an external ID. |
| server/tests/integration/db/full-subject-cache/cache-warmer-warms-customer-and-entities.test.ts | Comprehensive integration test covering the happy path: invalidates cache, runs warmer, asserts both the return value and that Redis keys are populated for customer + 5 entities. |
| apps/docs/mintlify/documentation/webhooks.mdx | Renames `customer.products.updated` to `billing.updated`, expands the payload schema with `plan_changes` / `previous_attributes` / `tags`, and removes the beta note from webhooks setup. |
| README.md | Swaps the local hero image for a GitHub-hosted attachment URL. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Hono as Hono (refreshCacheMiddleware)
    participant Redis
    participant TriggerDev as trigger.dev
    participant Task as warmFullSubjectCacheTask

    Client->>Hono: API request (mutating route)
    Hono->>Hono: await next()
    Hono->>Redis: deleteCachedFullCustomer
    Hono->>TriggerDev: warmFullSubjectCacheTask.trigger() [fire-and-forget, allowlisted only]
    Hono-->>Client: response
    TriggerDev->>Task: run (concurrencyKey prevents parallel runs)
    Task->>Redis: warmupRegionalRedis
    Task->>Task: CusService.get (verify customer exists)
    Task->>Redis: getOrSetCachedFullSubject (customer level)
    Task->>Task: "EntityService.list (isDeleted=false)"
    loop Batches of 25 entities
        Task->>Redis: getOrSetCachedFullSubject (per entity) via Promise.allSettled
        Task->>Task: pause 100ms between batches
    end
    Task-->>TriggerDev: WarmFullSubjectResult
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/trigger/cache/warmFullSubjectCacheTask.ts:94-95
**Entity `internal_id` used as cache key when `id` is absent**

`entity.id ?? entity.internal_id` falls back to the internal UUID when the external ID is not set. `buildFullSubjectKey` embeds whichever string is passed as `entityId` literally into the Redis key (e.g., `{cus}:org:env:entity:<entityId>:full_subject`). If production lookups always supply the external `entity.id`, warming with `internal_id` creates an unreachable cache entry and `getOrSetCachedFullSubject` may throw `EntityNotFoundError` (caught as a failed warm, not a skip) because `getFullSubjectNormalized` might not recognise the UUID as a valid external ID. For active entities (`isDeleted: false`) the external `id` should usually be set, so consider returning `false` (skip) rather than falling back to `internal_id` — or at minimum logging a warning when the fallback fires.

### Issue 2 of 2
server/src/internal/customers/cache/fullSubject/actions/warmFullSubjectCache.ts:15-18
**Hard-coded production customer ID in source code**

`"64138004cce3c9e82a7083d9"` is a raw production customer ID baked into the allowlist. Adding or removing a pilot customer requires a code change and full deployment. Consider loading the allowlist from an environment variable or a feature-flag store (e.g., `process.env.WARM_CACHE_CUSTOMER_IDS?.split(",")`) so the set can be updated without a release. The test-fixture ID `"cache-warmer-feature-test-cus"` is fine to keep in source.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: clean up warm full subject cache"](https://github.com/useautumn/autumn/commit/7f5901dc8d8e9836b188a4e3d86cea03b1158131) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33330547)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->