### PR TITLE
Add FullSubject gate admin UI + fix 3 review comments

### DIFF
--- a/server/src/internal/admin/handleGetAdminFullSubjectGateConfig.ts
+++ b/server/src/internal/admin/handleGetAdminFullSubjectGateConfig.ts
@@ -2,6 +2,7 @@ import { Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import {
 	getFullSubjectGateConfigFromSource,
+	getRuntimeFullSubjectGateConfig,
 	getRuntimeFullSubjectGateConfigStatus,
 } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
 
@@ -9,14 +10,20 @@ export const handleGetAdminFullSubjectGateConfig = createRoute({
 	scopes: [Scopes.Superuser],
 	handler: async (c) => {
 		const status = getRuntimeFullSubjectGateConfigStatus();
-		const config = await getFullSubjectGateConfigFromSource();
+		let config = getRuntimeFullSubjectGateConfig();
+		let sourceError: string | null = null;
+		try {
+			config = await getFullSubjectGateConfigFromSource();
+		} catch (error) {
+			sourceError = error instanceof Error ? error.message : String(error);
+		}
 
 		return c.json({
 			...config,
-			configHealthy: status.healthy,
+			configHealthy: status.healthy && sourceError === null,
 			configConfigured: status.configured,
 			lastSuccessAt: status.lastSuccessAt ?? null,
-			error: status.error ?? null,
+			error: sourceError ?? status.error ?? null,
 		});
 	},
 });

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -138,12 +138,8 @@ export const runWithFullSubjectGate = async <T>({
 	} = getRuntimeFullSubjectGateConfig();
 	const enqueuedAt = Date.now();
 	const labels = attrs({ orgId, env });
-	startedCounter.add(1, labels);
 
 	const orgLimiter = getOrgLimiter({ orgId, env, limit: per_org_limit });
-	if (orgLimiter.pendingCount >= per_org_pending_max) {
-		rejectOverloaded({ reason: "per_org_queue_full", labels });
-	}
 
 	let customerLimiter: LimitFunction | undefined;
 	if (customerId) {
@@ -156,7 +152,11 @@ export const runWithFullSubjectGate = async <T>({
 		if (customerLimiter.pendingCount >= per_customer_pending_max) {
 			rejectOverloaded({ reason: "per_customer_queue_full", labels });
 		}
+	} else if (orgLimiter.pendingCount >= per_org_pending_max) {
+		rejectOverloaded({ reason: "per_org_queue_full", labels });
 	}
+
+	startedCounter.add(1, labels);
 
 	const execute = async (): Promise<T> => {
 		const waitMs = Date.now() - enqueuedAt;
@@ -182,7 +182,12 @@ export const runWithFullSubjectGate = async <T>({
 	};
 
 	if (customerLimiter) {
-		return customerLimiter(() => orgLimiter(execute));
+		return customerLimiter(() => {
+			if (orgLimiter.pendingCount >= per_org_pending_max) {
+				rejectOverloaded({ reason: "per_org_queue_full", labels });
+			}
+			return orgLimiter(execute);
+		});
 	}
 	return orgLimiter(execute);
 };

--- a/vite/src/views/admin/components/EdgeConfigTab.tsx
+++ b/vite/src/views/admin/components/EdgeConfigTab.tsx
@@ -6,6 +6,7 @@ import { CacheV2RampDialog } from "./CacheV2RampDialog";
 import { CustomerBlockDialog } from "./CustomerBlockDialog";
 import { EdgeConfigDialog } from "./EdgeConfigDialog";
 import { FeatureFlagsDialog } from "./FeatureFlagsDialog";
+import { FullSubjectGateDialog } from "./FullSubjectGateDialog";
 import { JobQueuesDialog } from "./JobQueuesDialog";
 import { MiscellaneousEdgeConfigDialog } from "./MiscellaneousEdgeConfigDialog";
 import { OrgLimitsDialog } from "./OrgLimitsDialog";
@@ -37,6 +38,7 @@ export function EdgeConfigTab() {
 	const [redisV2CacheOpen, setRedisV2CacheOpen] = useState(false);
 	const [cacheV2RampOpen, setCacheV2RampOpen] = useState(false);
 	const [miscellaneousOpen, setMiscellaneousOpen] = useState(false);
+	const [fullSubjectGateOpen, setFullSubjectGateOpen] = useState(false);
 
 	const { data: source } = useQuery<EdgeConfigSource>({
 		queryKey: ["admin-edge-config-sources"],
@@ -271,6 +273,26 @@ export function EdgeConfigTab() {
 				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
 					<div className="flex flex-col gap-0.5">
 						<div className="text-sm font-medium text-foreground">
+							FullSubject Concurrency Gate
+						</div>
+						<div className="text-xs text-tertiary-foreground">
+							Per-customer + per-org caps on concurrent FullSubject DB
+							hydrations. 429s with rate_limit_exceeded when queues/waits
+							exceed thresholds.
+						</div>
+					</div>
+					<Button
+						variant="primary"
+						size="sm"
+						onClick={() => setFullSubjectGateOpen(true)}
+					>
+						Edit
+					</Button>
+				</div>
+
+				<div className="flex items-center justify-between border-t border-border p-4 last:border-b-0">
+					<div className="flex flex-col gap-0.5">
+						<div className="text-sm font-medium text-foreground">
 							Miscellaneous
 						</div>
 						<div className="text-xs text-tertiary-foreground">
@@ -338,6 +360,11 @@ export function EdgeConfigTab() {
 			<MiscellaneousEdgeConfigDialog
 				open={miscellaneousOpen}
 				onOpenChange={setMiscellaneousOpen}
+			/>
+
+			<FullSubjectGateDialog
+				open={fullSubjectGateOpen}
+				onOpenChange={setFullSubjectGateOpen}
 			/>
 		</div>
 	);

--- a/vite/src/views/admin/components/FullSubjectGateDialog.tsx
+++ b/vite/src/views/admin/components/FullSubjectGateDialog.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/v2/badges/Badge";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+
+type FullSubjectGateConfig = {
+	per_customer_limit: number;
+	per_org_limit: number;
+	max_wait_ms: number;
+	per_customer_pending_max: number;
+	per_org_pending_max: number;
+	configHealthy?: boolean;
+	configConfigured?: boolean;
+	lastSuccessAt?: string | null;
+	error?: string | null;
+};
+
+const DEFAULT_CONFIG: FullSubjectGateConfig = {
+	per_customer_limit: 200,
+	per_org_limit: 500,
+	max_wait_ms: 2_000,
+	per_customer_pending_max: 500,
+	per_org_pending_max: 1_000,
+};
+
+const FIELDS: Array<{
+	key: keyof Omit<
+		FullSubjectGateConfig,
+		"configHealthy" | "configConfigured" | "lastSuccessAt" | "error"
+	>;
+	label: string;
+	description: string;
+	min: number;
+	max: number;
+}> = [
+	{
+		key: "per_customer_limit",
+		label: "Per-customer concurrent limit",
+		description:
+			"Max DB hydrations in flight at once for a single (org, env, customer). Per process — multiply by replica count for cluster-wide cap.",
+		min: 1,
+		max: 10_000,
+	},
+	{
+		key: "per_org_limit",
+		label: "Per-org concurrent limit",
+		description:
+			"Max DB hydrations in flight at once for a single (org, env). Per process.",
+		min: 1,
+		max: 10_000,
+	},
+	{
+		key: "max_wait_ms",
+		label: "Max queue wait (ms)",
+		description:
+			"Reject with 429 if a queued request waits longer than this before its slot opens.",
+		min: 100,
+		max: 60_000,
+	},
+	{
+		key: "per_customer_pending_max",
+		label: "Per-customer queue depth cap",
+		description:
+			"Reject with 429 before queueing if the per-customer pending count is at or above this. Bounds heap memory + worst-case wait.",
+		min: 1,
+		max: 100_000,
+	},
+	{
+		key: "per_org_pending_max",
+		label: "Per-org queue depth cap",
+		description:
+			"Reject with 429 before queueing if the per-org pending count is at or above this.",
+		min: 1,
+		max: 100_000,
+	},
+];
+
+export function FullSubjectGateDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const axiosInstance = useAxiosInstance();
+	const [loading, setLoading] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [config, setConfig] = useState<FullSubjectGateConfig>(DEFAULT_CONFIG);
+	const [drafts, setDrafts] = useState<Record<string, string>>({});
+
+	useEffect(() => {
+		if (!open) return;
+
+		let cancelled = false;
+		setLoading(true);
+
+		void axiosInstance
+			.get<FullSubjectGateConfig>("/admin/full-subject-gate-config")
+			.then(({ data }) => {
+				if (cancelled) return;
+				const merged: FullSubjectGateConfig = { ...DEFAULT_CONFIG, ...data };
+				setConfig(merged);
+				const initialDrafts: Record<string, string> = {};
+				for (const field of FIELDS) {
+					initialDrafts[field.key] = String(merged[field.key]);
+				}
+				setDrafts(initialDrafts);
+			})
+			.catch((error) => {
+				if (!cancelled)
+					toast.error(
+						getBackendErr(error, "Failed to load FullSubject gate config"),
+					);
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [axiosInstance, open]);
+
+	const handleSave = async () => {
+		const next: Record<string, number> = {};
+		for (const field of FIELDS) {
+			const raw = drafts[field.key];
+			const parsed = Number(raw);
+			if (!Number.isInteger(parsed) || parsed < field.min || parsed > field.max) {
+				toast.error(
+					`${field.label} must be an integer between ${field.min} and ${field.max}`,
+				);
+				return;
+			}
+			next[field.key] = parsed;
+		}
+
+		setSaving(true);
+		try {
+			await axiosInstance.put("/admin/full-subject-gate-config", next);
+			toast.success("FullSubject gate config updated (takes effect in ≤30s)");
+			onOpenChange(false);
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to update gate config"));
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-2xl">
+				<DialogHeader>
+					<DialogTitle>FullSubject Concurrency Gate</DialogTitle>
+					<DialogDescription>
+						Cluster-wide caps on concurrent FullSubject DB hydrations. Changes
+						take effect within ~30s on all replicas, no redeploy required.
+					</DialogDescription>
+				</DialogHeader>
+
+				{loading ? (
+					<div className="py-8 text-center text-sm text-tertiary-foreground">
+						Loading…
+					</div>
+				) : (
+					<div className="flex flex-col gap-4">
+						<div className="flex items-center gap-2 text-xs">
+							<Badge variant={config.configHealthy ? "success" : "warning"}>
+								{config.configHealthy ? "Healthy" : "Unhealthy"}
+							</Badge>
+							<Badge variant={config.configConfigured ? "info" : "secondary"}>
+								{config.configConfigured ? "S3 set" : "Using defaults"}
+							</Badge>
+							{config.lastSuccessAt && (
+								<span className="text-tertiary-foreground">
+									Last sync: {new Date(config.lastSuccessAt).toLocaleString()}
+								</span>
+							)}
+							{config.error && (
+								<span className="text-destructive">{config.error}</span>
+							)}
+						</div>
+
+						{FIELDS.map((field) => (
+							<div key={field.key} className="flex flex-col gap-1">
+								<FormLabel>{field.label}</FormLabel>
+								<div className="flex items-center gap-3">
+									<Input
+										type="number"
+										min={field.min}
+										max={field.max}
+										value={drafts[field.key] ?? ""}
+										onChange={(e) =>
+											setDrafts((prev) => ({
+												...prev,
+												[field.key]: e.target.value,
+											}))
+										}
+										className="w-32 font-mono text-xs"
+									/>
+									<span className="text-xs text-tertiary-foreground">
+										{field.description}
+									</span>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button
+						variant="secondary"
+						onClick={() => onOpenChange(false)}
+						disabled={saving}
+					>
+						Cancel
+					</Button>
+					<Button onClick={handleSave} disabled={loading || saving}>
+						{saving ? "Saving…" : "Save"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an admin dialog to view and edit the FullSubject concurrency gate in Edge Config, plus tighter overload checks and clearer health reporting for the gate config endpoint.

- New Features
  - New `FullSubjectGateDialog` in Edge Config to edit: `per_customer_limit`, `per_org_limit`, `max_wait_ms`, `per_customer_pending_max`, `per_org_pending_max`.
  - Shows health/status (healthy, configured, last sync, error). Loads via `GET /admin/full-subject-gate-config`, saves via `PUT /admin/full-subject-gate-config`.
  - Validates integer ranges and shows toasts. Changes propagate within ~30s.

- Bug Fixes
  - Increment `startedCounter` only after queue checks so rejected requests aren’t counted.
  - Enforce per-org pending cap even when using a customer limiter; reject before enqueuing when queues are full.
  - Admin endpoint falls back to runtime config on source read failures and surfaces source errors; `configHealthy` is false when source fetch fails.

<sup>Written for commit 07c5420cd133c15cb4b302a060f7aad246477674. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1698?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

