### PR TITLE
fix: invalid email

### DIFF
--- a/server/src/internal/customers/actions/updateCustomerData.ts
+++ b/server/src/internal/customers/actions/updateCustomerData.ts
@@ -23,7 +23,11 @@ export const updateCustomerData = async ({
 		updates.name = customerData.name;
 	}
 	if (!fullSubject.customer.email && customerData?.email) {
-		if (z.string().email().safeParse(customerData.email).error) {
+		if (
+			z
+				.email({ pattern: z.regexes.unicodeEmail })
+				.safeParse(customerData.email).error
+		) {
 			logger.info(`Invalid email ${customerData.email}, skipping update`);
 		} else {
 			updates.email = customerData.email;

--- a/server/src/internal/customers/cusUtils/cusUtils.ts
+++ b/server/src/internal/customers/cusUtils/cusUtils.ts
@@ -10,7 +10,7 @@ import {
 	sortCusEntsForDeduction,
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
-import { z } from "zod";
+import { z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import {
@@ -41,8 +41,11 @@ export const updateCustomerDetails = async ({
 		updates.name = customerData.name;
 	}
 	if (!fullCustomer.email && customerData?.email) {
-		// Check that email is valid, if not skip...
-		if (z.string().email().safeParse(customerData.email).error) {
+		if (
+			z
+				.email({ pattern: z.regexes.unicodeEmail })
+				.safeParse(customerData.email).error
+		) {
 			logger.info(`Invalid email ${customerData.email}, skipping update`);
 		} else {
 			updates.email = customerData.email;

--- a/server/tests/unit/customers/customer-data-schema-email.test.ts
+++ b/server/tests/unit/customers/customer-data-schema-email.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Email validation in CustomerDataSchema must accept everything Google
+ * Workspace marks as a valid username, including characters zod's default
+ * `z.email()` rejects (&, =, <, >, ',', !, %, ^, accents, trailing symbols).
+ *
+ * Reference: https://support.google.com/a/answer/9193374
+ *
+ * Red-failure mode (current behavior):
+ *  - z.email() with the default pattern rejects every "permissive" case below,
+ *    so `customers.getOrCreate` returns 400 for legitimate Workspace emails.
+ *
+ * Green-success criteria (after fix):
+ *  - All Google Workspace valid emails parse successfully via CustomerDataSchema.
+ *  - Inputs without an "@" still fail (i.e. we're not regressing to anything goes).
+ *  - .nullish() behavior preserved (null + undefined still allowed).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { CustomerDataSchema } from "@autumn/shared";
+
+const expectAccept = (email: string) => {
+	const result = CustomerDataSchema.safeParse({ email });
+	if (!result.success) {
+		throw new Error(
+			`Expected email "${email}" to be accepted, got: ${JSON.stringify(result.error.issues)}`,
+		);
+	}
+	expect(result.data.email).toBe(email);
+};
+
+const expectReject = (email: unknown) => {
+	const result = CustomerDataSchema.safeParse({ email });
+	expect(result.success).toBe(false);
+};
+
+describe("CustomerDataSchema email — Google Workspace acceptance", () => {
+	// Plain ASCII baselines that were already accepted.
+	test.each([
+		"john@example.com",
+		"john.doe@example.com",
+		"john+tag@example.co.uk",
+		"a@b.co",
+	])("accepts standard email %s", (email) => {
+		expectAccept(email);
+	});
+
+	// Characters Google explicitly allows in usernames that the default
+	// zod email regex rejects.
+	test.each([
+		// Apostrophes
+		["apostrophe in local", "o'brien@example.com"],
+		// Ampersand
+		["ampersand in local", "a&b@example.com"],
+		// Equals sign
+		["equals in local", "a=b@example.com"],
+		// Angle brackets
+		["angle brackets in local", "user<tag>@example.com"],
+		// Plus already works but include for completeness
+		["plus in local", "user+tag@example.com"],
+		// Comma
+		["comma in local", "first,last@example.com"],
+		// Exclamation
+		["exclamation in local", "wow!@example.com"],
+		// Percent
+		["percent in local", "100%@example.com"],
+		// Caret
+		["caret in local", "up^stairs@example.com"],
+	])("accepts Google-allowed special char (%s)", (_label, email) => {
+		expectAccept(email);
+	});
+
+	test.each([
+		// Accented latin
+		["é", "josé@example.com"],
+		// CJK
+		["chinese", "用户@example.com"],
+		// Cyrillic
+		["cyrillic", "пользователь@example.com"],
+		// Arabic
+		["arabic", "مستخدم@example.com"],
+	])("accepts unicode local-part (%s)", (_label, email) => {
+		expectAccept(email);
+	});
+
+	test.each([
+		// Google: "Can begin or end with non-alphanumeric characters except periods (.)"
+		["trailing apostrophe", "user'@example.com"],
+		["trailing ampersand", "user&@example.com"],
+		["leading underscore", "_user@example.com"],
+		["leading dash", "-user@example.com"],
+	])("accepts non-alphanumeric boundary (%s)", (_label, email) => {
+		expectAccept(email);
+	});
+
+	test("accepts subdomain + multi-label TLD", () => {
+		expectAccept("user@mail.googleworkspace.co.uk");
+	});
+
+	test("accepts null email (nullish preserved)", () => {
+		const result = CustomerDataSchema.safeParse({ email: null });
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts undefined email (nullish preserved)", () => {
+		const result = CustomerDataSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects strings missing @", () => {
+		expectReject("not-an-email");
+	});
+
+	test("rejects strings with whitespace", () => {
+		expectReject("user name@example.com");
+	});
+
+	test("rejects whitespace in domain", () => {
+		expectReject("user@exa mple.com");
+	});
+
+	test("rejects empty string", () => {
+		expectReject("");
+	});
+
+	test("rejects local part longer than 64 chars", () => {
+		expectReject(`${"a".repeat(65)}@example.com`);
+	});
+
+	test("rejects non-string types", () => {
+		expectReject(42);
+		expectReject({});
+		expectReject([]);
+		expectReject(true);
+	});
+
+	// Regression: every form previously accepted by z.email() must keep parsing.
+	test.each([
+		"simple@example.com",
+		"first.last@example.com",
+		"first+last@example.com",
+		"first_last@example.com",
+		"first-last@example.com",
+		"a.b.c.d@example.com",
+		"123@example.com",
+		"user@sub.example.com",
+		"user@example.co.uk",
+		"user@a-domain-with-dashes.com",
+	])("regression: %s still accepted", (email) => {
+		expectAccept(email);
+	});
+
+	// Sanity: surrounding CustomerDataSchema fields keep working.
+	test("schema still validates other fields alongside email", () => {
+		const result = CustomerDataSchema.safeParse({
+			name: "Jane",
+			email: "jane@example.com",
+			fingerprint: "fp-1",
+			stripe_id: "cus_123",
+			metadata: { plan: "pro" },
+			create_in_stripe: true,
+			send_email_receipts: false,
+		});
+		expect(result.success).toBe(true);
+	});
+});

--- a/shared/api/common/customerData.ts
+++ b/shared/api/common/customerData.ts
@@ -19,9 +19,15 @@ export const CustomerDataSchema = z
 		name: z.string().nullish().meta({
 			description: "Customer's name",
 		}),
-		email: z.email({ message: "not a valid email address" }).nullish().meta({
-			description: "Customer's email address",
-		}),
+		email: z
+			.email({
+				pattern: z.regexes.unicodeEmail,
+				message: "not a valid email address",
+			})
+			.nullish()
+			.meta({
+				description: "Customer's email address",
+			}),
 
 		fingerprint: z.string().nullish().meta({
 			description:


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes over-strict email validation that rejected valid Google Workspace addresses. Switches to `zod` v4 unicode email validation to accept Unicode and special characters, unblocking customer creation/update.

- **Bug Fixes**
  - Updated `CustomerDataSchema.email` to `z.email({ pattern: z.regexes.unicodeEmail })` and kept `.nullish()` behavior.
  - Aligned server validators in `updateCustomerData` and `cusUtils.updateCustomerDetails`; switched imports to `zod/v4`.
  - Added unit tests covering Google-allowed specials, Unicode local parts, boundaries, nullish, regressions, and invalid cases.

<sup>Written for commit a31b2387046195afffd0745dba8cb710262dfea3. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1722?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where legitimate Google Workspace email addresses containing special characters (apostrophes, ampersands, Unicode) were rejected by the default zod email validator. It switches all email validation from `z.string().email()` / `z.email()` (the default "reasonable" regex) to `z.email({ pattern: z.regexes.unicodeEmail })`, which uses a looser regex that accepts Unicode characters in the local part.

- **Bug fixes** — `CustomerDataSchema`, `updateCustomerDetails`, and `updateCustomerData` now all use `z.regexes.unicodeEmail` so international email addresses no longer receive a 400 error on `customers.getOrCreate`.
- **Improvements** — `cusUtils.ts` import is updated from `\"zod\"` to `\"zod/v4\"` to align with the v4 API surface used by `z.email()` and `z.regexes`.
- **Improvements** — A new unit test suite (`customer-data-schema-email.test.ts`) documents and validates the expanded acceptance criteria, including Unicode local parts and Google Workspace special characters.
</details>

<h3>Confidence Score: 4/5</h3>

The core fix is correct and well-applied across all three validation sites; the only concern is a test assertion that is likely wrong.

The production code change is straightforward and consistent — all email validation paths now use the same `unicodeEmail` pattern. The one concern is the test assertion that a 65-character local part should be rejected: `z.regexes.unicodeEmail` is explicitly documented as a "loose" regex, and zod's built-in validators are known not to enforce RFC 5321 length limits, so that `expectReject` call will likely throw and turn the new test suite red on an otherwise correct fix.

server/tests/unit/customers/customer-data-schema-email.test.ts — the 64-char local-part rejection test may fail with the chosen loose validator.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/common/customerData.ts | Switches email validation from default z.email() to z.email({ pattern: z.regexes.unicodeEmail }) to accept Unicode/international email addresses; change is correct and well-scoped. |
| server/src/internal/customers/cusUtils/cusUtils.ts | Updates import from "zod" to "zod/v4" and aligns inline email validator with the unicodeEmail pattern used in CustomerDataSchema; consistent with the schema change. |
| server/src/internal/customers/actions/updateCustomerData.ts | Mirrors the same unicodeEmail pattern change for the second email validation path; already imported from "zod/v4" before this PR. |
| server/tests/unit/customers/customer-data-schema-email.test.ts | New test suite covers Unicode/special-char acceptance and standard rejection cases; the 64-char local-part rejection assertion is likely incorrect given the loose nature of unicodeEmail. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Request with customerData.email] --> B[CustomerDataSchema.safeParse]
    B -->|Before: z.email default regex| C1[Rejects Unicode/special chars → 400]
    B -->|After: z.regexes.unicodeEmail| C2[Accepts Unicode/special chars]
    C2 --> D{updateCustomerDetails / updateCustomerData}
    D --> E{customer already has email?}
    E -->|Yes| F[Skip update]
    E -->|No| G[Re-validate with unicodeEmail inline]
    G -->|invalid| H[Log warning, skip update]
    G -->|valid| I[Save email to DB & cache]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/unit/customers/customer-data-schema-email.test.ts:133-135
**64-char limit assertion may not hold with `unicodeEmail`**

`z.regexes.unicodeEmail` is documented as "a loose regex that allows Unicode" — it does not enforce RFC 5321's 64-character local-part limit (this is a [known gap](https://github.com/colinhacks/zod/issues/3155) in all of zod's built-in email validators). If the regex has no length constraint, `"a".repeat(65) + "@example.com"` will pass validation and this test will fail, producing a misleading red build from the new test suite on an otherwise correct change.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: invalid email"](https://github.com/useautumn/autumn/commit/a31b2387046195afffd0745dba8cb710262dfea3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34130075)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->