### PR TITLE
fix: revenuecat

### DIFF
--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -69,6 +69,8 @@ export const resolveRevenuecatResources = async ({
 			: CusService.getFull({
 					ctx,
 					idOrInternalId: customerId,
+					withEntities: true,
+					withSubs: true,
 				}),
 	]);
 

--- a/server/tests/_temp/revenuecat-expiration-no-entities.test.ts
+++ b/server/tests/_temp/revenuecat-expiration-no-entities.test.ts
@@ -1,0 +1,131 @@
+/**
+ * TDD test for RevenueCat EXPIRATION crash when free-default activation runs.
+ *
+ * Red-failure mode (current behavior):
+ *  - resolveRevenuecatResources fetches customer without `withEntities: true`,
+ *    so `fullCustomer.entities` is `undefined`. EXPIRATION → expireAndActivateDefault
+ *    → activateFreeDefaultProduct → initFullCustomerProductFromProduct →
+ *    applyExistingStatesToCustomerProduct passes `entities: undefined` to
+ *    mergeEntitiesWithExistingUsages, where `for (const entity of entities)`
+ *    throws: "undefined is not an object (evaluating 'entities')".
+ *  - The DB status=Expired write succeeded before the crash, so the customer ends
+ *    up with the pro product expired AND no free default attached (no plan).
+ *
+ * Green-success criteria (after fix):
+ *  - EXPIRATION webhook completes successfully (200).
+ *  - Pro product is removed from active set.
+ *  - Free default product is attached as active.
+ *
+ * Real-world repro: customer JfB02xZKR79Qim8SVPbqSQErX433basl in org `runable`.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import {
+	expectWebhookSuccess,
+	RevenueCatWebhookClient,
+} from "@tests/integration/external-psps/revenuecat/utils/revenue-cat-webhook-client.js";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import chalk from "chalk";
+import { RCMappingService } from "@/external/revenueCat/misc/RCMappingService";
+import { OrgService } from "@/internal/orgs/OrgService";
+import { encryptData } from "@/utils/encryptUtils";
+
+const RC_WEBHOOK_SECRET = "test_rc_webhook_secret_no_entities";
+
+beforeAll(async () => {
+	if (
+		ctx.org.processor_configs?.revenuecat?.sandbox_webhook_secret !==
+		RC_WEBHOOK_SECRET
+	) {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				processor_configs: {
+					...ctx.org.processor_configs,
+					revenuecat: {
+						api_key: encryptData("mock_rc_api_key_live"),
+						sandbox_api_key: encryptData("mock_rc_api_key_sandbox"),
+						project_id: "mock_project_live",
+						sandbox_project_id: "mock_project_sandbox",
+						webhook_secret: RC_WEBHOOK_SECRET,
+						sandbox_webhook_secret: RC_WEBHOOK_SECRET,
+					},
+				},
+			},
+		});
+	}
+});
+
+afterAll(async () => {});
+
+test(
+	`${chalk.yellowBright("rc-webhook: expiration with free-default activates default without crashing on undefined entities")}`,
+	async () => {
+		const customerId = "rc-webhook-expire-no-entities";
+		const RC_PRO_MONTHLY_ID = "com.app.rcwh_no_entities_pro_monthly";
+
+		const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+		const freeDefault = products.base({
+			id: "free-default-no-entities",
+			items: [items.monthlyMessages({ includedUsage: 10 })],
+			isDefault: true,
+		});
+		const proMonthly = products.pro({
+			id: "pro-monthly-no-entities",
+			items: [messagesItem],
+		});
+
+		await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, skipWebhooks: true }),
+				s.products({ list: [freeDefault, proMonthly] }),
+			],
+			actions: [],
+		});
+
+		await RCMappingService.upsert({
+			db: ctx.db,
+			data: {
+				org_id: ctx.org.id,
+				env: AppEnv.Sandbox,
+				autumn_product_id: proMonthly.id,
+				revenuecat_product_ids: [RC_PRO_MONTHLY_ID],
+			},
+		});
+
+		const rcClient = new RevenueCatWebhookClient({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			webhookSecret: RC_WEBHOOK_SECRET,
+		});
+
+		const initialResult = await rcClient.initialPurchase({
+			productId: RC_PRO_MONTHLY_ID,
+			appUserId: customerId,
+			originalTransactionId: "rcwh_no_entities_tx_001",
+		});
+		expectWebhookSuccess(initialResult);
+
+		// Then: expiration. Without the fix this returns 500 and never attaches the default.
+		const expireResult = await rcClient.expiration({
+			productId: RC_PRO_MONTHLY_ID,
+			appUserId: customerId,
+			originalTransactionId: "rcwh_no_entities_tx_001",
+		});
+		expectWebhookSuccess(expireResult);
+
+		await expectCustomerProducts({
+			customerId,
+			active: [freeDefault.id],
+			notPresent: [proMonthly.id],
+		});
+	},
+	30_000,
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a crash in the RevenueCat expiration webhook by fetching full customer data with entities and subscriptions. Expiration now cleanly removes the paid plan and activates the free default.

- **Bug Fixes**
  - In `resolveRevenuecatResources`, fetch customer with `withEntities: true` and `withSubs: true` to avoid undefined entities during free-default activation.
  - Added `server/tests/_temp/revenuecat-expiration-no-entities.test.ts` to verify the webhook returns 200 and attaches the free default after expiration.

<sup>Written for commit 847747bb269c8f682b8ea153a2ab6e4a9ffb4fb9. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1729?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash in the RevenueCat EXPIRATION webhook path where `fullCustomer.entities` was `undefined` because `CusService.getFull` was called without `withEntities: true`, causing `mergeEntitiesWithExistingUsages` to throw when trying to iterate over it. A regression test is included to document the failure scenario and verify the fix.

- **Bug fixes** — Adds `withEntities: true` and `withSubs: true` to the `CusService.getFull` call in `resolveRevenuecatResources`, ensuring entities and subscriptions are loaded before any expiration/default-activation logic runs.
- **Improvements** — Adds a `_temp` TDD test (`revenuecat-expiration-no-entities.test.ts`) that exercises the full EXPIRATION → free-default-activation flow and asserts the webhook returns 200 with the correct product state.
</details>

<h3>Confidence Score: 4/5</h3>

The change is a narrow, targeted fix — two additional fields on a single CusService.getFull call — with a dedicated regression test. Low risk of unintended side effects.

The fix itself is clear and correct: the missing withEntities/withSubs flags are now present for the standard (non-auto-create) path. The only open question is whether the autoCreateCustomer: true path could ever reach the same mergeEntitiesWithExistingUsages code with entities unloaded, but that handler's flow does not appear to trigger the default-activation branch. The test lives in _temp and has a trivial unused import.

The test in server/tests/_temp/revenuecat-expiration-no-entities.test.ts may benefit from being promoted to the main integration test suite once stabilised, so it runs automatically in CI.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/misc/resolveRevenuecatResources.ts | Adds withEntities: true and withSubs: true to the non-autoCreateCustomer CusService.getFull call, fixing a crash when EXPIRATION triggers free-default activation with undefined entities. |
| server/tests/_temp/revenuecat-expiration-no-entities.test.ts | New TDD regression test for the EXPIRATION crash; lives in the _temp directory and has an unused expect import. The test logic itself is sound. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RC as RevenueCat
    participant EH as handleRevenuecatExpiration
    participant RR as resolveRevenuecatResources
    participant CS as CusService.getFull
    participant EAD as expireAndActivateDefault

    RC->>EH: EXPIRATION webhook
    EH->>RR: resolveRevenuecatResources(customerId)
    RR->>CS: "getFull({ withEntities: true, withSubs: true })"
    Note over CS: Before fix: withEntities/withSubs omitted → entities: undefined
    CS-->>RR: "FullCustomer (with entities & subs)"
    RR-->>EH: "{ customer, product, cusProducts }"
    EH->>EAD: expireAndActivateDefault(customer)
    Note over EAD: activateFreeDefaultProduct →<br/>mergeEntitiesWithExistingUsages(entities)<br/>Before fix: crash on undefined
    EAD-->>EH: free default attached ✓
    EH-->>RC: 200 OK
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/_temp/revenuecat-expiration-no-entities.test.ts:22
`expect` is imported but never used in the test body — all assertions go through `expectWebhookSuccess` and `expectCustomerProducts`.

```suggestion
import { afterAll, beforeAll, test } from "bun:test";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: revenue cat entities not found"](https://github.com/useautumn/autumn/commit/847747bb269c8f682b8ea153a2ab6e4a9ffb4fb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34168293)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->