### PR TITLE
fix: list entities docs

### DIFF
--- a/apps/docs/mintlify/api-reference/entities/listEntities.mdx
+++ b/apps/docs/mintlify/api-reference/entities/listEntities.mdx
@@ -39,6 +39,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
   Filter by parent customer processor type (stripe, revenuecat, vercel).
 </DynamicParamField>
 
+<DynamicParamField body="customer_id" type="string">
+  Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get.
+</DynamicParamField>
+
 
 ### Response
 

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -17999,6 +17999,12 @@ paths:
                     type: string
                   description: Filter by parent customer processor type (stripe, revenuecat,
                     vercel).
+                customer_id:
+                  type: string
+                  minLength: 1
+                  description: Restrict the response to entities owned by this customer id. Use to
+                    bulk-fetch all entities for one customer in a single
+                    paginated call instead of iterating entities.get.
               title: ListEntitiesParams
               examples:
                 - &a65

--- a/others/python-sdk/.speakeasy/gen.lock
+++ b/others/python-sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 05940b80-1ef8-40f4-9878-822fb2792070
 management:
-  docChecksum: f7445cb18c3f49c563032c18efee5a5e
+  docChecksum: 0a2c575dd30c36f09f8c1a23ebf69639
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.4.18
   configChecksum: 2263d20254e354a1792248274002f650
 persistentEdits:
-  generation_id: e37d7642-1d8b-4556-bb09-4e747cc0ecaf
-  pristine_commit_hash: aef17ce6561fe32d616dbb634223326f7aaee97f
-  pristine_tree_hash: c4c3e69e2fa148b268b701bbf97cf7c7d57bf3a0
+  generation_id: 7177ce98-81f4-45b3-8ff2-b046c8360f07
+  pristine_commit_hash: a014e9ab83701e9f7976471f13f23c4fc38084d4
+  pristine_tree_hash: c589be051703c82af0e9ba8af9d86a392b1e8b48
 features:
   python:
     additionalDependencies: 1.0.0
@@ -2049,8 +2049,8 @@ trackedFiles:
     pristine_git_object: 0d6ca7bd4d0aff01cfbb4b2d81703523d24b1e6e
   docs/models/listentitiesparams.md:
     id: a98fa41dacb7
-    last_write_checksum: sha1:92519d46339ac94f703fab562a52d26eb4b52cc1
-    pristine_git_object: 0fa5a5d8ee0d78889fb2049b2fe6c69632848b29
+    last_write_checksum: sha1:63179c73ff1e654f25b6a653706ace3ea7181c8e
+    pristine_git_object: 347a05bfd65517b8667f37b6cfa7ffb8adc346db
   docs/models/listentitiesplan.md:
     id: 35b85f6fd4b3
     last_write_checksum: sha1:fa8c2a8ef01dfe81b72c9103d38db67585ac55ae
@@ -4141,8 +4141,8 @@ trackedFiles:
     pristine_git_object: 45bb7e0da6bc397921f731c45f2a8bb8e1ecc664
   docs/sdks/entities/README.md:
     id: a140ac5181b9
-    last_write_checksum: sha1:ce657711d3d6ba38e92cd3d96964248dffafbabe
-    pristine_git_object: 51e73e75e6156f7471111069d2a84223089dd56e
+    last_write_checksum: sha1:ab85b1f4eb774ba87a36f850732043a4c03bba0a
+    pristine_git_object: 011261888d5a845d108a17b70893a23eadef04fe
   docs/sdks/events/README.md:
     id: cf45a4390b9b
     last_write_checksum: sha1:2291068c2b8ae415d71094b02d38cdac7ad83284
@@ -4217,8 +4217,8 @@ trackedFiles:
     pristine_git_object: aaf9171b48544d4e5039a9a210a67350bf2a8e71
   src/autumn_sdk/entities.py:
     id: 32ba2aa0874c
-    last_write_checksum: sha1:ced8d05bea86e3c180b1247bd3bbb6c72ed6c2f8
-    pristine_git_object: 8b05ef6046e2704c45a50c5149774c0aacaa552c
+    last_write_checksum: sha1:edbf5fd1fcd7d3ba91b86880d0badb2ef7cdd1f5
+    pristine_git_object: f1462f80caff8fa59f2a55f24d7370166d4923a6
   src/autumn_sdk/errors/__init__.py:
     id: 242853123cf2
     last_write_checksum: sha1:1c4f4e0181a6598b531c2621340548b003df6e2a
@@ -4369,8 +4369,8 @@ trackedFiles:
     pristine_git_object: efb7ae861ed3c85269dea269465c198119fe37fe
   src/autumn_sdk/models/listentitiesop.py:
     id: 918a05430967
-    last_write_checksum: sha1:dbcc46f4782eab84662ba8426cadecdae7473927
-    pristine_git_object: 7fe4e89b0d9c2a6cb6df185e6f0fc995687a4f97
+    last_write_checksum: sha1:449f3fb97195ee88ead6093f6f2b2e05798d5d7b
+    pristine_git_object: b2cdd998afdeb5dfdc83210df15f9df4fa5e9ab2
   src/autumn_sdk/models/listeventsop.py:
     id: 751b0200d91d
     last_write_checksum: sha1:a57b8d56c96c341e8572b4395c12209a62ff6b74

--- a/others/python-sdk/src/autumn_sdk/entities.py
+++ b/others/python-sdk/src/autumn_sdk/entities.py
@@ -446,6 +446,7 @@ class Entities(BaseSDK):
         subscription_status: Optional[models.ListEntitiesSubscriptionStatus] = None,
         search: Optional[str] = None,
         processors: Optional[List[models.ListEntitiesProcessor]] = None,
+        customer_id: Optional[str] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
@@ -461,6 +462,7 @@ class Entities(BaseSDK):
         :param subscription_status: Filter customer products used for entity hydration and plan matching. Defaults to active and scheduled.
         :param search: Search entities by id or name.
         :param processors: Filter by parent customer processor type (stripe, revenuecat, vercel).
+        :param customer_id: Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -485,6 +487,7 @@ class Entities(BaseSDK):
             subscription_status=subscription_status,
             search=search,
             processors=processors,
