### PR TITLE
fix: double carry over

### DIFF
--- a/server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts
+++ b/server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts
@@ -1,4 +1,5 @@
 import {
+	addCusProductToCusEnt,
 	type AttachBillingContext,
 	type AttachParamsV1,
 	type Entitlement,
@@ -6,6 +7,7 @@ import {
 	type InsertCustomerEntitlement,
 	isBooleanCusEnt,
 	isEntityScopedCusEnt,
+	isOneOffPrepaidConsumableCustomerEntitlement,
 	isUnlimitedCusEnt,
 } from "@autumn/shared";
 import {
@@ -47,6 +49,17 @@ export const cusProductToExistingBalanceCarryOvers = ({
 		if (isBooleanCusEnt({ cusEnt })) continue;
 		if (isUnlimitedCusEnt(cusEnt)) continue;
 		if (featureUtils.isAllocated(cusEnt.entitlement.feature)) continue;
+
+		// One-off prepaid consumable cusEnts are already auto-preserved as a
+		// lifetime cusEnt by cusProductToOneOffPrepaidCarryOvers — skip here
+		// to avoid minting a second carry-over row for the same balance.
+		const cusEntWithCusProduct = addCusProductToCusEnt({
+			cusEnt,
+			cusProduct: currentCustomerProduct,
+		});
+		if (isOneOffPrepaidConsumableCustomerEntitlement(cusEntWithCusProduct))
+			continue;
+
 		if (featureIds && !featureIds.includes(cusEnt.entitlement.feature.id))
 			continue;
 

--- a/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
@@ -5,10 +5,8 @@ import {
 	type FullCusProduct,
 	featureUtils,
 	isBooleanCusEnt,
-	isConsumableCustomerEntitlement,
 	isEntityScopedCusEnt,
-	isOneOffCustomerEntitlement,
-	isPrepaidCustomerEntitlement,
+	isOneOffPrepaidConsumableCustomerEntitlement,
 	isUnlimitedCusEnt,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
@@ -48,11 +46,8 @@ export const cusProductToExistingUsages = ({
 			cusProduct,
 		});
 
-		const isOneOffPrepaidConsumable =
-			isPrepaidCustomerEntitlement(cusEntWithCusProduct) &&
-			isConsumableCustomerEntitlement(cusEntWithCusProduct) &&
-			isOneOffCustomerEntitlement(cusEntWithCusProduct);
-		if (isOneOffPrepaidConsumable) continue;
+		if (isOneOffPrepaidConsumableCustomerEntitlement(cusEntWithCusProduct))
+			continue;
 
 		const isAllocated = featureUtils.isAllocated(cusEnt.entitlement.feature);
 

--- a/server/tests/integration/billing/attach/one-off-prepaid-preserve/no-double-carry-over.test.ts
+++ b/server/tests/integration/billing/attach/one-off-prepaid-preserve/no-double-carry-over.test.ts
@@ -1,0 +1,95 @@
+/**
+ * TDD test for double carry-over on one-off prepaid cusEnts.
+ *
+ * Bug:
+ *   One-off prepaid cusEnts are now ALWAYS auto-preserved as a lifetime
+ *   cusEnt via cusProductToOneOffPrepaidCarryOvers (no opt-in needed).
+ *   When the caller ALSO passes `carry_over_balances: { enabled: true }`,
+ *   the existing-balance carry-over helper iterates the same one-off
+ *   prepaid cusEnt and mints a second carry-over row — doubling the
+ *   preserved balance.
+ *
+ * Red-failure mode (pre-fix):
+ *   Upgrade pro(one-off-prepaid 200, 50 used → 150) → premium(500 monthly)
+ *   with carry_over_balances enabled yields balance 800 (= 500 + 150 + 150)
+ *   instead of the expected 650 (= 500 + 150).
+ *
+ * Green (post-fix):
+ *   cusProductToExistingBalanceCarryOvers skips cusEnts already handled by
+ *   the dedicated one-off prepaid path, so total balance = 650.
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("no-double-carry-over: one-off prepaid + carry_over_balances on same feature only carries balance once")}`,
+	async () => {
+		const customerId = "no-double-carry-over-one-off-prepaid";
+
+		const proOneOff = items.oneOffMessages({
+			includedUsage: 0,
+			billingUnits: 100,
+			price: 10,
+		});
+		const pro = products.pro({ id: "pro-ndco", items: [proOneOff] });
+
+		const premiumMessages = items.monthlyMessages({ includedUsage: 500 });
+		const premium = products.premium({
+			id: "premium-ndco",
+			items: [premiumMessages],
+		});
+
+		const { autumnV1, autumnV2_1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [
+				s.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+				}),
+			],
+		});
+
+		// Burn 50 of 200 → one-off cusEnt balance = 150.
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 50,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		// Upgrade WITH carry_over_balances on messages — the dedicated one-off
+		// prepaid path will also mint a carry-over, so the existing-balance
+		// path must NOT mint a second row for the same cusEnt.
+		await autumnV2_1.billing.attach({
+			customer_id: customerId,
+			plan_id: premium.id,
+			carry_over_balances: {
+				enabled: true,
+				feature_ids: [TestFeature.Messages],
+			},
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		// 500 premium + 150 preserved one-off = 650. Pre-fix: 800 (double-counted).
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			balance: 650,
+			usage: 0,
+		});
+	},
+);

--- a/shared/utils/cusEntUtils/classifyCusEntUtils.ts
+++ b/shared/utils/cusEntUtils/classifyCusEntUtils.ts
@@ -155,3 +155,16 @@ export const isOneOffCustomerEntitlement = (
 export const isConsumableCustomerEntitlement = (
 	cusEnt: FullCusEntWithFullCusProduct,
 ) => !isAllocatedCustomerEntitlement(cusEnt);
+
+/**
+ * One-off prepaid consumable cusEnts are auto-preserved as a lifetime cusEnt
+ * on product transitions (cusProductToOneOffPrepaidCarryOvers). Any other
+ * carry-over / existing-usage path that iterates cusEnts must skip these to
+ * avoid double-counting the same balance.
+ */
+export const isOneOffPrepaidConsumableCustomerEntitlement = (
+	cusEnt: FullCusEntWithFullCusProduct,
+) =>
+	isPrepaidCustomerEntitlement(cusEnt) &&
+	isConsumableCustomerEntitlement(cusEnt) &&
+	isOneOffCustomerEntitlement(cusEnt);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes double carry-over when upgrading with one-off prepaid consumable entitlements and `carry_over_balances` enabled by skipping entitlements already auto-preserved. Prevents minting a second carry-over row and stops balances from doubling.

- **Bug Fixes**
  - Skip one-off prepaid consumable entitlements in existing-balance carry-over using a new `isOneOffPrepaidConsumableCustomerEntitlement` helper to avoid double minting.
  - Simplified existing-usage handling to use the same helper and ignore these entitlements.
  - Added integration test (`no-double-carry-over.test.ts`) verifying a 200 one-off (50 used) → 500 monthly upgrade yields 650, not 800.

<sup>Written for commit 13a554a1f096198be547465492057bcc5c7a799c. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1695?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a double carry-over bug that could double a customer's preserved balance when upgrading from a one-off prepaid plan with `carry_over_balances: { enabled: true }`. The root cause was that `cusProductToOneOffPrepaidCarryOvers` always auto-preserves one-off prepaid balances as lifetime entries, while `cusProductToExistingBalanceCarryOvers` was independently iterating the same cusEnts and minting a second row.

- **Bug fixes**: `cusProductToExistingBalanceCarryOvers` now skips one-off prepaid consumable cusEnts — those already handled by the dedicated one-off path — preventing a second carry-over row being created for the same balance.
- **Improvements**: A new shared helper `isOneOffPrepaidConsumableCustomerEntitlement` encapsulates the three-way predicate (`isPrepaid && isConsumable && isOneOff`) in one place; `cusProductToExistingUsages` is also updated to use it, replacing an inline duplicate.
- **Improvements**: An integration test documents the pre-fix failure mode (balance 800 = 500 + 150 + 150) and the expected post-fix result (balance 650 = 500 + 150).
</details>

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to the carry-over path and only adds a skip guard; no existing behaviour is altered for non-one-off-prepaid cusEnts.

The fix correctly identifies that cusProductToOneOffPrepaidCarryOvers always fires on immediate transitions while cusProductToExistingBalanceCarryOvers was independently iterating the same entries. The new guard checks the same predicate used by the dedicated one-off path, the shared helper is clearly documented, and the integration test covers the exact failure scenario. No unrelated logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/cusEntUtils/classifyCusEntUtils.ts | Adds isOneOffPrepaidConsumableCustomerEntitlement helper, consolidating the three-way check into a single reusable predicate with a doc-comment explaining its purpose. |
| server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts | Core bug fix: inserts a guard that skips one-off prepaid consumable cusEnts (already preserved by the dedicated one-off path) before the existing-balance carry-over loop proceeds, preventing double-minting. |
| server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts | Refactors the inline three-condition check to use the new shared helper — behaviour is unchanged, just cleaner. |
| server/tests/integration/billing/attach/one-off-prepaid-preserve/no-double-carry-over.test.ts | New integration test that exercises the exact scenario (pro one-off 200 units, burn 50, upgrade to premium with carry_over_balances enabled) and asserts the final balance is 650 rather than the pre-fix 800. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as computeAttachPlan
    participant OneOff as cusProductToOneOffPrepaidCarryOvers
    participant Existing as cusProductToExistingBalanceCarryOvers
    participant DB as Inserted Rows

    Caller->>OneOff: "always (planTiming=immediate)"
    OneOff->>DB: "lifetime cusEnt row (balance=150)"

    Caller->>Existing: "only when carry_over_balances.enabled=true"
    Note over Existing: iterate cusEnts
    Existing->>Existing: isOneOffPrepaidConsumableCustomerEntitlement?
    alt pre-fix: check missing
        Existing->>DB: "DUPLICATE lifetime cusEnt row (balance=150)"
        Note over DB: Total: 500+150+150=800
    else post-fix: skip if one-off prepaid
        Existing-->>Existing: continue (skip)
        Note over DB: Total: 500+150=650
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: no double carry over balance for on..."](https://github.com/useautumn/autumn/commit/13a554a1f096198be547465492057bcc5c7a799c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33469575)</sub>

<!-- /greptile_comment -->