### PR TITLE
Release 22/05/2026

### DIFF
--- a/server/src/internal/entities/handlers/handleListEntitiesV2.ts
+++ b/server/src/internal/entities/handlers/handleListEntitiesV2.ts
@@ -113,6 +113,7 @@ const runOffsetListEntities = async ({
 		plans: body.plans,
 		processors: body.processors,
 		search: body.search,
+		customer_id: body.customer_id,
 	});
 
 	const [subjectRows, totalCount] = await Promise.all([
@@ -134,6 +135,7 @@ const runOffsetListEntities = async ({
 					plans: body.plans,
 					processors: body.processors,
 					search: body.search,
+					customer_id: body.customer_id,
 				},
 				inStatuses,
 			})
@@ -198,6 +200,7 @@ export const handleListEntitiesV2 = createRoute({
 					plans: body.plans,
 					processors: body.processors,
 					search: body.search,
+					customerId: body.customer_id,
 				}),
 			);
 

--- a/server/src/internal/entities/handlers/handleListEntitiesV2.ts
+++ b/server/src/internal/entities/handlers/handleListEntitiesV2.ts
@@ -113,7 +113,7 @@ const runOffsetListEntities = async ({
 		plans: body.plans,
 		processors: body.processors,
 		search: body.search,
-		customer_id: body.customer_id,
+		customerId: body.customer_id,
 	});
 
 	const [subjectRows, totalCount] = await Promise.all([
@@ -135,7 +135,7 @@ const runOffsetListEntities = async ({
 					plans: body.plans,
 					processors: body.processors,
 					search: body.search,
-					customer_id: body.customer_id,
+					customerId: body.customer_id,
 				},
 				inStatuses,
 			})

--- a/server/src/internal/entities/repos/cursorListEntitiesQuery.ts
+++ b/server/src/internal/entities/repos/cursorListEntitiesQuery.ts
@@ -11,11 +11,20 @@ const getEntityListFilterSql = ({
 	plans,
 	processors,
 	search,
+	customer_id,
 	inStatuses,
-}: Pick<ListEntitiesParams, "plans" | "processors" | "search"> & {
+}: Pick<
+	ListEntitiesParams,
+	"plans" | "processors" | "search" | "customer_id"
+> & {
 	inStatuses: CusProductStatus[];
 }) => {
 	const filters: SQL[] = [];
+
+	const trimmedCustomerId = customer_id?.trim();
+	if (trimmedCustomerId) {
+		filters.push(sql`AND c.id = ${trimmedCustomerId}`);
+	}
 
 	if (plans && plans.length > 0) {
 		const planConditions = plans.map((plan) => {
@@ -89,6 +98,7 @@ export const getCursorPaginatedEntitySubjectsQuery = ({
 	plans,
 	processors,
 	search,
+	customerId,
 }: {
 	orgId: string;
 	env: AppEnv;
@@ -98,11 +108,13 @@ export const getCursorPaginatedEntitySubjectsQuery = ({
 	plans?: ListEntitiesParams["plans"];
 	processors?: ListEntitiesParams["processors"];
 	search?: string;
+	customerId?: string;
 }) => {
 	const filterSql = getEntityListFilterSql({
 		plans,
 		processors,
 		search,
+		customer_id: customerId,
 		inStatuses,
 	});
 

--- a/server/src/internal/entities/repos/cursorListEntitiesQuery.ts
+++ b/server/src/internal/entities/repos/cursorListEntitiesQuery.ts
@@ -11,17 +11,15 @@ const getEntityListFilterSql = ({
 	plans,
 	processors,
 	search,
-	customer_id,
+	customerId,
 	inStatuses,
-}: Pick<
-	ListEntitiesParams,
-	"plans" | "processors" | "search" | "customer_id"
-> & {
+}: Pick<ListEntitiesParams, "plans" | "processors" | "search"> & {
+	customerId?: string;
 	inStatuses: CusProductStatus[];
 }) => {
 	const filters: SQL[] = [];
 
-	const trimmedCustomerId = customer_id?.trim();
+	const trimmedCustomerId = customerId?.trim();
 	if (trimmedCustomerId) {
 		filters.push(sql`AND c.id = ${trimmedCustomerId}`);
 	}
@@ -114,7 +112,7 @@ export const getCursorPaginatedEntitySubjectsQuery = ({
 		plans,
 		processors,
 		search,
-		customer_id: customerId,
+		customerId,
 		inStatuses,
 	});
 

--- a/server/src/internal/entities/repos/listEntitiesQuery.ts
+++ b/server/src/internal/entities/repos/listEntitiesQuery.ts
@@ -11,11 +11,16 @@ export const hasEntityListFilters = ({
 	plans,
 	processors,
 	search,
-}: Pick<ListEntitiesParams, "plans" | "processors" | "search">) => {
+	customer_id,
+}: Pick<
+	ListEntitiesParams,
+	"plans" | "processors" | "search" | "customer_id"
+>) => {
 	return Boolean(
 		(plans && plans.length > 0) ||
 			(processors && processors.length > 0) ||
-			search?.trim(),
+			search?.trim() ||
+			customer_id?.trim(),
 	);
 };
 
@@ -23,11 +28,20 @@ const getEntityListFilterSql = ({
 	plans,
 	processors,
 	search,
+	customer_id,
 	inStatuses,
-}: Pick<ListEntitiesParams, "plans" | "processors" | "search"> & {
+}: Pick<
+	ListEntitiesParams,
+	"plans" | "processors" | "search" | "customer_id"
+> & {
 	inStatuses: CusProductStatus[];
 }) => {
 	const filters: SQL[] = [];
+
+	const trimmedCustomerId = customer_id?.trim();
+	if (trimmedCustomerId) {
+		filters.push(sql`AND c.id = ${trimmedCustomerId}`);
+	}
 
 	if (plans && plans.length > 0) {
 		const planConditions = plans.map((plan) => {
@@ -127,6 +141,7 @@ export const getPaginatedEntitySubjectsQuery = ({
 		plans: query.plans,
 		processors: query.processors,
 		search: query.search,
+		customer_id: query.customer_id,
 		inStatuses,
 	});
 
@@ -196,7 +211,10 @@ export const countFilteredEntitiesByOrgIdAndEnv = async ({
 	inStatuses,
 }: {
 	ctx: AutumnContext;
-	query: Pick<ListEntitiesParams, "plans" | "processors" | "search">;
+	query: Pick<
+		ListEntitiesParams,
+		"plans" | "processors" | "search" | "customer_id"
+	>;
 	inStatuses: CusProductStatus[];
 }) => {
 	if (!hasEntityListFilters(query)) {
@@ -209,6 +227,7 @@ export const countFilteredEntitiesByOrgIdAndEnv = async ({
 			plans: query.plans,
 			processors: query.processors,
 			search: query.search,
+			customer_id: query.customer_id,
 			inStatuses,
 		}),
 	});

--- a/server/src/internal/entities/repos/listEntitiesQuery.ts
+++ b/server/src/internal/entities/repos/listEntitiesQuery.ts
@@ -7,20 +7,24 @@ import { type SQL, sql } from "drizzle-orm";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectRowsQuery } from "@/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.js";
 
+type EntityListFilters = Pick<
+	ListEntitiesParams,
+	"plans" | "processors" | "search"
+> & {
+	customerId?: string;
+};
+
 export const hasEntityListFilters = ({
 	plans,
 	processors,
 	search,
-	customer_id,
-}: Pick<
-	ListEntitiesParams,
-	"plans" | "processors" | "search" | "customer_id"
->) => {
+	customerId,
+}: EntityListFilters) => {
 	return Boolean(
 		(plans && plans.length > 0) ||
 			(processors && processors.length > 0) ||
 			search?.trim() ||
-			customer_id?.trim(),
+			customerId?.trim(),
 	);
 };
 
@@ -28,17 +32,14 @@ const getEntityListFilterSql = ({
 	plans,
 	processors,
 	search,
-	customer_id,
+	customerId,
 	inStatuses,
-}: Pick<
-	ListEntitiesParams,
-	"plans" | "processors" | "search" | "customer_id"
-> & {
+}: EntityListFilters & {
 	inStatuses: CusProductStatus[];
 }) => {
 	const filters: SQL[] = [];
 
-	const trimmedCustomerId = customer_id?.trim();
+	const trimmedCustomerId = customerId?.trim();
 	if (trimmedCustomerId) {
 		filters.push(sql`AND c.id = ${trimmedCustomerId}`);
 	}
@@ -141,7 +142,7 @@ export const getPaginatedEntitySubjectsQuery = ({
 		plans: query.plans,
 		processors: query.processors,
 		search: query.search,
-		customer_id: query.customer_id,
+		customerId: query.customer_id,
 		inStatuses,
 	});
 
@@ -211,10 +212,7 @@ export const countFilteredEntitiesByOrgIdAndEnv = async ({
 	inStatuses,
 }: {
 	ctx: AutumnContext;
-	query: Pick<
-		ListEntitiesParams,
-		"plans" | "processors" | "search" | "customer_id"
-	>;
+	query: EntityListFilters;
 	inStatuses: CusProductStatus[];
 }) => {
 	if (!hasEntityListFilters(query)) {
@@ -227,7 +225,7 @@ export const countFilteredEntitiesByOrgIdAndEnv = async ({
 			plans: query.plans,
 			processors: query.processors,
 			search: query.search,
-			customer_id: query.customer_id,
+			customerId: query.customerId,
 			inStatuses,
 		}),
 	});

--- a/server/tests/integration/crud/entities/list-entities-customer-id-filter.test.ts
+++ b/server/tests/integration/crud/entities/list-entities-customer-id-filter.test.ts
@@ -1,23 +1,3 @@
-/**
- * TDD test for the entities.list `customer_id` filter.
- *
- * Contract under test:
- *   - POST /v1/entities.list accepts an optional `customer_id` param.
- *   - When set, the response list contains ONLY entities owned by that customer.
- *   - When set, total_filtered_count reflects the customer-scoped count.
- *   - When unset, behavior matches today (org-wide scan).
- *
- * Motivation:
- *   Replaces fan-out `entities.get` polling (1 request per entity for a given
- *   customer) with a paginated bulk fetch (~limit-many calls). Drives the same
- *   per-entity hydration pipeline as today's list path, just filtered.
- *
- * Pre-impl red: the schema rejects `customer_id` and entities from other
- * customers leak through.
- * Post-impl green: the filter is honored at the query level and the response
- * only contains entities for the requested customer.
- */
-
 import { expect, test } from "bun:test";
 import {
 	type ApiEntityV2,
@@ -38,13 +18,13 @@ type ListEntitiesResponse<T> = PagePaginatedResponse<T> & {
 test.concurrent(
 	`${chalk.yellowBright("list entities: customer_id filter scopes results to one customer")}`,
 	async () => {
+		const runId = Date.now().toString(36);
 		const targetCustomerId = "list-entities-customer-filter-target";
-		const otherCustomerId = "list-entities-customer-filter-other";
+		const otherCustomerId = `list-entities-customer-filter-other-${runId}`;
 		const targetEntityAlpha = `${targetCustomerId}-alpha`;
 		const targetEntityBeta = `${targetCustomerId}-beta`;
 		const otherEntityGamma = `${otherCustomerId}-gamma`;
 
-		// Set up the target customer + two entities.
 		const { autumnV2_1 } = await initScenario({
 			customerId: targetCustomerId,
 			setup: [s.customer({})],
@@ -64,9 +44,6 @@ test.concurrent(
 			name: "Target Beta",
 		});
 
-		// Set up a second customer with an entity that should NOT appear in the
-		// filtered result. Uses the same org (initScenario shares org), so the
-		// org-wide listing would otherwise return all three entities.
 		await autumnV2_1.customers.create({
 			id: otherCustomerId,
 			name: "Other Customer",
@@ -78,7 +55,6 @@ test.concurrent(
 			name: "Other Gamma",
 		});
 
-		// Contract: with customer_id set, only entities for that customer come back.
 		const filtered = await autumnV2_1.entitiesV2.list<
 			ListEntitiesResponse<ApiEntityV2>
 		>({
@@ -95,8 +71,6 @@ test.concurrent(
 			expect(entity.customer_id).toBe(targetCustomerId);
 		}
 
-		// Contract: without customer_id, the unrelated entity is also visible
-		// (sanity check that the filter is what excluded it, not the test setup).
 		const unfiltered = await autumnV2_1.entitiesV2.list<
 			ListEntitiesResponse<ApiEntityV2>
 		>({
@@ -115,8 +89,9 @@ test.concurrent(
 test.concurrent(
 	`${chalk.yellowBright("list entities: customer_id filter works on the latest cursor-paginated response")}`,
 	async () => {
+		const runId = Date.now().toString(36);
 		const targetCustomerId = "list-entities-customer-filter-cursor-target";
-		const otherCustomerId = "list-entities-customer-filter-cursor-other";
+		const otherCustomerId = `list-entities-customer-filter-cursor-other-${runId}`;
 		const targetEntityId = `${targetCustomerId}-only`;
 		const otherEntityId = `${otherCustomerId}-only`;
 
@@ -144,7 +119,6 @@ test.concurrent(
 			name: "Other Cursor Only",
 		});
 
-		// Latest version routes through the cursor pagination handler.
 		const latestClient = new AutumnInt({
 			version: ApiVersion.V2_3,
 			secretKey: ctx.orgSecretKey,
@@ -206,19 +180,17 @@ test.concurrent(
 			),
 		);
 
-		// Sort both sides by entity id so the comparison is order-independent.
 		const byId = (a: ApiEntityV2, b: ApiEntityV2): number =>
 			(a.id ?? "").localeCompare(b.id ?? "");
-		const sortedList = [...listResponse.list].sort(byId);
-		const sortedGets = [...perEntityResponses].sort(byId);
+		// entities.list omits `invoices` (handleListEntitiesV2.ts); entities.get
+		// returns `invoices: []`. Strip from both sides before deep-equal.
+		const stripInvoices = ({ invoices: _, ...rest }: ApiEntityV2) => rest;
+		const sortedList = [...listResponse.list].sort(byId).map(stripInvoices);
+		const sortedGets = [...perEntityResponses].sort(byId).map(stripInvoices);
 
 		expect(sortedList.map((entity) => entity.id)).toEqual(
 			sortedGets.map((entity) => entity.id),
 		);
-
-		// Full per-entity shape must match — the list builder and the get
-		// handler hydrate from the same FullSubject pipeline, so any drift
-		// here is a regression we want to catch.
 		expect(sortedList).toEqual(sortedGets);
 	},
 );
@@ -242,8 +214,6 @@ test.concurrent(
 			name: "Existing Entity",
 		});
 
-		// Contract: unknown customer id returns zero entities, NOT the org-wide
-		// list. This is the access-scoping guarantee callers rely on.
 		const unknownResponse = await autumnV2_1.entitiesV2.list<
 			ListEntitiesResponse<ApiEntityV2>
 		>({

--- a/server/tests/integration/crud/entities/list-entities-customer-id-filter.test.ts
+++ b/server/tests/integration/crud/entities/list-entities-customer-id-filter.test.ts
@@ -1,0 +1,259 @@
+/**
+ * TDD test for the entities.list `customer_id` filter.
+ *
+ * Contract under test:
+ *   - POST /v1/entities.list accepts an optional `customer_id` param.
+ *   - When set, the response list contains ONLY entities owned by that customer.
+ *   - When set, total_filtered_count reflects the customer-scoped count.
+ *   - When unset, behavior matches today (org-wide scan).
+ *
+ * Motivation:
+ *   Replaces fan-out `entities.get` polling (1 request per entity for a given
+ *   customer) with a paginated bulk fetch (~limit-many calls). Drives the same
+ *   per-entity hydration pipeline as today's list path, just filtered.
+ *
+ * Pre-impl red: the schema rejects `customer_id` and entities from other
+ * customers leak through.
+ * Post-impl green: the filter is honored at the query level and the response
+ * only contains entities for the requested customer.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiEntityV2,
+	ApiVersion,
+	type CursorPaginatedResponse,
+	type PagePaginatedResponse,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+type ListEntitiesResponse<T> = PagePaginatedResponse<T> & {
+	total_count: number;
+	total_filtered_count: number;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("list entities: customer_id filter scopes results to one customer")}`,
+	async () => {
+		const targetCustomerId = "list-entities-customer-filter-target";
+		const otherCustomerId = "list-entities-customer-filter-other";
+		const targetEntityAlpha = `${targetCustomerId}-alpha`;
+		const targetEntityBeta = `${targetCustomerId}-beta`;
+		const otherEntityGamma = `${otherCustomerId}-gamma`;
+
+		// Set up the target customer + two entities.
+		const { autumnV2_1 } = await initScenario({
+			customerId: targetCustomerId,
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		await autumnV2_1.entitiesV2.create({
+			customer_id: targetCustomerId,
+			entity_id: targetEntityAlpha,
+			feature_id: TestFeature.Users,
+			name: "Target Alpha",
+		});
+		await autumnV2_1.entitiesV2.create({
+			customer_id: targetCustomerId,
+			entity_id: targetEntityBeta,
+			feature_id: TestFeature.Users,
+			name: "Target Beta",
+		});
+
+		// Set up a second customer with an entity that should NOT appear in the
+		// filtered result. Uses the same org (initScenario shares org), so the
+		// org-wide listing would otherwise return all three entities.
+		await autumnV2_1.customers.create({
+			id: otherCustomerId,
+			name: "Other Customer",
+		});
+		await autumnV2_1.entitiesV2.create({
+			customer_id: otherCustomerId,
+			entity_id: otherEntityGamma,
+			feature_id: TestFeature.Users,
+			name: "Other Gamma",
+		});
+
+		// Contract: with customer_id set, only entities for that customer come back.
+		const filtered = await autumnV2_1.entitiesV2.list<
+			ListEntitiesResponse<ApiEntityV2>
+		>({
+			customer_id: targetCustomerId,
+			limit: 10,
+			offset: 0,
+			keepInternalFields: true,
+		});
+
+		const filteredIds = filtered.list.map((entity) => entity.id).sort();
+		expect(filteredIds).toEqual([targetEntityAlpha, targetEntityBeta].sort());
+		expect(filtered.total_filtered_count).toBe(2);
+		for (const entity of filtered.list) {
+			expect(entity.customer_id).toBe(targetCustomerId);
+		}
+
+		// Contract: without customer_id, the unrelated entity is also visible
+		// (sanity check that the filter is what excluded it, not the test setup).
+		const unfiltered = await autumnV2_1.entitiesV2.list<
+			ListEntitiesResponse<ApiEntityV2>
+		>({
+			limit: 100,
+			offset: 0,
+			keepInternalFields: true,
+		});
+
+		const unfilteredIds = unfiltered.list.map((entity) => entity.id);
+		expect(unfilteredIds).toContain(targetEntityAlpha);
+		expect(unfilteredIds).toContain(targetEntityBeta);
+		expect(unfilteredIds).toContain(otherEntityGamma);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("list entities: customer_id filter works on the latest cursor-paginated response")}`,
+	async () => {
+		const targetCustomerId = "list-entities-customer-filter-cursor-target";
+		const otherCustomerId = "list-entities-customer-filter-cursor-other";
+		const targetEntityId = `${targetCustomerId}-only`;
+		const otherEntityId = `${otherCustomerId}-only`;
+
+		const { autumnV2_1, ctx } = await initScenario({
+			customerId: targetCustomerId,
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		await autumnV2_1.entitiesV2.create({
+			customer_id: targetCustomerId,
+			entity_id: targetEntityId,
+			feature_id: TestFeature.Users,
+			name: "Target Cursor Only",
+		});
+
+		await autumnV2_1.customers.create({
+			id: otherCustomerId,
+			name: "Other Cursor Customer",
+		});
+		await autumnV2_1.entitiesV2.create({
+			customer_id: otherCustomerId,
+			entity_id: otherEntityId,
+			feature_id: TestFeature.Users,
+			name: "Other Cursor Only",
+		});
+
+		// Latest version routes through the cursor pagination handler.
+		const latestClient = new AutumnInt({
+			version: ApiVersion.V2_3,
+			secretKey: ctx.orgSecretKey,
+		});
+
+		const cursorResponse = await latestClient.entitiesV2.list<
+			CursorPaginatedResponse<ApiEntityV2>
+		>({
+			customer_id: targetCustomerId,
+			limit: 25,
+			keepInternalFields: true,
+		});
+
+		const cursorIds = cursorResponse.list.map((entity) => entity.id);
+		expect(cursorIds).toEqual([targetEntityId]);
+		for (const entity of cursorResponse.list) {
+			expect(entity.customer_id).toBe(targetCustomerId);
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("list entities: bulk filtered response matches the union of per-entity entities.get calls")}`,
+	async () => {
+		const customerId = "list-entities-customer-filter-parity";
+		const entityIds = [
+			`${customerId}-entity-1`,
+			`${customerId}-entity-2`,
+			`${customerId}-entity-3`,
+		];
+
+		const { autumnV2_1 } = await initScenario({
+			customerId,
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		for (const [index, entityId] of entityIds.entries()) {
+			await autumnV2_1.entitiesV2.create({
+				customer_id: customerId,
+				entity_id: entityId,
+				feature_id: TestFeature.Users,
+				name: `Parity Entity ${index + 1}`,
+			});
+		}
+
+		const listResponse = await autumnV2_1.entitiesV2.list<
+			ListEntitiesResponse<ApiEntityV2>
+		>({
+			customer_id: customerId,
+			limit: 25,
+			offset: 0,
+			keepInternalFields: true,
+		});
+
+		const perEntityResponses = await Promise.all(
+			entityIds.map((entityId) =>
+				autumnV2_1.entities.get<ApiEntityV2>(customerId, entityId),
+			),
+		);
+
+		// Sort both sides by entity id so the comparison is order-independent.
+		const byId = (a: ApiEntityV2, b: ApiEntityV2): number =>
+			(a.id ?? "").localeCompare(b.id ?? "");
+		const sortedList = [...listResponse.list].sort(byId);
+		const sortedGets = [...perEntityResponses].sort(byId);
+
+		expect(sortedList.map((entity) => entity.id)).toEqual(
+			sortedGets.map((entity) => entity.id),
+		);
+
+		// Full per-entity shape must match — the list builder and the get
+		// handler hydrate from the same FullSubject pipeline, so any drift
+		// here is a regression we want to catch.
+		expect(sortedList).toEqual(sortedGets);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("list entities: customer_id filter returns an empty list for an unknown customer")}`,
+	async () => {
+		const customerId = "list-entities-customer-filter-empty-target";
+		const entityId = `${customerId}-entity`;
+
+		const { autumnV2_1 } = await initScenario({
+			customerId,
+			setup: [s.customer({})],
+			actions: [],
+		});
+
+		await autumnV2_1.entitiesV2.create({
+			customer_id: customerId,
+			entity_id: entityId,
+			feature_id: TestFeature.Users,
+			name: "Existing Entity",
+		});
+
+		// Contract: unknown customer id returns zero entities, NOT the org-wide
+		// list. This is the access-scoping guarantee callers rely on.
+		const unknownResponse = await autumnV2_1.entitiesV2.list<
+			ListEntitiesResponse<ApiEntityV2>
+		>({
+			customer_id: "list-entities-customer-filter-does-not-exist",
+			limit: 25,
+			offset: 0,
+			keepInternalFields: true,
+		});
+
+		expect(unknownResponse.list).toEqual([]);
+		expect(unknownResponse.total_filtered_count).toBe(0);
+	},
+);

--- a/shared/api/entities/crud/listEntitiesParams.ts
+++ b/shared/api/entities/crud/listEntitiesParams.ts
@@ -33,6 +33,11 @@ export const ListEntitiesParamsSchema = createPaginationParamsSchema({
 			description:
 				"Filter by parent customer processor type (stripe, revenuecat, vercel).",
 		}),
+
+	customer_id: z.string().trim().min(1).optional().meta({
+		description:
+			"Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get.",
+	}),
 });
 
 export type ListEntitiesParams = z.infer<typeof ListEntitiesParamsSchema>;

--- a/shared/api/entities/crud/listEntitiesParamsV2_3.ts
+++ b/shared/api/entities/crud/listEntitiesParamsV2_3.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
 import {
-	createCursorLimitSchema,
 	CursorRequestFieldSchema,
+	createCursorLimitSchema,
 	PaginationDefaults,
 } from "../../common/cursorPaginationSchemas.js";
 
@@ -40,6 +40,11 @@ export const ListEntitiesV2_3ParamsSchema = z.object({
 			description:
 				"Filter by parent customer processor type (stripe, revenuecat, vercel).",
 		}),
+
+	customer_id: z.string().trim().min(1).optional().meta({
+		description:
+			"Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get.",
+	}),
 });
 
 export type ListEntitiesV2_3Params = z.infer<


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an optional `customer_id` filter to `entitiesV2.list` to fetch all entities for a single customer in one paginated call. Works with both offset and cursor pagination to reduce per-entity requests.

- **New Features**
  - Added `customer_id` to `ListEntitiesParams` and `ListEntitiesV2_3Params`; applied in offset and cursor queries (value is trimmed).
  - Updated handlers and SQL to filter by customer and return accurate filtered counts.
  - Added integration tests covering scoping, cursor behavior in `v2.3`, parity with per-entity `entities.get`, and empty results for unknown customers.

<sup>Written for commit f8be5a47c3950b4b8eb316a4b0a07756a574dde1. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1692?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

