### PR TITLE
Gate timeout and queue caps

### DIFF
--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -108,9 +108,11 @@ const rejectOverloaded = ({
 }): never => {
 	rejectedCounter.add(1, { ...labels, reason });
 	throw new RecaseError({
-		message: `FullSubject concurrency gate overloaded (${reason})`,
-		code: "full_subject_gate_overloaded",
+		message:
+			"Too many concurrent requests for this customer. Please retry shortly.",
+		code: "rate_limit_exceeded",
 		statusCode: 429,
+		data: { reason },
 	});
 };
 

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -1,4 +1,5 @@
 import type { AppEnv } from "@autumn/shared";
+import { RecaseError } from "@autumn/shared";
 import { metrics } from "@opentelemetry/api";
 import { LRUCache } from "lru-cache";
 import pLimit, { type LimitFunction } from "p-limit";
@@ -28,7 +29,8 @@ const getOrUpdateLimiter = (
 ): LimitFunction => {
 	const existing = cache.get(key);
 	if (existing) {
-		if (existing.concurrency !== concurrency) existing.concurrency = concurrency;
+		if (existing.concurrency !== concurrency)
+			existing.concurrency = concurrency;
 		return existing;
 	}
 	const limiter = pLimit(concurrency);
@@ -47,7 +49,11 @@ const getCustomerLimiter = ({
 	customerId: string;
 	limit: number;
 }): LimitFunction =>
-	getOrUpdateLimiter(perCustomerLimiters, `${orgId}:${env}:${customerId}`, limit);
+	getOrUpdateLimiter(
+		perCustomerLimiters,
+		`${orgId}:${env}:${customerId}`,
+		limit,
+	);
 
 const getOrgLimiter = ({
 	orgId,
@@ -83,11 +89,30 @@ const activeCounter = meter.createUpDownCounter(
 	"autumn.full_subject.gate.active",
 	{ description: "FullSubject hydrations currently executing" },
 );
+const rejectedCounter = meter.createCounter(
+	"autumn.full_subject.gate.rejected",
+	{ description: "FullSubject hydrations rejected (queue full or timed out)" },
+);
 
 const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
 	org_id: orgId,
 	env,
 });
+
+const rejectOverloaded = ({
+	reason,
+	labels,
+}: {
+	reason: string;
+	labels: Record<string, string>;
+}): never => {
+	rejectedCounter.add(1, { ...labels, reason });
+	throw new RecaseError({
+		message: `FullSubject concurrency gate overloaded (${reason})`,
+		code: "full_subject_gate_overloaded",
+		statusCode: 429,
+	});
+};
 
 export const runWithFullSubjectGate = async <T>({
 	customerId,
@@ -102,15 +127,41 @@ export const runWithFullSubjectGate = async <T>({
 	logger?: Logger;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
-	const { per_customer_limit, per_org_limit } =
-		getRuntimeFullSubjectGateConfig();
+	const {
+		per_customer_limit,
+		per_org_limit,
+		max_wait_ms,
+		per_customer_pending_max,
+		per_org_pending_max,
+	} = getRuntimeFullSubjectGateConfig();
 	const enqueuedAt = Date.now();
 	const labels = attrs({ orgId, env });
 	startedCounter.add(1, labels);
 
+	const orgLimiter = getOrgLimiter({ orgId, env, limit: per_org_limit });
+	if (orgLimiter.pendingCount >= per_org_pending_max) {
+		rejectOverloaded({ reason: "per_org_queue_full", labels });
+	}
+
+	let customerLimiter: LimitFunction | undefined;
+	if (customerId) {
+		customerLimiter = getCustomerLimiter({
+			orgId,
+			env,
+			customerId,
+			limit: per_customer_limit,
+		});
+		if (customerLimiter.pendingCount >= per_customer_pending_max) {
+			rejectOverloaded({ reason: "per_customer_queue_full", labels });
+		}
+	}
+
 	const execute = async (): Promise<T> => {
 		const waitMs = Date.now() - enqueuedAt;
 		waitHistogram.record(waitMs, labels);
+		if (waitMs >= max_wait_ms) {
+			rejectOverloaded({ reason: "wait_timeout", labels });
+		}
 		if (waitMs >= GATE_LOG_WAIT_MS_THRESHOLD) {
 			logger?.info(
 				`[full_subject_gate] queued ${waitMs}ms customer=${customerId ?? "unknown"} org=${orgId} env=${env}`,
@@ -128,15 +179,8 @@ export const runWithFullSubjectGate = async <T>({
 		}
 	};
 
-	if (customerId) {
-		return getCustomerLimiter({
-			orgId,
-			env,
-			customerId,
-			limit: per_customer_limit,
-		})(() =>
-			getOrgLimiter({ orgId, env, limit: per_org_limit })(execute),
-		);
+	if (customerLimiter) {
+		return customerLimiter(() => orgLimiter(execute));
 	}
-	return getOrgLimiter({ orgId, env, limit: per_org_limit })(execute);
+	return orgLimiter(execute);
 };

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
@@ -1,8 +1,18 @@
 import { z } from "zod/v4";
 
+// Defaults are deliberately loose — initial deploy is effectively a no-op
+// for normal traffic. Tighten to target values (15 / 30) via the admin API
+// after observing real load via OTel metrics. See runbook in PR description.
 export const FullSubjectGateEdgeConfigSchema = z.object({
-	per_customer_limit: z.number().int().min(1).max(10_000).default(15),
-	per_org_limit: z.number().int().min(1).max(10_000).default(30),
+	per_customer_limit: z.number().int().min(1).max(10_000).default(200),
+	per_org_limit: z.number().int().min(1).max(10_000).default(500),
+	// Max time a request can wait at the gate before being rejected with 429.
+	// Set generously by default; tighten once we have wait_ms p99 data.
+	max_wait_ms: z.number().int().min(100).max(60_000).default(2_000),
+	// Max number of queued (pending) requests per (org,env,customer) and
+	// (org,env) before rejecting new ones with 429 — bounds memory + wait time.
+	per_customer_pending_max: z.number().int().min(1).max(100_000).default(500),
+	per_org_pending_max: z.number().int().min(1).max(100_000).default(1_000),
 });
 
 export type FullSubjectGateEdgeConfig = z.infer<

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,11 +1,17 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { AppEnv } from "@autumn/shared";
-import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 import { runWithFullSubjectGate } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
+import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
 beforeAll(() => {
 	_setFullSubjectGateConfigForTesting({
-		config: { per_customer_limit: 2, per_org_limit: 4 },
+		config: {
+			per_customer_limit: 2,
+			per_org_limit: 4,
+			max_wait_ms: 60_000,
+			per_customer_pending_max: 1000,
+			per_org_pending_max: 1000,
+		},
 	});
 });
 
@@ -151,7 +157,13 @@ describe("runWithFullSubjectGate", () => {
 
 	test("limit changes take effect at runtime without recreating limiters", async () => {
 		_setFullSubjectGateConfigForTesting({
-			config: { per_customer_limit: 1, per_org_limit: 4 },
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
 		});
 
 		const counter = makeCounter();
@@ -167,9 +179,97 @@ describe("runWithFullSubjectGate", () => {
 		await Promise.all(tasks);
 		expect(counter.peak).toBe(1);
 
-		// Restore for any subsequent tests.
 		_setFullSubjectGateConfigForTesting({
-			config: { per_customer_limit: 2, per_org_limit: 4 },
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+	});
+
+	test("rejects with 429 when per-customer pending queue is full", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 100,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 2,
+				per_org_pending_max: 1000,
+			},
+		});
+
+		const slow = () => new Promise((resolve) => setTimeout(resolve, 100));
+		const results = await Promise.allSettled(
+			Array.from({ length: 10 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-queue-full",
+					orgId: "org-queue-full",
+					env: AppEnv.Live,
+					queryFn: slow,
+				}),
+			),
+		);
+
+		const rejected = results.filter((r) => r.status === "rejected");
+		expect(rejected.length).toBeGreaterThan(0);
+		for (const r of rejected as PromiseRejectedResult[]) {
+			expect(r.reason.statusCode).toBe(429);
+			expect(r.reason.code).toBe("full_subject_gate_overloaded");
+		}
+
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+	});
+
+	test("rejects with 429 when a queued request exceeds max_wait_ms", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 100,
+				max_wait_ms: 30,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+
+		const slow = () => new Promise((resolve) => setTimeout(resolve, 80));
+		const results = await Promise.allSettled(
+			Array.from({ length: 4 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-wait-timeout",
+					orgId: "org-wait-timeout",
+					env: AppEnv.Live,
+					queryFn: slow,
+				}),
+			),
+		);
+
+		const timeouts = results.filter(
+			(r) =>
+				r.status === "rejected" &&
+				(r as PromiseRejectedResult).reason.code ===
+					"full_subject_gate_overloaded",
+		);
+		expect(timeouts.length).toBeGreaterThan(0);
+
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
 		});
 	});
 

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -217,7 +217,7 @@ describe("runWithFullSubjectGate", () => {
 		expect(rejected.length).toBeGreaterThan(0);
 		for (const r of rejected as PromiseRejectedResult[]) {
 			expect(r.reason.statusCode).toBe(429);
-			expect(r.reason.code).toBe("full_subject_gate_overloaded");
+			expect(r.reason.code).toBe("rate_limit_exceeded");
 		}
 
 		_setFullSubjectGateConfigForTesting({
@@ -258,7 +258,7 @@ describe("runWithFullSubjectGate", () => {
 			(r) =>
 				r.status === "rejected" &&
 				(r as PromiseRejectedResult).reason.code ===
-					"full_subject_gate_overloaded",
+					"rate_limit_exceeded",
 		);
 		expect(timeouts.length).toBeGreaterThan(0);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add queue caps and a wait timeout to the FullSubject gate to bound latency and memory under load. Overloaded requests now fail fast with 429 `rate_limit_exceeded` and clear metrics.

- **New Features**
  - New config keys: `max_wait_ms`, `per_customer_pending_max`, `per_org_pending_max` (safe defaults).
  - Reject when per-customer or per-org pending queues exceed caps, or when queued wait > `max_wait_ms` (throws `RecaseError` with 429 `rate_limit_exceeded`).
  - Added `autumn.full_subject.gate.rejected` OTel counter; continue recording wait histogram and long-wait logs.
  - Limiters keep instances and apply runtime concurrency changes without recreation.
  - Tests cover queue-full and wait-timeout paths.

- **Migration**
  - No action required; defaults are conservative.
  - After observing metrics, lower `per_customer_limit`/`per_org_limit` and tighten `max_wait_ms` via the admin API as needed.

<sup>Written for commit 8969e6feea0753f7fc28121ae693ad4ec886484a. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1696?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

