### PR TITLE
show proration toggle even when there is a past trial

### DIFF
--- a/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
@@ -35,8 +35,7 @@ export function useAttachBillingOptionsState() {
 		() =>
 			((customer?.customer_products ?? []) as CusProduct[]).some(
 				(cp) =>
-					(ACTIVE_STATUSES.includes(cp.status) ||
-						cp.status === CusProductStatus.Trialing) &&
+					cp.status === CusProductStatus.Trialing &&
 					cp.subscription_ids &&
 					cp.subscription_ids.length > 0 &&
 					!!cp.free_trial_id,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show the proration toggle even when a customer had a past trial. We now hide it only if there’s an active trial.

- **Bug Fixes**
  - In `useAttachBillingOptionsState`, trial detection now requires `CusProductStatus.Trialing` (removed `ACTIVE_STATUSES` check) so past trials no longer hide the proration toggle.

<sup>Written for commit 12e2bb1412f36d6b82a739cdffc914bf21388fc1. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1704?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a condition in `useAttachBillingOptionsState` so that the proration toggle is shown even when a customer has a past (completed) trial, not just an actively ongoing one.

- **Bug fixes** — `hasActiveProductWithTrial` previously included products in any `ACTIVE_STATUSES` that also had a `free_trial_id`, which suppressed the proration row even after a trial ended. The fix narrows the check to `CusProductStatus.Trialing` only, correctly hiding the toggle only during an active trial.
- **Improvements** — The variable name `hasActiveProductWithTrial` now accurately reflects its semantic intent: a product that is currently trialing, not one that once had a trial.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the logic change is small and intentional, with one leftover unused import to clean up.

The narrowing of `hasActiveProductWithTrial` to `Trialing`-only status is correct and aligns with the PR intent. The only artifact of the change is that `ACTIVE_STATUSES` is now imported but never used in this file.

vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts — unused `ACTIVE_STATUSES` import should be removed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts | Narrows `hasActiveProductWithTrial` to only `Trialing` status, so customers with a completed/past trial now see the proration toggle. Leaves `ACTIVE_STATUSES` as an unused import. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Customer products loop] --> B{cp.status === Trialing?}
    B -- No --> C[hasActiveProductWithTrial = false]
    B -- Yes --> D{has subscription_ids AND free_trial_id?}
    D -- No --> C
    D -- Yes --> E[hasActiveProductWithTrial = true]

    C --> F{hasActiveSubscription?}
    E --> G[hasSubscriptionToProrate = false / showProrationRow = false]

    F -- No --> H[hasSubscriptionToProrate = false / showProrationRow = false]
    F -- Yes --> I[hasSubscriptionToProrate = true / showProrationRow = true]

    I --> J{effectivePlanSchedule === immediate?}
    J -- Yes --> K[Show Proration Toggle]
    J -- No --> L[Hide Proration Toggle]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts`, line 1-3 ([link](https://github.com/useautumn/autumn/blob/12e2bb1412f36d6b82a739cdffc914bf21388fc1/vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts#L1-L3)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `ACTIVE_STATUSES` is now unused in this file — its only reference was in the condition that was removed by this PR. This will cause a lint warning (and potentially a build error depending on the project's TypeScript/ESLint configuration).

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts
   Line: 1-3

   Comment:
   `ACTIVE_STATUSES` is now unused in this file — its only reference was in the condition that was removed by this PR. This will cause a lint warning (and potentially a build error depending on the project's TypeScript/ESLint configuration).

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/components/forms/attach-v2/hooks/useAttachBillingOptionsState.ts:1-3
`ACTIVE_STATUSES` is now unused in this file — its only reference was in the condition that was removed by this PR. This will cause a lint warning (and potentially a build error depending on the project's TypeScript/ESLint configuration).

```suggestion
import {
	type BillingBehavior,
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["show proration toggle even when there is..."](https://github.com/useautumn/autumn/commit/12e2bb1412f36d6b82a739cdffc914bf21388fc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33500529)</sub>

<!-- /greptile_comment -->