### PR TITLE
feat: preflight tax address existence before taxing

### DIFF
--- a/MIGRATIONS_FIX_TARGET_LIMIT.md
+++ b/MIGRATIONS_FIX_TARGET_LIMIT.md
@@ -1,0 +1,95 @@
+# Migration Runs `target_limit` Dev DB Note
+
+While writing the automatic-tax missing-address regression test, the integration
+harness could not reach billing setup because the dev database schema was behind
+the checked-in Drizzle model.
+
+## Symptom
+
+Running:
+
+```bash
+cd server
+./run.sh /Users/amianthus/.superset/worktrees/06ef6d27-730a-4eec-a0b1-3f2853221478/fix/automatic-tax-retry/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
+```
+
+failed during setup with:
+
+```text
+error: column organizations_migration_runs.target_limit does not exist
+code: "internal_error"
+```
+
+This happened before the test reached customer/product billing behavior.
+
+## Investigation
+
+The checked-in table model is:
+
+```text
+shared/models/migrationV2Models/migrationRunTable.ts
+```
+
+It defines:
+
+```ts
+export const migrationRuns = pgTable(
+  "migration_runs",
+  {
+    ...
+    target_limit: numeric({ mode: "number" }),
+    ...
+  },
+);
+```
+
+The actual dev DB had `migration_runs`, not `organizations_migration_runs`.
+I verified with:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); const rows = await sql`select table_schema, table_name from information_schema.tables where table_name like ${"%migration%run%"} order by table_schema, table_name`; console.log(rows); await sql.end();'
+```
+
+which returned:
+
+```text
+public.migration_item_runs
+public.migration_runs
+```
+
+The `organizations_migration_runs.target_limit` wording appears to be a SQL
+alias/prefix in the failing query, not the physical table name.
+
+## Temporary Local Fix Applied
+
+I first tried the alias-looking table name:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); await sql`ALTER TABLE organizations_migration_runs ADD COLUMN IF NOT EXISTS target_limit numeric`; await sql.end(); console.log("added target_limit if missing");'
+```
+
+That failed with:
+
+```text
+PostgresError: relation "organizations_migration_runs" does not exist
+code: "42P01"
+```
+
+Then I applied the actual checked-in table name:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); await sql`ALTER TABLE migration_runs ADD COLUMN IF NOT EXISTS target_limit numeric`; await sql.end(); console.log("added migration_runs.target_limit if missing");'
+```
+
+That succeeded:
+
+```text
+added migration_runs.target_limit if missing
+```
+
+After that, the automatic-tax test reached the intended billing failure.
+
+## Follow-up Needed
+
+Create/apply the real migration for `migration_runs.target_limit` so future
+agents and dev environments do not need the manual `ALTER TABLE`.

--- a/server/src/external/stripe/customers/operations/createStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/createStripeCustomer.ts
@@ -14,6 +14,7 @@ export const createStripeCustomer = async ({
 	customer: Customer;
 	options?: {
 		testClockId?: string;
+		expandTax?: boolean;
 	};
 }): Promise<ExpandedStripeCustomer> => {
 	const { org, env } = ctx;
@@ -43,6 +44,7 @@ export const createStripeCustomer = async ({
 				"test_clock",
 				"invoice_settings.default_payment_method",
 				"discount.source.coupon.applies_to",
+				...(options.expandTax ? ["tax"] : []),
 			],
 		},
 		idempotencyKey

--- a/server/src/external/stripe/customers/operations/getExpandedStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getExpandedStripeCustomer.ts
@@ -28,28 +28,34 @@ export function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound,
+	expandTax,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId: string;
 	errorOnNotFound: true;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer>;
 export function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound,
+	expandTax,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId?: string;
 	errorOnNotFound?: false;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer | undefined>;
 export async function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound = false,
+	expandTax = false,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId?: string;
 	errorOnNotFound?: boolean;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer | undefined> {
 	const { org, env } = ctx;
 	const stripeCli = createStripeCli({ org, env });
@@ -63,6 +69,7 @@ export async function getExpandedStripeCustomer({
 					"test_clock",
 					"invoice_settings.default_payment_method",
 					"discount.source.coupon.applies_to",
+					...(expandTax ? ["tax"] : []),
 				],
 			}),
 		);

--- a/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
@@ -14,9 +14,7 @@ import { CusService } from "@/internal/customers/CusService";
 export const getOrCreateStripeCustomer = async ({
 	ctx,
 	customer,
-	options = {
-		updateDb: true,
-	},
+	options,
 }: {
 	ctx: AutumnContext;
 	customer: Customer;
@@ -26,11 +24,15 @@ export const getOrCreateStripeCustomer = async ({
 	};
 }): Promise<ExpandedStripeCustomer | undefined> => {
 	const { logger } = ctx;
+	const resolvedOptions = {
+		updateDb: true,
+		...options,
+	};
 
 	const currentStripeCustomer = await getExpandedStripeCustomer({
 		ctx,
 		stripeCustomerId: customer.processor?.id,
-		expandTax: options.expandTax,
+		expandTax: resolvedOptions.expandTax,
 	});
 
 	if (currentStripeCustomer) return currentStripeCustomer;
@@ -43,11 +45,11 @@ export const getOrCreateStripeCustomer = async ({
 		ctx,
 		customer,
 		options: {
-			expandTax: options.expandTax,
+			expandTax: resolvedOptions.expandTax,
 		},
 	});
 
-	if (options.updateDb) {
+	if (resolvedOptions.updateDb) {
 		await CusService.update({
 			ctx,
 			idOrInternalId: customer.id || customer.internal_id,

--- a/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
@@ -22,6 +22,7 @@ export const getOrCreateStripeCustomer = async ({
 	customer: Customer;
 	options?: {
 		updateDb?: boolean;
+		expandTax?: boolean;
 	};
 }): Promise<ExpandedStripeCustomer | undefined> => {
 	const { logger } = ctx;
@@ -29,6 +30,7 @@ export const getOrCreateStripeCustomer = async ({
 	const currentStripeCustomer = await getExpandedStripeCustomer({
 		ctx,
 		stripeCustomerId: customer.processor?.id,
+		expandTax: options.expandTax,
 	});
 
 	if (currentStripeCustomer) return currentStripeCustomer;
@@ -40,6 +42,9 @@ export const getOrCreateStripeCustomer = async ({
 	const stripeCustomer = await createStripeCustomer({
 		ctx,
 		customer,
+		options: {
+			expandTax: options.expandTax,
+		},
 	});
 
 	if (options.updateDb) {

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
@@ -19,15 +19,20 @@ export const fetchStripeCustomerForBilling = async ({
 }) => {
 	const { org, env } = ctx;
 	const stripeCli = createStripeCli({ org, env });
+	const expandTax = !!ctx.org.config.automatic_tax;
 
 	const stripeCus = createIfMissing
 		? await getOrCreateStripeCustomer({
 				ctx,
 				customer: fullCus,
+				options: {
+					expandTax,
+				},
 			})
 		: await getExpandedStripeCustomer({
 				ctx,
 				stripeCustomerId: fullCus.processor?.id,
+				expandTax,
 			});
 
 	if (!stripeCus) {

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
@@ -27,6 +27,7 @@ export const fetchStripeCustomerForBilling = async ({
 				customer: fullCus,
 				options: {
 					expandTax,
+					updateDb: true,
 				},
 			})
 		: await getExpandedStripeCustomer({

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -16,6 +16,7 @@ import type { Stripe } from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { mergeStripeMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/mergeStripeMetadata";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 
 const stripeDiscountsToInvoiceParams = ({
 	stripeDiscounts,
@@ -93,10 +94,7 @@ export const createInvoiceForBilling = async ({
 		stripeDiscounts: billingContext.stripeDiscounts ?? [],
 	});
 
-	// Skip auto_tax in invoice mode: send_invoice has no address-collection
-	// UI so Stripe Tax rejects. charge_automatically relies on Stripe's
-	// address waterfall.
-	const wantsAutoTax = !!ctx.org.config.automatic_tax && !isInvoiceMode;
+	const wantsAutoTax = shouldEnableStripeAutomaticTax({ ctx, billingContext });
 	const draftInvoice = await createStripeInvoice({
 		stripeCli,
 		stripeCusId: billingContext.stripeCustomer?.id ?? "none",

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
@@ -9,6 +9,7 @@ import { notNullish } from "@shared/utils/utils";
 import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { stripeDiscountsToParams } from "@/internal/billing/v2/providers/stripe/utils/discounts/stripeDiscountsToParams";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 
 export const buildStripeSubscriptionUpdateAction = ({
 	ctx,
@@ -96,10 +97,9 @@ export const buildStripeSubscriptionUpdateAction = ({
 		}),
 
 		// Propagate auto_tax onto every sub.update so existing subs catch up
-		// when the org flag flips. Baked in here (not execute) for log
-		// self-description. Skipped in invoice mode: send_invoice invoices
-		// can't collect address, so Stripe Tax rejects.
-		...(ctx.org.config.automatic_tax && !billingContext.invoiceMode
+		// when the org flag flips. Baked in here for log self-description;
+		// execute re-applies the same preflight before writing to Stripe.
+		...(shouldEnableStripeAutomaticTax({ ctx, billingContext })
 			? { automatic_tax: { enabled: true } }
 			: {}),
 	};

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -4,6 +4,7 @@ import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
 import { mergeStripeMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/mergeStripeMetadata";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 import { willStripeSubscriptionUpdateCreateInvoice } from "./willStripeSubscriptionUpdateCreateInvoice";
 
 export const executeStripeSubscriptionOperation = async ({
@@ -46,10 +47,7 @@ export const executeStripeSubscriptionOperation = async ({
 			actionSource: billingContext.actionSource,
 		}),
 	});
-	// Skip auto_tax in invoice mode: send_invoice has no address-collection
-	// UI so Stripe Tax rejects.
-	const wantsAutoTax =
-		!!ctx.org.config.automatic_tax && !billingContext.invoiceMode;
+	const wantsAutoTax = shouldEnableStripeAutomaticTax({ ctx, billingContext });
 
 	const taxRateParams = billingContext.taxRateId
 		? { default_tax_rates: [billingContext.taxRateId] }

--- a/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
@@ -6,8 +6,10 @@ const hasUsableTaxAddress = (address?: Stripe.Address | null) => {
 	return Boolean(address?.country);
 };
 
-const customerHasUsableTaxLocation = (stripeCustomer?: Stripe.Customer) => {
-	if (!stripeCustomer) return true;
+export const customerHasUsableTaxLocationForStripeTax = (
+	stripeCustomer?: Stripe.Customer,
+) => {
+	if (!stripeCustomer) return false;
 
 	if (stripeCustomer.tax?.automatic_tax) {
 		return ["supported", "not_collecting"].includes(
@@ -35,7 +37,7 @@ export const shouldEnableStripeAutomaticTax = ({
 
 	// Use only the already-fetched Stripe customer. If setup did not fetch one,
 	// do not fetch again on the write path.
-	if (!customerHasUsableTaxLocation(billingContext.stripeCustomer)) {
+	if (!customerHasUsableTaxLocationForStripeTax(billingContext.stripeCustomer)) {
 		return false;
 	}
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
@@ -1,0 +1,43 @@
+import type { BillingContext } from "@autumn/shared";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+const hasUsableTaxAddress = (address?: Stripe.Address | null) => {
+	return Boolean(address?.country);
+};
+
+const customerHasUsableTaxLocation = (stripeCustomer?: Stripe.Customer) => {
+	if (!stripeCustomer) return true;
+
+	if (stripeCustomer.tax?.automatic_tax) {
+		return ["supported", "not_collecting"].includes(
+			stripeCustomer.tax.automatic_tax,
+		);
+	}
+
+	return (
+		hasUsableTaxAddress(stripeCustomer.address) ||
+		hasUsableTaxAddress(stripeCustomer.shipping?.address)
+	);
+};
+
+export const shouldEnableStripeAutomaticTax = ({
+	ctx,
+	billingContext,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+}) => {
+	if (!ctx.org.config.automatic_tax) return false;
+
+	// Invoice mode uses send_invoice and has no address collection UI.
+	if (billingContext.invoiceMode) return false;
+
+	// Use only the already-fetched Stripe customer. If setup did not fetch one,
+	// do not fetch again on the write path.
+	if (!customerHasUsableTaxLocation(billingContext.stripeCustomer)) {
+		return false;
+	}
+
+	return true;
+};

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -9,6 +9,7 @@ import {
 } from "@/external/stripe/stripeSubUtils/convertSubUtils.js";
 import { sanitizeSubItems } from "@/external/stripe/stripeSubUtils/getStripeSubItems.js";
 import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.js";
+import { customerHasUsableTaxLocationForStripeTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.js";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
 import { buildInvoiceMemoFromEntitlements } from "@/internal/invoices/invoiceMemoUtils.js";
 import { freeTrialToStripeTimestamp } from "@/internal/products/free-trials/freeTrialUtils.js";
@@ -63,7 +64,9 @@ export const createStripeSub2 = async ({
 		// Skip auto_tax in invoice mode: send_invoice has no
 		// address-collection UI so Stripe Tax rejects.
 		const wantsAutoTax =
-			!!org.config.automatic_tax && !attachParams.invoiceOnly;
+			!!org.config.automatic_tax &&
+			!attachParams.invoiceOnly &&
+			customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
 
 		const subscription = await stripeCli.subscriptions.create({
 			...paymentMethodData,

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
@@ -11,6 +11,7 @@ import {
 import { addMinutes } from "date-fns";
 import { Decimal } from "decimal.js";
 import { payForInvoice } from "@/external/stripe/stripeInvoiceUtils.js";
+import { customerHasUsableTaxLocationForStripeTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.js";
 import { createFullCusProduct } from "@/internal/customers/add-product/createFullCusProduct.js";
 import { handleCreateCheckout } from "@/internal/customers/add-product/handleCreateCheckout.js";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
@@ -135,8 +136,10 @@ export const handleOneOffFunction = async ({
 
 	// Skip auto_tax in invoice mode: send_invoice has no
 	// address-collection UI so Stripe Tax rejects.
-	const wantsAutoTax =
-		!!org.config.automatic_tax && !attachParams.invoiceOnly;
+const wantsAutoTax =
+		!!org.config.automatic_tax &&
+		!attachParams.invoiceOnly &&
+		customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
 
 	let stripeInvoice = await stripeCli.invoices.create({
 		customer: customer.processor.id!,

--- a/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getStripeCusData.ts
+++ b/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getStripeCusData.ts
@@ -24,6 +24,9 @@ export const getStripeCusData = async ({
 	const stripeCus = await getOrCreateStripeCustomer({
 		ctx,
 		customer,
+		options: {
+			expandTax: !!ctx.org.config.automatic_tax,
+		},
 	});
 
 	if (!stripeCus) {

--- a/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
@@ -1,93 +1,100 @@
 /**
- * Regression guard: when `automatic_tax: true` but the customer has no
- * address, attach must surface an actionable tax/address error (Stripe's
- * `customer_tax_location_invalid` or a typed RecaseError) instead of a
- * generic 500. Covers both v1 `/v1/attach` and v2 `/v1/billing.attach`.
+ * Regression guard for orgs that enable `automatic_tax` after customers
+ * already have paid subscriptions but no Stripe tax location on file.
+ *
+ * Red-failure mode (current behavior):
+ *  - Pro -> Premium upgrade sends `automatic_tax.enabled=true` to Stripe.
+ *  - Stripe rejects with `customer_tax_location_invalid`.
+ *
+ * Green-success criteria (after fix):
+ *  - Upgrade succeeds by falling back to no automatic tax for this mutation.
+ *  - Resulting subscription and upgrade invoice have automatic tax disabled.
  */
 
 import { expect, test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 
-function hasActionableTaxSignal(err: unknown): boolean {
-	const errorString = JSON.stringify(err, [
-		"message",
-		"code",
-		"name",
-		"type",
-	]).toLowerCase();
-	return (
-		errorString.includes("tax") ||
-		errorString.includes("address") ||
-		errorString.includes("location")
-	);
-}
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-no-address (v2 pre-flip upgrade): succeeds without tax when Stripe customer has no location")}`,
+	async () => {
+		const customerId = "tax-no-address-preflip-upgrade";
+		const pro = products.pro({ id: "pro", items: [] });
+		const premium = products.premium({ id: "premium", items: [] });
 
-test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v1 legacy /v1/attach): customer without address surfaces actionable error")}`, async () => {
-	const customerId = "tax-no-address-v1";
-	const proProd = products.pro({ id: "pro", items: [] });
-
-	const { autumnV1 } = await initScenario({
-		customerId,
-		setup: [
-			s.platform.create({
-				configOverrides: { automatic_tax: true },
-				taxRegistrations: ["AU"],
-			}),
-			s.customer({
-				testClock: false,
-				paymentMethod: "success",
-			}),
-			s.products({ list: [proProd] }),
-		],
-		actions: [],
-	});
-
-	let caughtError: unknown;
-	try {
-		await autumnV1.attach({
-			customer_id: customerId,
-			product_id: `pro_${customerId}`,
+		const { ctx, customer, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+				}),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
 		});
