### PR TITLE
fix: stale revalidate

### DIFF
--- a/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
@@ -22,6 +22,7 @@ import {
 import { sanitizeCachedFullSubject } from "../sanitize/index.js";
 import { invalidateCachedFullSubject } from "./invalidate/invalidateFullSubject.js";
 import { invalidateCachedFullSubjectExact } from "./invalidate/invalidateFullSubjectExact.js";
+import { shouldWarmCache } from "./warmFullSubjectCache.js";
 
 export type GetCachedFullSubjectResult = {
 	fullSubject: FullSubject | undefined;
@@ -33,11 +34,13 @@ export const getCachedFullSubject = async ({
 	customerId,
 	entityId,
 	source,
+	staleWhileRevalidate = false,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	source?: string;
+	staleWhileRevalidate?: boolean;
 }): Promise<GetCachedFullSubjectResult> => {
 	const { org, env, logger, redisV2 } = ctx;
 	const subjectKey = buildFullSubjectKey({
@@ -106,19 +109,28 @@ export const getCachedFullSubject = async ({
 	}
 
 	if (cached.subjectViewEpoch !== currentSubjectViewEpoch) {
-		logger.warn(
-			`[getCachedFullSubject] Stale subject view epoch for ${customerId}${entityId ? `:${entityId}` : ""}, cached=${cached.subjectViewEpoch}, current=${currentSubjectViewEpoch}, source: ${source}`,
-		);
-		await invalidateCachedFullSubjectExact({
-			ctx,
-			customerId,
-			entityId,
-			source: "stale-subject-view-epoch",
-		});
-		return {
-			fullSubject: undefined,
-			subjectViewEpoch: currentSubjectViewEpoch,
-		};
+		// Allow-listed high-cardinality customers serve the stale subject and
+		// rehydrate via the warm task, instead of rebuilding 10k+ entities
+		// inline on every reader.
+		if (staleWhileRevalidate && shouldWarmCache(customerId)) {
+			logger.warn(
+				`[getCachedFullSubject] Serving stale-while-revalidate for ${customerId}${entityId ? `:${entityId}` : ""}, cached= ${cached.subjectViewEpoch}, current= ${currentSubjectViewEpoch}, source: ${source}`,
+			);
+		} else {
+			logger.warn(
+				`[getCachedFullSubject] Stale subject view epoch for ${customerId}${entityId ? `:${entityId}` : ""}, cached=${cached.subjectViewEpoch}, current= ${currentSubjectViewEpoch}, source: ${source}`,
+			);
+			await invalidateCachedFullSubjectExact({
+				ctx,
+				customerId,
+				entityId,
+				source: "stale-subject-view-epoch",
+			});
+			return {
+				fullSubject: undefined,
+				subjectViewEpoch: currentSubjectViewEpoch,
+			};
+		}
 	}
 
 	if (cached._schemaVersion !== FULL_SUBJECT_CACHE_SCHEMA_VERSION) {

--- a/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
@@ -14,11 +14,13 @@ export const getOrSetCachedFullSubject = async ({
 	customerId,
 	entityId,
 	source,
+	staleWhileRevalidate = true,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
 	entityId?: string;
 	source?: string;
+	staleWhileRevalidate?: boolean;
 }): Promise<FullSubject> => {
 	const { skipCache, logger } = ctx;
 	const useRedis = !skipCache;
@@ -35,6 +37,7 @@ export const getOrSetCachedFullSubject = async ({
 				customerId,
 				entityId,
 				source,
+				staleWhileRevalidate,
 			});
 		fetchedSubjectViewEpoch = subjectViewEpoch;
 

--- a/server/src/trigger/cache/warmFullSubjectCacheTask.ts
+++ b/server/src/trigger/cache/warmFullSubjectCacheTask.ts
@@ -70,6 +70,9 @@ export const runWarmFullSubjectCache = async ({
 			ctx,
 			customerId,
 			source: source ?? "warm-full-subject-cache",
+			// The warmer IS the revalidator — never serve stale here, or we'd
+			// loop on our own stale read and never rebuild.
+			staleWhileRevalidate: false,
 		});
 		warmCustomerCounter.add(1, { source: source ?? "unknown" });
 		warmedCustomer = 1;
@@ -98,6 +101,7 @@ export const runWarmFullSubjectCache = async ({
 					customerId,
 					entityId,
 					source: source ?? "warm-full-subject-cache",
+					staleWhileRevalidate: false,
 				});
 				return true;
 			}),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stale-while-revalidate for the full subject cache to reduce read latency for large customers. Serve stale data for allow-listed tenants and rehydrate via the cache warmer; others continue to invalidate immediately.

- **Bug Fixes**
  - Added a `staleWhileRevalidate` flag (default true in get-or-set; plumbed through to cached read).
  - Enabled SWR only for allow-listed customers via `shouldWarmCache(customerId)`; otherwise invalidate stale entries.
  - Forced the warmer to never serve stale (`staleWhileRevalidate: false`) to avoid revalidation loops.
  - Improved logging to distinguish SWR vs. hard invalidations with subject view epoch details.

<sup>Written for commit f6c0bf3935857c9f83f797411eafac175f7d2e1c. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1684?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a stale-while-revalidate (SWR) optimisation for high-cardinality customers on an explicit allowlist: instead of evicting and blocking on a full DB rebuild every time a stale epoch is detected, readers now serve the cached subject while deferring the rebuild to an async warm task. The warm-task path explicitly disables SWR to prevent it from looping on its own stale output.

- **Bug fixes / Improvements** — `getCachedFullSubject` gains a `staleWhileRevalidate` parameter (default `false`) that, when combined with a passing `shouldWarmCache` guard, skips inline invalidation and serves the existing cached subject for allowlisted customers with many entities.
- **Improvements** — `getOrSetCachedFullSubject` defaults `staleWhileRevalidate` to `true`, transparently opting callers into SWR while letting the warm task and internal callers override to `false`.
- **Bug fixes** — `warmFullSubjectCacheTask` passes `staleWhileRevalidate: false` to both the customer-level and entity-level `getOrSetCachedFullSubject` calls, ensuring the warmer always forces a fresh rebuild rather than re-serving stale state.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge for most customers, but the stale-while-revalidate path has no self-healing mechanism for allowlisted customers if the warm task was never triggered or silently failed.

The core idea is sound and the warm-task loop guard is correctly placed. The gap is that once a reader enters the SWR branch it only logs — it never re-enqueues a warm task. If the warm task was skipped (non-HTTP invalidation path) or failed, stale data will be served indefinitely for the two allowlisted customer IDs with no automatic recovery.

getCachedFullSubject.ts — the stale-while-revalidate branch at line 115 needs a warmFullSubjectCache() call as a self-healing fallback.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts | Adds stale-while-revalidate logic guarded by a customer allowlist; the SWR branch serves the stale subject without re-triggering the warm task, risking indefinite staleness if the warm task was never enqueued or failed. |
| server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts | Threads the new staleWhileRevalidate flag (default true) through to getCachedFullSubject; straightforward and correct plumbing. |
| server/src/trigger/cache/warmFullSubjectCacheTask.ts | Explicitly sets staleWhileRevalidate: false in both customer and entity warm paths, correctly preventing the warmer from looping on its own stale read. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant MW as refreshCacheMiddleware
    participant Redis as Redis
    participant Reader as Reader (getOrSetCachedFullSubject)
    participant SWR as getCachedFullSubject (SWR=true)
    participant Warm as warmFullSubjectCacheTask (SWR=false)
    participant DB as Database

    MW->>Redis: deleteCachedFullCustomer (INCR epoch E+1)
    MW-->>Warm: trigger warmFullSubjectCacheTask
    Note over Redis: epoch=E+1, cached blob epoch=E

    Reader->>SWR: "getCachedFullSubject(staleWhileRevalidate=true)"
    SWR->>Redis: pipeline GET subject + GET epoch
    Redis-->>SWR: "cached epoch=E, current epoch=E+1 (mismatch)"
    SWR->>SWR: shouldWarmCache true - serve stale, log warn
    SWR-->>Reader: FullSubject (stale E)

    Warm->>SWR: "getCachedFullSubject(staleWhileRevalidate=false)"
    SWR->>Redis: pipeline GET subject + GET epoch
    Redis-->>SWR: "cached epoch=E, current epoch=E+1 (mismatch, no SWR)"
    SWR-->>Warm: "fullSubject=undefined"
    Warm->>DB: getFullSubjectNormalized
    DB-->>Warm: fresh normalized subject
    Warm->>Redis: "setCachedFullSubject (write blob, epoch=E+1)"

    Reader->>SWR: getCachedFullSubject (next request)
    SWR->>Redis: pipeline GET subject + GET epoch
    Redis-->>SWR: "cached epoch=E+1, current epoch=E+1 (match)"
    SWR-->>Reader: FullSubject (fresh)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts:115-118
**Stale cache never escapes without a fresh warm-task trigger**

When the SWR branch fires, the code logs and falls through — but it never calls `warmFullSubjectCache()`. The design relies entirely on the warm task already being in-flight (enqueued by `refreshCacheMiddleware` when the epoch was bumped). If the warm task wasn't triggered (e.g., the epoch was bumped via a non-HTTP path such as a background job or admin script) or if it failed silently, every subsequent read will keep serving the stale subject indefinitely with no mechanism to re-enqueue a rebuild. Because `warmFullSubjectCacheTask` uses a per-customer `concurrencyKey`, calling `warmFullSubjectCache()` here is safe — a running task is not duplicated — and it provides a self-healing safety net.

### Issue 2 of 2
server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts:120-122
Log format inconsistency: the `cached=` token has no space after `=` but `current=` does (`current= ${...}`). The original pre-PR message used `cached=X, current=Y` uniformly. Aligning them makes log parsing and grepping consistent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stale revalidate strat"](https://github.com/useautumn/autumn/commit/f6c0bf3935857c9f83f797411eafac175f7d2e1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33345271)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->