### PR TITLE
feat: 🎸 preflight tax address existence before taxing

### DIFF
--- a/MIGRATIONS_FIX_TARGET_LIMIT.md
+++ b/MIGRATIONS_FIX_TARGET_LIMIT.md
@@ -1,0 +1,95 @@
+# Migration Runs `target_limit` Dev DB Note
+
+While writing the automatic-tax missing-address regression test, the integration
+harness could not reach billing setup because the dev database schema was behind
+the checked-in Drizzle model.
+
+## Symptom
+
+Running:
+
+```bash
+cd server
+./run.sh /Users/amianthus/.superset/worktrees/06ef6d27-730a-4eec-a0b1-3f2853221478/fix/automatic-tax-retry/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
+```
+
+failed during setup with:
+
+```text
+error: column organizations_migration_runs.target_limit does not exist
+code: "internal_error"
+```
+
+This happened before the test reached customer/product billing behavior.
+
+## Investigation
+
+The checked-in table model is:
+
+```text
+shared/models/migrationV2Models/migrationRunTable.ts
+```
+
+It defines:
+
+```ts
+export const migrationRuns = pgTable(
+  "migration_runs",
+  {
+    ...
+    target_limit: numeric({ mode: "number" }),
+    ...
+  },
+);
+```
+
+The actual dev DB had `migration_runs`, not `organizations_migration_runs`.
+I verified with:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); const rows = await sql`select table_schema, table_name from information_schema.tables where table_name like ${"%migration%run%"} order by table_schema, table_name`; console.log(rows); await sql.end();'
+```
+
+which returned:
+
+```text
+public.migration_item_runs
+public.migration_runs
+```
+
+The `organizations_migration_runs.target_limit` wording appears to be a SQL
+alias/prefix in the failing query, not the physical table name.
+
+## Temporary Local Fix Applied
+
+I first tried the alias-looking table name:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); await sql`ALTER TABLE organizations_migration_runs ADD COLUMN IF NOT EXISTS target_limit numeric`; await sql.end(); console.log("added target_limit if missing");'
+```
+
+That failed with:
+
+```text
+PostgresError: relation "organizations_migration_runs" does not exist
+code: "42P01"
+```
+
+Then I applied the actual checked-in table name:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); await sql`ALTER TABLE migration_runs ADD COLUMN IF NOT EXISTS target_limit numeric`; await sql.end(); console.log("added migration_runs.target_limit if missing");'
+```
+
+That succeeded:
+
+```text
+added migration_runs.target_limit if missing
+```
+
+After that, the automatic-tax test reached the intended billing failure.
+
+## Follow-up Needed
+
+Create/apply the real migration for `migration_runs.target_limit` so future
+agents and dev environments do not need the manual `ALTER TABLE`.

--- a/server/src/external/stripe/customers/operations/createStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/createStripeCustomer.ts
@@ -14,6 +14,7 @@ export const createStripeCustomer = async ({
 	customer: Customer;
 	options?: {
 		testClockId?: string;
+		expandTax?: boolean;
 	};
 }): Promise<ExpandedStripeCustomer> => {
 	const { org, env } = ctx;
@@ -43,6 +44,7 @@ export const createStripeCustomer = async ({
 				"test_clock",
 				"invoice_settings.default_payment_method",
 				"discount.source.coupon.applies_to",
+				...(options.expandTax ? ["tax"] : []),
 			],
 		},
 		idempotencyKey

--- a/server/src/external/stripe/customers/operations/getExpandedStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getExpandedStripeCustomer.ts
@@ -28,28 +28,34 @@ export function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound,
+	expandTax,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId: string;
 	errorOnNotFound: true;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer>;
 export function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound,
+	expandTax,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId?: string;
 	errorOnNotFound?: false;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer | undefined>;
 export async function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound = false,
+	expandTax = false,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId?: string;
 	errorOnNotFound?: boolean;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer | undefined> {
 	const { org, env } = ctx;
 	const stripeCli = createStripeCli({ org, env });
@@ -63,6 +69,7 @@ export async function getExpandedStripeCustomer({
 					"test_clock",
 					"invoice_settings.default_payment_method",
 					"discount.source.coupon.applies_to",
+					...(expandTax ? ["tax"] : []),
 				],
 			}),
 		);

--- a/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
@@ -14,9 +14,7 @@ import { CusService } from "@/internal/customers/CusService";
 export const getOrCreateStripeCustomer = async ({
 	ctx,
 	customer,
-	options = {
-		updateDb: true,
-	},
+	options,
 }: {
 	ctx: AutumnContext;
 	customer: Customer;
@@ -26,11 +24,15 @@ export const getOrCreateStripeCustomer = async ({
 	};
 }): Promise<ExpandedStripeCustomer | undefined> => {
 	const { logger } = ctx;
+	const resolvedOptions = {
+		updateDb: true,
+		...options,
+	};
 
 	const currentStripeCustomer = await getExpandedStripeCustomer({
 		ctx,
 		stripeCustomerId: customer.processor?.id,
-		expandTax: options.expandTax,
+		expandTax: resolvedOptions.expandTax,
 	});
 
 	if (currentStripeCustomer) return currentStripeCustomer;
@@ -43,11 +45,11 @@ export const getOrCreateStripeCustomer = async ({
 		ctx,
 		customer,
 		options: {
-			expandTax: options.expandTax,
+			expandTax: resolvedOptions.expandTax,
 		},
 	});
 
-	if (options.updateDb) {
+	if (resolvedOptions.updateDb) {
 		await CusService.update({
 			ctx,
 			idOrInternalId: customer.id || customer.internal_id,

--- a/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
@@ -22,6 +22,7 @@ export const getOrCreateStripeCustomer = async ({
 	customer: Customer;
 	options?: {
 		updateDb?: boolean;
+		expandTax?: boolean;
 	};
 }): Promise<ExpandedStripeCustomer | undefined> => {
 	const { logger } = ctx;
@@ -29,6 +30,7 @@ export const getOrCreateStripeCustomer = async ({
 	const currentStripeCustomer = await getExpandedStripeCustomer({
 		ctx,
 		stripeCustomerId: customer.processor?.id,
+		expandTax: options.expandTax,
 	});
 
 	if (currentStripeCustomer) return currentStripeCustomer;
@@ -40,6 +42,9 @@ export const getOrCreateStripeCustomer = async ({
 	const stripeCustomer = await createStripeCustomer({
 		ctx,
 		customer,
+		options: {
+			expandTax: options.expandTax,
+		},
 	});
 
 	if (options.updateDb) {

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
@@ -19,15 +19,20 @@ export const fetchStripeCustomerForBilling = async ({
 }) => {
 	const { org, env } = ctx;
 	const stripeCli = createStripeCli({ org, env });
+	const expandTax = !!ctx.org.config.automatic_tax;
 
 	const stripeCus = createIfMissing
 		? await getOrCreateStripeCustomer({
 				ctx,
 				customer: fullCus,
+				options: {
+					expandTax,
+				},
 			})
 		: await getExpandedStripeCustomer({
 				ctx,
 				stripeCustomerId: fullCus.processor?.id,
+				expandTax,
 			});
 
 	if (!stripeCus) {

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
@@ -27,6 +27,7 @@ export const fetchStripeCustomerForBilling = async ({
 				customer: fullCus,
 				options: {
 					expandTax,
+					updateDb: true,
 				},
 			})
 		: await getExpandedStripeCustomer({

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -16,6 +16,7 @@ import type { Stripe } from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { mergeStripeMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/mergeStripeMetadata";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 
 const stripeDiscountsToInvoiceParams = ({
 	stripeDiscounts,
@@ -93,10 +94,7 @@ export const createInvoiceForBilling = async ({
 		stripeDiscounts: billingContext.stripeDiscounts ?? [],
 	});
 
-	// Skip auto_tax in invoice mode: send_invoice has no address-collection
-	// UI so Stripe Tax rejects. charge_automatically relies on Stripe's
-	// address waterfall.
-	const wantsAutoTax = !!ctx.org.config.automatic_tax && !isInvoiceMode;
+	const wantsAutoTax = shouldEnableStripeAutomaticTax({ ctx, billingContext });
 	const draftInvoice = await createStripeInvoice({
 		stripeCli,
 		stripeCusId: billingContext.stripeCustomer?.id ?? "none",

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
@@ -9,6 +9,7 @@ import { notNullish } from "@shared/utils/utils";
 import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { stripeDiscountsToParams } from "@/internal/billing/v2/providers/stripe/utils/discounts/stripeDiscountsToParams";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 
 export const buildStripeSubscriptionUpdateAction = ({
 	ctx,
@@ -96,10 +97,9 @@ export const buildStripeSubscriptionUpdateAction = ({
 		}),
 
 		// Propagate auto_tax onto every sub.update so existing subs catch up
-		// when the org flag flips. Baked in here (not execute) for log
-		// self-description. Skipped in invoice mode: send_invoice invoices
-		// can't collect address, so Stripe Tax rejects.
-		...(ctx.org.config.automatic_tax && !billingContext.invoiceMode
+		// when the org flag flips. Baked in here for log self-description;
+		// execute re-applies the same preflight before writing to Stripe.
+		...(shouldEnableStripeAutomaticTax({ ctx, billingContext })
 			? { automatic_tax: { enabled: true } }
 			: {}),
 	};

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -4,6 +4,7 @@ import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
 import { mergeStripeMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/mergeStripeMetadata";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 import { willStripeSubscriptionUpdateCreateInvoice } from "./willStripeSubscriptionUpdateCreateInvoice";
 
 export const executeStripeSubscriptionOperation = async ({
@@ -46,10 +47,7 @@ export const executeStripeSubscriptionOperation = async ({
 			actionSource: billingContext.actionSource,
 		}),
 	});
-	// Skip auto_tax in invoice mode: send_invoice has no address-collection
-	// UI so Stripe Tax rejects.
-	const wantsAutoTax =
-		!!ctx.org.config.automatic_tax && !billingContext.invoiceMode;
+	const wantsAutoTax = shouldEnableStripeAutomaticTax({ ctx, billingContext });
 
 	const taxRateParams = billingContext.taxRateId
 		? { default_tax_rates: [billingContext.taxRateId] }

--- a/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
@@ -6,8 +6,10 @@ const hasUsableTaxAddress = (address?: Stripe.Address | null) => {
 	return Boolean(address?.country);
 };
 
-const customerHasUsableTaxLocation = (stripeCustomer?: Stripe.Customer) => {
-	if (!stripeCustomer) return true;
+export const customerHasUsableTaxLocationForStripeTax = (
+	stripeCustomer?: Stripe.Customer,
+) => {
+	if (!stripeCustomer) return false;
 
 	if (stripeCustomer.tax?.automatic_tax) {
 		return ["supported", "not_collecting"].includes(
@@ -35,7 +37,7 @@ export const shouldEnableStripeAutomaticTax = ({
 
 	// Use only the already-fetched Stripe customer. If setup did not fetch one,
 	// do not fetch again on the write path.
-	if (!customerHasUsableTaxLocation(billingContext.stripeCustomer)) {
+	if (!customerHasUsableTaxLocationForStripeTax(billingContext.stripeCustomer)) {
 		return false;
 	}
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
@@ -1,0 +1,43 @@
+import type { BillingContext } from "@autumn/shared";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+const hasUsableTaxAddress = (address?: Stripe.Address | null) => {
+	return Boolean(address?.country);
+};
+
+const customerHasUsableTaxLocation = (stripeCustomer?: Stripe.Customer) => {
+	if (!stripeCustomer) return true;
+
+	if (stripeCustomer.tax?.automatic_tax) {
+		return ["supported", "not_collecting"].includes(
+			stripeCustomer.tax.automatic_tax,
+		);
+	}
+
+	return (
+		hasUsableTaxAddress(stripeCustomer.address) ||
+		hasUsableTaxAddress(stripeCustomer.shipping?.address)
+	);
+};
+
+export const shouldEnableStripeAutomaticTax = ({
+	ctx,
+	billingContext,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+}) => {
+	if (!ctx.org.config.automatic_tax) return false;
+
+	// Invoice mode uses send_invoice and has no address collection UI.
+	if (billingContext.invoiceMode) return false;
+
+	// Use only the already-fetched Stripe customer. If setup did not fetch one,
+	// do not fetch again on the write path.
+	if (!customerHasUsableTaxLocation(billingContext.stripeCustomer)) {
+		return false;
+	}
+
+	return true;
+};

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -9,6 +9,7 @@ import {
 } from "@/external/stripe/stripeSubUtils/convertSubUtils.js";
 import { sanitizeSubItems } from "@/external/stripe/stripeSubUtils/getStripeSubItems.js";
 import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.js";
+import { customerHasUsableTaxLocationForStripeTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.js";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
 import { buildInvoiceMemoFromEntitlements } from "@/internal/invoices/invoiceMemoUtils.js";
 import { freeTrialToStripeTimestamp } from "@/internal/products/free-trials/freeTrialUtils.js";
@@ -63,7 +64,9 @@ export const createStripeSub2 = async ({
 		// Skip auto_tax in invoice mode: send_invoice has no
 		// address-collection UI so Stripe Tax rejects.
 		const wantsAutoTax =
-			!!org.config.automatic_tax && !attachParams.invoiceOnly;
+			!!org.config.automatic_tax &&
+			!attachParams.invoiceOnly &&
+			customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
 
 		const subscription = await stripeCli.subscriptions.create({
 			...paymentMethodData,

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
@@ -11,6 +11,7 @@ import {
 import { addMinutes } from "date-fns";
 import { Decimal } from "decimal.js";
 import { payForInvoice } from "@/external/stripe/stripeInvoiceUtils.js";
+import { customerHasUsableTaxLocationForStripeTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.js";
 import { createFullCusProduct } from "@/internal/customers/add-product/createFullCusProduct.js";
 import { handleCreateCheckout } from "@/internal/customers/add-product/handleCreateCheckout.js";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
@@ -135,8 +136,10 @@ export const handleOneOffFunction = async ({
 
 	// Skip auto_tax in invoice mode: send_invoice has no
 	// address-collection UI so Stripe Tax rejects.
-	const wantsAutoTax =
-		!!org.config.automatic_tax && !attachParams.invoiceOnly;
+const wantsAutoTax =
+		!!org.config.automatic_tax &&
+		!attachParams.invoiceOnly &&
+		customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
 
 	let stripeInvoice = await stripeCli.invoices.create({
 		customer: customer.processor.id!,

--- a/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getStripeCusData.ts
+++ b/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getStripeCusData.ts
@@ -24,6 +24,9 @@ export const getStripeCusData = async ({
 	const stripeCus = await getOrCreateStripeCustomer({
 		ctx,
 		customer,
+		options: {
+			expandTax: !!ctx.org.config.automatic_tax,
+		},
 	});
 
 	if (!stripeCus) {

--- a/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
@@ -1,93 +1,100 @@
 /**
- * Regression guard: when `automatic_tax: true` but the customer has no
- * address, attach must surface an actionable tax/address error (Stripe's
- * `customer_tax_location_invalid` or a typed RecaseError) instead of a
- * generic 500. Covers both v1 `/v1/attach` and v2 `/v1/billing.attach`.
+ * Regression guard for orgs that enable `automatic_tax` after customers
+ * already have paid subscriptions but no Stripe tax location on file.
+ *
+ * Red-failure mode (current behavior):
+ *  - Pro -> Premium upgrade sends `automatic_tax.enabled=true` to Stripe.
+ *  - Stripe rejects with `customer_tax_location_invalid`.
+ *
+ * Green-success criteria (after fix):
+ *  - Upgrade succeeds by falling back to no automatic tax for this mutation.
+ *  - Resulting subscription and upgrade invoice have automatic tax disabled.
  */
 
 import { expect, test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 
-function hasActionableTaxSignal(err: unknown): boolean {
-	const errorString = JSON.stringify(err, [
-		"message",
-		"code",
-		"name",
-		"type",
-	]).toLowerCase();
-	return (
-		errorString.includes("tax") ||
-		errorString.includes("address") ||
-		errorString.includes("location")
-	);
-}
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-no-address (v2 pre-flip upgrade): succeeds without tax when Stripe customer has no location")}`,
+	async () => {
+		const customerId = "tax-no-address-preflip-upgrade";
+		const pro = products.pro({ id: "pro", items: [] });
+		const premium = products.premium({ id: "premium", items: [] });
 
-test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v1 legacy /v1/attach): customer without address surfaces actionable error")}`, async () => {
-	const customerId = "tax-no-address-v1";
-	const proProd = products.pro({ id: "pro", items: [] });
-
-	const { autumnV1 } = await initScenario({
-		customerId,
-		setup: [
-			s.platform.create({
-				configOverrides: { automatic_tax: true },
-				taxRegistrations: ["AU"],
-			}),
-			s.customer({
-				testClock: false,
-				paymentMethod: "success",
-			}),
-			s.products({ list: [proProd] }),
-		],
-		actions: [],
-	});
-
-	let caughtError: unknown;
-	try {
-		await autumnV1.attach({
-			customer_id: customerId,
-			product_id: `pro_${customerId}`,
+		const { ctx, customer, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+				}),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
 		});