-	} catch (err) {
-		caughtError = err;
-	}
 
-	expect(caughtError).toBeDefined();
-	expect(hasActionableTaxSignal(caughtError)).toBe(true);
-}, 240_000);
+		const stripeCustomerId = customer!.processor!.id!;
+		const stripeCustomerBefore =
+			await ctx.stripeCli.customers.retrieve(stripeCustomerId);
+		if ("deleted" in stripeCustomerBefore && stripeCustomerBefore.deleted) {
+			throw new Error("Stripe customer was unexpectedly deleted");
+		}
+		expect(stripeCustomerBefore.address).toBeNull();
 
-test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v2 /v1/billing.attach): customer without address surfaces actionable error")}`, async () => {
-	const customerId = "tax-no-address-v2";
-	const proProd = products.pro({ id: "pro", items: [] });
-
-	const { autumnV2_2 } = await initScenario({
-		customerId,
-		setup: [
-			s.platform.create({
-				configOverrides: { automatic_tax: true },
-				taxRegistrations: ["AU"],
-			}),
-			s.customer({
-				testClock: false,
-				paymentMethod: "success",
-			}),
-			s.products({ list: [proProd] }),
-		],
-		actions: [],
-	});
-
-	let caughtError: unknown;
-	try {
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: `pro_${customerId}`,
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				config: { ...ctx.org.config, automatic_tax: false },
+			},
 		});
