### PR TITLE
fix: tax id preview

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -137,6 +137,7 @@ export const setupAttachBillingContext = async ({
 		stripeSubscriptionSchedule,
 		stripeCustomer,
 		stripeDiscounts,
+		stripeTaxRate,
 		paymentMethod,
 		testClockFrozenTime,
 	} = await setupStripeBillingContext({
@@ -150,6 +151,7 @@ export const setupAttachBillingContext = async ({
 		skipBillingFetching,
 		createStripeCustomerIfMissing:
 			!preview && params.no_billing_changes !== true,
+		fetchTaxRate: preview,
 	});
 
 	const featureQuantities = setupFeatureQuantitiesContext({
@@ -267,6 +269,7 @@ export const setupAttachBillingContext = async ({
 		stripeSubscription,
 		stripeSubscriptionSchedule,
 		stripeDiscounts,
+		stripeTaxRate,
 		paymentMethod,
 
 		currentEpochMs,

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -172,6 +172,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		stripeSubscriptionSchedule,
 		stripeCustomer,
 		stripeDiscounts,
+		stripeTaxRate,
 		paymentMethod,
 		testClockFrozenTime,
 	} = await setupStripeBillingContext({
@@ -242,6 +243,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		stripeSubscription,
 		stripeSubscriptionSchedule,
 		stripeDiscounts,
+		stripeTaxRate,
 		paymentMethod,
 		customPrices,
 		customEnts,

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -97,6 +97,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		stripeSubscriptionSchedule,
 		stripeCustomer,
 		stripeDiscounts,
+		stripeTaxRate,
 		paymentMethod,
 		testClockFrozenTime,
 	} = await setupStripeBillingContext({
@@ -189,6 +190,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		stripeSubscriptionSchedule,
 		stripeDiscounts,
 		stripeCustomer,
+		stripeTaxRate,
 		paymentMethod,
 
 		currentEpochMs,

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeTaxRateForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeTaxRateForBilling.ts
@@ -1,0 +1,21 @@
+import type Stripe from "stripe";
+import { createStripeCli } from "@server/external/connect/createStripeCli";
+import type { AutumnContext } from "@server/honoUtils/HonoEnv";
+
+/**
+ * Fetches a Stripe TaxRate by id. Returns undefined when no id is provided
+ * so this can be wired unconditionally into setup. Errors on missing/deleted
+ * rates surface naturally to the caller — the real attach also lets Stripe
+ * reject an invalid `default_tax_rates`.
+ */
+export const fetchStripeTaxRateForBilling = async ({
+	ctx,
+	taxRateId,
+}: {
+	ctx: AutumnContext;
+	taxRateId?: string;
+}): Promise<Stripe.TaxRate | undefined> => {
+	if (!taxRateId) return undefined;
+	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+	return await stripeCli.taxRates.retrieve(taxRateId);
+};

--- a/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
@@ -15,6 +15,7 @@ import { fetchStripeCustomerForBilling } from "./fetchStripeCustomerForBilling";
 import { fetchStripeDiscountsForBilling } from "./fetchStripeDiscountsForBilling";
 import { fetchStripeSubscriptionForBilling } from "./fetchStripeSubscriptionForBilling";
 import { fetchStripeSubscriptionScheduleForBilling } from "./fetchStripeSubscriptionScheduleForBilling";
+import { fetchStripeTaxRateForBilling } from "./fetchStripeTaxRateForBilling";
 
 export const setupStripeBillingContext = async ({
 	ctx,
@@ -27,6 +28,7 @@ export const setupStripeBillingContext = async ({
 	skipBillingFetching,
 	skipSubscriptionFetching,
 	createStripeCustomerIfMissing = true,
+	fetchTaxRate = false,
 }: {
 	ctx: AutumnContext;
 	fullCustomer: FullCustomer;
@@ -38,6 +40,7 @@ export const setupStripeBillingContext = async ({
 	skipBillingFetching?: boolean;
 	skipSubscriptionFetching?: boolean;
 	createStripeCustomerIfMissing?: boolean;
+	fetchTaxRate?: boolean;
 }) => {
 	const { stripeBillingContext } = contextOverride;
 
@@ -49,6 +52,7 @@ export const setupStripeBillingContext = async ({
 			stripeSubscriptionSchedule: undefined,
 			stripeCustomer: undefined,
 			stripeDiscounts: undefined,
+			stripeTaxRate: undefined,
 			paymentMethod: undefined,
 			testClockFrozenTime: undefined,
 		};
@@ -63,6 +67,7 @@ export const setupStripeBillingContext = async ({
 		stripeSubscription,
 		stripeSubscriptionSchedule,
 		stripeDiscounts,
+		stripeTaxRate,
 	} = await all({
 		async stripeContext() {
 			return fetchStripeCustomerForBilling({
@@ -117,6 +122,12 @@ export const setupStripeBillingContext = async ({
 					params && "discounts" in params ? params.discounts : undefined,
 			});
 		},
+		async stripeTaxRate() {
+			if (!fetchTaxRate) return undefined;
+			const taxRateId =
+				params && "tax_rate_id" in params ? params.tax_rate_id : undefined;
+			return fetchStripeTaxRateForBilling({ ctx, taxRateId });
+		},
 	});
 
 	return {
@@ -124,6 +135,7 @@ export const setupStripeBillingContext = async ({
 		stripeSubscriptionSchedule,
 		stripeCustomer,
 		stripeDiscounts,
+		stripeTaxRate,
 		paymentMethod,
 		testClockFrozenTime,
 	};

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/computeAttachPreviewBillingPlan.ts
@@ -6,6 +6,7 @@ import type {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeAttachInvoiceCreditPreview } from "./invoiceCredits/computeAttachInvoiceCreditPreview";
 import { computeAttachTaxPreview } from "./tax/computeAttachTaxPreview";
+import { computeAttachTaxRateIdPreview } from "./tax/computeAttachTaxRateIdPreview";
 
 /**
  * Build-stage orchestrator for preview-only enrichments. Originally
@@ -32,10 +33,16 @@ export const computeAttachPreviewBillingPlan = async ({
 	billingContext: BillingContext;
 	autumnBillingPlan: AutumnBillingPlan;
 }): Promise<PreviewBillingPlan> => {
-	// Tax involves a Stripe round-trip; invoice-credits is local. Run in
-	// parallel so the credits read doesn't add to the wall-clock latency.
+	// tax_rate_id overrides automatic_tax on the real Stripe subscription,
+	// so we mirror that precedence here. The tax-rate-id branch is pure
+	// math (rate was fetched at setup); the automatic_tax branch hits
+	// Stripe Tax. Both produce the same `PreviewTax` shape.
+	const taxPromise = billingContext.taxRateId
+		? computeAttachTaxRateIdPreview({ ctx, billingContext, autumnBillingPlan })
+		: computeAttachTaxPreview({ ctx, billingContext, autumnBillingPlan });
+
 	const [tax, invoiceCredits] = await Promise.all([
-		computeAttachTaxPreview({ ctx, billingContext, autumnBillingPlan }),
+		taxPromise,
 		Promise.resolve(
 			computeAttachInvoiceCreditPreview({ ctx, billingContext }),
 		),

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
@@ -1,0 +1,111 @@
+import type {
+	AutumnBillingPlan,
+	BillingContext,
+	PreviewTax,
+} from "@autumn/shared";
+import {
+	atmnToStripeAmount,
+	orgToCurrency,
+	stripeToAtmnAmount,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+/**
+ * Build-stage helper that computes a tax preview for an attach when the
+ * caller passed an explicit Stripe `tax_rate_id`. Sibling to
+ * `computeAttachTaxPreview` (which handles automatic_tax).
+ *
+ * Pure math: the Stripe TaxRate was fetched once at setup and lives on
+ * `billingContext.stripeTaxRate`. Tax is applied to the same net
+ * `chargeImmediately` subtotal the automatic-tax helper uses, so both
+ * branches feed the formatter and total-assembly identically.
+ *
+ * Skip-conditions (return undefined):
+ *  - no `taxRateId` on context
+ *  - flow is `stripe_checkout` (Stripe Checkout computes tax itself, same
+ *    reasoning as the automatic-tax helper)
+ *  - no `chargeImmediately` line items
+ *
+ * On `netSubtotal <= 0` we short-circuit with `{ status: "complete", ...zeros }` —
+ * tax does not apply to a credit invoice.
+ *
+ * On a missing/expanded `stripeTaxRate` (fetch failed at setup) we return
+ * `{ status: "incomplete", ...zeros }` so the merchant sees an explicit
+ * "tax not computed" signal rather than a silently missing field.
+ */
+export const computeAttachTaxRateIdPreview = async ({
+	ctx,
+	billingContext,
+	autumnBillingPlan,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+	autumnBillingPlan: AutumnBillingPlan;
+}): Promise<PreviewTax | undefined> => {
+	if (!billingContext.taxRateId) return undefined;
+	if (billingContext.checkoutMode === "stripe_checkout") return undefined;
+
+	const allLineItems = autumnBillingPlan.lineItems ?? [];
+	if (allLineItems.length === 0) return undefined;
+
+	const immediateLines = allLineItems.filter((line) => line.chargeImmediately);
+	if (immediateLines.length === 0) return undefined;
+
+	const netSubtotal = immediateLines.reduce(
+		(sum, line) => sum + (line.amountAfterDiscounts ?? line.amount),
+		0,
+	);
+
+	const currency = orgToCurrency({ org: ctx.org });
+
+	if (netSubtotal <= 0) {
+		return {
+			total: 0,
+			amount_inclusive: 0,
+			amount_exclusive: 0,
+			currency,
+			status: "complete",
+		};
+	}
+
+	const taxRate = billingContext.stripeTaxRate;
+	if (!taxRate) {
+		ctx.logger.warn(
+			`[computeAttachTaxRateIdPreview] stripeTaxRate missing on billing context for taxRateId=${billingContext.taxRateId}; returning incomplete`,
+		);
+		return {
+			total: 0,
+			amount_inclusive: 0,
+			amount_exclusive: 0,
+			currency,
+			status: "incomplete",
+		};
+	}
+
+	// Round through Stripe minor-units to match how Stripe rounds tax on
+	// the real invoice (per-line rounding to the nearest cent).
+	const subtotalMinorUnits = atmnToStripeAmount({
+		amount: netSubtotal,
+		currency,
+	});
+
+	const taxMinorUnits = taxRate.inclusive
+		? Math.round(
+				(subtotalMinorUnits * taxRate.percentage) / (100 + taxRate.percentage),
+			)
+		: Math.round((subtotalMinorUnits * taxRate.percentage) / 100);
+
+	const taxAmount = stripeToAtmnAmount({ amount: taxMinorUnits, currency });
+
+	// For an inclusive rate the line amount already contains the tax, so
+	// Stripe charges only the line amount. `total` drives
+	// applyPreviewAdjustmentsToTotal and must stay 0 here to avoid inflating
+	// preview.total. `amount_inclusive` still reports the notional split.
+	return {
+		total: taxRate.inclusive ? 0 : taxAmount,
+		amount_inclusive: taxRate.inclusive ? taxAmount : 0,
+		amount_exclusive: taxRate.inclusive ? 0 : taxAmount,
+		currency,
+		status: "complete",
+	};
+};

--- a/server/tests/integration/billing/tax/attach-tax-rates/preview-attach-tax-rate-id.test.ts
+++ b/server/tests/integration/billing/tax/attach-tax-rates/preview-attach-tax-rate-id.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Preview attach with explicit `tax_rate_id`: the preview response must
+ * populate `tax` and reflect the rate in `total`, mirroring how
+ * `automatic-tax-preview-attach-immediate.test.ts` validates the
+ * `automatic_tax` branch.
+ *
+ * Three cases:
+ *  - exclusive 10% rate → preview.tax.amount_exclusive > 0,
+ *    preview.total = subtotal + tax.total
+ *  - inclusive 10% rate → preview.tax.amount_inclusive > 0,
+ *    preview.total = subtotal (tax does not inflate the charge)
+ *  - no tax_rate_id, automatic_tax off → preview.tax === undefined
+ *    (regression guard for the existing branch)
+ */
+
+import { expect, test } from "bun:test";
+import type { AttachPreviewResponse } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("preview-attach-tax-rate-id (exclusive 10%): preview returns tax.status=complete and inflates total")}`,
+	async () => {
+		const customerId = "preview-tax-rate-exclusive";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "Test Tax Exclusive",
+			percentage: 10,
+			inclusive: false,
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: proProd.id,
+			tax_rate_id: taxRate.id,
+		})) as AttachPreviewResponse;
+
+		expect(preview.tax).toBeDefined();
+		expect(preview.tax?.status).toBe("complete");
+		expect(preview.tax?.currency).toBe(preview.currency);
+		expect(preview.tax?.amount_exclusive).toBeGreaterThan(0);
+		expect(preview.tax?.amount_inclusive).toBe(0);
+		expect(preview.tax?.total).toBeCloseTo(preview.subtotal * 0.1, 2);
+
+		expect(preview.total).toBeCloseTo(
+			preview.subtotal + (preview.tax?.total ?? 0),
+			2,
+		);
+		expect(preview.total).toBeGreaterThan(preview.subtotal);
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-attach-tax-rate-id (inclusive 10%): preview reports amount_inclusive but keeps total === subtotal")}`,
+	async () => {
+		const customerId = "preview-tax-rate-inclusive";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "Test Tax Inclusive",
+			percentage: 10,
+			inclusive: true,
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: proProd.id,
+			tax_rate_id: taxRate.id,
+		})) as AttachPreviewResponse;
+
+		expect(preview.tax).toBeDefined();
+		expect(preview.tax?.status).toBe("complete");
+		expect(preview.tax?.currency).toBe(preview.currency);
+		expect(preview.tax?.amount_inclusive).toBeGreaterThan(0);
+		expect(preview.tax?.amount_exclusive).toBe(0);
+		expect(preview.tax?.amount_inclusive).toBeCloseTo(
+			preview.subtotal * (10 / 110),
+			2,
+		);
+
+		expect(preview.tax?.total).toBe(0);
+		expect(preview.total).toBeCloseTo(preview.subtotal, 2);
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-attach-tax-rate-id (no tax_rate_id, auto_tax off): preview omits tax field")}`,
+	async () => {
+		const customerId = "preview-tax-rate-omitted";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: proProd.id,
+		})) as AttachPreviewResponse;
+
+		expect(preview.tax).toBeUndefined();
+	},
+	300_000,
+);

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -68,6 +68,7 @@ export interface BillingContext {
 	stripeSubscription?: Stripe.Subscription;
 	stripeSubscriptionSchedule?: Stripe.SubscriptionSchedule;
 	stripeDiscounts?: StripeDiscountWithCoupon[];
+	stripeTaxRate?: Stripe.TaxRate;
 	paymentMethod?: Stripe.PaymentMethod;
 
 	// Unforunately, need to add custom prices, custom entitlements and free trial here, because it's determined in the setup step.

--- a/shared/models/billingModels/context/billingContextOverride.ts
+++ b/shared/models/billingModels/context/billingContextOverride.ts
@@ -19,6 +19,7 @@ export interface StripeBillingContextOverride {
 	paymentMethod?: Stripe.PaymentMethod;
 	testClockFrozenTime?: number;
 	stripeDiscounts: StripeDiscountWithCoupon[];
+	stripeTaxRate?: Stripe.TaxRate;
 }
 
 export interface BillingContextOverride {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes attach preview to honor an explicit Stripe `tax_rate_id`. The preview now shows correct tax and totals for both inclusive and exclusive rates, matching live billing behavior.

- **Bug Fixes**
  - Respect `tax_rate_id` in attach preview; it overrides `automatic_tax` like Stripe does.
  - Fetch `Stripe.TaxRate` during preview setup (gated by `fetchTaxRate`) and pass it via `billingContext.stripeTaxRate`.
  - Add `computeAttachTaxRateIdPreview` to compute tax locally with Stripe-style rounding, inclusive/exclusive handling, and safe fallbacks (skips for `stripe_checkout`, no immediate lines, or returns `incomplete` if the rate is missing).
  - Update the preview orchestrator to branch: use tax-rate-id path when present, else fallback to `automatic_tax`.
  - Add integration tests for exclusive 10%, inclusive 10%, and no `tax_rate_id` cases.

<sup>Written for commit 1e37dd16906b48617b8f2b2900d710fb76608ff3. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1728?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the preview response for attach requests that pass an explicit `tax_rate_id` — previously the preview omitted or produced an incorrect `tax` field because the Stripe `TaxRate` object was never fetched during the preview path.

- **[Bug fixes]** `setupAttachBillingContext` now passes `fetchTaxRate: preview` to `setupStripeBillingContext`, which fetches the Stripe `TaxRate` once at setup time and stores it on `BillingContext.stripeTaxRate`. The new `computeAttachTaxRateIdPreview` helper uses that pre-fetched rate to compute inclusive/exclusive tax math without an extra Stripe round-trip.
- **[Improvements]** `computeAttachPreviewBillingPlan` branches on `billingContext.taxRateId` to select between the new `tax_rate_id` path and the existing `automatic_tax` path, mirroring how Stripe itself prioritises explicit rates over automatic tax.
- **[Improvements]** `stripeTaxRate` is also wired into `setupImmediateMultiProductBillingContext` and `setupUpdateSubscriptionBillingContext` for future use, though `fetchTaxRate` is not yet passed in those callers.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the core attach preview fix is correct and well-tested; the two suggestion comments are latent wiring gaps that don't affect current behaviour.

The attach preview path is correctly fixed end-to-end: the TaxRate is fetched only during preview, the inclusive/exclusive math is sound, and three integration test cases cover the happy paths and the regression guard. The only gaps are in setupImmediateMultiProductBillingContext and setupUpdateSubscriptionBillingContext, where stripeTaxRate is threaded through but fetchTaxRate is never set, so those contexts will always carry an undefined rate.

server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts and server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts — both wire stripeTaxRate without passing fetchTaxRate: preview.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts | New helper computing inclusive/exclusive tax math for explicit tax_rate_id previews; logic and rounding are correct. |
| server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts | Correctly adds fetchTaxRate: preview to the setupStripeBillingContext call; stripeTaxRate is properly threaded through. |
| server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts | stripeTaxRate wired into the return context but fetchTaxRate: preview never passed; field will always be undefined. |
| server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts | Same pattern — stripeTaxRate returned but never fetched; safe today, incomplete wiring for future use. |
| server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts | Adds stripeTaxRate async task inside the all() block, guarded by fetchTaxRate flag. |
| server/src/internal/billing/v2/providers/stripe/setup/fetchStripeTaxRateForBilling.ts | New helper wrapping stripeCli.taxRates.retrieve; short-circuits on undefined input. |
| shared/models/billingModels/context/billingContext.ts | Adds optional stripeTaxRate field to BillingContext alongside the existing taxRateId string. |
| shared/models/billingModels/context/billingContextOverride.ts | Adds optional stripeTaxRate to StripeBillingContextOverride, consistent with BillingContext. |
| server/tests/integration/billing/tax/attach-tax-rates/preview-attach-tax-rate-id.test.ts | Good coverage for exclusive rate, inclusive rate, and the no-tax regression guard. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant setupAttachBillingContext
    participant setupStripeBillingContext
    participant fetchStripeTaxRateForBilling
    participant computeAttachPreviewBillingPlan
    participant computeAttachTaxRateIdPreview
    participant computeAttachTaxPreview

    Client->>setupAttachBillingContext: "preview=true, tax_rate_id"
    setupAttachBillingContext->>setupStripeBillingContext: "fetchTaxRate=true"
    setupStripeBillingContext->>fetchStripeTaxRateForBilling: taxRateId
    fetchStripeTaxRateForBilling-->>setupStripeBillingContext: Stripe.TaxRate
    setupStripeBillingContext-->>setupAttachBillingContext: stripeTaxRate
    setupAttachBillingContext-->>computeAttachPreviewBillingPlan: billingContext

    alt billingContext.taxRateId is set
        computeAttachPreviewBillingPlan->>computeAttachTaxRateIdPreview: pure math on stripeTaxRate
        computeAttachTaxRateIdPreview-->>computeAttachPreviewBillingPlan: PreviewTax
    else no taxRateId
        computeAttachPreviewBillingPlan->>computeAttachTaxPreview: Stripe Tax API call
        computeAttachTaxPreview-->>computeAttachPreviewBillingPlan: PreviewTax
    end

    computeAttachPreviewBillingPlan-->>Client: PreviewBillingPlan
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts`, line 178-186 ([link](https://github.com/useautumn/autumn/blob/1e37dd16906b48617b8f2b2900d710fb76608ff3/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts#L178-L186)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`stripeTaxRate` is wired in but never fetched.** `fetchTaxRate` is not passed to `setupStripeBillingContext` here, so `stripeTaxRate` will always be `undefined`. Today this is harmless because `MultiAttachParamsV0` has no `tax_rate_id` field, but if that changes the preview will silently return `{ status: "incomplete" }` instead of computing the actual tax. `setupAttachBillingContext` handles this correctly with `fetchTaxRate: preview`; the same pattern should be applied here for consistency.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
   Line: 178-186

   Comment:
   **`stripeTaxRate` is wired in but never fetched.** `fetchTaxRate` is not passed to `setupStripeBillingContext` here, so `stripeTaxRate` will always be `undefined`. Today this is harmless because `MultiAttachParamsV0` has no `tax_rate_id` field, but if that changes the preview will silently return `{ status: "incomplete" }` instead of computing the actual tax. `setupAttachBillingContext` handles this correctly with `fetchTaxRate: preview`; the same pattern should be applied here for consistency.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts`, line 103-113 ([link](https://github.com/useautumn/autumn/blob/1e37dd16906b48617b8f2b2900d710fb76608ff3/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts#L103-L113)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Same incomplete wiring as `setupImmediateMultiProductBillingContext`.** `stripeTaxRate` is destructured and returned, but `fetchTaxRate` is not passed so it will always be `undefined`. The fix is a single line, mirroring `setupAttachBillingContext`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
   Line: 103-113

   Comment:
   **Same incomplete wiring as `setupImmediateMultiProductBillingContext`.** `stripeTaxRate` is destructured and returned, but `fetchTaxRate` is not passed so it will always be `undefined`. The fix is a single line, mirroring `setupAttachBillingContext`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts:178-186
**`stripeTaxRate` is wired in but never fetched.** `fetchTaxRate` is not passed to `setupStripeBillingContext` here, so `stripeTaxRate` will always be `undefined`. Today this is harmless because `MultiAttachParamsV0` has no `tax_rate_id` field, but if that changes the preview will silently return `{ status: "incomplete" }` instead of computing the actual tax. `setupAttachBillingContext` handles this correctly with `fetchTaxRate: preview`; the same pattern should be applied here for consistency.

```suggestion
	} = await setupStripeBillingContext({
		ctx,
		fullCustomer,
		targetCustomerProduct: undefined,
		params,
		skipSubscriptionFetching: fullProducts.every(isOneOffProduct),
		newBillingSubscription: params.new_billing_subscription || undefined,
		createStripeCustomerIfMissing: !preview,
		fetchTaxRate: preview,
	});
```

### Issue 2 of 2
server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts:103-113
**Same incomplete wiring as `setupImmediateMultiProductBillingContext`.** `stripeTaxRate` is destructured and returned, but `fetchTaxRate` is not passed so it will always be `undefined`. The fix is a single line, mirroring `setupAttachBillingContext`.

```suggestion
	} = await setupStripeBillingContext({
		ctx,
		fullCustomer,
		targetCustomerProduct: customerProduct,
		contextOverride,
		params,
		skipBillingFetching,
		product: fullProduct,
		skipSubscriptionFetching: isUpdatingFreeCustomerProduct,
		createStripeCustomerIfMissing: !preview,
		fetchTaxRate: preview,
	});
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: tax id preview"](https://github.com/useautumn/autumn/commit/1e37dd16906b48617b8f2b2900d710fb76608ff3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34161358)</sub>

<!-- /greptile_comment -->