-	} catch (err) {
-		caughtError = err;
-	}
 
-	expect(caughtError).toBeDefined();
-	expect(hasActionableTaxSignal(caughtError)).toBe(true);
-}, 240_000);
+		const stripeCustomerId = customer!.processor!.id!;
+		const stripeCustomerBefore =
+			await ctx.stripeCli.customers.retrieve(stripeCustomerId);
+		if ("deleted" in stripeCustomerBefore && stripeCustomerBefore.deleted) {
+			throw new Error("Stripe customer was unexpectedly deleted");
+		}
+		expect(stripeCustomerBefore.address).toBeNull();
 
-test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v2 /v1/billing.attach): customer without address surfaces actionable error")}`, async () => {
-	const customerId = "tax-no-address-v2";
-	const proProd = products.pro({ id: "pro", items: [] });
-
-	const { autumnV2_2 } = await initScenario({
-		customerId,
-		setup: [
-			s.platform.create({
-				configOverrides: { automatic_tax: true },
-				taxRegistrations: ["AU"],
-			}),
-			s.customer({
-				testClock: false,
-				paymentMethod: "success",
-			}),
-			s.products({ list: [proProd] }),
-		],
-		actions: [],
-	});
-
-	let caughtError: unknown;
-	try {
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: `pro_${customerId}`,
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				config: { ...ctx.org.config, automatic_tax: false },
+			},
 		});
