### PR TITLE
Add async track param

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   AWS_REGION: us-west-2
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: axiom-ingest-cuts
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: axiom-ingest-cuts feat/track-async-consumer-loop
 
 jobs:
   checks:

--- a/apps/docs/api-reference-generator/core/track.mdx
+++ b/apps/docs/api-reference-generator/core/track.mdx
@@ -40,4 +40,13 @@ await autumn.track({
 });
 ```
 
+```typescript Async (fire-and-forget)
+await autumn.track({
+  customerId: "cus_123",
+  featureId: "ai_messages",
+  value: 1,
+  async: true // Returns 202 immediately; usage processed in the background
+});
+```
+
 </CodeGroup>

--- a/packages/openapi/v2.3/contracts/balancesContract.ts
+++ b/packages/openapi/v2.3/contracts/balancesContract.ts
@@ -90,7 +90,7 @@ export const balancesTrackContract = oc
 			withAcceptedResponse(
 				spec,
 				"track",
-				"Accepted. Autumn is experiencing degraded service from a downstream provider, so the event was accepted for replay and will be tracked as soon as the service is restored.",
+				"Event accepted. Returned in two cases: (1) the request was sent with `async: true`, so the event was placed on the dedicated async ingest queue, or (2) Autumn was unable to process the event synchronously (e.g. transient Redis unavailability) and queued it on the replay queue. The balance is not returned in this response.",
 			),
 	})
 	.input(

--- a/packages/openapi/v2.3/contracts/balancesContract.ts
+++ b/packages/openapi/v2.3/contracts/balancesContract.ts
@@ -90,7 +90,7 @@ export const balancesTrackContract = oc
 			withAcceptedResponse(
 				spec,
 				"track",
-				"Event accepted. Returned in two cases: (1) the request was sent with `async: true`, so the event was placed on the dedicated async ingest queue, or (2) Autumn was unable to process the event synchronously (e.g. transient Redis unavailability) and queued it on the replay queue. The balance is not returned in this response.",
+				"Accepted. Autumn is experiencing degraded service from a downstream provider, so the event was accepted for replay and will be tracked as soon as the service is restored.",
 			),
 	})
 	.input(

--- a/server/src/internal/balances/handlers/handleTrack.ts
+++ b/server/src/internal/balances/handlers/handleTrack.ts
@@ -1,16 +1,14 @@
 import {
 	AffectedResource,
 	ApiVersion,
-	ErrCode,
-	RecaseError,
 	Scopes,
 	TrackParamsSchema,
 	TrackQuerySchema,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { runAsyncTrack } from "@/internal/balances/track/runAsyncTrack.js";
 import { runTrackWithRollout } from "@/internal/balances/track/runTrackWithRollout.js";
 import { getTrackFeatureDeductionsForBody } from "@/internal/balances/track/utils/getFeatureDeductions.js";
-import { queueTrack } from "@/internal/balances/track/utils/queueTrack.js";
 
 export const handleTrack = createRoute({
 	scopes: [Scopes.Balances.Write],
@@ -26,25 +24,7 @@ export const handleTrack = createRoute({
 		const featureDeductions = getTrackFeatureDeductionsForBody({ ctx, body });
 
 		if (body.async === true) {
-			const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
-			if (!queueUrl) {
-				ctx.logger.error(
-					"[track] async=true requested but TRACK_ASYNC_SQS_QUEUE_URL is unset",
-				);
-				throw new RecaseError({
-					message: "Async track is not available right now",
-					code: ErrCode.InternalError,
-					statusCode: 503,
-				});
-			}
-			const queued = await queueTrack({ ctx, body, queueUrl });
-			if (!queued) {
-				throw new RecaseError({
-					message: "Async track is not available right now",
-					code: ErrCode.InternalError,
-					statusCode: 503,
-				});
-			}
+			await runAsyncTrack({ ctx, body });
 			return c.json({ success: true }, 202);
 		}
 

--- a/server/src/internal/balances/handlers/handleTrack.ts
+++ b/server/src/internal/balances/handlers/handleTrack.ts
@@ -28,9 +28,11 @@ export const handleTrack = createRoute({
 		if (body.async === true) {
 			const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
 			if (!queueUrl) {
+				ctx.logger.error(
+					"[track] async=true requested but TRACK_ASYNC_SQS_QUEUE_URL is unset",
+				);
 				throw new RecaseError({
-					message:
-						"Async track requested but TRACK_ASYNC_SQS_QUEUE_URL is unset",
+					message: "Async track is not available right now",
 					code: ErrCode.InternalError,
 					statusCode: 503,
 				});
@@ -38,7 +40,7 @@ export const handleTrack = createRoute({
 			const queued = await queueTrack({ ctx, body, queueUrl });
 			if (!queued) {
 				throw new RecaseError({
-					message: "Failed to enqueue async track",
+					message: "Async track is not available right now",
 					code: ErrCode.InternalError,
 					statusCode: 503,
 				});

--- a/server/src/internal/balances/handlers/handleTrack.ts
+++ b/server/src/internal/balances/handlers/handleTrack.ts
@@ -1,13 +1,16 @@
 import {
 	AffectedResource,
 	ApiVersion,
+	ErrCode,
+	RecaseError,
+	Scopes,
 	TrackParamsSchema,
 	TrackQuerySchema,
-	Scopes,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { runTrackWithRollout } from "@/internal/balances/track/runTrackWithRollout.js";
 import { getTrackFeatureDeductionsForBody } from "@/internal/balances/track/utils/getFeatureDeductions.js";
+import { queueTrack } from "@/internal/balances/track/utils/queueTrack.js";
 
 export const handleTrack = createRoute({
 	scopes: [Scopes.Balances.Write],
@@ -21,6 +24,28 @@ export const handleTrack = createRoute({
 		const body = c.req.valid("json");
 		const ctx = c.get("ctx");
 		const featureDeductions = getTrackFeatureDeductionsForBody({ ctx, body });
+
+		if (body.async === true) {
+			const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+			if (!queueUrl) {
+				throw new RecaseError({
+					message:
+						"Async track requested but TRACK_ASYNC_SQS_QUEUE_URL is unset",
+					code: ErrCode.InternalError,
+					statusCode: 503,
+				});
+			}
+			const queued = await queueTrack({ ctx, body, queueUrl });
+			if (!queued) {
+				throw new RecaseError({
+					message: "Failed to enqueue async track",
+					code: ErrCode.InternalError,
+					statusCode: 503,
+				});
+			}
+			return c.json({ success: true }, 202);
+		}
+
 		const response = await runTrackWithRollout({
 			ctx,
 			body,

--- a/server/src/internal/balances/track/runAsyncTrack.ts
+++ b/server/src/internal/balances/track/runAsyncTrack.ts
@@ -1,0 +1,35 @@
+import { ErrCode, RecaseError, type TrackParams } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { queueTrack } from "./utils/queueTrack.js";
+
+const ASYNC_TRACK_UNAVAILABLE_MESSAGE =
+	"Async track is not available right now";
+
+export const runAsyncTrack = async ({
+	ctx,
+	body,
+}: {
+	ctx: AutumnContext;
+	body: TrackParams;
+}): Promise<void> => {
+	const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+	if (!queueUrl) {
+		ctx.logger.error(
+			"[track] async=true requested but TRACK_ASYNC_SQS_QUEUE_URL is unset",
+		);
+		throw new RecaseError({
+			message: ASYNC_TRACK_UNAVAILABLE_MESSAGE,
+			code: ErrCode.InternalError,
+			statusCode: 503,
+		});
+	}
+
+	const queued = await queueTrack({ ctx, body, queueUrl });
+	if (!queued) {
+		throw new RecaseError({
+			message: ASYNC_TRACK_UNAVAILABLE_MESSAGE,
+			code: ErrCode.InternalError,
+			statusCode: 503,
+		});
+	}
+};

--- a/server/src/internal/balances/track/utils/queueTrack.ts
+++ b/server/src/internal/balances/track/utils/queueTrack.ts
@@ -8,13 +8,15 @@ import { getQueuedTrackResponse } from "./getQueuedTrackResponse.js";
 export const queueTrack = async ({
 	ctx,
 	body,
+	queueUrl,
 }: {
 	ctx: AutumnContext;
 	body: TrackParams;
+	queueUrl?: string;
 }) => {
 	try {
-		const queueUrl = process.env.TRACK_SQS_QUEUE_URL;
-		if (!queueUrl) {
+		const resolvedQueueUrl = queueUrl ?? process.env.TRACK_SQS_QUEUE_URL;
+		if (!resolvedQueueUrl) {
 			ctx.logger.warn(
 				"[track] Redis unavailable and TRACK_SQS_QUEUE_URL is unset; falling back to synchronous track",
 			);
@@ -23,7 +25,7 @@ export const queueTrack = async ({
 
 		await addTaskToQueue({
 			jobName: JobName.Track,
-			queueUrl,
+			queueUrl: resolvedQueueUrl,
 			messageGroupId: `${ctx.org.id}:${ctx.env}:${body.customer_id}:${body.entity_id ?? "none"}`,
 			messageDeduplicationId: ctx.id,
 			payload: {
@@ -42,7 +44,7 @@ export const queueTrack = async ({
 			feature_id: body.feature_id,
 			event_name: body.event_name,
 			env: ctx.env,
-			queue_name: queueUrl.split("/").pop(),
+			queue_name: resolvedQueueUrl.split("/").pop(),
 		});
 		addToExtraLogs({
 			ctx,

--- a/server/src/internal/misc/jobQueues/jobQueueStore.ts
+++ b/server/src/internal/misc/jobQueues/jobQueueStore.ts
@@ -9,6 +9,7 @@ import {
 export const JOB_QUEUE_IDS = {
 	primary: "primary",
 	track: "track",
+	trackAsync: "trackAsync",
 } as const;
 
 export const KNOWN_JOB_QUEUES = [
@@ -21,7 +22,14 @@ export const KNOWN_JOB_QUEUES = [
 	{
 		id: JOB_QUEUE_IDS.track,
 		label: "Track Replay Queue",
-		description: "Dedicated async track replay queue used during fail-open recovery.",
+		description:
+			"Dedicated async track replay queue used during fail-open recovery.",
+		defaultEnabled: true,
+	},
+	{
+		id: JOB_QUEUE_IDS.trackAsync,
+		label: "Track Async Queue",
+		description: "Customer-driven async / batch track ingest.",
 		defaultEnabled: true,
 	},
 ] as const;

--- a/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
+++ b/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
@@ -41,9 +41,11 @@ const probe = async ({
 };
 
 const getConfiguredQueueUrls = () =>
-	[QUEUE_URL, process.env.TRACK_SQS_QUEUE_URL].filter(
-		(url): url is string => Boolean(url),
-	);
+	[
+		QUEUE_URL,
+		process.env.TRACK_SQS_QUEUE_URL,
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+	].filter((url): url is string => Boolean(url));
 
 export const getBlueGreenQueueUrls = ({
 	knownQueueUrls = [],

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -467,6 +467,10 @@ export const initWorkers = async ({
 			queueId: JOB_QUEUE_IDS.track,
 			queueUrl: process.env.TRACK_SQS_QUEUE_URL,
 		},
+		{
+			queueId: JOB_QUEUE_IDS.trackAsync,
+			queueUrl: process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+		},
 	]) {
 		if (!queueUrl) continue;
 

--- a/server/tests/balances/track/track-async.test.ts
+++ b/server/tests/balances/track/track-async.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { ApiVersion } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { constructProduct } from "@/utils/scriptUtils/createTestProducts.js";
+import { initCustomerV3 } from "@/utils/scriptUtils/testUtils/initCustomerV3.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+
+const testCase = "track-async";
+const customerId = testCase;
+
+const free = constructProduct({
+	type: "free",
+	isDefault: false,
+	items: [
+		constructFeatureItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+		}),
+	],
+});
+
+const ASYNC_QUEUE_URL_TEST =
+	"https://sqs.us-east-1.amazonaws.com/123456789012/track-async-test.fifo";
+
+describe(`${chalk.yellowBright("track-async: async=true returns 202 + success")}`, () => {
+	const autumn: AutumnInt = new AutumnInt({ version: ApiVersion.V1_2 });
+	let originalAsyncEnv: string | undefined;
+
+	beforeAll(async () => {
+		originalAsyncEnv = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL = ASYNC_QUEUE_URL_TEST;
+
+		await initCustomerV3({
+			ctx,
+			customerId,
+			customerData: {},
+			attachPm: "success",
+			withTestClock: false,
+		});
+
+		await initProductsV0({
+			ctx,
+			products: [free],
+			prefix: customerId,
+		});
+
+		await autumn.attach({ customer_id: customerId, product_id: free.id });
+	});
+
+	afterAll(() => {
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL = originalAsyncEnv;
+	});
+
+	test("POST /v1/track with async=true returns 202 and { success: true }", async () => {
+		const response = await fetch(`${autumn["baseUrl"]}/track`, {
+			method: "POST",
+			headers: autumn["headers"],
+			body: JSON.stringify({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: 1,
+				async: true,
+			}),
+		});
+
+		expect(response.status).toBe(202);
+		const body = await response.json();
+		expect(body).toEqual({ success: true });
+	});
+
+	test("POST /v1/track without async still returns 200 and a balance", async () => {
+		const response = await fetch(`${autumn["baseUrl"]}/track`, {
+			method: "POST",
+			headers: autumn["headers"],
+			body: JSON.stringify({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: 1,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toHaveProperty("customer_id", customerId);
+		expect(body).toHaveProperty("value");
+	});
+});

--- a/server/tests/balances/track/track-async.test.ts
+++ b/server/tests/balances/track/track-async.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { ApiVersion } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
@@ -23,17 +23,10 @@ const free = constructProduct({
 	],
 });
 
-const ASYNC_QUEUE_URL_TEST =
-	"https://sqs.us-east-1.amazonaws.com/123456789012/track-async-test.fifo";
-
 describe(`${chalk.yellowBright("track-async: async=true returns 202 + success")}`, () => {
 	const autumn: AutumnInt = new AutumnInt({ version: ApiVersion.V1_2 });
-	let originalAsyncEnv: string | undefined;
 
 	beforeAll(async () => {
-		originalAsyncEnv = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
-		process.env.TRACK_ASYNC_SQS_QUEUE_URL = ASYNC_QUEUE_URL_TEST;
-
 		await initCustomerV3({
 			ctx,
 			customerId,
@@ -51,10 +44,6 @@ describe(`${chalk.yellowBright("track-async: async=true returns 202 + success")}
 		await autumn.attach({ customer_id: customerId, product_id: free.id });
 	});
 
