### PR TITLE
feat: org usage alerts

### DIFF
--- a/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
+++ b/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
@@ -12,6 +12,8 @@ import { Decimal } from "decimal.js";
 import { sendSvixEvent } from "@/external/svix/svixHelpers.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
+type AlertScope = "customer" | "entity" | "org";
+
 const wasThresholdCrossed = ({
 	alert,
 	oldApiBalance,
@@ -82,18 +84,17 @@ const processAlerts = async ({
 	newFullCus,
 	feature,
 	entityId,
+	alerts,
+	scope,
 }: {
 	ctx: AutumnContext;
 	oldFullCus: FullCustomer;
 	newFullCus: FullCustomer;
 	feature: Feature;
 	entityId?: string;
+	alerts: DbUsageAlert[];
+	scope: AlertScope;
 }) => {
-	const entity = entityId
-		? newFullCus.entities?.find((e) => e.id === entityId)
-		: undefined;
-
-	const alerts = entity ? entity.usage_alerts : newFullCus.usage_alerts;
 	if (!alerts || alerts.length === 0) return;
 
 	const matchingAlerts = alerts.filter(
@@ -102,6 +103,10 @@ const processAlerts = async ({
 	);
 
 	if (matchingAlerts.length === 0) return;
+
+	const entity = entityId
+		? newFullCus.entities?.find((e) => e.id === entityId)
+		: undefined;
 
 	const oldCustomerEntitlements = fullCustomerToCustomerEntitlements({
 		fullCustomer: oldFullCus,
@@ -146,6 +151,7 @@ const processAlerts = async ({
 			ctx.env,
 			customerId,
 			entityId ?? "_",
+			scope,
 			feature.id,
 			alert.threshold_type,
 			alert.threshold,
@@ -172,7 +178,7 @@ const processAlerts = async ({
 		});
 
 		ctx.logger.info(
-			`Usage alert triggered for customer ${customerId}, feature ${feature.id}, threshold ${alert.threshold} (${alert.threshold_type})${entityId ? `, entity ${entityId}` : ""}`,
+			`Usage alert triggered (scope=${scope}) for customer ${customerId}, feature ${feature.id}, threshold ${alert.threshold} (${alert.threshold_type})${entityId ? `, entity ${entityId}` : ""}`,
 		);
 	}
 };
@@ -191,9 +197,38 @@ export const checkUsageAlerts = async ({
 	entityId?: string;
 }) => {
 	// 1. Customer-level alerts (always checked, no entity scoping)
-	await processAlerts({ ctx, oldFullCus, newFullCus, feature });
+	await processAlerts({
+		ctx,
+		oldFullCus,
+		newFullCus,
+		feature,
+		alerts: newFullCus.usage_alerts ?? [],
+		scope: "customer",
+	});
 
-	// 2. Entity-level alerts (only when entityId is provided)
+	// 2. Org-level alerts (apply to all customers; evaluated against customer-level balance)
+	const orgAlerts = ctx.org.config?.usage_alerts ?? [];
+	if (orgAlerts.length > 0) {
+		await processAlerts({
+			ctx,
+			oldFullCus,
+			newFullCus,
+			feature,
+			alerts: orgAlerts,
+			scope: "org",
+		});
+	}
+
+	// 3. Entity-level alerts (only when entityId is provided)
 	if (!entityId) return;
-	await processAlerts({ ctx, oldFullCus, newFullCus, feature, entityId });
+	const entity = newFullCus.entities?.find((e) => e.id === entityId);
+	await processAlerts({
+		ctx,
+		oldFullCus,
+		newFullCus,
+		feature,
+		entityId,
+		alerts: entity?.usage_alerts ?? [],
+		scope: "entity",
+	});
 };

--- a/server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts
+++ b/server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts
@@ -1,11 +1,10 @@
-import { OrgConfigSchema, type OrgConfig, Scopes } from "@autumn/shared";
+import { type OrgConfig, OrgConfigSchema, Scopes } from "@autumn/shared";
+import { sql } from "drizzle-orm";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { clearOrgCache } from "../orgUtils/clearOrgCache.js";
-import { sql } from "drizzle-orm";
-import { z } from "zod/v4";
 
 const validKeys = new Set(Object.keys(OrgConfigSchema.shape));
-const bodySchema = z.record(z.string(), z.boolean());
+const bodySchema = OrgConfigSchema.partial();
 
 export const handleUpdateOrgConfig = createRoute({
 	scopes: [Scopes.Organisation.Write],
@@ -15,11 +14,16 @@ export const handleUpdateOrgConfig = createRoute({
 		const raw = c.req.valid("json");
 
 		const updates = Object.fromEntries(
-			Object.entries(raw).filter(([k]) => validKeys.has(k)),
+			Object.entries(raw).filter(
+				([k, v]) => validKeys.has(k) && v !== undefined,
+			),
 		) as Partial<OrgConfig>;
 
 		if (Object.keys(updates).length === 0) {
-			return c.json({ success: true, config: OrgConfigSchema.parse(org.config) });
+			return c.json({
+				success: true,
+				config: OrgConfigSchema.parse(org.config),
+			});
 		}
 
 		const rows = await db.execute<{ config: OrgConfig }>(

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-org.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-org.test.ts
@@ -1,0 +1,392 @@
+/**
+ * TDD test for org-level usage alerts.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - OrgConfig.usage_alerts: DbUsageAlert[]   (org-scope alerts in organizations.config)
+ *   New behaviors:
+ *     - checkUsageAlerts evaluates ctx.org.config.usage_alerts in addition to
+ *       customer-level and entity-level alerts.
+ *     - Org alerts fire INDEPENDENTLY of customer alerts (idempotency key
+ *       takes a scope segment so Svix does not dedup them).
+ *     - Org alerts evaluate against the customer-level balance only — they do
+ *       not iterate per entity.
+ *     - Disabled org alerts (enabled: false) do not fire.
+ *     - Org alert with no feature_id fires on usage of any feature (global).
+ *   Side effects:
+ *     - Svix `balances.usage_alert_triggered` event per customer per
+ *       (scope, feature, threshold, threshold_type) per minute-bucket.
+ *
+ * Pre-impl red:
+ *   - OrgConfig.usage_alerts type doesn't exist → TS error on the org config
+ *     update payload.
+ *   - checkUsageAlerts does not read ctx.org.config.usage_alerts → no webhook
+ *     fires → waitForWebhook returns null → assertions fail.
+ *
+ * Post-impl green: all assertions pass once OrgConfigSchema includes
+ * usage_alerts and checkUsageAlerts iterates ctx.org.config.usage_alerts as a
+ * third scope.
+ */
+
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
+import type { DbUsageAlert } from "@autumn/shared";
+import {
+	getPlayHistory,
+	getTestSvixAppId,
+	parseEventBody,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { db } from "@/db/initDrizzle.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { setCustomerUsageAlerts } from "../../utils/usage-alert-utils/customerUsageAlertUtils.js";
+
+type BalancesUsageAlertTriggeredPayload = {
+	type: string;
+	data: {
+		customer_id: string;
+		feature_id: string;
+		entity_id?: string;
+		usage_alert: {
+			name?: string;
+			threshold: number;
+			threshold_type: string;
+		};
+	};
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SVIX PLAY SETUP
+// ═══════════════════════════════════════════════════════════════════════════════
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	const appId = getTestSvixAppId({ svixConfig: defaultCtx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["balances.usage_alert_triggered"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+	// Final reset to ensure config doesn't leak to other suites.
+	await setOrgUsageAlerts([]);
+});
+
+// Each test sets the org-level alerts then clears them in afterEach so tests
+// can run sequentially without bleeding across each other.
+afterEach(async () => {
+	await setOrgUsageAlerts([]);
+});
+
+async function setOrgUsageAlerts(usageAlerts: DbUsageAlert[]) {
+	await OrgService.update({
+		db,
+		orgId: defaultCtx.org.id,
+		updates: {
+			config: {
+				...defaultCtx.org.config,
+				usage_alerts: usageAlerts,
+			},
+		},
+	});
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Org-level alert fires when customer crosses threshold
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("org-alert1: org-level alert fires when customer crosses threshold")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const prod = products.base({
+		id: "org-ua-threshold-1",
+		items: [messagesItem],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			feature_id: TestFeature.Messages,
+			threshold: 750,
+			threshold_type: "usage",
+			enabled: true,
+			name: "org-threshold-750",
+		},
+	]);
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "org-usage-alert-threshold-1",
+		setup: [s.customer({ testClock: false }), s.products({ list: [prod] })],
+		actions: [s.attach({ productId: prod.id })],
+	});
+
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 850,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.threshold === 750 &&
+			payload.data?.usage_alert?.name === "org-threshold-750",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	const { data } = result!.payload;
+	expect(data.customer_id).toBe(customerId);
+	expect(data.feature_id).toBe(TestFeature.Messages);
+	expect(data.usage_alert.threshold).toBe(750);
+	expect(data.usage_alert.threshold_type).toBe("usage");
+	expect(data.usage_alert.name).toBe("org-threshold-750");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Org alert applies to ALL customers (not customer-specific)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("org-alert2: org-level alert fires for multiple customers independently")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const prod = products.base({
+		id: "org-ua-multi-customer-1",
+		items: [messagesItem],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			feature_id: TestFeature.Messages,
+			threshold: 600,
+			threshold_type: "usage",
+			enabled: true,
+			name: "org-multi-cust",
+		},
+	]);
+
+	const { customerId: customerIdA, autumnV2_1: autumnA } = await initScenario({
+		customerId: "org-usage-alert-multi-a",
+		setup: [s.customer({ testClock: false }), s.products({ list: [prod] })],
+		actions: [s.attach({ productId: prod.id })],
+	});
+
+	const { customerId: customerIdB, autumnV2_1: autumnB } = await initScenario({
+		customerId: "org-usage-alert-multi-b",
+		setup: [s.customer({ testClock: false }), s.products({ list: [prod] })],
+		actions: [s.attach({ productId: prod.id })],
+	});
+
+	await autumnA.track({
+		customer_id: customerIdA,
+		feature_id: TestFeature.Messages,
+		value: 700,
+	});
+	await autumnB.track({
+		customer_id: customerIdB,
+		feature_id: TestFeature.Messages,
+		value: 700,
+	});
+
+	const resultA = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerIdA &&
+			payload.data?.usage_alert?.threshold === 600 &&
+			payload.data?.usage_alert?.name === "org-multi-cust",
+		timeoutMs: 15000,
+	});
+	const resultB = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerIdB &&
+			payload.data?.usage_alert?.threshold === 600 &&
+			payload.data?.usage_alert?.name === "org-multi-cust",
+		timeoutMs: 15000,
+	});
+
+	expect(resultA).not.toBeNull();
+	expect(resultB).not.toBeNull();
+	expect(resultA!.payload.data.customer_id).toBe(customerIdA);
+	expect(resultB!.payload.data.customer_id).toBe(customerIdB);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: Org alert + customer alert at same threshold both fire independently
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("org-alert3: org and customer alerts at same threshold both fire")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const prod = products.base({
+		id: "org-ua-coexist-1",
+		items: [messagesItem],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			feature_id: TestFeature.Messages,
+			threshold: 400,
+			threshold_type: "usage",
+			enabled: true,
+			name: "org-coexist",
+		},
+	]);
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "org-usage-alert-coexist-1",
+		setup: [s.customer({ testClock: false }), s.products({ list: [prod] })],
+		actions: [s.attach({ productId: prod.id })],
+	});
+
+	await setCustomerUsageAlerts({
+		autumn: autumnV2_1,
+		customerId,
+		usageAlerts: [
+			{
+				feature_id: TestFeature.Messages,
+				threshold: 400,
+				threshold_type: "usage",
+				enabled: true,
+				name: "customer-coexist",
+			},
+		],
+	});
+
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 500,
+	});
+
+	await timeout(5000);
+
+	const history = await getPlayHistory({ token: playToken });
+	let orgMatch = 0;
+	let customerMatch = 0;
+	for (const event of history.data) {
+		try {
+			const payload = parseEventBody<BalancesUsageAlertTriggeredPayload>(event);
+			if (
+				payload.type !== "balances.usage_alert_triggered" ||
+				payload.data?.customer_id !== customerId ||
+				payload.data?.usage_alert?.threshold !== 400
+			)
+				continue;
+			if (payload.data.usage_alert.name === "org-coexist") orgMatch++;
+			if (payload.data.usage_alert.name === "customer-coexist") customerMatch++;
+		} catch {
+			// skip unparseable
+		}
+	}
+
+	expect(orgMatch).toBe(1);
+	expect(customerMatch).toBe(1);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 4: Org alert with no feature_id (global) fires on any feature
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("org-alert4: org-level global alert (no feature_id) fires on any feature")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const prod = products.base({
+		id: "org-ua-global-1",
+		items: [messagesItem],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			threshold: 80,
+			threshold_type: "usage_percentage",
+			enabled: true,
+			name: "org-global",
+		},
+	]);
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "org-usage-alert-global-1",
+		setup: [s.customer({ testClock: false }), s.products({ list: [prod] })],
+		actions: [s.attach({ productId: prod.id })],
+	});
+
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 900,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.name === "org-global",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result!.payload.data.feature_id).toBe(TestFeature.Messages);
+	expect(result!.payload.data.usage_alert.threshold).toBe(80);
+	expect(result!.payload.data.usage_alert.threshold_type).toBe(
+		"usage_percentage",
+	);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 5: Disabled org-level alert does not fire
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("org-alert5: disabled org-level alert does not fire")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const prod = products.base({
+		id: "org-ua-disabled-1",
+		items: [messagesItem],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			feature_id: TestFeature.Messages,
+			threshold: 300,
+			threshold_type: "usage",
+			enabled: false,
+			name: "org-disabled",
+		},
+	]);
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "org-usage-alert-disabled-1",
+		setup: [s.customer({ testClock: false }), s.products({ list: [prod] })],
+		actions: [s.attach({ productId: prod.id })],
+	});
+
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 500,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.name === "org-disabled",
+		timeoutMs: 8000,
+	});
+
+	expect(result).toBeNull();
+});

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -1,6 +1,9 @@
 import { z } from "zod/v4";
