### PR TITLE
release: 🚢 automatic tax retries

### DIFF
--- a/MIGRATIONS_FIX_TARGET_LIMIT.md
+++ b/MIGRATIONS_FIX_TARGET_LIMIT.md
@@ -1,0 +1,95 @@
+# Migration Runs `target_limit` Dev DB Note
+
+While writing the automatic-tax missing-address regression test, the integration
+harness could not reach billing setup because the dev database schema was behind
+the checked-in Drizzle model.
+
+## Symptom
+
+Running:
+
+```bash
+cd server
+./run.sh /Users/amianthus/.superset/worktrees/06ef6d27-730a-4eec-a0b1-3f2853221478/fix/automatic-tax-retry/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
+```
+
+failed during setup with:
+
+```text
+error: column organizations_migration_runs.target_limit does not exist
+code: "internal_error"
+```
+
+This happened before the test reached customer/product billing behavior.
+
+## Investigation
+
+The checked-in table model is:
+
+```text
+shared/models/migrationV2Models/migrationRunTable.ts
+```
+
+It defines:
+
+```ts
+export const migrationRuns = pgTable(
+  "migration_runs",
+  {
+    ...
+    target_limit: numeric({ mode: "number" }),
+    ...
+  },
+);
+```
+
+The actual dev DB had `migration_runs`, not `organizations_migration_runs`.
+I verified with:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); const rows = await sql`select table_schema, table_name from information_schema.tables where table_name like ${"%migration%run%"} order by table_schema, table_name`; console.log(rows); await sql.end();'
+```
+
+which returned:
+
+```text
+public.migration_item_runs
+public.migration_runs
+```
+
+The `organizations_migration_runs.target_limit` wording appears to be a SQL
+alias/prefix in the failing query, not the physical table name.
+
+## Temporary Local Fix Applied
+
+I first tried the alias-looking table name:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); await sql`ALTER TABLE organizations_migration_runs ADD COLUMN IF NOT EXISTS target_limit numeric`; await sql.end(); console.log("added target_limit if missing");'
+```
+
+That failed with:
+
+```text
+PostgresError: relation "organizations_migration_runs" does not exist
+code: "42P01"
+```
+
+Then I applied the actual checked-in table name:
+
+```bash
+infisical run --env=dev --recursive -- bun -e 'import postgres from "postgres"; const sql = postgres(process.env.DATABASE_URL!); await sql`ALTER TABLE migration_runs ADD COLUMN IF NOT EXISTS target_limit numeric`; await sql.end(); console.log("added migration_runs.target_limit if missing");'
+```
+
+That succeeded:
+
+```text
+added migration_runs.target_limit if missing
+```
+
+After that, the automatic-tax test reached the intended billing failure.
+
+## Follow-up Needed
+
+Create/apply the real migration for `migration_runs.target_limit` so future
+agents and dev environments do not need the manual `ALTER TABLE`.

--- a/server/src/external/stripe/customers/operations/createStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/createStripeCustomer.ts
@@ -14,6 +14,7 @@ export const createStripeCustomer = async ({
 	customer: Customer;
 	options?: {
 		testClockId?: string;
+		expandTax?: boolean;
 	};
 }): Promise<ExpandedStripeCustomer> => {
 	const { org, env } = ctx;
@@ -43,6 +44,7 @@ export const createStripeCustomer = async ({
 				"test_clock",
 				"invoice_settings.default_payment_method",
 				"discount.source.coupon.applies_to",
+				...(options.expandTax ? ["tax"] : []),
 			],
 		},
 		idempotencyKey

--- a/server/src/external/stripe/customers/operations/getExpandedStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getExpandedStripeCustomer.ts
@@ -28,28 +28,34 @@ export function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound,
+	expandTax,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId: string;
 	errorOnNotFound: true;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer>;
 export function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound,
+	expandTax,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId?: string;
 	errorOnNotFound?: false;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer | undefined>;
 export async function getExpandedStripeCustomer({
 	ctx,
 	stripeCustomerId,
 	errorOnNotFound = false,
+	expandTax = false,
 }: {
 	ctx: AutumnContext;
 	stripeCustomerId?: string;
 	errorOnNotFound?: boolean;
+	expandTax?: boolean;
 }): Promise<ExpandedStripeCustomer | undefined> {
 	const { org, env } = ctx;
 	const stripeCli = createStripeCli({ org, env });
@@ -63,6 +69,7 @@ export async function getExpandedStripeCustomer({
 					"test_clock",
 					"invoice_settings.default_payment_method",
 					"discount.source.coupon.applies_to",
+					...(expandTax ? ["tax"] : []),
 				],
 			}),
 		);