-	} catch (err) {
-		caughtError = err;
-	}
 
-	expect(caughtError).toBeDefined();
-	expect(hasActionableTaxSignal(caughtError)).toBe(true);
-}, 240_000);
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+		});
+
+		const initialSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			limit: 1,
+		});
+		expect(initialSubscriptions.data[0].automatic_tax.enabled).toBe(false);
+
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				config: { ...ctx.org.config, automatic_tax: true },
+			},
+		});
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+
+		const upgradedSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			limit: 1,
+		});
+		const upgradedSubscription = upgradedSubscriptions.data[0];
+		expect(upgradedSubscription).toBeDefined();
+		expect(upgradedSubscription.automatic_tax.enabled).toBe(false);
+
+		const invoices = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			limit: 5,
+		});
+		const upgradeInvoice = invoices.data[0];
+		expect(upgradeInvoice).toBeDefined();
+		expect(upgradeInvoice.automatic_tax.enabled).toBe(false);
+	},
+	300_000,
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preflight a customer's tax location before enabling Stripe Automatic Tax on invoices, subscriptions, and attach flows. This prevents `customer_tax_location_invalid` by skipping automatic tax when the customer lacks a usable tax address or when using invoice mode.

- **Bug Fixes**
  - Added `shouldEnableStripeAutomaticTax` to gate automatic tax by org config, invoice mode, and customer tax location; defaults to off when customer data is missing.
  - Applied the guard in invoice creation, subscription update/execute, and legacy attach flows; only set `automatic_tax.enabled=true` when safe.
  - Threaded `expandTax` through Stripe customer fetch/create and billing setup; preserved `updateDb: true` defaults so new Stripe customer IDs are persisted.
  - Rewrote the integration test to cover a post-flip upgrade; verifies the upgrade succeeds without automatic tax and resulting subscription/invoice have automatic tax disabled.

