### PR TITLE
Test per_org_pending_max rejection for customerId requests

### DIFF
--- a/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
+++ b/server/tests/unit/full-subject-gate/get-full-subject-gate.test.ts
@@ -231,6 +231,57 @@ describe("runWithFullSubjectGate", () => {
 		});
 	});
 
+	test("rejects with 429 (per_org_queue_full) when per-org queue fills via many customers in one org", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 1,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 2,
+			},
+		});
+
+		const slow = () => new Promise((resolve) => setTimeout(resolve, 100));
+		const results = await Promise.allSettled(
+			Array.from({ length: 10 }, (_, idx) =>
+				runWithFullSubjectGate({
+					customerId: `cus-org-cap-${idx}`,
+					orgId: "org-cap",
+					env: AppEnv.Live,
+					queryFn: slow,
+				}),
+			),
+		);
+
+		const rejectedReasons = results
+			.filter((r) => r.status === "rejected")
+			.map(
+				(r) =>
+					(r as PromiseRejectedResult).reason.data?.reason as string | undefined,
+			);
+		expect(rejectedReasons.length).toBeGreaterThan(0);
+		expect(rejectedReasons.some((reason) => reason === "per_org_queue_full")).toBe(
+			true,
+		);
+		for (const r of results.filter(
+			(x) => x.status === "rejected",
+		) as PromiseRejectedResult[]) {
+			expect(r.reason.statusCode).toBe(429);
+			expect(r.reason.code).toBe("rate_limit_exceeded");
+		}
+
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 2,
+				per_org_limit: 4,
+				max_wait_ms: 60_000,
+				per_customer_pending_max: 1000,
+				per_org_pending_max: 1000,
+			},
+		});
+	});
+
 	test("rejects with 429 when a queued request exceeds max_wait_ms", async () => {
 		_setFullSubjectGateConfigForTesting({
 			config: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a unit test that verifies `per_org_pending_max` enforcement for `customerId` requests. When multiple customers in the same org fill the per‑org queue, requests are rejected with 429 `rate_limit_exceeded` and reason `per_org_queue_full`.

<sup>Written for commit 0cc50509aae0f7f339ba9a57fe093bb55d8f43eb. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1700?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

