### PR TITLE
Add per-cus and per-org concurrency gate for fullsubject db hydrations

### DIFF
--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -10,6 +10,8 @@ export const ADMIN_CACHE_V2_RAMP_CONFIG_KEY = "admin/cache-v2-ramp-config.json";
 export const ADMIN_JOB_QUEUE_CONFIG_KEY = "admin/job-queue-config.json";
 export const ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY =
 	"admin/miscellaneous-edge-config.json";
+export const ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY =
+	"admin/full-subject-gate-config.json";
 export const BLUE_GREEN_ACTIVE_SLOT_KEY = "admin/blue-green-active-slot.json";
 export const BLUE_GREEN_CRON_ACTIVE_SLOT_KEY =
 	"admin/blue-green-cron-active-slot.json";
@@ -64,6 +66,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "miscellaneous",
 			label: "Miscellaneous",
 			key: ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY,
+		},
+		{
+			id: "full-subject-gate",
+			label: "FullSubject Concurrency Gate",
+			key: ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY,
 		},
 		{
 			id: "stripe-sync",

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -15,6 +15,7 @@ import {
 import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
 import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSources";
 import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsConfig";
+import { handleGetAdminFullSubjectGateConfig } from "./handleGetAdminFullSubjectGateConfig";
 import { handleGetAdminJobQueueConfig } from "./handleGetAdminJobQueueConfig";
 import { handleGetAdminMiscellaneousEdgeConfig } from "./handleGetAdminMiscellaneousEdgeConfig";
 import { handleGetAdminOrgLimitsConfig } from "./handleGetAdminOrgLimitsConfig";
@@ -31,6 +32,7 @@ import { handleListAdminUsers } from "./handleListAdminUsers";
 import { handleListOAuthClients } from "./handleListOAuthClients";
 import { handleUpsertAdminCustomerBlockConfig } from "./handleUpsertAdminCustomerBlockConfig";
 import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureFlagsConfig";
+import { handleUpsertAdminFullSubjectGateConfig } from "./handleUpsertAdminFullSubjectGateConfig";
 import { handleUpsertAdminJobQueueConfig } from "./handleUpsertAdminJobQueueConfig";
 import { handleUpsertAdminMiscellaneousEdgeConfig } from "./handleUpsertAdminMiscellaneousEdgeConfig";
 import { handleUpsertAdminOrgLimitsConfig } from "./handleUpsertAdminOrgLimitsConfig";
@@ -93,6 +95,14 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/miscellaneous-edge-config",
 	...handleUpsertAdminMiscellaneousEdgeConfig,
+);
+honoAdminRouter.get(
+	"/full-subject-gate-config",
+	...handleGetAdminFullSubjectGateConfig,
+);
+honoAdminRouter.put(
+	"/full-subject-gate-config",
+	...handleUpsertAdminFullSubjectGateConfig,
 );
 honoAdminRouter.get(
 	"/customer-block-config",

--- a/server/src/internal/admin/handleGetAdminFullSubjectGateConfig.ts
+++ b/server/src/internal/admin/handleGetAdminFullSubjectGateConfig.ts
@@ -1,0 +1,22 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getFullSubjectGateConfigFromSource,
+	getRuntimeFullSubjectGateConfigStatus,
+} from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+
+export const handleGetAdminFullSubjectGateConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const status = getRuntimeFullSubjectGateConfigStatus();
+		const config = await getFullSubjectGateConfigFromSource();
+
+		return c.json({
+			...config,
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminFullSubjectGateConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminFullSubjectGateConfig.ts
@@ -1,0 +1,14 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { FullSubjectGateEdgeConfigSchema } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.js";
+import { updateFullSubjectGateConfig } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+
+export const handleUpsertAdminFullSubjectGateConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	body: FullSubjectGateEdgeConfigSchema,
+	handler: async (c) => {
+		const body = c.req.valid("json");
+		await updateFullSubjectGateConfig({ config: body });
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -37,6 +37,7 @@ export async function getFullSubject({
 		customerId,
 		orgId: org.id,
 		env,
+		logger: ctx.logger,
 		queryFn: () =>
 			db.execute(
 				getFullSubjectQuery({
@@ -88,6 +89,7 @@ export async function getFullSubjectNormalized({
 		customerId,
 		orgId: org.id,
 		env,
+		logger: ctx.logger,
 		queryFn: () =>
 			db.execute(
 				getFullSubjectQuery({

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -36,6 +36,7 @@ export async function getFullSubject({
 	const result = await runWithFullSubjectGate({
 		customerId,
 		orgId: org.id,
+		env,
 		queryFn: () =>
 			db.execute(
 				getFullSubjectQuery({
@@ -86,6 +87,7 @@ export async function getFullSubjectNormalized({
 	const result = await runWithFullSubjectGate({
 		customerId,
 		orgId: org.id,
+		env,
 		queryFn: () =>
 			db.execute(
 				getFullSubjectQuery({

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -10,6 +10,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { checkPendingMigrationsForCustomer } from "@/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.js";
 import { lazyResetSubjectEntitlements } from "../../actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
 import { RELEVANT_STATUSES } from "../../cusProducts/CusProductService.js";
+import { runWithFullSubjectGate } from "./getFullSubjectGate.js";
 import { getFullSubjectQuery } from "./getFullSubjectQuery.js";
 import {
 	resultToFullSubject,
@@ -32,16 +33,21 @@ export async function getFullSubject({
 }): Promise<FullSubject | undefined> {
 	const { db, org, env } = ctx;
 
-	const result = await db.execute(
-		getFullSubjectQuery({
-			orgId: org.id,
-			env,
-			customerId,
-			entityId,
-			inStatuses,
-			allowMissingEntity,
-		}),
-	);
+	const result = await runWithFullSubjectGate({
+		customerId,
+		orgId: org.id,
+		queryFn: () =>
+			db.execute(
+				getFullSubjectQuery({
+					orgId: org.id,
+					env,
+					customerId,
+					entityId,
+					inStatuses,
+					allowMissingEntity,
+				}),
+			),
+	});
 
 	if (!result?.length) return undefined;
 
@@ -77,16 +83,21 @@ export async function getFullSubjectNormalized({
 > {
 	const { db, org, env } = ctx;
 
-	const result = await db.execute(
-		getFullSubjectQuery({
-			orgId: org.id,
-			env,
-			customerId,
-			entityId,
-			inStatuses,
-			allowMissingEntity,
-		}),
-	);
+	const result = await runWithFullSubjectGate({
+		customerId,
+		orgId: org.id,
+		queryFn: () =>
+			db.execute(
+				getFullSubjectQuery({
+					orgId: org.id,
+					env,
+					customerId,
+					entityId,
+					inStatuses,
+					allowMissingEntity,
+				}),
+			),
+	});
 
 	if (!result?.length) return undefined;
 

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -1,3 +1,4 @@
+import type { AppEnv } from "@autumn/shared";
 import { metrics } from "@opentelemetry/api";
 import { LRUCache } from "lru-cache";
 import pLimit, { type LimitFunction } from "p-limit";
@@ -24,19 +25,35 @@ const perOrgLimiters = new LRUCache<string, LimitFunction>({
 	updateAgeOnGet: true,
 });
 
-const getCustomerLimiter = (customerId: string): LimitFunction => {
-	const existing = perCustomerLimiters.get(customerId);
+const getCustomerLimiter = ({
+	orgId,
+	env,
+	customerId,
+}: {
+	orgId: string;
+	env: AppEnv;
+	customerId: string;
+}): LimitFunction => {
+	const key = `${orgId}:${env}:${customerId}`;
+	const existing = perCustomerLimiters.get(key);
 	if (existing) return existing;
 	const limiter = pLimit(PER_CUSTOMER_LIMIT);
-	perCustomerLimiters.set(customerId, limiter);
+	perCustomerLimiters.set(key, limiter);
 	return limiter;
 };
 
-const getOrgLimiter = (orgId: string): LimitFunction => {
-	const existing = perOrgLimiters.get(orgId);
+const getOrgLimiter = ({
+	orgId,
+	env,
+}: {
+	orgId: string;
+	env: AppEnv;
+}): LimitFunction => {
+	const key = `${orgId}:${env}`;
+	const existing = perOrgLimiters.get(key);
 	if (existing) return existing;
 	const limiter = pLimit(PER_ORG_LIMIT);
-	perOrgLimiters.set(orgId, limiter);
+	perOrgLimiters.set(key, limiter);
 	return limiter;
 };
 
@@ -71,12 +88,15 @@ const perOrgActiveCounter = meter.createUpDownCounter(
 const attrs = ({
 	customerId,
 	orgId,
+	env,
 }: {
 	customerId: string | undefined;
 	orgId: string;
+	env: AppEnv;
 }) => ({
 	customer_id: customerId ?? "unknown",
 	org_id: orgId,
+	env,
 });
 
 /**
@@ -94,14 +114,16 @@ const attrs = ({
 export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
+	env,
 	queryFn,
 }: {
 	customerId: string | undefined;
 	orgId: string;
+	env: AppEnv;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
 	const enqueuedAt = Date.now();
-	const labels = attrs({ customerId, orgId });
+	const labels = attrs({ customerId, orgId, env });
 	startedCounter.add(1, labels);
 
 	const execute = async (): Promise<T> => {
@@ -120,10 +142,12 @@ export const runWithFullSubjectGate = async <T>({
 		}
 	};
 
-	const orgLimit = getOrgLimiter(orgId);
-
 	if (customerId) {
-		return getCustomerLimiter(customerId)(() => orgLimit(execute));
+		// Resolve the org limiter inside the customer callback so a stale
+		// LRU-evicted org limiter can't be used after a customer slot opens.
+		return getCustomerLimiter({ orgId, env, customerId })(() =>
+			getOrgLimiter({ orgId, env })(execute),
+		);
 	}
-	return orgLimit(execute);
+	return getOrgLimiter({ orgId, env })(execute);
 };

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -79,13 +79,9 @@ const waitHistogram = meter.createHistogram(
 		unit: "ms",
 	},
 );
-const perCustomerActiveCounter = meter.createUpDownCounter(
-	"autumn.full_subject.gate.per_customer_active",
-	{ description: "Hydrations currently executing for a given customer" },
-);
-const perOrgActiveCounter = meter.createUpDownCounter(
-	"autumn.full_subject.gate.per_org_active",
-	{ description: "Hydrations currently executing for a given org" },
+const activeCounter = meter.createUpDownCounter(
+	"autumn.full_subject.gate.active",
+	{ description: "FullSubject hydrations currently executing" },
 );
 
 const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
@@ -120,16 +116,14 @@ export const runWithFullSubjectGate = async <T>({
 				`[full_subject_gate] queued ${waitMs}ms customer=${customerId ?? "unknown"} org=${orgId} env=${env}`,
 			);
 		}
-		perOrgActiveCounter.add(1, labels);
-		perCustomerActiveCounter.add(1, labels);
+		activeCounter.add(1, labels);
 		try {
 			return await queryFn();
 		} catch (error) {
 			failedCounter.add(1, labels);
 			throw error;
 		} finally {
-			perOrgActiveCounter.add(-1, labels);
-			perCustomerActiveCounter.add(-1, labels);
+			activeCounter.add(-1, labels);
 			completedCounter.add(1, labels);
 		}
 	};

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -3,22 +3,12 @@ import { metrics } from "@opentelemetry/api";
 import { LRUCache } from "lru-cache";
 import pLimit, { type LimitFunction } from "p-limit";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { getRuntimeFullSubjectGateConfig } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
-// Log per-customer attribution when a request queued for at least this long.
-// Sub-threshold engagements are still counted in metrics — just not logged
-// (avoids spam under healthy load).
 const GATE_LOG_WAIT_MS_THRESHOLD = 50;
-
-const PER_CUSTOMER_LIMIT = Number(
-	process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT ?? 15,
-);
-const PER_ORG_LIMIT = Number(process.env.FULL_SUBJECT_PER_ORG_LIMIT ?? 30);
 const LIMITER_CACHE_MAX = 5000;
 const LIMITER_CACHE_TTL_MS = 30 * 60 * 1000;
 
-// updateAgeOnGet keeps active customers/orgs alive — without it, an in-flight
-// burst that straddles a TTL expiry could see a fresh limiter and effectively
-// double the cap.
 const perCustomerLimiters = new LRUCache<string, LimitFunction>({
 	max: LIMITER_CACHE_MAX,
 	ttl: LIMITER_CACHE_TTL_MS,
@@ -31,37 +21,44 @@ const perOrgLimiters = new LRUCache<string, LimitFunction>({
 	updateAgeOnGet: true,
 });
 
+const getOrUpdateLimiter = (
+	cache: LRUCache<string, LimitFunction>,
+	key: string,
+	concurrency: number,
+): LimitFunction => {
+	const existing = cache.get(key);
+	if (existing) {
+		if (existing.concurrency !== concurrency) existing.concurrency = concurrency;
+		return existing;
+	}
+	const limiter = pLimit(concurrency);
+	cache.set(key, limiter);
+	return limiter;
+};
+
 const getCustomerLimiter = ({
 	orgId,
 	env,
 	customerId,
+	limit,
 }: {
 	orgId: string;
 	env: AppEnv;
 	customerId: string;
-}): LimitFunction => {
-	const key = `${orgId}:${env}:${customerId}`;
-	const existing = perCustomerLimiters.get(key);
-	if (existing) return existing;
-	const limiter = pLimit(PER_CUSTOMER_LIMIT);
-	perCustomerLimiters.set(key, limiter);
-	return limiter;
-};
+	limit: number;
+}): LimitFunction =>
+	getOrUpdateLimiter(perCustomerLimiters, `${orgId}:${env}:${customerId}`, limit);
 
 const getOrgLimiter = ({
 	orgId,
 	env,
+	limit,
 }: {
 	orgId: string;
 	env: AppEnv;
-}): LimitFunction => {
-	const key = `${orgId}:${env}`;
-	const existing = perOrgLimiters.get(key);
-	if (existing) return existing;
-	const limiter = pLimit(PER_ORG_LIMIT);
-	perOrgLimiters.set(key, limiter);
-	return limiter;
-};
+	limit: number;
+}): LimitFunction =>
+	getOrUpdateLimiter(perOrgLimiters, `${orgId}:${env}`, limit);
 
 const meter = metrics.getMeter("autumn-server");
 const startedCounter = meter.createCounter("autumn.full_subject.gate.started", {
@@ -91,26 +88,11 @@ const perOrgActiveCounter = meter.createUpDownCounter(
 	{ description: "Hydrations currently executing for a given org" },
 );
 
-// Metric labels intentionally exclude customer_id — that's high-cardinality
-// (hundreds of thousands of customers) and would balloon time-series count
-// + ingestion cost. Per-customer attribution lives in log lines, not metrics.
 const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
 	org_id: orgId,
 	env,
 });
 
-/**
- * Wrap a FullSubject DB hydration so it goes through per-customer + per-org
- * concurrency gates. Per-customer slot is acquired FIRST so one customer's
- * burst can't hold per-org slots while waiting on its own customer cap
- * (head-of-line starves siblings within the same org).
- *
- * Limits are PER-PROCESS, not cluster-wide — with N API replicas, effective
- * caps are PER_CUSTOMER_LIMIT*N and PER_ORG_LIMIT*N. Sized accordingly.
- *
- * Defaults: 15 per-customer, 30 per-org per process. Override via
- * FULL_SUBJECT_PER_CUSTOMER_LIMIT / FULL_SUBJECT_PER_ORG_LIMIT.
- */
 export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
@@ -124,6 +106,8 @@ export const runWithFullSubjectGate = async <T>({
 	logger?: Logger;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
+	const { per_customer_limit, per_org_limit } =
+		getRuntimeFullSubjectGateConfig();
 	const enqueuedAt = Date.now();
 	const labels = attrs({ orgId, env });
 	startedCounter.add(1, labels);
@@ -151,11 +135,14 @@ export const runWithFullSubjectGate = async <T>({
 	};
 
 	if (customerId) {
-		// Resolve the org limiter inside the customer callback so a stale
-		// LRU-evicted org limiter can't be used after a customer slot opens.
-		return getCustomerLimiter({ orgId, env, customerId })(() =>
-			getOrgLimiter({ orgId, env })(execute),
+		return getCustomerLimiter({
+			orgId,
+			env,
+			customerId,
+			limit: per_customer_limit,
+		})(() =>
+			getOrgLimiter({ orgId, env, limit: per_org_limit })(execute),
 		);
 	}
-	return getOrgLimiter({ orgId, env })(execute);
+	return getOrgLimiter({ orgId, env, limit: per_org_limit })(execute);
 };

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -2,6 +2,12 @@ import type { AppEnv } from "@autumn/shared";
 import { metrics } from "@opentelemetry/api";
 import { LRUCache } from "lru-cache";
 import pLimit, { type LimitFunction } from "p-limit";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+
+// Log per-customer attribution when a request queued for at least this long.
+// Sub-threshold engagements are still counted in metrics — just not logged
+// (avoids spam under healthy load).
+const GATE_LOG_WAIT_MS_THRESHOLD = 50;
 
 const PER_CUSTOMER_LIMIT = Number(
 	process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT ?? 15,
@@ -85,16 +91,10 @@ const perOrgActiveCounter = meter.createUpDownCounter(
 	{ description: "Hydrations currently executing for a given org" },
 );
 
-const attrs = ({
-	customerId,
-	orgId,
-	env,
-}: {
-	customerId: string | undefined;
-	orgId: string;
-	env: AppEnv;
-}) => ({
-	customer_id: customerId ?? "unknown",
+// Metric labels intentionally exclude customer_id — that's high-cardinality
+// (hundreds of thousands of customers) and would balloon time-series count
+// + ingestion cost. Per-customer attribution lives in log lines, not metrics.
+const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
 	org_id: orgId,
 	env,
 });
@@ -115,19 +115,27 @@ export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
 	env,
+	logger,
 	queryFn,
 }: {
 	customerId: string | undefined;
 	orgId: string;
 	env: AppEnv;
+	logger?: Logger;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
 	const enqueuedAt = Date.now();
-	const labels = attrs({ customerId, orgId, env });
+	const labels = attrs({ orgId, env });
 	startedCounter.add(1, labels);
 
 	const execute = async (): Promise<T> => {
-		waitHistogram.record(Date.now() - enqueuedAt, labels);
+		const waitMs = Date.now() - enqueuedAt;
+		waitHistogram.record(waitMs, labels);
+		if (waitMs >= GATE_LOG_WAIT_MS_THRESHOLD) {
+			logger?.info(
+				`[full_subject_gate] queued ${waitMs}ms customer=${customerId ?? "unknown"} org=${orgId} env=${env}`,
+			);
+		}
 		perOrgActiveCounter.add(1, labels);
 		perCustomerActiveCounter.add(1, labels);
 		try {

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -1,0 +1,129 @@
+import { metrics } from "@opentelemetry/api";
+import { LRUCache } from "lru-cache";
+import pLimit, { type LimitFunction } from "p-limit";
+
+const PER_CUSTOMER_LIMIT = Number(
+	process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT ?? 15,
+);
+const PER_ORG_LIMIT = Number(process.env.FULL_SUBJECT_PER_ORG_LIMIT ?? 30);
+const LIMITER_CACHE_MAX = 5000;
+const LIMITER_CACHE_TTL_MS = 30 * 60 * 1000;
+
+// updateAgeOnGet keeps active customers/orgs alive — without it, an in-flight
+// burst that straddles a TTL expiry could see a fresh limiter and effectively
+// double the cap.
+const perCustomerLimiters = new LRUCache<string, LimitFunction>({
+	max: LIMITER_CACHE_MAX,
+	ttl: LIMITER_CACHE_TTL_MS,
+	updateAgeOnGet: true,
+});
+
+const perOrgLimiters = new LRUCache<string, LimitFunction>({
+	max: LIMITER_CACHE_MAX,
+	ttl: LIMITER_CACHE_TTL_MS,
+	updateAgeOnGet: true,
+});
+
+const getCustomerLimiter = (customerId: string): LimitFunction => {
+	const existing = perCustomerLimiters.get(customerId);
+	if (existing) return existing;
+	const limiter = pLimit(PER_CUSTOMER_LIMIT);
+	perCustomerLimiters.set(customerId, limiter);
+	return limiter;
+};
+
+const getOrgLimiter = (orgId: string): LimitFunction => {
+	const existing = perOrgLimiters.get(orgId);
+	if (existing) return existing;
+	const limiter = pLimit(PER_ORG_LIMIT);
+	perOrgLimiters.set(orgId, limiter);
+	return limiter;
+};
+
+const meter = metrics.getMeter("autumn-server");
+const startedCounter = meter.createCounter("autumn.full_subject.gate.started", {
+	description: "FullSubject DB hydrations entering the gate",
+});
+const completedCounter = meter.createCounter(
+	"autumn.full_subject.gate.completed",
+	{ description: "FullSubject DB hydrations finished (success or failure)" },
+);
+const failedCounter = meter.createCounter("autumn.full_subject.gate.failed", {
+	description: "FullSubject DB hydrations that threw",
+});
+const waitHistogram = meter.createHistogram(
+	"autumn.full_subject.gate.wait_ms",
+	{
+		description:
+			"Time spent queued before the DB hydration started, in milliseconds.",
+		unit: "ms",
+	},
+);
+const perCustomerActiveCounter = meter.createUpDownCounter(
+	"autumn.full_subject.gate.per_customer_active",
+	{ description: "Hydrations currently executing for a given customer" },
+);
+const perOrgActiveCounter = meter.createUpDownCounter(
+	"autumn.full_subject.gate.per_org_active",
+	{ description: "Hydrations currently executing for a given org" },
+);
+
+const attrs = ({
+	customerId,
+	orgId,
+}: {
+	customerId: string | undefined;
+	orgId: string;
+}) => ({
+	customer_id: customerId ?? "unknown",
+	org_id: orgId,
+});
+
+/**
+ * Wrap a FullSubject DB hydration so it goes through per-customer + per-org
+ * concurrency gates. Per-customer slot is acquired FIRST so one customer's
+ * burst can't hold per-org slots while waiting on its own customer cap
+ * (head-of-line starves siblings within the same org).
+ *
+ * Limits are PER-PROCESS, not cluster-wide — with N API replicas, effective
+ * caps are PER_CUSTOMER_LIMIT*N and PER_ORG_LIMIT*N. Sized accordingly.
+ *
+ * Defaults: 15 per-customer, 30 per-org per process. Override via
+ * FULL_SUBJECT_PER_CUSTOMER_LIMIT / FULL_SUBJECT_PER_ORG_LIMIT.
+ */
+export const runWithFullSubjectGate = async <T>({
+	customerId,
+	orgId,
+	queryFn,
+}: {
+	customerId: string | undefined;
+	orgId: string;
+	queryFn: () => Promise<T>;
+}): Promise<T> => {
+	const enqueuedAt = Date.now();
+	const labels = attrs({ customerId, orgId });
+	startedCounter.add(1, labels);
+
+	const execute = async (): Promise<T> => {
+		waitHistogram.record(Date.now() - enqueuedAt, labels);
+		perOrgActiveCounter.add(1, labels);
+		perCustomerActiveCounter.add(1, labels);
+		try {
+			return await queryFn();
+		} catch (error) {
+			failedCounter.add(1, labels);
+			throw error;
+		} finally {
+			perOrgActiveCounter.add(-1, labels);
+			perCustomerActiveCounter.add(-1, labels);
+			completedCounter.add(1, labels);
+		}
+	};
+
+	const orgLimit = getOrgLimiter(orgId);
+
+	if (customerId) {
+		return getCustomerLimiter(customerId)(() => orgLimit(execute));
+	}
+	return orgLimit(execute);
+};

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod/v4";
+
+export const FullSubjectGateEdgeConfigSchema = z.object({
+	per_customer_limit: z.number().int().min(1).max(10_000).default(15),
+	per_org_limit: z.number().int().min(1).max(10_000).default(30),
+});
+
+export type FullSubjectGateEdgeConfig = z.infer<
+	typeof FullSubjectGateEdgeConfigSchema
+>;

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.ts
@@ -1,0 +1,39 @@
+import { ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type FullSubjectGateEdgeConfig,
+	FullSubjectGateEdgeConfigSchema,
+} from "./fullSubjectGateEdgeConfigSchemas.js";
+
+const store = createEdgeConfigStore<FullSubjectGateEdgeConfig>({
+	s3Key: ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY,
+	schema: FullSubjectGateEdgeConfigSchema,
+	defaultValue: () => FullSubjectGateEdgeConfigSchema.parse({}),
+});
+
+registerEdgeConfig({ store });
+
+export const getRuntimeFullSubjectGateConfigStatus = () => store.getStatus();
+
+export const getRuntimeFullSubjectGateConfig = (): FullSubjectGateEdgeConfig =>
+	store.get();
+
+export const getFullSubjectGateConfigFromSource =
+	async (): Promise<FullSubjectGateEdgeConfig> => store.readFromSource();
+
+export const updateFullSubjectGateConfig = async ({
+	config,
+}: {
+	config: FullSubjectGateEdgeConfig;
+}): Promise<void> => {
+	await store.writeToSource({ config });
+};
+
+export const _setFullSubjectGateConfigForTesting = ({
+	config,
+}: {
+	config: FullSubjectGateEdgeConfig;
+}): void => {
+	store._setRuntimeConfigForTesting(config);
+};

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
 
 // Tight limits so the assertions are clear: per-org=4, per-customer=2.
 // Must be set BEFORE the gate module is imported — its env reads happen at
@@ -35,6 +36,7 @@ describe("runWithFullSubjectGate", () => {
 			runWithFullSubjectGate({
 				customerId: "cus-same",
 				orgId: "org-a",
+				env: AppEnv.Live,
 				queryFn: () => queryFn(index),
 			}),
 		);
@@ -51,6 +53,7 @@ describe("runWithFullSubjectGate", () => {
 			runWithFullSubjectGate({
 				customerId: `cus-${index}`,
 				orgId: "org-shared",
+				env: AppEnv.Live,
 				queryFn: () => queryFn(index),
 			}),
 		);
@@ -68,11 +71,11 @@ describe("runWithFullSubjectGate", () => {
 			runWithFullSubjectGate({
 				customerId: `cus-${index}`,
 				orgId: index < 6 ? "org-x" : "org-y",
+				env: AppEnv.Live,
 				queryFn: () => queryFn(index),
 			}),
 		);
 		await Promise.all(tasks);
-		// Each org caps at 4, two orgs in parallel → up to 8 concurrent.
 		expect(counter.peak).toBeLessThanOrEqual(8);
 		expect(counter.peak).toBeGreaterThan(4);
 		expect(counter.current).toBe(0);
@@ -85,10 +88,67 @@ describe("runWithFullSubjectGate", () => {
 			runWithFullSubjectGate({
 				customerId: undefined,
 				orgId: "org-no-cus",
+				env: AppEnv.Live,
 				queryFn: () => queryFn(index),
 			}),
 		);
 		await Promise.all(tasks);
+		expect(counter.peak).toBeLessThanOrEqual(4);
+		expect(counter.current).toBe(0);
+	});
+
+	test("same customerId in different orgs does NOT share a per-customer cap", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = [
+			...Array.from({ length: 5 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-shared-id",
+					orgId: "org-a",
+					env: AppEnv.Live,
+					queryFn: () => queryFn(`a-${index}`),
+				}),
+			),
+			...Array.from({ length: 5 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-shared-id",
+					orgId: "org-b",
+					env: AppEnv.Live,
+					queryFn: () => queryFn(`b-${index}`),
+				}),
+			),
+		];
+		await Promise.all(tasks);
+		// Keys are scoped per-org so each org keeps its own per-customer cap.
+		expect(counter.peak).toBeGreaterThan(2);
+		expect(counter.peak).toBeLessThanOrEqual(4);
+		expect(counter.current).toBe(0);
+	});
+
+	test("same customerId in live and sandbox of the same org do NOT share a per-customer cap", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = [
+			...Array.from({ length: 5 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-live-vs-sandbox",
+					orgId: "org-c",
+					env: AppEnv.Live,
+					queryFn: () => queryFn(`live-${index}`),
+				}),
+			),
+			...Array.from({ length: 5 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-live-vs-sandbox",
+					orgId: "org-c",
+					env: AppEnv.Sandbox,
+					queryFn: () => queryFn(`sandbox-${index}`),
+				}),
+			),
+		];
+		await Promise.all(tasks);
+		// Per-env keys — live and sandbox run independently, peak up to 4.
+		expect(counter.peak).toBeGreaterThan(2);
 		expect(counter.peak).toBeLessThanOrEqual(4);
 		expect(counter.current).toBe(0);
 	});
@@ -108,6 +168,7 @@ describe("runWithFullSubjectGate", () => {
 				runWithFullSubjectGate({
 					customerId: "cus-reject",
 					orgId: "org-reject",
+					env: AppEnv.Live,
 					queryFn: failing,
 				}),
 			),
@@ -115,13 +176,13 @@ describe("runWithFullSubjectGate", () => {
 		expect(failures.every((result) => result.status === "rejected")).toBe(true);
 		expect(counter.current).toBe(0);
 
-		// Subsequent calls succeed — proves slots were released, not leaked.
 		const queryFn = makeQueryFn(counter, 5);
 		const followUp = await Promise.all(
 			Array.from({ length: 4 }, (_, index) =>
 				runWithFullSubjectGate({
 					customerId: "cus-reject",
 					orgId: "org-reject",
+					env: AppEnv.Live,
 					queryFn: () => queryFn(index),
 				}),
 			),

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,15 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { AppEnv } from "@autumn/shared";
+import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+import { runWithFullSubjectGate } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
 
-// Tight limits so the assertions are clear: per-org=4, per-customer=2.
-// Must be set BEFORE the gate module is imported — its env reads happen at
-// module init.
-process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT = "2";
-process.env.FULL_SUBJECT_PER_ORG_LIMIT = "4";
-
-const { runWithFullSubjectGate } = await import(
-	"@/internal/customers/repos/getFullSubject/getFullSubjectGate.js"
-);
+beforeAll(() => {
+	_setFullSubjectGateConfigForTesting({
+		config: { per_customer_limit: 2, per_org_limit: 4 },
+	});
+});
 
 type Counter = {
 	current: number;
@@ -119,7 +117,6 @@ describe("runWithFullSubjectGate", () => {
 			),
 		];
 		await Promise.all(tasks);
-		// Keys are scoped per-org so each org keeps its own per-customer cap.
 		expect(counter.peak).toBeGreaterThan(2);
 		expect(counter.peak).toBeLessThanOrEqual(4);
 		expect(counter.current).toBe(0);
@@ -147,10 +144,33 @@ describe("runWithFullSubjectGate", () => {
 			),
 		];
 		await Promise.all(tasks);
-		// Per-env keys — live and sandbox run independently, peak up to 4.
 		expect(counter.peak).toBeGreaterThan(2);
 		expect(counter.peak).toBeLessThanOrEqual(4);
 		expect(counter.current).toBe(0);
+	});
+
+	test("limit changes take effect at runtime without recreating limiters", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: { per_customer_limit: 1, per_org_limit: 4 },
+		});
+
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 20);
+		const tasks = Array.from({ length: 5 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: "cus-runtime-change",
+				orgId: "org-runtime-change",
+				env: AppEnv.Live,
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		expect(counter.peak).toBe(1);
+
+		// Restore for any subsequent tests.
+		_setFullSubjectGateConfigForTesting({
+			config: { per_customer_limit: 2, per_org_limit: 4 },
+		});
 	});
 
 	test("rejection releases the per-customer and per-org slots", async () => {

--- a/server/tests/unit/full-subject-gate/getFullSubjectGate.test.ts
+++ b/server/tests/unit/full-subject-gate/getFullSubjectGate.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+// Tight limits so the assertions are clear: per-org=4, per-customer=2.
+// Must be set BEFORE the gate module is imported — its env reads happen at
+// module init.
+process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT = "2";
+process.env.FULL_SUBJECT_PER_ORG_LIMIT = "4";
+
+const { runWithFullSubjectGate } = await import(
+	"@/internal/customers/repos/getFullSubject/getFullSubjectGate.js"
+);
+
+type Counter = {
+	current: number;
+	peak: number;
+};
+
+const makeCounter = (): Counter => ({ current: 0, peak: 0 });
+
+const makeQueryFn =
+	(counter: Counter, holdMs: number) =>
+	async <T>(value: T): Promise<T> => {
+		counter.current += 1;
+		counter.peak = Math.max(counter.peak, counter.current);
+		await new Promise((resolve) => setTimeout(resolve, holdMs));
+		counter.current -= 1;
+		return value;
+	};
+
+describe("runWithFullSubjectGate", () => {
+	test("caps concurrent calls for the same customer at PER_CUSTOMER_LIMIT", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 10 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: "cus-same",
+				orgId: "org-a",
+				queryFn: () => queryFn(index),
+			}),
+		);
+		const results = await Promise.all(tasks);
+		expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+		expect(counter.peak).toBeLessThanOrEqual(2);
+		expect(counter.current).toBe(0);
+	});
+
+	test("different customers within the same org compete for the per-org cap", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 8 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: `cus-${index}`,
+				orgId: "org-shared",
+				queryFn: () => queryFn(index),
+			}),
+		);
+		const results = await Promise.all(tasks);
+		expect(new Set(results)).toEqual(new Set([0, 1, 2, 3, 4, 5, 6, 7]));
+		expect(counter.peak).toBeLessThanOrEqual(4);
+		expect(counter.peak).toBeGreaterThan(2);
+		expect(counter.current).toBe(0);
+	});
+
+	test("different orgs do not share a cap — each has its own per-org limit", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 12 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: `cus-${index}`,
+				orgId: index < 6 ? "org-x" : "org-y",
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		// Each org caps at 4, two orgs in parallel → up to 8 concurrent.
+		expect(counter.peak).toBeLessThanOrEqual(8);
+		expect(counter.peak).toBeGreaterThan(4);
+		expect(counter.current).toBe(0);
+	});
+
+	test("missing customerId still goes through the per-org gate", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 20);
+		const tasks = Array.from({ length: 10 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: undefined,
+				orgId: "org-no-cus",
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		expect(counter.peak).toBeLessThanOrEqual(4);
+		expect(counter.current).toBe(0);
+	});
+
+	test("rejection releases the per-customer and per-org slots", async () => {
+		const counter = makeCounter();
+		const failing = async () => {
+			counter.current += 1;
+			counter.peak = Math.max(counter.peak, counter.current);
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			counter.current -= 1;
+			throw new Error("boom");
+		};
+
+		const failures = await Promise.allSettled(
+			Array.from({ length: 5 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-reject",
+					orgId: "org-reject",
+					queryFn: failing,
+				}),
+			),
+		);
+		expect(failures.every((result) => result.status === "rejected")).toBe(true);
+		expect(counter.current).toBe(0);
+
+		// Subsequent calls succeed — proves slots were released, not leaked.
+		const queryFn = makeQueryFn(counter, 5);
+		const followUp = await Promise.all(
+			Array.from({ length: 4 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-reject",
+					orgId: "org-reject",
+					queryFn: () => queryFn(index),
+				}),
+			),
+		);
+		expect(followUp).toEqual([0, 1, 2, 3]);
+		expect(counter.current).toBe(0);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds per-customer and per-org concurrency gates for FullSubject DB hydrations to prevent a single customer from saturating org capacity and to reduce DB pressure. Limits are runtime-tunable via Admin Edge Config; metrics avoid `customer_id` for low-cardinality.

- **New Features**
  - Limits & config: Defaults 15 per customer and 30 per org; configurable at runtime via Admin Edge Config (GET/PUT `/full-subject-gate-config`, stored at `admin/full-subject-gate-config.json`) with status fields (healthy/configured/lastSuccessAt/error).
  - Scoping & order: Keys use `orgId` + `env` (+ `customerId` when present); missing `customerId` uses per-org gate; customer slot is acquired before org slot.
  - Implementation: `p-limit` + `lru-cache` (TTL 30m, size 5k, `updateAgeOnGet`) to reuse limiters; concurrency values update at runtime without recreating limiters; per-process gates.
  - Telemetry & logs: metrics via `@opentelemetry/api` (started/completed/failed counters, `wait_ms` histogram, single gate active up/down counter labeled by org/env); logs include customer attribution only when queued ≥50ms.
  - Integration & tests: `getFullSubject` and `getFullSubjectNormalized` wrap DB calls with `runWithFullSubjectGate`; unit tests cover caps, scoping, org/env isolation, slot release on failures, and runtime limit changes.

<sup>Written for commit ced6ca6f4d8636b7b8879f37e3bb898a21c36bbd. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1693?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