<sup>Written for commit f2253622831b2dfa973f95d4388047a2bef7c795. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1694?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a preflight check that suppresses Stripe automatic tax when a customer has no valid billing address/location, preventing `customer_tax_location_invalid` errors on plan upgrades for orgs that enable tax after customers have already subscribed without an address.

- **[Bug fixes, Improvements]** New `shouldEnableStripeAutomaticTax` utility centralises all three tax-enable conditions (org flag, non-invoice mode, valid customer location) and is wired into subscription create/update and invoice creation paths.
- **[Improvements]** `getExpandedStripeCustomer` and `createStripeCustomer` gain an `expandTax` option; `fetchStripeCustomerForBilling` conditionally expands the `tax` field only when `automatic_tax` is configured.
- **[Bug fixes]** Integration test is rewritten from \"must surface an error\" to \"must silently skip tax and succeed\", matching the new graceful-degradation behaviour.
</details>

<h3>Confidence Score: 3/5</h3>

The options: { expandTax } change in fetchStripeCustomerForBilling drops the updateDb: true default, so net-new customers will have a Stripe customer created but never persisted to the database.

The tax-guard logic in shouldEnableStripeAutomaticTax and all three write-path refactors are correct. The regression is isolated to the new-customer creation path in fetchStripeCustomerForBilling where omitting updateDb: true means the Stripe customer ID is never saved — subsequent requests will create fresh orphaned Stripe customers indefinitely.