+import { DbUsageAlertSchema } from "../cusModels/billingControls/usageAlert.js";
 
 export const OrgConfigSchema = z.object({
+	usage_alerts: z.array(DbUsageAlertSchema).optional().default([]),
+
 	bill_upgrade_immediately: z.boolean().default(true),
 	convert_to_charge_automatically: z.boolean().default(true),
 	anchor_start_of_month: z.boolean().default(false), // If true, the billing cycle will start on the first day of the month

--- a/vite/src/views/settings/SettingsView.tsx
+++ b/vite/src/views/settings/SettingsView.tsx
@@ -1,4 +1,5 @@
 import {
+	BellIcon,
 	BuildingIcon,
 	CreditCardIcon,
 	PaletteIcon,
@@ -15,8 +16,16 @@ import { MembersSection } from "./sections/MembersSection";
 import { AuthorizedAppsSection } from "./sections/AuthorizedAppsSection";
 import { AppearanceSection } from "./sections/AppearanceSection";
 import { BillingSettingsSection } from "./sections/BillingSettingsSection";
+import { UsageAlertsSection } from "./sections/UsageAlertsSection";
 
-type SettingsTab = "account" | "organization" | "members" | "billing" | "appearance" | "apps";
+type SettingsTab =
+	| "account"
+	| "organization"
+	| "members"
+	| "billing"
+	| "usage-alerts"
+	| "appearance"
+	| "apps";
 
 interface SettingsNavItem {
 	readonly id: SettingsTab;
@@ -42,6 +51,11 @@ const SETTINGS_TABS: readonly SettingsNavItem[] = [
 		icon: <CreditCardIcon className="size-4" />,
 	},
 	{
+		id: "usage-alerts",
+		label: "Usage Alerts",
+		icon: <BellIcon className="size-4" />,
+	},
+	{
 		id: "appearance",
 		label: "Appearance",
 		icon: <PaletteIcon className="size-4" />,
@@ -58,6 +72,7 @@ const SECTION_MAP: Record<SettingsTab, React.ComponentType> = {
 	organization: OrganizationSection,
 	members: MembersSection,
 	billing: BillingSettingsSection,
+	"usage-alerts": UsageAlertsSection,
 	appearance: AppearanceSection,
 	apps: AuthorizedAppsSection,
 };

--- a/vite/src/views/settings/sections/UsageAlertsSection.tsx
+++ b/vite/src/views/settings/sections/UsageAlertsSection.tsx
@@ -1,0 +1,13 @@
+import { SettingsSection } from "../SettingsSection";
+import { OrgUsageAlertsSubsection } from "./components/OrgUsageAlertsSubsection";
+
+export const UsageAlertsSection = () => {
+	return (
+		<SettingsSection
+			title="Usage Alerts"
+			description="Configure org-wide usage alerts that fire for every customer when their balance crosses a threshold."
+		>
+			<OrgUsageAlertsSubsection />
+		</SettingsSection>
+	);
+};

--- a/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
+++ b/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
@@ -1,0 +1,182 @@
+import { type DbUsageAlert, type Feature, FeatureType } from "@autumn/shared";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/v2/buttons/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+
+type ThresholdType = DbUsageAlert["threshold_type"];
+
+interface OrgUsageAlertDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	features: Feature[];
+	initialAlert?: DbUsageAlert;
+	onSubmit: (alert: DbUsageAlert) => Promise<void>;
+	isSaving: boolean;
+}
+
+const isPercentageType = (type: ThresholdType) =>
+	type === "usage_percentage" || type === "remaining_percentage";
+
+export const OrgUsageAlertDialog = ({
+	open,
+	onOpenChange,
+	features,
+	initialAlert,
+	onSubmit,
+	isSaving,
+}: OrgUsageAlertDialogProps) => {
+	const isEdit = initialAlert !== undefined;
+	const [draft, setDraft] = useState<DbUsageAlert>(
+		initialAlert ?? {
+			enabled: true,
+			threshold: 0,
+			threshold_type: "usage",
+			feature_id: undefined,
+			name: undefined,
+		},
+	);
+
+	const nonArchivedFeatures = features.filter(
+		(f) => !f.archived && f.type !== FeatureType.Boolean,
+	);
+
+	const updateDraft = (patch: Partial<DbUsageAlert>) =>
+		setDraft((prev) => ({ ...prev, ...patch }));
+
+	const handleSave = async () => {
+		if (Number.isNaN(draft.threshold) || draft.threshold < 0) {
+			toast.error("Please enter a valid threshold");
+			return;
+		}
+		if (isPercentageType(draft.threshold_type) && draft.threshold > 100) {
+			toast.error("Percentage threshold must be between 0 and 100");
+			return;
+		}
+
+		const cleaned: DbUsageAlert = {
+			...draft,
+			feature_id: draft.feature_id || undefined,
+			name: draft.name?.trim() ? draft.name.trim() : undefined,
+		};
+		await onSubmit(cleaned);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>
+						{isEdit ? "Edit org usage alert" : "Add org usage alert"}
+					</DialogTitle>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-4">
+					<div>
+						<FormLabel>Feature</FormLabel>
+						<FeatureSearchDropdown
+							features={nonArchivedFeatures}
+							value={draft.feature_id ?? null}
+							onSelect={(featureId) =>
+								updateDraft({ feature_id: featureId || undefined })
+							}
+							placeholder="Optional — leave empty for all features"
+						/>
+					</div>
+
+					<div className="flex items-center justify-between">
+						<FormLabel className="mb-0">Enabled</FormLabel>
+						<Switch
+							checked={draft.enabled}
+							onCheckedChange={(value) => updateDraft({ enabled: value })}
+						/>
+					</div>
+
+					<div>
+						<FormLabel>Name</FormLabel>
+						<Input
+							placeholder="Optional label for this alert"
+							value={draft.name ?? ""}
+							onChange={(e) => updateDraft({ name: e.target.value })}
+						/>
+					</div>
+
+					<div>
+						<FormLabel>Threshold type</FormLabel>
+						<Select
+							value={draft.threshold_type}
+							onValueChange={(value) =>
+								updateDraft({ threshold_type: value as ThresholdType })
+							}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="usage">Usage (absolute value)</SelectItem>
+								<SelectItem value="usage_percentage">
+									Percentage used of allowance
+								</SelectItem>
+								<SelectItem value="remaining">
+									Remaining (absolute value)
+								</SelectItem>
+								<SelectItem value="remaining_percentage">
+									Percentage remaining of allowance
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div>
+						<FormLabel>
+							Threshold
+							{isPercentageType(draft.threshold_type) ? " (%)" : ""}
+						</FormLabel>
+						<Input
+							type="number"
+							placeholder={
+								isPercentageType(draft.threshold_type) ? "eg, 80" : "eg, 1000"
+							}
+							value={Number.isFinite(draft.threshold) ? draft.threshold : ""}
+							onChange={(e) =>
+								updateDraft({
+									threshold: Number.parseFloat(e.target.value),
+								})
+							}
+						/>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="secondary"
+						onClick={() => onOpenChange(false)}
+						disabled={isSaving}
+					>
+						Cancel
+					</Button>
+					<Button variant="primary" onClick={handleSave} isLoading={isSaving}>
+						{isEdit ? "Save" : "Add"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx
@@ -1,0 +1,206 @@
+import type { DbUsageAlert, Feature, FrontendOrg, OrgConfig } from "@autumn/shared";
+import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/v2/buttons/Button";
+import { useOrg } from "@/hooks/common/useOrg";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { cn } from "@/lib/utils";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useEnv } from "@/utils/envUtils";
+import { OrgUsageAlertDialog } from "./OrgUsageAlertDialog";
+
+const pillClassName =
+	"rounded-md bg-muted px-1.5 py-0.5 text-xs text-tertiary-foreground whitespace-nowrap";
+
+const thresholdTypeLabel: Record<DbUsageAlert["threshold_type"], string> = {
+	usage: "absolute usage",
+	usage_percentage: "% used of allowance",
+	remaining: "absolute remaining",
+	remaining_percentage: "% remaining of allowance",
+};
+
+const formatThreshold = (alert: DbUsageAlert) => {
+	const isPct =
+		alert.threshold_type === "usage_percentage" ||
+		alert.threshold_type === "remaining_percentage";
+	return isPct ? `${alert.threshold}%` : alert.threshold.toLocaleString();
+};
+
+interface DialogState {
+	open: boolean;
+	editingIndex: number | null;
+}
+
+export const OrgUsageAlertsSubsection = () => {
+	const { org } = useOrg();
+	const { features } = useFeaturesQuery();
+	const axiosInstance = useAxiosInstance();
+	const queryClient = useQueryClient();
+	const env = useEnv();
+	const orgQueryKey = ["org", env];
+
+	const [dialog, setDialog] = useState<DialogState>({
+		open: false,
+		editingIndex: null,
+	});
+
+	const orgAlerts: DbUsageAlert[] = useMemo(
+		() => org?.config?.usage_alerts ?? [],
+		[org?.config?.usage_alerts],
+	);
+
+	const featureNameById = useMemo(
+		() => new Map((features ?? []).map((f: Feature) => [f.id, f.name])),
+		[features],
+	);
+
+	const { mutateAsync, isPending } = useMutation({
+		mutationFn: async (updatedAlerts: DbUsageAlert[]) => {
+			const { data } = await axiosInstance.patch("/organization/config", {
+				usage_alerts: updatedAlerts,
+			});
+			return data as { config: OrgConfig };
+		},
+		onSuccess: (data) => {
+			queryClient.setQueryData<FrontendOrg>(orgQueryKey, (old) =>
+				old ? { ...old, config: data.config } : old,
+			);
+		},
+		onError: () => {
+			toast.error("Failed to update usage alerts");
+			queryClient.invalidateQueries({ queryKey: orgQueryKey });
+		},
+	});
+
+	const handleAddClick = () =>
+		setDialog({ open: true, editingIndex: null });
+
+	const handleEditClick = (index: number) =>
+		setDialog({ open: true, editingIndex: index });
+
+	const handleDialogOpenChange = (open: boolean) => {
+		if (!open) setDialog({ open: false, editingIndex: null });
+	};
+
+	const handleSubmit = async (alert: DbUsageAlert) => {
+		const next = [...orgAlerts];
+		if (dialog.editingIndex !== null) {
+			next[dialog.editingIndex] = alert;
+		} else {
+			next.push(alert);
+		}
+
+		try {
+			await mutateAsync(next);
+			setDialog({ open: false, editingIndex: null });
+			toast.success(
+				dialog.editingIndex !== null ? "Usage alert updated" : "Usage alert added",
+			);
+		} catch {
+			// onError handles toast + invalidate
+		}
+	};
+
+	const handleDelete = async (index: number) => {
+		const next = orgAlerts.filter((_, i) => i !== index);
+		try {
+			await mutateAsync(next);
+			toast.success("Usage alert removed");
+		} catch {
+			// onError handles toast + invalidate
+		}
+	};
+
+	const editingAlert =
+		dialog.editingIndex !== null ? orgAlerts[dialog.editingIndex] : undefined;
+
+	return (
+		<div className="flex flex-col gap-3">
+			<div className="flex justify-end">
+				<Button
+					variant="secondary"
+					size="mini"
+					className="gap-2 font-medium shrink-0"
+					onClick={handleAddClick}
+				>
+					<PlusIcon className="size-3.5" />
+					Add alert
+				</Button>
+			</div>
+
+			{orgAlerts.length === 0 ? (
+				<div className="rounded-lg border border-dashed bg-interactive-secondary px-3 py-4 text-center text-xs text-tertiary-foreground">
+					No org-level usage alerts configured.
+				</div>
+			) : (
+				<div className="flex flex-col gap-1.5">
+					{orgAlerts.map((alert, index) => (
+						<div
+							key={`org-alert-${alert.feature_id ?? "global"}-${alert.threshold_type}-${alert.threshold}-${alert.name ?? index}`}
+							className={cn(
+								"flex items-center gap-2 rounded-lg border bg-interactive-secondary px-3 py-2 min-w-0",
+							)}
+						>
+							<button
+								type="button"
+								className="flex items-center gap-2 min-w-0 flex-1 text-left cursor-pointer"
+								onClick={() => handleEditClick(index)}
+							>
+								<span
+									className={cn(
+										"shrink-0 rounded-md px-1.5 py-0.5 text-xs font-medium",
+										alert.enabled
+											? "bg-green-500/10 text-green-600"
+											: "bg-muted text-tertiary-foreground",
+									)}
+								>
+									{alert.enabled ? "Enabled" : "Disabled"}
+								</span>
+								<span className="truncate text-sm font-medium">
+									{alert.feature_id
+										? (featureNameById.get(alert.feature_id) ?? alert.feature_id)
+										: "All features"}
+								</span>
+								{alert.name && (
+									<span className="truncate text-xs text-tertiary-foreground font-mono ml-2">
+										{alert.name}
+									</span>
+								)}
+								<div className="ml-auto flex items-center gap-1.5 shrink-0">
+									<span className={pillClassName}>
+										At: {formatThreshold(alert)}
+									</span>
+									<span className={cn(pillClassName, "hidden sm:inline")}>
+										{thresholdTypeLabel[alert.threshold_type]}
+									</span>
+								</div>
+							</button>
+							<Button
+								variant="ghost"
+								size="mini"
+								className="text-destructive hover:text-destructive shrink-0"
+								onClick={() => handleDelete(index)}
+								disabled={isPending}
+							>
+								<TrashIcon className="size-3.5" />
+							</Button>
+						</div>
+					))}
+				</div>
+			)}
+
+			{dialog.open && (
+				<OrgUsageAlertDialog
+					open={dialog.open}
+					onOpenChange={handleDialogOpenChange}
+					features={features ?? []}
+					initialAlert={editingAlert}
+					onSubmit={handleSubmit}
+					isSaving={isPending}
+				/>
+			)}
+		</div>
+	);
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds org-level usage alerts that fire when any customer's balance crosses defined thresholds, plus a Settings UI to manage them. Org alerts work alongside customer/entity alerts and trigger separate webhooks without deduping.

- **New Features**
  - Server: `checkUsageAlerts` now evaluates org alerts from `ctx.org.config.usage_alerts` in addition to customer and entity alerts.
  - Behavior: Org alerts apply to all customers, use the customer-level balance, support global (no `feature_id`) or per-feature rules, and respect `enabled`.
  - Webhooks: Idempotency key now includes alert scope (`customer` | `entity` | `org`) so org and customer alerts at the same threshold both fire.
  - Schema: `@autumn/shared` adds `OrgConfigSchema.usage_alerts: DbUsageAlert[]` with a default of `[]`.
  - API: `PATCH /organization/config` validates with `OrgConfigSchema.partial()`, ignores `undefined` keys, and returns the parsed config.
  - UI: New Settings tab “Usage Alerts” to add, edit, and remove org-wide alerts (feature picker, threshold type/value, enabled, optional name).
  - Tests: Added integration coverage for org alerts firing, multiple customers, coexistence with customer alerts, global alerts, and disabled alerts.

<sup>Written for commit f48961cccca5a8cd0026b775d19944931cd4c23a. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1707?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces org-level usage alerts — a new feature that lets org admins define usage thresholds that fire `balances.usage_alert_triggered` webhooks for *every* customer, complementing the existing per-customer and per-entity alert scopes. A new "Usage Alerts" settings tab exposes a full CRUD UI, and the `OrgConfig` schema is extended with `usage_alerts: DbUsageAlert[]`.

- **[Improvements]** `checkUsageAlerts` gains a second pass that evaluates `ctx.org.config.usage_alerts` against the customer-level balance; the new `scope` segment in the idempotency key prevents Svix from deduplicating org-scope events against customer-scope events at the same threshold.
- **[Improvements]** `handleUpdateOrgConfig` body schema is upgraded from `z.record(z.string(), z.boolean())` to `OrgConfigSchema.partial()`, enabling the API to accept the new `usage_alerts` array field.
- **[Improvements]** New settings UI (`OrgUsageAlertDialog`, `OrgUsageAlertsSubsection`, `UsageAlertsSection`) with full add/edit/delete support, backed by a TDD integration test suite with 5 org-alert scenarios.
</details>


<h3>Confidence Score: 3/5</h3>

The core alert-processing logic is correct, but the idempotency key omission means two org alerts at the same threshold will silently collapse into one Svix delivery.

The new org-scope pass in checkUsageAlerts is well-structured and the scope field correctly prevents cross-scope deduplication. However, alert.name is not part of the idempotency key, so any two alerts (org- or customer-scoped) that share feature_id + threshold_type + threshold will have an identical key — Svix will drop one event per minute bucket. This is an observable defect for users who configure multiple named alerts at the same threshold for different routing purposes. The rest of the changes (schema extension, UI, handler update) are straightforward and carry low risk.

checkUsageAlerts.ts deserves a second look at the idempotency key construction; handleUpdateOrgConfig.ts has a minor cleanup opportunity.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts | Adds org-scope alert processing as a third pass in checkUsageAlerts; idempotency key does not include alert.name, causing Svix to dedup two same-threshold alerts with different names. |
| server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts | Body schema upgraded from z.record to OrgConfigSchema.partial(), enabling usage_alerts array updates; validKeys guard is now redundant dead code. |
| shared/models/orgModels/orgConfig.ts | Adds usage_alerts: DbUsageAlert[] (optional, default []) to OrgConfigSchema — clean, minimal change. |
| server/tests/integration/balances/track/usage-alerts/usage-alert-org.test.ts | New integration test suite with 5 tests covering threshold crossing, multi-customer, coexistence with customer alerts, global (no feature_id) alerts, and disabled alerts. |
| vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx | New subsection managing CRUD for org-level alerts; delete fires immediately with no confirmation, which is risky for an org-wide destructive action. |
| vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx | New dialog for creating/editing a single org usage alert with feature picker, threshold type/value, name, and enabled toggle — looks correct. |
| vite/src/views/settings/SettingsView.tsx | Adds 'Usage Alerts' tab to the settings navigation and section map — straightforward wiring. |
| vite/src/views/settings/sections/UsageAlertsSection.tsx | Thin wrapper section component — no issues. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[checkUsageAlerts called] --> B[1. Customer-scope\nnewFullCus.usage_alerts]
    A --> C[2. Org-scope\nctx.org.config.usage_alerts]
    A --> D{entityId provided?}
    D -- No --> E[Done]
    D -- Yes --> F[3. Entity-scope\nentity.usage_alerts]

    B --> PA[processAlerts\nscope=customer]
    C --> PB[processAlerts\nscope=org]
    F --> PC[processAlerts\nscope=entity]

    PA --> IK[Build idempotency key\norg:env:customerId:_:scope:featureId:type:threshold:minuteBucket]
    PB --> IK
    PC --> IK2[Build idempotency key\norg:env:customerId:entityId:scope:featureId:type:threshold:minuteBucket]

    IK --> WH[sendSvixEvent\nbalances.usage_alert_triggered]
    IK2 --> WH
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts`, line 148-159 ([link](https://github.com/useautumn/autumn/blob/f48961cccca5a8cd0026b775d19944931cd4c23a/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts#L148-L159)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Idempotency key collision for distinct same-threshold alerts**

   `alert.name` is not included in the idempotency key, so two org-level (or customer-level) alerts that share the same `(feature_id, threshold_type, threshold)` but carry different `name` values will produce the same key. Svix will deduplicate them and silently drop one webhook per minute bucket. Within the new org scope this is easy to trigger — an admin might legitimately configure two named alerts at, say, 80% usage for notification routing purposes.

   Adding `alert.name ?? ""` to the key array prevents the collision without breaking any existing unique-key behaviour.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
   Line: 148-159

   Comment:
   **Idempotency key collision for distinct same-threshold alerts**

   `alert.name` is not included in the idempotency key, so two org-level (or customer-level) alerts that share the same `(feature_id, threshold_type, threshold)` but carry different `name` values will produce the same key. Svix will deduplicate them and silently drop one webhook per minute bucket. Within the new org scope this is easy to trigger — an admin might legitimately configure two named alerts at, say, 80% usage for notification routing purposes.

   Adding `alert.name ?? ""` to the key array prevents the collision without breaking any existing unique-key behaviour.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx`, line 923-931 ([link](https://github.com/useautumn/autumn/blob/f48961cccca5a8cd0026b775d19944931cd4c23a/vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx#L923-L931)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Destructive delete has no confirmation step**

   Clicking the trash icon immediately fires the mutation without any confirmation dialog or undo affordance. Because alerts are org-wide, a misclick would silently remove an alert that affects every customer's webhook delivery. A simple confirmation dialog (or at minimum a brief optimistic delay with a toast "undo" action) would prevent accidental deletions.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx
   Line: 923-931

   Comment:
   **Destructive delete has no confirmation step**

   Clicking the trash icon immediately fires the mutation without any confirmation dialog or undo affordance. Because alerts are org-wide, a misclick would silently remove an alert that affects every customer's webhook delivery. A simple confirmation dialog (or at minimum a brief optimistic delay with a toast "undo" action) would prevent accidental deletions.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts:148-159
**Idempotency key collision for distinct same-threshold alerts**

`alert.name` is not included in the idempotency key, so two org-level (or customer-level) alerts that share the same `(feature_id, threshold_type, threshold)` but carry different `name` values will produce the same key. Svix will deduplicate them and silently drop one webhook per minute bucket. Within the new org scope this is easy to trigger — an admin might legitimately configure two named alerts at, say, 80% usage for notification routing purposes.

Adding `alert.name ?? ""` to the key array prevents the collision without breaking any existing unique-key behaviour.

### Issue 2 of 3
server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts:16-20
**Redundant `validKeys` guard after schema change**

`bodySchema` was changed from `z.record(z.string(), z.boolean())` (which admitted arbitrary keys) to `OrgConfigSchema.partial()`, which already strips unknown keys during Zod validation. The `validKeys.has(k)` check in the filter is now a no-op and can be removed to keep the intent clear.

```suggestion
		const updates = Object.fromEntries(
			Object.entries(raw).filter(
				([_k, v]) => v !== undefined,
			),
		) as Partial<OrgConfig>;
```

### Issue 3 of 3
vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx:923-931
**Destructive delete has no confirmation step**

Clicking the trash icon immediately fires the mutation without any confirmation dialog or undo affordance. Because alerts are org-wide, a misclick would silently remove an alert that affects every customer's webhook delivery. A simple confirmation dialog (or at minimum a brief optimistic delay with a toast "undo" action) would prevent accidental deletions.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: usage alert threshold"](https://github.com/useautumn/autumn/commit/f48961cccca5a8cd0026b775d19944931cd4c23a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33675091)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->