### PR TITLE
chore: entity list improvements

### DIFF
--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -112,7 +112,7 @@ const buildOptimizedCusProductsCTE = ({
       ) ft_data ON true
       WHERE cp.internal_customer_id = (SELECT internal_id FROM customer_record)
       ${withStatusFilter()}
-      ORDER BY ${entityId ? sql`CASE WHEN cp.entity_id = ${entityId} THEN 0 WHEN cp.entity_id IS NULL THEN 1 ELSE 2 END,` : sql``} ${relevantStatusFirst}, ${hasCustomerPrices} DESC, prod.is_add_on ASC, cp.created_at DESC
+      ORDER BY ${entityId ? sql`CASE WHEN cp.entity_id = ${entityId} OR cp.internal_entity_id = ${entityId} THEN 0 WHEN cp.entity_id IS NULL THEN 1 ELSE 2 END,` : sql``} ${relevantStatusFirst}, ${hasCustomerPrices} DESC, prod.is_add_on ASC, cp.created_at DESC
       LIMIT ${cusProductLimit}
     )
   `;
@@ -438,7 +438,7 @@ export const getFullCusQuery = ({
     COALESCE(
       (
         SELECT json_agg(cpwp ORDER BY
-          ${entityId ? sql`CASE WHEN cpwp.entity_id = ${entityId} THEN 0 WHEN cpwp.entity_id IS NULL THEN 1 ELSE 2 END,` : sql``}
+          ${entityId ? sql`CASE WHEN cpwp.entity_id = ${entityId} OR cpwp.internal_entity_id = ${entityId} THEN 0 WHEN cpwp.entity_id IS NULL THEN 1 ELSE 2 END,` : sql``}
           CASE WHEN cpwp.status = ANY(ARRAY[${sql.join(
 						RELEVANT_STATUSES.map((status) => sql`${status}`),
 						sql`, `,

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -21,9 +21,11 @@ export type DashboardProductVersionFilter = {
 const buildOptimizedCusProductsCTE = ({
 	inStatuses,
 	cusProductLimit,
+	entityId,
 }: {
 	inStatuses?: CusProductStatus[];
 	cusProductLimit: number;
+	entityId?: string;
 }) => {
 	const withStatusFilter = () => {
 		return inStatuses
@@ -110,7 +112,7 @@ const buildOptimizedCusProductsCTE = ({
       ) ft_data ON true
       WHERE cp.internal_customer_id = (SELECT internal_id FROM customer_record)
       ${withStatusFilter()}
-      ORDER BY ${relevantStatusFirst}, ${hasCustomerPrices} DESC, prod.is_add_on ASC, cp.created_at DESC
+      ORDER BY ${entityId ? sql`CASE WHEN cp.entity_id = ${entityId} THEN 0 WHEN cp.entity_id IS NULL THEN 1 ELSE 2 END,` : sql``} ${relevantStatusFirst}, ${hasCustomerPrices} DESC, prod.is_add_on ASC, cp.created_at DESC
       LIMIT ${cusProductLimit}
     )
   `;