server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts — the missing updateDb: true in the new options object needs to be addressed before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts | Adds expandTax option when fetching/creating the Stripe customer, but the explicit options object drops the updateDb: true default, preventing new Stripe customer IDs from being persisted to the database. |
| server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts | New preflight utility checking org flag, invoice mode, and customer tax location. Logic is sound except returning true when the customer is absent skips the preflight guard. |
| server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts | Threads expandTax option through to both getExpandedStripeCustomer and createStripeCustomer. Minimal and correct in isolation. |
| server/src/external/stripe/customers/operations/getExpandedStripeCustomer.ts | Adds optional expandTax parameter to all overloads; conditionally includes tax in the expand list. Overload signatures and implementation are consistent. |
| server/src/external/stripe/customers/operations/createStripeCustomer.ts | Adds expandTax option that conditionally appends tax to the Stripe expand array. Straightforward and correct. |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts | Replaces inline wantsAutoTax expression with shouldEnableStripeAutomaticTax. Refactor preserves identical logic. |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts | Same inline-to-utility refactor. No logic change. |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts | Delegates wantsAutoTax to the new shared utility. Clean refactor. |
| server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts | Test rewritten from expect-an-error to expect-silent-fallback. Covers the pre-flip upgrade scenario well. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts:24-31
**`updateDb: true` default silently dropped for new customers**

