### PR TITLE
fix metadata thing in checkout session

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/buildCheckoutSessionParams.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/buildCheckoutSessionParams.ts
@@ -77,14 +77,18 @@ export const buildCheckoutSessionParams = ({
 			checkoutSessionMetadata: checkoutSessionParams?.metadata,
 			autumnMetadataId,
 		}),
-		subscription_data: mergeSubscriptionData({
-			userMetadata,
-			paramsSubscriptionData: params.subscription_data as
-				| Stripe.Checkout.SessionCreateParams.SubscriptionData
-				| undefined,
-			userSubscriptionData: checkoutSessionParams?.subscription_data as
-				| Stripe.Checkout.SessionCreateParams.SubscriptionData
-				| undefined,
-		}),
+		subscription_data:
+			mergedParams.mode === "payment"
+				? undefined
+				: mergeSubscriptionData({
+						userMetadata,
+						paramsSubscriptionData: params.subscription_data as
+							| Stripe.Checkout.SessionCreateParams.SubscriptionData
+							| undefined,
+						userSubscriptionData:
+							checkoutSessionParams?.subscription_data as
+								| Stripe.Checkout.SessionCreateParams.SubscriptionData
+								| undefined,
+					}),
 	};
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip `subscription_data` when building `stripe` Checkout Sessions in `mode: "payment"` to fix incorrect metadata handling. This prevents one-time payment errors while preserving subscription behavior.

<sup>Written for commit 193848ee0ef602a7b523a192277987b585047271. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1719?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Stripe API error by skipping `subscription_data` on checkout sessions whose mode is `\"payment\"`, since Stripe rejects that field for non-subscription sessions.

- **[Bug fix]** Adds a mode guard so `subscription_data` is set to `undefined` when `mergedParams.mode === \"payment\"`, preventing Stripe from rejecting the checkout session create call.
</details>

<h3>Confidence Score: 3/5</h3>

The fix addresses the reported crash for payment mode but leaves setup mode sessions still passing subscription_data to Stripe, which will trigger the same API error.

Any caller that creates a setup-mode checkout session with subscription_data will still receive a Stripe rejection after this change lands.

buildCheckoutSessionParams.ts needs the mode guard broadened to also exclude setup mode.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/buildCheckoutSessionParams.ts | Guards `subscription_data` from being sent on `payment`-mode sessions, but the same guard is missing for `setup` mode, which also disallows `subscription_data` in Stripe's API. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildCheckoutSessionParams called] --> B[Merge params into mergedParams]
    B --> C{mergedParams.mode?}
    C -->|"payment"| D[subscription_data = undefined]
    C -->|"subscription"| E[mergeSubscriptionData called]
    C -->|undefined / other| E
    E --> F[Return merged Stripe checkout session params]
    D --> F
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/buildCheckoutSessionParams.ts:80-92
**`setup` mode also rejects `subscription_data`**

Stripe's Checkout API rejects `subscription_data` for both `"payment"` and `"setup"` modes — it's only valid for `"subscription"` mode. The guard here only skips `"payment"`, so a `setup`-mode session will still pass `subscription_data` and trigger a Stripe error. Consider inverting the condition to only include `subscription_data` when the mode is explicitly `"subscription"` (or unset, which lets Stripe infer it).

```suggestion
		subscription_data:
			mergedParams.mode !== undefined && mergedParams.mode !== "subscription"
				? undefined
				: mergeSubscriptionData({
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix metadata thing in checkout session"](https://github.com/useautumn/autumn/commit/193848ee0ef602a7b523a192277987b585047271) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33973293)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->