--- a/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
@@ -14,9 +14,7 @@ import { CusService } from "@/internal/customers/CusService";
 export const getOrCreateStripeCustomer = async ({
 	ctx,
 	customer,
-	options = {
-		updateDb: true,
-	},
+	options,
 }: {
 	ctx: AutumnContext;
 	customer: Customer;
@@ -26,11 +24,15 @@ export const getOrCreateStripeCustomer = async ({
 	};
 }): Promise<ExpandedStripeCustomer | undefined> => {
 	const { logger } = ctx;
+	const resolvedOptions = {
+		updateDb: true,
+		...options,
+	};
 
 	const currentStripeCustomer = await getExpandedStripeCustomer({
 		ctx,
 		stripeCustomerId: customer.processor?.id,
-		expandTax: options.expandTax,
+		expandTax: resolvedOptions.expandTax,
 	});
 
 	if (currentStripeCustomer) return currentStripeCustomer;
@@ -43,11 +45,11 @@ export const getOrCreateStripeCustomer = async ({
 		ctx,
 		customer,
 		options: {
-			expandTax: options.expandTax,
+			expandTax: resolvedOptions.expandTax,
 		},
 	});
 
-	if (options.updateDb) {
+	if (resolvedOptions.updateDb) {
 		await CusService.update({
 			ctx,
 			idOrInternalId: customer.id || customer.internal_id,

--- a/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
@@ -22,6 +22,7 @@ export const getOrCreateStripeCustomer = async ({
 	customer: Customer;
 	options?: {
 		updateDb?: boolean;
+		expandTax?: boolean;
 	};
 }): Promise<ExpandedStripeCustomer | undefined> => {
 	const { logger } = ctx;
@@ -29,6 +30,7 @@ export const getOrCreateStripeCustomer = async ({
 	const currentStripeCustomer = await getExpandedStripeCustomer({
 		ctx,
 		stripeCustomerId: customer.processor?.id,
+		expandTax: options.expandTax,
 	});
 
 	if (currentStripeCustomer) return currentStripeCustomer;
@@ -40,6 +42,9 @@ export const getOrCreateStripeCustomer = async ({
 	const stripeCustomer = await createStripeCustomer({
 		ctx,
 		customer,
+		options: {
+			expandTax: options.expandTax,
+		},
 	});
 
 	if (options.updateDb) {

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
@@ -19,15 +19,20 @@ export const fetchStripeCustomerForBilling = async ({
 }) => {
 	const { org, env } = ctx;
 	const stripeCli = createStripeCli({ org, env });
+	const expandTax = !!ctx.org.config.automatic_tax;
 
 	const stripeCus = createIfMissing
 		? await getOrCreateStripeCustomer({
 				ctx,
 				customer: fullCus,
+				options: {
+					expandTax,
+				},
 			})
 		: await getExpandedStripeCustomer({
 				ctx,
 				stripeCustomerId: fullCus.processor?.id,
+				expandTax,
 			});
 
 	if (!stripeCus) {

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts
@@ -27,6 +27,7 @@ export const fetchStripeCustomerForBilling = async ({
 				customer: fullCus,
 				options: {
 					expandTax,
+					updateDb: true,
 				},
 			})
 		: await getExpandedStripeCustomer({

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -16,6 +16,7 @@ import type { Stripe } from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { mergeStripeMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/mergeStripeMetadata";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 
 const stripeDiscountsToInvoiceParams = ({
 	stripeDiscounts,
@@ -93,10 +94,7 @@ export const createInvoiceForBilling = async ({
 		stripeDiscounts: billingContext.stripeDiscounts ?? [],
 	});
 
-	// Skip auto_tax in invoice mode: send_invoice has no address-collection
-	// UI so Stripe Tax rejects. charge_automatically relies on Stripe's
-	// address waterfall.
-	const wantsAutoTax = !!ctx.org.config.automatic_tax && !isInvoiceMode;
+	const wantsAutoTax = shouldEnableStripeAutomaticTax({ ctx, billingContext });
 	const draftInvoice = await createStripeInvoice({
 		stripeCli,
 		stripeCusId: billingContext.stripeCustomer?.id ?? "none",

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
@@ -9,6 +9,7 @@ import { notNullish } from "@shared/utils/utils";
 import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { stripeDiscountsToParams } from "@/internal/billing/v2/providers/stripe/utils/discounts/stripeDiscountsToParams";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 
 export const buildStripeSubscriptionUpdateAction = ({
 	ctx,
@@ -96,10 +97,9 @@ export const buildStripeSubscriptionUpdateAction = ({
 		}),
 
 		// Propagate auto_tax onto every sub.update so existing subs catch up
-		// when the org flag flips. Baked in here (not execute) for log
-		// self-description. Skipped in invoice mode: send_invoice invoices
-		// can't collect address, so Stripe Tax rejects.
-		...(ctx.org.config.automatic_tax && !billingContext.invoiceMode
+		// when the org flag flips. Baked in here for log self-description;
+		// execute re-applies the same preflight before writing to Stripe.
+		...(shouldEnableStripeAutomaticTax({ ctx, billingContext })
 			? { automatic_tax: { enabled: true } }
 			: {}),
 	};

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -4,6 +4,7 @@ import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
 import { mergeStripeMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/mergeStripeMetadata";
+import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 import { willStripeSubscriptionUpdateCreateInvoice } from "./willStripeSubscriptionUpdateCreateInvoice";
 
 export const executeStripeSubscriptionOperation = async ({
@@ -46,10 +47,7 @@ export const executeStripeSubscriptionOperation = async ({
 			actionSource: billingContext.actionSource,
 		}),
 	});
-	// Skip auto_tax in invoice mode: send_invoice has no address-collection
-	// UI so Stripe Tax rejects.
-	const wantsAutoTax =
-		!!ctx.org.config.automatic_tax && !billingContext.invoiceMode;
+	const wantsAutoTax = shouldEnableStripeAutomaticTax({ ctx, billingContext });
 
 	const taxRateParams = billingContext.taxRateId
 		? { default_tax_rates: [billingContext.taxRateId] }

--- a/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
@@ -6,8 +6,10 @@ const hasUsableTaxAddress = (address?: Stripe.Address | null) => {
 	return Boolean(address?.country);
 };
 
-const customerHasUsableTaxLocation = (stripeCustomer?: Stripe.Customer) => {
-	if (!stripeCustomer) return true;
+export const customerHasUsableTaxLocationForStripeTax = (
+	stripeCustomer?: Stripe.Customer,
+) => {
+	if (!stripeCustomer) return false;
 
 	if (stripeCustomer.tax?.automatic_tax) {
 		return ["supported", "not_collecting"].includes(
@@ -35,7 +37,7 @@ export const shouldEnableStripeAutomaticTax = ({
 
 	// Use only the already-fetched Stripe customer. If setup did not fetch one,
 	// do not fetch again on the write path.
-	if (!customerHasUsableTaxLocation(billingContext.stripeCustomer)) {
+	if (!customerHasUsableTaxLocationForStripeTax(billingContext.stripeCustomer)) {
 		return false;
 	}
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts
@@ -1,0 +1,43 @@
+import type { BillingContext } from "@autumn/shared";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+const hasUsableTaxAddress = (address?: Stripe.Address | null) => {
+	return Boolean(address?.country);
+};
+
+const customerHasUsableTaxLocation = (stripeCustomer?: Stripe.Customer) => {
+	if (!stripeCustomer) return true;
+
+	if (stripeCustomer.tax?.automatic_tax) {
+		return ["supported", "not_collecting"].includes(
+			stripeCustomer.tax.automatic_tax,
+		);
+	}
+
+	return (
+		hasUsableTaxAddress(stripeCustomer.address) ||
+		hasUsableTaxAddress(stripeCustomer.shipping?.address)
+	);
+};
+
+export const shouldEnableStripeAutomaticTax = ({
+	ctx,
+	billingContext,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+}) => {
+	if (!ctx.org.config.automatic_tax) return false;
+
+	// Invoice mode uses send_invoice and has no address collection UI.
+	if (billingContext.invoiceMode) return false;
+
+	// Use only the already-fetched Stripe customer. If setup did not fetch one,
+	// do not fetch again on the write path.
+	if (!customerHasUsableTaxLocation(billingContext.stripeCustomer)) {
+		return false;
+	}
+
+	return true;
+};

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -9,6 +9,7 @@ import {
 } from "@/external/stripe/stripeSubUtils/convertSubUtils.js";
 import { sanitizeSubItems } from "@/external/stripe/stripeSubUtils/getStripeSubItems.js";
 import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata.js";
+import { customerHasUsableTaxLocationForStripeTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.js";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
 import { buildInvoiceMemoFromEntitlements } from "@/internal/invoices/invoiceMemoUtils.js";
 import { freeTrialToStripeTimestamp } from "@/internal/products/free-trials/freeTrialUtils.js";
@@ -63,7 +64,9 @@ export const createStripeSub2 = async ({
 		// Skip auto_tax in invoice mode: send_invoice has no
 		// address-collection UI so Stripe Tax rejects.
 		const wantsAutoTax =
-			!!org.config.automatic_tax && !attachParams.invoiceOnly;
+			!!org.config.automatic_tax &&
+			!attachParams.invoiceOnly &&
+			customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
 
 		const subscription = await stripeCli.subscriptions.create({
 			...paymentMethodData,

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
@@ -11,6 +11,7 @@ import {
 import { addMinutes } from "date-fns";
 import { Decimal } from "decimal.js";
 import { payForInvoice } from "@/external/stripe/stripeInvoiceUtils.js";
+import { customerHasUsableTaxLocationForStripeTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.js";
 import { createFullCusProduct } from "@/internal/customers/add-product/createFullCusProduct.js";
 import { handleCreateCheckout } from "@/internal/customers/add-product/handleCreateCheckout.js";
 import type { AttachParams } from "@/internal/customers/cusProducts/AttachParams.js";
@@ -135,8 +136,10 @@ export const handleOneOffFunction = async ({
 
 	// Skip auto_tax in invoice mode: send_invoice has no
 	// address-collection UI so Stripe Tax rejects.
-	const wantsAutoTax =
-		!!org.config.automatic_tax && !attachParams.invoiceOnly;
+const wantsAutoTax =
+		!!org.config.automatic_tax &&
+		!attachParams.invoiceOnly &&
+		customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
 
 	let stripeInvoice = await stripeCli.invoices.create({
 		customer: customer.processor.id!,

--- a/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getStripeCusData.ts
+++ b/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getStripeCusData.ts
@@ -24,6 +24,9 @@ export const getStripeCusData = async ({
 	const stripeCus = await getOrCreateStripeCustomer({
 		ctx,
 		customer,
+		options: {
+			expandTax: !!ctx.org.config.automatic_tax,
+		},
 	});
 
 	if (!stripeCus) {

--- a/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts
@@ -1,93 +1,100 @@
 /**
- * Regression guard: when `automatic_tax: true` but the customer has no
- * address, attach must surface an actionable tax/address error (Stripe's
- * `customer_tax_location_invalid` or a typed RecaseError) instead of a
- * generic 500. Covers both v1 `/v1/attach` and v2 `/v1/billing.attach`.
+ * Regression guard for orgs that enable `automatic_tax` after customers
+ * already have paid subscriptions but no Stripe tax location on file.
+ *
+ * Red-failure mode (current behavior):
+ *  - Pro -> Premium upgrade sends `automatic_tax.enabled=true` to Stripe.
+ *  - Stripe rejects with `customer_tax_location_invalid`.
+ *
+ * Green-success criteria (after fix):
+ *  - Upgrade succeeds by falling back to no automatic tax for this mutation.
+ *  - Resulting subscription and upgrade invoice have automatic tax disabled.
  */
 
 import { expect, test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 
-function hasActionableTaxSignal(err: unknown): boolean {
-	const errorString = JSON.stringify(err, [
-		"message",
-		"code",
-		"name",
-		"type",
-	]).toLowerCase();
-	return (
-		errorString.includes("tax") ||
-		errorString.includes("address") ||
-		errorString.includes("location")
-	);
-}
+test.concurrent(
+	`${chalk.yellowBright("automatic-tax-no-address (v2 pre-flip upgrade): succeeds without tax when Stripe customer has no location")}`,
+	async () => {
+		const customerId = "tax-no-address-preflip-upgrade";
+		const pro = products.pro({ id: "pro", items: [] });
+		const premium = products.premium({ id: "premium", items: [] });
 
-test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v1 legacy /v1/attach): customer without address surfaces actionable error")}`, async () => {
-	const customerId = "tax-no-address-v1";
-	const proProd = products.pro({ id: "pro", items: [] });
-
-	const { autumnV1 } = await initScenario({
-		customerId,
-		setup: [
-			s.platform.create({
-				configOverrides: { automatic_tax: true },
-				taxRegistrations: ["AU"],
-			}),
-			s.customer({
-				testClock: false,
-				paymentMethod: "success",
-			}),
-			s.products({ list: [proProd] }),
-		],
-		actions: [],
-	});
-
-	let caughtError: unknown;
-	try {
-		await autumnV1.attach({
-			customer_id: customerId,
-			product_id: `pro_${customerId}`,
+		const { ctx, customer, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					taxRegistrations: ["AU"],
+				}),
+				s.customer({
+					testClock: false,
+					paymentMethod: "success",
+				}),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
 		});
-	} catch (err) {
-		caughtError = err;
-	}
 
-	expect(caughtError).toBeDefined();
-	expect(hasActionableTaxSignal(caughtError)).toBe(true);
-}, 240_000);
+		const stripeCustomerId = customer!.processor!.id!;
+		const stripeCustomerBefore =
+			await ctx.stripeCli.customers.retrieve(stripeCustomerId);
+		if ("deleted" in stripeCustomerBefore && stripeCustomerBefore.deleted) {
+			throw new Error("Stripe customer was unexpectedly deleted");
+		}
+		expect(stripeCustomerBefore.address).toBeNull();
 
-test.concurrent(`${chalk.yellowBright("automatic-tax-no-address-error (v2 /v1/billing.attach): customer without address surfaces actionable error")}`, async () => {
-	const customerId = "tax-no-address-v2";
-	const proProd = products.pro({ id: "pro", items: [] });
-
-	const { autumnV2_2 } = await initScenario({
-		customerId,
-		setup: [
-			s.platform.create({
-				configOverrides: { automatic_tax: true },
-				taxRegistrations: ["AU"],
-			}),
-			s.customer({
-				testClock: false,
-				paymentMethod: "success",
-			}),
-			s.products({ list: [proProd] }),
-		],
-		actions: [],
-	});
-
-	let caughtError: unknown;
-	try {
-		await autumnV2_2.billing.attach({
-			customer_id: customerId,
-			plan_id: `pro_${customerId}`,
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				config: { ...ctx.org.config, automatic_tax: false },
+			},
 		});
-	} catch (err) {
-		caughtError = err;
-	}
 
-	expect(caughtError).toBeDefined();
-	expect(hasActionableTaxSignal(caughtError)).toBe(true);
-}, 240_000);
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+		});
+
+		const initialSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			limit: 1,
+		});
+		expect(initialSubscriptions.data[0].automatic_tax.enabled).toBe(false);
+
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				config: { ...ctx.org.config, automatic_tax: true },
+			},
+		});
+
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: premium.id,
+		});
+
+		const upgradedSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			limit: 1,
+		});
+		const upgradedSubscription = upgradedSubscriptions.data[0];
+		expect(upgradedSubscription).toBeDefined();
+		expect(upgradedSubscription.automatic_tax.enabled).toBe(false);
+
+		const invoices = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			limit: 5,
+		});
+		const upgradeInvoice = invoices.data[0];
+		expect(upgradeInvoice).toBeDefined();
+		expect(upgradeInvoice.automatic_tax.enabled).toBe(false);
+	},
+	300_000,
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Stripe Automatic Tax only when safe, based on a preflight check of customer tax location, so upgrades don’t fail with `customer_tax_location_invalid`. Upgrades now proceed without tax when the customer has no address.

- **Bug Fixes**
  - Gate Automatic Tax via `shouldEnableStripeAutomaticTax` and `customerHasUsableTaxLocationForStripeTax`.
  - Apply gating in subscription updates/execution, invoice creation, and attach flows (new subs and one-offs).
  - Expand Stripe customer fetch/create with `expandTax` to read `customer.tax` when orgs have Automatic Tax enabled.
  - Add regression test that confirms post-flag upgrades succeed and remain untaxed when the Stripe customer has no location.

- **Migration**
  - No production migration.
  - Dev note: some environments may miss `migration_runs.target_limit`; see `MIGRATIONS_FIX_TARGET_LIMIT.md`.

<sup>Written for commit 86f0b0a399da7f1146cda3ca0acc66650ce18668. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1701?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes how Stripe automatic tax is applied: instead of failing with a `customer_tax_location_invalid` error when a customer has no address on file, the system now silently skips automatic tax for that mutation and succeeds. A new `shouldEnableStripeAutomaticTax` helper centralises the eligibility check (org flag, invoice mode, and Stripe customer tax status) and the `expandTax` option is threaded through the customer-fetch layer so the `tax` field is available for the preflight check without an extra API call.

- **Improvements**: New `shouldEnableStripeAutomaticTax` utility de-duplicates the invoice-mode guard and adds a customer tax-location preflight, replacing three separate inline conditions across the codebase.
- **Improvements**: `expandTax` propagated through `getOrCreateStripeCustomer`, `getExpandedStripeCustomer`, and `createStripeCustomer` so the `tax` field is fetched exactly when needed.
- **Bug fixes**: Fixes `customer_tax_location_invalid` Stripe errors on upgrades/one-off charges by gracefully disabling automatic tax when the customer has no resolvable tax location.
</details>

<h3>Confidence Score: 3/5</h3>

The new integration test depends on a schema column added via manual ALTER TABLE with no checked-in migration, so other developers and CI will hit a setup failure when running it.

The accidentally committed notes file contains a personal filesystem path and explicitly marks the missing migration as unresolved follow-up work — until that migration lands, the test is broken for everyone else.

MIGRATIONS_FIX_TARGET_LIMIT.md should be removed and replaced with an actual Drizzle migration for migration_runs.target_limit; handleOneOffFunction.ts has a minor indentation regression on the wantsAutoTax declaration.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax.ts | New utility centralising automatic-tax eligibility logic; correctly checks org flag, invoice mode, and Stripe customer tax status with a safe fallback to address-based detection. |
| server/src/internal/billing/v2/providers/stripe/setup/fetchStripeCustomerForBilling.ts | Correctly gates `expandTax` on the org flag so the `tax` field is populated on the billing context only when needed. |
| server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts | Correct logic change but `const wantsAutoTax` is missing its leading indentation (column 0 inside a function body). |
| MIGRATIONS_FIX_TARGET_LIMIT.md | Developer investigation notes file accidentally committed; contains a personal local path and acknowledges a missing migration for `target_limit` without including the fix. |
| server/tests/integration/billing/tax/automatic-tax-no-address-error.test.ts | Test updated from "must error" to "must succeed without tax"; depends on `migration_runs.target_limit` column that has no accompanying migration in this PR. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Billing operation triggered] --> B{org.config.automatic_tax?}
    B -- No --> Z[automatic_tax disabled]
    B -- Yes --> C[Fetch Stripe customer with expandTax=true]
    C --> D{billingContext.invoiceMode?}
    D -- Yes --> Z
    D -- No --> E{customerHasUsableTaxLocationForStripeTax}
    E --> F{stripeCustomer.tax.automatic_tax present?}
    F -- Yes --> G{status in supported / not_collecting?}
    G -- Yes --> Y[automatic_tax enabled on Stripe call]
    G -- No --> Z
    F -- No --> H{address.country OR shipping.address.country?}
    H -- Yes --> Y
    H -- No --> Z
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts:139-142
`const wantsAutoTax` is missing its leading tab, placing it at column 0 inside the function body. The surrounding lines are all indented, making this visually jarring and inconsistent with `createStripeSub2.ts` where the same pattern is correctly indented.

```suggestion
	const wantsAutoTax =
		!!org.config.automatic_tax &&
		!attachParams.invoiceOnly &&
		customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
```

### Issue 2 of 2
MIGRATIONS_FIX_TARGET_LIMIT.md:1-9
**Dev investigation notes accidentally committed**

This file is developer investigation notes, not project documentation. It includes a hardcoded personal local path (`/Users/amianthus/.superset/worktrees/...`) and manual SQL commands run against a dev database. The "Follow-up Needed" section also notes that a proper migration for `migration_runs.target_limit` was never created — without it, any other developer (or CI) that runs the new integration test will hit the same `column target_limit does not exist` error. The file should be removed and the missing migration should be created and checked in instead.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1699 from useautumn/..."](https://github.com/useautumn/autumn/commit/86f0b0a399da7f1146cda3ca0acc66650ce18668) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33486693)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->