@@ -354,7 +356,7 @@ export const getFullCusQuery = ({
 	// Add customer products CTE
 	sqlChunks.push(sql`, `);
 	// sqlChunks.push(buildCusProductsCTE(inStatuses));
-	sqlChunks.push(buildOptimizedCusProductsCTE({ inStatuses, cusProductLimit }));
+	sqlChunks.push(buildOptimizedCusProductsCTE({ inStatuses, cusProductLimit, entityId }));
 
 	// Conditionally add trials used CTE
 	if (withTrialsUsed) {
@@ -436,6 +438,7 @@ export const getFullCusQuery = ({
     COALESCE(
       (
         SELECT json_agg(cpwp ORDER BY
+          ${entityId ? sql`CASE WHEN cpwp.entity_id = ${entityId} THEN 0 WHEN cpwp.entity_id IS NULL THEN 1 ELSE 2 END,` : sql``}
           CASE WHEN cpwp.status = ANY(ARRAY[${sql.join(
 						RELEVANT_STATUSES.map((status) => sql`${status}`),
 						sql`, `,

--- a/server/src/internal/customers/internalCusRouter.ts
+++ b/server/src/internal/customers/internalCusRouter.ts
@@ -7,6 +7,7 @@ import { handleGetCustomerProduct } from "./internalHandlers/handleGetCustomerPr
 import { handleGetCustomerSchedule } from "./internalHandlers/handleGetCustomerSchedule.js";
 import { handleGetFullCustomers } from "./internalHandlers/handleGetFullCustomers.js";
 import { handleGetInvoiceLineItems } from "./internalHandlers/handleGetInvoiceLineItems.js";
+import { handleListEntitiesInternal } from "./internalHandlers/handleListEntitiesInternal.js";
 import { handleSearchCustomers } from "./internalHandlers/handleSearchCustomers.js";
 
 export const internalCusRouter = new Hono<HonoEnv>();
@@ -21,6 +22,10 @@ internalCusRouter.get(
 );
 internalCusRouter.get("/:customer_id/referrals", ...handleGetCusReferrals);
 internalCusRouter.get("/:customer_id/schedule", ...handleGetCustomerSchedule);
+internalCusRouter.get(
+	"/:customer_id/entities",
+	...handleListEntitiesInternal,
+);
 internalCusRouter.post(
 	"/:customer_id/invoice-line-items",
 	...handleGetInvoiceLineItems,

--- a/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
@@ -27,6 +27,7 @@ export const handleGetCustomer = createRoute({
 		const { customer_id } = c.req.param();
 
 		const expandParam = c.req.query("expand");
+		const entityId = c.req.query("entity_id");
 		const extraExpands = expandParam
 			? (expandParam.split(",").filter(Boolean) as CustomerExpand[])
 			: [];
@@ -38,6 +39,7 @@ export const handleGetCustomer = createRoute({
 			withEntities: true,
 			expand,
 			inStatuses: ALL_STATUSES,
+			entityId: entityId || undefined,
 		});
 
 		const [testClockFrozenTimeMs, autoTopupsWithLimits, rewards] =

--- a/server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts
+++ b/server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts
@@ -1,0 +1,70 @@
+import { type Entity, Scopes, entities } from "@autumn/shared";
+import { and, eq, ilike, or, sql } from "drizzle-orm";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+
+const DEFAULT_LIMIT = 50;
+
+export const handleListEntitiesInternal = createRoute({
+	scopes: [Scopes.Customers.Read],
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { customer_id } = c.req.param();
+		const search = c.req.query("search")?.trim();
+		const limit = Number(c.req.query("limit")) || DEFAULT_LIMIT;
+
+		const internalCustomerResult = await ctx.db
+			.select({ internal_id: sql<string>`internal_id` })
+			.from(sql`customers`)
+			.where(
+				and(
+					or(
+						eq(sql`id`, customer_id),
+						eq(sql`internal_id`, customer_id),
+					),
+					eq(sql`org_id`, ctx.org.id),
+					eq(sql`env`, ctx.env),
+				),
+			)
+			.limit(1);
+
+		if (internalCustomerResult.length === 0) {
+			return c.json({ list: [], total: 0 });
+		}
+
+		const internalCustomerId = internalCustomerResult[0].internal_id;
+
+		const baseConditions = and(
+			eq(entities.internal_customer_id, internalCustomerId),
+			eq(entities.deleted, false),
+		);
+
+		const searchCondition = search
+			? and(
+					baseConditions,
+					or(
+						ilike(entities.id, `%${search}%`),
+						ilike(entities.name, `%${search}%`),
+					),
+				)
+			: baseConditions;
+
+		const [results, countResult] = await Promise.all([
+			ctx.db
+				.select()
+				.from(entities)
+				.where(searchCondition)
+				.orderBy(sql`created_at DESC`)
+				.limit(limit),
+			ctx.db
+				.select({ count: sql<number>`count(*)::int` })
+				.from(entities)
+				.where(baseConditions),
+		]);
+
+		return c.json({
+			list: results as Entity[],
+			total: results.length,
+			total_count: countResult[0]?.count ?? 0,
+		});
+	},
+});

--- a/server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts
+++ b/server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts
@@ -38,12 +38,13 @@ export const handleListEntitiesInternal = createRoute({
 			eq(entities.deleted, false),
 		);
 
-		const searchCondition = search
+		const escapedSearch = search?.replace(/[%_\\]/g, "\\$&");
+		const searchCondition = escapedSearch
 			? and(
 					baseConditions,
 					or(
-						ilike(entities.id, `%${search}%`),
-						ilike(entities.name, `%${search}%`),
+						ilike(entities.id, `%${escapedSearch}%`),
+						ilike(entities.name, `%${escapedSearch}%`),
 					),
 				)
 			: baseConditions;
@@ -63,7 +64,6 @@ export const handleListEntitiesInternal = createRoute({
 
 		return c.json({
 			list: results as Entity[],
-			total: results.length,
 			total_count: countResult[0]?.count ?? 0,
 		});
 	},

--- a/server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts
+++ b/server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts
@@ -28,7 +28,7 @@ export const handleListEntitiesInternal = createRoute({
 			.limit(1);
 
 		if (internalCustomerResult.length === 0) {
-			return c.json({ list: [], total: 0 });
+			return c.json({ list: [], total_count: 0 });
 		}
 
 		const internalCustomerId = internalCustomerResult[0].internal_id;
@@ -59,7 +59,7 @@ export const handleListEntitiesInternal = createRoute({
 			ctx.db
 				.select({ count: sql<number>`count(*)::int` })
 				.from(entities)
-				.where(baseConditions),
+				.where(searchCondition),
 		]);
 
 		return c.json({

--- a/server/tests/integration/crud/entities/get-full-entity-ordering.test.ts
+++ b/server/tests/integration/crud/entities/get-full-entity-ordering.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { type FullCusProduct } from "@autumn/shared";
+import { type Entity, type FullCusProduct } from "@autumn/shared";
 import { CusService } from "@/internal/customers/CusService.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -64,5 +64,67 @@ test.concurrent(
 		);
 
 		expect(firstEntityScopedIndex).toBeLessThan(firstCustomerLevelIndex);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("get-full: entity-scoped cusProducts ordered first when internal entityId passed")}`,
+	async () => {
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const creditsItem = items.monthlyCredits({ includedUsage: 50 });
+
+		const customerProd = products.pro({
+			id: "cus-level-internal",
+			items: [messagesItem],
+		});
+		const entityProd = products.base({
+			id: "ent-level-internal",
+			items: [creditsItem],
+		});
+
+		const { customerId, ctx, entities } = await initScenario({
+			customerId: "get-full-entity-ordering-internal",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [customerProd, entityProd] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: customerProd.id }),
+				s.attach({ productId: entityProd.id, entityIndex: 0 }),
+				s.attach({ productId: entityProd.id, entityIndex: 1 }),
+			],
+		});
+
+		const baseCus = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			withEntities: true,
+		});
+		const targetInternalId = (baseCus.entities as Entity[]).find(
+			(e) => e.id === entities[0].id,
+		)?.internal_id;
+		expect(targetInternalId).toBeDefined();
+
+		const fullCus = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			entityId: targetInternalId!,
+			withEntities: true,
+		});
+
+		const cusProducts = fullCus.customer_products as FullCusProduct[];
+		expect(cusProducts.length).toBeGreaterThanOrEqual(2);
+
+		const firstEntityIndex = cusProducts.findIndex(
+			(cp) => cp.internal_entity_id === targetInternalId,
+		);
+		const firstCustomerIndex = cusProducts.findIndex(
+			(cp) => !cp.entity_id && !cp.internal_entity_id,
+		);
+
+		expect(firstEntityIndex).toBeGreaterThanOrEqual(0);
+		expect(firstCustomerIndex).toBeGreaterThanOrEqual(0);
+		expect(firstEntityIndex).toBeLessThan(firstCustomerIndex);
 	},
 );

--- a/server/tests/integration/crud/entities/get-full-entity-ordering.test.ts
+++ b/server/tests/integration/crud/entities/get-full-entity-ordering.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import { type FullCusProduct } from "@autumn/shared";
+import { CusService } from "@/internal/customers/CusService.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("get-full: entity-scoped cusProducts ordered before customer-level when entityId passed")}`,
+	async () => {
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const creditsItem = items.monthlyCredits({ includedUsage: 50 });
+
+		const customerProd = products.pro({
+			id: "cus-level-prod",
+			items: [messagesItem],
+		});
+		const entityProd = products.base({
+			id: "ent-level-prod",
+			items: [creditsItem],
+		});
+
+		const { customerId, ctx, entities } = await initScenario({
+			customerId: "get-full-entity-ordering",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [customerProd, entityProd] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: customerProd.id }),
+				s.attach({ productId: entityProd.id, entityIndex: 0 }),
+				s.attach({ productId: entityProd.id, entityIndex: 1 }),
+			],
+		});
+
+		const fullCus = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			entityId: entities[0].id,
+			withEntities: true,
+		});
+
+		const cusProducts = fullCus.customer_products as FullCusProduct[];
+		expect(cusProducts.length).toBeGreaterThanOrEqual(2);
+
+		const entityScopedProducts = cusProducts.filter(
+			(cp) => cp.entity_id === entities[0].id,
+		);
+		const customerLevelProducts = cusProducts.filter(
+			(cp) => !cp.entity_id,
+		);
+
+		expect(entityScopedProducts.length).toBeGreaterThan(0);
+		expect(customerLevelProducts.length).toBeGreaterThan(0);
+
+		const firstEntityScopedIndex = cusProducts.findIndex(
+			(cp) => cp.entity_id === entities[0].id,
+		);
+		const firstCustomerLevelIndex = cusProducts.findIndex(
+			(cp) => !cp.entity_id,
+		);
+
+		expect(firstEntityScopedIndex).toBeLessThan(firstCustomerLevelIndex);
+	},
+);

--- a/server/tests/unit/escapeIlikePattern.test.ts
+++ b/server/tests/unit/escapeIlikePattern.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+const escapeIlikePattern = (input: string): string =>
+	input.replace(/[%_\\]/g, "\\$&");
+
+describe("escapeIlikePattern", () => {
+	test("passes through plain text unchanged", () => {
+		expect(escapeIlikePattern("hello")).toBe("hello");
+	});
+
+	test("escapes % wildcard", () => {
+		expect(escapeIlikePattern("50%")).toBe("50\\%");
+	});
+
+	test("escapes _ single-char wildcard", () => {
+		expect(escapeIlikePattern("us_r")).toBe("us\\_r");
+	});
+
+	test("escapes backslash", () => {
+		expect(escapeIlikePattern("path\\to")).toBe("path\\\\to");
+	});
+
+	test("escapes multiple wildcards in one string", () => {
+		expect(escapeIlikePattern("a%b_c\\d")).toBe("a\\%b\\_c\\\\d");
+	});
+
+	test("handles empty string", () => {
+		expect(escapeIlikePattern("")).toBe("");
+	});
+
+	test("leaves normal entity IDs unchanged", () => {
+		expect(escapeIlikePattern("dispersive-preview")).toBe(
+			"dispersive-preview",
+		);
+		expect(escapeIlikePattern("6a13cf0b9b6845d6edbb4aa4")).toBe(
+			"6a13cf0b9b6845d6edbb4aa4",
+		);
+	});
+});

--- a/vite/src/components/general/AdminHover.tsx
+++ b/vite/src/components/general/AdminHover.tsx
@@ -36,14 +36,16 @@ export const AdminHover = forwardRef<
 				>
 					<PreviewCard.Popup className="bg-white/50 dark:bg-zinc-900/50 backdrop-blur-sm shadow-sm border rounded-md px-2 pr-6 py-2 max-w-none origin-(--transform-origin) transition-[opacity,scale] duration-150 data-[starting-style]:opacity-0 data-[starting-style]:scale-95 data-[ending-style]:opacity-0 data-[ending-style]:scale-95">
 						<div className="text-xs text-gray-500 dark:text-gray-400 flex flex-col gap-2 whitespace-nowrap">
-							{texts.map((text) => {
+							{texts.map((text, i) => {
 								if (!text) return null;
 								if (typeof text === "object") {
 									return (
-										<div key={text.key}>
-											<p className="text-xs text-gray-500 dark:text-gray-400 font-medium">
-												{text.key}
-											</p>
+										<div key={`${text.key || i}-${text.value}`}>
+											{text.key && (
+												<p className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+													{text.key}
+												</p>
+											)}
 											<CopyText text={text.value} />
 										</div>
 									);

--- a/vite/src/components/v2/selects/SearchableSelect.tsx
+++ b/vite/src/components/v2/selects/SearchableSelect.tsx
@@ -2,6 +2,7 @@ import { CheckIcon, ChevronDownIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
+import SmallSpinner from "@/components/general/SmallSpinner";
 import {
 	Command,
 	CommandEmpty,
@@ -36,6 +37,8 @@ export type SearchableSelectProps<T> = {
 	defaultOpen?: boolean;
 	header?: ReactNode;
 	footer?: ReactNode;
+	onSearchChange?: (search: string) => void;
+	isLoading?: boolean;
 };
 
 export function SearchableSelect<T>({
@@ -57,6 +60,8 @@ export function SearchableSelect<T>({
 	defaultOpen = false,
 	header,
 	footer,
+	onSearchChange,
+	isLoading = false,
 }: SearchableSelectProps<T>) {
 	const [open, setOpen] = useState(false);
 
@@ -134,28 +139,43 @@ export function SearchableSelect<T>({
 							<Command
 								className="bg-interactive-secondary"
 								filter={
-									searchable
-										? (optionValue, search) => {
-												const option = options.find(
-													(opt) => getOptionValue(opt) === optionValue,
-												);
-												if (!option) return 0;
-												const searchLower = search.toLowerCase();
-												const labelMatch = getOptionLabel(option)
-													.toLowerCase()
-													.includes(searchLower);
-												const valueMatch = optionValue
-													.toLowerCase()
-													.includes(searchLower);
-												return labelMatch || valueMatch ? 1 : 0;
-											}
-										: undefined
+									onSearchChange
+										? () => 1
+										: searchable
+											? (optionValue, search) => {
+													const option = options.find(
+														(opt) => getOptionValue(opt) === optionValue,
+													);
+													if (!option) return 0;
+													const searchLower = search.toLowerCase();
+													const labelMatch = getOptionLabel(option)
+														.toLowerCase()
+														.includes(searchLower);
+													const valueMatch = optionValue
+														.toLowerCase()
+														.includes(searchLower);
+													return labelMatch || valueMatch ? 1 : 0;
+												}
+											: undefined
 								}
 							>
-								{searchable && <CommandInput placeholder={searchPlaceholder} />}
+								{searchable && (
+									<CommandInput
+										placeholder={searchPlaceholder}
+										onValueChange={onSearchChange}
+									/>
+								)}
 								{header}
 								<CommandList>
-									<CommandEmpty className="text-tertiary-foreground">{emptyText}</CommandEmpty>
+									<CommandEmpty className="text-tertiary-foreground">
+										{isLoading ? (
+											<div className="flex justify-center items-center py-2">
+												<SmallSpinner size={14} />
+											</div>
+										) : (
+											emptyText
+										)}
+									</CommandEmpty>
 									<CommandGroup>
 										{options.map((option) => {
 											const optionValue = getOptionValue(option);

--- a/vite/src/hooks/stores/useSubscriptionStore.ts
+++ b/vite/src/hooks/stores/useSubscriptionStore.ts
@@ -1,65 +1,42 @@
 import {
 	cusProductToProduct,
-	type Entity,
 	type FullCusProduct,
-	type FullCustomer,
 	mapToProductV2,
 	productV2ToFrontendProduct,
 } from "@autumn/shared";
 import { parseAsString, useQueryStates } from "nuqs";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 
-// Hook to sync entity_id between query params and store
 export const useEntity = () => {
 	const [{ entity_id }, setQueryStates] = useQueryStates({
 		entity_id: parseAsString,
 	});
 
-	const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
-
-	const { customer } = useCusQuery();
-	const entities = (customer as FullCustomer)?.entities || [];
-
-	// Find the full entity object
-	const entity = entities.find(
-		(e: Entity) =>
-			e != null &&
-			(e.id === selectedEntityId || e.internal_id === selectedEntityId),
-	);
-
-	// Sync query param to store on mount/change
-	useEffect(() => {
-		if (entity_id !== selectedEntityId) {
-			setSelectedEntityId(entity_id);
-		}
-	}, [entity_id, selectedEntityId]);
-
-	// Function to update both store and query param
 	const setEntityId = (entityId: string | null) => {
-		setSelectedEntityId(entityId);
 		setQueryStates({ entity_id: entityId });
 	};
 
-	return { entityId: selectedEntityId, entity, setEntityId };
+	return { entityId: entity_id, setEntityId };
 };
 
-// Hook to get a customer product and its productV2 by customer product ID
 export const useSubscriptionById = ({ itemId }: { itemId: string | null }) => {
 	const { customer } = useCusQuery();
 
 	const cusProduct = useMemo(() => {
 		if (!itemId || !customer?.customer_products) return null;
-		return customer.customer_products.find(
-			(p: FullCusProduct) => p.id === itemId,
-		) ?? null;
+		return (
+			customer.customer_products.find(
+				(p: FullCusProduct) => p.id === itemId,
+			) ?? null
+		);
 	}, [itemId, customer?.customer_products]);
 
 	const productV2 = useMemo(() => {
 		if (!cusProduct) return null;
 		const fullProduct = cusProductToProduct({ cusProduct });
-		const productV2 = mapToProductV2({ product: fullProduct });
-		return productV2ToFrontendProduct({ product: productV2 });
+		const mapped = mapToProductV2({ product: fullProduct });
+		return productV2ToFrontendProduct({ product: mapped });
 	}, [cusProduct]);
 
 	return { cusProduct, productV2 };

--- a/vite/src/views/customers/customer/hooks/useCusQuery.tsx
+++ b/vite/src/views/customers/customer/hooks/useCusQuery.tsx
@@ -1,9 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useParams } from "react-router";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import { useEntity } from "@/hooks/stores/useSubscriptionStore";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { throwBackendError } from "@/utils/genUtils";
 import { useCachedCustomer } from "./useCachedCustomer";
@@ -33,12 +34,31 @@ export const useCusQuery = ({
 	const axiosInstance = useAxiosInstance();
 	const buildKey = useQueryKeyFactory();
 	const { getCachedCustomer } = useCachedCustomer(customer_id);
+	const { entityId } = useEntity();
 
+	const queryClient = useQueryClient();
 	const cachedCustomer = useMemo(getCachedCustomer, [getCachedCustomer]);
+
+	const baseKey = buildKey(["customer", customer_id, null]);
+	const cachedData = queryClient.getQueryData<any>(baseKey);
+	const currentCustomer = cachedData?.customer ?? cachedCustomer;
+
+	const entityAlreadyLoaded =
+		!entityId ||
+		currentCustomer?.customer_products?.some(
+			(cp: any) => cp.entity_id === entityId,
+		);
+
+	const effectiveEntityId = entityAlreadyLoaded ? null : entityId;
 
 	const fetcher = async () => {
 		try {
-			const { data } = await axiosInstance.get(`/customers/${customer_id}`);
+			const params = effectiveEntityId
+				? `?entity_id=${effectiveEntityId}`
+				: "";
+			const { data } = await axiosInstance.get(
+				`/customers/${customer_id}${params}`,
+			);
 			return data;
 		} catch (error) {
 			throwBackendError(error);
@@ -48,13 +68,16 @@ export const useCusQuery = ({
 	const {
 		data,
 		isLoading: customerLoading,
+		isFetching: customerFetching,
+		isPlaceholderData,
 		error,
 		refetch,
 	} = useQuery({
-		queryKey: buildKey(["customer", customer_id]),
+		queryKey: buildKey(["customer", customer_id, effectiveEntityId]),
 		queryFn: fetcher,
 		enabled: enabled && !!customer_id,
 		retry: false,
+		placeholderData: keepPreviousData,
 	});
 
 	const scheduleFetcher = async (): Promise<ScheduleResponse> => {
@@ -125,6 +148,8 @@ export const useCusQuery = ({
 		products,
 		features,
 		isLoading,
+		isFetching: customerFetching,
+		isPlaceholderData,
 		error,
 		refetch,
 		refetchSchedule,

--- a/vite/src/views/customers/customer/hooks/useCusQuery.tsx
+++ b/vite/src/views/customers/customer/hooks/useCusQuery.tsx
@@ -47,7 +47,8 @@ export const useCusQuery = ({
 	const entityAlreadyLoaded =
 		!entityId ||
 		(currentCustomer as FullCustomer)?.customer_products?.some(
-			(cp: FullCusProduct) => cp.entity_id === entityId,
+			(cp: FullCusProduct) =>
+				cp.entity_id === entityId || cp.internal_entity_id === entityId,
 		);
 
 	const effectiveEntityId = entityAlreadyLoaded ? null : entityId;

--- a/vite/src/views/customers/customer/hooks/useCusQuery.tsx
+++ b/vite/src/views/customers/customer/hooks/useCusQuery.tsx
@@ -1,3 +1,4 @@
+import type { FullCusProduct, FullCustomer } from "@autumn/shared";
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useParams } from "react-router";
@@ -40,13 +41,13 @@ export const useCusQuery = ({
 	const cachedCustomer = useMemo(getCachedCustomer, [getCachedCustomer]);
 
 	const baseKey = buildKey(["customer", customer_id, null]);
-	const cachedData = queryClient.getQueryData<any>(baseKey);
+	const cachedData = queryClient.getQueryData<{ customer?: FullCustomer }>(baseKey);
 	const currentCustomer = cachedData?.customer ?? cachedCustomer;
 
 	const entityAlreadyLoaded =
 		!entityId ||
-		currentCustomer?.customer_products?.some(
-			(cp: any) => cp.entity_id === entityId,
+		(currentCustomer as FullCustomer)?.customer_products?.some(
+			(cp: FullCusProduct) => cp.entity_id === entityId,
 		);
 
 	const effectiveEntityId = entityAlreadyLoaded ? null : entityId;

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
@@ -65,6 +65,7 @@ export function CustomerProductsTable() {
 	const {
 		customer,
 		isLoading,
+		isEntityTransitioning,
 		showExpired,
 		setShowExpired,
 		subscriptions,
@@ -92,7 +93,7 @@ export function CustomerProductsTable() {
 	const columns = useMemo(() => {
 		const baseColumns = [CustomerProductsColumns[0]];
 
-		if (hasEntityProducts) {
+		if (hasEntities) {
 			baseColumns.push(createScopeColumn(customer.entities, setEntityId));
 		}
 
@@ -104,7 +105,7 @@ export function CustomerProductsTable() {
 		);
 
 		return baseColumns;
-	}, [hasEntityProducts, customer.entities, setEntityId]);
+	}, [hasEntities, customer.entities, setEntityId]);
 
 	const handleCancelClick = (product: FullCusProduct) => {
 		setSheet({ type: "subscription-cancel", itemId: product.id });
@@ -201,7 +202,7 @@ export function CustomerProductsTable() {
 					table: subscriptionTable,
 					numberOfColumns: columns.length,
 					enableSorting: false,
-					isLoading,
+					isLoading: isLoading || isEntityTransitioning,
 					onRowClick: handleRowClick,
 					emptyStateChildren,
 					flexibleTableColumns: true,
@@ -237,7 +238,7 @@ export function CustomerProductsTable() {
 						table: purchaseTable,
 						numberOfColumns: columns.length,
 						enableSorting: false,
-						isLoading,
+						isLoading: isLoading || isEntityTransitioning,
 						onRowClick: handleRowClick,
 						emptyStateText: "No purchases found",
 						flexibleTableColumns: true,

--- a/vite/src/views/customers2/components/table/customer-products/customerProductsTableFilters.ts
+++ b/vite/src/views/customers2/components/table/customer-products/customerProductsTableFilters.ts
@@ -10,13 +10,13 @@ import { filterByExpiredStatus } from "@/views/customers2/utils/tableFilterUtils
 /**
  * Determines if a customer product is a one-off purchase using existing utilities
  */
-function isOneOffCusProduct(cusProduct: FullCusProduct): boolean {
+export function isOneOffCusProduct(cusProduct: FullCusProduct): boolean {
 	const fullProduct = cusProductToProduct({ cusProduct });
 	const productV2 = mapToProductV2({ product: fullProduct });
 	return isOneOffProductV2({ items: productV2.items });
 }
 
-function filterCustomerProducts({
+export function filterCustomerProducts({
 	customer,
 	showExpired,
 }: {

--- a/vite/src/views/customers2/customer/CustomerBreadcrumbs2.tsx
+++ b/vite/src/views/customers2/customer/CustomerBreadcrumbs2.tsx
@@ -40,12 +40,19 @@ export const CustomerBreadcrumbs = () => {
 									key: "Stripe ID",
 									value: customer.processor?.id,
 								},
-								{
-									key: "Entities",
-									value: (customer.entities || [])
-										.map((e: Entity) => e.id)
-										.join(", "),
-								},
+								...(() => {
+									const ents = (customer.entities || []) as Entity[];
+									if (ents.length === 0) return [];
+									const shown = ents.slice(0, 3);
+									const remaining = ents.length - shown.length;
+									return [
+										{ key: `Entities (${ents.length})`, value: shown[0].id },
+										...shown.slice(1).map((e) => ({ key: "", value: e.id })),
+										...(remaining > 0
+											? [{ key: "", value: `+${remaining} more` }]
+											: []),
+									];
+								})(),
 							]}
 						>
 							Customers

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -60,9 +60,7 @@ export default function CustomerView2() {
 	const { isDismissed } = useOnboardingVisibility();
 	const showOnboarding = env === AppEnv.Sandbox && !isDismissed;
 
-	// useSheetCleanup();
-
-	if (cusLoading) return <LoadingScreen />;
+	if (cusLoading && !customer) return <LoadingScreen />;
 
 	if (!customer) {
 		return (

--- a/vite/src/views/customers2/customer/components/CreateEntity.tsx
+++ b/vite/src/views/customers2/customer/components/CreateEntity.tsx
@@ -29,9 +29,11 @@ import { useCustomerContext } from "../CustomerContext";
 export const CreateEntity = ({
 	open,
 	setOpen,
+	onCreated,
 }: {
 	open: boolean;
 	setOpen: (open: boolean) => void;
+	onCreated?: () => void;
 }) => {
 	const { customer, refetch } = useCusQuery();
 	const { setEntityId } = useCustomerContext();
@@ -84,6 +86,7 @@ export const CreateEntity = ({
 			);
 
 			await refetch();
+			onCreated?.();
 			setOpen(false);
 
 			const params = new URLSearchParams(location.search);

--- a/vite/src/views/customers2/customer/components/DeleteEntity.tsx
+++ b/vite/src/views/customers2/customer/components/DeleteEntity.tsx
@@ -19,10 +19,12 @@ export const DeleteEntity = ({
 	open,
 	setOpen,
 	entity,
+	onDeleted,
 }: {
 	open: boolean;
 	setOpen: (open: boolean) => void;
 	entity: Entity | null | undefined;
+	onDeleted?: () => void;
 }) => {
 	const { customer, refetch } = useCusQuery();
 	const { setEntityId } = useCustomerContext();
@@ -42,9 +44,9 @@ export const DeleteEntity = ({
 			);
 
 			await refetch();
+			onDeleted?.();
 			setOpen(false);
 
-			// Clear the selection
 			const params = new URLSearchParams(location.search);
 			params.delete("entity_id");
 			navigate(`${location.pathname}?${params.toString()}`);

--- a/vite/src/views/customers2/customer/components/SelectedEntityDetails.tsx
+++ b/vite/src/views/customers2/customer/components/SelectedEntityDetails.tsx
@@ -1,79 +1,36 @@
-import type { Entity, Feature, FullCustomer } from "@autumn/shared";
-import { FeatureUsageType, getFeatureName } from "@autumn/shared";
 import { PlusIcon, TrashIcon, XIcon } from "@phosphor-icons/react";
 import { CheckIcon } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/v2/buttons/Button";
 import { CopyButton } from "@/components/v2/buttons/CopyButton";
 import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
-import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
-import { useEntity } from "@/hooks/stores/useSubscriptionStore";
-import { useCusQuery } from "../../../customers/customer/hooks/useCusQuery";
+import { cn } from "@/lib/utils";
+import { useEntitySelector } from "../hooks/useEntitySelector";
 import { CreateEntity } from "./CreateEntity";
 import { DeleteEntity } from "./DeleteEntity";
 
-const mutedDivClassName =
-	"py-0.5 px-1.5 bg-muted rounded-lg text-tertiary-foreground text-sm flex items-center gap-1 h-6 max-w-48 truncate ";
-
-const placeholderText = "PENDING";
+const PLACEHOLDER = "PENDING";
 
 export const SelectedEntityDetails = () => {
-	const { customer } = useCusQuery();
-	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-	const [createEntityOpen, setCreateEntityOpen] = useState(false);
-	const { features } = useFeaturesQuery();
+	const [isDeleteOpen, setDeleteOpen] = useState(false);
+	const [isCreateOpen, setCreateOpen] = useState(false);
 
-	const { entityId, setEntityId } = useEntity();
+	const {
+		entities,
+		selectedEntity,
+		entityId,
+		totalCount,
+		entityTypeText,
+		isLoading,
+		isVisible,
+		setEntityId,
+		setSearch,
+		refetch,
+		getEntityValue,
+		getEntityLabel,
+	} = useEntitySelector();
 
-	const entities = (customer as FullCustomer)?.entities || [];
-
-	const fullEntity = entities.find(
-		(e: Entity) => e.id === entityId || e.internal_id === entityId,
-	);
-
-	const handleValueChange = (value: string) => {
-		setEntityId(value);
-	};
-
-	const handleClearSelection = () => {
-		setEntityId(null);
-	};
-
-	// Check if we should show the selector at all
-	const hasContinuousUseFeatures = features?.some(
-		(feature: Feature) =>
-			feature.config?.usage_type === FeatureUsageType.Continuous,
-	);
-
-	if (!hasContinuousUseFeatures || !entities || entities.length === 0)
-		return null;
-
-	// Get the entity type display name
-	const getEntityTypeText = () => {
-		if (entities.length === 0) return "entities";
-
-		// Check if all entities have the same feature_id
-		const firstFeatureId = entities[0].feature_id;
-		const allSameType = entities.every(
-			(e: Entity) => e.feature_id === firstFeatureId,
-		);
-
-		if (allSameType && firstFeatureId && features) {
-			const feature = features.find((f: Feature) => f.id === firstFeatureId);
-			if (feature) {
-				return getFeatureName({
-					feature,
-					units: entities.length,
-				});
-			}
-		}
-
-		return entities.length === 1 ? "entity" : "entities";
-	};
-
-	const getEntityValue = (entity: Entity) => entity.id || entity.internal_id;
-	const getEntityLabel = (entity: Entity) =>
-		entity.name || entity.id || placeholderText;
+	if (!isVisible) return null;
 
 	return (
 		<>
@@ -81,7 +38,7 @@ export const SelectedEntityDetails = () => {
 				<div className="flex items-center gap-2 min-w-0 flex-1">
 					<SearchableSelect
 						value={entityId}
-						onValueChange={handleValueChange}
+						onValueChange={setEntityId}
 						options={entities}
 						getOptionValue={getEntityValue}
 						getOptionLabel={getEntityLabel}
@@ -90,39 +47,44 @@ export const SelectedEntityDetails = () => {
 						searchPlaceholder="Search entities..."
 						emptyText="No entities found"
 						triggerClassName="w-full sm:w-72"
-						renderValue={(entity) =>
-							entity ? (
-								<span className="text-muted-foreground truncate">
-									{entity.name || entity.id || placeholderText}
-								</span>
-							) : (
-								<span className="text-tertiary-foreground">Select entity</span>
-							)
-						}
-						renderOption={(entity, isSelected) => {
-							const entityLabel = entity.id || placeholderText;
-							return (
-								<>
-									<div className="flex gap-2 items-center min-w-0 flex-1">
-										{entity.name && (
-											<span className="text-sm shrink-0">{entity.name}</span>
-										)}
-										<span className="truncate text-tertiary-foreground font-mono text-xs min-w-0">
-											{entityLabel}
-										</span>
-									</div>
-									{isSelected && <CheckIcon className="size-4 shrink-0" />}
-								</>
-							);
-						}}
+						onSearchChange={setSearch}
+						isLoading={isLoading}
+						renderValue={(entity) => (
+							<span
+								className={cn(
+									"truncate",
+									entity ? "text-muted-foreground" : "text-tertiary-foreground",
+								)}
+							>
+								{entity
+									? (entity.name || entity.id || PLACEHOLDER)
+									: "Select entity"}
+							</span>
+						)}
+						renderOption={(entity, isSelected) => (
+							<>
+								<div className="flex gap-2 items-center min-w-0 flex-1">
+									{entity.name && (
+										<span className="text-sm shrink-0">{entity.name}</span>
+									)}
+									<span className="truncate text-tertiary-foreground font-mono text-xs min-w-0">
+										{entity.id || PLACEHOLDER}
+									</span>
+								</div>
+								{isSelected && <CheckIcon className="size-4 shrink-0" />}
+							</>
+						)}
 						footer={
 							<div className="border-t py-1.5 px-2">
 								<Button
 									variant="muted"
 									className="w-full"
-									onClick={() => setCreateEntityOpen(true)}
+									onClick={() => setCreateOpen(true)}
 								>
-									<PlusIcon className="size-[14px] text-muted-foreground" weight="regular" />
+									<PlusIcon
+										className="size-[14px] text-muted-foreground"
+										weight="regular"
+									/>
 									Create new entity
 								</Button>
 							</div>
@@ -132,51 +94,55 @@ export const SelectedEntityDetails = () => {
 						<Button
 							size="icon"
 							variant="skeleton"
-							onClick={handleClearSelection}
-							disabled={!entityId}
-							className="text-tertiary-foreground hover:text-foreground h-5 w-5 disabled:opacity-50 -mx-1"
+							onClick={() => setEntityId(null)}
+							className="text-tertiary-foreground hover:text-foreground h-5 w-5 -mx-1"
 						>
 							<XIcon size={12} />
 						</Button>
 					)}
 				</div>
+
 				{entityId ? (
 					<div className="flex gap-2 items-center min-w-0 shrink">
 						<CopyButton
-							text={fullEntity?.id || placeholderText}
+							text={selectedEntity?.id || PLACEHOLDER}
 							size="mini"
 							className="text-tertiary-foreground"
 							innerClassName="max-w-48 text-tiny-id truncate !font-normal"
 						/>
-						{fullEntity?.feature_id && (
-							<div className={mutedDivClassName}>
+						{selectedEntity?.feature_id && (
+							<div className="py-0.5 px-1.5 bg-muted rounded-lg text-tertiary-foreground text-sm flex items-center gap-1 h-6 max-w-48 truncate">
 								<span className="font-mono text-tiny-id">
-									{fullEntity.feature_id}
+									{selectedEntity.feature_id}
 								</span>
 							</div>
 						)}
 						<Button
 							size="icon"
 							variant="secondary"
-							onClick={() => setDeleteDialogOpen(true)}
-							disabled={!entityId}
+							onClick={() => setDeleteOpen(true)}
 						>
 							<TrashIcon className="text-tertiary-foreground" />
 						</Button>
 					</div>
 				) : (
 					<div className="text-tertiary-foreground text-sm pr-2">
-						{entities.length} {getEntityTypeText()} active
+						{totalCount} {entityTypeText} active
 					</div>
 				)}
 			</div>
 
 			<DeleteEntity
-				open={deleteDialogOpen}
-				setOpen={setDeleteDialogOpen}
-				entity={fullEntity}
+				open={isDeleteOpen}
+				setOpen={setDeleteOpen}
+				entity={selectedEntity}
+				onDeleted={refetch}
 			/>
-			<CreateEntity open={createEntityOpen} setOpen={setCreateEntityOpen} />
+			<CreateEntity
+				open={isCreateOpen}
+				setOpen={setCreateOpen}
+				onCreated={refetch}
+			/>
 		</>
 	);
 };

--- a/vite/src/views/customers2/customer/hooks/useEntitiesQuery.ts
+++ b/vite/src/views/customers2/customer/hooks/useEntitiesQuery.ts
@@ -1,0 +1,51 @@
+import type { Entity } from "@autumn/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+type UseEntitiesQueryOptions = {
+	search?: string;
+	limit?: number;
+	enabled?: boolean;
+};
+
+export const useEntitiesQuery = ({
+	search,
+	limit = 50,
+	enabled = true,
+}: UseEntitiesQueryOptions = {}) => {
+	const { customer_id } = useParams();
+	const axiosInstance = useAxiosInstance();
+	const buildKey = useQueryKeyFactory();
+
+	const fetcher = async (): Promise<{
+		list: Entity[];
+		total: number;
+		total_count: number;
+	}> => {
+		const params = new URLSearchParams();
+		if (search) params.set("search", search);
+		if (limit) params.set("limit", String(limit));
+
+		const qs = params.toString();
+		const url = `/customers/${customer_id}/entities${qs ? `?${qs}` : ""}`;
+		const { data } = await axiosInstance.get(url);
+		return data;
+	};
+
+	const { data, isLoading, error, refetch } = useQuery({
+		queryKey: buildKey(["entities", customer_id, search, limit]),
+		queryFn: fetcher,
+		enabled: enabled && !!customer_id,
+	});
+
+	return {
+		entities: (data?.list ?? []) as Entity[],
+		total: data?.total ?? 0,
+		totalCount: data?.total_count ?? 0,
+		isLoading,
+		error,
+		refetch,
+	};
+};

--- a/vite/src/views/customers2/customer/hooks/useEntitiesQuery.ts
+++ b/vite/src/views/customers2/customer/hooks/useEntitiesQuery.ts
@@ -21,7 +21,6 @@ export const useEntitiesQuery = ({
 
 	const fetcher = async (): Promise<{
 		list: Entity[];
-		total: number;
 		total_count: number;
 	}> => {
 		const params = new URLSearchParams();
@@ -42,7 +41,6 @@ export const useEntitiesQuery = ({
 
 	return {
 		entities: (data?.list ?? []) as Entity[],
-		total: data?.total ?? 0,
 		totalCount: data?.total_count ?? 0,
 		isLoading,
 		error,

--- a/vite/src/views/customers2/customer/hooks/useEntitySelector.ts
+++ b/vite/src/views/customers2/customer/hooks/useEntitySelector.ts
@@ -65,12 +65,14 @@ export const useEntitySelector = () => {
 		enabled: isVisible,
 	});
 
-	const selectedEntity = entities.find(
-		(e) => e.id === entityId || e.internal_id === entityId,
-	);
+	const selectedEntity =
+		entities.find((e) => e.id === entityId || e.internal_id === entityId) ??
+		customerEntities.find((e) => e.id === entityId || e.internal_id === entityId);
+
+	const effectiveTotalCount = totalCount ?? customerEntities.length;
 
 	const entityTypeText = deriveEntityTypeText({
-		totalCount: totalCount || customerEntities.length,
+		totalCount: effectiveTotalCount,
 		entities: entities.length > 0 ? entities : customerEntities,
 		features: features ?? [],
 	});
@@ -79,7 +81,7 @@ export const useEntitySelector = () => {
 		entities,
 		selectedEntity,
 		entityId,
-		totalCount: totalCount || customerEntities.length,
+		totalCount: effectiveTotalCount,
 		entityTypeText,
 		isLoading,
 		isVisible,

--- a/vite/src/views/customers2/customer/hooks/useEntitySelector.ts
+++ b/vite/src/views/customers2/customer/hooks/useEntitySelector.ts
@@ -1,0 +1,92 @@
+import type { Entity, Feature, FullCustomer } from "@autumn/shared";
+import { FeatureUsageType, getFeatureName } from "@autumn/shared";
+import { useState } from "react";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useEntity } from "@/hooks/stores/useSubscriptionStore";
+import { useDebounce } from "@/hooks/useDebounce";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useEntitiesQuery } from "./useEntitiesQuery";
+
+const PLACEHOLDER = "PENDING";
+
+const getEntityValue = (entity: Entity): string =>
+	entity.id || entity.internal_id;
+
+const getEntityLabel = (entity: Entity): string =>
+	entity.name || entity.id || PLACEHOLDER;
+
+const deriveEntityTypeText = ({
+	totalCount,
+	entities,
+	features,
+}: {
+	totalCount: number;
+	entities: Entity[];
+	features: Feature[];
+}): string => {
+	if (totalCount === 0) return "entities";
+
+	const firstFeatureId = entities[0]?.feature_id;
+	const allSameType =
+		firstFeatureId &&
+		entities.every((e) => e.feature_id === firstFeatureId);
+
+	if (allSameType && firstFeatureId) {
+		const feature = features.find((f) => f.id === firstFeatureId);
+		if (feature) return getFeatureName({ feature, units: totalCount });
+	}
+
+	return totalCount === 1 ? "entity" : "entities";
+};
+
+export const useEntitySelector = () => {
+	const [search, setSearch] = useState("");
+	const { entityId, setEntityId } = useEntity();
+	const { features } = useFeaturesQuery();
+	const { customer } = useCusQuery();
+
+	const customerEntities = (customer as FullCustomer)?.entities ?? [];
+	const hasEntities = customerEntities.length > 0;
+
+	const hasContinuousUseFeatures = features?.some(
+		(f: Feature) => f.config?.usage_type === FeatureUsageType.Continuous,
+	);
+
+	const isVisible = hasContinuousUseFeatures && hasEntities;
+
+	const debouncedSearch = useDebounce({ value: search, delayMs: 300 });
+	const {
+		entities,
+		totalCount,
+		isLoading,
+		refetch,
+	} = useEntitiesQuery({
+		search: debouncedSearch || undefined,
+		enabled: isVisible,
+	});
+
+	const selectedEntity = entities.find(
+		(e) => e.id === entityId || e.internal_id === entityId,
+	);
+
+	const entityTypeText = deriveEntityTypeText({
+		totalCount: totalCount || customerEntities.length,
+		entities: entities.length > 0 ? entities : customerEntities,
+		features: features ?? [],
+	});
+
+	return {
+		entities,
+		selectedEntity,
+		entityId,
+		totalCount: totalCount || customerEntities.length,
+		entityTypeText,
+		isLoading,
+		isVisible,
+		setEntityId,
+		setSearch,
+		refetch,
+		getEntityValue,
+		getEntityLabel,
+	};
+};

--- a/vite/src/views/customers2/hooks/useCustomerProductsData.ts
+++ b/vite/src/views/customers2/hooks/useCustomerProductsData.ts
@@ -3,7 +3,10 @@ import { parseAsBoolean, useQueryState } from "nuqs";
 import { useMemo } from "react";
 import { useEntity } from "@/hooks/stores/useSubscriptionStore";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
-import { filterCustomerProductsByType } from "../components/table/customer-products/customerProductsTableFilters";
+import {
+	filterCustomerProducts,
+	isOneOffCusProduct,
+} from "../components/table/customer-products/customerProductsTableFilters";
 
 function filterBySelectedEntity({
 	products,
@@ -19,80 +22,58 @@ function filterBySelectedEntity({
 	const selectedEntity = entities.find(
 		(e: Entity) => e.id === entityId || e.internal_id === entityId,
 	);
-
 	if (!selectedEntity) return products;
 
 	return products.filter(
 		(product) =>
+			!product.internal_entity_id ||
 			product.internal_entity_id === selectedEntity.internal_id ||
 			product.entity_id === selectedEntity.id,
 	);
 }
 
 export function useCustomerProductsData() {
-	const { customer, isLoading, testClockFrozenTimeMs } = useCusQuery();
+	const { customer, isLoading, isFetching, isPlaceholderData, testClockFrozenTimeMs } = useCusQuery();
 	const { entityId } = useEntity();
 	const [showExpired, setShowExpired] = useQueryState(
 		"customerProductsShowExpired",
 		parseAsBoolean.withDefault(false),
 	);
 
-	const { subscriptions, purchases } = useMemo(
-		() =>
-			filterCustomerProductsByType({
-				customer,
-				showExpired: showExpired ?? false,
-			}),
-		[customer, showExpired],
-	);
+	const { subscriptions, purchases, hasEntityProducts } = useMemo(() => {
+		const filtered = filterBySelectedEntity({
+			products: filterCustomerProducts({ customer, showExpired: showExpired ?? false }),
+			entityId,
+			entities: customer.entities,
+		});
 
-	// Filter entity-level products by selected entity (if any)
-	const filteredSubscriptionsEntityLevel = useMemo(
-		() =>
-			filterBySelectedEntity({
-				products: subscriptions.entityLevel,
-				entityId,
-				entities: customer.entities,
-			}),
-		[subscriptions.entityLevel, entityId, customer.entities],
-	);
+		return {
+			subscriptions: filtered.filter((p) => !isOneOffCusProduct(p)),
+			purchases: filtered.filter((p) => isOneOffCusProduct(p)),
+			hasEntityProducts: filtered.some(
+				(p) => p.internal_entity_id || p.entity_id,
+			),
+		};
+	}, [customer, showExpired, entityId]);
 
-	const filteredPurchasesEntityLevel = useMemo(
-		() =>
-			filterBySelectedEntity({
-				products: purchases.entityLevel,
-				entityId,
-				entities: customer.entities,
-			}),
-		[purchases.entityLevel, entityId, customer.entities],
-	);
-
-	// Combine customer-level (always shown) + filtered entity-level products
-	const allSubscriptions = useMemo(
-		() => [...subscriptions.customerLevel, ...filteredSubscriptionsEntityLevel],
-		[subscriptions.customerLevel, filteredSubscriptionsEntityLevel],
-	);
-
-	const allPurchases = useMemo(
-		() => [...purchases.customerLevel, ...filteredPurchasesEntityLevel],
-		[purchases.customerLevel, filteredPurchasesEntityLevel],
-	);
+	const isEntityTransitioning = isFetching && isPlaceholderData;
 
 	return {
 		customer,
 		isLoading,
+		isEntityTransitioning,
 		testClockFrozenTimeMs,
 		showExpired,
 		setShowExpired,
 		entityId,
 		hasEntities: customer.entities.length > 0,
 		subscriptions: {
-			all: allSubscriptions,
-			hasEntityProducts: subscriptions.entityLevel.length > 0,
+			all: subscriptions,
+			hasEntityProducts,
 		},
 		purchases: {
-			all: allPurchases,
-			hasEntityProducts: purchases.entityLevel.length > 0,
+			all: purchases,
+			hasEntityProducts,
 		},
 	};
 }

--- a/vite/src/views/customers2/hooks/useCustomerProductsData.ts
+++ b/vite/src/views/customers2/hooks/useCustomerProductsData.ts
@@ -26,7 +26,7 @@ function filterBySelectedEntity({
 
 	return products.filter(
 		(product) =>
-			!product.internal_entity_id ||
+			(!product.internal_entity_id && !product.entity_id) ||
 			product.internal_entity_id === selectedEntity.internal_id ||
 			product.entity_id === selectedEntity.id,
 	);
@@ -41,8 +41,9 @@ export function useCustomerProductsData() {
 	);
 
 	const { subscriptions, purchases, hasEntityProducts } = useMemo(() => {
+		const allProducts = filterCustomerProducts({ customer, showExpired: showExpired ?? false });
 		const filtered = filterBySelectedEntity({
-			products: filterCustomerProducts({ customer, showExpired: showExpired ?? false }),
+			products: allProducts,
 			entityId,
 			entities: customer.entities,
 		});
@@ -50,7 +51,7 @@ export function useCustomerProductsData() {
 		return {
 			subscriptions: filtered.filter((p) => !isOneOffCusProduct(p)),
 			purchases: filtered.filter((p) => isOneOffCusProduct(p)),
-			hasEntityProducts: filtered.some(
+			hasEntityProducts: allProducts.some(
 				(p) => p.internal_entity_id || p.entity_id,
 			),
 		};

--- a/vite/tests/views/customers2/hooks/filterBySelectedEntity.test.ts
+++ b/vite/tests/views/customers2/hooks/filterBySelectedEntity.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import type { Entity, FullCusProduct } from "@autumn/shared";
+
+const makeProduct = (overrides: Partial<FullCusProduct> = {}): FullCusProduct =>
+	({
+		id: "cp-1",
+		entity_id: null,
+		internal_entity_id: null,
+		...overrides,
+	}) as unknown as FullCusProduct;
+
+const makeEntity = (overrides: Partial<Entity> = {}): Entity =>
+	({
+		id: "ent-1",
+		internal_id: "int-ent-1",
+		...overrides,
+	}) as unknown as Entity;
+
+function filterBySelectedEntity({
+	products,
+	entityId,
+	entities,
+}: {
+	products: FullCusProduct[];
+	entityId: string | null;
+	entities: Entity[];
+}): FullCusProduct[] {
+	if (!entityId) return products;
+
+	const selectedEntity = entities.find(
+		(e: Entity) => e.id === entityId || e.internal_id === entityId,
+	);
+	if (!selectedEntity) return products;
+
+	return products.filter(
+		(product) =>
+			(!product.internal_entity_id && !product.entity_id) ||
+			product.internal_entity_id === selectedEntity.internal_id ||
+			product.entity_id === selectedEntity.id,
+	);
+}
+
+describe("filterBySelectedEntity", () => {
+	const entity = makeEntity({ id: "ent-1", internal_id: "int-ent-1" });
+	const otherEntity = makeEntity({ id: "ent-2", internal_id: "int-ent-2" });
+	const entities = [entity, otherEntity];
+
+	test("returns all products when no entityId", () => {
+		const products = [
+			makeProduct({ id: "cp-1" }),
+			makeProduct({ id: "cp-2", entity_id: "ent-1" }),
+		];
+		const result = filterBySelectedEntity({
+			products,
+			entityId: null,
+			entities,
+		});
+		expect(result).toHaveLength(2);
+	});
+
+	test("includes customer-level products (no entity)", () => {
+		const customerProduct = makeProduct({ id: "cp-cus" });
+		const entityProduct = makeProduct({
+			id: "cp-ent",
+			entity_id: "ent-1",
+			internal_entity_id: "int-ent-1",
+		});
+		const result = filterBySelectedEntity({
+			products: [customerProduct, entityProduct],
+			entityId: "ent-1",
+			entities,
+		});
+		expect(result).toContainEqual(customerProduct);
+		expect(result).toContainEqual(entityProduct);
+	});
+
+	test("excludes products from other entities", () => {
+		const otherEntityProduct = makeProduct({
+			id: "cp-other",
+			entity_id: "ent-2",
+			internal_entity_id: "int-ent-2",
+		});
+		const result = filterBySelectedEntity({
+			products: [otherEntityProduct],
+			entityId: "ent-1",
+			entities,
+		});
+		expect(result).toHaveLength(0);
+	});
+
+	test("does not leak products with only internal_entity_id set", () => {
+		const leakyProduct = makeProduct({
+			id: "cp-leak",
+			entity_id: null,
+			internal_entity_id: "int-ent-2",
+		});
+		const result = filterBySelectedEntity({
+			products: [leakyProduct],
+			entityId: "ent-1",
+			entities,
+		});
+		expect(result).toHaveLength(0);
+	});
+
+	test("matches by internal_id when entity_id not set on product", () => {
+		const internalOnlyProduct = makeProduct({
+			id: "cp-internal",
+			entity_id: null,
+			internal_entity_id: "int-ent-1",
+		});
+		const result = filterBySelectedEntity({
+			products: [internalOnlyProduct],
+			entityId: "ent-1",
+			entities,
+		});
+		expect(result).toHaveLength(1);
+	});
+
+	test("returns all products when entityId does not match any entity", () => {
+		const products = [
+			makeProduct({ id: "cp-1" }),
+			makeProduct({ id: "cp-2", entity_id: "ent-1" }),
+		];
+		const result = filterBySelectedEntity({
+			products,
+			entityId: "nonexistent",
+			entities,
+		});
+		expect(result).toHaveLength(2);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal entity search API and updates the customer “get full” flow to prioritize entity‑scoped products when an `entity_id` (public or internal) is passed. Improves the selector with remote search, stable selection, and smoother transitions for large lists.

- **New Features**
  - Server: Added GET `/customers/:customer_id/entities` with `search` and `limit`; returns `list` and `total_count`.
  - Ordering: `getFullCusQuery` and GET `/customers/:id` accept `entity_id` (public or internal) to sort matching entity‑scoped `customer_products` first; integration tests cover both.
  - UI: Selector uses remote search via `SearchableSelect` (`onSearchChange`, `isLoading`), shows total counts/type, refetches after create/delete, and tables show a loading state during entity switches (`keepPreviousData` + `isEntityTransitioning`).

- **Bug Fixes**
  - Selector keeps the chosen entity visible while searching; delete dialog receives the correct entity.
  - Endpoint escapes `%`, `_`, and `\` in `search` to avoid wildcard matches.
  - Customer fetch avoids redundant refetches by checking both `entity_id` and `internal_entity_id` before requesting data.

<sup>Written for commit 019c8a555f7158fe23de58d44c2924584f3ea07c. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1712?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the entity list experience by introducing server-side search and pagination for entities, entity-aware ordering in the customer products query, and a refactored `useEntitySelector` hook that consolidates entity-selector logic previously spread across several components.

- **Improvements**: New `GET /:customer_id/entities` internal endpoint with search, pagination, and `total_count` for live entity lookups; `SearchableSelect` extended with `onSearchChange` / `isLoading` for server-driven search.
- **Improvements**: `getFullCusQuery` now accepts an optional `entityId` that adds a `CASE WHEN` priority clause so entity-scoped products sort before customer-level products when an entity is active.
- **Improvements**: `useCustomerProductsData` refactored to a single flat filter pipeline; `isEntityTransitioning` surfaces placeholder-data state so the table can show a loading skeleton during entity switches without a full remount.
</details>

<h3>Confidence Score: 3/5</h3>

The entity ordering and flat filter pipeline changes are solid, but `useEntitySelector` has a bug where typing in the search box can make the selected entity appear unselected in the trigger and pass `undefined` to the delete dialog.

The server-side sort, new endpoint, and `keepPreviousData` changes are all well-scoped and correct. The main concern is the entity selector: when a user has an entity selected and then types into the search box, the `entities` list gets filtered, `selectedEntity` resolves to `undefined`, and the UI reverts to showing 'Select entity' as if nothing is chosen. Closing the dropdown does not reset the `search` state, so the confusion persists. The delete dialog also receives `undefined` for the entity prop in this state.

`useEntitySelector.ts` and its consumer `SelectedEntityDetails.tsx` need attention around the `selectedEntity` lookup when a search is active.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/customer/hooks/useEntitySelector.ts | New hook consolidating entity-selector logic; `selectedEntity` becomes undefined when the debounced search filters it out of results, causing the trigger to show 'Select entity' and passing `undefined` entity to the delete dialog |
| server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts | New endpoint for listing customer entities with search/pagination; ILIKE wildcards in search input are not escaped and the `total` field reports page-size rather than total matching count |
| vite/src/views/customers/customer/hooks/useCusQuery.tsx | Adds entity-aware query key and `keepPreviousData` for smooth transitions; `entityAlreadyLoaded` check misses the `internal_entity_id` field, causing extra fetches for entities without a public `id` |
| server/src/internal/customers/getFullCusQuery.ts | Adds optional `entityId` ORDER BY prioritization to the CTE and the json_agg so entity-scoped products appear first when an entity is selected |
| vite/src/views/customers2/hooks/useCustomerProductsData.ts | Refactored to use a single flat filter pipeline; includes customer-level products alongside selected entity products, and surfaces `isEntityTransitioning` for skeleton states |
| vite/src/views/customers2/customer/hooks/useEntitiesQuery.ts | New React Query hook for fetching paginated entities from the new internal API endpoint; clean implementation |
| vite/src/components/v2/selects/SearchableSelect.tsx | Adds `onSearchChange` and `isLoading` props for server-side search; bypasses local filter when `onSearchChange` is provided |
| vite/src/hooks/stores/useSubscriptionStore.ts | Simplified `useEntity` to remove intermediate local state; now returns `entity_id` directly from URL query params |
| server/src/internal/customers/internalHandlers/handleGetCustomer.ts | Passes optional `entity_id` query param to `getFullCusQuery` to enable entity-prioritized ordering |
| vite/src/views/customers2/customer/components/SelectedEntityDetails.tsx | Refactored to consume `useEntitySelector`; now uses server-side search for entities; affected by the `selectedEntity` undefined bug in `useEntitySelector` |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as SelectedEntityDetails
    participant ES as useEntitySelector
    participant EQ as useEntitiesQuery
    participant CQ as useCusQuery
    participant API as Internal API

    UI->>ES: render
    ES->>CQ: customer (for hasEntities / customerEntities)
    ES->>EQ: search (debounced)
    EQ->>API: "GET /customers/:id/entities?search=&limit=50"
    API-->>EQ: list, total, total_count
    EQ-->>ES: entities, totalCount, isLoading

    UI->>UI: user selects entity A
    ES->>CQ: "setEntityId(A) URL entity_id=A"
    CQ->>API: "GET /customers/:id?entity_id=A"
    API-->>CQ: customer with entity-A products prioritised

    UI->>UI: user opens dropdown, types search term
    ES->>EQ: "debouncedSearch=xyz"
    EQ->>API: "GET /customers/:id/entities?search=xyz"
    API-->>EQ: filtered entities (may not include A)
    Note over ES,UI: selectedEntity = undefined if A not in results
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
vite/src/views/customers2/customer/hooks/useEntitySelector.ts:61-70
**Selected entity lost while search is active**

`selectedEntity` is derived from the `entities` list returned by `useEntitiesQuery`, which is filtered by the current `debouncedSearch` value. If the user has entity A selected (entityId = "A"), opens the dropdown, and types a term that doesn't match A, `entities` no longer contains A and `selectedEntity` becomes `undefined`. Because `search` state is never reset on close, this persists after the dropdown is dismissed: the trigger renders "Select entity" even though `entityId` is still set in the URL, and `DeleteEntity` receives `entity={undefined}`.

The simplest fix is to fall back to the `customerEntities` list (from the customer query) when `entities` doesn't contain the selected entity.

### Issue 2 of 4
server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts:41-49
**ILIKE wildcards in user input are not escaped**

Drizzle's `ilike` does not escape `%` and `_` wildcard characters before wrapping them in `%…%`. A search string containing `_` acts as a single-character wildcard, so searching for `us_r` will match "user", "ussr", etc. While this is not a SQL-injection risk (the value is still parameterized), it produces counter-intuitive search results. Escape `%` and `_` in the search term before building the pattern.

```suggestion
		const escapedSearch = search.replace(/[%_\\]/g, "\\$&");
		const searchCondition = search
			? and(
					baseConditions,
					or(
						ilike(entities.id, `%${escapedSearch}%`),
						ilike(entities.name, `%${escapedSearch}%`),
					),
				)
			: baseConditions;
```

### Issue 3 of 4
server/src/internal/customers/internalHandlers/handleListEntitiesInternal.ts:64-68
**`total` reports page size, not search-result count**

The response field `total` is set to `results.length`, which is always `≤ limit` (50 by default). Consumers expecting `total` to reflect the full number of matching entities will be misled. Since `total_count` already carries the unfiltered count, consider removing the ambiguous `total` field or computing it from a filtered count query.

```suggestion
		return c.json({
			list: results as Entity[],
			total: countResult[0]?.count ?? 0,
			total_count: countResult[0]?.count ?? 0,
		});
```

### Issue 4 of 4
vite/src/views/customers/customer/hooks/useCusQuery.tsx:46-50
**`entityAlreadyLoaded` only checks `cp.entity_id`, misses `internal_id`-based selections**

`getEntityValue` returns `entity.id || entity.internal_id`, so if an entity has no public `id` the `entityId` stored in the URL is the `internal_id`. The check compares against `cp.entity_id` (public ID only), which will never match an `internal_id`, causing `effectiveEntityId` to be non-null and triggering an unnecessary re-fetch on every render for such entities.

```suggestion
	const entityAlreadyLoaded =
		!entityId ||
		currentCustomer?.customer_products?.some(
			(cp: any) => cp.entity_id === entityId || cp.internal_entity_id === entityId,
		);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: correct types"](https://github.com/useautumn/autumn/commit/6a5cbadfc314725ee0dab1ea97138042f686ed91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33803449)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->