### PR TITLE
accept apostrophe-before-@, %-aliases in customer email

### DIFF
--- a/server/src/internal/customers/actions/updateCustomerData.ts
+++ b/server/src/internal/customers/actions/updateCustomerData.ts
@@ -1,5 +1,9 @@
-import type { Customer, CustomerData, FullSubject } from "@autumn/shared";
-import { z } from "zod/v4";
+import {
+	type Customer,
+	type CustomerData,
+	type FullSubject,
+	isPermissiveEmail,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { updateCachedCustomerData } from "@/internal/customers/cache/fullSubject/index.js";
@@ -23,10 +27,10 @@ export const updateCustomerData = async ({
 		updates.name = customerData.name;
 	}
 	if (!fullSubject.customer.email && customerData?.email) {
-		if (z.string().email().safeParse(customerData.email).error) {
-			logger.info(`Invalid email ${customerData.email}, skipping update`);
-		} else {
+		if (isPermissiveEmail(customerData.email)) {
 			updates.email = customerData.email;
+		} else {
+			logger.info(`Invalid email ${customerData.email}, skipping update`);
 		}
 	}
 	if (

--- a/server/src/internal/customers/cusUtils/cusUtils.ts
+++ b/server/src/internal/customers/cusUtils/cusUtils.ts
@@ -7,10 +7,10 @@ import {
 	type Feature,
 	type FullCustomer,
 	type Invoice,
+	isPermissiveEmail,
 	sortCusEntsForDeduction,
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
-import { z } from "zod";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import {
@@ -41,11 +41,10 @@ export const updateCustomerDetails = async ({
 		updates.name = customerData.name;
 	}
 	if (!fullCustomer.email && customerData?.email) {
-		// Check that email is valid, if not skip...
-		if (z.string().email().safeParse(customerData.email).error) {
-			logger.info(`Invalid email ${customerData.email}, skipping update`);
-		} else {
+		if (isPermissiveEmail(customerData.email)) {
 			updates.email = customerData.email;
+		} else {
+			logger.info(`Invalid email ${customerData.email}, skipping update`);
 		}
 	}
 	// Update send_email_receipts if explicitly provided

--- a/shared/api/common/customerData.ts
+++ b/shared/api/common/customerData.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import { CustomerBillingControlsParamsSchema } from "../../models/cusModels/billingControls/customerBillingControls";
 import { ExternalProcessorsSchema } from "../../models/genModels/processorSchemas";
+import { isPermissiveEmail } from "../../utils/common/emailUtils";
 
 // for internal use only
 export const CreateCustomerInternalOptionsSchema = z.object({
@@ -19,9 +20,13 @@ export const CustomerDataSchema = z
 		name: z.string().nullish().meta({
 			description: "Customer's name",
 		}),
-		email: z.email({ message: "not a valid email address" }).nullish().meta({
-			description: "Customer's email address",
-		}),
+		email: z
+			.string()
+			.refine(isPermissiveEmail, { message: "not a valid email address" })
+			.nullish()
+			.meta({
+				description: "Customer's email address",
+			}),
 
 		fingerprint: z.string().nullish().meta({
 			description:

--- a/shared/utils/common/emailUtils.test.ts
+++ b/shared/utils/common/emailUtils.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { CustomerDataSchema } from "../../api/common/customerData";
+import { isPermissiveEmail } from "./emailUtils";
+
+describe("isPermissiveEmail", () => {
+	describe("accepts patterns Zod incorrectly rejects", () => {
+		test("apostrophe immediately before @", () => {
+			expect(isPermissiveEmail("foo'@bar.com")).toBe(true);
+			expect(
+				isPermissiveEmail("bortuna.matteo'@istitutonervialaimo.edu.it"),
+			).toBe(true);
+		});
+
+		test("apostrophe mid-local", () => {
+			expect(isPermissiveEmail("o'brien@example.com")).toBe(true);
+		});
+
+		test("%-aliased Workspace addresses", () => {
+			expect(
+				isPermissiveEmail("pranayp%officebeacon.com@gtempaccount.com"),
+			).toBe(true);
+			expect(
+				isPermissiveEmail("james.maher%kornferry.com@gtempaccount.com"),
+			).toBe(true);
+		});
+
+		test("punycode IDN TLDs", () => {
+			expect(isPermissiveEmail("user@example.xn--p1ai")).toBe(true);
+			expect(isPermissiveEmail("user@xn--mnchen-3ya.de")).toBe(true);
+		});
+	});
+
+	describe("accepts common signup addresses", () => {
+		const valid = [
+			"o'brien@example.com",
+			"john.q.public@example.com",
+			"j_doe@example.com",
+			"user+tag@example.com",
+			"12345@example.com",
+			"user@example.museum",
+			"a@b.co",
+			"POSTMASTER@example.com",
+			"jose.maria@example.com",
+			"user@sub.deep.example.com",
+			"user-name@example-host.com",
+		];
+		test.each(valid.map((v) => [v]))("%s", (input) => {
+			expect(isPermissiveEmail(input)).toBe(true);
+		});
+	});
+
+	describe("rejects out-of-scope patterns", () => {
+		const cases: Array<[string, string]> = [
+			["user@mail_server.example.com", "underscore in domain"],
+			["user@münchen.de", "raw unicode domain"],
+			["用户@example.com", "raw unicode local"],
+			["user@example.com.", "trailing-dot FQDN"],
+			["user@[127.0.0.1]", "IPv4 literal"],
+			["user@[IPv6:2001:db8::1]", "IPv6 literal"],
+			["user&me@example.com", "& in local"],
+			["user!chief@example.com", "! in local"],
+			["user#1@example.com", "# in local"],
+			["user?q@example.com", "? in local"],
+			["foo@bar.c", "single-letter TLD"],
+			["foo@bar.123", "all-numeric TLD"],
+			["user@1.2.3.4", "unbracketed IP"],
+		];
+		test.each(cases)("%s (%s)", (input) => {
+			expect(isPermissiveEmail(input)).toBe(false);
+		});
+	});
+
+	describe("rejects malformed addresses", () => {
+		const SPACE = String.fromCharCode(0x20);
+		const NL = String.fromCharCode(0x0a);
+		const TAB = String.fromCharCode(0x09);
+		const NUL = String.fromCharCode(0x00);
+		const longLocal = `${"a".repeat(65)}@example.com`;
+		const longDomainLabel = `user@${"a".repeat(64)}.com`;
+		const longTotal = `user@${"a".repeat(250)}.com`;
+
+		const cases: Array<[string, string]> = [
+			["", "empty"],
+			["no-at-sign", "missing @"],
+			["@no-local.com", "empty local"],
+			["no-domain@", "empty domain"],
+			["8615919252438", "raw phone, no @"],
+			["393406157378", "raw phone, no @"],
+			["missingatsign.com", "no @"],
+			["+81080 8130 9089@phone.runable.com", "whitespace in local"],
+			[`spaces${SPACE}in@example.com`, "whitespace in local"],
+			[`user@no${SPACE}tld.com`, "whitespace in domain"],
+			["user@no-tld", "domain has no dot"],
+			[".leading@example.com", "leading dot in local"],
+			["trailing.@example.com", "trailing dot in local"],
+			["two..dots@example.com", "consecutive dots in local"],
+			[longLocal, "local > 64 chars"],
+			[longTotal, "total > 254 chars"],
+			["user@.example.com", "domain starts with dot"],
+			["user@example..com", "consecutive dots in domain"],
+			["user@-example.com", "domain label starts with hyphen"],
+			["user@example-.com", "domain label ends with hyphen"],
+			[longDomainLabel, "domain label > 63 chars"],
+			[`user${TAB}@example.com`, "tab in local"],
+			[`user@example.com${NL}`, "trailing newline"],
+			[`user${NUL}@example.com`, "NUL byte"],
+			["a@b@example.com", "multiple @"],
+			["user@@example.com", "consecutive @"],
+		];
+
+		test.each(cases)("%s (%s)", (input) => {
+			expect(isPermissiveEmail(input)).toBe(false);
+		});
+	});
+
+	describe("boundary cases", () => {
+		test("local part exactly 64 chars", () => {
+			expect(isPermissiveEmail(`${"a".repeat(64)}@example.com`)).toBe(true);
+		});
+
+		test("domain label exactly 63 chars", () => {
+			expect(isPermissiveEmail(`user@${"a".repeat(63)}.com`)).toBe(true);
+		});
+
+		test("total length exactly 254 chars", () => {
+			const label = "a".repeat(63);
+			const finalLabel = `${"a".repeat(53)}.com`;
+			const email = `user@${label}.${label}.${label}.${finalLabel}`;
+			expect(email.length).toBe(254);
+			expect(isPermissiveEmail(email)).toBe(true);
+		});
+	});
+});
+
+describe("CustomerDataSchema email field", () => {
+	const parse = (email: unknown) =>
+		CustomerDataSchema.safeParse({ name: "test", email });
+
+	test("accepts apostrophe-before-@", () => {
+		expect(
+			parse("bortuna.matteo'@istitutonervialaimo.edu.it").success,
+		).toBe(true);
+	});
+
+	test("accepts %-aliased Workspace addresses", () => {
+		expect(
+			parse("pranayp%officebeacon.com@gtempaccount.com").success,
+		).toBe(true);
+	});
+
+	test("accepts punycode IDN TLDs", () => {
+		expect(parse("user@example.xn--p1ai").success).toBe(true);
+	});
+
+	test("accepts null/undefined", () => {
+		expect(parse(null).success).toBe(true);
+		expect(parse(undefined).success).toBe(true);
+	});
+
+	test("rejects raw unicode domain", () => {
+		expect(parse("user@münchen.de").success).toBe(false);
+	});
+
+	test("rejects underscore in domain", () => {
+		expect(parse("user@mail_server.example.com").success).toBe(false);
+	});
+
+	test("rejects raw phone number", () => {
+		const result = parse("8615919252438");
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe("not a valid email address");
+		}
+	});
+
+	test("rejects empty string", () => {
+		expect(parse("").success).toBe(false);
+	});
+});

--- a/shared/utils/common/emailUtils.ts
+++ b/shared/utils/common/emailUtils.ts
@@ -1,0 +1,38 @@
+const CONTROL_CHARS_REGEX = new RegExp("[\\u0000-\\u001F\\u007F]");
+const LOCAL_CHARS_REGEX = /^[A-Za-z0-9._'+%\-]+$/;
+const DOMAIN_LABEL_REGEX = /^[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?$/;
+
+export const isPermissiveEmail = (value: string): boolean => {
+	if (typeof value !== "string") return false;
+	if (value.length === 0 || value.length > 254) return false;
+	if (CONTROL_CHARS_REGEX.test(value)) return false;
+	if (/\s/.test(value)) return false;
+
+	const atIdx = value.indexOf("@");
+	if (atIdx <= 0 || atIdx === value.length - 1) return false;
+
+	const local = value.slice(0, atIdx);
+	const domain = value.slice(atIdx + 1);
+
+	if (local.includes("@") || domain.includes("@")) return false;
+
+	if (local.length > 64) return false;
+	if (local.startsWith(".") || local.endsWith(".")) return false;
+	if (local.includes("..")) return false;
+	if (!LOCAL_CHARS_REGEX.test(local)) return false;
+
+	if (domain.length === 0 || domain.length > 253) return false;
+	if (!domain.includes(".")) return false;
+
+	const labels = domain.split(".");
+	for (const label of labels) {
+		if (label.length === 0 || label.length > 63) return false;
+		if (!DOMAIN_LABEL_REGEX.test(label)) return false;
+	}
+
+	const tld = labels[labels.length - 1];
+	if (tld.length < 2) return false;
+	if (!/[A-Za-z]/.test(tld)) return false;
+
+	return true;
+};

--- a/shared/utils/common/index.ts
+++ b/shared/utils/common/index.ts
@@ -1,2 +1,3 @@
+export * from "./emailUtils";
 export * from "./formatUtils/index";
 export * from "./unixUtils";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Loosened customer email validation to accept apostrophe-before-@, %-aliased Workspace addresses, and punycode TLDs so valid emails are no longer skipped during updates. Replaced strict `z.email()` checks with a permissive `isPermissiveEmail` validator across `@autumn/shared` and server flows.

- **Bug Fixes**
  - Added `isPermissiveEmail` in `shared/utils/common` and exported.
  - Switched `updateCustomerData` and `updateCustomerDetails` to use `isPermissiveEmail`, with logging for invalid inputs.
  - Updated `CustomerDataSchema.email` to `refine(isPermissiveEmail)`.
  - Added unit tests covering accepted and rejected patterns, including apostrophe-before-@, `%` aliases, and punycode TLDs.

<sup>Written for commit 2d5eb7e6fd59bc83671f5b07f6e922db2ed4bdb2. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1721?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