-	} catch (err) {
-		caughtError = err;
-	}
 
-	expect(caughtError).toBeDefined();
-	expect(hasActionableTaxSignal(caughtError)).toBe(true);
-}, 240_000);
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+		});
+
+		const initialSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			limit: 1,
+		});
+		expect(initialSubscriptions.data[0].automatic_tax.enabled).toBe(false);
+
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				config: { ...ctx.org.config, automatic_tax: true },
+			},
+		});
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+
+		const upgradedSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			limit: 1,
+		});
+		const upgradedSubscription = upgradedSubscriptions.data[0];
+		expect(upgradedSubscription).toBeDefined();
+		expect(upgradedSubscription.automatic_tax.enabled).toBe(false);
+
+		const invoices = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			limit: 5,
+		});
+		const upgradeInvoice = invoices.data[0];
+		expect(upgradeInvoice).toBeDefined();
+		expect(upgradeInvoice.automatic_tax.enabled).toBe(false);
+	},
+	300_000,
+);


### PR DESCRIPTION
## Summary
- preflight Stripe automatic tax using the already-fetched customer tax/location context
- expand Stripe customer tax details only when org automatic tax is enabled
- skip automatic tax for no-location customers and invoice-mode writes instead of retrying
- preserve Stripe customer persistence defaults when passing partial customer options
- cover the no-address upgrade fallback and legacy/V2 default-off tax paths

