### PR TITLE
fix: rate limit entities get

### DIFF
--- a/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
@@ -10,6 +10,7 @@ export enum RateLimitType {
 	Events = "events",
 	Attach = "attach",
 	ListCustomers = "list_customers",
+	CustomerEntitiesGet = "customer_entities_get",
 }
 
 type RoutePattern = {
@@ -98,8 +99,11 @@ const RATE_LIMIT_ROUTE_GROUPS: RateLimitRouteGroup[] = [
 			route({ method: "POST", url: "/v1/customers" }),
 			route({ method: "POST", url: "/v1/customers.get" }),
 			route({ method: "POST", url: "/v1/customers.get_or_create" }),
-			route({ method: "POST", url: "/v1/entities.get" }),
 		],
+	},
+	{
+		type: RateLimitType.CustomerEntitiesGet,
+		patterns: [route({ method: "POST", url: "/v1/entities.get" })],
 	},
 ];
 
@@ -216,5 +220,12 @@ export const RATE_LIMIT_CONFIGS: Record<RateLimitType, RateLimitConfig> = {
 		windowMs: 1000,
 		notInRedis: false,
 		scope: RateLimitScope.Org,
+	},
+	[RateLimitType.CustomerEntitiesGet]: {
+		name: "customer_entities_get",
+		limit: 100,
+		windowMs: 1000,
+		notInRedis: false,
+		scope: RateLimitScope.Customer,
 	},
 };

--- a/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
@@ -223,7 +223,7 @@ export const RATE_LIMIT_CONFIGS: Record<RateLimitType, RateLimitConfig> = {
 	},
 	[RateLimitType.CustomerEntitiesGet]: {
 		name: "customer_entities_get",
-		limit: 100,
+		limit: 50,
 		windowMs: 1000,
 		notInRedis: false,
 		scope: RateLimitScope.Customer,

--- a/server/tests/integration/others/rate-limits/rate-limit-entities-get.test.ts
+++ b/server/tests/integration/others/rate-limits/rate-limit-entities-get.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { ApiVersion } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import AutumnError, { AutumnInt } from "@/external/autumn/autumnCli.js";
+import {
+	RATE_LIMIT_CONFIGS,
+	RateLimitType,
+} from "@/internal/misc/rateLimiter/rateLimitConfigs.js";
+
+const testCase = "rate-limit-entities-get";
+const ENTITIES_GET_LIMIT = RATE_LIMIT_CONFIGS[RateLimitType.CustomerEntitiesGet].limit;
+
+const countRateLimited = (results: PromiseSettledResult<unknown>[]): number =>
+	results.filter(
+		(result) =>
+			result.status === "rejected" &&
+			result.reason instanceof AutumnError &&
+			result.reason.code === "rate_limit_exceeded",
+	).length;
+
+test(`${chalk.yellowBright(`${testCase}: trips the per-customer bucket above the limit`)}`, async () => {
+	const customerId = "rate-limit-entities-get";
+	const entityId = "entity-rate-limit";
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false })],
+		actions: [],
+	});
+
+	await autumnV1.entities.create(customerId, {
+		id: entityId,
+		name: "Rate Limit Entity",
+		feature_id: TestFeature.Users,
+	});
+
+	const client = new AutumnInt({
+		version: ApiVersion.V1_2,
+		secretKey: ctx.orgSecretKey,
+	});
+
+	const overLimit = ENTITIES_GET_LIMIT + 10;
+	const results = await Promise.allSettled(
+		Array.from({ length: overLimit }, () =>
+			client.post("/entities.get", {
+				customer_id: customerId,
+				entity_id: entityId,
+			}),
+		),
+	);
+
+	expect(countRateLimited(results)).toBeGreaterThan(0);
+});

--- a/server/tests/unit/rate-limits/get-rate-limit-type.test.ts
+++ b/server/tests/unit/rate-limits/get-rate-limit-type.test.ts
@@ -102,6 +102,14 @@ describe("getRateLimitType", () => {
 		).toBe(RateLimitType.Attach);
 	});
 
+	test("classifies entities.get into its dedicated per-customer bucket", () => {
+		expect(
+			getRateLimitType(
+				createContext({ method: "POST", path: "/v1/entities.get" }),
+			),
+		).toBe(RateLimitType.CustomerEntitiesGet);
+	});
+
 	test("falls back to the general bucket for uncategorized routes", () => {
 		expect(
 			getRateLimitType(createContext({ method: "GET", path: "/v1/products" })),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets a dedicated per-customer rate limit for `POST /v1/entities.get` to stop sharing the general customers bucket. Adds tests to verify route classification and that the limit is enforced.

- **Bug Fixes**
  - Introduced `RateLimitType.CustomerEntitiesGet` (`customer_entities_get`) at 50 req/s, scoped to Customer.
  - Reclassified `/v1/entities.get` into this bucket and added unit + integration tests.

<sup>Written for commit 6a0e3d102ff5f99f6982af1d75ac7c9c0ec7e967. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1685?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the `POST /v1/entities.get` endpoint out of the shared `Check` rate-limit bucket and into a new dedicated `CustomerEntitiesGet` bucket with a stricter 100 req/s per-customer limit backed by Redis, down from the prior 10,000 req/s in-memory limit.

- **[Bug fixes]** Adds a new `CustomerEntitiesGet` rate-limit type with its own 100 req/s per-customer Redis-backed config, preventing `entities.get` from consuming the very permissive `Check` bucket allowance.
- **[Improvements]** Adds both a unit test for route classification and an integration test that fires over-limit concurrent requests and asserts at least one is rate-limited.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is tightly scoped to rate-limit classification and config, with no effect on request handling logic.

The route is correctly extracted from the shared Check bucket into its own dedicated config. Key generation for the Customer scope already uses ctx.customerId for POST body requests, so the scoping works correctly for entities.get. Both a unit test and an integration test cover the new behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/misc/rateLimiter/rateLimitConfigs.ts | Adds CustomerEntitiesGet enum value, moves /v1/entities.get to a new dedicated route group, and adds its rate-limit config (100 req/s per customer, Redis-backed). Change is self-contained and correct. |
| server/tests/integration/others/rate-limits/rate-limit-entities-get.test.ts | New integration test fires ENTITIES_GET_LIMIT + 10 concurrent requests and asserts at least one is rate-limited; correctly uses Promise.allSettled and checks for rate_limit_exceeded error code. |
| server/tests/unit/rate-limits/get-rate-limit-type.test.ts | Adds a unit test asserting /v1/entities.get classifies into the CustomerEntitiesGet bucket; follows existing test patterns cleanly. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["POST /v1/entities.get"] --> B["rateLimitMiddleware"]
    B --> C["getRateLimitType()"]
    C --> D{"Route group match?"}
    D -- "After PR" --> E["CustomerEntitiesGet\n100 req per sec, per customer, Redis"]
    D -- "Before PR" --> F["Check\n10000 req per sec, in-memory"]
    E --> G["getRateLimitKey()\ncustomer_entities_get:orgId:env:customerId"]
    G --> H["Redis-backed limiter"]
    H --> I{Under limit?}
    I -- Yes --> J["Handler"]
    I -- No --> K["429 rate_limit_exceeded"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: rate limit get entities"](https://github.com/useautumn/autumn/commit/799392e5ea4135702d6e5235cd87094cbab90b3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33349554)</sub>

<!-- /greptile_comment -->