### PR TITLE
Fire usage alerts when remaining lands on threshold

### DIFF
--- a/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
+++ b/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
@@ -43,8 +43,8 @@ const wasThresholdCrossed = ({
 			.toNumber();
 
 		return (
-			currentRemainingPercentage < alert.threshold &&
-			oldRemainingPercentage >= alert.threshold
+			currentRemainingPercentage <= alert.threshold &&
+			oldRemainingPercentage > alert.threshold
 		);
 	}
 
@@ -53,7 +53,7 @@ const wasThresholdCrossed = ({
 		const oldRemaining = oldApiBalance.remaining;
 
 		return (
-			currentRemaining < alert.threshold && oldRemaining >= alert.threshold
+			currentRemaining <= alert.threshold && oldRemaining > alert.threshold
 		);
 	}
 

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-basic.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-basic.test.ts
@@ -463,6 +463,62 @@ test(`${chalk.yellowBright("usage-alert6: remaining threshold crossing triggers 
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// TEST 6b: Remaining threshold of 0 fires when balance lands on 0 (no overage)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("usage-alert6b: remaining=0 threshold fires when balance hits 0 with overage disabled")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const freeProd = products.base({
+		id: "ua-remaining-zero-1",
+		items: [messagesItem],
+	});
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "usage-alert-remaining-zero-1",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	await setCustomerUsageAlerts({
+		autumn: autumnV2_1,
+		customerId,
+		usageAlerts: [
+			{
+				feature_id: TestFeature.Messages,
+				threshold: 0,
+				threshold_type: "remaining",
+				enabled: true,
+			},
+		],
+	});
+
+	// Track exactly 1000 usage — remaining hits 0 (lands on threshold, doesn't go below)
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 1000,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.threshold === 0,
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result?.payload.type).toBe("balances.usage_alert_triggered");
+
+	const { data } = result!.payload;
+	expect(data.customer_id).toBe(customerId);
+	expect(data.feature_id).toBe(TestFeature.Messages);
+	expect(data.usage_alert.threshold).toBe(0);
+	expect(data.usage_alert.threshold_type).toBe("remaining");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // TEST 7: Remaining percentage threshold crossing triggers webhook
 // ═══════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Usage alerts now trigger when remaining lands exactly on the threshold (including 0), not only when it goes below. This prevents missed alerts for both absolute and percentage thresholds.

- **Bug Fixes**
  - Changed threshold check to fire when current remaining <= threshold and previous > threshold (absolute and percentage).
  - Added integration test: remaining=0 sends alert when balance hits 0 with overage disabled.

<sup>Written for commit 74bd3c51fa487710bfb43ffecbc3f8ecaa415109. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1705?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

