### PR TITLE
fix: usage alert threshold

### DIFF
--- a/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
+++ b/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
@@ -23,8 +23,8 @@ const wasThresholdCrossed = ({
 }) => {
 	if (alert.threshold_type === "usage") {
 		const shldAlert =
-			oldApiBalance.usage < alert.threshold &&
-			newApiBalance.usage >= alert.threshold;
+			oldApiBalance.usage <= alert.threshold &&
+			newApiBalance.usage > alert.threshold;
 
 		return shldAlert;
 	}
@@ -43,8 +43,8 @@ const wasThresholdCrossed = ({
 			.toNumber();
 
 		return (
-			currentRemainingPercentage < alert.threshold &&
-			oldRemainingPercentage >= alert.threshold
+			currentRemainingPercentage <= alert.threshold &&
+			oldRemainingPercentage > alert.threshold
 		);
 	}
 
@@ -53,7 +53,7 @@ const wasThresholdCrossed = ({
 		const oldRemaining = oldApiBalance.remaining;
 
 		return (
-			currentRemaining < alert.threshold && oldRemaining >= alert.threshold
+			currentRemaining <= alert.threshold && oldRemaining > alert.threshold
 		);
 	}
 
@@ -70,7 +70,7 @@ const wasThresholdCrossed = ({
 			.mul(100)
 			.toNumber();
 
-		return oldPercentage < alert.threshold && newPercentage >= alert.threshold;
+		return oldPercentage <= alert.threshold && newPercentage > alert.threshold;
 	}
 
 	return false;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed threshold crossing logic in `checkUsageAlerts.ts` to handle equality correctly and only trigger alerts on true crossings. This prevents duplicate or missed usage alerts when values sit exactly at the threshold.

<sup>Written for commit dc571770709d2958a4811868d3fa40ebc2ff05b5. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1706?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts the threshold-crossing comparisons in `wasThresholdCrossed` from `<`/`>=` to `<=`/`>` across all four alert types, aiming to handle the case where a balance was already sitting exactly at the threshold between two events.

- **[Bug fixes]** For `remaining` and `remaining_percentage` types, `current <= threshold` now correctly fires when the value lands exactly on the threshold (e.g., drops from 11 → 10 with threshold 10), fixing the previously silent miss.
- **[Bug fixes]** For `usage` and `usage_percentage` types, `old <= threshold` fixes the stale-at-threshold edge case, but the companion change to `new > threshold` (strict) means usage landing exactly on the threshold (e.g., 99 → 100 with threshold 100) no longer fires — effectively delaying integer-based alerts by one increment.
</details>

<h3>Confidence Score: 3/5</h3>

The change corrects remaining-type alerts but silently skips usage alerts when the new value lands exactly on the threshold, which is a common scenario for integer usage counters.

The `remaining` fix is correct and beneficial. However, swapping `new >= threshold` to `new > threshold` for the `usage` and `usage_percentage` types means that a customer whose usage increments to exactly the configured threshold (e.g., 99 → 100 with threshold 100) will receive no alert until the next event pushes past it — a silent miss that users would reasonably expect to fire.

server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts — specifically the `usage` and `usage_percentage` threshold branches

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts | Shifts the threshold-crossing boundary from `<`/`>=` to `<=`/`>` across all four alert types — fixes the stale-at-threshold edge case for remaining types but introduces a missed-fire edge case for usage types when the new value lands exactly on the threshold. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[wasThresholdCrossed called] --> B{threshold_type?}

    B -->|usage| C["old <= threshold\nAND new > threshold"]
    B -->|usage_percentage| D["oldPct <= threshold\nAND newPct > threshold"]
    B -->|remaining| E["current <= threshold\nAND old > threshold"]
    B -->|remaining_percentage| F["currentPct <= threshold\nAND oldPct > threshold"]

    C --> G{Result}
    D --> G
    E --> G
    F --> G

    G -->|true| H[Send Svix webhook event]
    G -->|false| I[Skip alert]

    H --> J[Log alert triggered]

    style C fill:#f9a,stroke:#f00
    style D fill:#f9a,stroke:#f00
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts:24-30
With `new > threshold` (strict), usage landing exactly on the threshold value (e.g., going from 99 → 100 with threshold 100) will no longer fire the alert. For integer-based usage counters this means the alert is silently delayed until usage increments past the threshold (100 → 101). The original `new >= threshold` fired at the boundary; the corrected form to preserve that while also handling the `old === threshold` edge case would be to keep `>=` on the new side.

```suggestion
	if (alert.threshold_type === "usage") {
		const shldAlert =
			oldApiBalance.usage < alert.threshold &&
			newApiBalance.usage >= alert.threshold;

		return shldAlert;
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: usage alert threshold"](https://github.com/useautumn/autumn/commit/dc571770709d2958a4811868d3fa40ebc2ff05b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33656135)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->