Before this PR, `getOrCreateStripeCustomer` was called without `options`, so the default `options = { updateDb: true }` was active. Now `options: { expandTax }` is passed, which prevents the default from applying — `options.updateDb` becomes `undefined` and the `CusService.update` call that persists the new Stripe customer ID back to the database is skipped.

For any customer who does not yet have a `processor.id` when `fetchStripeCustomerForBilling` is first called (i.e., a brand-new customer), the freshly-created Stripe customer ID will never be written to the DB. Every subsequent request will find no `processor.id`, create another Stripe customer, and discard it — leaving orphaned Stripe customers and no billing continuity.

```suggestion
	const stripeCus = createIfMissing
		? await getOrCreateStripeCustomer({
				ctx,
				customer: fullCus,
				options: {
					expandTax,
					updateDb: true,
				},
			})
```

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts:9-10
**Returning `true` when `stripeCustomer` is absent skips the preflight**

`customerHasUsableTaxLocation(undefined)` returns `true`, so if `billingContext.stripeCustomer` is ever `undefined` while `automatic_tax` is enabled, the address preflight is bypassed and Stripe will still receive `automatic_tax: { enabled: true }` — the exact error scenario this PR is designed to prevent. Returning `false` as the safe default when customer data is unavailable would be more defensive.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 preflight tax address existence..."](https://github.com/useautumn/autumn/commit/2bf07e935ffef89e30b8f53a9a617bf42ead14f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33469239)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->