+            customer_id=customer_id,
         )
 
         req = self._build_request(
@@ -557,6 +560,7 @@ class Entities(BaseSDK):
         subscription_status: Optional[models.ListEntitiesSubscriptionStatus] = None,
         search: Optional[str] = None,
         processors: Optional[List[models.ListEntitiesProcessor]] = None,
+        customer_id: Optional[str] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
@@ -572,6 +576,7 @@ class Entities(BaseSDK):
         :param subscription_status: Filter customer products used for entity hydration and plan matching. Defaults to active and scheduled.
         :param search: Search entities by id or name.
         :param processors: Filter by parent customer processor type (stripe, revenuecat, vercel).
+        :param customer_id: Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -596,6 +601,7 @@ class Entities(BaseSDK):
             subscription_status=subscription_status,
             search=search,
             processors=processors,
+            customer_id=customer_id,
         )
 
         req = self._build_request_async(

--- a/others/python-sdk/src/autumn_sdk/models/listentitiesop.py
+++ b/others/python-sdk/src/autumn_sdk/models/listentitiesop.py
@@ -100,6 +100,8 @@ class ListEntitiesParamsTypedDict(TypedDict):
     r"""Search entities by id or name."""
     processors: NotRequired[List[ListEntitiesProcessor]]
     r"""Filter by parent customer processor type (stripe, revenuecat, vercel)."""
+    customer_id: NotRequired[str]
+    r"""Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get."""
 
 
 class ListEntitiesParams(BaseModel):
@@ -121,6 +123,9 @@ class ListEntitiesParams(BaseModel):
     processors: Optional[List[ListEntitiesProcessor]] = None
     r"""Filter by parent customer processor type (stripe, revenuecat, vercel)."""
 
+    customer_id: Optional[str] = None
+    r"""Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = set(
@@ -131,6 +136,7 @@ class ListEntitiesParams(BaseModel):
                 "subscription_status",
                 "search",
                 "processors",
+                "customer_id",
             ]
         )
         serialized = handler(self)

--- a/packages/autumn-js/src/generated/aggregateEventsSchemas.ts
+++ b/packages/autumn-js/src/generated/aggregateEventsSchemas.ts
@@ -2,49 +2,64 @@
 import { z } from "zod/v4";
 
 export const aggregateEventsGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
-export const aggregateEventsFeatureIdSchema = z.union([z.string(), z.array(z.string())]);
+export const aggregateEventsFeatureIdSchema = z.union([
+	z.string(),
+	z.array(z.string()),
+]);
 
 export const aggregateEventsCustomRangeSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const aggregateEventsListSchema = z.object({
-    period: z.number(),
-    values: z.record(z.string(), z.number()),
-    groupedValues: z.union([z.record(z.string(), z.record(z.string(), z.number())), z.undefined()]).optional()
+	period: z.number(),
+	values: z.record(z.string(), z.number()),
+	groupedValues: z
+		.union([
+			z.record(z.string(), z.record(z.string(), z.number())),
+			z.undefined(),
+		])
+		.optional(),
 });
 
 export const totalSchema = z.object({
-    count: z.number(),
-    sum: z.number()
+	count: z.number(),
+	sum: z.number(),
 });
 
 export const aggregateEventsResponseSchema = z.object({
-    list: z.array(aggregateEventsListSchema),
-    total: z.record(z.string(), totalSchema)
+	list: z.array(aggregateEventsListSchema),
+	total: z.record(z.string(), totalSchema),
 });
 
-export const aggregateEventsFeatureIdOutboundSchema = z.union([z.string(), z.array(z.string())]);
+export const aggregateEventsFeatureIdOutboundSchema = z.union([
+	z.string(),
+	z.array(z.string()),
+]);
 
 export const aggregateEventsCustomRangeOutboundSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const eventsAggregateParamsOutboundSchema = z.object({
-    customer_id: z.union([z.string(), z.undefined()]).optional(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    feature_id: z.union([z.string(), z.array(z.string())]),
-    group_by: z.union([z.string(), z.undefined()]).optional(),
-    range: z.union([z.string(), z.undefined()]).optional(),
-    bin_size: z.string(),
-    custom_range: z.union([aggregateEventsCustomRangeOutboundSchema, z.undefined()]).optional(),
-    filter_by: z.union([z.record(z.string(), z.string()), z.undefined()]).optional(),
-    max_groups: z.union([z.number(), z.undefined()]).optional()
+	customer_id: z.union([z.string(), z.undefined()]).optional(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	feature_id: z.union([z.string(), z.array(z.string())]),
+	group_by: z.union([z.string(), z.undefined()]).optional(),
+	range: z.union([z.string(), z.undefined()]).optional(),
+	bin_size: z.string(),
+	custom_range: z
+		.union([aggregateEventsCustomRangeOutboundSchema, z.undefined()])
+		.optional(),
+	filter_by: z
+		.union([z.record(z.string(), z.string()), z.undefined()])
+		.optional(),
+	max_groups: z.union([z.number(), z.undefined()]).optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -54,13 +69,17 @@ export const rangeSchema = closedEnumSchema;
 export const binSizeSchema = closedEnumSchema;
 
 export const eventsAggregateParamsSchema = z.object({
-    customerId: z.union([z.string(), z.undefined()]).optional(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    featureId: z.union([z.string(), z.array(z.string())]),
-    groupBy: z.union([z.string(), z.undefined()]).optional(),
-    range: z.union([rangeSchema, z.undefined()]).optional(),
-    binSize: z.union([binSizeSchema, z.undefined()]).optional(),
-    customRange: z.union([aggregateEventsCustomRangeSchema, z.undefined()]).optional(),
-    filterBy: z.union([z.record(z.string(), z.string()), z.undefined()]).optional(),
-    maxGroups: z.union([z.number(), z.undefined()]).optional()
+	customerId: z.union([z.string(), z.undefined()]).optional(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	featureId: z.union([z.string(), z.array(z.string())]),
+	groupBy: z.union([z.string(), z.undefined()]).optional(),
+	range: z.union([rangeSchema, z.undefined()]).optional(),
+	binSize: z.union([binSizeSchema, z.undefined()]).optional(),
+	customRange: z
+		.union([aggregateEventsCustomRangeSchema, z.undefined()])
+		.optional(),
+	filterBy: z
+		.union([z.record(z.string(), z.string()), z.undefined()])
+		.optional(),
+	maxGroups: z.union([z.number(), z.undefined()]).optional(),
 });

--- a/packages/autumn-js/src/generated/attachSchemas.ts
+++ b/packages/autumn-js/src/generated/attachSchemas.ts
@@ -2,243 +2,283 @@
 import { z } from "zod/v4";
 
 export const attachGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const attachFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const attachItemToSchema = z.union([z.number(), z.string()]);
 
 export const attachItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAddItemToSchema = z.union([z.number(), z.string()]);
 
 export const attachAddItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachInvoiceModeSchema = z.object({
-    enabled: z.boolean(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    finalize: z.union([z.boolean(), z.undefined()]).optional()
+	enabled: z.boolean(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	finalize: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const attachAttachDiscountSchema = z.object({
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    promotionCode: z.union([z.string(), z.undefined()]).optional()
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	promotionCode: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const attachCustomLineItemSchema = z.object({
-    amount: z.number(),
-    description: z.string()
+	amount: z.number(),
+	description: z.string(),
 });
 
 export const attachCarryOverBalancesSchema = z.object({
-    enabled: z.boolean(),
-    featureIds: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	featureIds: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const attachCarryOverUsagesSchema = z.object({
-    enabled: z.boolean(),
-    featureIds: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	featureIds: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const attachInvoiceSchema = z.object({
-    status: z.string().nullable(),
-    stripeId: z.string(),
-    total: z.number(),
-    currency: z.string(),
-    hostedInvoiceUrl: z.string().nullable()
+	status: z.string().nullable(),
+	stripeId: z.string(),
+	total: z.number(),
+	currency: z.string(),
+	hostedInvoiceUrl: z.string().nullable(),
 });
 
 export const attachFeatureQuantityOutboundSchema = z.object({
-    feature_id: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	feature_id: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const attachBasePriceOutboundSchema = z.object({
-    amount: z.number(),
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemToOutboundSchema = z.union([z.number(), z.string()]);
 
 export const attachItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(attachItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(attachItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const attachItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([attachItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([attachItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([attachItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([attachItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([attachItemResetOutboundSchema, z.undefined()]).optional(),
+	price: z.union([attachItemPriceOutboundSchema, z.undefined()]).optional(),
+	proration: z
+		.union([attachItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([attachItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const attachAddItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAddItemToOutboundSchema = z.union([z.number(), z.string()]);
 
 export const attachAddItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAddItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(attachAddItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(attachAddItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAddItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const attachAddItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAddItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([attachAddItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([attachAddItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([attachAddItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([attachAddItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([attachAddItemResetOutboundSchema, z.undefined()]).optional(),
+	price: z.union([attachAddItemPriceOutboundSchema, z.undefined()]).optional(),
+	proration: z
+		.union([attachAddItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([attachAddItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const attachPlanItemFilterOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    billing_method: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.union([z.string(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	billing_method: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const attachFreeTrialParamsOutboundSchema = z.object({
-    duration_length: z.number(),
-    duration_type: z.string(),
-    card_required: z.boolean(),
-    on_end: z.union([z.string(), z.undefined()]).optional()
+	duration_length: z.number(),
+	duration_type: z.string(),
+	card_required: z.boolean(),
+	on_end: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const attachCustomizeOutboundSchema = z.object({
-    price: z.union([attachBasePriceOutboundSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(attachItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    add_items: z.union([z.array(attachAddItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    remove_items: z.union([z.array(attachPlanItemFilterOutboundSchema), z.undefined()]).optional(),
-    free_trial: z.union([attachFreeTrialParamsOutboundSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([attachBasePriceOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(attachItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	add_items: z
+		.union([z.array(attachAddItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	remove_items: z
+		.union([z.array(attachPlanItemFilterOutboundSchema), z.undefined()])
+		.optional(),
+	free_trial: z
+		.union([attachFreeTrialParamsOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const attachInvoiceModeOutboundSchema = z.object({
-    enabled: z.boolean(),
-    enable_plan_immediately: z.boolean(),
-    finalize: z.boolean()
+	enabled: z.boolean(),
+	enable_plan_immediately: z.boolean(),
+	finalize: z.boolean(),
 });
 
 export const attachAttachDiscountOutboundSchema = z.object({
-    reward_id: z.union([z.string(), z.undefined()]).optional(),
-    promotion_code: z.union([z.string(), z.undefined()]).optional()
+	reward_id: z.union([z.string(), z.undefined()]).optional(),
+	promotion_code: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const attachCustomLineItemOutboundSchema = z.object({
-    amount: z.number(),
-    description: z.string()
+	amount: z.number(),
+	description: z.string(),
 });
 
 export const attachCarryOverBalancesOutboundSchema = z.object({
-    enabled: z.boolean(),
-    feature_ids: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	feature_ids: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const attachCarryOverUsagesOutboundSchema = z.object({
-    enabled: z.boolean(),
-    feature_ids: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	feature_ids: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const attachParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    plan_id: z.string(),
-    feature_quantities: z.union([z.array(attachFeatureQuantityOutboundSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([attachCustomizeOutboundSchema, z.undefined()]).optional(),
-    invoice_mode: z.union([attachInvoiceModeOutboundSchema, z.undefined()]).optional(),
-    proration_behavior: z.union([z.string(), z.undefined()]).optional(),
-    redirect_mode: z.string(),
-    subscription_id: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(attachAttachDiscountOutboundSchema), z.undefined()]).optional(),
-    success_url: z.union([z.string(), z.undefined()]).optional(),
-    new_billing_subscription: z.union([z.boolean(), z.undefined()]).optional(),
-    billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    plan_schedule: z.union([z.string(), z.undefined()]).optional(),
-    starts_at: z.union([z.number(), z.undefined()]).optional(),
-    ends_at: z.union([z.number(), z.undefined()]).optional(),
-    checkout_session_params: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    custom_line_items: z.union([z.array(attachCustomLineItemOutboundSchema), z.undefined()]).optional(),
-    processor_subscription_id: z.union([z.string(), z.undefined()]).optional(),
-    carry_over_balances: z.union([attachCarryOverBalancesOutboundSchema, z.undefined()]).optional(),
-    carry_over_usages: z.union([attachCarryOverUsagesOutboundSchema, z.undefined()]).optional(),
-    metadata: z.union([z.record(z.string(), z.string()), z.undefined()]).optional(),
-    no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
-    enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
-    tax_rate_id: z.union([z.string(), z.undefined()]).optional()
+	customer_id: z.string(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	plan_id: z.string(),
+	feature_quantities: z
+		.union([z.array(attachFeatureQuantityOutboundSchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z.union([attachCustomizeOutboundSchema, z.undefined()]).optional(),
+	invoice_mode: z
+		.union([attachInvoiceModeOutboundSchema, z.undefined()])
+		.optional(),
+	proration_behavior: z.union([z.string(), z.undefined()]).optional(),
+	redirect_mode: z.string(),
+	subscription_id: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(attachAttachDiscountOutboundSchema), z.undefined()])
+		.optional(),
+	success_url: z.union([z.string(), z.undefined()]).optional(),
+	new_billing_subscription: z.union([z.boolean(), z.undefined()]).optional(),
+	billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	plan_schedule: z.union([z.string(), z.undefined()]).optional(),
+	starts_at: z.union([z.number(), z.undefined()]).optional(),
+	ends_at: z.union([z.number(), z.undefined()]).optional(),
+	checkout_session_params: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	custom_line_items: z
+		.union([z.array(attachCustomLineItemOutboundSchema), z.undefined()])
+		.optional(),
+	processor_subscription_id: z.union([z.string(), z.undefined()]).optional(),
+	carry_over_balances: z
+		.union([attachCarryOverBalancesOutboundSchema, z.undefined()])
+		.optional(),
+	carry_over_usages: z
+		.union([attachCarryOverUsagesOutboundSchema, z.undefined()])
+		.optional(),
+	metadata: z
+		.union([z.record(z.string(), z.string()), z.undefined()])
+		.optional(),
+	no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
+	enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
+	tax_rate_id: z.union([z.string(), z.undefined()]).optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -248,16 +288,16 @@ const openEnumSchema = z.any();
 export const attachPriceIntervalSchema = closedEnumSchema;
 
 export const attachBasePriceSchema = z.object({
-    amount: z.number(),
-    interval: attachPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: attachPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemResetIntervalSchema = closedEnumSchema;
 
 export const attachItemResetSchema = z.object({
-    interval: attachItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: attachItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemTierBehaviorSchema = closedEnumSchema;
@@ -267,14 +307,16 @@ export const attachItemPriceIntervalSchema = closedEnumSchema;
 export const attachItemBillingMethodSchema = closedEnumSchema;
 
 export const attachItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(attachItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([attachItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: attachItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: attachItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z.union([z.array(attachItemTierSchema), z.undefined()]).optional(),
+	tierBehavior: z
+		.union([attachItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: attachItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: attachItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemOnIncreaseSchema = closedEnumSchema;
@@ -282,34 +324,34 @@ export const attachItemOnIncreaseSchema = closedEnumSchema;
 export const attachItemOnDecreaseSchema = closedEnumSchema;
 
 export const attachItemProrationSchema = z.object({
-    onIncrease: attachItemOnIncreaseSchema,
-    onDecrease: attachItemOnDecreaseSchema
+	onIncrease: attachItemOnIncreaseSchema,
+	onDecrease: attachItemOnDecreaseSchema,
 });
 
 export const attachItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const attachItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: attachItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: attachItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([attachItemResetSchema, z.undefined()]).optional(),
-    price: z.union([attachItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([attachItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([attachItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([attachItemResetSchema, z.undefined()]).optional(),
+	price: z.union([attachItemPriceSchema, z.undefined()]).optional(),
+	proration: z.union([attachItemProrationSchema, z.undefined()]).optional(),
+	rollover: z.union([attachItemRolloverSchema, z.undefined()]).optional(),
 });
 
 export const attachAddItemResetIntervalSchema = closedEnumSchema;
 
 export const attachAddItemResetSchema = z.object({
-    interval: attachAddItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: attachAddItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAddItemTierBehaviorSchema = closedEnumSchema;
@@ -319,14 +361,16 @@ export const attachAddItemPriceIntervalSchema = closedEnumSchema;
 export const attachAddItemBillingMethodSchema = closedEnumSchema;
 
 export const attachAddItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(attachAddItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([attachAddItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: attachAddItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: attachAddItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z.union([z.array(attachAddItemTierSchema), z.undefined()]).optional(),
+	tierBehavior: z
+		.union([attachAddItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: attachAddItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: attachAddItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAddItemOnIncreaseSchema = closedEnumSchema;
@@ -334,27 +378,27 @@ export const attachAddItemOnIncreaseSchema = closedEnumSchema;
 export const attachAddItemOnDecreaseSchema = closedEnumSchema;
 
 export const attachAddItemProrationSchema = z.object({
-    onIncrease: attachAddItemOnIncreaseSchema,
-    onDecrease: attachAddItemOnDecreaseSchema
+	onIncrease: attachAddItemOnIncreaseSchema,
+	onDecrease: attachAddItemOnDecreaseSchema,
 });
 
 export const attachAddItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const attachAddItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: attachAddItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: attachAddItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const attachAddItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([attachAddItemResetSchema, z.undefined()]).optional(),
-    price: z.union([attachAddItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([attachAddItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([attachAddItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([attachAddItemResetSchema, z.undefined()]).optional(),
+	price: z.union([attachAddItemPriceSchema, z.undefined()]).optional(),
+	proration: z.union([attachAddItemProrationSchema, z.undefined()]).optional(),
+	rollover: z.union([attachAddItemRolloverSchema, z.undefined()]).optional(),
 });
 
 export const attachRemoveItemBillingMethodSchema = closedEnumSchema;
@@ -362,9 +406,11 @@ export const attachRemoveItemBillingMethodSchema = closedEnumSchema;
 export const attachRemoveItemIntervalSchema = closedEnumSchema;
 
 export const attachPlanItemFilterSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    billingMethod: z.union([attachRemoveItemBillingMethodSchema, z.undefined()]).optional(),
-    interval: z.union([attachRemoveItemIntervalSchema, z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	billingMethod: z
+		.union([attachRemoveItemBillingMethodSchema, z.undefined()])
+		.optional(),
+	interval: z.union([attachRemoveItemIntervalSchema, z.undefined()]).optional(),
 });
 
 export const attachDurationTypeSchema = closedEnumSchema;
@@ -372,18 +418,25 @@ export const attachDurationTypeSchema = closedEnumSchema;
 export const attachOnEndSchema = closedEnumSchema;
 
 export const attachFreeTrialParamsSchema = z.object({
-    durationLength: z.number(),
-    durationType: z.union([attachDurationTypeSchema, z.undefined()]).optional(),
-    cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
-    onEnd: z.union([attachOnEndSchema, z.undefined()]).optional()
+	durationLength: z.number(),
+	durationType: z.union([attachDurationTypeSchema, z.undefined()]).optional(),
+	cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
+	onEnd: z.union([attachOnEndSchema, z.undefined()]).optional(),
 });
 
 export const attachCustomizeSchema = z.object({
-    price: z.union([attachBasePriceSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(attachItemPlanItemSchema), z.undefined()]).optional(),
-    addItems: z.union([z.array(attachAddItemPlanItemSchema), z.undefined()]).optional(),
-    removeItems: z.union([z.array(attachPlanItemFilterSchema), z.undefined()]).optional(),
-    freeTrial: z.union([attachFreeTrialParamsSchema, z.undefined()]).optional().nullable()
+	price: z.union([attachBasePriceSchema, z.undefined()]).optional().nullable(),
+	items: z.union([z.array(attachItemPlanItemSchema), z.undefined()]).optional(),
+	addItems: z
+		.union([z.array(attachAddItemPlanItemSchema), z.undefined()])
+		.optional(),
+	removeItems: z
+		.union([z.array(attachPlanItemFilterSchema), z.undefined()])
+		.optional(),
+	freeTrial: z
+		.union([attachFreeTrialParamsSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const attachProrationBehaviorSchema = closedEnumSchema;
@@ -393,45 +446,63 @@ export const attachRedirectModeSchema = closedEnumSchema;
 export const attachPlanScheduleSchema = closedEnumSchema;
 
 export const attachParamsSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    planId: z.string(),
-    featureQuantities: z.union([z.array(attachFeatureQuantitySchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([attachCustomizeSchema, z.undefined()]).optional(),
-    invoiceMode: z.union([attachInvoiceModeSchema, z.undefined()]).optional(),
-    prorationBehavior: z.union([attachProrationBehaviorSchema, z.undefined()]).optional(),
-    redirectMode: z.union([attachRedirectModeSchema, z.undefined()]).optional(),
-    subscriptionId: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(attachAttachDiscountSchema), z.undefined()]).optional(),
-    successUrl: z.union([z.string(), z.undefined()]).optional(),
-    newBillingSubscription: z.union([z.boolean(), z.undefined()]).optional(),
-    billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    planSchedule: z.union([attachPlanScheduleSchema, z.undefined()]).optional(),
-    startsAt: z.union([z.number(), z.undefined()]).optional(),
-    endsAt: z.union([z.number(), z.undefined()]).optional(),
-    checkoutSessionParams: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    customLineItems: z.union([z.array(attachCustomLineItemSchema), z.undefined()]).optional(),
-    processorSubscriptionId: z.union([z.string(), z.undefined()]).optional(),
-    carryOverBalances: z.union([attachCarryOverBalancesSchema, z.undefined()]).optional(),
-    carryOverUsages: z.union([attachCarryOverUsagesSchema, z.undefined()]).optional(),
-    metadata: z.union([z.record(z.string(), z.string()), z.undefined()]).optional(),
-    noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    taxRateId: z.union([z.string(), z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	planId: z.string(),
+	featureQuantities: z
+		.union([z.array(attachFeatureQuantitySchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z.union([attachCustomizeSchema, z.undefined()]).optional(),
+	invoiceMode: z.union([attachInvoiceModeSchema, z.undefined()]).optional(),
+	prorationBehavior: z
+		.union([attachProrationBehaviorSchema, z.undefined()])
+		.optional(),
+	redirectMode: z.union([attachRedirectModeSchema, z.undefined()]).optional(),
+	subscriptionId: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(attachAttachDiscountSchema), z.undefined()])
+		.optional(),
+	successUrl: z.union([z.string(), z.undefined()]).optional(),
+	newBillingSubscription: z.union([z.boolean(), z.undefined()]).optional(),
+	billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	planSchedule: z.union([attachPlanScheduleSchema, z.undefined()]).optional(),
+	startsAt: z.union([z.number(), z.undefined()]).optional(),
+	endsAt: z.union([z.number(), z.undefined()]).optional(),
+	checkoutSessionParams: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	customLineItems: z
+		.union([z.array(attachCustomLineItemSchema), z.undefined()])
+		.optional(),
+	processorSubscriptionId: z.union([z.string(), z.undefined()]).optional(),
+	carryOverBalances: z
+		.union([attachCarryOverBalancesSchema, z.undefined()])
+		.optional(),
+	carryOverUsages: z
+		.union([attachCarryOverUsagesSchema, z.undefined()])
+		.optional(),
+	metadata: z
+		.union([z.record(z.string(), z.string()), z.undefined()])
+		.optional(),
+	noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	taxRateId: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const attachCodeSchema = openEnumSchema;
 
 export const attachRequiredActionSchema = z.object({
-    code: attachCodeSchema,
-    reason: z.string()
+	code: attachCodeSchema,
+	reason: z.string(),
 });
 
 export const attachResponseSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    invoice: z.union([attachInvoiceSchema, z.undefined()]).optional(),
-    paymentUrl: z.string().nullable(),
-    requiredAction: z.union([attachRequiredActionSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	invoice: z.union([attachInvoiceSchema, z.undefined()]).optional(),
+	paymentUrl: z.string().nullable(),
+	requiredAction: z
+		.union([attachRequiredActionSchema, z.undefined()])
+		.optional(),
 });

--- a/packages/autumn-js/src/generated/createReferralCodeSchemas.ts
+++ b/packages/autumn-js/src/generated/createReferralCodeSchemas.ts
@@ -2,21 +2,21 @@
 import { z } from "zod/v4";
 
 export const createReferralCodeGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const createReferralCodeParamsSchema = z.object({
-    customerId: z.string(),
-    programId: z.string()
+	customerId: z.string(),
+	programId: z.string(),
 });
 
 export const createReferralCodeResponseSchema = z.object({
-    code: z.string(),
-    customerId: z.string(),
-    createdAt: z.number()
+	code: z.string(),
+	customerId: z.string(),
+	createdAt: z.number(),
 });
 
 export const createReferralCodeParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    program_id: z.string()
+	customer_id: z.string(),
+	program_id: z.string(),
 });

--- a/packages/autumn-js/src/generated/getOrCreateCustomerSchemas.ts
+++ b/packages/autumn-js/src/generated/getOrCreateCustomerSchemas.ts
@@ -2,82 +2,108 @@
 import { z } from "zod/v4";
 
 export const getOrCreateCustomerGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerSpendLimitSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional(),
-    overageLimit: z.union([z.number(), z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
+	overageLimit: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerOverageAllowedSchema = z.object({
-    featureId: z.string(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerConfigSchema = z.object({
-    disablePooledBalance: z.union([z.boolean(), z.undefined()]).optional()
+	disablePooledBalance: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerPurchaseLimitOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.number(),
-    limit: z.number()
+	interval: z.string(),
+	interval_count: z.number(),
+	limit: z.number(),
 });
 
 export const getOrCreateCustomerAutoTopupOutboundSchema = z.object({
-    feature_id: z.string(),
-    enabled: z.boolean(),
-    threshold: z.number(),
-    quantity: z.number(),
-    purchase_limit: z.union([getOrCreateCustomerPurchaseLimitOutboundSchema, z.undefined()]).optional(),
-    invoice_mode: z.union([z.boolean(), z.undefined()]).optional()
+	feature_id: z.string(),
+	enabled: z.boolean(),
+	threshold: z.number(),
+	quantity: z.number(),
+	purchase_limit: z
+		.union([getOrCreateCustomerPurchaseLimitOutboundSchema, z.undefined()])
+		.optional(),
+	invoice_mode: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerSpendLimitOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.boolean(),
-    overage_limit: z.union([z.number(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.boolean(),
+	overage_limit: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerUsageAlertOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.boolean(),
-    threshold: z.number(),
-    threshold_type: z.string(),
-    name: z.union([z.string(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.boolean(),
+	threshold: z.number(),
+	threshold_type: z.string(),
+	name: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerOverageAllowedOutboundSchema = z.object({
-    feature_id: z.string(),
-    enabled: z.boolean()
+	feature_id: z.string(),
+	enabled: z.boolean(),
 });
 
 export const getOrCreateCustomerBillingControlsOutboundSchema = z.object({
-    auto_topups: z.union([z.array(getOrCreateCustomerAutoTopupOutboundSchema), z.undefined()]).optional(),
-    spend_limits: z.union([z.array(getOrCreateCustomerSpendLimitOutboundSchema), z.undefined()]).optional(),
-    usage_alerts: z.union([z.array(getOrCreateCustomerUsageAlertOutboundSchema), z.undefined()]).optional(),
-    overage_allowed: z.union([z.array(getOrCreateCustomerOverageAllowedOutboundSchema), z.undefined()]).optional()
+	auto_topups: z
+		.union([z.array(getOrCreateCustomerAutoTopupOutboundSchema), z.undefined()])
+		.optional(),
+	spend_limits: z
+		.union([
+			z.array(getOrCreateCustomerSpendLimitOutboundSchema),
+			z.undefined(),
+		])
+		.optional(),
+	usage_alerts: z
+		.union([
+			z.array(getOrCreateCustomerUsageAlertOutboundSchema),
+			z.undefined(),
+		])
+		.optional(),
+	overage_allowed: z
+		.union([
+			z.array(getOrCreateCustomerOverageAllowedOutboundSchema),
+			z.undefined(),
+		])
+		.optional(),
 });
 
 export const getOrCreateCustomerConfigOutboundSchema = z.object({
-    disable_pooled_balance: z.union([z.boolean(), z.undefined()]).optional()
+	disable_pooled_balance: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerParamsOutboundSchema = z.object({
-    customer_id: z.string().nullable(),
-    name: z.union([z.string(), z.undefined()]).optional().nullable(),
-    email: z.union([z.string(), z.undefined()]).optional().nullable(),
-    fingerprint: z.union([z.string(), z.undefined()]).optional().nullable(),
-    metadata: z.union([z.record(z.string(), z.any()), z.undefined()]).optional().nullable(),
-    stripe_id: z.union([z.string(), z.undefined()]).optional().nullable(),
-    create_in_stripe: z.union([z.boolean(), z.undefined()]).optional(),
-    auto_enable_plan_id: z.union([z.string(), z.undefined()]).optional(),
-    send_email_receipts: z.union([z.boolean(), z.undefined()]).optional(),
-    billing_controls: z.union([getOrCreateCustomerBillingControlsOutboundSchema, z.undefined()]).optional(),
-    config: z.union([getOrCreateCustomerConfigOutboundSchema, z.undefined()]).optional(),
-    expand: z.union([z.array(z.string()), z.undefined()]).optional()
+	customer_id: z.string().nullable(),
+	name: z.union([z.string(), z.undefined()]).optional().nullable(),
+	email: z.union([z.string(), z.undefined()]).optional().nullable(),
+	fingerprint: z.union([z.string(), z.undefined()]).optional().nullable(),
+	metadata: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional()
+		.nullable(),
+	stripe_id: z.union([z.string(), z.undefined()]).optional().nullable(),
+	create_in_stripe: z.union([z.boolean(), z.undefined()]).optional(),
+	auto_enable_plan_id: z.union([z.string(), z.undefined()]).optional(),
+	send_email_receipts: z.union([z.boolean(), z.undefined()]).optional(),
+	billing_controls: z
+		.union([getOrCreateCustomerBillingControlsOutboundSchema, z.undefined()])
+		.optional(),
+	config: z
+		.union([getOrCreateCustomerConfigOutboundSchema, z.undefined()])
+		.optional(),
+	expand: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -87,48 +113,63 @@ const customerExpandSchema = z.any();
 export const getOrCreateCustomerIntervalSchema = closedEnumSchema;
 
 export const getOrCreateCustomerPurchaseLimitSchema = z.object({
-    interval: getOrCreateCustomerIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    limit: z.number()
+	interval: getOrCreateCustomerIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	limit: z.number(),
 });
 
 export const getOrCreateCustomerAutoTopupSchema = z.object({
-    featureId: z.string(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional(),
-    threshold: z.number(),
-    quantity: z.number(),
-    purchaseLimit: z.union([getOrCreateCustomerPurchaseLimitSchema, z.undefined()]).optional(),
-    invoiceMode: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
+	threshold: z.number(),
+	quantity: z.number(),
+	purchaseLimit: z
+		.union([getOrCreateCustomerPurchaseLimitSchema, z.undefined()])
+		.optional(),
+	invoiceMode: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerThresholdTypeSchema = closedEnumSchema;
 
 export const getOrCreateCustomerUsageAlertSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional(),
-    threshold: z.number(),
-    thresholdType: getOrCreateCustomerThresholdTypeSchema,
-    name: z.union([z.string(), z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
+	threshold: z.number(),
+	thresholdType: getOrCreateCustomerThresholdTypeSchema,
+	name: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const getOrCreateCustomerBillingControlsSchema = z.object({
-    autoTopups: z.union([z.array(getOrCreateCustomerAutoTopupSchema), z.undefined()]).optional(),
-    spendLimits: z.union([z.array(getOrCreateCustomerSpendLimitSchema), z.undefined()]).optional(),
-    usageAlerts: z.union([z.array(getOrCreateCustomerUsageAlertSchema), z.undefined()]).optional(),
-    overageAllowed: z.union([z.array(getOrCreateCustomerOverageAllowedSchema), z.undefined()]).optional()
+	autoTopups: z
+		.union([z.array(getOrCreateCustomerAutoTopupSchema), z.undefined()])
+		.optional(),
+	spendLimits: z
+		.union([z.array(getOrCreateCustomerSpendLimitSchema), z.undefined()])
+		.optional(),
+	usageAlerts: z
+		.union([z.array(getOrCreateCustomerUsageAlertSchema), z.undefined()])
+		.optional(),
+	overageAllowed: z
+		.union([z.array(getOrCreateCustomerOverageAllowedSchema), z.undefined()])
+		.optional(),
 });
 
 export const getOrCreateCustomerParamsSchema = z.object({
-    customerId: z.string().nullable(),
-    name: z.union([z.string(), z.undefined()]).optional().nullable(),
-    email: z.union([z.string(), z.undefined()]).optional().nullable(),
-    fingerprint: z.union([z.string(), z.undefined()]).optional().nullable(),
-    metadata: z.union([z.record(z.string(), z.any()), z.undefined()]).optional().nullable(),
-    stripeId: z.union([z.string(), z.undefined()]).optional().nullable(),
-    createInStripe: z.union([z.boolean(), z.undefined()]).optional(),
-    autoEnablePlanId: z.union([z.string(), z.undefined()]).optional(),
-    sendEmailReceipts: z.union([z.boolean(), z.undefined()]).optional(),
-    billingControls: z.union([getOrCreateCustomerBillingControlsSchema, z.undefined()]).optional(),
-    config: z.union([getOrCreateCustomerConfigSchema, z.undefined()]).optional(),
-    expand: z.union([z.array(customerExpandSchema), z.undefined()]).optional()
+	customerId: z.string().nullable(),
+	name: z.union([z.string(), z.undefined()]).optional().nullable(),
+	email: z.union([z.string(), z.undefined()]).optional().nullable(),
+	fingerprint: z.union([z.string(), z.undefined()]).optional().nullable(),
+	metadata: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional()
+		.nullable(),
+	stripeId: z.union([z.string(), z.undefined()]).optional().nullable(),
+	createInStripe: z.union([z.boolean(), z.undefined()]).optional(),
+	autoEnablePlanId: z.union([z.string(), z.undefined()]).optional(),
+	sendEmailReceipts: z.union([z.boolean(), z.undefined()]).optional(),
+	billingControls: z
+		.union([getOrCreateCustomerBillingControlsSchema, z.undefined()])
+		.optional(),
+	config: z.union([getOrCreateCustomerConfigSchema, z.undefined()]).optional(),
+	expand: z.union([z.array(customerExpandSchema), z.undefined()]).optional(),
 });

--- a/packages/autumn-js/src/generated/index.ts
+++ b/packages/autumn-js/src/generated/index.ts
@@ -1,17 +1,17 @@
 // Generated schemas from Speakeasy SDK types
 // Run `bun api` to regenerate
 
-export * from "./getOrCreateCustomerSchemas";
-export * from "./attachSchemas";
-export * from "./previewAttachSchemas";
-export * from "./updateSubscriptionSchemas";
-export * from "./previewUpdateSubscriptionSchemas";
-export * from "./openCustomerPortalSchemas";
-export * from "./setupPaymentSchemas";
-export * from "./multiAttachSchemas";
-export * from "./previewMultiAttachSchemas";
-export * from "./listPlansSchemas";
-export * from "./listEventsSchemas";
 export * from "./aggregateEventsSchemas";
+export * from "./attachSchemas";
 export * from "./createReferralCodeSchemas";
+export * from "./getOrCreateCustomerSchemas";
+export * from "./listEventsSchemas";
+export * from "./listPlansSchemas";
+export * from "./multiAttachSchemas";
+export * from "./openCustomerPortalSchemas";
+export * from "./previewAttachSchemas";
+export * from "./previewMultiAttachSchemas";
+export * from "./previewUpdateSubscriptionSchemas";
 export * from "./redeemReferralCodeSchemas";
+export * from "./setupPaymentSchemas";
+export * from "./updateSubscriptionSchemas";

--- a/packages/autumn-js/src/generated/listEventsSchemas.ts
+++ b/packages/autumn-js/src/generated/listEventsSchemas.ts
@@ -2,72 +2,87 @@
 import { z } from "zod/v4";
 
 export const listEventsGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
-export const listEventsFeatureIdSchema = z.union([z.string(), z.array(z.string())]);
+export const listEventsFeatureIdSchema = z.union([
+	z.string(),
+	z.array(z.string()),
+]);
 
 export const listEventsCustomRangeSchema = z.object({
-    start: z.union([z.number(), z.undefined()]).optional(),
-    end: z.union([z.number(), z.undefined()]).optional()
+	start: z.union([z.number(), z.undefined()]).optional(),
+	end: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const eventsListParamsSchema = z.object({
-    startCursor: z.union([z.string(), z.undefined()]).optional(),
-    limit: z.union([z.number(), z.undefined()]).optional(),
-    customerId: z.union([z.string(), z.undefined()]).optional(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    featureId: z.union([z.string(), z.array(z.string()), z.undefined()]).optional(),
-    customRange: z.union([listEventsCustomRangeSchema, z.undefined()]).optional()
+	startCursor: z.union([z.string(), z.undefined()]).optional(),
+	limit: z.union([z.number(), z.undefined()]).optional(),
+	customerId: z.union([z.string(), z.undefined()]).optional(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	featureId: z
+		.union([z.string(), z.array(z.string()), z.undefined()])
+		.optional(),
+	customRange: z.union([listEventsCustomRangeSchema, z.undefined()]).optional(),
 });
 
-export const listEventsFeatureIdOutboundSchema = z.union([z.string(), z.array(z.string())]);
+export const listEventsFeatureIdOutboundSchema = z.union([
+	z.string(),
+	z.array(z.string()),
+]);
 
 export const listEventsCustomRangeOutboundSchema = z.object({
-    start: z.union([z.number(), z.undefined()]).optional(),
-    end: z.union([z.number(), z.undefined()]).optional()
+	start: z.union([z.number(), z.undefined()]).optional(),
+	end: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const eventsListParamsOutboundSchema = z.object({
-    start_cursor: z.string(),
-    limit: z.number(),
-    customer_id: z.union([z.string(), z.undefined()]).optional(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    feature_id: z.union([z.string(), z.array(z.string()), z.undefined()]).optional(),
-    custom_range: z.union([listEventsCustomRangeOutboundSchema, z.undefined()]).optional()
+	start_cursor: z.string(),
+	limit: z.number(),
+	customer_id: z.union([z.string(), z.undefined()]).optional(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	feature_id: z
+		.union([z.string(), z.array(z.string()), z.undefined()])
+		.optional(),
+	custom_range: z
+		.union([listEventsCustomRangeOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 const openEnumSchema = z.any();
 
 export const listEventsIntervalEnumSchema = openEnumSchema;
 
-export const listEventsIntervalUnionSchema = z.union([listEventsIntervalEnumSchema, z.string()]);
+export const listEventsIntervalUnionSchema = z.union([
+	listEventsIntervalEnumSchema,
+	z.string(),
+]);
 
 export const listEventsResetSchema = z.object({
-    interval: z.union([listEventsIntervalEnumSchema, z.string()]),
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    resetsAt: z.number().nullable()
+	interval: z.union([listEventsIntervalEnumSchema, z.string()]),
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	resetsAt: z.number().nullable(),
 });
 
 export const deductionsSchema = z.object({
-    balanceId: z.string(),
-    featureId: z.string(),
-    planId: z.string().nullable(),
-    reset: listEventsResetSchema.nullable(),
-    value: z.number()
+	balanceId: z.string(),
+	featureId: z.string(),
+	planId: z.string().nullable(),
+	reset: listEventsResetSchema.nullable(),
+	value: z.number(),
 });
 
 export const listEventsListSchema = z.object({
-    id: z.string(),
-    timestamp: z.number(),
-    featureId: z.string(),
-    customerId: z.string(),
-    value: z.number(),
-    properties: z.record(z.string(), z.any()),
-    deductions: z.array(deductionsSchema).nullable()
+	id: z.string(),
+	timestamp: z.number(),
+	featureId: z.string(),
+	customerId: z.string(),
+	value: z.number(),
+	properties: z.record(z.string(), z.any()),
+	deductions: z.array(deductionsSchema).nullable(),
 });
 
 export const listEventsResponseSchema = z.object({
-    list: z.array(listEventsListSchema),
-    nextCursor: z.string().nullable()
+	list: z.array(listEventsListSchema),
+	nextCursor: z.string().nullable(),
 });

--- a/packages/autumn-js/src/generated/listPlansSchemas.ts
+++ b/packages/autumn-js/src/generated/listPlansSchemas.ts
@@ -2,43 +2,43 @@
 import { z } from "zod/v4";
 
 export const listPlansGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const listPlansParamsSchema = z.object({
-    customerId: z.union([z.string(), z.undefined()]).optional(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    includeArchived: z.union([z.boolean(), z.undefined()]).optional()
+	customerId: z.union([z.string(), z.undefined()]).optional(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	includeArchived: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const listPlansPriceDisplaySchema = z.object({
-    primaryText: z.string(),
-    secondaryText: z.union([z.string(), z.undefined()]).optional()
+	primaryText: z.string(),
+	secondaryText: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const listPlansFeatureDisplaySchema = z.object({
-    singular: z.string(),
-    plural: z.string()
+	singular: z.string(),
+	plural: z.string(),
 });
 
 export const listPlansCreditSchemaSchema = z.object({
-    meteredFeatureId: z.string(),
-    creditCost: z.number()
+	meteredFeatureId: z.string(),
+	creditCost: z.number(),
 });
 
 export const listPlansItemDisplaySchema = z.object({
-    primaryText: z.string(),
-    secondaryText: z.union([z.string(), z.undefined()]).optional()
+	primaryText: z.string(),
+	secondaryText: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const listPlansConfigSchema = z.object({
-    ignorePastDue: z.boolean()
+	ignorePastDue: z.boolean(),
 });
 
 export const listPlansParamsOutboundSchema = z.object({
-    customer_id: z.union([z.string(), z.undefined()]).optional(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    include_archived: z.union([z.boolean(), z.undefined()]).optional()
+	customer_id: z.union([z.string(), z.undefined()]).optional(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	include_archived: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 const openEnumSchema = z.any();
@@ -46,28 +46,34 @@ const openEnumSchema = z.any();
 export const listPlansPriceIntervalSchema = openEnumSchema;
 
 export const listPlansPriceSchema = z.object({
-    amount: z.number(),
-    interval: listPlansPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    display: z.union([listPlansPriceDisplaySchema, z.undefined()]).optional()
+	amount: z.number(),
+	interval: listPlansPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	display: z.union([listPlansPriceDisplaySchema, z.undefined()]).optional(),
 });
 
 export const listPlansTypeSchema = openEnumSchema;
 
 export const listPlansFeatureSchema = z.object({
-    id: z.string(),
-    name: z.union([z.string(), z.undefined()]).optional().nullable(),
-    type: listPlansTypeSchema,
-    display: z.union([listPlansFeatureDisplaySchema, z.undefined()]).optional().nullable(),
-    creditSchema: z.union([z.array(listPlansCreditSchemaSchema), z.undefined()]).optional().nullable(),
-    archived: z.union([z.boolean(), z.undefined()]).optional().nullable()
+	id: z.string(),
+	name: z.union([z.string(), z.undefined()]).optional().nullable(),
+	type: listPlansTypeSchema,
+	display: z
+		.union([listPlansFeatureDisplaySchema, z.undefined()])
+		.optional()
+		.nullable(),
+	creditSchema: z
+		.union([z.array(listPlansCreditSchemaSchema), z.undefined()])
+		.optional()
+		.nullable(),
+	archived: z.union([z.boolean(), z.undefined()]).optional().nullable(),
 });
 
 export const listPlansResetIntervalSchema = openEnumSchema;
 
 export const listPlansResetSchema = z.object({
-    interval: listPlansResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: listPlansResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const listPlansTierBehaviorSchema = openEnumSchema;
@@ -77,34 +83,36 @@ export const listPlansPriceItemIntervalSchema = openEnumSchema;
 export const listPlansBillingMethodSchema = openEnumSchema;
 
 export const listPlansItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(z.any().nullable()), z.undefined()]).optional(),
-    tierBehavior: z.union([listPlansTierBehaviorSchema, z.undefined()]).optional(),
-    interval: listPlansPriceItemIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.number(),
-    billingMethod: listPlansBillingMethodSchema,
-    maxPurchase: z.number().nullable()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z.union([z.array(z.any().nullable()), z.undefined()]).optional(),
+	tierBehavior: z
+		.union([listPlansTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: listPlansPriceItemIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.number(),
+	billingMethod: listPlansBillingMethodSchema,
+	maxPurchase: z.number().nullable(),
 });
 
 export const listPlansExpiryDurationTypeSchema = openEnumSchema;
 
 export const listPlansRolloverSchema = z.object({
-    max: z.number().nullable(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional().nullable(),
-    expiryDurationType: listPlansExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.number().nullable(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional().nullable(),
+	expiryDurationType: listPlansExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const listPlansItemSchema = z.object({
-    featureId: z.string(),
-    feature: z.union([listPlansFeatureSchema, z.undefined()]).optional(),
-    included: z.number(),
-    unlimited: z.boolean(),
-    reset: listPlansResetSchema.nullable(),
-    price: listPlansItemPriceSchema.nullable(),
-    display: z.union([listPlansItemDisplaySchema, z.undefined()]).optional(),
-    rollover: z.union([listPlansRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	feature: z.union([listPlansFeatureSchema, z.undefined()]).optional(),
+	included: z.number(),
+	unlimited: z.boolean(),
+	reset: listPlansResetSchema.nullable(),
+	price: listPlansItemPriceSchema.nullable(),
+	display: z.union([listPlansItemDisplaySchema, z.undefined()]).optional(),
+	rollover: z.union([listPlansRolloverSchema, z.undefined()]).optional(),
 });
 
 export const listPlansDurationTypeSchema = openEnumSchema;
@@ -112,10 +120,10 @@ export const listPlansDurationTypeSchema = openEnumSchema;
 export const listPlansOnEndSchema = openEnumSchema;
 
 export const listPlansFreeTrialSchema = z.object({
-    durationLength: z.number(),
-    durationType: listPlansDurationTypeSchema,
-    cardRequired: z.boolean(),
-    onEnd: z.union([listPlansOnEndSchema, z.undefined()]).optional().nullable()
+	durationLength: z.number(),
+	durationType: listPlansDurationTypeSchema,
+	cardRequired: z.boolean(),
+	onEnd: z.union([listPlansOnEndSchema, z.undefined()]).optional().nullable(),
 });
 
 export const listPlansEnvSchema = openEnumSchema;
@@ -125,32 +133,34 @@ export const listPlansStatusSchema = openEnumSchema;
 export const listPlansAttachActionSchema = openEnumSchema;
 
 export const listPlansCustomerEligibilitySchema = z.object({
-    trialAvailable: z.union([z.boolean(), z.undefined()]).optional(),
-    status: z.union([listPlansStatusSchema, z.undefined()]).optional(),
-    canceling: z.union([z.boolean(), z.undefined()]).optional(),
-    trialing: z.union([z.boolean(), z.undefined()]).optional(),
-    attachAction: listPlansAttachActionSchema
+	trialAvailable: z.union([z.boolean(), z.undefined()]).optional(),
+	status: z.union([listPlansStatusSchema, z.undefined()]).optional(),
+	canceling: z.union([z.boolean(), z.undefined()]).optional(),
+	trialing: z.union([z.boolean(), z.undefined()]).optional(),
+	attachAction: listPlansAttachActionSchema,
 });
 
 export const listPlansListSchema = z.object({
-    id: z.string(),
-    name: z.string(),
-    description: z.string().nullable(),
-    group: z.string().nullable(),
-    version: z.number(),
-    addOn: z.boolean(),
-    autoEnable: z.boolean(),
-    price: listPlansPriceSchema.nullable(),
-    items: z.array(listPlansItemSchema),
-    freeTrial: z.union([listPlansFreeTrialSchema, z.undefined()]).optional(),
-    createdAt: z.number(),
-    env: listPlansEnvSchema,
-    archived: z.boolean(),
-    baseVariantId: z.string().nullable(),
-    config: listPlansConfigSchema,
-    customerEligibility: z.union([listPlansCustomerEligibilitySchema, z.undefined()]).optional()
+	id: z.string(),
+	name: z.string(),
+	description: z.string().nullable(),
+	group: z.string().nullable(),
+	version: z.number(),
+	addOn: z.boolean(),
+	autoEnable: z.boolean(),
+	price: listPlansPriceSchema.nullable(),
+	items: z.array(listPlansItemSchema),
+	freeTrial: z.union([listPlansFreeTrialSchema, z.undefined()]).optional(),
+	createdAt: z.number(),
+	env: listPlansEnvSchema,
+	archived: z.boolean(),
+	baseVariantId: z.string().nullable(),
+	config: listPlansConfigSchema,
+	customerEligibility: z
+		.union([listPlansCustomerEligibilitySchema, z.undefined()])
+		.optional(),
 });
 
 export const listPlansResponseSchema = z.object({
-    list: z.array(listPlansListSchema)
+	list: z.array(listPlansListSchema),
 });

--- a/packages/autumn-js/src/generated/multiAttachSchemas.ts
+++ b/packages/autumn-js/src/generated/multiAttachSchemas.ts
@@ -2,171 +2,194 @@
 import { z } from "zod/v4";
 
 export const multiAttachGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const multiAttachToSchema = z.union([z.number(), z.string()]);
 
 export const multiAttachTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const multiAttachInvoiceModeSchema = z.object({
-    enabled: z.boolean(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    finalize: z.union([z.boolean(), z.undefined()]).optional()
+	enabled: z.boolean(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	finalize: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const multiAttachAttachDiscountSchema = z.object({
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    promotionCode: z.union([z.string(), z.undefined()]).optional()
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	promotionCode: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const multiAttachSpendLimitSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional(),
-    overageLimit: z.union([z.number(), z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
+	overageLimit: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachOverageAllowedSchema = z.object({
-    featureId: z.string(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const multiAttachInvoiceSchema = z.object({
-    status: z.string().nullable(),
-    stripeId: z.string(),
-    total: z.number(),
-    currency: z.string(),
-    hostedInvoiceUrl: z.string().nullable()
+	status: z.string().nullable(),
+	stripeId: z.string(),
+	total: z.number(),
+	currency: z.string(),
+	hostedInvoiceUrl: z.string().nullable(),
 });
 
 export const multiAttachBasePriceOutboundSchema = z.object({
-    amount: z.number(),
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachToOutboundSchema = z.union([z.number(), z.string()]);
 
 export const multiAttachTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(multiAttachTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(multiAttachTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const multiAttachRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([multiAttachResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([multiAttachPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([multiAttachProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([multiAttachRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([multiAttachResetOutboundSchema, z.undefined()]).optional(),
+	price: z.union([multiAttachPriceOutboundSchema, z.undefined()]).optional(),
+	proration: z
+		.union([multiAttachProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([multiAttachRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const multiAttachCustomizeOutboundSchema = z.object({
-    price: z.union([multiAttachBasePriceOutboundSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(multiAttachPlanItemOutboundSchema), z.undefined()]).optional()
+	price: z
+		.union([multiAttachBasePriceOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(multiAttachPlanItemOutboundSchema), z.undefined()])
+		.optional(),
 });
 
 export const multiAttachFeatureQuantityOutboundSchema = z.object({
-    feature_id: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	feature_id: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const multiAttachPlanOutboundSchema = z.object({
-    plan_id: z.string(),
-    customize: z.union([multiAttachCustomizeOutboundSchema, z.undefined()]).optional(),
-    feature_quantities: z.union([z.array(multiAttachFeatureQuantityOutboundSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    subscription_id: z.union([z.string(), z.undefined()]).optional()
+	plan_id: z.string(),
+	customize: z
+		.union([multiAttachCustomizeOutboundSchema, z.undefined()])
+		.optional(),
+	feature_quantities: z
+		.union([z.array(multiAttachFeatureQuantityOutboundSchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	subscription_id: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const multiAttachFreeTrialParamsOutboundSchema = z.object({
-    duration_length: z.number(),
-    duration_type: z.string(),
-    card_required: z.boolean(),
-    on_end: z.union([z.string(), z.undefined()]).optional()
+	duration_length: z.number(),
+	duration_type: z.string(),
+	card_required: z.boolean(),
+	on_end: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const multiAttachInvoiceModeOutboundSchema = z.object({
-    enabled: z.boolean(),
-    enable_plan_immediately: z.boolean(),
-    finalize: z.boolean()
+	enabled: z.boolean(),
+	enable_plan_immediately: z.boolean(),
+	finalize: z.boolean(),
 });
 
 export const multiAttachAttachDiscountOutboundSchema = z.object({
-    reward_id: z.union([z.string(), z.undefined()]).optional(),
-    promotion_code: z.union([z.string(), z.undefined()]).optional()
+	reward_id: z.union([z.string(), z.undefined()]).optional(),
+	promotion_code: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const multiAttachSpendLimitOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.boolean(),
-    overage_limit: z.union([z.number(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.boolean(),
+	overage_limit: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachUsageAlertOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.boolean(),
-    threshold: z.number(),
-    threshold_type: z.string(),
-    name: z.union([z.string(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.boolean(),
+	threshold: z.number(),
+	threshold_type: z.string(),
+	name: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const multiAttachOverageAllowedOutboundSchema = z.object({
-    feature_id: z.string(),
-    enabled: z.boolean()
+	feature_id: z.string(),
+	enabled: z.boolean(),
 });
 
 export const multiAttachBillingControlsOutboundSchema = z.object({
-    spend_limits: z.union([z.array(multiAttachSpendLimitOutboundSchema), z.undefined()]).optional(),
-    usage_alerts: z.union([z.array(multiAttachUsageAlertOutboundSchema), z.undefined()]).optional(),
-    overage_allowed: z.union([z.array(multiAttachOverageAllowedOutboundSchema), z.undefined()]).optional()
+	spend_limits: z
+		.union([z.array(multiAttachSpendLimitOutboundSchema), z.undefined()])
+		.optional(),
+	usage_alerts: z
+		.union([z.array(multiAttachUsageAlertOutboundSchema), z.undefined()])
+		.optional(),
+	overage_allowed: z
+		.union([z.array(multiAttachOverageAllowedOutboundSchema), z.undefined()])
+		.optional(),
 });
 
 export const multiAttachEntityDataOutboundSchema = z.object({
-    feature_id: z.string(),
-    name: z.union([z.string(), z.undefined()]).optional(),
-    billing_controls: z.union([multiAttachBillingControlsOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	name: z.union([z.string(), z.undefined()]).optional(),
+	billing_controls: z
+		.union([multiAttachBillingControlsOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -180,16 +203,16 @@ const customerDataOutboundSchema = z.any();
 export const multiAttachPriceIntervalSchema = closedEnumSchema;
 
 export const multiAttachBasePriceSchema = z.object({
-    amount: z.number(),
-    interval: multiAttachPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: multiAttachPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachResetIntervalSchema = closedEnumSchema;
 
 export const multiAttachResetSchema = z.object({
-    interval: multiAttachResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: multiAttachResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachTierBehaviorSchema = closedEnumSchema;
@@ -199,14 +222,16 @@ export const multiAttachItemPriceIntervalSchema = closedEnumSchema;
 export const multiAttachBillingMethodSchema = closedEnumSchema;
 
 export const multiAttachPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(multiAttachTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([multiAttachTierBehaviorSchema, z.undefined()]).optional(),
-    interval: multiAttachItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: multiAttachBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z.union([z.array(multiAttachTierSchema), z.undefined()]).optional(),
+	tierBehavior: z
+		.union([multiAttachTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: multiAttachItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: multiAttachBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachOnIncreaseSchema = closedEnumSchema;
@@ -214,40 +239,47 @@ export const multiAttachOnIncreaseSchema = closedEnumSchema;
 export const multiAttachOnDecreaseSchema = closedEnumSchema;
 
 export const multiAttachProrationSchema = z.object({
-    onIncrease: multiAttachOnIncreaseSchema,
-    onDecrease: multiAttachOnDecreaseSchema
+	onIncrease: multiAttachOnIncreaseSchema,
+	onDecrease: multiAttachOnDecreaseSchema,
 });
 
 export const multiAttachExpiryDurationTypeSchema = closedEnumSchema;
 
 export const multiAttachRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: multiAttachExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: multiAttachExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const multiAttachPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([multiAttachResetSchema, z.undefined()]).optional(),
-    price: z.union([multiAttachPriceSchema, z.undefined()]).optional(),
-    proration: z.union([multiAttachProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([multiAttachRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([multiAttachResetSchema, z.undefined()]).optional(),
+	price: z.union([multiAttachPriceSchema, z.undefined()]).optional(),
+	proration: z.union([multiAttachProrationSchema, z.undefined()]).optional(),
+	rollover: z.union([multiAttachRolloverSchema, z.undefined()]).optional(),
 });
 
 export const multiAttachCustomizeSchema = z.object({
-    price: z.union([multiAttachBasePriceSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(multiAttachPlanItemSchema), z.undefined()]).optional()
+	price: z
+		.union([multiAttachBasePriceSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(multiAttachPlanItemSchema), z.undefined()])
+		.optional(),
 });
 
 export const multiAttachPlanSchema = z.object({
-    planId: z.string(),
-    customize: z.union([multiAttachCustomizeSchema, z.undefined()]).optional(),
-    featureQuantities: z.union([z.array(multiAttachFeatureQuantitySchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    subscriptionId: z.union([z.string(), z.undefined()]).optional()
+	planId: z.string(),
+	customize: z.union([multiAttachCustomizeSchema, z.undefined()]).optional(),
+	featureQuantities: z
+		.union([z.array(multiAttachFeatureQuantitySchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	subscriptionId: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const multiAttachDurationTypeSchema = closedEnumSchema;
@@ -255,10 +287,12 @@ export const multiAttachDurationTypeSchema = closedEnumSchema;
 export const multiAttachOnEndSchema = closedEnumSchema;
 
 export const multiAttachFreeTrialParamsSchema = z.object({
-    durationLength: z.number(),
-    durationType: z.union([multiAttachDurationTypeSchema, z.undefined()]).optional(),
-    cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
-    onEnd: z.union([multiAttachOnEndSchema, z.undefined()]).optional()
+	durationLength: z.number(),
+	durationType: z
+		.union([multiAttachDurationTypeSchema, z.undefined()])
+		.optional(),
+	cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
+	onEnd: z.union([multiAttachOnEndSchema, z.undefined()]).optional(),
 });
 
 export const multiAttachRedirectModeSchema = closedEnumSchema;
@@ -266,68 +300,102 @@ export const multiAttachRedirectModeSchema = closedEnumSchema;
 export const multiAttachThresholdTypeSchema = closedEnumSchema;
 
 export const multiAttachUsageAlertSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional(),
-    threshold: z.number(),
-    thresholdType: multiAttachThresholdTypeSchema,
-    name: z.union([z.string(), z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
+	threshold: z.number(),
+	thresholdType: multiAttachThresholdTypeSchema,
+	name: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const multiAttachBillingControlsSchema = z.object({
-    spendLimits: z.union([z.array(multiAttachSpendLimitSchema), z.undefined()]).optional(),
-    usageAlerts: z.union([z.array(multiAttachUsageAlertSchema), z.undefined()]).optional(),
-    overageAllowed: z.union([z.array(multiAttachOverageAllowedSchema), z.undefined()]).optional()
+	spendLimits: z
+		.union([z.array(multiAttachSpendLimitSchema), z.undefined()])
+		.optional(),
+	usageAlerts: z
+		.union([z.array(multiAttachUsageAlertSchema), z.undefined()])
+		.optional(),
+	overageAllowed: z
+		.union([z.array(multiAttachOverageAllowedSchema), z.undefined()])
+		.optional(),
 });
 
 export const multiAttachEntityDataSchema = z.object({
-    featureId: z.string(),
-    name: z.union([z.string(), z.undefined()]).optional(),
-    billingControls: z.union([multiAttachBillingControlsSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	name: z.union([z.string(), z.undefined()]).optional(),
+	billingControls: z
+		.union([multiAttachBillingControlsSchema, z.undefined()])
+		.optional(),
 });
 
 export const multiAttachParamsSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    plans: z.array(multiAttachPlanSchema),
-    freeTrial: z.union([multiAttachFreeTrialParamsSchema, z.undefined()]).optional().nullable(),
-    invoiceMode: z.union([multiAttachInvoiceModeSchema, z.undefined()]).optional(),
-    discounts: z.union([z.array(multiAttachAttachDiscountSchema), z.undefined()]).optional(),
-    successUrl: z.union([z.string(), z.undefined()]).optional(),
-    checkoutSessionParams: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    redirectMode: z.union([multiAttachRedirectModeSchema, z.undefined()]).optional(),
-    newBillingSubscription: z.union([z.boolean(), z.undefined()]).optional(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    customerData: z.union([customerDataSchema, z.undefined()]).optional(),
-    entityData: z.union([multiAttachEntityDataSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	plans: z.array(multiAttachPlanSchema),
+	freeTrial: z
+		.union([multiAttachFreeTrialParamsSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	invoiceMode: z
+		.union([multiAttachInvoiceModeSchema, z.undefined()])
+		.optional(),
+	discounts: z
+		.union([z.array(multiAttachAttachDiscountSchema), z.undefined()])
+		.optional(),
+	successUrl: z.union([z.string(), z.undefined()]).optional(),
+	checkoutSessionParams: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	redirectMode: z
+		.union([multiAttachRedirectModeSchema, z.undefined()])
+		.optional(),
+	newBillingSubscription: z.union([z.boolean(), z.undefined()]).optional(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	customerData: z.union([customerDataSchema, z.undefined()]).optional(),
+	entityData: z.union([multiAttachEntityDataSchema, z.undefined()]).optional(),
 });
 
 export const multiAttachCodeSchema = openEnumSchema;
 
 export const multiAttachRequiredActionSchema = z.object({
-    code: multiAttachCodeSchema,
-    reason: z.string()
+	code: multiAttachCodeSchema,
+	reason: z.string(),
 });
 
 export const multiAttachResponseSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    invoice: z.union([multiAttachInvoiceSchema, z.undefined()]).optional(),
-    paymentUrl: z.string().nullable(),
-    requiredAction: z.union([multiAttachRequiredActionSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	invoice: z.union([multiAttachInvoiceSchema, z.undefined()]).optional(),
+	paymentUrl: z.string().nullable(),
+	requiredAction: z
+		.union([multiAttachRequiredActionSchema, z.undefined()])
+		.optional(),
 });
 
 export const multiAttachParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    plans: z.array(multiAttachPlanOutboundSchema),
-    free_trial: z.union([multiAttachFreeTrialParamsOutboundSchema, z.undefined()]).optional().nullable(),
-    invoice_mode: z.union([multiAttachInvoiceModeOutboundSchema, z.undefined()]).optional(),
-    discounts: z.union([z.array(multiAttachAttachDiscountOutboundSchema), z.undefined()]).optional(),
-    success_url: z.union([z.string(), z.undefined()]).optional(),
-    checkout_session_params: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    redirect_mode: z.string(),
-    new_billing_subscription: z.union([z.boolean(), z.undefined()]).optional(),
-    enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
-    customer_data: z.union([customerDataOutboundSchema, z.undefined()]).optional(),
-    entity_data: z.union([multiAttachEntityDataOutboundSchema, z.undefined()]).optional()
+	customer_id: z.string(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	plans: z.array(multiAttachPlanOutboundSchema),
+	free_trial: z
+		.union([multiAttachFreeTrialParamsOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	invoice_mode: z
+		.union([multiAttachInvoiceModeOutboundSchema, z.undefined()])
+		.optional(),
+	discounts: z
+		.union([z.array(multiAttachAttachDiscountOutboundSchema), z.undefined()])
+		.optional(),
+	success_url: z.union([z.string(), z.undefined()]).optional(),
+	checkout_session_params: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	redirect_mode: z.string(),
+	new_billing_subscription: z.union([z.boolean(), z.undefined()]).optional(),
+	enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
+	customer_data: z
+		.union([customerDataOutboundSchema, z.undefined()])
+		.optional(),
+	entity_data: z
+		.union([multiAttachEntityDataOutboundSchema, z.undefined()])
+		.optional(),
 });

--- a/packages/autumn-js/src/generated/openCustomerPortalSchemas.ts
+++ b/packages/autumn-js/src/generated/openCustomerPortalSchemas.ts
@@ -2,22 +2,22 @@
 import { z } from "zod/v4";
 
 export const openCustomerPortalGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const openCustomerPortalParamsSchema = z.object({
-    customerId: z.string(),
-    configurationId: z.union([z.string(), z.undefined()]).optional(),
-    returnUrl: z.union([z.string(), z.undefined()]).optional()
+	customerId: z.string(),
+	configurationId: z.union([z.string(), z.undefined()]).optional(),
+	returnUrl: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const openCustomerPortalResponseSchema = z.object({
-    customerId: z.string(),
-    url: z.string()
+	customerId: z.string(),
+	url: z.string(),
 });
 
 export const openCustomerPortalParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    configuration_id: z.union([z.string(), z.undefined()]).optional(),
-    return_url: z.union([z.string(), z.undefined()]).optional()
+	customer_id: z.string(),
+	configuration_id: z.union([z.string(), z.undefined()]).optional(),
+	return_url: z.union([z.string(), z.undefined()]).optional(),
 });

--- a/packages/autumn-js/src/generated/previewAttachSchemas.ts
+++ b/packages/autumn-js/src/generated/previewAttachSchemas.ts
@@ -2,318 +2,387 @@
 import { z } from "zod/v4";
 
 export const previewAttachGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewAttachFeatureQuantityRequestSchema = z.object({
-    featureId: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemToSchema = z.union([z.number(), z.string()]);
 
 export const previewAttachItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAddItemToSchema = z.union([z.number(), z.string()]);
 
 export const previewAttachAddItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachInvoiceModeSchema = z.object({
-    enabled: z.boolean(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    finalize: z.union([z.boolean(), z.undefined()]).optional()
+	enabled: z.boolean(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	finalize: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewAttachAttachDiscountSchema = z.object({
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    promotionCode: z.union([z.string(), z.undefined()]).optional()
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	promotionCode: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewAttachCustomLineItemSchema = z.object({
-    amount: z.number(),
-    description: z.string()
+	amount: z.number(),
+	description: z.string(),
 });
 
 export const previewAttachCarryOverBalancesSchema = z.object({
-    enabled: z.boolean(),
-    featureIds: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	featureIds: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const previewAttachCarryOverUsagesSchema = z.object({
-    enabled: z.boolean(),
-    featureIds: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	featureIds: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const previewAttachDiscountSchema = z.object({
-    amountOff: z.number(),
-    percentOff: z.union([z.number(), z.undefined()]).optional(),
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    rewardName: z.union([z.string(), z.undefined()]).optional()
+	amountOff: z.number(),
+	percentOff: z.union([z.number(), z.undefined()]).optional(),
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	rewardName: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewAttachLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewAttachLineItemSchema = z.object({
-    displayName: z.string(),
-    description: z.string(),
-    subtotal: z.number(),
-    total: z.number(),
-    discounts: z.union([z.array(previewAttachDiscountSchema), z.undefined()]).optional(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewAttachLineItemPeriodSchema, z.undefined()]).optional(),
-    quantity: z.number()
+	displayName: z.string(),
+	description: z.string(),
+	subtotal: z.number(),
+	total: z.number(),
+	discounts: z
+		.union([z.array(previewAttachDiscountSchema), z.undefined()])
+		.optional(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewAttachLineItemPeriodSchema, z.undefined()])
+		.optional(),
+	quantity: z.number(),
 });
 
 export const previewAttachNextCycleDiscountSchema = z.object({
-    amountOff: z.number(),
-    percentOff: z.union([z.number(), z.undefined()]).optional(),
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    rewardName: z.union([z.string(), z.undefined()]).optional()
+	amountOff: z.number(),
+	percentOff: z.union([z.number(), z.undefined()]).optional(),
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	rewardName: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewAttachNextCycleLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewAttachNextCycleLineItemSchema = z.object({
-    displayName: z.string(),
-    description: z.string(),
-    subtotal: z.number(),
-    total: z.number(),
-    discounts: z.union([z.array(previewAttachNextCycleDiscountSchema), z.undefined()]).optional(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewAttachNextCycleLineItemPeriodSchema, z.undefined()]).optional(),
-    quantity: z.number()
+	displayName: z.string(),
+	description: z.string(),
+	subtotal: z.number(),
+	total: z.number(),
+	discounts: z
+		.union([z.array(previewAttachNextCycleDiscountSchema), z.undefined()])
+		.optional(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewAttachNextCycleLineItemPeriodSchema, z.undefined()])
+		.optional(),
+	quantity: z.number(),
 });
 
 export const previewAttachUsageLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewAttachUsageLineItemSchema = z.object({
-    displayName: z.string(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewAttachUsageLineItemPeriodSchema, z.undefined()]).optional()
+	displayName: z.string(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewAttachUsageLineItemPeriodSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewAttachNextCycleSchema = z.object({
-    startsAt: z.number(),
-    subtotal: z.number(),
-    total: z.number(),
-    lineItems: z.array(previewAttachNextCycleLineItemSchema),
-    usageLineItems: z.array(previewAttachUsageLineItemSchema)
+	startsAt: z.number(),
+	subtotal: z.number(),
+	total: z.number(),
+	lineItems: z.array(previewAttachNextCycleLineItemSchema),
+	usageLineItems: z.array(previewAttachUsageLineItemSchema),
 });
 
 export const previewAttachIncomingFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.number()
+	featureId: z.string(),
+	quantity: z.number(),
 });
 
 export const previewAttachOutgoingFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.number()
+	featureId: z.string(),
+	quantity: z.number(),
 });
 
 export const previewAttachInvoiceCreditsSchema = z.object({
-    balance: z.number(),
-    currency: z.string()
+	balance: z.number(),
+	currency: z.string(),
 });
 
 export const previewAttachFeatureQuantityRequestOutboundSchema = z.object({
-    feature_id: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	feature_id: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewAttachBasePriceOutboundSchema = z.object({
-    amount: z.number(),
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const previewAttachItemToOutboundSchema = z.union([z.number(), z.string()]);
+export const previewAttachItemToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const previewAttachItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewAttachItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewAttachItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const previewAttachItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewAttachItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([previewAttachItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([previewAttachItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([previewAttachItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([previewAttachItemResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([previewAttachItemPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([previewAttachItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewAttachItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewAttachAddItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const previewAttachAddItemToOutboundSchema = z.union([z.number(), z.string()]);
+export const previewAttachAddItemToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const previewAttachAddItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAddItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewAttachAddItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewAttachAddItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAddItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const previewAttachAddItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAddItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewAttachAddItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([previewAttachAddItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([previewAttachAddItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([previewAttachAddItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([previewAttachAddItemResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([previewAttachAddItemPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([previewAttachAddItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewAttachAddItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewAttachPlanItemFilterOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    billing_method: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.union([z.string(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	billing_method: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewAttachFreeTrialParamsOutboundSchema = z.object({
-    duration_length: z.number(),
-    duration_type: z.string(),
-    card_required: z.boolean(),
-    on_end: z.union([z.string(), z.undefined()]).optional()
+	duration_length: z.number(),
+	duration_type: z.string(),
+	card_required: z.boolean(),
+	on_end: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewAttachCustomizeOutboundSchema = z.object({
-    price: z.union([previewAttachBasePriceOutboundSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(previewAttachItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    add_items: z.union([z.array(previewAttachAddItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    remove_items: z.union([z.array(previewAttachPlanItemFilterOutboundSchema), z.undefined()]).optional(),
-    free_trial: z.union([previewAttachFreeTrialParamsOutboundSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([previewAttachBasePriceOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(previewAttachItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	add_items: z
+		.union([z.array(previewAttachAddItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	remove_items: z
+		.union([z.array(previewAttachPlanItemFilterOutboundSchema), z.undefined()])
+		.optional(),
+	free_trial: z
+		.union([previewAttachFreeTrialParamsOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const previewAttachInvoiceModeOutboundSchema = z.object({
-    enabled: z.boolean(),
-    enable_plan_immediately: z.boolean(),
-    finalize: z.boolean()
+	enabled: z.boolean(),
+	enable_plan_immediately: z.boolean(),
+	finalize: z.boolean(),
 });
 
 export const previewAttachAttachDiscountOutboundSchema = z.object({
-    reward_id: z.union([z.string(), z.undefined()]).optional(),
-    promotion_code: z.union([z.string(), z.undefined()]).optional()
+	reward_id: z.union([z.string(), z.undefined()]).optional(),
+	promotion_code: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewAttachCustomLineItemOutboundSchema = z.object({
-    amount: z.number(),
-    description: z.string()
+	amount: z.number(),
+	description: z.string(),
 });
 
 export const previewAttachCarryOverBalancesOutboundSchema = z.object({
-    enabled: z.boolean(),
-    feature_ids: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	feature_ids: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const previewAttachCarryOverUsagesOutboundSchema = z.object({
-    enabled: z.boolean(),
-    feature_ids: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	feature_ids: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const previewAttachParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    plan_id: z.string(),
-    feature_quantities: z.union([z.array(previewAttachFeatureQuantityRequestOutboundSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([previewAttachCustomizeOutboundSchema, z.undefined()]).optional(),
-    invoice_mode: z.union([previewAttachInvoiceModeOutboundSchema, z.undefined()]).optional(),
-    proration_behavior: z.union([z.string(), z.undefined()]).optional(),
-    redirect_mode: z.string(),
-    subscription_id: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(previewAttachAttachDiscountOutboundSchema), z.undefined()]).optional(),
-    success_url: z.union([z.string(), z.undefined()]).optional(),
-    new_billing_subscription: z.union([z.boolean(), z.undefined()]).optional(),
-    billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    plan_schedule: z.union([z.string(), z.undefined()]).optional(),
-    starts_at: z.union([z.number(), z.undefined()]).optional(),
-    ends_at: z.union([z.number(), z.undefined()]).optional(),
-    checkout_session_params: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    custom_line_items: z.union([z.array(previewAttachCustomLineItemOutboundSchema), z.undefined()]).optional(),
-    processor_subscription_id: z.union([z.string(), z.undefined()]).optional(),
-    carry_over_balances: z.union([previewAttachCarryOverBalancesOutboundSchema, z.undefined()]).optional(),
-    carry_over_usages: z.union([previewAttachCarryOverUsagesOutboundSchema, z.undefined()]).optional(),
-    metadata: z.union([z.record(z.string(), z.string()), z.undefined()]).optional(),
-    no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
-    enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
-    tax_rate_id: z.union([z.string(), z.undefined()]).optional()
+	customer_id: z.string(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	plan_id: z.string(),
+	feature_quantities: z
+		.union([
+			z.array(previewAttachFeatureQuantityRequestOutboundSchema),
+			z.undefined(),
+		])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z
+		.union([previewAttachCustomizeOutboundSchema, z.undefined()])
+		.optional(),
+	invoice_mode: z
+		.union([previewAttachInvoiceModeOutboundSchema, z.undefined()])
+		.optional(),
+	proration_behavior: z.union([z.string(), z.undefined()]).optional(),
+	redirect_mode: z.string(),
+	subscription_id: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(previewAttachAttachDiscountOutboundSchema), z.undefined()])
+		.optional(),
+	success_url: z.union([z.string(), z.undefined()]).optional(),
+	new_billing_subscription: z.union([z.boolean(), z.undefined()]).optional(),
+	billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	plan_schedule: z.union([z.string(), z.undefined()]).optional(),
+	starts_at: z.union([z.number(), z.undefined()]).optional(),
+	ends_at: z.union([z.number(), z.undefined()]).optional(),
+	checkout_session_params: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	custom_line_items: z
+		.union([z.array(previewAttachCustomLineItemOutboundSchema), z.undefined()])
+		.optional(),
+	processor_subscription_id: z.union([z.string(), z.undefined()]).optional(),
+	carry_over_balances: z
+		.union([previewAttachCarryOverBalancesOutboundSchema, z.undefined()])
+		.optional(),
+	carry_over_usages: z
+		.union([previewAttachCarryOverUsagesOutboundSchema, z.undefined()])
+		.optional(),
+	metadata: z
+		.union([z.record(z.string(), z.string()), z.undefined()])
+		.optional(),
+	no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
+	enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
+	tax_rate_id: z.union([z.string(), z.undefined()]).optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -325,16 +394,16 @@ const openEnumSchema = z.any();
 export const previewAttachPriceIntervalSchema = closedEnumSchema;
 
 export const previewAttachBasePriceSchema = z.object({
-    amount: z.number(),
-    interval: previewAttachPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: previewAttachPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemResetIntervalSchema = closedEnumSchema;
 
 export const previewAttachItemResetSchema = z.object({
-    interval: previewAttachItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: previewAttachItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemTierBehaviorSchema = closedEnumSchema;
@@ -344,14 +413,18 @@ export const previewAttachItemPriceIntervalSchema = closedEnumSchema;
 export const previewAttachItemBillingMethodSchema = closedEnumSchema;
 
 export const previewAttachItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewAttachItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([previewAttachItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: previewAttachItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: previewAttachItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewAttachItemTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([previewAttachItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: previewAttachItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: previewAttachItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemOnIncreaseSchema = closedEnumSchema;
@@ -359,34 +432,38 @@ export const previewAttachItemOnIncreaseSchema = closedEnumSchema;
 export const previewAttachItemOnDecreaseSchema = closedEnumSchema;
 
 export const previewAttachItemProrationSchema = z.object({
-    onIncrease: previewAttachItemOnIncreaseSchema,
-    onDecrease: previewAttachItemOnDecreaseSchema
+	onIncrease: previewAttachItemOnIncreaseSchema,
+	onDecrease: previewAttachItemOnDecreaseSchema,
 });
 
 export const previewAttachItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const previewAttachItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: previewAttachItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: previewAttachItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewAttachItemResetSchema, z.undefined()]).optional(),
-    price: z.union([previewAttachItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([previewAttachItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([previewAttachItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([previewAttachItemResetSchema, z.undefined()]).optional(),
+	price: z.union([previewAttachItemPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([previewAttachItemProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewAttachItemRolloverSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewAttachAddItemResetIntervalSchema = closedEnumSchema;
 
 export const previewAttachAddItemResetSchema = z.object({
-    interval: previewAttachAddItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: previewAttachAddItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAddItemTierBehaviorSchema = closedEnumSchema;
@@ -396,14 +473,18 @@ export const previewAttachAddItemPriceIntervalSchema = closedEnumSchema;
 export const previewAttachAddItemBillingMethodSchema = closedEnumSchema;
 
 export const previewAttachAddItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewAttachAddItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([previewAttachAddItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: previewAttachAddItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: previewAttachAddItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewAttachAddItemTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([previewAttachAddItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: previewAttachAddItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: previewAttachAddItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAddItemOnIncreaseSchema = closedEnumSchema;
@@ -411,27 +492,31 @@ export const previewAttachAddItemOnIncreaseSchema = closedEnumSchema;
 export const previewAttachAddItemOnDecreaseSchema = closedEnumSchema;
 
 export const previewAttachAddItemProrationSchema = z.object({
-    onIncrease: previewAttachAddItemOnIncreaseSchema,
-    onDecrease: previewAttachAddItemOnDecreaseSchema
+	onIncrease: previewAttachAddItemOnIncreaseSchema,
+	onDecrease: previewAttachAddItemOnDecreaseSchema,
 });
 
 export const previewAttachAddItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const previewAttachAddItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: previewAttachAddItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: previewAttachAddItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewAttachAddItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewAttachAddItemResetSchema, z.undefined()]).optional(),
-    price: z.union([previewAttachAddItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([previewAttachAddItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([previewAttachAddItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([previewAttachAddItemResetSchema, z.undefined()]).optional(),
+	price: z.union([previewAttachAddItemPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([previewAttachAddItemProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewAttachAddItemRolloverSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewAttachRemoveItemBillingMethodSchema = closedEnumSchema;
@@ -439,9 +524,13 @@ export const previewAttachRemoveItemBillingMethodSchema = closedEnumSchema;
 export const previewAttachRemoveItemIntervalSchema = closedEnumSchema;
 
 export const previewAttachPlanItemFilterSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    billingMethod: z.union([previewAttachRemoveItemBillingMethodSchema, z.undefined()]).optional(),
-    interval: z.union([previewAttachRemoveItemIntervalSchema, z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	billingMethod: z
+		.union([previewAttachRemoveItemBillingMethodSchema, z.undefined()])
+		.optional(),
+	interval: z
+		.union([previewAttachRemoveItemIntervalSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewAttachDurationTypeSchema = closedEnumSchema;
@@ -449,18 +538,32 @@ export const previewAttachDurationTypeSchema = closedEnumSchema;
 export const previewAttachOnEndSchema = closedEnumSchema;
 
 export const previewAttachFreeTrialParamsSchema = z.object({
-    durationLength: z.number(),
-    durationType: z.union([previewAttachDurationTypeSchema, z.undefined()]).optional(),
-    cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
-    onEnd: z.union([previewAttachOnEndSchema, z.undefined()]).optional()
+	durationLength: z.number(),
+	durationType: z
+		.union([previewAttachDurationTypeSchema, z.undefined()])
+		.optional(),
+	cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
+	onEnd: z.union([previewAttachOnEndSchema, z.undefined()]).optional(),
 });
 
 export const previewAttachCustomizeSchema = z.object({
-    price: z.union([previewAttachBasePriceSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(previewAttachItemPlanItemSchema), z.undefined()]).optional(),
-    addItems: z.union([z.array(previewAttachAddItemPlanItemSchema), z.undefined()]).optional(),
-    removeItems: z.union([z.array(previewAttachPlanItemFilterSchema), z.undefined()]).optional(),
-    freeTrial: z.union([previewAttachFreeTrialParamsSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([previewAttachBasePriceSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(previewAttachItemPlanItemSchema), z.undefined()])
+		.optional(),
+	addItems: z
+		.union([z.array(previewAttachAddItemPlanItemSchema), z.undefined()])
+		.optional(),
+	removeItems: z
+		.union([z.array(previewAttachPlanItemFilterSchema), z.undefined()])
+		.optional(),
+	freeTrial: z
+		.union([previewAttachFreeTrialParamsSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const previewAttachProrationBehaviorSchema = closedEnumSchema;
@@ -470,50 +573,72 @@ export const previewAttachRedirectModeSchema = closedEnumSchema;
 export const previewAttachPlanScheduleSchema = closedEnumSchema;
 
 export const previewAttachParamsSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    planId: z.string(),
-    featureQuantities: z.union([z.array(previewAttachFeatureQuantityRequestSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([previewAttachCustomizeSchema, z.undefined()]).optional(),
-    invoiceMode: z.union([previewAttachInvoiceModeSchema, z.undefined()]).optional(),
-    prorationBehavior: z.union([previewAttachProrationBehaviorSchema, z.undefined()]).optional(),
-    redirectMode: z.union([previewAttachRedirectModeSchema, z.undefined()]).optional(),
-    subscriptionId: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(previewAttachAttachDiscountSchema), z.undefined()]).optional(),
-    successUrl: z.union([z.string(), z.undefined()]).optional(),
-    newBillingSubscription: z.union([z.boolean(), z.undefined()]).optional(),
-    billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    planSchedule: z.union([previewAttachPlanScheduleSchema, z.undefined()]).optional(),
-    startsAt: z.union([z.number(), z.undefined()]).optional(),
-    endsAt: z.union([z.number(), z.undefined()]).optional(),
-    checkoutSessionParams: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    customLineItems: z.union([z.array(previewAttachCustomLineItemSchema), z.undefined()]).optional(),
-    processorSubscriptionId: z.union([z.string(), z.undefined()]).optional(),
-    carryOverBalances: z.union([previewAttachCarryOverBalancesSchema, z.undefined()]).optional(),
-    carryOverUsages: z.union([previewAttachCarryOverUsagesSchema, z.undefined()]).optional(),
-    metadata: z.union([z.record(z.string(), z.string()), z.undefined()]).optional(),
-    noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    taxRateId: z.union([z.string(), z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	planId: z.string(),
+	featureQuantities: z
+		.union([z.array(previewAttachFeatureQuantityRequestSchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z.union([previewAttachCustomizeSchema, z.undefined()]).optional(),
+	invoiceMode: z
+		.union([previewAttachInvoiceModeSchema, z.undefined()])
+		.optional(),
+	prorationBehavior: z
+		.union([previewAttachProrationBehaviorSchema, z.undefined()])
+		.optional(),
+	redirectMode: z
+		.union([previewAttachRedirectModeSchema, z.undefined()])
+		.optional(),
+	subscriptionId: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(previewAttachAttachDiscountSchema), z.undefined()])
+		.optional(),
+	successUrl: z.union([z.string(), z.undefined()]).optional(),
+	newBillingSubscription: z.union([z.boolean(), z.undefined()]).optional(),
+	billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	planSchedule: z
+		.union([previewAttachPlanScheduleSchema, z.undefined()])
+		.optional(),
+	startsAt: z.union([z.number(), z.undefined()]).optional(),
+	endsAt: z.union([z.number(), z.undefined()]).optional(),
+	checkoutSessionParams: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	customLineItems: z
+		.union([z.array(previewAttachCustomLineItemSchema), z.undefined()])
+		.optional(),
+	processorSubscriptionId: z.union([z.string(), z.undefined()]).optional(),
+	carryOverBalances: z
+		.union([previewAttachCarryOverBalancesSchema, z.undefined()])
+		.optional(),
+	carryOverUsages: z
+		.union([previewAttachCarryOverUsagesSchema, z.undefined()])
+		.optional(),
+	metadata: z
+		.union([z.record(z.string(), z.string()), z.undefined()])
+		.optional(),
+	noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	taxRateId: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewAttachIncomingSchema = z.object({
-    planId: z.string(),
-    plan: z.union([planSchema, z.undefined()]).optional(),
-    featureQuantities: z.array(previewAttachIncomingFeatureQuantitySchema),
-    effectiveAt: z.number().nullable(),
-    canceledAt: z.number().nullable(),
-    expiresAt: z.number().nullable()
+	planId: z.string(),
+	plan: z.union([planSchema, z.undefined()]).optional(),
+	featureQuantities: z.array(previewAttachIncomingFeatureQuantitySchema),
+	effectiveAt: z.number().nullable(),
+	canceledAt: z.number().nullable(),
+	expiresAt: z.number().nullable(),
 });
 
 export const previewAttachOutgoingSchema = z.object({
-    planId: z.string(),
-    plan: z.union([planSchema, z.undefined()]).optional(),
-    featureQuantities: z.array(previewAttachOutgoingFeatureQuantitySchema),
-    effectiveAt: z.number().nullable(),
-    canceledAt: z.number().nullable(),
-    expiresAt: z.number().nullable()
+	planId: z.string(),
+	plan: z.union([planSchema, z.undefined()]).optional(),
+	featureQuantities: z.array(previewAttachOutgoingFeatureQuantitySchema),
+	effectiveAt: z.number().nullable(),
+	canceledAt: z.number().nullable(),
+	expiresAt: z.number().nullable(),
 });
 
 export const previewAttachCheckoutTypeSchema = openEnumSchema;
@@ -521,25 +646,27 @@ export const previewAttachCheckoutTypeSchema = openEnumSchema;
 export const previewAttachStatusSchema = openEnumSchema;
 
 export const previewAttachTaxSchema = z.object({
-    total: z.number(),
-    amountInclusive: z.number(),
-    amountExclusive: z.number(),
-    currency: z.string(),
-    status: previewAttachStatusSchema
+	total: z.number(),
+	amountInclusive: z.number(),
+	amountExclusive: z.number(),
+	currency: z.string(),
+	status: previewAttachStatusSchema,
 });
 
 export const previewAttachResponseSchema = z.object({
-    customerId: z.string(),
-    lineItems: z.array(previewAttachLineItemSchema),
-    subtotal: z.number(),
-    total: z.number(),
-    currency: z.string(),
-    nextCycle: z.union([previewAttachNextCycleSchema, z.undefined()]).optional(),
-    expand: z.union([z.array(z.string()), z.undefined()]).optional(),
-    incoming: z.array(previewAttachIncomingSchema),
-    outgoing: z.array(previewAttachOutgoingSchema),
-    redirectToCheckout: z.boolean(),
-    checkoutType: previewAttachCheckoutTypeSchema.nullable(),
-    tax: z.union([previewAttachTaxSchema, z.undefined()]).optional(),
-    invoiceCredits: z.union([previewAttachInvoiceCreditsSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	lineItems: z.array(previewAttachLineItemSchema),
+	subtotal: z.number(),
+	total: z.number(),
+	currency: z.string(),
+	nextCycle: z.union([previewAttachNextCycleSchema, z.undefined()]).optional(),
+	expand: z.union([z.array(z.string()), z.undefined()]).optional(),
+	incoming: z.array(previewAttachIncomingSchema),
+	outgoing: z.array(previewAttachOutgoingSchema),
+	redirectToCheckout: z.boolean(),
+	checkoutType: previewAttachCheckoutTypeSchema.nullable(),
+	tax: z.union([previewAttachTaxSchema, z.undefined()]).optional(),
+	invoiceCredits: z
+		.union([previewAttachInvoiceCreditsSchema, z.undefined()])
+		.optional(),
 });

--- a/packages/autumn-js/src/generated/previewMultiAttachSchemas.ts
+++ b/packages/autumn-js/src/generated/previewMultiAttachSchemas.ts
@@ -2,246 +2,292 @@
 import { z } from "zod/v4";
 
 export const previewMultiAttachGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachToSchema = z.union([z.number(), z.string()]);
 
 export const previewMultiAttachTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachPlanFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachInvoiceModeSchema = z.object({
-    enabled: z.boolean(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    finalize: z.union([z.boolean(), z.undefined()]).optional()
+	enabled: z.boolean(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	finalize: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachAttachDiscountSchema = z.object({
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    promotionCode: z.union([z.string(), z.undefined()]).optional()
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	promotionCode: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachSpendLimitSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional(),
-    overageLimit: z.union([z.number(), z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
+	overageLimit: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachOverageAllowedSchema = z.object({
-    featureId: z.string(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachDiscountSchema = z.object({
-    amountOff: z.number(),
-    percentOff: z.union([z.number(), z.undefined()]).optional(),
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    rewardName: z.union([z.string(), z.undefined()]).optional()
+	amountOff: z.number(),
+	percentOff: z.union([z.number(), z.undefined()]).optional(),
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	rewardName: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewMultiAttachLineItemSchema = z.object({
-    displayName: z.string(),
-    description: z.string(),
-    subtotal: z.number(),
-    total: z.number(),
-    discounts: z.union([z.array(previewMultiAttachDiscountSchema), z.undefined()]).optional(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewMultiAttachLineItemPeriodSchema, z.undefined()]).optional(),
-    quantity: z.number()
+	displayName: z.string(),
+	description: z.string(),
+	subtotal: z.number(),
+	total: z.number(),
+	discounts: z
+		.union([z.array(previewMultiAttachDiscountSchema), z.undefined()])
+		.optional(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewMultiAttachLineItemPeriodSchema, z.undefined()])
+		.optional(),
+	quantity: z.number(),
 });
 
 export const previewMultiAttachNextCycleDiscountSchema = z.object({
-    amountOff: z.number(),
-    percentOff: z.union([z.number(), z.undefined()]).optional(),
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    rewardName: z.union([z.string(), z.undefined()]).optional()
+	amountOff: z.number(),
+	percentOff: z.union([z.number(), z.undefined()]).optional(),
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	rewardName: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachNextCycleLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewMultiAttachNextCycleLineItemSchema = z.object({
-    displayName: z.string(),
-    description: z.string(),
-    subtotal: z.number(),
-    total: z.number(),
-    discounts: z.union([z.array(previewMultiAttachNextCycleDiscountSchema), z.undefined()]).optional(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewMultiAttachNextCycleLineItemPeriodSchema, z.undefined()]).optional(),
-    quantity: z.number()
+	displayName: z.string(),
+	description: z.string(),
+	subtotal: z.number(),
+	total: z.number(),
+	discounts: z
+		.union([z.array(previewMultiAttachNextCycleDiscountSchema), z.undefined()])
+		.optional(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewMultiAttachNextCycleLineItemPeriodSchema, z.undefined()])
+		.optional(),
+	quantity: z.number(),
 });
 
 export const previewMultiAttachUsageLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewMultiAttachUsageLineItemSchema = z.object({
-    displayName: z.string(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewMultiAttachUsageLineItemPeriodSchema, z.undefined()]).optional()
+	displayName: z.string(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewMultiAttachUsageLineItemPeriodSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachNextCycleSchema = z.object({
-    startsAt: z.number(),
-    subtotal: z.number(),
-    total: z.number(),
-    lineItems: z.array(previewMultiAttachNextCycleLineItemSchema),
-    usageLineItems: z.array(previewMultiAttachUsageLineItemSchema)
+	startsAt: z.number(),
+	subtotal: z.number(),
+	total: z.number(),
+	lineItems: z.array(previewMultiAttachNextCycleLineItemSchema),
+	usageLineItems: z.array(previewMultiAttachUsageLineItemSchema),
 });
 
 export const previewMultiAttachIncomingFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.number()
+	featureId: z.string(),
+	quantity: z.number(),
 });
 
 export const previewMultiAttachOutgoingFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.number()
+	featureId: z.string(),
+	quantity: z.number(),
 });
 
 export const previewMultiAttachInvoiceCreditsSchema = z.object({
-    balance: z.number(),
-    currency: z.string()
+	balance: z.number(),
+	currency: z.string(),
 });
 
 export const previewMultiAttachBasePriceOutboundSchema = z.object({
-    amount: z.number(),
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const previewMultiAttachToOutboundSchema = z.union([z.number(), z.string()]);
+export const previewMultiAttachToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const previewMultiAttachTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewMultiAttachTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewMultiAttachTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const previewMultiAttachRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewMultiAttachResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([previewMultiAttachPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([previewMultiAttachProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([previewMultiAttachRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([previewMultiAttachResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([previewMultiAttachPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([previewMultiAttachProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewMultiAttachRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachCustomizeOutboundSchema = z.object({
-    price: z.union([previewMultiAttachBasePriceOutboundSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(previewMultiAttachPlanItemOutboundSchema), z.undefined()]).optional()
+	price: z
+		.union([previewMultiAttachBasePriceOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(previewMultiAttachPlanItemOutboundSchema), z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachPlanFeatureQuantityOutboundSchema = z.object({
-    feature_id: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	feature_id: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachPlanOutboundSchema = z.object({
-    plan_id: z.string(),
-    customize: z.union([previewMultiAttachCustomizeOutboundSchema, z.undefined()]).optional(),
-    feature_quantities: z.union([z.array(previewMultiAttachPlanFeatureQuantityOutboundSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    subscription_id: z.union([z.string(), z.undefined()]).optional()
+	plan_id: z.string(),
+	customize: z
+		.union([previewMultiAttachCustomizeOutboundSchema, z.undefined()])
+		.optional(),
+	feature_quantities: z
+		.union([
+			z.array(previewMultiAttachPlanFeatureQuantityOutboundSchema),
+			z.undefined(),
+		])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	subscription_id: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachFreeTrialParamsOutboundSchema = z.object({
-    duration_length: z.number(),
-    duration_type: z.string(),
-    card_required: z.boolean(),
-    on_end: z.union([z.string(), z.undefined()]).optional()
+	duration_length: z.number(),
+	duration_type: z.string(),
+	card_required: z.boolean(),
+	on_end: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachInvoiceModeOutboundSchema = z.object({
-    enabled: z.boolean(),
-    enable_plan_immediately: z.boolean(),
-    finalize: z.boolean()
+	enabled: z.boolean(),
+	enable_plan_immediately: z.boolean(),
+	finalize: z.boolean(),
 });
 
 export const previewMultiAttachAttachDiscountOutboundSchema = z.object({
-    reward_id: z.union([z.string(), z.undefined()]).optional(),
-    promotion_code: z.union([z.string(), z.undefined()]).optional()
+	reward_id: z.union([z.string(), z.undefined()]).optional(),
+	promotion_code: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachSpendLimitOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.boolean(),
-    overage_limit: z.union([z.number(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.boolean(),
+	overage_limit: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachUsageAlertOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.boolean(),
-    threshold: z.number(),
-    threshold_type: z.string(),
-    name: z.union([z.string(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.boolean(),
+	threshold: z.number(),
+	threshold_type: z.string(),
+	name: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachOverageAllowedOutboundSchema = z.object({
-    feature_id: z.string(),
-    enabled: z.boolean()
+	feature_id: z.string(),
+	enabled: z.boolean(),
 });
 
 export const previewMultiAttachBillingControlsOutboundSchema = z.object({
-    spend_limits: z.union([z.array(previewMultiAttachSpendLimitOutboundSchema), z.undefined()]).optional(),
-    usage_alerts: z.union([z.array(previewMultiAttachUsageAlertOutboundSchema), z.undefined()]).optional(),
-    overage_allowed: z.union([z.array(previewMultiAttachOverageAllowedOutboundSchema), z.undefined()]).optional()
+	spend_limits: z
+		.union([z.array(previewMultiAttachSpendLimitOutboundSchema), z.undefined()])
+		.optional(),
+	usage_alerts: z
+		.union([z.array(previewMultiAttachUsageAlertOutboundSchema), z.undefined()])
+		.optional(),
+	overage_allowed: z
+		.union([
+			z.array(previewMultiAttachOverageAllowedOutboundSchema),
+			z.undefined(),
+		])
+		.optional(),
 });
 
 export const previewMultiAttachEntityDataOutboundSchema = z.object({
-    feature_id: z.string(),
-    name: z.union([z.string(), z.undefined()]).optional(),
-    billing_controls: z.union([previewMultiAttachBillingControlsOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	name: z.union([z.string(), z.undefined()]).optional(),
+	billing_controls: z
+		.union([previewMultiAttachBillingControlsOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -257,16 +303,16 @@ const customerDataOutboundSchema = z.any();
 export const previewMultiAttachPriceIntervalSchema = closedEnumSchema;
 
 export const previewMultiAttachBasePriceSchema = z.object({
-    amount: z.number(),
-    interval: previewMultiAttachPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: previewMultiAttachPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachResetIntervalSchema = closedEnumSchema;
 
 export const previewMultiAttachResetSchema = z.object({
-    interval: previewMultiAttachResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: previewMultiAttachResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachTierBehaviorSchema = closedEnumSchema;
@@ -276,14 +322,18 @@ export const previewMultiAttachItemPriceIntervalSchema = closedEnumSchema;
 export const previewMultiAttachBillingMethodSchema = closedEnumSchema;
 
 export const previewMultiAttachPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewMultiAttachTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([previewMultiAttachTierBehaviorSchema, z.undefined()]).optional(),
-    interval: previewMultiAttachItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: previewMultiAttachBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewMultiAttachTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([previewMultiAttachTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: previewMultiAttachItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: previewMultiAttachBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachOnIncreaseSchema = closedEnumSchema;
@@ -291,40 +341,56 @@ export const previewMultiAttachOnIncreaseSchema = closedEnumSchema;
 export const previewMultiAttachOnDecreaseSchema = closedEnumSchema;
 
 export const previewMultiAttachProrationSchema = z.object({
-    onIncrease: previewMultiAttachOnIncreaseSchema,
-    onDecrease: previewMultiAttachOnDecreaseSchema
+	onIncrease: previewMultiAttachOnIncreaseSchema,
+	onDecrease: previewMultiAttachOnDecreaseSchema,
 });
 
 export const previewMultiAttachExpiryDurationTypeSchema = closedEnumSchema;
 
 export const previewMultiAttachRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: previewMultiAttachExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: previewMultiAttachExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewMultiAttachResetSchema, z.undefined()]).optional(),
-    price: z.union([previewMultiAttachPriceSchema, z.undefined()]).optional(),
-    proration: z.union([previewMultiAttachProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([previewMultiAttachRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([previewMultiAttachResetSchema, z.undefined()]).optional(),
+	price: z.union([previewMultiAttachPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([previewMultiAttachProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewMultiAttachRolloverSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachCustomizeSchema = z.object({
-    price: z.union([previewMultiAttachBasePriceSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(previewMultiAttachPlanItemSchema), z.undefined()]).optional()
+	price: z
+		.union([previewMultiAttachBasePriceSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(previewMultiAttachPlanItemSchema), z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachPlanSchema = z.object({
-    planId: z.string(),
-    customize: z.union([previewMultiAttachCustomizeSchema, z.undefined()]).optional(),
-    featureQuantities: z.union([z.array(previewMultiAttachPlanFeatureQuantitySchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    subscriptionId: z.union([z.string(), z.undefined()]).optional()
+	planId: z.string(),
+	customize: z
+		.union([previewMultiAttachCustomizeSchema, z.undefined()])
+		.optional(),
+	featureQuantities: z
+		.union([
+			z.array(previewMultiAttachPlanFeatureQuantitySchema),
+			z.undefined(),
+		])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	subscriptionId: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachDurationTypeSchema = closedEnumSchema;
@@ -332,10 +398,12 @@ export const previewMultiAttachDurationTypeSchema = closedEnumSchema;
 export const previewMultiAttachOnEndSchema = closedEnumSchema;
 
 export const previewMultiAttachFreeTrialParamsSchema = z.object({
-    durationLength: z.number(),
-    durationType: z.union([previewMultiAttachDurationTypeSchema, z.undefined()]).optional(),
-    cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
-    onEnd: z.union([previewMultiAttachOnEndSchema, z.undefined()]).optional()
+	durationLength: z.number(),
+	durationType: z
+		.union([previewMultiAttachDurationTypeSchema, z.undefined()])
+		.optional(),
+	cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
+	onEnd: z.union([previewMultiAttachOnEndSchema, z.undefined()]).optional(),
 });
 
 export const previewMultiAttachRedirectModeSchema = closedEnumSchema;
@@ -343,57 +411,78 @@ export const previewMultiAttachRedirectModeSchema = closedEnumSchema;
 export const previewMultiAttachThresholdTypeSchema = closedEnumSchema;
 
 export const previewMultiAttachUsageAlertSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    enabled: z.union([z.boolean(), z.undefined()]).optional(),
-    threshold: z.number(),
-    thresholdType: previewMultiAttachThresholdTypeSchema,
-    name: z.union([z.string(), z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	enabled: z.union([z.boolean(), z.undefined()]).optional(),
+	threshold: z.number(),
+	thresholdType: previewMultiAttachThresholdTypeSchema,
+	name: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewMultiAttachBillingControlsSchema = z.object({
-    spendLimits: z.union([z.array(previewMultiAttachSpendLimitSchema), z.undefined()]).optional(),
-    usageAlerts: z.union([z.array(previewMultiAttachUsageAlertSchema), z.undefined()]).optional(),
-    overageAllowed: z.union([z.array(previewMultiAttachOverageAllowedSchema), z.undefined()]).optional()
+	spendLimits: z
+		.union([z.array(previewMultiAttachSpendLimitSchema), z.undefined()])
+		.optional(),
+	usageAlerts: z
+		.union([z.array(previewMultiAttachUsageAlertSchema), z.undefined()])
+		.optional(),
+	overageAllowed: z
+		.union([z.array(previewMultiAttachOverageAllowedSchema), z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachEntityDataSchema = z.object({
-    featureId: z.string(),
-    name: z.union([z.string(), z.undefined()]).optional(),
-    billingControls: z.union([previewMultiAttachBillingControlsSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	name: z.union([z.string(), z.undefined()]).optional(),
+	billingControls: z
+		.union([previewMultiAttachBillingControlsSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachParamsSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    plans: z.array(previewMultiAttachPlanSchema),
-    freeTrial: z.union([previewMultiAttachFreeTrialParamsSchema, z.undefined()]).optional().nullable(),
-    invoiceMode: z.union([previewMultiAttachInvoiceModeSchema, z.undefined()]).optional(),
-    discounts: z.union([z.array(previewMultiAttachAttachDiscountSchema), z.undefined()]).optional(),
-    successUrl: z.union([z.string(), z.undefined()]).optional(),
-    checkoutSessionParams: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    redirectMode: z.union([previewMultiAttachRedirectModeSchema, z.undefined()]).optional(),
-    newBillingSubscription: z.union([z.boolean(), z.undefined()]).optional(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    customerData: z.union([customerDataSchema, z.undefined()]).optional(),
-    entityData: z.union([previewMultiAttachEntityDataSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	plans: z.array(previewMultiAttachPlanSchema),
+	freeTrial: z
+		.union([previewMultiAttachFreeTrialParamsSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	invoiceMode: z
+		.union([previewMultiAttachInvoiceModeSchema, z.undefined()])
+		.optional(),
+	discounts: z
+		.union([z.array(previewMultiAttachAttachDiscountSchema), z.undefined()])
+		.optional(),
+	successUrl: z.union([z.string(), z.undefined()]).optional(),
+	checkoutSessionParams: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	redirectMode: z
+		.union([previewMultiAttachRedirectModeSchema, z.undefined()])
+		.optional(),
+	newBillingSubscription: z.union([z.boolean(), z.undefined()]).optional(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	customerData: z.union([customerDataSchema, z.undefined()]).optional(),
+	entityData: z
+		.union([previewMultiAttachEntityDataSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachIncomingSchema = z.object({
-    planId: z.string(),
-    plan: z.union([planSchema, z.undefined()]).optional(),
-    featureQuantities: z.array(previewMultiAttachIncomingFeatureQuantitySchema),
-    effectiveAt: z.number().nullable(),
-    canceledAt: z.number().nullable(),
-    expiresAt: z.number().nullable()
+	planId: z.string(),
+	plan: z.union([planSchema, z.undefined()]).optional(),
+	featureQuantities: z.array(previewMultiAttachIncomingFeatureQuantitySchema),
+	effectiveAt: z.number().nullable(),
+	canceledAt: z.number().nullable(),
+	expiresAt: z.number().nullable(),
 });
 
 export const previewMultiAttachOutgoingSchema = z.object({
-    planId: z.string(),
-    plan: z.union([planSchema, z.undefined()]).optional(),
-    featureQuantities: z.array(previewMultiAttachOutgoingFeatureQuantitySchema),
-    effectiveAt: z.number().nullable(),
-    canceledAt: z.number().nullable(),
-    expiresAt: z.number().nullable()
+	planId: z.string(),
+	plan: z.union([planSchema, z.undefined()]).optional(),
+	featureQuantities: z.array(previewMultiAttachOutgoingFeatureQuantitySchema),
+	effectiveAt: z.number().nullable(),
+	canceledAt: z.number().nullable(),
+	expiresAt: z.number().nullable(),
 });
 
 export const previewMultiAttachCheckoutTypeSchema = openEnumSchema;
@@ -401,41 +490,61 @@ export const previewMultiAttachCheckoutTypeSchema = openEnumSchema;
 export const previewMultiAttachStatusSchema = openEnumSchema;
 
 export const previewMultiAttachTaxSchema = z.object({
-    total: z.number(),
-    amountInclusive: z.number(),
-    amountExclusive: z.number(),
-    currency: z.string(),
-    status: previewMultiAttachStatusSchema
+	total: z.number(),
+	amountInclusive: z.number(),
+	amountExclusive: z.number(),
+	currency: z.string(),
+	status: previewMultiAttachStatusSchema,
 });
 
 export const previewMultiAttachResponseSchema = z.object({
-    customerId: z.string(),
-    lineItems: z.array(previewMultiAttachLineItemSchema),
-    subtotal: z.number(),
-    total: z.number(),
-    currency: z.string(),
-    nextCycle: z.union([previewMultiAttachNextCycleSchema, z.undefined()]).optional(),
-    expand: z.union([z.array(z.string()), z.undefined()]).optional(),
-    incoming: z.array(previewMultiAttachIncomingSchema),
-    outgoing: z.array(previewMultiAttachOutgoingSchema),
-    redirectToCheckout: z.boolean(),
-    checkoutType: previewMultiAttachCheckoutTypeSchema.nullable(),
-    tax: z.union([previewMultiAttachTaxSchema, z.undefined()]).optional(),
-    invoiceCredits: z.union([previewMultiAttachInvoiceCreditsSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	lineItems: z.array(previewMultiAttachLineItemSchema),
+	subtotal: z.number(),
+	total: z.number(),
+	currency: z.string(),
+	nextCycle: z
+		.union([previewMultiAttachNextCycleSchema, z.undefined()])
+		.optional(),
+	expand: z.union([z.array(z.string()), z.undefined()]).optional(),
+	incoming: z.array(previewMultiAttachIncomingSchema),
+	outgoing: z.array(previewMultiAttachOutgoingSchema),
+	redirectToCheckout: z.boolean(),
+	checkoutType: previewMultiAttachCheckoutTypeSchema.nullable(),
+	tax: z.union([previewMultiAttachTaxSchema, z.undefined()]).optional(),
+	invoiceCredits: z
+		.union([previewMultiAttachInvoiceCreditsSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewMultiAttachParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    plans: z.array(previewMultiAttachPlanOutboundSchema),
-    free_trial: z.union([previewMultiAttachFreeTrialParamsOutboundSchema, z.undefined()]).optional().nullable(),
-    invoice_mode: z.union([previewMultiAttachInvoiceModeOutboundSchema, z.undefined()]).optional(),
-    discounts: z.union([z.array(previewMultiAttachAttachDiscountOutboundSchema), z.undefined()]).optional(),
-    success_url: z.union([z.string(), z.undefined()]).optional(),
-    checkout_session_params: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    redirect_mode: z.string(),
-    new_billing_subscription: z.union([z.boolean(), z.undefined()]).optional(),
-    enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
-    customer_data: z.union([customerDataOutboundSchema, z.undefined()]).optional(),
-    entity_data: z.union([previewMultiAttachEntityDataOutboundSchema, z.undefined()]).optional()
+	customer_id: z.string(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	plans: z.array(previewMultiAttachPlanOutboundSchema),
+	free_trial: z
+		.union([previewMultiAttachFreeTrialParamsOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	invoice_mode: z
+		.union([previewMultiAttachInvoiceModeOutboundSchema, z.undefined()])
+		.optional(),
+	discounts: z
+		.union([
+			z.array(previewMultiAttachAttachDiscountOutboundSchema),
+			z.undefined(),
+		])
+		.optional(),
+	success_url: z.union([z.string(), z.undefined()]).optional(),
+	checkout_session_params: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	redirect_mode: z.string(),
+	new_billing_subscription: z.union([z.boolean(), z.undefined()]).optional(),
+	enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
+	customer_data: z
+		.union([customerDataOutboundSchema, z.undefined()])
+		.optional(),
+	entity_data: z
+		.union([previewMultiAttachEntityDataOutboundSchema, z.undefined()])
+		.optional(),
 });

--- a/packages/autumn-js/src/generated/previewUpdateSubscriptionSchemas.ts
+++ b/packages/autumn-js/src/generated/previewUpdateSubscriptionSchemas.ts
@@ -2,285 +2,346 @@
 import { z } from "zod/v4";
 
 export const previewUpdateGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewUpdateFeatureQuantityRequestSchema = z.object({
-    featureId: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemToSchema = z.union([z.number(), z.string()]);
 
 export const previewUpdateItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAddItemToSchema = z.union([z.number(), z.string()]);
 
 export const previewUpdateAddItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateInvoiceModeSchema = z.object({
-    enabled: z.boolean(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    finalize: z.union([z.boolean(), z.undefined()]).optional()
+	enabled: z.boolean(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	finalize: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAttachDiscountSchema = z.object({
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    promotionCode: z.union([z.string(), z.undefined()]).optional()
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	promotionCode: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewUpdateRecalculateBalancesSchema = z.object({
-    enabled: z.boolean()
+	enabled: z.boolean(),
 });
 
 export const previewUpdateDiscountSchema = z.object({
-    amountOff: z.number(),
-    percentOff: z.union([z.number(), z.undefined()]).optional(),
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    rewardName: z.union([z.string(), z.undefined()]).optional()
+	amountOff: z.number(),
+	percentOff: z.union([z.number(), z.undefined()]).optional(),
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	rewardName: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewUpdateLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewUpdateLineItemSchema = z.object({
-    displayName: z.string(),
-    description: z.string(),
-    subtotal: z.number(),
-    total: z.number(),
-    discounts: z.union([z.array(previewUpdateDiscountSchema), z.undefined()]).optional(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewUpdateLineItemPeriodSchema, z.undefined()]).optional(),
-    quantity: z.number()
+	displayName: z.string(),
+	description: z.string(),
+	subtotal: z.number(),
+	total: z.number(),
+	discounts: z
+		.union([z.array(previewUpdateDiscountSchema), z.undefined()])
+		.optional(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewUpdateLineItemPeriodSchema, z.undefined()])
+		.optional(),
+	quantity: z.number(),
 });
 
 export const previewUpdateNextCycleDiscountSchema = z.object({
-    amountOff: z.number(),
-    percentOff: z.union([z.number(), z.undefined()]).optional(),
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    rewardName: z.union([z.string(), z.undefined()]).optional()
+	amountOff: z.number(),
+	percentOff: z.union([z.number(), z.undefined()]).optional(),
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	rewardName: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewUpdateNextCycleLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewUpdateNextCycleLineItemSchema = z.object({
-    displayName: z.string(),
-    description: z.string(),
-    subtotal: z.number(),
-    total: z.number(),
-    discounts: z.union([z.array(previewUpdateNextCycleDiscountSchema), z.undefined()]).optional(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewUpdateNextCycleLineItemPeriodSchema, z.undefined()]).optional(),
-    quantity: z.number()
+	displayName: z.string(),
+	description: z.string(),
+	subtotal: z.number(),
+	total: z.number(),
+	discounts: z
+		.union([z.array(previewUpdateNextCycleDiscountSchema), z.undefined()])
+		.optional(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewUpdateNextCycleLineItemPeriodSchema, z.undefined()])
+		.optional(),
+	quantity: z.number(),
 });
 
 export const previewUpdateUsageLineItemPeriodSchema = z.object({
-    start: z.number(),
-    end: z.number()
+	start: z.number(),
+	end: z.number(),
 });
 
 export const previewUpdateUsageLineItemSchema = z.object({
-    displayName: z.string(),
-    planId: z.string(),
-    featureId: z.string().nullable(),
-    period: z.union([previewUpdateUsageLineItemPeriodSchema, z.undefined()]).optional()
+	displayName: z.string(),
+	planId: z.string(),
+	featureId: z.string().nullable(),
+	period: z
+		.union([previewUpdateUsageLineItemPeriodSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewUpdateNextCycleSchema = z.object({
-    startsAt: z.number(),
-    subtotal: z.number(),
-    total: z.number(),
-    lineItems: z.array(previewUpdateNextCycleLineItemSchema),
-    usageLineItems: z.array(previewUpdateUsageLineItemSchema)
+	startsAt: z.number(),
+	subtotal: z.number(),
+	total: z.number(),
+	lineItems: z.array(previewUpdateNextCycleLineItemSchema),
+	usageLineItems: z.array(previewUpdateUsageLineItemSchema),
 });
 
 export const previewUpdateIncomingFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.number()
+	featureId: z.string(),
+	quantity: z.number(),
 });
 
 export const previewUpdateOutgoingFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.number()
+	featureId: z.string(),
+	quantity: z.number(),
 });
 
 export const previewUpdateInvoiceCreditsSchema = z.object({
-    balance: z.number(),
-    currency: z.string()
+	balance: z.number(),
+	currency: z.string(),
 });
 
 export const previewUpdateFeatureQuantityRequestOutboundSchema = z.object({
-    feature_id: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	feature_id: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const previewUpdateBasePriceOutboundSchema = z.object({
-    amount: z.number(),
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const previewUpdateItemToOutboundSchema = z.union([z.number(), z.string()]);
+export const previewUpdateItemToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const previewUpdateItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewUpdateItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewUpdateItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const previewUpdateItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewUpdateItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([previewUpdateItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([previewUpdateItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([previewUpdateItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([previewUpdateItemResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([previewUpdateItemPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([previewUpdateItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewUpdateItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewUpdateAddItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const previewUpdateAddItemToOutboundSchema = z.union([z.number(), z.string()]);
+export const previewUpdateAddItemToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const previewUpdateAddItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAddItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewUpdateAddItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewUpdateAddItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAddItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const previewUpdateAddItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAddItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewUpdateAddItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([previewUpdateAddItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([previewUpdateAddItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([previewUpdateAddItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([previewUpdateAddItemResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([previewUpdateAddItemPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([previewUpdateAddItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewUpdateAddItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewUpdatePlanItemFilterOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    billing_method: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.union([z.string(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	billing_method: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewUpdateFreeTrialParamsOutboundSchema = z.object({
-    duration_length: z.number(),
-    duration_type: z.string(),
-    card_required: z.boolean(),
-    on_end: z.union([z.string(), z.undefined()]).optional()
+	duration_length: z.number(),
+	duration_type: z.string(),
+	card_required: z.boolean(),
+	on_end: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewUpdateCustomizeOutboundSchema = z.object({
-    price: z.union([previewUpdateBasePriceOutboundSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(previewUpdateItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    add_items: z.union([z.array(previewUpdateAddItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    remove_items: z.union([z.array(previewUpdatePlanItemFilterOutboundSchema), z.undefined()]).optional(),
-    free_trial: z.union([previewUpdateFreeTrialParamsOutboundSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([previewUpdateBasePriceOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(previewUpdateItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	add_items: z
+		.union([z.array(previewUpdateAddItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	remove_items: z
+		.union([z.array(previewUpdatePlanItemFilterOutboundSchema), z.undefined()])
+		.optional(),
+	free_trial: z
+		.union([previewUpdateFreeTrialParamsOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const previewUpdateInvoiceModeOutboundSchema = z.object({
-    enabled: z.boolean(),
-    enable_plan_immediately: z.boolean(),
-    finalize: z.boolean()
+	enabled: z.boolean(),
+	enable_plan_immediately: z.boolean(),
+	finalize: z.boolean(),
 });
 
 export const previewUpdateAttachDiscountOutboundSchema = z.object({
-    reward_id: z.union([z.string(), z.undefined()]).optional(),
-    promotion_code: z.union([z.string(), z.undefined()]).optional()
+	reward_id: z.union([z.string(), z.undefined()]).optional(),
+	promotion_code: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const previewUpdateRecalculateBalancesOutboundSchema = z.object({
-    enabled: z.boolean()
+	enabled: z.boolean(),
 });
 
 export const previewUpdateParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    plan_id: z.union([z.string(), z.undefined()]).optional(),
-    feature_quantities: z.union([z.array(previewUpdateFeatureQuantityRequestOutboundSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([previewUpdateCustomizeOutboundSchema, z.undefined()]).optional(),
-    invoice_mode: z.union([previewUpdateInvoiceModeOutboundSchema, z.undefined()]).optional(),
-    proration_behavior: z.union([z.string(), z.undefined()]).optional(),
-    redirect_mode: z.string(),
-    subscription_id: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(previewUpdateAttachDiscountOutboundSchema), z.undefined()]).optional(),
-    cancel_action: z.union([z.string(), z.undefined()]).optional(),
-    billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
-    recalculate_balances: z.union([previewUpdateRecalculateBalancesOutboundSchema, z.undefined()]).optional()
+	customer_id: z.string(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	plan_id: z.union([z.string(), z.undefined()]).optional(),
+	feature_quantities: z
+		.union([
+			z.array(previewUpdateFeatureQuantityRequestOutboundSchema),
+			z.undefined(),
+		])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z
+		.union([previewUpdateCustomizeOutboundSchema, z.undefined()])
+		.optional(),
+	invoice_mode: z
+		.union([previewUpdateInvoiceModeOutboundSchema, z.undefined()])
+		.optional(),
+	proration_behavior: z.union([z.string(), z.undefined()]).optional(),
+	redirect_mode: z.string(),
+	subscription_id: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(previewUpdateAttachDiscountOutboundSchema), z.undefined()])
+		.optional(),
+	cancel_action: z.union([z.string(), z.undefined()]).optional(),
+	billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
+	recalculate_balances: z
+		.union([previewUpdateRecalculateBalancesOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -292,16 +353,16 @@ const openEnumSchema = z.any();
 export const previewUpdatePriceIntervalSchema = closedEnumSchema;
 
 export const previewUpdateBasePriceSchema = z.object({
-    amount: z.number(),
-    interval: previewUpdatePriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: previewUpdatePriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemResetIntervalSchema = closedEnumSchema;
 
 export const previewUpdateItemResetSchema = z.object({
-    interval: previewUpdateItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: previewUpdateItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemTierBehaviorSchema = closedEnumSchema;
@@ -311,14 +372,18 @@ export const previewUpdateItemPriceIntervalSchema = closedEnumSchema;
 export const previewUpdateItemBillingMethodSchema = closedEnumSchema;
 
 export const previewUpdateItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewUpdateItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([previewUpdateItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: previewUpdateItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: previewUpdateItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewUpdateItemTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([previewUpdateItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: previewUpdateItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: previewUpdateItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemOnIncreaseSchema = closedEnumSchema;
@@ -326,34 +391,38 @@ export const previewUpdateItemOnIncreaseSchema = closedEnumSchema;
 export const previewUpdateItemOnDecreaseSchema = closedEnumSchema;
 
 export const previewUpdateItemProrationSchema = z.object({
-    onIncrease: previewUpdateItemOnIncreaseSchema,
-    onDecrease: previewUpdateItemOnDecreaseSchema
+	onIncrease: previewUpdateItemOnIncreaseSchema,
+	onDecrease: previewUpdateItemOnDecreaseSchema,
 });
 
 export const previewUpdateItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const previewUpdateItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: previewUpdateItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: previewUpdateItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewUpdateItemResetSchema, z.undefined()]).optional(),
-    price: z.union([previewUpdateItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([previewUpdateItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([previewUpdateItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([previewUpdateItemResetSchema, z.undefined()]).optional(),
+	price: z.union([previewUpdateItemPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([previewUpdateItemProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewUpdateItemRolloverSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewUpdateAddItemResetIntervalSchema = closedEnumSchema;
 
 export const previewUpdateAddItemResetSchema = z.object({
-    interval: previewUpdateAddItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: previewUpdateAddItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAddItemTierBehaviorSchema = closedEnumSchema;
@@ -363,14 +432,18 @@ export const previewUpdateAddItemPriceIntervalSchema = closedEnumSchema;
 export const previewUpdateAddItemBillingMethodSchema = closedEnumSchema;
 
 export const previewUpdateAddItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(previewUpdateAddItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([previewUpdateAddItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: previewUpdateAddItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: previewUpdateAddItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(previewUpdateAddItemTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([previewUpdateAddItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: previewUpdateAddItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: previewUpdateAddItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAddItemOnIncreaseSchema = closedEnumSchema;
@@ -378,27 +451,31 @@ export const previewUpdateAddItemOnIncreaseSchema = closedEnumSchema;
 export const previewUpdateAddItemOnDecreaseSchema = closedEnumSchema;
 
 export const previewUpdateAddItemProrationSchema = z.object({
-    onIncrease: previewUpdateAddItemOnIncreaseSchema,
-    onDecrease: previewUpdateAddItemOnDecreaseSchema
+	onIncrease: previewUpdateAddItemOnIncreaseSchema,
+	onDecrease: previewUpdateAddItemOnDecreaseSchema,
 });
 
 export const previewUpdateAddItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const previewUpdateAddItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: previewUpdateAddItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: previewUpdateAddItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const previewUpdateAddItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([previewUpdateAddItemResetSchema, z.undefined()]).optional(),
-    price: z.union([previewUpdateAddItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([previewUpdateAddItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([previewUpdateAddItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([previewUpdateAddItemResetSchema, z.undefined()]).optional(),
+	price: z.union([previewUpdateAddItemPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([previewUpdateAddItemProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([previewUpdateAddItemRolloverSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewUpdateRemoveItemBillingMethodSchema = closedEnumSchema;
@@ -406,9 +483,13 @@ export const previewUpdateRemoveItemBillingMethodSchema = closedEnumSchema;
 export const previewUpdateRemoveItemIntervalSchema = closedEnumSchema;
 
 export const previewUpdatePlanItemFilterSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    billingMethod: z.union([previewUpdateRemoveItemBillingMethodSchema, z.undefined()]).optional(),
-    interval: z.union([previewUpdateRemoveItemIntervalSchema, z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	billingMethod: z
+		.union([previewUpdateRemoveItemBillingMethodSchema, z.undefined()])
+		.optional(),
+	interval: z
+		.union([previewUpdateRemoveItemIntervalSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewUpdateDurationTypeSchema = closedEnumSchema;
@@ -416,18 +497,32 @@ export const previewUpdateDurationTypeSchema = closedEnumSchema;
 export const previewUpdateOnEndSchema = closedEnumSchema;
 
 export const previewUpdateFreeTrialParamsSchema = z.object({
-    durationLength: z.number(),
-    durationType: z.union([previewUpdateDurationTypeSchema, z.undefined()]).optional(),
-    cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
-    onEnd: z.union([previewUpdateOnEndSchema, z.undefined()]).optional()
+	durationLength: z.number(),
+	durationType: z
+		.union([previewUpdateDurationTypeSchema, z.undefined()])
+		.optional(),
+	cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
+	onEnd: z.union([previewUpdateOnEndSchema, z.undefined()]).optional(),
 });
 
 export const previewUpdateCustomizeSchema = z.object({
-    price: z.union([previewUpdateBasePriceSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(previewUpdateItemPlanItemSchema), z.undefined()]).optional(),
-    addItems: z.union([z.array(previewUpdateAddItemPlanItemSchema), z.undefined()]).optional(),
-    removeItems: z.union([z.array(previewUpdatePlanItemFilterSchema), z.undefined()]).optional(),
-    freeTrial: z.union([previewUpdateFreeTrialParamsSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([previewUpdateBasePriceSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(previewUpdateItemPlanItemSchema), z.undefined()])
+		.optional(),
+	addItems: z
+		.union([z.array(previewUpdateAddItemPlanItemSchema), z.undefined()])
+		.optional(),
+	removeItems: z
+		.union([z.array(previewUpdatePlanItemFilterSchema), z.undefined()])
+		.optional(),
+	freeTrial: z
+		.union([previewUpdateFreeTrialParamsSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const previewUpdateProrationBehaviorSchema = closedEnumSchema;
@@ -437,39 +532,53 @@ export const previewUpdateRedirectModeSchema = closedEnumSchema;
 export const previewUpdateCancelActionSchema = closedEnumSchema;
 
 export const previewUpdateParamsSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    planId: z.union([z.string(), z.undefined()]).optional(),
-    featureQuantities: z.union([z.array(previewUpdateFeatureQuantityRequestSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([previewUpdateCustomizeSchema, z.undefined()]).optional(),
-    invoiceMode: z.union([previewUpdateInvoiceModeSchema, z.undefined()]).optional(),
-    prorationBehavior: z.union([previewUpdateProrationBehaviorSchema, z.undefined()]).optional(),
-    redirectMode: z.union([previewUpdateRedirectModeSchema, z.undefined()]).optional(),
-    subscriptionId: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(previewUpdateAttachDiscountSchema), z.undefined()]).optional(),
-    cancelAction: z.union([previewUpdateCancelActionSchema, z.undefined()]).optional(),
-    billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
-    recalculateBalances: z.union([previewUpdateRecalculateBalancesSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	planId: z.union([z.string(), z.undefined()]).optional(),
+	featureQuantities: z
+		.union([z.array(previewUpdateFeatureQuantityRequestSchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z.union([previewUpdateCustomizeSchema, z.undefined()]).optional(),
+	invoiceMode: z
+		.union([previewUpdateInvoiceModeSchema, z.undefined()])
+		.optional(),
+	prorationBehavior: z
+		.union([previewUpdateProrationBehaviorSchema, z.undefined()])
+		.optional(),
+	redirectMode: z
+		.union([previewUpdateRedirectModeSchema, z.undefined()])
+		.optional(),
+	subscriptionId: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(previewUpdateAttachDiscountSchema), z.undefined()])
+		.optional(),
+	cancelAction: z
+		.union([previewUpdateCancelActionSchema, z.undefined()])
+		.optional(),
+	billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
+	recalculateBalances: z
+		.union([previewUpdateRecalculateBalancesSchema, z.undefined()])
+		.optional(),
 });
 
 export const previewUpdateIncomingSchema = z.object({
-    planId: z.string(),
-    plan: z.union([planSchema, z.undefined()]).optional(),
-    featureQuantities: z.array(previewUpdateIncomingFeatureQuantitySchema),
-    effectiveAt: z.number().nullable(),
-    canceledAt: z.number().nullable(),
-    expiresAt: z.number().nullable()
+	planId: z.string(),
+	plan: z.union([planSchema, z.undefined()]).optional(),
+	featureQuantities: z.array(previewUpdateIncomingFeatureQuantitySchema),
+	effectiveAt: z.number().nullable(),
+	canceledAt: z.number().nullable(),
+	expiresAt: z.number().nullable(),
 });
 
 export const previewUpdateOutgoingSchema = z.object({
-    planId: z.string(),
-    plan: z.union([planSchema, z.undefined()]).optional(),
-    featureQuantities: z.array(previewUpdateOutgoingFeatureQuantitySchema),
-    effectiveAt: z.number().nullable(),
-    canceledAt: z.number().nullable(),
-    expiresAt: z.number().nullable()
+	planId: z.string(),
+	plan: z.union([planSchema, z.undefined()]).optional(),
+	featureQuantities: z.array(previewUpdateOutgoingFeatureQuantitySchema),
+	effectiveAt: z.number().nullable(),
+	canceledAt: z.number().nullable(),
+	expiresAt: z.number().nullable(),
 });
 
 export const intentSchema = openEnumSchema;
@@ -477,24 +586,26 @@ export const intentSchema = openEnumSchema;
 export const previewUpdateStatusSchema = openEnumSchema;
 
 export const previewUpdateTaxSchema = z.object({
-    total: z.number(),
-    amountInclusive: z.number(),
-    amountExclusive: z.number(),
-    currency: z.string(),
-    status: previewUpdateStatusSchema
+	total: z.number(),
+	amountInclusive: z.number(),
+	amountExclusive: z.number(),
+	currency: z.string(),
+	status: previewUpdateStatusSchema,
 });
 
 export const previewUpdateResponseSchema = z.object({
-    customerId: z.string(),
-    lineItems: z.array(previewUpdateLineItemSchema),
-    subtotal: z.number(),
-    total: z.number(),
-    currency: z.string(),
-    nextCycle: z.union([previewUpdateNextCycleSchema, z.undefined()]).optional(),
-    expand: z.union([z.array(z.string()), z.undefined()]).optional(),
-    incoming: z.array(previewUpdateIncomingSchema),
-    outgoing: z.array(previewUpdateOutgoingSchema),
-    intent: intentSchema,
-    tax: z.union([previewUpdateTaxSchema, z.undefined()]).optional(),
-    invoiceCredits: z.union([previewUpdateInvoiceCreditsSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	lineItems: z.array(previewUpdateLineItemSchema),
+	subtotal: z.number(),
+	total: z.number(),
+	currency: z.string(),
+	nextCycle: z.union([previewUpdateNextCycleSchema, z.undefined()]).optional(),
+	expand: z.union([z.array(z.string()), z.undefined()]).optional(),
+	incoming: z.array(previewUpdateIncomingSchema),
+	outgoing: z.array(previewUpdateOutgoingSchema),
+	intent: intentSchema,
+	tax: z.union([previewUpdateTaxSchema, z.undefined()]).optional(),
+	invoiceCredits: z
+		.union([previewUpdateInvoiceCreditsSchema, z.undefined()])
+		.optional(),
 });

--- a/packages/autumn-js/src/generated/redeemReferralCodeSchemas.ts
+++ b/packages/autumn-js/src/generated/redeemReferralCodeSchemas.ts
@@ -2,21 +2,21 @@
 import { z } from "zod/v4";
 
 export const redeemReferralCodeGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const redeemReferralCodeParamsSchema = z.object({
-    code: z.string(),
-    customerId: z.string()
+	code: z.string(),
+	customerId: z.string(),
 });
 
 export const redeemReferralCodeResponseSchema = z.object({
-    id: z.string(),
-    customerId: z.string(),
-    rewardId: z.string()
+	id: z.string(),
+	customerId: z.string(),
+	rewardId: z.string(),
 });
 
 export const redeemReferralCodeParamsOutboundSchema = z.object({
-    code: z.string(),
-    customer_id: z.string()
+	code: z.string(),
+	customer_id: z.string(),
 });

--- a/packages/autumn-js/src/generated/setupPaymentSchemas.ts
+++ b/packages/autumn-js/src/generated/setupPaymentSchemas.ts
@@ -2,225 +2,279 @@
 import { z } from "zod/v4";
 
 export const setupPaymentGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const setupPaymentFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemToSchema = z.union([z.number(), z.string()]);
 
 export const setupPaymentItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAddItemToSchema = z.union([z.number(), z.string()]);
 
 export const setupPaymentAddItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAttachDiscountSchema = z.object({
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    promotionCode: z.union([z.string(), z.undefined()]).optional()
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	promotionCode: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const setupPaymentCustomLineItemSchema = z.object({
-    amount: z.number(),
-    description: z.string()
+	amount: z.number(),
+	description: z.string(),
 });
 
 export const setupPaymentCarryOverBalancesSchema = z.object({
-    enabled: z.boolean(),
-    featureIds: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	featureIds: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const setupPaymentCarryOverUsagesSchema = z.object({
-    enabled: z.boolean(),
-    featureIds: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	featureIds: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const setupPaymentResponseSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    url: z.string()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	url: z.string(),
 });
 
 export const setupPaymentFeatureQuantityOutboundSchema = z.object({
-    feature_id: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	feature_id: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const setupPaymentBasePriceOutboundSchema = z.object({
-    amount: z.number(),
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const setupPaymentItemToOutboundSchema = z.union([z.number(), z.string()]);
+export const setupPaymentItemToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const setupPaymentItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(setupPaymentItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(setupPaymentItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const setupPaymentItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([setupPaymentItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([setupPaymentItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([setupPaymentItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([setupPaymentItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([setupPaymentItemResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([setupPaymentItemPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([setupPaymentItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([setupPaymentItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const setupPaymentAddItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const setupPaymentAddItemToOutboundSchema = z.union([z.number(), z.string()]);
+export const setupPaymentAddItemToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const setupPaymentAddItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAddItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(setupPaymentAddItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(setupPaymentAddItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAddItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const setupPaymentAddItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAddItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([setupPaymentAddItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([setupPaymentAddItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([setupPaymentAddItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([setupPaymentAddItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([setupPaymentAddItemResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([setupPaymentAddItemPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([setupPaymentAddItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([setupPaymentAddItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const setupPaymentPlanItemFilterOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    billing_method: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.union([z.string(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	billing_method: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const setupPaymentFreeTrialParamsOutboundSchema = z.object({
-    duration_length: z.number(),
-    duration_type: z.string(),
-    card_required: z.boolean(),
-    on_end: z.union([z.string(), z.undefined()]).optional()
+	duration_length: z.number(),
+	duration_type: z.string(),
+	card_required: z.boolean(),
+	on_end: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const setupPaymentCustomizeOutboundSchema = z.object({
-    price: z.union([setupPaymentBasePriceOutboundSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(setupPaymentItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    add_items: z.union([z.array(setupPaymentAddItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    remove_items: z.union([z.array(setupPaymentPlanItemFilterOutboundSchema), z.undefined()]).optional(),
-    free_trial: z.union([setupPaymentFreeTrialParamsOutboundSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([setupPaymentBasePriceOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(setupPaymentItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	add_items: z
+		.union([z.array(setupPaymentAddItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	remove_items: z
+		.union([z.array(setupPaymentPlanItemFilterOutboundSchema), z.undefined()])
+		.optional(),
+	free_trial: z
+		.union([setupPaymentFreeTrialParamsOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const setupPaymentAttachDiscountOutboundSchema = z.object({
-    reward_id: z.union([z.string(), z.undefined()]).optional(),
-    promotion_code: z.union([z.string(), z.undefined()]).optional()
+	reward_id: z.union([z.string(), z.undefined()]).optional(),
+	promotion_code: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const setupPaymentCustomLineItemOutboundSchema = z.object({
-    amount: z.number(),
-    description: z.string()
+	amount: z.number(),
+	description: z.string(),
 });
 
 export const setupPaymentCarryOverBalancesOutboundSchema = z.object({
-    enabled: z.boolean(),
-    feature_ids: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	feature_ids: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const setupPaymentCarryOverUsagesOutboundSchema = z.object({
-    enabled: z.boolean(),
-    feature_ids: z.union([z.array(z.string()), z.undefined()]).optional()
+	enabled: z.boolean(),
+	feature_ids: z.union([z.array(z.string()), z.undefined()]).optional(),
 });
 
 export const setupPaymentParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    plan_id: z.union([z.string(), z.undefined()]).optional(),
-    feature_quantities: z.union([z.array(setupPaymentFeatureQuantityOutboundSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([setupPaymentCustomizeOutboundSchema, z.undefined()]).optional(),
-    proration_behavior: z.union([z.string(), z.undefined()]).optional(),
-    subscription_id: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(setupPaymentAttachDiscountOutboundSchema), z.undefined()]).optional(),
-    success_url: z.union([z.string(), z.undefined()]).optional(),
-    billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    starts_at: z.union([z.number(), z.undefined()]).optional(),
-    ends_at: z.union([z.number(), z.undefined()]).optional(),
-    checkout_session_params: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    custom_line_items: z.union([z.array(setupPaymentCustomLineItemOutboundSchema), z.undefined()]).optional(),
-    processor_subscription_id: z.union([z.string(), z.undefined()]).optional(),
-    carry_over_balances: z.union([setupPaymentCarryOverBalancesOutboundSchema, z.undefined()]).optional(),
-    carry_over_usages: z.union([setupPaymentCarryOverUsagesOutboundSchema, z.undefined()]).optional(),
-    metadata: z.union([z.record(z.string(), z.string()), z.undefined()]).optional(),
-    no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
-    enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
-    tax_rate_id: z.union([z.string(), z.undefined()]).optional()
+	customer_id: z.string(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	plan_id: z.union([z.string(), z.undefined()]).optional(),
+	feature_quantities: z
+		.union([z.array(setupPaymentFeatureQuantityOutboundSchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z
+		.union([setupPaymentCustomizeOutboundSchema, z.undefined()])
+		.optional(),
+	proration_behavior: z.union([z.string(), z.undefined()]).optional(),
+	subscription_id: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(setupPaymentAttachDiscountOutboundSchema), z.undefined()])
+		.optional(),
+	success_url: z.union([z.string(), z.undefined()]).optional(),
+	billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	starts_at: z.union([z.number(), z.undefined()]).optional(),
+	ends_at: z.union([z.number(), z.undefined()]).optional(),
+	checkout_session_params: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	custom_line_items: z
+		.union([z.array(setupPaymentCustomLineItemOutboundSchema), z.undefined()])
+		.optional(),
+	processor_subscription_id: z.union([z.string(), z.undefined()]).optional(),
+	carry_over_balances: z
+		.union([setupPaymentCarryOverBalancesOutboundSchema, z.undefined()])
+		.optional(),
+	carry_over_usages: z
+		.union([setupPaymentCarryOverUsagesOutboundSchema, z.undefined()])
+		.optional(),
+	metadata: z
+		.union([z.record(z.string(), z.string()), z.undefined()])
+		.optional(),
+	no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
+	enable_plan_immediately: z.union([z.boolean(), z.undefined()]).optional(),
+	tax_rate_id: z.union([z.string(), z.undefined()]).optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -228,16 +282,16 @@ const closedEnumSchema = z.any();
 export const setupPaymentPriceIntervalSchema = closedEnumSchema;
 
 export const setupPaymentBasePriceSchema = z.object({
-    amount: z.number(),
-    interval: setupPaymentPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: setupPaymentPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemResetIntervalSchema = closedEnumSchema;
 
 export const setupPaymentItemResetSchema = z.object({
-    interval: setupPaymentItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: setupPaymentItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemTierBehaviorSchema = closedEnumSchema;
@@ -247,14 +301,18 @@ export const setupPaymentItemPriceIntervalSchema = closedEnumSchema;
 export const setupPaymentItemBillingMethodSchema = closedEnumSchema;
 
 export const setupPaymentItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(setupPaymentItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([setupPaymentItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: setupPaymentItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: setupPaymentItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(setupPaymentItemTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([setupPaymentItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: setupPaymentItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: setupPaymentItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemOnIncreaseSchema = closedEnumSchema;
@@ -262,34 +320,36 @@ export const setupPaymentItemOnIncreaseSchema = closedEnumSchema;
 export const setupPaymentItemOnDecreaseSchema = closedEnumSchema;
 
 export const setupPaymentItemProrationSchema = z.object({
-    onIncrease: setupPaymentItemOnIncreaseSchema,
-    onDecrease: setupPaymentItemOnDecreaseSchema
+	onIncrease: setupPaymentItemOnIncreaseSchema,
+	onDecrease: setupPaymentItemOnDecreaseSchema,
 });
 
 export const setupPaymentItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const setupPaymentItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: setupPaymentItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: setupPaymentItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([setupPaymentItemResetSchema, z.undefined()]).optional(),
-    price: z.union([setupPaymentItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([setupPaymentItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([setupPaymentItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([setupPaymentItemResetSchema, z.undefined()]).optional(),
+	price: z.union([setupPaymentItemPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([setupPaymentItemProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z.union([setupPaymentItemRolloverSchema, z.undefined()]).optional(),
 });
 
 export const setupPaymentAddItemResetIntervalSchema = closedEnumSchema;
 
 export const setupPaymentAddItemResetSchema = z.object({
-    interval: setupPaymentAddItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: setupPaymentAddItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAddItemTierBehaviorSchema = closedEnumSchema;
@@ -299,14 +359,18 @@ export const setupPaymentAddItemPriceIntervalSchema = closedEnumSchema;
 export const setupPaymentAddItemBillingMethodSchema = closedEnumSchema;
 
 export const setupPaymentAddItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(setupPaymentAddItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([setupPaymentAddItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: setupPaymentAddItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: setupPaymentAddItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(setupPaymentAddItemTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([setupPaymentAddItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: setupPaymentAddItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: setupPaymentAddItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAddItemOnIncreaseSchema = closedEnumSchema;
@@ -314,27 +378,31 @@ export const setupPaymentAddItemOnIncreaseSchema = closedEnumSchema;
 export const setupPaymentAddItemOnDecreaseSchema = closedEnumSchema;
 
 export const setupPaymentAddItemProrationSchema = z.object({
-    onIncrease: setupPaymentAddItemOnIncreaseSchema,
-    onDecrease: setupPaymentAddItemOnDecreaseSchema
+	onIncrease: setupPaymentAddItemOnIncreaseSchema,
+	onDecrease: setupPaymentAddItemOnDecreaseSchema,
 });
 
 export const setupPaymentAddItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const setupPaymentAddItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: setupPaymentAddItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: setupPaymentAddItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const setupPaymentAddItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([setupPaymentAddItemResetSchema, z.undefined()]).optional(),
-    price: z.union([setupPaymentAddItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([setupPaymentAddItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([setupPaymentAddItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([setupPaymentAddItemResetSchema, z.undefined()]).optional(),
+	price: z.union([setupPaymentAddItemPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([setupPaymentAddItemProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([setupPaymentAddItemRolloverSchema, z.undefined()])
+		.optional(),
 });
 
 export const setupPaymentRemoveItemBillingMethodSchema = closedEnumSchema;
@@ -342,9 +410,13 @@ export const setupPaymentRemoveItemBillingMethodSchema = closedEnumSchema;
 export const setupPaymentRemoveItemIntervalSchema = closedEnumSchema;
 
 export const setupPaymentPlanItemFilterSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    billingMethod: z.union([setupPaymentRemoveItemBillingMethodSchema, z.undefined()]).optional(),
-    interval: z.union([setupPaymentRemoveItemIntervalSchema, z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	billingMethod: z
+		.union([setupPaymentRemoveItemBillingMethodSchema, z.undefined()])
+		.optional(),
+	interval: z
+		.union([setupPaymentRemoveItemIntervalSchema, z.undefined()])
+		.optional(),
 });
 
 export const setupPaymentDurationTypeSchema = closedEnumSchema;
@@ -352,43 +424,73 @@ export const setupPaymentDurationTypeSchema = closedEnumSchema;
 export const setupPaymentOnEndSchema = closedEnumSchema;
 
 export const setupPaymentFreeTrialParamsSchema = z.object({
-    durationLength: z.number(),
-    durationType: z.union([setupPaymentDurationTypeSchema, z.undefined()]).optional(),
-    cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
-    onEnd: z.union([setupPaymentOnEndSchema, z.undefined()]).optional()
+	durationLength: z.number(),
+	durationType: z
+		.union([setupPaymentDurationTypeSchema, z.undefined()])
+		.optional(),
+	cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
+	onEnd: z.union([setupPaymentOnEndSchema, z.undefined()]).optional(),
 });
 
 export const setupPaymentCustomizeSchema = z.object({
-    price: z.union([setupPaymentBasePriceSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(setupPaymentItemPlanItemSchema), z.undefined()]).optional(),
-    addItems: z.union([z.array(setupPaymentAddItemPlanItemSchema), z.undefined()]).optional(),
-    removeItems: z.union([z.array(setupPaymentPlanItemFilterSchema), z.undefined()]).optional(),
-    freeTrial: z.union([setupPaymentFreeTrialParamsSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([setupPaymentBasePriceSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(setupPaymentItemPlanItemSchema), z.undefined()])
+		.optional(),
+	addItems: z
+		.union([z.array(setupPaymentAddItemPlanItemSchema), z.undefined()])
+		.optional(),
+	removeItems: z
+		.union([z.array(setupPaymentPlanItemFilterSchema), z.undefined()])
+		.optional(),
+	freeTrial: z
+		.union([setupPaymentFreeTrialParamsSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const setupPaymentProrationBehaviorSchema = closedEnumSchema;
 
 export const setupPaymentParamsSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    planId: z.union([z.string(), z.undefined()]).optional(),
-    featureQuantities: z.union([z.array(setupPaymentFeatureQuantitySchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([setupPaymentCustomizeSchema, z.undefined()]).optional(),
-    prorationBehavior: z.union([setupPaymentProrationBehaviorSchema, z.undefined()]).optional(),
-    subscriptionId: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(setupPaymentAttachDiscountSchema), z.undefined()]).optional(),
-    successUrl: z.union([z.string(), z.undefined()]).optional(),
-    billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    startsAt: z.union([z.number(), z.undefined()]).optional(),
-    endsAt: z.union([z.number(), z.undefined()]).optional(),
-    checkoutSessionParams: z.union([z.record(z.string(), z.any()), z.undefined()]).optional(),
-    customLineItems: z.union([z.array(setupPaymentCustomLineItemSchema), z.undefined()]).optional(),
-    processorSubscriptionId: z.union([z.string(), z.undefined()]).optional(),
-    carryOverBalances: z.union([setupPaymentCarryOverBalancesSchema, z.undefined()]).optional(),
-    carryOverUsages: z.union([setupPaymentCarryOverUsagesSchema, z.undefined()]).optional(),
-    metadata: z.union([z.record(z.string(), z.string()), z.undefined()]).optional(),
-    noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    taxRateId: z.union([z.string(), z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	planId: z.union([z.string(), z.undefined()]).optional(),
+	featureQuantities: z
+		.union([z.array(setupPaymentFeatureQuantitySchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z.union([setupPaymentCustomizeSchema, z.undefined()]).optional(),
+	prorationBehavior: z
+		.union([setupPaymentProrationBehaviorSchema, z.undefined()])
+		.optional(),
+	subscriptionId: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(setupPaymentAttachDiscountSchema), z.undefined()])
+		.optional(),
+	successUrl: z.union([z.string(), z.undefined()]).optional(),
+	billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	startsAt: z.union([z.number(), z.undefined()]).optional(),
+	endsAt: z.union([z.number(), z.undefined()]).optional(),
+	checkoutSessionParams: z
+		.union([z.record(z.string(), z.any()), z.undefined()])
+		.optional(),
+	customLineItems: z
+		.union([z.array(setupPaymentCustomLineItemSchema), z.undefined()])
+		.optional(),
+	processorSubscriptionId: z.union([z.string(), z.undefined()]).optional(),
+	carryOverBalances: z
+		.union([setupPaymentCarryOverBalancesSchema, z.undefined()])
+		.optional(),
+	carryOverUsages: z
+		.union([setupPaymentCarryOverUsagesSchema, z.undefined()])
+		.optional(),
+	metadata: z
+		.union([z.record(z.string(), z.string()), z.undefined()])
+		.optional(),
+	noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	taxRateId: z.union([z.string(), z.undefined()]).optional(),
 });

--- a/packages/autumn-js/src/generated/updateSubscriptionSchemas.ts
+++ b/packages/autumn-js/src/generated/updateSubscriptionSchemas.ts
@@ -2,210 +2,258 @@
 import { z } from "zod/v4";
 
 export const billingUpdateGlobalsSchema = z.object({
-    xApiVersion: z.union([z.string(), z.undefined()]).optional()
+	xApiVersion: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const billingUpdateFeatureQuantitySchema = z.object({
-    featureId: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	featureId: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemToSchema = z.union([z.number(), z.string()]);
 
 export const billingUpdateItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAddItemToSchema = z.union([z.number(), z.string()]);
 
 export const billingUpdateAddItemTierSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flatAmount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flatAmount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateInvoiceModeSchema = z.object({
-    enabled: z.boolean(),
-    enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
-    finalize: z.union([z.boolean(), z.undefined()]).optional()
+	enabled: z.boolean(),
+	enablePlanImmediately: z.union([z.boolean(), z.undefined()]).optional(),
+	finalize: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAttachDiscountSchema = z.object({
-    rewardId: z.union([z.string(), z.undefined()]).optional(),
-    promotionCode: z.union([z.string(), z.undefined()]).optional()
+	rewardId: z.union([z.string(), z.undefined()]).optional(),
+	promotionCode: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const billingUpdateRecalculateBalancesSchema = z.object({
-    enabled: z.boolean()
+	enabled: z.boolean(),
 });
 
 export const billingUpdateInvoiceSchema = z.object({
-    status: z.string().nullable(),
-    stripeId: z.string(),
-    total: z.number(),
-    currency: z.string(),
-    hostedInvoiceUrl: z.string().nullable()
+	status: z.string().nullable(),
+	stripeId: z.string(),
+	total: z.number(),
+	currency: z.string(),
+	hostedInvoiceUrl: z.string().nullable(),
 });
 
 export const billingUpdateFeatureQuantityOutboundSchema = z.object({
-    feature_id: z.string(),
-    quantity: z.union([z.number(), z.undefined()]).optional(),
-    adjustable: z.union([z.boolean(), z.undefined()]).optional()
+	feature_id: z.string(),
+	quantity: z.union([z.number(), z.undefined()]).optional(),
+	adjustable: z.union([z.boolean(), z.undefined()]).optional(),
 });
 
 export const billingUpdateBasePriceOutboundSchema = z.object({
-    amount: z.number(),
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const billingUpdateItemToOutboundSchema = z.union([z.number(), z.string()]);
+export const billingUpdateItemToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const billingUpdateItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(billingUpdateItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(billingUpdateItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const billingUpdateItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([billingUpdateItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([billingUpdateItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([billingUpdateItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([billingUpdateItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([billingUpdateItemResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([billingUpdateItemPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([billingUpdateItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([billingUpdateItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const billingUpdateAddItemResetOutboundSchema = z.object({
-    interval: z.string(),
-    interval_count: z.union([z.number(), z.undefined()]).optional()
+	interval: z.string(),
+	interval_count: z.union([z.number(), z.undefined()]).optional(),
 });
 
-export const billingUpdateAddItemToOutboundSchema = z.union([z.number(), z.string()]);
+export const billingUpdateAddItemToOutboundSchema = z.union([
+	z.number(),
+	z.string(),
+]);
 
 export const billingUpdateAddItemTierOutboundSchema = z.object({
-    to: z.union([z.number(), z.string()]),
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    flat_amount: z.union([z.number(), z.undefined()]).optional()
+	to: z.union([z.number(), z.string()]),
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	flat_amount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAddItemPriceOutboundSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(billingUpdateAddItemTierOutboundSchema), z.undefined()]).optional(),
-    tier_behavior: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.string(),
-    interval_count: z.number(),
-    billing_units: z.number(),
-    billing_method: z.string(),
-    max_purchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(billingUpdateAddItemTierOutboundSchema), z.undefined()])
+		.optional(),
+	tier_behavior: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.string(),
+	interval_count: z.number(),
+	billing_units: z.number(),
+	billing_method: z.string(),
+	max_purchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAddItemProrationOutboundSchema = z.object({
-    on_increase: z.string(),
-    on_decrease: z.string()
+	on_increase: z.string(),
+	on_decrease: z.string(),
 });
 
 export const billingUpdateAddItemRolloverOutboundSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    max_percentage: z.union([z.number(), z.undefined()]).optional(),
-    expiry_duration_type: z.string(),
-    expiry_duration_length: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	max_percentage: z.union([z.number(), z.undefined()]).optional(),
+	expiry_duration_type: z.string(),
+	expiry_duration_length: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAddItemPlanItemOutboundSchema = z.object({
-    feature_id: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([billingUpdateAddItemResetOutboundSchema, z.undefined()]).optional(),
-    price: z.union([billingUpdateAddItemPriceOutboundSchema, z.undefined()]).optional(),
-    proration: z.union([billingUpdateAddItemProrationOutboundSchema, z.undefined()]).optional(),
-    rollover: z.union([billingUpdateAddItemRolloverOutboundSchema, z.undefined()]).optional()
+	feature_id: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z
+		.union([billingUpdateAddItemResetOutboundSchema, z.undefined()])
+		.optional(),
+	price: z
+		.union([billingUpdateAddItemPriceOutboundSchema, z.undefined()])
+		.optional(),
+	proration: z
+		.union([billingUpdateAddItemProrationOutboundSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([billingUpdateAddItemRolloverOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 export const billingUpdatePlanItemFilterOutboundSchema = z.object({
-    feature_id: z.union([z.string(), z.undefined()]).optional(),
-    billing_method: z.union([z.string(), z.undefined()]).optional(),
-    interval: z.union([z.string(), z.undefined()]).optional()
+	feature_id: z.union([z.string(), z.undefined()]).optional(),
+	billing_method: z.union([z.string(), z.undefined()]).optional(),
+	interval: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const billingUpdateFreeTrialParamsOutboundSchema = z.object({
-    duration_length: z.number(),
-    duration_type: z.string(),
-    card_required: z.boolean(),
-    on_end: z.union([z.string(), z.undefined()]).optional()
+	duration_length: z.number(),
+	duration_type: z.string(),
+	card_required: z.boolean(),
+	on_end: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const billingUpdateCustomizeOutboundSchema = z.object({
-    price: z.union([billingUpdateBasePriceOutboundSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(billingUpdateItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    add_items: z.union([z.array(billingUpdateAddItemPlanItemOutboundSchema), z.undefined()]).optional(),
-    remove_items: z.union([z.array(billingUpdatePlanItemFilterOutboundSchema), z.undefined()]).optional(),
-    free_trial: z.union([billingUpdateFreeTrialParamsOutboundSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([billingUpdateBasePriceOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(billingUpdateItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	add_items: z
+		.union([z.array(billingUpdateAddItemPlanItemOutboundSchema), z.undefined()])
+		.optional(),
+	remove_items: z
+		.union([z.array(billingUpdatePlanItemFilterOutboundSchema), z.undefined()])
+		.optional(),
+	free_trial: z
+		.union([billingUpdateFreeTrialParamsOutboundSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const billingUpdateInvoiceModeOutboundSchema = z.object({
-    enabled: z.boolean(),
-    enable_plan_immediately: z.boolean(),
-    finalize: z.boolean()
+	enabled: z.boolean(),
+	enable_plan_immediately: z.boolean(),
+	finalize: z.boolean(),
 });
 
 export const billingUpdateAttachDiscountOutboundSchema = z.object({
-    reward_id: z.union([z.string(), z.undefined()]).optional(),
-    promotion_code: z.union([z.string(), z.undefined()]).optional()
+	reward_id: z.union([z.string(), z.undefined()]).optional(),
+	promotion_code: z.union([z.string(), z.undefined()]).optional(),
 });
 
 export const billingUpdateRecalculateBalancesOutboundSchema = z.object({
-    enabled: z.boolean()
+	enabled: z.boolean(),
 });
 
 export const updateSubscriptionParamsOutboundSchema = z.object({
-    customer_id: z.string(),
-    entity_id: z.union([z.string(), z.undefined()]).optional(),
-    plan_id: z.union([z.string(), z.undefined()]).optional(),
-    feature_quantities: z.union([z.array(billingUpdateFeatureQuantityOutboundSchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([billingUpdateCustomizeOutboundSchema, z.undefined()]).optional(),
-    invoice_mode: z.union([billingUpdateInvoiceModeOutboundSchema, z.undefined()]).optional(),
-    proration_behavior: z.union([z.string(), z.undefined()]).optional(),
-    redirect_mode: z.string(),
-    subscription_id: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(billingUpdateAttachDiscountOutboundSchema), z.undefined()]).optional(),
-    cancel_action: z.union([z.string(), z.undefined()]).optional(),
-    billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
-    recalculate_balances: z.union([billingUpdateRecalculateBalancesOutboundSchema, z.undefined()]).optional()
+	customer_id: z.string(),
+	entity_id: z.union([z.string(), z.undefined()]).optional(),
+	plan_id: z.union([z.string(), z.undefined()]).optional(),
+	feature_quantities: z
+		.union([z.array(billingUpdateFeatureQuantityOutboundSchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z
+		.union([billingUpdateCustomizeOutboundSchema, z.undefined()])
+		.optional(),
+	invoice_mode: z
+		.union([billingUpdateInvoiceModeOutboundSchema, z.undefined()])
+		.optional(),
+	proration_behavior: z.union([z.string(), z.undefined()]).optional(),
+	redirect_mode: z.string(),
+	subscription_id: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(billingUpdateAttachDiscountOutboundSchema), z.undefined()])
+		.optional(),
+	cancel_action: z.union([z.string(), z.undefined()]).optional(),
+	billing_cycle_anchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	no_billing_changes: z.union([z.boolean(), z.undefined()]).optional(),
+	recalculate_balances: z
+		.union([billingUpdateRecalculateBalancesOutboundSchema, z.undefined()])
+		.optional(),
 });
 
 const closedEnumSchema = z.any();
@@ -215,16 +263,16 @@ const openEnumSchema = z.any();
 export const billingUpdatePriceIntervalSchema = closedEnumSchema;
 
 export const billingUpdateBasePriceSchema = z.object({
-    amount: z.number(),
-    interval: billingUpdatePriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	amount: z.number(),
+	interval: billingUpdatePriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemResetIntervalSchema = closedEnumSchema;
 
 export const billingUpdateItemResetSchema = z.object({
-    interval: billingUpdateItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: billingUpdateItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemTierBehaviorSchema = closedEnumSchema;
@@ -234,14 +282,18 @@ export const billingUpdateItemPriceIntervalSchema = closedEnumSchema;
 export const billingUpdateItemBillingMethodSchema = closedEnumSchema;
 
 export const billingUpdateItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(billingUpdateItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([billingUpdateItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: billingUpdateItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: billingUpdateItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(billingUpdateItemTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([billingUpdateItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: billingUpdateItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: billingUpdateItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemOnIncreaseSchema = closedEnumSchema;
@@ -249,34 +301,38 @@ export const billingUpdateItemOnIncreaseSchema = closedEnumSchema;
 export const billingUpdateItemOnDecreaseSchema = closedEnumSchema;
 
 export const billingUpdateItemProrationSchema = z.object({
-    onIncrease: billingUpdateItemOnIncreaseSchema,
-    onDecrease: billingUpdateItemOnDecreaseSchema
+	onIncrease: billingUpdateItemOnIncreaseSchema,
+	onDecrease: billingUpdateItemOnDecreaseSchema,
 });
 
 export const billingUpdateItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const billingUpdateItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: billingUpdateItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: billingUpdateItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([billingUpdateItemResetSchema, z.undefined()]).optional(),
-    price: z.union([billingUpdateItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([billingUpdateItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([billingUpdateItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([billingUpdateItemResetSchema, z.undefined()]).optional(),
+	price: z.union([billingUpdateItemPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([billingUpdateItemProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([billingUpdateItemRolloverSchema, z.undefined()])
+		.optional(),
 });
 
 export const billingUpdateAddItemResetIntervalSchema = closedEnumSchema;
 
 export const billingUpdateAddItemResetSchema = z.object({
-    interval: billingUpdateAddItemResetIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional()
+	interval: billingUpdateAddItemResetIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAddItemTierBehaviorSchema = closedEnumSchema;
@@ -286,14 +342,18 @@ export const billingUpdateAddItemPriceIntervalSchema = closedEnumSchema;
 export const billingUpdateAddItemBillingMethodSchema = closedEnumSchema;
 
 export const billingUpdateAddItemPriceSchema = z.object({
-    amount: z.union([z.number(), z.undefined()]).optional(),
-    tiers: z.union([z.array(billingUpdateAddItemTierSchema), z.undefined()]).optional(),
-    tierBehavior: z.union([billingUpdateAddItemTierBehaviorSchema, z.undefined()]).optional(),
-    interval: billingUpdateAddItemPriceIntervalSchema,
-    intervalCount: z.union([z.number(), z.undefined()]).optional(),
-    billingUnits: z.union([z.number(), z.undefined()]).optional(),
-    billingMethod: billingUpdateAddItemBillingMethodSchema,
-    maxPurchase: z.union([z.number(), z.undefined()]).optional()
+	amount: z.union([z.number(), z.undefined()]).optional(),
+	tiers: z
+		.union([z.array(billingUpdateAddItemTierSchema), z.undefined()])
+		.optional(),
+	tierBehavior: z
+		.union([billingUpdateAddItemTierBehaviorSchema, z.undefined()])
+		.optional(),
+	interval: billingUpdateAddItemPriceIntervalSchema,
+	intervalCount: z.union([z.number(), z.undefined()]).optional(),
+	billingUnits: z.union([z.number(), z.undefined()]).optional(),
+	billingMethod: billingUpdateAddItemBillingMethodSchema,
+	maxPurchase: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAddItemOnIncreaseSchema = closedEnumSchema;
@@ -301,27 +361,31 @@ export const billingUpdateAddItemOnIncreaseSchema = closedEnumSchema;
 export const billingUpdateAddItemOnDecreaseSchema = closedEnumSchema;
 
 export const billingUpdateAddItemProrationSchema = z.object({
-    onIncrease: billingUpdateAddItemOnIncreaseSchema,
-    onDecrease: billingUpdateAddItemOnDecreaseSchema
+	onIncrease: billingUpdateAddItemOnIncreaseSchema,
+	onDecrease: billingUpdateAddItemOnDecreaseSchema,
 });
 
 export const billingUpdateAddItemExpiryDurationTypeSchema = closedEnumSchema;
 
 export const billingUpdateAddItemRolloverSchema = z.object({
-    max: z.union([z.number(), z.undefined()]).optional(),
-    maxPercentage: z.union([z.number(), z.undefined()]).optional(),
-    expiryDurationType: billingUpdateAddItemExpiryDurationTypeSchema,
-    expiryDurationLength: z.union([z.number(), z.undefined()]).optional()
+	max: z.union([z.number(), z.undefined()]).optional(),
+	maxPercentage: z.union([z.number(), z.undefined()]).optional(),
+	expiryDurationType: billingUpdateAddItemExpiryDurationTypeSchema,
+	expiryDurationLength: z.union([z.number(), z.undefined()]).optional(),
 });
 
 export const billingUpdateAddItemPlanItemSchema = z.object({
-    featureId: z.string(),
-    included: z.union([z.number(), z.undefined()]).optional(),
-    unlimited: z.union([z.boolean(), z.undefined()]).optional(),
-    reset: z.union([billingUpdateAddItemResetSchema, z.undefined()]).optional(),
-    price: z.union([billingUpdateAddItemPriceSchema, z.undefined()]).optional(),
-    proration: z.union([billingUpdateAddItemProrationSchema, z.undefined()]).optional(),
-    rollover: z.union([billingUpdateAddItemRolloverSchema, z.undefined()]).optional()
+	featureId: z.string(),
+	included: z.union([z.number(), z.undefined()]).optional(),
+	unlimited: z.union([z.boolean(), z.undefined()]).optional(),
+	reset: z.union([billingUpdateAddItemResetSchema, z.undefined()]).optional(),
+	price: z.union([billingUpdateAddItemPriceSchema, z.undefined()]).optional(),
+	proration: z
+		.union([billingUpdateAddItemProrationSchema, z.undefined()])
+		.optional(),
+	rollover: z
+		.union([billingUpdateAddItemRolloverSchema, z.undefined()])
+		.optional(),
 });
 
 export const billingUpdateRemoveItemBillingMethodSchema = closedEnumSchema;
@@ -329,9 +393,13 @@ export const billingUpdateRemoveItemBillingMethodSchema = closedEnumSchema;
 export const billingUpdateRemoveItemIntervalSchema = closedEnumSchema;
 
 export const billingUpdatePlanItemFilterSchema = z.object({
-    featureId: z.union([z.string(), z.undefined()]).optional(),
-    billingMethod: z.union([billingUpdateRemoveItemBillingMethodSchema, z.undefined()]).optional(),
-    interval: z.union([billingUpdateRemoveItemIntervalSchema, z.undefined()]).optional()
+	featureId: z.union([z.string(), z.undefined()]).optional(),
+	billingMethod: z
+		.union([billingUpdateRemoveItemBillingMethodSchema, z.undefined()])
+		.optional(),
+	interval: z
+		.union([billingUpdateRemoveItemIntervalSchema, z.undefined()])
+		.optional(),
 });
 
 export const billingUpdateDurationTypeSchema = closedEnumSchema;
@@ -339,18 +407,32 @@ export const billingUpdateDurationTypeSchema = closedEnumSchema;
 export const billingUpdateOnEndSchema = closedEnumSchema;
 
 export const billingUpdateFreeTrialParamsSchema = z.object({
-    durationLength: z.number(),
-    durationType: z.union([billingUpdateDurationTypeSchema, z.undefined()]).optional(),
-    cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
-    onEnd: z.union([billingUpdateOnEndSchema, z.undefined()]).optional()
+	durationLength: z.number(),
+	durationType: z
+		.union([billingUpdateDurationTypeSchema, z.undefined()])
+		.optional(),
+	cardRequired: z.union([z.boolean(), z.undefined()]).optional(),
+	onEnd: z.union([billingUpdateOnEndSchema, z.undefined()]).optional(),
 });
 
 export const billingUpdateCustomizeSchema = z.object({
-    price: z.union([billingUpdateBasePriceSchema, z.undefined()]).optional().nullable(),
-    items: z.union([z.array(billingUpdateItemPlanItemSchema), z.undefined()]).optional(),
-    addItems: z.union([z.array(billingUpdateAddItemPlanItemSchema), z.undefined()]).optional(),
-    removeItems: z.union([z.array(billingUpdatePlanItemFilterSchema), z.undefined()]).optional(),
-    freeTrial: z.union([billingUpdateFreeTrialParamsSchema, z.undefined()]).optional().nullable()
+	price: z
+		.union([billingUpdateBasePriceSchema, z.undefined()])
+		.optional()
+		.nullable(),
+	items: z
+		.union([z.array(billingUpdateItemPlanItemSchema), z.undefined()])
+		.optional(),
+	addItems: z
+		.union([z.array(billingUpdateAddItemPlanItemSchema), z.undefined()])
+		.optional(),
+	removeItems: z
+		.union([z.array(billingUpdatePlanItemFilterSchema), z.undefined()])
+		.optional(),
+	freeTrial: z
+		.union([billingUpdateFreeTrialParamsSchema, z.undefined()])
+		.optional()
+		.nullable(),
 });
 
 export const billingUpdateProrationBehaviorSchema = closedEnumSchema;
@@ -360,34 +442,50 @@ export const billingUpdateRedirectModeSchema = closedEnumSchema;
 export const billingUpdateCancelActionSchema = closedEnumSchema;
 
 export const updateSubscriptionParamsSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    planId: z.union([z.string(), z.undefined()]).optional(),
-    featureQuantities: z.union([z.array(billingUpdateFeatureQuantitySchema), z.undefined()]).optional(),
-    version: z.union([z.number(), z.undefined()]).optional(),
-    customize: z.union([billingUpdateCustomizeSchema, z.undefined()]).optional(),
-    invoiceMode: z.union([billingUpdateInvoiceModeSchema, z.undefined()]).optional(),
-    prorationBehavior: z.union([billingUpdateProrationBehaviorSchema, z.undefined()]).optional(),
-    redirectMode: z.union([billingUpdateRedirectModeSchema, z.undefined()]).optional(),
-    subscriptionId: z.union([z.string(), z.undefined()]).optional(),
-    discounts: z.union([z.array(billingUpdateAttachDiscountSchema), z.undefined()]).optional(),
-    cancelAction: z.union([billingUpdateCancelActionSchema, z.undefined()]).optional(),
-    billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
-    noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
-    recalculateBalances: z.union([billingUpdateRecalculateBalancesSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	planId: z.union([z.string(), z.undefined()]).optional(),
+	featureQuantities: z
+		.union([z.array(billingUpdateFeatureQuantitySchema), z.undefined()])
+		.optional(),
+	version: z.union([z.number(), z.undefined()]).optional(),
+	customize: z.union([billingUpdateCustomizeSchema, z.undefined()]).optional(),
+	invoiceMode: z
+		.union([billingUpdateInvoiceModeSchema, z.undefined()])
+		.optional(),
+	prorationBehavior: z
+		.union([billingUpdateProrationBehaviorSchema, z.undefined()])
+		.optional(),
+	redirectMode: z
+		.union([billingUpdateRedirectModeSchema, z.undefined()])
+		.optional(),
+	subscriptionId: z.union([z.string(), z.undefined()]).optional(),
+	discounts: z
+		.union([z.array(billingUpdateAttachDiscountSchema), z.undefined()])
+		.optional(),
+	cancelAction: z
+		.union([billingUpdateCancelActionSchema, z.undefined()])
+		.optional(),
+	billingCycleAnchor: z.union([z.literal("now"), z.undefined()]).optional(),
+	noBillingChanges: z.union([z.boolean(), z.undefined()]).optional(),
+	recalculateBalances: z
+		.union([billingUpdateRecalculateBalancesSchema, z.undefined()])
+		.optional(),
 });
 
 export const billingUpdateCodeSchema = openEnumSchema;
 
 export const billingUpdateRequiredActionSchema = z.object({
-    code: billingUpdateCodeSchema,
-    reason: z.string()
+	code: billingUpdateCodeSchema,
+	reason: z.string(),
 });
 
 export const billingUpdateResponseSchema = z.object({
-    customerId: z.string(),
-    entityId: z.union([z.string(), z.undefined()]).optional(),
-    invoice: z.union([billingUpdateInvoiceSchema, z.undefined()]).optional(),
-    paymentUrl: z.string().nullable(),
-    requiredAction: z.union([billingUpdateRequiredActionSchema, z.undefined()]).optional()
+	customerId: z.string(),
+	entityId: z.union([z.string(), z.undefined()]).optional(),
+	invoice: z.union([billingUpdateInvoiceSchema, z.undefined()]).optional(),
+	paymentUrl: z.string().nullable(),
+	requiredAction: z
+		.union([billingUpdateRequiredActionSchema, z.undefined()])
+		.optional(),
 });

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -17069,6 +17069,12 @@ paths:
                     type: string
                   description: Filter by parent customer processor type (stripe, revenuecat,
                     vercel).
+                customer_id:
+                  type: string
+                  minLength: 1
+                  description: Restrict the response to entities owned by this customer id. Use to
+                    bulk-fetch all entities for one customer in a single
+                    paginated call instead of iterating entities.get.
               title: ListEntitiesParams
               examples:
                 - &a65

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -8678,7 +8678,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779292757190,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780502357190,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779471392768,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780680992768,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -17964,6 +17964,10 @@ paths:
         @param processors - Filter by parent customer processor type (stripe,
         revenuecat, vercel). (optional)
 
+        @param customerId - Restrict the response to entities owned by this
+        customer id. Use to bulk-fetch all entities for one customer in a single
+        paginated call instead of iterating entities.get. (optional)
+
 
         @returns A paginated list of entity objects including their current
         subscriptions, purchases, balances, and flags.
@@ -18024,6 +18028,12 @@ paths:
                     type: string
                   description: Filter by parent customer processor type (stripe, revenuecat,
                     vercel).
+                customer_id:
+                  type: string
+                  minLength: 1
+                  description: Restrict the response to entities owned by this customer id. Use to
+                    bulk-fetch all entities for one customer in a single
+                    paginated call instead of iterating entities.get.
               title: ListEntitiesParams
               examples:
                 - start_cursor: ""

--- a/packages/sdk/.speakeasy/gen.lock
+++ b/packages/sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 7b300647-cd76-49e9-bf77-7d1bf5446d66
 management:
-  docChecksum: fd622c742a283a0f30afad7727090fdb
+  docChecksum: 6d3387e307a19f883e71bd92d10705ab
   docVersion: 2.3.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
   releaseVersion: 0.10.17
   configChecksum: bae45df54c836a79d656f78f967da99b
 persistentEdits:
-  generation_id: aff5214d-31ba-4dad-bf8a-38b4e7690511
-  pristine_commit_hash: b6687d7a88f141b20692b73b34f7b23cd833f3c6
-  pristine_tree_hash: f20144f70008461f2a74d1d4b7731300ca6ee0e8
+  generation_id: cda422b6-e041-44f7-9037-3f74c03b0561
+  pristine_commit_hash: 0f86af9f1e8c01e1cd22f2690f95e2f9886cf4cf
+  pristine_tree_hash: 253386659e84f1f8d2d03dedc08109353e425c14
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -2068,8 +2068,8 @@ trackedFiles:
     pristine_git_object: 19202b44796241442484db1fee13164091c3497c
   docs/models/list-entities-params.md:
     id: 92aba00d96aa
-    last_write_checksum: sha1:63f6d8d5c87aa3e9f30afa967d02c9d7f460bda0
-    pristine_git_object: 096d712b4791c84909b9f465f36f777c0d44b03f
+    last_write_checksum: sha1:eb00e7d04db7bcf5cc96669538c531c48bbd2946
+    pristine_git_object: 409eede145afb691774fdde8ea90ae2c2183a65e
   docs/models/list-entities-plan.md:
     id: 46b5b6920b73
     last_write_checksum: sha1:0a15106cb1bdb2cd03c181351dfd44dbe36a2643
@@ -4148,16 +4148,16 @@ trackedFiles:
     pristine_git_object: 0ebe5146cd24c153cb9b7655e4f502c09f7d4abd
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:9a4fc3e15e59ee4c9e67940c8f018c51a26b4b20
-    pristine_git_object: 78602549ff88ec966759e008c36bd0ba217358f7
+    last_write_checksum: sha1:9fc12c7d0edbe4ab4ed6e58441d13a0aad1c0909
+    pristine_git_object: 198732d189bf6bcc949449b72bf77c24c7093625
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:74cd5f6cf800e1d86b2c332fed3c3cd53f3eeb6b
     pristine_git_object: 94228c7448e58f0dd1d53e5ae3be57b0aaae8ade
   docs/sdks/entities/README.md:
     id: a140ac5181b9
-    last_write_checksum: sha1:9218d9c57b0f880056012a0058b6fcf22266809b
-    pristine_git_object: 660ee5a5ae602d5a59262df8be417b158b483b57
+    last_write_checksum: sha1:5574bc92c257f788670c4703173f1cd2f1ca78ce
+    pristine_git_object: f683b63897d2cd18e55cb3d207f1f1f353027f03
   docs/sdks/events/README.md:
     id: cf45a4390b9b
     last_write_checksum: sha1:45cecb8b22ef4a343e770296553fb77fa91f6a24
@@ -4232,8 +4232,8 @@ trackedFiles:
     pristine_git_object: d1d2c39eb61de5da6dc66da31605995ee35edd8b
   src/funcs/billing-create-schedule.ts:
     id: fd662bfcdc10
-    last_write_checksum: sha1:c33eafe7ebb47759d83e9ed220ee3c5ddeee921b
-    pristine_git_object: 1f5c0e795bc20f267bc9831e865adbf4aac9b903
+    last_write_checksum: sha1:d3dc3a63ddf2e1d733d436a088c0666e3783b7bc
+    pristine_git_object: 27b6622242ac2e908784c44ad8b99ffb6463033d
   src/funcs/billing-multi-attach.ts:
     id: 67491e2d8249
     last_write_checksum: sha1:00ba80c1f98e7a8be29db0cf5a6957433f687861
@@ -4300,8 +4300,8 @@ trackedFiles:
     pristine_git_object: ac3e07687390946e85825e6711f1b9f02f3195fd
   src/funcs/entities-list.ts:
     id: 589baf7729a5
-    last_write_checksum: sha1:96b615462da46c38d0d9f8160798733c11074a62
-    pristine_git_object: ec78a585695d94482aafe01de6f554e391c94365
+    last_write_checksum: sha1:6df35894c500b5b5e6263b01693542ae5ffc20ad
+    pristine_git_object: 91d6b8831f0bf0069cbe1cabce713bd4a6def288
   src/funcs/entities-update.ts:
     id: 45a3fa3d37e9
     last_write_checksum: sha1:9d094430bd69e5393225a4b16144ffdab3634f13
@@ -4572,8 +4572,8 @@ trackedFiles:
     pristine_git_object: 49c50334b82a7d58677307d3791be2ced19c8a06
   src/models/list-entities-op.ts:
     id: 4cbb69f4a0cd
-    last_write_checksum: sha1:18424f0889282c5c4e62efabaac1a703c2a5dab0
-    pristine_git_object: 681ba8b7d889f2d04a7bba6f3f9bd1a16aa6ba27
+    last_write_checksum: sha1:a48ac579bc008f7a3100664b4dfe0a4803a5650e
+    pristine_git_object: 298ba3d842c166c29339394e9b8173cefc500431
   src/models/list-events-op.ts:
     id: 82a9f364bb21
     last_write_checksum: sha1:32c875df2a181a5aa651f4350a2a7114a8c92bd1
@@ -4664,16 +4664,16 @@ trackedFiles:
     pristine_git_object: 571de419ea3321d79acec4bddbb46b1580007115
   src/sdk/billing.ts:
     id: 10905058c4ad
-    last_write_checksum: sha1:3c7183849465b82416816faecf440b4ac29ae17d
-    pristine_git_object: 298f33f82706d9b36ba1c65b0806ab2d66bfc083
+    last_write_checksum: sha1:79f318830a67e54703596f277f68053c99be2b34
+    pristine_git_object: 162dc874221b81ad1a212adda36a247b2964c8e3
   src/sdk/customers.ts:
     id: d33e193e0c00
     last_write_checksum: sha1:8d64f03efa17b4ef45a6d67a44d23e2943f1cd8b
     pristine_git_object: 307ba52467887f429aac029db75944b5812fc502
   src/sdk/entities.ts:
     id: 71997b5f9b62
-    last_write_checksum: sha1:2b2f2ccb94c4a1799990766605cc381af00c6a44
-    pristine_git_object: 9f30b7a762a7771dc31428c9ea6d1c7ff8215fcc
+    last_write_checksum: sha1:74312ff6c6c810294596acd86cbe59644623441d
+    pristine_git_object: d322b70d571d5aa9d3bde9b08c6c012fcd20e0a0
   src/sdk/events.ts:
     id: c7d130088b17
     last_write_checksum: sha1:1dd099274cb75cb4ae46d01fa68ea13b53a79e1a

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -8017,7 +8017,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779292757190,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780502357190,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779471392768,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780680992768,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -16478,6 +16478,8 @@ paths:
 
         @param processors - Filter by parent customer processor type (stripe, revenuecat, vercel). (optional)
 
+        @param customerId - Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get. (optional)
+
 
         @returns A paginated list of entity objects including their current subscriptions, purchases, balances, and flags.
       tags:
@@ -16531,6 +16533,10 @@ paths:
                       - vercel
                     type: string
                   description: Filter by parent customer processor type (stripe, revenuecat, vercel).
+                customer_id:
+                  type: string
+                  minLength: 1
+                  description: Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get.
               title: ListEntitiesParams
               examples:
                 - start_cursor: ""

--- a/packages/sdk/.speakeasy/workflow.lock
+++ b/packages/sdk/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Autumn API:
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:60582eaf2873eef162c828bee020b951379aefacd15d15f8b92a2c5b947b1802
-        sourceBlobDigest: sha256:4f214e215cb673be15a2ae97b12b6f85bf3e9f7092b1d77e5811cdfca548e113
+        sourceRevisionDigest: sha256:7135f6b3ddd7e1ef1c88ebf16563435eecfec754217a75dfabd86c0b1237d752
+        sourceBlobDigest: sha256:568617eef908ddf450e6cc5fac8171a353c6420b9c6db265acecef0c15f8bbf0
         tags:
             - latest
             - 2.3.0
@@ -18,10 +18,10 @@ targets:
     autumn:
         source: Autumn API
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:60582eaf2873eef162c828bee020b951379aefacd15d15f8b92a2c5b947b1802
-        sourceBlobDigest: sha256:4f214e215cb673be15a2ae97b12b6f85bf3e9f7092b1d77e5811cdfca548e113
+        sourceRevisionDigest: sha256:7135f6b3ddd7e1ef1c88ebf16563435eecfec754217a75dfabd86c0b1237d752
+        sourceBlobDigest: sha256:568617eef908ddf450e6cc5fac8171a353c6420b9c6db265acecef0c15f8bbf0
         codeSamplesNamespace: autumn-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:50d8d0200f9c5b6576e88bfbd9419b90203c445bb380005cb5c98ed290d494d3
+        codeSamplesRevisionDigest: sha256:3a2da6b39719cec0765a8414b33b9d920fdf316bf1d5da4b203d6c4ae72d1038
     autumn-python:
         source: Autumn API Stripped
         sourceNamespace: autumn-api-stripped

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -272,7 +272,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779292757190,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780502357190,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779471392768,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780680992768,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.
@@ -566,6 +566,7 @@ const response = await client.entities.list({ search: "workspace" });
 @param subscriptionStatus - Filter customer products used for entity hydration and plan matching. Defaults to active and scheduled. (optional)
 @param search - Search entities by id or name. (optional)
 @param processors - Filter by parent customer processor type (stripe, revenuecat, vercel). (optional)
+@param customerId - Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get. (optional)
 
 @returns A paginated list of entity objects including their current subscriptions, purchases, balances, and flags.
 * [update](docs/sdks/entities/README.md#update) - Updates an existing entity and returns the refreshed entity object.
@@ -789,7 +790,7 @@ Use this endpoint to schedule future plan changes (e.g. switch from a trial plan
 @example
 ```typescript
 // Schedule a transition from a trial plan to a paid plan
-const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779292757190,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780502357190,"plans":[{"planId":"pro_plan"}]}] });
+const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779471392768,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780680992768,"plans":[{"planId":"pro_plan"}]}] });
 ```
 
 @param customerId - The ID of the customer to create the schedule for.
@@ -1123,6 +1124,7 @@ const response = await client.entities.list({ search: "workspace" });
 @param subscriptionStatus - Filter customer products used for entity hydration and plan matching. Defaults to active and scheduled. (optional)
 @param search - Search entities by id or name. (optional)
 @param processors - Filter by parent customer processor type (stripe, revenuecat, vercel). (optional)
+@param customerId - Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get. (optional)
 
 @returns A paginated list of entity objects including their current subscriptions, purchases, balances, and flags.
 - [`entitiesUpdate`](docs/sdks/entities/README.md#update) - Updates an existing entity and returns the refreshed entity object.

--- a/packages/sdk/src/funcs/billing-create-schedule.ts
+++ b/packages/sdk/src/funcs/billing-create-schedule.ts
@@ -34,7 +34,7 @@ import { Result } from "../types/fp.js";
  * @example
  * ```typescript
  * // Schedule a transition from a trial plan to a paid plan
- * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779292757190,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780502357190,"plans":[{"planId":"pro_plan"}]}] });
+ * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779471392768,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780680992768,"plans":[{"planId":"pro_plan"}]}] });
  * ```
  *
  * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/funcs/entities-list.ts
+++ b/packages/sdk/src/funcs/entities-list.ts
@@ -49,6 +49,7 @@ import { Result } from "../types/fp.js";
  * @param subscriptionStatus - Filter customer products used for entity hydration and plan matching. Defaults to active and scheduled. (optional)
  * @param search - Search entities by id or name. (optional)
  * @param processors - Filter by parent customer processor type (stripe, revenuecat, vercel). (optional)
+ * @param customerId - Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get. (optional)
  *
  * @returns A paginated list of entity objects including their current subscriptions, purchases, balances, and flags.
  */

--- a/packages/sdk/src/models/list-entities-op.ts
+++ b/packages/sdk/src/models/list-entities-op.ts
@@ -68,6 +68,10 @@ export type ListEntitiesParams = {
    * Filter by parent customer processor type (stripe, revenuecat, vercel).
    */
   processors?: Array<ListEntitiesProcessor> | undefined;
+  /**
+   * Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get.
+   */
+  customerId?: string | undefined;
 };
 
 /**
@@ -495,6 +499,7 @@ export type ListEntitiesParams$Outbound = {
   subscription_status?: string | undefined;
   search?: string | undefined;
   processors?: Array<string> | undefined;
+  customer_id?: string | undefined;
 };
 
 /** @internal */
@@ -511,11 +516,13 @@ export const ListEntitiesParams$outboundSchema: z.ZodMiniType<
     ),
     search: z.optional(z.string()),
     processors: z.optional(z.array(ListEntitiesProcessor$outboundSchema)),
+    customerId: z.optional(z.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
       startCursor: "start_cursor",
       subscriptionStatus: "subscription_status",
+      customerId: "customer_id",
     });
   }),
 );

--- a/packages/sdk/src/sdk/billing.ts
+++ b/packages/sdk/src/sdk/billing.ts
@@ -87,7 +87,7 @@ export class Billing extends ClientSDK {
    * @example
    * ```typescript
    * // Schedule a transition from a trial plan to a paid plan
-   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779292757190,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780502357190,"plans":[{"planId":"pro_plan"}]}] });
+   * const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1779471392768,"plans":[{"planId":"trial_plan"}]},{"startsAt":1780680992768,"plans":[{"planId":"pro_plan"}]}] });
    * ```
    *
    * @param customerId - The ID of the customer to create the schedule for.

--- a/packages/sdk/src/sdk/entities.ts
+++ b/packages/sdk/src/sdk/entities.ts
@@ -105,6 +105,7 @@ export class Entities extends ClientSDK {
    * @param subscriptionStatus - Filter customer products used for entity hydration and plan matching. Defaults to active and scheduled. (optional)
    * @param search - Search entities by id or name. (optional)
    * @param processors - Filter by parent customer processor type (stripe, revenuecat, vercel). (optional)
+   * @param customerId - Restrict the response to entities owned by this customer id. Use to bulk-fetch all entities for one customer in a single paginated call instead of iterating entities.get. (optional)
    *
    * @returns A paginated list of entity objects including their current subscriptions, purchases, balances, and flags.
    */


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional `customerId` filter to `entities.list` so you can bulk-fetch all entities for a single customer in one paginated call. OpenAPI, docs, and SDKs (TypeScript and Python) are updated to expose this param.

- **New Features**
  - `entities.list` now accepts `customerId` (sent as `customer_id`) to restrict results to a specific customer across `packages/sdk`, `others/python-sdk`, and `apps/docs`.

<sup>Written for commit 2148487474af7a39531107050516155c5df9628d. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1703?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `customer_id` filter parameter to the `entities.list` endpoint, enabling callers to fetch all entities for a single customer in one paginated call. The change is propagated consistently across the OpenAPI spec, Mintlify docs, TypeScript SDK, and Python SDK (all Speakeasy-regenerated).

- **[API changes]** `customer_id` request body field added to `POST /v1/entities.list` in both the main and stripped OpenAPI specs, with `minLength: 1` constraint and a clear description.
- **[Improvements]** TypeScript and Python SDK models (`ListEntitiesParams`) updated with the new optional `customerId`/`customer_id` field, including correct snake_case remapping in the outbound Zod/Pydantic schemas.
- **[Bug fixes]** Mintlify API reference doc updated to document the new filter parameter alongside the correct response example showing `customer_id` in the entity object.
</details>


<h3>Confidence Score: 4/5</h3>

The change is a straightforward additive filter across docs and generated SDK files with no logic mutations; all three SDK targets are in sync with the OpenAPI spec.

The `customer_id` addition is consistently applied across the OpenAPI spec, Mintlify docs, TypeScript SDK, and Python SDK. The only concern is a pre-existing stale JSDoc in the generated TypeScript files (`@param offset` and wrong `limit` defaults) that was not corrected during this regeneration pass, which could mislead SDK consumers.

`packages/sdk/src/funcs/entities-list.ts` and `packages/sdk/src/sdk/entities.ts` carry stale `@param offset` and incorrect limit defaults in their JSDoc; these should be cleaned up in the upstream OpenAPI spec or Speakeasy template.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/docs/mintlify/api-reference/entities/listEntities.mdx | Added `customer_id` body parameter documentation with accurate description; docs are consistent with the OpenAPI spec change. |
| packages/openapi/openapi.yml | Added `customer_id` field with `type: string`, `minLength: 1`, and description to the `ListEntitiesParams` request body schema; change is consistent across all OpenAPI files. |
| packages/sdk/src/models/list-entities-op.ts | Added `customerId?: string` to `ListEntitiesParams` and its Zod outbound schema with correct snake_case remapping; model is consistent with the OpenAPI addition. |
| packages/sdk/src/funcs/entities-list.ts | Added `@param customerId` JSDoc; however, the pre-existing `@param offset` (field doesn't exist) and wrong limit defaults are preserved through this regeneration. |
| others/python-sdk/src/autumn_sdk/models/listentitiesop.py | Added `customer_id: Optional[str] = None` to Python `ListEntitiesParams` and `ListEntitiesParamsTypedDict` with proper serialization; consistent with the TypeScript and OpenAPI changes. |
| packages/autumn-js/src/generated/index.ts | Re-generated schemas for customer-facing endpoints; no entities-list schema is exposed here (expected, as it is a server-side admin endpoint). |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as SDK Caller
    participant SDK as TypeScript/Python SDK
    participant API as POST /v1/entities.list

    Caller->>SDK: "entities.list({ customerId: "cus_123", limit: 50 })"
    SDK->>SDK: Validate via Zod/Pydantic (optional customerId)
    SDK->>API: "POST body { customer_id: "cus_123", start_cursor: "", limit: 50 }"
    API-->>SDK: "{ list: [...entities for cus_123], next_cursor: null }"
    SDK-->>Caller: ListEntitiesResponse
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/sdk/src/funcs/entities-list.ts`, line 37-52 ([link](https://github.com/useautumn/autumn/blob/2148487474af7a39531107050516155c5df9628d/packages/sdk/src/funcs/entities-list.ts#L37-L52)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale JSDoc params reference `offset` which doesn't exist**

   The example on line 37 passes `offset: 0` but `ListEntitiesParams` has no `offset` field — the API switched to cursor-based pagination (`startCursor`). Developers copying this example will silently pass a property that is stripped by the Zod schema and ignored by the API.

   The `@param offset` doc on line 46 and the `@param limit - Default 10, max 1000` on line 47 are also stale: the actual schema defaults `limit` to `50` with a hard ceiling of `5000`, not `10`/`1000`. The same stale doc appears in `packages/sdk/src/sdk/entities.ts` lines 93–108.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/sdk/src/funcs/entities-list.ts
   Line: 37-52

   Comment:
   **Stale JSDoc params reference `offset` which doesn't exist**

   The example on line 37 passes `offset: 0` but `ListEntitiesParams` has no `offset` field — the API switched to cursor-based pagination (`startCursor`). Developers copying this example will silently pass a property that is stripped by the Zod schema and ignored by the API.

   The `@param offset` doc on line 46 and the `@param limit - Default 10, max 1000` on line 47 are also stale: the actual schema defaults `limit` to `50` with a hard ceiling of `5000`, not `10`/`1000`. The same stale doc appears in `packages/sdk/src/sdk/entities.ts` lines 93–108.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/sdk/src/funcs/entities-list.ts:37-52
**Stale JSDoc params reference `offset` which doesn't exist**

The example on line 37 passes `offset: 0` but `ListEntitiesParams` has no `offset` field — the API switched to cursor-based pagination (`startCursor`). Developers copying this example will silently pass a property that is stripped by the Zod schema and ignored by the API.

The `@param offset` doc on line 46 and the `@param limit - Default 10, max 1000` on line 47 are also stale: the actual schema defaults `limit` to `50` with a hard ceiling of `5000`, not `10`/`1000`. The same stale doc appears in `packages/sdk/src/sdk/entities.ts` lines 93–108.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: list entities docs"](https://github.com/useautumn/autumn/commit/2148487474af7a39531107050516155c5df9628d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33494018)</sub>

<!-- /greptile_comment -->