## Verification
- bunx tsgo --build --noEmit
- ./run.sh server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
- ./run.sh server/tests/integration/billing/tax/automatic-tax-default-off.test.ts
- full billing/tax directory: 27 pass, 0 fail

Replaces closed PR #1694.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Stripe Automatic Tax only when the org has it on and the customer has a usable tax location; otherwise skip it. This prevents upgrade failures and 500s by avoiding Stripe `customer_tax_location_invalid`, and skips auto tax for invoice-mode writes.

- **Bug Fixes**
  - Added `shouldEnableStripeAutomaticTax` preflight that uses the already-fetched `billingContext.stripeCustomer` and skips auto tax if no address/location or in invoice mode.
  - Expand Stripe `tax` data only when org automatic tax is enabled (`expandTax` propagated through `getExpandedStripeCustomer`, `createStripeCustomer`, and `getOrCreateStripeCustomer`).
  - Applied preflight across invoices, subscription updates/executes, and attach flows.
  - Updated tests: upgrade without a customer address now succeeds and leaves automatic tax disabled on the sub and invoice.

<sup>Written for commit f2253622831b2dfa973f95d4388047a2bef7c795. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1699?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a preflight check before enabling Stripe automatic tax: the system now inspects the already-fetched Stripe customer's tax location (via the expanded `tax` field or billing/shipping address) and silently skips `automatic_tax: enabled` for customers with no usable location, rather than letting Stripe reject the write with `customer_tax_location_invalid`. It also fixes a pre-existing bug where passing any `options` to `getOrCreateStripeCustomer` without `updateDb: true` would silently skip the DB persistence step.