-	afterAll(() => {
-		process.env.TRACK_ASYNC_SQS_QUEUE_URL = originalAsyncEnv;
-	});
-
 	test("POST /v1/track with async=true returns 202 and { success: true }", async () => {
 		const response = await fetch(`${autumn["baseUrl"]}/track`, {
 			method: "POST",
@@ -70,22 +59,5 @@ describe(`${chalk.yellowBright("track-async: async=true returns 202 + success")}
 		expect(response.status).toBe(202);
 		const body = await response.json();
 		expect(body).toEqual({ success: true });
-	});
-
-	test("POST /v1/track without async still returns 200 and a balance", async () => {
-		const response = await fetch(`${autumn["baseUrl"]}/track`, {
-			method: "POST",
-			headers: autumn["headers"],
-			body: JSON.stringify({
-				customer_id: customerId,
-				feature_id: TestFeature.Messages,
-				value: 1,
-			}),
-		});
-
-		expect(response.status).toBe(200);
-		const body = await response.json();
-		expect(body).toHaveProperty("customer_id", customerId);
-		expect(body).toHaveProperty("value");
 	});
 });

--- a/server/tests/unit/balances/track/queueTrack.test.ts
+++ b/server/tests/unit/balances/track/queueTrack.test.ts
@@ -10,6 +10,8 @@ const mockState = {
 };
 const trackQueueUrl =
 	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-dev.fifo";
+const trackAsyncQueueUrl =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
 
 mock.module(
 	"@/internal/balances/track/utils/getQueuedTrackResponse.js",
@@ -81,10 +83,7 @@ describe("queueTrack", () => {
 	});
 
 	test("routes to explicit queueUrl when passed, ignoring TRACK_SQS_QUEUE_URL", async () => {
-		const asyncQueueUrl =
-			"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
-
-		const sqsClient = getSqsClient({ queueUrl: asyncQueueUrl });
+		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
 		const originalAsyncSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			mockState.queueCommands.push(command.input);
@@ -108,12 +107,12 @@ describe("queueTrack", () => {
 				feature_id: "messages",
 				value: 1,
 			},
-			queueUrl: asyncQueueUrl,
+			queueUrl: trackAsyncQueueUrl,
 		});
 
 		expect(mockState.queueCommands).toHaveLength(1);
 		expect(mockState.queueCommands[0]).toMatchObject({
-			QueueUrl: asyncQueueUrl,
+			QueueUrl: trackAsyncQueueUrl,
 		});
 
 		sqsClient.send = originalAsyncSend;

--- a/server/tests/unit/balances/track/queueTrack.test.ts
+++ b/server/tests/unit/balances/track/queueTrack.test.ts
@@ -11,13 +11,16 @@ const mockState = {
 const trackQueueUrl =
 	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-dev.fifo";
 
-mock.module("@/internal/balances/track/utils/getQueuedTrackResponse.js", () => ({
-	getQueuedTrackResponse: () => ({
-		customer_id: "cus_123",
-		value: 2,
-		balance: null,
+mock.module(
+	"@/internal/balances/track/utils/getQueuedTrackResponse.js",
+	() => ({
+		getQueuedTrackResponse: () => ({
+			customer_id: "cus_123",
+			value: 2,
+			balance: null,
+		}),
 	}),
-}));
+);
 
 import { queueTrack } from "@/internal/balances/track/utils/queueTrack.js";
 
@@ -62,7 +65,9 @@ describe("queueTrack", () => {
 			MessageGroupId: "org_123:sandbox:cus_123:ent_123",
 			MessageDeduplicationId: "req_123",
 		});
-		expect(JSON.parse(mockState.queueCommands[0]?.MessageBody as string)).toMatchObject({
+		expect(
+			JSON.parse(mockState.queueCommands[0]?.MessageBody as string),
+		).toMatchObject({
 			name: "track",
 			data: {
 				orgId: "org_123",
@@ -73,6 +78,100 @@ describe("queueTrack", () => {
 				apiVersion: ApiVersion.V2_1,
 			},
 		});
+	});
+
+	test("routes to explicit queueUrl when passed, ignoring TRACK_SQS_QUEUE_URL", async () => {
+		const asyncQueueUrl =
+			"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
+
+		const sqsClient = getSqsClient({ queueUrl: asyncQueueUrl });
+		const originalAsyncSend = sqsClient.send.bind(sqsClient);
+		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
+			mockState.queueCommands.push(command.input);
+			return {};
+		}) as typeof sqsClient.send;
+
+		const ctx = {
+			id: "req_async_1",
+			org: { id: "org_123" },
+			env: AppEnv.Sandbox,
+			apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+			logger: {
+				warn: mock(() => {}),
+			},
+		} as unknown as AutumnContext;
+
+		await queueTrack({
+			ctx,
+			body: {
+				customer_id: "cus_123",
+				feature_id: "messages",
+				value: 1,
+			},
+			queueUrl: asyncQueueUrl,
+		});
+
+		expect(mockState.queueCommands).toHaveLength(1);
+		expect(mockState.queueCommands[0]).toMatchObject({
+			QueueUrl: asyncQueueUrl,
+		});
+
+		sqsClient.send = originalAsyncSend;
+	});
+
+	test("falls back to TRACK_SQS_QUEUE_URL when queueUrl arg is undefined", async () => {
+		const ctx = {
+			id: "req_fallback_1",
+			org: { id: "org_123" },
+			env: AppEnv.Sandbox,
+			apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+			logger: {
+				warn: mock(() => {}),
+			},
+		} as unknown as AutumnContext;
+
+		await queueTrack({
+			ctx,
+			body: {
+				customer_id: "cus_123",
+				feature_id: "messages",
+				value: 1,
+			},
+		});
+
+		expect(mockState.queueCommands).toHaveLength(1);
+		expect(mockState.queueCommands[0]).toMatchObject({
+			QueueUrl: trackQueueUrl,
+		});
+	});
+
+	test("returns null when no queueUrl arg and env var is unset", async () => {
+		const previousEnv = process.env.TRACK_SQS_QUEUE_URL;
+		process.env.TRACK_SQS_QUEUE_URL = undefined;
+
+		const warnSpy = mock(() => {});
+		const ctx = {
+			id: "req_no_queue",
+			org: { id: "org_123" },
+			env: AppEnv.Sandbox,
+			apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+			logger: { warn: warnSpy },
+		} as unknown as AutumnContext;
+
+		const result = await queueTrack({
+			ctx,
+			body: {
+				customer_id: "cus_123",
+				feature_id: "messages",
+				value: 1,
+			},
+		});
+
+		expect(result).toBeNull();
+		expect(mockState.queueCommands).toHaveLength(0);
+		expect(warnSpy).toHaveBeenCalled();
+
+		process.env.TRACK_SQS_QUEUE_URL = previousEnv;
 	});
 
 	afterEach(() => {

--- a/server/tests/unit/balances/track/runAsyncTrack.test.ts
+++ b/server/tests/unit/balances/track/runAsyncTrack.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv, ErrCode } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const mockState = {
+	queueTrackCalls: [] as Record<string, unknown>[],
+	queueTrackResult: null as unknown,
+};
+
+const trackAsyncQueueUrl =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
+
+mock.module("@/internal/balances/track/utils/queueTrack.js", () => ({
+	queueTrack: async (args: Record<string, unknown>) => {
+		mockState.queueTrackCalls.push(args);
+		return mockState.queueTrackResult;
+	},
+}));
+
+import { runAsyncTrack } from "@/internal/balances/track/runAsyncTrack.js";
+
+const buildCtx = () =>
+	({
+		id: "req_async_1",
+		org: { id: "org_123" },
+		env: AppEnv.Sandbox,
+		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		logger: {
+			warn: mock(() => {}),
+			error: mock(() => {}),
+		},
+	}) as unknown as AutumnContext;
+
+const body = {
+	customer_id: "cus_123",
+	feature_id: "messages",
+	value: 1,
+	async: true,
+};
+
+describe("runAsyncTrack", () => {
+	const originalEnv = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+
+	beforeEach(() => {
+		mockState.queueTrackCalls = [];
+		mockState.queueTrackResult = {
+			customer_id: "cus_123",
+			value: 1,
+			balance: null,
+		};
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
+	});
+
+	afterEach(() => {
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL = originalEnv;
+	});
+
+	test("calls queueTrack with TRACK_ASYNC_SQS_QUEUE_URL and resolves without throwing", async () => {
+		const ctx = buildCtx();
+
+		await runAsyncTrack({ ctx, body });
+
+		expect(mockState.queueTrackCalls).toHaveLength(1);
+		expect(mockState.queueTrackCalls[0]).toMatchObject({
+			ctx,
+			body,
+			queueUrl: trackAsyncQueueUrl,
+		});
+	});
+
+	test("throws 503 RecaseError when TRACK_ASYNC_SQS_QUEUE_URL is unset", async () => {
+		process.env.TRACK_ASYNC_SQS_QUEUE_URL = undefined;
+		const ctx = buildCtx();
+
+		await expect(runAsyncTrack({ ctx, body })).rejects.toMatchObject({
+			code: ErrCode.InternalError,
+			statusCode: 503,
+			message: "Async track is not available right now",
+		});
+
+		expect(mockState.queueTrackCalls).toHaveLength(0);
+		expect(ctx.logger.error).toHaveBeenCalled();
+	});
+
+	test("throws 503 RecaseError when queueTrack returns null", async () => {
+		mockState.queueTrackResult = null;
+		const ctx = buildCtx();
+
+		await expect(runAsyncTrack({ ctx, body })).rejects.toMatchObject({
+			code: ErrCode.InternalError,
+			statusCode: 503,
+			message: "Async track is not available right now",
+		});
+
+		expect(mockState.queueTrackCalls).toHaveLength(1);
+	});
+});

--- a/shared/api/balances/track/trackParams.ts
+++ b/shared/api/balances/track/trackParams.ts
@@ -52,6 +52,11 @@ export const TrackParamsSchema = BalanceParamsBaseSchema.extend({
 		internal: true,
 	}),
 
+	async: z.boolean().optional().meta({
+		description:
+			"If true, enqueue the event for asynchronous processing and return 202 immediately. The response will not include balance information.",
+	}),
+
 	lock: LockParamsSchema.optional(),
 }).refine(
 	(data) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable async track ingestion via a new `trackAsync` SQS queue and an `async` flag on `/v1/track`. Requests with `async: true` return 202 immediately and process in the background; workers and readiness checks include the new queue, and staging deploys from this branch are allowed.

- New Features
  - Wire new `trackAsync` queue: added to job queues; worker polls `TRACK_ASYNC_SQS_QUEUE_URL`; blue/green checks include it.
  - Add `async` flag to `/v1/track`: calls `runAsyncTrack` to enqueue via `queueTrack` (supports explicit `queueUrl`, falls back to `TRACK_SQS_QUEUE_URL`); returns 202 `{ success: true }`, 503 if unset or enqueue fails. Docs updated; tests cover 202, queue override/fallback, and `runAsyncTrack` error paths.

- Migration
  - Set `TRACK_ASYNC_SQS_QUEUE_URL` in each environment.
  - Ensure the worker IAM role can read from the new queue.

<sup>Written for commit a8b9ae1b53349a4309968bda3db98c79bf8a1e40. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1727?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

