### PR TITLE
Release 22/05/2026

### DIFF
--- a/server/src/external/aws/s3/adminS3Config.ts
+++ b/server/src/external/aws/s3/adminS3Config.ts
@@ -10,6 +10,8 @@ export const ADMIN_CACHE_V2_RAMP_CONFIG_KEY = "admin/cache-v2-ramp-config.json";
 export const ADMIN_JOB_QUEUE_CONFIG_KEY = "admin/job-queue-config.json";
 export const ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY =
 	"admin/miscellaneous-edge-config.json";
+export const ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY =
+	"admin/full-subject-gate-config.json";
 export const BLUE_GREEN_ACTIVE_SLOT_KEY = "admin/blue-green-active-slot.json";
 export const BLUE_GREEN_CRON_ACTIVE_SLOT_KEY =
 	"admin/blue-green-cron-active-slot.json";
@@ -64,6 +66,11 @@ export const getAdminEdgeConfigSources = () => ({
 			id: "miscellaneous",
 			label: "Miscellaneous",
 			key: ADMIN_MISCELLANEOUS_EDGE_CONFIG_KEY,
+		},
+		{
+			id: "full-subject-gate",
+			label: "FullSubject Concurrency Gate",
+			key: ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY,
 		},
 		{
 			id: "stripe-sync",

--- a/server/src/internal/admin/adminRouter.ts
+++ b/server/src/internal/admin/adminRouter.ts
@@ -15,6 +15,7 @@ import {
 import { handleGetAdminCustomerBlockConfig } from "./handleGetAdminCustomerBlockConfig";
 import { handleGetAdminEdgeConfigSources } from "./handleGetAdminEdgeConfigSources";
 import { handleGetAdminFeatureFlagsConfig } from "./handleGetAdminFeatureFlagsConfig";
+import { handleGetAdminFullSubjectGateConfig } from "./handleGetAdminFullSubjectGateConfig";
 import { handleGetAdminJobQueueConfig } from "./handleGetAdminJobQueueConfig";
 import { handleGetAdminMiscellaneousEdgeConfig } from "./handleGetAdminMiscellaneousEdgeConfig";
 import { handleGetAdminOrgLimitsConfig } from "./handleGetAdminOrgLimitsConfig";
@@ -31,6 +32,7 @@ import { handleListAdminUsers } from "./handleListAdminUsers";
 import { handleListOAuthClients } from "./handleListOAuthClients";
 import { handleUpsertAdminCustomerBlockConfig } from "./handleUpsertAdminCustomerBlockConfig";
 import { handleUpsertAdminFeatureFlagsConfig } from "./handleUpsertAdminFeatureFlagsConfig";
+import { handleUpsertAdminFullSubjectGateConfig } from "./handleUpsertAdminFullSubjectGateConfig";
 import { handleUpsertAdminJobQueueConfig } from "./handleUpsertAdminJobQueueConfig";
 import { handleUpsertAdminMiscellaneousEdgeConfig } from "./handleUpsertAdminMiscellaneousEdgeConfig";
 import { handleUpsertAdminOrgLimitsConfig } from "./handleUpsertAdminOrgLimitsConfig";
@@ -93,6 +95,14 @@ honoAdminRouter.get(
 honoAdminRouter.put(
 	"/miscellaneous-edge-config",
 	...handleUpsertAdminMiscellaneousEdgeConfig,
+);
+honoAdminRouter.get(
+	"/full-subject-gate-config",
+	...handleGetAdminFullSubjectGateConfig,
+);
+honoAdminRouter.put(
+	"/full-subject-gate-config",
+	...handleUpsertAdminFullSubjectGateConfig,
 );
 honoAdminRouter.get(
 	"/customer-block-config",

--- a/server/src/internal/admin/handleGetAdminFullSubjectGateConfig.ts
+++ b/server/src/internal/admin/handleGetAdminFullSubjectGateConfig.ts
@@ -2,6 +2,7 @@ import { Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import {
 	getFullSubjectGateConfigFromSource,
+	getRuntimeFullSubjectGateConfig,
 	getRuntimeFullSubjectGateConfigStatus,
 } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
@@ -9,14 +10,20 @@ export const handleGetAdminFullSubjectGateConfig = createRoute({
 	scopes: [Scopes.Superuser],
 	handler: async (c) => {
 		const status = getRuntimeFullSubjectGateConfigStatus();
-		const config = await getFullSubjectGateConfigFromSource();
+		let config = getRuntimeFullSubjectGateConfig();
+		let sourceError: string | null = null;
+		try {
+			config = await getFullSubjectGateConfigFromSource();
+		} catch (error) {
+			sourceError = error instanceof Error ? error.message : String(error);
+		}
 
 		return c.json({
 			...config,
-			configHealthy: status.healthy,
+			configHealthy: status.healthy && sourceError === null,
 			configConfigured: status.configured,
 			lastSuccessAt: status.lastSuccessAt ?? null,
-			error: status.error ?? null,
+			error: sourceError ?? status.error ?? null,
 		});
 	},
 });

--- a/server/src/internal/admin/handleGetAdminFullSubjectGateConfig.ts
+++ b/server/src/internal/admin/handleGetAdminFullSubjectGateConfig.ts
@@ -1,0 +1,22 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	getFullSubjectGateConfigFromSource,
+	getRuntimeFullSubjectGateConfigStatus,
+} from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+
+export const handleGetAdminFullSubjectGateConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	handler: async (c) => {
+		const status = getRuntimeFullSubjectGateConfigStatus();
+		const config = await getFullSubjectGateConfigFromSource();
+
+		return c.json({
+			...config,
+			configHealthy: status.healthy,
+			configConfigured: status.configured,
+			lastSuccessAt: status.lastSuccessAt ?? null,
+			error: status.error ?? null,
+		});
+	},
+});

--- a/server/src/internal/admin/handleUpsertAdminFullSubjectGateConfig.ts
+++ b/server/src/internal/admin/handleUpsertAdminFullSubjectGateConfig.ts
@@ -1,0 +1,14 @@
+import { Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { FullSubjectGateEdgeConfigSchema } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.js";
+import { updateFullSubjectGateConfig } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+
+export const handleUpsertAdminFullSubjectGateConfig = createRoute({
+	scopes: [Scopes.Superuser],
+	body: FullSubjectGateEdgeConfigSchema,
+	handler: async (c) => {
+		const body = c.req.valid("json");
+		await updateFullSubjectGateConfig({ config: body });
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -37,6 +37,7 @@ export async function getFullSubject({
 		customerId,
 		orgId: org.id,
 		env,
+		logger: ctx.logger,
 		queryFn: () =>
 			db.execute(
 				getFullSubjectQuery({
@@ -88,6 +89,7 @@ export async function getFullSubjectNormalized({
 		customerId,
 		orgId: org.id,
 		env,
+		logger: ctx.logger,
 		queryFn: () =>
 			db.execute(
 				getFullSubjectQuery({

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -36,6 +36,7 @@ export async function getFullSubject({
 	const result = await runWithFullSubjectGate({
 		customerId,
 		orgId: org.id,
+		env,
 		queryFn: () =>
 			db.execute(
 				getFullSubjectQuery({
@@ -86,6 +87,7 @@ export async function getFullSubjectNormalized({
 	const result = await runWithFullSubjectGate({
 		customerId,
 		orgId: org.id,
+		env,
 		queryFn: () =>
 			db.execute(
 				getFullSubjectQuery({

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubject.ts
@@ -10,6 +10,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { checkPendingMigrationsForCustomer } from "@/internal/migrations/v2/lazy/checkPendingMigrationsForCustomer.js";
 import { lazyResetSubjectEntitlements } from "../../actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.js";
 import { RELEVANT_STATUSES } from "../../cusProducts/CusProductService.js";
+import { runWithFullSubjectGate } from "./getFullSubjectGate.js";
 import { getFullSubjectQuery } from "./getFullSubjectQuery.js";
 import {
 	resultToFullSubject,
@@ -32,16 +33,21 @@ export async function getFullSubject({
 }): Promise<FullSubject | undefined> {
 	const { db, org, env } = ctx;
 
-	const result = await db.execute(
-		getFullSubjectQuery({
-			orgId: org.id,
-			env,
-			customerId,
-			entityId,
-			inStatuses,
-			allowMissingEntity,
-		}),
-	);
+	const result = await runWithFullSubjectGate({
+		customerId,
+		orgId: org.id,
+		queryFn: () =>
+			db.execute(
+				getFullSubjectQuery({
+					orgId: org.id,
+					env,
+					customerId,
+					entityId,
+					inStatuses,
+					allowMissingEntity,
+				}),
+			),
+	});
 
 	if (!result?.length) return undefined;
 
@@ -77,16 +83,21 @@ export async function getFullSubjectNormalized({
 > {
 	const { db, org, env } = ctx;
 
-	const result = await db.execute(
-		getFullSubjectQuery({
-			orgId: org.id,
-			env,
-			customerId,
-			entityId,
-			inStatuses,
-			allowMissingEntity,
-		}),
-	);
+	const result = await runWithFullSubjectGate({
+		customerId,
+		orgId: org.id,
+		queryFn: () =>
+			db.execute(
+				getFullSubjectQuery({
+					orgId: org.id,
+					env,
+					customerId,
+					entityId,
+					inStatuses,
+					allowMissingEntity,
+				}),
+			),
+	});
 
 	if (!result?.length) return undefined;
 

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -1,3 +1,4 @@
+import type { AppEnv } from "@autumn/shared";
 import { metrics } from "@opentelemetry/api";
 import { LRUCache } from "lru-cache";
 import pLimit, { type LimitFunction } from "p-limit";
@@ -24,19 +25,35 @@ const perOrgLimiters = new LRUCache<string, LimitFunction>({
 	updateAgeOnGet: true,
 });
 
-const getCustomerLimiter = (customerId: string): LimitFunction => {
-	const existing = perCustomerLimiters.get(customerId);
+const getCustomerLimiter = ({
+	orgId,
+	env,
+	customerId,
+}: {
+	orgId: string;
+	env: AppEnv;
+	customerId: string;
+}): LimitFunction => {
+	const key = `${orgId}:${env}:${customerId}`;
+	const existing = perCustomerLimiters.get(key);
 	if (existing) return existing;
 	const limiter = pLimit(PER_CUSTOMER_LIMIT);
-	perCustomerLimiters.set(customerId, limiter);
+	perCustomerLimiters.set(key, limiter);
 	return limiter;
 };
 
-const getOrgLimiter = (orgId: string): LimitFunction => {
-	const existing = perOrgLimiters.get(orgId);
+const getOrgLimiter = ({
+	orgId,
+	env,
+}: {
+	orgId: string;
+	env: AppEnv;
+}): LimitFunction => {
+	const key = `${orgId}:${env}`;
+	const existing = perOrgLimiters.get(key);
 	if (existing) return existing;
 	const limiter = pLimit(PER_ORG_LIMIT);
-	perOrgLimiters.set(orgId, limiter);
+	perOrgLimiters.set(key, limiter);
 	return limiter;
 };
 
@@ -71,12 +88,15 @@ const perOrgActiveCounter = meter.createUpDownCounter(
 const attrs = ({
 	customerId,
 	orgId,
+	env,
 }: {
 	customerId: string | undefined;
 	orgId: string;
+	env: AppEnv;
 }) => ({
 	customer_id: customerId ?? "unknown",
 	org_id: orgId,
+	env,
 });
 
 /**
@@ -94,14 +114,16 @@ const attrs = ({
 export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
+	env,
 	queryFn,
 }: {
 	customerId: string | undefined;
 	orgId: string;
+	env: AppEnv;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
 	const enqueuedAt = Date.now();
-	const labels = attrs({ customerId, orgId });
+	const labels = attrs({ customerId, orgId, env });
 	startedCounter.add(1, labels);
 
 	const execute = async (): Promise<T> => {
@@ -120,10 +142,12 @@ export const runWithFullSubjectGate = async <T>({
 		}
 	};
 
-	const orgLimit = getOrgLimiter(orgId);
-
 	if (customerId) {
-		return getCustomerLimiter(customerId)(() => orgLimit(execute));
+		// Resolve the org limiter inside the customer callback so a stale
+		// LRU-evicted org limiter can't be used after a customer slot opens.
+		return getCustomerLimiter({ orgId, env, customerId })(() =>
+			getOrgLimiter({ orgId, env })(execute),
+		);
 	}
-	return orgLimit(execute);
+	return getOrgLimiter({ orgId, env })(execute);
 };

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -138,12 +138,8 @@ export const runWithFullSubjectGate = async <T>({
 	} = getRuntimeFullSubjectGateConfig();
 	const enqueuedAt = Date.now();
 	const labels = attrs({ orgId, env });
-	startedCounter.add(1, labels);
 
 	const orgLimiter = getOrgLimiter({ orgId, env, limit: per_org_limit });
-	if (orgLimiter.pendingCount >= per_org_pending_max) {
-		rejectOverloaded({ reason: "per_org_queue_full", labels });
-	}
 
 	let customerLimiter: LimitFunction | undefined;
 	if (customerId) {
@@ -156,7 +152,11 @@ export const runWithFullSubjectGate = async <T>({
 		if (customerLimiter.pendingCount >= per_customer_pending_max) {
 			rejectOverloaded({ reason: "per_customer_queue_full", labels });
 		}
+	} else if (orgLimiter.pendingCount >= per_org_pending_max) {
+		rejectOverloaded({ reason: "per_org_queue_full", labels });
 	}
+
+	startedCounter.add(1, labels);
 
 	const execute = async (): Promise<T> => {
 		const waitMs = Date.now() - enqueuedAt;
@@ -182,7 +182,12 @@ export const runWithFullSubjectGate = async <T>({
 	};
 
 	if (customerLimiter) {
-		return customerLimiter(() => orgLimiter(execute));
+		return customerLimiter(() => {
+			if (orgLimiter.pendingCount >= per_org_pending_max) {
+				rejectOverloaded({ reason: "per_org_queue_full", labels });
+			}
+			return orgLimiter(execute);
+		});
 	}
 	return orgLimiter(execute);
 };

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -108,9 +108,11 @@ const rejectOverloaded = ({
 }): never => {
 	rejectedCounter.add(1, { ...labels, reason });
 	throw new RecaseError({
-		message: `FullSubject concurrency gate overloaded (${reason})`,
-		code: "full_subject_gate_overloaded",
+		message:
+			"Too many concurrent requests for this customer. Please retry shortly.",
+		code: "rate_limit_exceeded",
 		statusCode: 429,
+		data: { reason },
 	});
 };
 

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -79,13 +79,9 @@ const waitHistogram = meter.createHistogram(
 		unit: "ms",
 	},
 );
-const perCustomerActiveCounter = meter.createUpDownCounter(
-	"autumn.full_subject.gate.per_customer_active",
-	{ description: "Hydrations currently executing for a given customer" },
-);
-const perOrgActiveCounter = meter.createUpDownCounter(
-	"autumn.full_subject.gate.per_org_active",
-	{ description: "Hydrations currently executing for a given org" },
+const activeCounter = meter.createUpDownCounter(
+	"autumn.full_subject.gate.active",
+	{ description: "FullSubject hydrations currently executing" },
 );
 
 const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
@@ -120,16 +116,14 @@ export const runWithFullSubjectGate = async <T>({
 				`[full_subject_gate] queued ${waitMs}ms customer=${customerId ?? "unknown"} org=${orgId} env=${env}`,
 			);
 		}
-		perOrgActiveCounter.add(1, labels);
-		perCustomerActiveCounter.add(1, labels);
+		activeCounter.add(1, labels);
 		try {
 			return await queryFn();
 		} catch (error) {
 			failedCounter.add(1, labels);
 			throw error;
 		} finally {
-			perOrgActiveCounter.add(-1, labels);
-			perCustomerActiveCounter.add(-1, labels);
+			activeCounter.add(-1, labels);
 			completedCounter.add(1, labels);
 		}
 	};

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -3,22 +3,12 @@ import { metrics } from "@opentelemetry/api";
 import { LRUCache } from "lru-cache";
 import pLimit, { type LimitFunction } from "p-limit";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { getRuntimeFullSubjectGateConfig } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
-// Log per-customer attribution when a request queued for at least this long.
-// Sub-threshold engagements are still counted in metrics — just not logged
-// (avoids spam under healthy load).
 const GATE_LOG_WAIT_MS_THRESHOLD = 50;
-
-const PER_CUSTOMER_LIMIT = Number(
-	process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT ?? 15,
-);
-const PER_ORG_LIMIT = Number(process.env.FULL_SUBJECT_PER_ORG_LIMIT ?? 30);
 const LIMITER_CACHE_MAX = 5000;
 const LIMITER_CACHE_TTL_MS = 30 * 60 * 1000;
 
-// updateAgeOnGet keeps active customers/orgs alive — without it, an in-flight
-// burst that straddles a TTL expiry could see a fresh limiter and effectively
-// double the cap.
 const perCustomerLimiters = new LRUCache<string, LimitFunction>({
 	max: LIMITER_CACHE_MAX,
 	ttl: LIMITER_CACHE_TTL_MS,
@@ -31,37 +21,44 @@ const perOrgLimiters = new LRUCache<string, LimitFunction>({
 	updateAgeOnGet: true,
 });
 
+const getOrUpdateLimiter = (
+	cache: LRUCache<string, LimitFunction>,
+	key: string,
+	concurrency: number,
+): LimitFunction => {
+	const existing = cache.get(key);
+	if (existing) {
+		if (existing.concurrency !== concurrency) existing.concurrency = concurrency;
+		return existing;
+	}
+	const limiter = pLimit(concurrency);
+	cache.set(key, limiter);
+	return limiter;
+};
+
 const getCustomerLimiter = ({
 	orgId,
 	env,
 	customerId,
+	limit,
 }: {
 	orgId: string;
 	env: AppEnv;
 	customerId: string;
-}): LimitFunction => {
-	const key = `${orgId}:${env}:${customerId}`;
-	const existing = perCustomerLimiters.get(key);
-	if (existing) return existing;
-	const limiter = pLimit(PER_CUSTOMER_LIMIT);
-	perCustomerLimiters.set(key, limiter);
-	return limiter;
-};
+	limit: number;
+}): LimitFunction =>
+	getOrUpdateLimiter(perCustomerLimiters, `${orgId}:${env}:${customerId}`, limit);
 
 const getOrgLimiter = ({
 	orgId,
 	env,
+	limit,
 }: {
 	orgId: string;
 	env: AppEnv;
-}): LimitFunction => {
-	const key = `${orgId}:${env}`;
-	const existing = perOrgLimiters.get(key);
-	if (existing) return existing;
-	const limiter = pLimit(PER_ORG_LIMIT);
-	perOrgLimiters.set(key, limiter);
-	return limiter;
-};
+	limit: number;
+}): LimitFunction =>
+	getOrUpdateLimiter(perOrgLimiters, `${orgId}:${env}`, limit);
 
 const meter = metrics.getMeter("autumn-server");
 const startedCounter = meter.createCounter("autumn.full_subject.gate.started", {
@@ -91,26 +88,11 @@ const perOrgActiveCounter = meter.createUpDownCounter(
 	{ description: "Hydrations currently executing for a given org" },
 );
 
-// Metric labels intentionally exclude customer_id — that's high-cardinality
-// (hundreds of thousands of customers) and would balloon time-series count
-// + ingestion cost. Per-customer attribution lives in log lines, not metrics.
 const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
 	org_id: orgId,
 	env,
 });
 
-/**
- * Wrap a FullSubject DB hydration so it goes through per-customer + per-org
- * concurrency gates. Per-customer slot is acquired FIRST so one customer's
- * burst can't hold per-org slots while waiting on its own customer cap
- * (head-of-line starves siblings within the same org).
- *
- * Limits are PER-PROCESS, not cluster-wide — with N API replicas, effective
- * caps are PER_CUSTOMER_LIMIT*N and PER_ORG_LIMIT*N. Sized accordingly.
- *
- * Defaults: 15 per-customer, 30 per-org per process. Override via
- * FULL_SUBJECT_PER_CUSTOMER_LIMIT / FULL_SUBJECT_PER_ORG_LIMIT.
- */
 export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
@@ -124,6 +106,8 @@ export const runWithFullSubjectGate = async <T>({
 	logger?: Logger;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
+	const { per_customer_limit, per_org_limit } =
+		getRuntimeFullSubjectGateConfig();
 	const enqueuedAt = Date.now();
 	const labels = attrs({ orgId, env });
 	startedCounter.add(1, labels);
@@ -151,11 +135,14 @@ export const runWithFullSubjectGate = async <T>({
 	};
 
 	if (customerId) {
-		// Resolve the org limiter inside the customer callback so a stale
-		// LRU-evicted org limiter can't be used after a customer slot opens.
-		return getCustomerLimiter({ orgId, env, customerId })(() =>
-			getOrgLimiter({ orgId, env })(execute),
+		return getCustomerLimiter({
+			orgId,
+			env,
+			customerId,
+			limit: per_customer_limit,
+		})(() =>
+			getOrgLimiter({ orgId, env, limit: per_org_limit })(execute),
 		);
 	}
-	return getOrgLimiter({ orgId, env })(execute);
+	return getOrgLimiter({ orgId, env, limit: per_org_limit })(execute);
 };

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -1,4 +1,5 @@
 import type { AppEnv } from "@autumn/shared";
+import { RecaseError } from "@autumn/shared";
 import { metrics } from "@opentelemetry/api";
 import { LRUCache } from "lru-cache";
 import pLimit, { type LimitFunction } from "p-limit";
@@ -28,7 +29,8 @@ const getOrUpdateLimiter = (
 ): LimitFunction => {
 	const existing = cache.get(key);
 	if (existing) {
-		if (existing.concurrency !== concurrency) existing.concurrency = concurrency;
+		if (existing.concurrency !== concurrency)
+			existing.concurrency = concurrency;
 		return existing;
 	}
 	const limiter = pLimit(concurrency);
@@ -47,7 +49,11 @@ const getCustomerLimiter = ({
 	customerId: string;
 	limit: number;
 }): LimitFunction =>
-	getOrUpdateLimiter(perCustomerLimiters, `${orgId}:${env}:${customerId}`, limit);
+	getOrUpdateLimiter(
+		perCustomerLimiters,
+		`${orgId}:${env}:${customerId}`,
+		limit,
+	);
 
 const getOrgLimiter = ({
 	orgId,
@@ -83,11 +89,30 @@ const activeCounter = meter.createUpDownCounter(
 	"autumn.full_subject.gate.active",
 	{ description: "FullSubject hydrations currently executing" },
 );
+const rejectedCounter = meter.createCounter(
+	"autumn.full_subject.gate.rejected",
+	{ description: "FullSubject hydrations rejected (queue full or timed out)" },
+);
 
 const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
 	org_id: orgId,
 	env,
 });
+
+const rejectOverloaded = ({
+	reason,
+	labels,
+}: {
+	reason: string;
+	labels: Record<string, string>;
+}): never => {
+	rejectedCounter.add(1, { ...labels, reason });
+	throw new RecaseError({
+		message: `FullSubject concurrency gate overloaded (${reason})`,
+		code: "full_subject_gate_overloaded",
+		statusCode: 429,
+	});
+};
 
 export const runWithFullSubjectGate = async <T>({
 	customerId,
@@ -102,15 +127,41 @@ export const runWithFullSubjectGate = async <T>({
 	logger?: Logger;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
-	const { per_customer_limit, per_org_limit } =
-		getRuntimeFullSubjectGateConfig();
+	const {
+		per_customer_limit,
+		per_org_limit,
+		max_wait_ms,
+		per_customer_pending_max,
+		per_org_pending_max,
+	} = getRuntimeFullSubjectGateConfig();
 	const enqueuedAt = Date.now();
 	const labels = attrs({ orgId, env });
 	startedCounter.add(1, labels);
 
+	const orgLimiter = getOrgLimiter({ orgId, env, limit: per_org_limit });
+	if (orgLimiter.pendingCount >= per_org_pending_max) {
+		rejectOverloaded({ reason: "per_org_queue_full", labels });
+	}
+
+	let customerLimiter: LimitFunction | undefined;
+	if (customerId) {
+		customerLimiter = getCustomerLimiter({
+			orgId,
+			env,
+			customerId,
+			limit: per_customer_limit,
+		});
+		if (customerLimiter.pendingCount >= per_customer_pending_max) {
+			rejectOverloaded({ reason: "per_customer_queue_full", labels });
+		}
+	}
+
 	const execute = async (): Promise<T> => {
 		const waitMs = Date.now() - enqueuedAt;
 		waitHistogram.record(waitMs, labels);
+		if (waitMs >= max_wait_ms) {
+			rejectOverloaded({ reason: "wait_timeout", labels });
+		}
 		if (waitMs >= GATE_LOG_WAIT_MS_THRESHOLD) {
 			logger?.info(
 				`[full_subject_gate] queued ${waitMs}ms customer=${customerId ?? "unknown"} org=${orgId} env=${env}`,
@@ -128,15 +179,8 @@ export const runWithFullSubjectGate = async <T>({
 		}
 	};
 
-	if (customerId) {
-		return getCustomerLimiter({
-			orgId,
-			env,
-			customerId,
-			limit: per_customer_limit,
-		})(() =>
-			getOrgLimiter({ orgId, env, limit: per_org_limit })(execute),
-		);
+	if (customerLimiter) {
+		return customerLimiter(() => orgLimiter(execute));
 	}
-	return getOrgLimiter({ orgId, env, limit: per_org_limit })(execute);
+	return orgLimiter(execute);
 };

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -2,6 +2,12 @@ import type { AppEnv } from "@autumn/shared";
 import { metrics } from "@opentelemetry/api";
 import { LRUCache } from "lru-cache";
 import pLimit, { type LimitFunction } from "p-limit";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+
+// Log per-customer attribution when a request queued for at least this long.
+// Sub-threshold engagements are still counted in metrics — just not logged
+// (avoids spam under healthy load).
+const GATE_LOG_WAIT_MS_THRESHOLD = 50;
 
 const PER_CUSTOMER_LIMIT = Number(
 	process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT ?? 15,
@@ -85,16 +91,10 @@ const perOrgActiveCounter = meter.createUpDownCounter(
 	{ description: "Hydrations currently executing for a given org" },
 );
 
-const attrs = ({
-	customerId,
-	orgId,
-	env,
-}: {
-	customerId: string | undefined;
-	orgId: string;
-	env: AppEnv;
-}) => ({
-	customer_id: customerId ?? "unknown",
+// Metric labels intentionally exclude customer_id — that's high-cardinality
+// (hundreds of thousands of customers) and would balloon time-series count
+// + ingestion cost. Per-customer attribution lives in log lines, not metrics.
+const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
 	org_id: orgId,
 	env,
 });
@@ -115,19 +115,27 @@ export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,
 	env,
+	logger,
 	queryFn,
 }: {
 	customerId: string | undefined;
 	orgId: string;
 	env: AppEnv;
+	logger?: Logger;
 	queryFn: () => Promise<T>;
 }): Promise<T> => {
 	const enqueuedAt = Date.now();
-	const labels = attrs({ customerId, orgId, env });
+	const labels = attrs({ orgId, env });
 	startedCounter.add(1, labels);
 
 	const execute = async (): Promise<T> => {
-		waitHistogram.record(Date.now() - enqueuedAt, labels);
+		const waitMs = Date.now() - enqueuedAt;
+		waitHistogram.record(waitMs, labels);
+		if (waitMs >= GATE_LOG_WAIT_MS_THRESHOLD) {
+			logger?.info(
+				`[full_subject_gate] queued ${waitMs}ms customer=${customerId ?? "unknown"} org=${orgId} env=${env}`,
+			);
+		}
 		perOrgActiveCounter.add(1, labels);
 		perCustomerActiveCounter.add(1, labels);
 		try {

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -1,0 +1,129 @@
+import { metrics } from "@opentelemetry/api";
+import { LRUCache } from "lru-cache";
+import pLimit, { type LimitFunction } from "p-limit";
+
+const PER_CUSTOMER_LIMIT = Number(
+	process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT ?? 15,
+);
+const PER_ORG_LIMIT = Number(process.env.FULL_SUBJECT_PER_ORG_LIMIT ?? 30);
+const LIMITER_CACHE_MAX = 5000;
+const LIMITER_CACHE_TTL_MS = 30 * 60 * 1000;
+
+// updateAgeOnGet keeps active customers/orgs alive — without it, an in-flight
+// burst that straddles a TTL expiry could see a fresh limiter and effectively
+// double the cap.
+const perCustomerLimiters = new LRUCache<string, LimitFunction>({
+	max: LIMITER_CACHE_MAX,
+	ttl: LIMITER_CACHE_TTL_MS,
+	updateAgeOnGet: true,
+});
+
+const perOrgLimiters = new LRUCache<string, LimitFunction>({
+	max: LIMITER_CACHE_MAX,
+	ttl: LIMITER_CACHE_TTL_MS,
+	updateAgeOnGet: true,
+});
+
+const getCustomerLimiter = (customerId: string): LimitFunction => {
+	const existing = perCustomerLimiters.get(customerId);
+	if (existing) return existing;
+	const limiter = pLimit(PER_CUSTOMER_LIMIT);
+	perCustomerLimiters.set(customerId, limiter);
+	return limiter;
+};
+
+const getOrgLimiter = (orgId: string): LimitFunction => {
+	const existing = perOrgLimiters.get(orgId);
+	if (existing) return existing;
+	const limiter = pLimit(PER_ORG_LIMIT);
+	perOrgLimiters.set(orgId, limiter);
+	return limiter;
+};
+
+const meter = metrics.getMeter("autumn-server");
+const startedCounter = meter.createCounter("autumn.full_subject.gate.started", {
+	description: "FullSubject DB hydrations entering the gate",
+});
+const completedCounter = meter.createCounter(
+	"autumn.full_subject.gate.completed",
+	{ description: "FullSubject DB hydrations finished (success or failure)" },
+);
+const failedCounter = meter.createCounter("autumn.full_subject.gate.failed", {
+	description: "FullSubject DB hydrations that threw",
+});
+const waitHistogram = meter.createHistogram(
+	"autumn.full_subject.gate.wait_ms",
+	{
+		description:
+			"Time spent queued before the DB hydration started, in milliseconds.",
+		unit: "ms",
+	},
+);
+const perCustomerActiveCounter = meter.createUpDownCounter(
+	"autumn.full_subject.gate.per_customer_active",
+	{ description: "Hydrations currently executing for a given customer" },
+);
+const perOrgActiveCounter = meter.createUpDownCounter(
+	"autumn.full_subject.gate.per_org_active",
+	{ description: "Hydrations currently executing for a given org" },
+);
+
+const attrs = ({
+	customerId,
+	orgId,
+}: {
+	customerId: string | undefined;
+	orgId: string;
+}) => ({
+	customer_id: customerId ?? "unknown",
+	org_id: orgId,
+});
+
+/**
+ * Wrap a FullSubject DB hydration so it goes through per-customer + per-org
+ * concurrency gates. Per-customer slot is acquired FIRST so one customer's
+ * burst can't hold per-org slots while waiting on its own customer cap
+ * (head-of-line starves siblings within the same org).
+ *
+ * Limits are PER-PROCESS, not cluster-wide — with N API replicas, effective
+ * caps are PER_CUSTOMER_LIMIT*N and PER_ORG_LIMIT*N. Sized accordingly.
+ *
+ * Defaults: 15 per-customer, 30 per-org per process. Override via
+ * FULL_SUBJECT_PER_CUSTOMER_LIMIT / FULL_SUBJECT_PER_ORG_LIMIT.
+ */
+export const runWithFullSubjectGate = async <T>({
+	customerId,
+	orgId,
+	queryFn,
+}: {
+	customerId: string | undefined;
+	orgId: string;
+	queryFn: () => Promise<T>;
+}): Promise<T> => {
+	const enqueuedAt = Date.now();
+	const labels = attrs({ customerId, orgId });
+	startedCounter.add(1, labels);
+
+	const execute = async (): Promise<T> => {
+		waitHistogram.record(Date.now() - enqueuedAt, labels);
+		perOrgActiveCounter.add(1, labels);
+		perCustomerActiveCounter.add(1, labels);
+		try {
+			return await queryFn();
+		} catch (error) {
+			failedCounter.add(1, labels);
+			throw error;
+		} finally {
+			perOrgActiveCounter.add(-1, labels);
+			perCustomerActiveCounter.add(-1, labels);
+			completedCounter.add(1, labels);
+		}
+	};
+
+	const orgLimit = getOrgLimiter(orgId);
+
+	if (customerId) {
+		return getCustomerLimiter(customerId)(() => orgLimit(execute));
+	}
+	return orgLimit(execute);
+};

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod/v4";
+
+export const FullSubjectGateEdgeConfigSchema = z.object({
+	per_customer_limit: z.number().int().min(1).max(10_000).default(15),
+	per_org_limit: z.number().int().min(1).max(10_000).default(30),
+});
+
+export type FullSubjectGateEdgeConfig = z.infer<
+	typeof FullSubjectGateEdgeConfigSchema
+>;

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigSchemas.ts
@@ -1,8 +1,18 @@
 import { z } from "zod/v4";
 
+// Defaults are deliberately loose — initial deploy is effectively a no-op
+// for normal traffic. Tighten to target values (15 / 30) via the admin API
+// after observing real load via OTel metrics. See runbook in PR description.
 export const FullSubjectGateEdgeConfigSchema = z.object({
-	per_customer_limit: z.number().int().min(1).max(10_000).default(15),
-	per_org_limit: z.number().int().min(1).max(10_000).default(30),
+	per_customer_limit: z.number().int().min(1).max(10_000).default(200),
+	per_org_limit: z.number().int().min(1).max(10_000).default(500),
+	// Max time a request can wait at the gate before being rejected with 429.
+	// Set generously by default; tighten once we have wait_ms p99 data.
+	max_wait_ms: z.number().int().min(100).max(60_000).default(2_000),
+	// Max number of queued (pending) requests per (org,env,customer) and
+	// (org,env) before rejecting new ones with 429 — bounds memory + wait time.
+	per_customer_pending_max: z.number().int().min(1).max(100_000).default(500),
+	per_org_pending_max: z.number().int().min(1).max(100_000).default(1_000),
 });
 
 export type FullSubjectGateEdgeConfig = z.infer<

--- a/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.ts
+++ b/server/src/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.ts
@@ -1,0 +1,39 @@
+import { ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY } from "@/external/aws/s3/adminS3Config.js";
+import { registerEdgeConfig } from "@/internal/misc/edgeConfig/edgeConfigRegistry.js";
+import { createEdgeConfigStore } from "@/internal/misc/edgeConfig/edgeConfigStore.js";
+import {
+	type FullSubjectGateEdgeConfig,
+	FullSubjectGateEdgeConfigSchema,
+} from "./fullSubjectGateEdgeConfigSchemas.js";
+
+const store = createEdgeConfigStore<FullSubjectGateEdgeConfig>({
+	s3Key: ADMIN_FULL_SUBJECT_GATE_CONFIG_KEY,
+	schema: FullSubjectGateEdgeConfigSchema,
+	defaultValue: () => FullSubjectGateEdgeConfigSchema.parse({}),
+});
+
+registerEdgeConfig({ store });
+
+export const getRuntimeFullSubjectGateConfigStatus = () => store.getStatus();
+
+export const getRuntimeFullSubjectGateConfig = (): FullSubjectGateEdgeConfig =>
+	store.get();
+
+export const getFullSubjectGateConfigFromSource =
+	async (): Promise<FullSubjectGateEdgeConfig> => store.readFromSource();
+
+export const updateFullSubjectGateConfig = async ({
+	config,
+}: {
+	config: FullSubjectGateEdgeConfig;
+}): Promise<void> => {
+	await store.writeToSource({ config });
+};
+
+export const _setFullSubjectGateConfigForTesting = ({
+	config,
+}: {
+	config: FullSubjectGateEdgeConfig;
+}): void => {
+	store._setRuntimeConfigForTesting(config);
+};

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -231,6 +231,57 @@ describe("runWithFullSubjectGate", () => {
 		});
 	});
 
+	test("rejects with 429 (per_org_queue_full) when per-org queue fills via many customers in one org", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 1,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 2,
+			},
+		});
+
+		const slow = () => new Promise((resolve) => setTimeout(resolve, 100));
+		const results = await Promise.allSettled(
+			Array.from({ length: 10 }, (_, idx) =>
+				runWithFullSubjectGate({
+					customerId: `cus-org-cap-${idx}`,
+					orgId: "org-cap",
+					env: AppEnv.Live,
+					queryFn: slow,
+				}),
+			),
+		);
+
+		const rejectedReasons = results
+			.filter((r) => r.status === "rejected")
+			.map(
+				(r) =>
+					(r as PromiseRejectedResult).reason.data?.reason as string | undefined,
+			);
+		expect(rejectedReasons.length).toBeGreaterThan(0);
+		expect(rejectedReasons.some((reason) => reason === "per_org_queue_full")).toBe(
+			true,
+		);
+		for (const r of results.filter(
+			(x) => x.status === "rejected",
+		) as PromiseRejectedResult[]) {
+			expect(r.reason.statusCode).toBe(429);
+			expect(r.reason.code).toBe("rate_limit_exceeded");
+		}
+
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+	});
+
 	test("rejects with 429 when a queued request exceeds max_wait_ms", async () => {
 		_setFullSubjectGateConfigForTesting({
 			config: {

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
 
 // Tight limits so the assertions are clear: per-org=4, per-customer=2.
 // Must be set BEFORE the gate module is imported — its env reads happen at
@@ -35,6 +36,7 @@ describe("runWithFullSubjectGate", () => {
 			runWithFullSubjectGate({
 				customerId: "cus-same",
 				orgId: "org-a",
+				env: AppEnv.Live,
 				queryFn: () => queryFn(index),
 			}),
 		);
@@ -51,6 +53,7 @@ describe("runWithFullSubjectGate", () => {
 			runWithFullSubjectGate({
 				customerId: `cus-${index}`,
 				orgId: "org-shared",
+				env: AppEnv.Live,
 				queryFn: () => queryFn(index),
 			}),
 		);
@@ -68,11 +71,11 @@ describe("runWithFullSubjectGate", () => {
 			runWithFullSubjectGate({
 				customerId: `cus-${index}`,
 				orgId: index < 6 ? "org-x" : "org-y",
+				env: AppEnv.Live,
 				queryFn: () => queryFn(index),
 			}),
 		);
 		await Promise.all(tasks);
-		// Each org caps at 4, two orgs in parallel → up to 8 concurrent.
 		expect(counter.peak).toBeLessThanOrEqual(8);
 		expect(counter.peak).toBeGreaterThan(4);
 		expect(counter.current).toBe(0);
@@ -85,10 +88,67 @@ describe("runWithFullSubjectGate", () => {
 			runWithFullSubjectGate({
 				customerId: undefined,
 				orgId: "org-no-cus",
+				env: AppEnv.Live,
 				queryFn: () => queryFn(index),
 			}),
 		);
 		await Promise.all(tasks);
+		expect(counter.peak).toBeLessThanOrEqual(4);
+		expect(counter.current).toBe(0);
+	});
+
+	test("same customerId in different orgs does NOT share a per-customer cap", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = [
+			...Array.from({ length: 5 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-shared-id",
+					orgId: "org-a",
+					env: AppEnv.Live,
+					queryFn: () => queryFn(`a-${index}`),
+				}),
+			),
+			...Array.from({ length: 5 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-shared-id",
+					orgId: "org-b",
+					env: AppEnv.Live,
+					queryFn: () => queryFn(`b-${index}`),
+				}),
+			),
+		];
+		await Promise.all(tasks);
+		// Keys are scoped per-org so each org keeps its own per-customer cap.
+		expect(counter.peak).toBeGreaterThan(2);
+		expect(counter.peak).toBeLessThanOrEqual(4);
+		expect(counter.current).toBe(0);
+	});
+
+	test("same customerId in live and sandbox of the same org do NOT share a per-customer cap", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = [
+			...Array.from({ length: 5 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-live-vs-sandbox",
+					orgId: "org-c",
+					env: AppEnv.Live,
+					queryFn: () => queryFn(`live-${index}`),
+				}),
+			),
+			...Array.from({ length: 5 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-live-vs-sandbox",
+					orgId: "org-c",
+					env: AppEnv.Sandbox,
+					queryFn: () => queryFn(`sandbox-${index}`),
+				}),
+			),
+		];
+		await Promise.all(tasks);
+		// Per-env keys — live and sandbox run independently, peak up to 4.
+		expect(counter.peak).toBeGreaterThan(2);
 		expect(counter.peak).toBeLessThanOrEqual(4);
 		expect(counter.current).toBe(0);
 	});
@@ -108,6 +168,7 @@ describe("runWithFullSubjectGate", () => {
 				runWithFullSubjectGate({
 					customerId: "cus-reject",
 					orgId: "org-reject",
+					env: AppEnv.Live,
 					queryFn: failing,
 				}),
 			),
@@ -115,13 +176,13 @@ describe("runWithFullSubjectGate", () => {
 		expect(failures.every((result) => result.status === "rejected")).toBe(true);
 		expect(counter.current).toBe(0);
 
-		// Subsequent calls succeed — proves slots were released, not leaked.
 		const queryFn = makeQueryFn(counter, 5);
 		const followUp = await Promise.all(
 			Array.from({ length: 4 }, (_, index) =>
 				runWithFullSubjectGate({
 					customerId: "cus-reject",
 					orgId: "org-reject",
+					env: AppEnv.Live,
 					queryFn: () => queryFn(index),
 				}),
 			),

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,15 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { AppEnv } from "@autumn/shared";
+import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+import { runWithFullSubjectGate } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
 
-// Tight limits so the assertions are clear: per-org=4, per-customer=2.
-// Must be set BEFORE the gate module is imported — its env reads happen at
-// module init.
-process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT = "2";
-process.env.FULL_SUBJECT_PER_ORG_LIMIT = "4";
-
-const { runWithFullSubjectGate } = await import(
-	"@/internal/customers/repos/getFullSubject/getFullSubjectGate.js"
-);
+beforeAll(() => {
+	_setFullSubjectGateConfigForTesting({
+		config: { per_customer_limit: 2, per_org_limit: 4 },
+	});
+});
 
 type Counter = {
 	current: number;
@@ -119,7 +117,6 @@ describe("runWithFullSubjectGate", () => {
 			),
 		];
 		await Promise.all(tasks);
-		// Keys are scoped per-org so each org keeps its own per-customer cap.
 		expect(counter.peak).toBeGreaterThan(2);
 		expect(counter.peak).toBeLessThanOrEqual(4);
 		expect(counter.current).toBe(0);
@@ -147,10 +144,33 @@ describe("runWithFullSubjectGate", () => {
 			),
 		];
 		await Promise.all(tasks);
-		// Per-env keys — live and sandbox run independently, peak up to 4.
 		expect(counter.peak).toBeGreaterThan(2);
 		expect(counter.peak).toBeLessThanOrEqual(4);
 		expect(counter.current).toBe(0);
+	});
+
+	test("limit changes take effect at runtime without recreating limiters", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: { per_customer_limit: 1, per_org_limit: 4 },
+		});
+
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 20);
+		const tasks = Array.from({ length: 5 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: "cus-runtime-change",
+				orgId: "org-runtime-change",
+				env: AppEnv.Live,
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		expect(counter.peak).toBe(1);
+
+		// Restore for any subsequent tests.
+		_setFullSubjectGateConfigForTesting({
+			config: { per_customer_limit: 2, per_org_limit: 4 },
+		});
 	});
 
 	test("rejection releases the per-customer and per-org slots", async () => {

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -1,11 +1,17 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { AppEnv } from "@autumn/shared";
-import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 import { runWithFullSubjectGate } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
+import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
 beforeAll(() => {
 	_setFullSubjectGateConfigForTesting({
-		config: { per_customer_limit: 2, per_org_limit: 4 },
+		config: {
+			per_customer_limit: 2,
+			per_org_limit: 4,
+			max_wait_ms: 60_000,
+			per_customer_pending_max: 1000,
+			per_org_pending_max: 1000,
+		},
 	});
 });
 
@@ -151,7 +157,13 @@ describe("runWithFullSubjectGate", () => {
 
 	test("limit changes take effect at runtime without recreating limiters", async () => {
 		_setFullSubjectGateConfigForTesting({
-			config: { per_customer_limit: 1, per_org_limit: 4 },
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
 		});
 
 		const counter = makeCounter();
@@ -167,9 +179,97 @@ describe("runWithFullSubjectGate", () => {
 		await Promise.all(tasks);
 		expect(counter.peak).toBe(1);
 
-		// Restore for any subsequent tests.
 		_setFullSubjectGateConfigForTesting({
-			config: { per_customer_limit: 2, per_org_limit: 4 },
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+	});
+
+	test("rejects with 429 when per-customer pending queue is full", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 100,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 2,
+				per_org_pending_max: 1000,
+			},
+		});
+
+		const slow = () => new Promise((resolve) => setTimeout(resolve, 100));
+		const results = await Promise.allSettled(
+			Array.from({ length: 10 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-queue-full",
+					orgId: "org-queue-full",
+					env: AppEnv.Live,
+					queryFn: slow,
+				}),
+			),
+		);
+
+		const rejected = results.filter((r) => r.status === "rejected");
+		expect(rejected.length).toBeGreaterThan(0);
+		for (const r of rejected as PromiseRejectedResult[]) {
+			expect(r.reason.statusCode).toBe(429);
+			expect(r.reason.code).toBe("full_subject_gate_overloaded");
+		}
+
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+	});
+
+	test("rejects with 429 when a queued request exceeds max_wait_ms", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 100,
+				max_wait_ms: 30,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+
+		const slow = () => new Promise((resolve) => setTimeout(resolve, 80));
+		const results = await Promise.allSettled(
+			Array.from({ length: 4 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-wait-timeout",
+					orgId: "org-wait-timeout",
+					env: AppEnv.Live,
+					queryFn: slow,
+				}),
+			),
+		);
+
+		const timeouts = results.filter(
+			(r) =>
+				r.status === "rejected" &&
+				(r as PromiseRejectedResult).reason.code ===
+					"full_subject_gate_overloaded",
+		);
+		expect(timeouts.length).toBeGreaterThan(0);
+
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
 		});
 	});
 

--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -217,7 +217,7 @@ describe("runWithFullSubjectGate", () => {
 		expect(rejected.length).toBeGreaterThan(0);
 		for (const r of rejected as PromiseRejectedResult[]) {
 			expect(r.reason.statusCode).toBe(429);
-			expect(r.reason.code).toBe("full_subject_gate_overloaded");
+			expect(r.reason.code).toBe("rate_limit_exceeded");
 		}
 
 		_setFullSubjectGateConfigForTesting({
@@ -258,7 +258,7 @@ describe("runWithFullSubjectGate", () => {
 			(r) =>
 				r.status === "rejected" &&
 				(r as PromiseRejectedResult).reason.code ===
-					"full_subject_gate_overloaded",
+					"rate_limit_exceeded",
 		);
 		expect(timeouts.length).toBeGreaterThan(0);
 

--- a/server/tests/unit/full-subject-gate/getFullSubjectGate.test.ts
+++ b/server/tests/unit/full-subject-gate/getFullSubjectGate.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+// Tight limits so the assertions are clear: per-org=4, per-customer=2.
+// Must be set BEFORE the gate module is imported — its env reads happen at
+// module init.
+process.env.FULL_SUBJECT_PER_CUSTOMER_LIMIT = "2";
+process.env.FULL_SUBJECT_PER_ORG_LIMIT = "4";
+
+const { runWithFullSubjectGate } = await import(
+	"@/internal/customers/repos/getFullSubject/getFullSubjectGate.js"
+);
+
+type Counter = {
+	current: number;
+	peak: number;
+};
+
+const makeCounter = (): Counter => ({ current: 0, peak: 0 });
+
+const makeQueryFn =
+	(counter: Counter, holdMs: number) =>
+	async <T>(value: T): Promise<T> => {
+		counter.current += 1;
+		counter.peak = Math.max(counter.peak, counter.current);
+		await new Promise((resolve) => setTimeout(resolve, holdMs));
+		counter.current -= 1;
+		return value;
+	};
+
+describe("runWithFullSubjectGate", () => {
+	test("caps concurrent calls for the same customer at PER_CUSTOMER_LIMIT", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 10 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: "cus-same",
+				orgId: "org-a",
+				queryFn: () => queryFn(index),
+			}),
+		);
+		const results = await Promise.all(tasks);
+		expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+		expect(counter.peak).toBeLessThanOrEqual(2);
+		expect(counter.current).toBe(0);
+	});
+
+	test("different customers within the same org compete for the per-org cap", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 8 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: `cus-${index}`,
+				orgId: "org-shared",
+				queryFn: () => queryFn(index),
+			}),
+		);
+		const results = await Promise.all(tasks);
+		expect(new Set(results)).toEqual(new Set([0, 1, 2, 3, 4, 5, 6, 7]));
+		expect(counter.peak).toBeLessThanOrEqual(4);
+		expect(counter.peak).toBeGreaterThan(2);
+		expect(counter.current).toBe(0);
+	});
+
+	test("different orgs do not share a cap — each has its own per-org limit", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 30);
+		const tasks = Array.from({ length: 12 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: `cus-${index}`,
+				orgId: index < 6 ? "org-x" : "org-y",
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		// Each org caps at 4, two orgs in parallel → up to 8 concurrent.
+		expect(counter.peak).toBeLessThanOrEqual(8);
+		expect(counter.peak).toBeGreaterThan(4);
+		expect(counter.current).toBe(0);
+	});
+
+	test("missing customerId still goes through the per-org gate", async () => {
+		const counter = makeCounter();
+		const queryFn = makeQueryFn(counter, 20);
+		const tasks = Array.from({ length: 10 }, (_, index) =>
+			runWithFullSubjectGate({
+				customerId: undefined,
+				orgId: "org-no-cus",
+				queryFn: () => queryFn(index),
+			}),
+		);
+		await Promise.all(tasks);
+		expect(counter.peak).toBeLessThanOrEqual(4);
+		expect(counter.current).toBe(0);
+	});
+
+	test("rejection releases the per-customer and per-org slots", async () => {
+		const counter = makeCounter();
+		const failing = async () => {
+			counter.current += 1;
+			counter.peak = Math.max(counter.peak, counter.current);
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			counter.current -= 1;
+			throw new Error("boom");
+		};
+
+		const failures = await Promise.allSettled(
+			Array.from({ length: 5 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-reject",
+					orgId: "org-reject",
+					queryFn: failing,
+				}),
+			),
+		);
+		expect(failures.every((result) => result.status === "rejected")).toBe(true);
+		expect(counter.current).toBe(0);
+
+		// Subsequent calls succeed — proves slots were released, not leaked.
+		const queryFn = makeQueryFn(counter, 5);
+		const followUp = await Promise.all(
+			Array.from({ length: 4 }, (_, index) =>
+				runWithFullSubjectGate({
+					customerId: "cus-reject",
+					orgId: "org-reject",
+					queryFn: () => queryFn(index),
+				}),
+			),
+		);
+		expect(followUp).toEqual([0, 1, 2, 3]);
+		expect(counter.current).toBe(0);
+	});
+});

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -6,6 +6,7 @@ import { CacheV2RampDialog } from "./CacheV2RampDialog";
 import { CustomerBlockDialog } from "./CustomerBlockDialog";
 import { EdgeConfigDialog } from "./EdgeConfigDialog";
 import { FeatureFlagsDialog } from "./FeatureFlagsDialog";
+import { FullSubjectGateDialog } from "./FullSubjectGateDialog";
 import { JobQueuesDialog } from "./JobQueuesDialog";
 import { MiscellaneousEdgeConfigDialog } from "./MiscellaneousEdgeConfigDialog";
 import { OrgLimitsDialog } from "./OrgLimitsDialog";
@@ -37,6 +38,7 @@ export function EdgeConfigTab() {
 	const [redisV2CacheOpen, setRedisV2CacheOpen] = useState(false);
 	const [cacheV2RampOpen, setCacheV2RampOpen] = useState(false);
 	const [miscellaneousOpen, setMiscellaneousOpen] = useState(false);
+	const [fullSubjectGateOpen, setFullSubjectGateOpen] = useState(false);
 
 	const { data: source } = useQuery<EdgeConfigSource>({
 		queryKey: ["admin-edge-config-sources"],
@@ -271,6 +273,26 @@ export function EdgeConfigTab() {
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
 						<div className="text-sm font-medium text-foreground">
+							FullSubject Concurrency Gate
+						</div>
+						<div className="text-xs text-tertiary-foreground">
+							Per-customer + per-org caps on concurrent FullSubject DB
+							hydrations. 429s with rate_limit_exceeded when queues/waits
+							exceed thresholds.
+						</div>
+					</div>
+					<Button
+						variant="primary"
+						size="sm"
+						onClick={() => setFullSubjectGateOpen(true)}
+					>
+						Edit
+					</Button>
+				</div>
+
+				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
+					<div className="flex flex-col gap-0.5">
+						<div className="text-sm font-medium text-foreground">
 							Miscellaneous
 						</div>
 						<div className="text-xs text-tertiary-foreground">
@@ -338,6 +360,11 @@ export function EdgeConfigTab() {
 			<MiscellaneousEdgeConfigDialog
 				open={miscellaneousOpen}
 				onOpenChange={setMiscellaneousOpen}
+			/>
+
+			<FullSubjectGateDialog
+				open={fullSubjectGateOpen}
+				onOpenChange={setFullSubjectGateOpen}
 			/>
 		</div>
 	);

--- a/vite/src/views/admin/components/FullSubjectGateDialog.tsx
+++ b/vite/src/views/admin/components/FullSubjectGateDialog.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/v2/badges/Badge";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+
+type FullSubjectGateConfig = {
+	per_customer_limit: number;
+	per_org_limit: number;
+	max_wait_ms: number;
+	per_customer_pending_max: number;
+	per_org_pending_max: number;
+	configHealthy?: boolean;
+	configConfigured?: boolean;
+	lastSuccessAt?: string | null;
+	error?: string | null;
+};
+
+const DEFAULT_CONFIG: FullSubjectGateConfig = {
+	per_customer_limit: 200,
+	per_org_limit: 500,
+	max_wait_ms: 2_000,
+	per_customer_pending_max: 500,
+	per_org_pending_max: 1_000,
+};
+
+const FIELDS: Array<{
+	key: keyof Omit<
+		FullSubjectGateConfig,
+		"configHealthy" | "configConfigured" | "lastSuccessAt" | "error"
+	>;
+	label: string;
+	description: string;
+	min: number;
+	max: number;
+}> = [
+	{
+		key: "per_customer_limit",
+		label: "Per-customer concurrent limit",
+		description:
+			"Max DB hydrations in flight at once for a single (org, env, customer). Per process — multiply by replica count for cluster-wide cap.",
+		min: 1,
+		max: 10_000,
+	},
+	{
+		key: "per_org_limit",
+		label: "Per-org concurrent limit",
+		description:
+			"Max DB hydrations in flight at once for a single (org, env). Per process.",
+		min: 1,
+		max: 10_000,
+	},
+	{
+		key: "max_wait_ms",
+		label: "Max queue wait (ms)",
+		description:
+			"Reject with 429 if a queued request waits longer than this before its slot opens.",
+		min: 100,
+		max: 60_000,
+	},
+	{
+		key: "per_customer_pending_max",
+		label: "Per-customer queue depth cap",
+		description:
+			"Reject with 429 before queueing if the per-customer pending count is at or above this. Bounds heap memory + worst-case wait.",
+		min: 1,
+		max: 100_000,
+	},
+	{
+		key: "per_org_pending_max",
+		label: "Per-org queue depth cap",
+		description:
+			"Reject with 429 before queueing if the per-org pending count is at or above this.",
+		min: 1,
+		max: 100_000,
+	},
+];
+
+export function FullSubjectGateDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const [loading, setLoading] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [config, setConfig] = useState<FullSubjectGateConfig>(DEFAULT_CONFIG);
+	const [drafts, setDrafts] = useState<Record<string, string>>({});
+
+	useEffect(() => {
+		if (!open) return;
+
+		let cancelled = false;
+		setLoading(true);
+
+		void axiosInstance
+			.get<FullSubjectGateConfig>("/admin/full-subject-gate-config")
+			.then(({ data }) => {
+				if (cancelled) return;
+				const merged: FullSubjectGateConfig = { ...DEFAULT_CONFIG, ...data };
+				setConfig(merged);
+				const initialDrafts: Record<string, string> = {};
+				for (const field of FIELDS) {
+					initialDrafts[field.key] = String(merged[field.key]);
+				}
+				setDrafts(initialDrafts);
+			})
+			.catch((error) => {
+				if (!cancelled)
+					toast.error(
+						getBackendErr(error, "Failed to load FullSubject gate config"),
+					);
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [axiosInstance, open]);
+
+	const handleSave = async () => {
+		const next: Record<string, number> = {};
+		for (const field of FIELDS) {
+			const raw = drafts[field.key];
+			const parsed = Number(raw);
+			if (!Number.isInteger(parsed) || parsed < field.min || parsed > field.max) {
+				toast.error(
+					`${field.label} must be an integer between ${field.min} and ${field.max}`,
+				);
+				return;
+			}
+			next[field.key] = parsed;
+		}
+
+		setSaving(true);
+		try {
+			await axiosInstance.put("/admin/full-subject-gate-config", next);
+			toast.success("FullSubject gate config updated (takes effect in ≤30s)");
+			onOpenChange(false);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to update gate config"));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-2xl">
+				<DialogHeader>
+					<DialogTitle>FullSubject Concurrency Gate</DialogTitle>
+					<DialogDescription>
+						Cluster-wide caps on concurrent FullSubject DB hydrations. Changes
+						take effect within ~30s on all replicas, no redeploy required.
+					</DialogDescription>
+				</DialogHeader>
+
+				{loading ? (
+					<div className="py-8 text-center text-sm text-tertiary-foreground">
+						Loading…
+					</div>
+				) : (
+					<div className="flex flex-col gap-4">
+						<div className="flex items-center gap-2 text-xs">
+							<Badge variant={config.configHealthy ? "success" : "warning"}>
+								{config.configHealthy ? "Healthy" : "Unhealthy"}
+							</Badge>
+							<Badge variant={config.configConfigured ? "info" : "secondary"}>
+								{config.configConfigured ? "S3 set" : "Using defaults"}
+							</Badge>
+							{config.lastSuccessAt && (
+								<span className="text-tertiary-foreground">
+									Last sync: {new Date(config.lastSuccessAt).toLocaleString()}
+								</span>
+							)}
+							{config.error && (
+								<span className="text-destructive">{config.error}</span>
+							)}
+						</div>
+
+						{FIELDS.map((field) => (
+							<div key={field.key} className="flex flex-col gap-1">
+								<FormLabel>{field.label}</FormLabel>
+								<div className="flex items-center gap-3">
+									<Input
+										type="number"
+										min={field.min}
+										max={field.max}
+										value={drafts[field.key] ?? ""}
+										onChange={(e) =>
+											setDrafts((prev) => ({
+												...prev,
+												[field.key]: e.target.value,
+											}))
+										}
+										className="w-32 font-mono text-xs"
+									/>
+									<span className="text-xs text-tertiary-foreground">
+										{field.description}
+									</span>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button
+						variant="secondary"
+						onClick={() => onOpenChange(false)}
+						disabled={saving}
+					>
+						Cancel
+					</Button>
+					<Button onClick={handleSave} disabled={loading || saving}>
+						{saving ? "Saving…" : "Save"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a per-customer and per-org concurrency gate for FullSubject DB hydrations to prevent overload and reduce timeouts. Adds admin UI and API to view and edit limits with live metrics.

- **New Features**
  - Gate queues and caps hydrations; rejects with 429 (`rate_limit_exceeded`) on wait timeout or queue full.
  - Wrapped `getFullSubject` and `getFullSubjectNormalized` to run through the gate.
  - Admin config: GET/PUT `/full-subject-gate-config`; stored at `admin/full-subject-gate-config.json`. New Edge Config dialog “FullSubject Concurrency Gate” to view health/status and edit limits.
  - Runtime-tunable limits via edge config; scoped by `orgId/env/customerId` using `p-limit` and `lru-cache`.
  - OTel metrics (`@opentelemetry/api`): started/completed/failed/active/rejected counters and `wait_ms` histogram. Unit tests cover caps, queue depth (incl. `per_org_pending_max` for `customerId` flows), timeouts, and slot release.

<sup>Written for commit feb6e60ce1c159a0d16622cbe2892160d3ace856. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1697?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