- **[Improvements]** Centralises the automatic-tax eligibility logic into `shouldEnableStripeAutomaticTax` and expands the Stripe customer `tax` field only when the org has `automatic_tax` enabled, reducing unnecessary API data.
- **[Bug fixes]** Fixes the `getOrCreateStripeCustomer` `updateDb` default loss: partial `options` objects no longer clobber the `updateDb: true` default.
- **[Improvements]** The regression test suite is updated to reflect the new \"succeed without tax\" contract for address-less customers, covering the v2 pre-flip upgrade path.
</details>

<h3>Confidence Score: 4/5</h3>

The core logic change is sound and well-tested for the v2 upgrade path; the main loose ends are a developer scratch file that was committed and a minor indentation regression.

The tax-preflight logic correctly gates automatic tax on the customer's Stripe-reported location, and the updateDb default fix prevents silent DB-skip regressions. The MIGRATIONS_FIX_TARGET_LIMIT.md file with local machine paths and manual ALTER scripts should not be in the repo. The indentation loss on wantsAutoTax in handleOneOffFunction.ts is cosmetic but should be cleaned up. The v1 legacy attach path's new behavior is no longer covered by the updated test suite.

MIGRATIONS_FIX_TARGET_LIMIT.md should be removed; server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts has a minor indentation regression.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts | New central preflight helper; correctly consolidates org-flag, invoice-mode, and customer-location checks, but the address-only fallback when tax is not expanded creates a latent footgun for future callers. |
| server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts | Adds address preflight to `wantsAutoTax`; logic is correct but the `const` declaration lost its leading tab indentation. |
| server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts | Correctly fixes the pre-existing `updateDb` default loss bug by merging options over a base object instead of using a parameter default; also threads `expandTax` through cleanly. |
| server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts | Test correctly validates the new "succeed without tax" behavior for the v2 upgrade path, but the v1 legacy `/v1/attach` scenario (previously tested) no longer has coverage for this changed behavior. |
| MIGRATIONS_FIX_TARGET_LIMIT.md | Developer scratch notes with hardcoded local paths and manual ALTER TABLE scripts; should not be committed to the repository. |
| server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts | Adds customer location preflight to `wantsAutoTax` for subscription creation; logic is correct and consistent with other call sites. |
| server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getStripeCusData.ts | Adds `expandTax` option when fetching/creating the Stripe customer in the v1 attach path; correctly tied to the `automatic_tax` org flag. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchStripeCustomer
    participant getOrCreateStripeCustomer
    participant Stripe API
    participant shouldEnableStripeAutomaticTax
    participant Stripe Write

    Caller->>fetchStripeCustomer: "fetch customer (expandTax = !!org.automatic_tax)"
    fetchStripeCustomer->>getOrCreateStripeCustomer: "options { expandTax, updateDb:true }"
    getOrCreateStripeCustomer->>Stripe API: retrieve/create customer, expand: tax
    Stripe API-->>getOrCreateStripeCustomer: Customer { tax.automatic_tax, address }
    getOrCreateStripeCustomer-->>fetchStripeCustomer: ExpandedStripeCustomer
    fetchStripeCustomer-->>Caller: stripeCus (with tax data)

    Caller->>shouldEnableStripeAutomaticTax: "{ ctx, billingContext }"
    note over shouldEnableStripeAutomaticTax: 1. org.automatic_tax enabled?<br/>2. not invoiceMode?<br/>3. tax.automatic_tax in [supported, not_collecting]<br/>   OR billing/shipping address.country?
    shouldEnableStripeAutomaticTax-->>Caller: true / false

    alt "wantsAutoTax = true"
        Caller->>Stripe Write: automatic_tax: { enabled: true }
    else "wantsAutoTax = false"
        Caller->>Stripe Write: (no automatic_tax param)
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts:137-142
Missing indentation on `wantsAutoTax` declaration — the `const` keyword is at column 0 while every surrounding statement is tab-indented. This is inconsistent with the rest of the function and should be fixed.

