### PR TITLE
Remove Bun release age exclusions

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -14,10 +14,3 @@ NODE_ENV = "test"
 [install]
 # Only install package versions published at least 3 days ago
 minimumReleaseAge = 259200 # seconds
-minimumReleaseAgeExcludes = [
-	"@trigger.dev/build",
-	"@trigger.dev/core",
-	"@trigger.dev/schema-to-json",
-	"@trigger.dev/sdk",
-	"trigger.dev",
-]


### PR DESCRIPTION
## Summary
- Remove `minimumReleaseAgeExcludes` from `bunfig.toml`
- Keep the existing 3-day `minimumReleaseAge` setting

## Tests
- Not run; config-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `minimumReleaseAgeExcludes` from `bunfig.toml` so the 3-day `minimumReleaseAge` applies to all dependencies. This standardizes installs and avoids pulling very new releases for previously excluded `@trigger.dev` packages.

<sup>Written for commit 19bb8d652a8bb7774c3452d27569742836212b6a. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1713?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the `minimumReleaseAgeExcludes` list from `bunfig.toml`, so `trigger.dev` packages are no longer exempt from the existing 3-day minimum release age policy.

- **[Improvements]** All packages, including the five previously-excluded `trigger.dev` / `@trigger.dev/*` packages, are now subject to the same 3-day release-age gate before Bun will install them.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change uniformly enforces the existing 3-day install policy with no functional code affected.

Single-line config deletion that tightens an existing supply-chain policy rather than loosening it. No logic, API surface, or runtime behaviour is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| bunfig.toml | Removes the minimumReleaseAgeExcludes list, applying the 3-day install age policy uniformly to all packages including trigger.dev. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun install package] --> B{Is package age >= 3 days?}
    B -- Yes --> C[Install allowed]
    B -- No --> D[Install blocked]

    style C fill:#22c55e,color:#fff
    style D fill:#ef4444,color:#fff
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove bun release age exclusions"](https://github.com/useautumn/autumn/commit/19bb8d652a8bb7774c3452d27569742836212b6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33812519)</sub>

<!-- /greptile_comment -->