### PR TITLE
fix: stripe checkout carry over

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/updateOptionsFromStripeCheckoutSession.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/updateOptionsFromStripeCheckoutSession.ts
@@ -8,6 +8,7 @@ import {
 	isCustomerProductEntityScoped,
 	priceUtils,
 } from "@autumn/shared";
+import { Decimal } from "decimal.js";
 import { stripeCheckoutSessionUtils } from "@/external/stripe/checkoutSessions/utils";
 import type { CheckoutSessionCompletedContext } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/setupCheckoutSessionCompletedContext";
 import { initCustomerEntitlementEntities } from "@/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementEntities";
@@ -74,36 +75,45 @@ export const updateOptionsFromStripeCheckoutSession = async ({
 					product: fullProduct,
 				});
 
-			newCustomerProduct.options[i].quantity = featureOptionsQuantity;
-
-			// // Update customer entitlement with the right balance
-			// const customerEntitlement =
-			// 	featureOptionUtils.convert.toCustomerEntitlement({
-			// 		featureOptions,
-			// 		customerEntitlements: newCustomerProduct.customer_entitlements,
-			// 	});
-
 			if (customerEntitlement) {
-				const startingBalance = getStartingBalance({
+				// The compute-time balance already has any existing-usage carry-over
+				// applied. Stripe may report a quantity that differs from what we
+				// initially planned (e.g. the customer edited it on the hosted
+				// checkout page) — apply only the *delta* in starting balance to the
+				// existing balance so the carry-over is preserved.
+				const oldStartingBalance = getStartingBalance({
 					entitlement: customerEntitlement.entitlement,
 					options: featureOptions,
+					relatedPrice: price,
+				});
+
+				newCustomerProduct.options[i].quantity = featureOptionsQuantity;
+
+				const newStartingBalance = getStartingBalance({
+					entitlement: customerEntitlement.entitlement,
+					options: newCustomerProduct.options[i],
 					relatedPrice: price,
 				});
 
 				const entities = initCustomerEntitlementEntities({
 					entitlement: customerEntitlement.entitlement,
 					customerEntities: fullCustomer.entities,
-					startingBalance,
+					startingBalance: newStartingBalance,
 				});
 
 				if (entities) {
 					customerEntitlement.entities = entities;
 				} else {
-					customerEntitlement.balance = startingBalance;
+					const startingBalanceDelta = new Decimal(newStartingBalance).sub(
+						oldStartingBalance,
+					);
+					customerEntitlement.balance = new Decimal(
+						customerEntitlement.balance ?? 0,
+					)
+						.add(startingBalanceDelta)
+						.toNumber();
 				}
 			}
 		}
-
-		
 	}
 };

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-org-over-100pct.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-org-over-100pct.test.ts
@@ -1,0 +1,242 @@
+/**
+ * TDD test for org-level usage_percentage alerts with thresholds > 100%.
+ *
+ * Red-failure mode (pre-fix):
+ *  - DbUsageAlertSchema.check() in shared/models/cusModels/billingControls/usageAlert.ts
+ *    rejected threshold > 100 for usage_percentage (and remaining_percentage),
+ *    so OrgConfigSchema.parse on next ctx.org read would throw and no
+ *    track request would even reach checkUsageAlerts.
+ *
+ * Green-success criteria (post-fix):
+ *  - usage_percentage thresholds > 100 (e.g. 200, 300) are accepted.
+ *  - With overage_allowed enabled on a consumable feature, usage can exceed
+ *    granted; when it crosses N% the org-level alert at N% fires.
+ *  - remaining_percentage stays capped at 100 (semantically remaining cannot
+ *    exceed granted).
+ */
+
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
+import type { DbUsageAlert } from "@autumn/shared";
+import {
+	getTestSvixAppId,
+	setupWebhookTest,
+	type WebhookTestSetup,
+	waitForWebhook,
+} from "@tests/integration/utils/svixWebhookTestUtils.js";
+import { setCustomerOverageAllowed } from "@tests/integration/balances/utils/overage-allowed-utils/customerOverageAllowedUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { db } from "@/db/initDrizzle.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+
+type BalancesUsageAlertTriggeredPayload = {
+	type: string;
+	data: {
+		customer_id: string;
+		feature_id: string;
+		usage_alert: {
+			name?: string;
+			threshold: number;
+			threshold_type: string;
+		};
+	};
+};
+
+let webhook: WebhookTestSetup;
+let playToken: string;
+
+beforeAll(async () => {
+	const appId = getTestSvixAppId({ svixConfig: defaultCtx.org.svix_config });
+	webhook = await setupWebhookTest({
+		appId,
+		filterTypes: ["balances.usage_alert_triggered"],
+	});
+	playToken = webhook.playToken;
+});
+
+afterAll(async () => {
+	await webhook?.cleanup();
+	await setOrgUsageAlerts([]);
+});
+
+afterEach(async () => {
+	await setOrgUsageAlerts([]);
+});
+
+async function setOrgUsageAlerts(usageAlerts: DbUsageAlert[]) {
+	await OrgService.update({
+		db,
+		orgId: defaultCtx.org.id,
+		updates: {
+			config: {
+				...defaultCtx.org.config,
+				usage_alerts: usageAlerts,
+			},
+		},
+	});
+}
+
+test(`${chalk.yellowBright("org-pct-200: usage_percentage threshold of 200% fires when customer is at 250%")}`, async () => {
+	const prod = products.base({
+		id: "org-ua-pct-200",
+		items: [items.consumableMessages({ includedUsage: 1000, price: 0.1 })],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			feature_id: TestFeature.Messages,
+			threshold: 200,
+			threshold_type: "usage_percentage",
+			enabled: true,
+			name: "org-200pct",
+		},
+	]);
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "org-ua-pct-200-cust",
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [prod] }),
+		],
+		actions: [s.billing.attach({ productId: prod.id })],
+	});
+
+	await setCustomerOverageAllowed({
+		autumn: autumnV2_1,
+		customerId,
+		featureId: TestFeature.Messages,
+		enabled: true,
+	});
+
+	// 2500 of 1000 allowance = 250% usage → crosses 200% threshold
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 2500,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.name === "org-200pct",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result!.payload.data.usage_alert.threshold).toBe(200);
+	expect(result!.payload.data.usage_alert.threshold_type).toBe(
+		"usage_percentage",
+	);
+});
+
+test(`${chalk.yellowBright("org-pct-300: usage_percentage threshold of 300% fires when customer is at 350%")}`, async () => {
+	const prod = products.base({
+		id: "org-ua-pct-300",
+		items: [items.consumableMessages({ includedUsage: 1000, price: 0.1 })],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			feature_id: TestFeature.Messages,
+			threshold: 300,
+			threshold_type: "usage_percentage",
+			enabled: true,
+			name: "org-300pct",
+		},
+	]);
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "org-ua-pct-300-cust",
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [prod] }),
+		],
+		actions: [s.billing.attach({ productId: prod.id })],
+	});
+
+	await setCustomerOverageAllowed({
+		autumn: autumnV2_1,
+		customerId,
+		featureId: TestFeature.Messages,
+		enabled: true,
+	});
+
+	// 3500 of 1000 allowance = 350% usage → crosses 300% threshold
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 3500,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.name === "org-300pct",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result!.payload.data.usage_alert.threshold).toBe(300);
+	expect(result!.payload.data.usage_alert.threshold_type).toBe(
+		"usage_percentage",
+	);
+});
+
+test(`${chalk.yellowBright("org-pct-200-not-yet: usage_percentage threshold of 200% does NOT fire at 150%")}`, async () => {
+	const prod = products.base({
+		id: "org-ua-pct-200-not-yet",
+		items: [items.consumableMessages({ includedUsage: 1000, price: 0.1 })],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			feature_id: TestFeature.Messages,
+			threshold: 200,
+			threshold_type: "usage_percentage",
+			enabled: true,
+			name: "org-200pct-not-yet",
+		},
+	]);
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "org-ua-pct-200-not-yet-cust",
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [prod] }),
+		],
+		actions: [s.billing.attach({ productId: prod.id })],
+	});
+
+	await setCustomerOverageAllowed({
+		autumn: autumnV2_1,
+		customerId,
+		featureId: TestFeature.Messages,
+		enabled: true,
+	});
+
+	// 1500 of 1000 allowance = 150% — below 200% threshold
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 1500,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.name === "org-200pct-not-yet",
+		timeoutMs: 8000,
+	});
+
+	expect(result).toBeNull();
+});