```suggestion
	// Skip auto_tax in invoice mode: send_invoice has no
	// address-collection UI so Stripe Tax rejects.
	const wantsAutoTax =
		!!org.config.automatic_tax &&
		!attachParams.invoiceOnly &&
		customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
```

### Issue 2 of 3
MIGRATIONS_FIX_TARGET_LIMIT.md:1-5
**Developer scratch file committed to repository**

This file contains internal investigation notes, hardcoded absolute paths from a local developer machine (`/Users/amianthus/.superset/worktrees/...`), and manual `ALTER TABLE` scripts used during local debugging. None of this is useful for other contributors or CI and it documents an unresolved DB schema gap (`migration_runs.target_limit` missing from dev DB) that could confuse future developers. The follow-up noted in the "Follow-up Needed" section should be a tracked issue, not a committed markdown file.

### Issue 3 of 3
server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts:14-23
**Address-only fallback when `tax` expansion was not requested**

When `expandTax` was `false` (i.e., automatic tax was disabled at fetch time), `stripeCustomer.tax` will be absent from the response, so `stripeCustomer.tax?.automatic_tax` is `undefined` (falsy). The function then falls through to the raw address check. All current call sites pass `expandTax: !!ctx.org.config.automatic_tax` so this is consistent today, but a future caller that passes a customer fetched without tax expansion while `automatic_tax` is enabled would silently base the decision on the billing address alone — missing the case where the address exists but Stripe reports `"not_supported"` or `"failed"` for that location. A guard or an explicit JSDoc note that the customer must be fetched with `expandTax: true` would harden this API.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve automatic tax preflight de..."](https://github.com/useautumn/autumn/commit/f2253622831b2dfa973f95d4388047a2bef7c795) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33478936)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->