--- a/server/tests/integration/billing/attach/immediate-switch/immediate-switch-reset-behavior.test.ts
+++ b/server/tests/integration/billing/attach/immediate-switch/immediate-switch-reset-behavior.test.ts
@@ -16,8 +16,10 @@ import type { ApiCustomerV3 } from "@autumn/shared";
 import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
 import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
+import { completeStripeCheckoutFormV2 } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { addMonths } from "date-fns";
@@ -637,5 +639,81 @@ test.concurrent(`${chalk.yellowBright("immediate-switch-reset 6: monthly to annu
 		balance: 100, // Usage resets for consumable on upgrade
 		usage: 0,
 		resetsAt: monthlyResetAt!,
+	});
+});
+
+/**
+ * Free (1 included workflow) → track 1 → Pro (3 prepaid workflows) via Stripe Checkout.
+ * Expected: balance = 2, usage = 1 (the used workflow carries over).
+ * Bug: usage resets and balance = 3 — surfaces in the checkout-session flow,
+ * not the direct-attach flow.
+ */
+test(`${chalk.yellowBright("immediate-switch-reset 7: free→prepaid via checkout carries usage over")}`, async () => {
+	const customerId = "reset-free-to-prepaid-carry-checkout";
+
+	const free = products.base({
+		id: "free-workflows-carry-co",
+		items: [items.freeAllocatedWorkflows({ includedUsage: 1 })],
+		isDefault: true,
+	});
+
+	const pro = products.pro({
+		id: "pro-prepaid-workflows-carry-co",
+		items: [
+			items.prepaid({
+				featureId: TestFeature.Workflows,
+				includedUsage: 0,
+				billingUnits: 1,
+				price: 10,
+			}),
+		],
+	});
+
+	// No payment method — upgrade must go via Stripe Checkout.
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ skipWebhooks: true }),
+			s.products({ list: [free, pro] }),
+		],
+		actions: [
+			s.billing.attach({ productId: free.id }),
+			s.track({ featureId: TestFeature.Workflows, value: 1, timeout: 2000 }),
+		],
+	});
+
+	const customerBefore =
+		await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	expectCustomerFeatureCorrect({
+		customer: customerBefore,
+		featureId: TestFeature.Workflows,
+		balance: 0,
+		usage: 1,
+	});
+
+	const upgradeResult = await autumnV1.billing.attach({
+		customer_id: customerId,
+		product_id: pro.id,
+		options: [{ feature_id: TestFeature.Workflows, quantity: 3 }],
+	});
+	expect(upgradeResult.payment_url).toBeDefined();
+
+	await completeStripeCheckoutFormV2({ url: upgradeResult.payment_url });
+	// Wait for checkout.session.completed → customer.products.updated webhook chain.
+	await timeout(12000);
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	await expectCustomerProducts({
+		customer,
+		active: [pro.id],
+		notPresent: [free.id],
+	});
+
+	expectCustomerFeatureCorrect({
+		customer,
+		featureId: TestFeature.Workflows,
+		balance: 2,
+		usage: 1,
 	});
 });

--- a/shared/models/cusModels/billingControls/usageAlert.ts
+++ b/shared/models/cusModels/billingControls/usageAlert.ts
@@ -31,16 +31,15 @@ export const DbUsageAlertSchema = z
 	.check((ctx) => {
 		const { threshold_type, threshold } = ctx.value;
 
-		if (
-			(threshold_type === "usage_percentage" ||
-				threshold_type === "remaining_percentage") &&
-			threshold > 100
-		) {
+		// remaining_percentage is bounded by granted, so > 100 has no sensible
+		// firing semantics. usage_percentage can legitimately exceed 100 when a
+		// customer is over their allowance (e.g. alert at 200% or 300% usage).
+		if (threshold_type === "remaining_percentage" && threshold > 100) {
 			ctx.issues.push({
 				code: "custom",
 				input: threshold,
 				path: ["threshold"],
-				message: `Threshold must be between 0 and 100 for ${threshold_type}`,
+				message: "Threshold must be between 0 and 100 for remaining_percentage",
 			});
 		}
 	});

--- a/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
@@ -147,12 +147,10 @@ export function BillingUsageAlertSheet() {
 			return;
 		}
 
-		if (
-			(thresholdType === "usage_percentage" ||
-				thresholdType === "remaining_percentage") &&
-			parsedThreshold > 100
-		) {
-			toast.error("Percentage threshold must be between 0 and 100");
+		if (thresholdType === "remaining_percentage" && parsedThreshold > 100) {
+			toast.error(
+				"Remaining percentage threshold must be between 0 and 100",
+			);
 			return;
 		}
 

--- a/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
+++ b/vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx
@@ -66,8 +66,10 @@ export const OrgUsageAlertDialog = ({
 			toast.error("Please enter a valid threshold");
 			return;
 		}
-		if (isPercentageType(draft.threshold_type) && draft.threshold > 100) {
-			toast.error("Percentage threshold must be between 0 and 100");
+		if (draft.threshold_type === "remaining_percentage" && draft.threshold > 100) {
+			toast.error(
+				"Remaining percentage threshold must be between 0 and 100",
+			);
 			return;
 		}
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes usage carry-over on plan upgrades via Stripe Checkout so existing usage isn’t reset, and allows org-level `usage_percentage` alerts above 100% while keeping `remaining_percentage` capped at 100.

- **Bug Fixes**
  - Stripe Checkout upgrades: preserve carry-over by applying the delta between old and new starting balances to the current entitlement balance (verified with a free→prepaid checkout test: balance=2, usage=1 after upgrade).
  - Usage alerts: permit `usage_percentage` > 100 and restrict `remaining_percentage` to ≤ 100; updated shared validation and UI messages, with integration tests confirming 200%/300% triggers and no trigger at 150%.

<sup>Written for commit 9d335aff5cbb3e47ba51ab73c1134a111ea2c604. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1708?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs: (1) when a customer upgrades from a free plan to a prepaid plan via Stripe Checkout, previously-consumed usage was being discarded and the balance reset to the full Stripe quantity; the fix computes a `startingBalanceDelta` and adds it to the pre-computed carry-over balance instead of overwriting it. (2) `usage_percentage` alert thresholds are now allowed to exceed 100 (e.g. 200%, 300%) to support overage-enabled features, while `remaining_percentage` stays capped at 100.

- **Bug fixes**: `updateOptionsFromStripeCheckoutSession` now preserves carry-over usage when a customer edits quantity in the hosted Stripe Checkout page by applying only the delta in starting balance rather than overwriting the entitlement balance outright.
- **Bug fixes**: `DbUsageAlertSchema` and both frontend validation guards no longer reject `usage_percentage` thresholds above 100, enabling org-level alerts at overage percentages like 200% or 300%.
- **Improvements**: Integration tests added for both fixes — a checkout carry-over regression test and three org-level usage-percentage alert tests (200%, 300%, and a negative case at 150% below the 200% threshold).
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the checkout carry-over fix correctly preserves existing usage when a customer edits quantity on the Stripe-hosted page, and the usage alert schema change is well-scoped with dedicated tests for both behaviors.

The balance-delta logic is sound and backed by a new integration test. The entity branch in the same function still passes a raw newStartingBalance rather than applying the carry-over delta, leaving a pre-existing inconsistency unaddressed. The UI label and placeholder for usage_percentage inputs still suggest a 0–100 range even though values above 100 are now valid, which could silently confuse users configuring overage alerts.

The entity-scoped branch in updateOptionsFromStripeCheckoutSession.ts and the threshold input UI in both BillingUsageAlertSheet.tsx and OrgUsageAlertDialog.tsx would benefit from a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/updateOptionsFromStripeCheckoutSession.ts | Core fix: computes oldStartingBalance before updating options, then applies only the delta to customerEntitlement.balance so existing carry-over is preserved; entity-branch still overwrites directly with newStartingBalance |
| shared/models/cusModels/billingControls/usageAlert.ts | Schema validation relaxed to allow usage_percentage > 100 while keeping remaining_percentage capped at 100; change is intentional and well-commented |
| vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx | Validation guard updated to allow usage_percentage > 100, but label and placeholder still suggest 0–100 range, which is misleading for the newly valid >100 case |
| vite/src/views/settings/sections/components/OrgUsageAlertDialog.tsx | Validation guard updated consistently with BillingUsageAlertSheet; same label/placeholder UX issue for usage_percentage |
| server/tests/integration/billing/attach/immediate-switch/immediate-switch-reset-behavior.test.ts | New regression test for the checkout carry-over bug (free→prepaid via Stripe Checkout); verifies balance=2, usage=1 after tracking 1 and buying 3 prepaid units |
| server/tests/integration/balances/track/usage-alerts/usage-alert-org-over-100pct.test.ts | New integration tests verifying org-level usage_percentage alerts at 200% and 300% thresholds fire correctly and that a 150% usage doesn't trigger a 200% alert |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SC as Stripe Checkout
    participant WH as Webhook Handler
    participant UP as updateOptionsFromStripeCheckoutSession
    participant CE as CustomerEntitlement

    SC->>WH: checkout.session.completed (qty may differ from planned)
    WH->>UP: updateOptionsFromStripeCheckoutSession(checkoutContext, deferredData)

    Note over UP: deferredData already has carry-over baked into balance
    UP->>UP: "oldStartingBalance = getStartingBalance(featureOptions)"
    UP->>UP: "options[i].quantity = stripeReportedQuantity"
    UP->>UP: "newStartingBalance = getStartingBalance(newOptions)"

    alt has entity-level records
        UP->>CE: "entities = initCustomerEntitlementEntities(newStartingBalance)"
        CE-->>UP: entity records set (carry-over NOT delta-adjusted)
    else balance-only entitlement
        UP->>UP: "delta = newStartingBalance - oldStartingBalance"
        UP->>CE: "balance = existingBalance + delta"
        Note over CE: carry-over is preserved
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx`, line 293-304 ([link](https://github.com/useautumn/autumn/blob/b62b8ed1412f2d0ae3f10584e08b28b80fdb87ce/vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx#L293-L304)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Misleading label and placeholder for `usage_percentage`**

   Now that `usage_percentage` thresholds above 100 are valid (e.g. 200, 300), the input still shows `" (%)"` and the placeholder `"eg, 80"`. A user who wants to fire an alert at 200% usage won't have any hint that values greater than 100 are accepted, and a user who sets 150 expecting it to be rejected will be surprised when it is silently accepted. The same pattern appears in `OrgUsageAlertDialog.tsx` at the equivalent label/placeholder lines.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx
   Line: 293-304

   Comment:
   **Misleading label and placeholder for `usage_percentage`**

   Now that `usage_percentage` thresholds above 100 are valid (e.g. 200, 300), the input still shows `" (%)"` and the placeholder `"eg, 80"`. A user who wants to fire an alert at 200% usage won't have any hint that values greater than 100 are accepted, and a user who sets 150 expecting it to be rejected will be surprised when it is silently accepted. The same pattern appears in `OrgUsageAlertDialog.tsx` at the equivalent label/placeholder lines.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/customers2/components/sheets/BillingUsageAlertSheet.tsx:293-304
**Misleading label and placeholder for `usage_percentage`**

Now that `usage_percentage` thresholds above 100 are valid (e.g. 200, 300), the input still shows `" (%)"` and the placeholder `"eg, 80"`. A user who wants to fire an alert at 200% usage won't have any hint that values greater than 100 are accepted, and a user who sets 150 expecting it to be rejected will be surprised when it is silently accepted. The same pattern appears in `OrgUsageAlertDialog.tsx` at the equivalent label/placeholder lines.

### Issue 2 of 2
server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/updateOptionsFromStripeCheckoutSession.ts:98-115
**Entity-scoped path still overwrites rather than delta-adjusting**

The carry-over fix applies the `newStartingBalance − oldStartingBalance` delta to `customerEntitlement.balance` in the `else` branch, but the `if (entities)` branch calls `initCustomerEntitlementEntities` with the raw `newStartingBalance`. If a customer had consumed some allowance before checkout and the entitlement happens to have entities, the carry-over would be discarded and replaced by the fresh Stripe quantity. Entity-scoped _products_ are already skipped at line 60, but a non-entity-scoped product can still return a truthy `entities` result here — the same pre-existing limitation now sits alongside a fixed `balance` path, making the two branches inconsistent.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/stripe-chec..."](https://github.com/useautumn/autumn/commit/b62b8ed1412f2d0ae3f10584e08b28b80fdb87ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33765952)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->