### PR TITLE
fix: exclude trial

### DIFF
--- a/server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts
+++ b/server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts
@@ -126,11 +126,12 @@ const processRedemption = async ({
 	}
 
 	if (
-		await isSubscriptionTrialing({
+		reward_program.exclude_trial &&
+		(await isSubscriptionTrialing({
 			stripeSubscriptionId,
 			stripeCli,
 			logger,
-		})
+		}))
 	) {
 		return;
 	}

--- a/server/tests/integration/billing/stripe-webhooks/checkout-session-completed/checkout-reward-trial.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/checkout-session-completed/checkout-reward-trial.test.ts
@@ -1,0 +1,80 @@
+/** Red: trial checkout left referral reward unapplied; green: exclude_trial=false applies at trial start. */
+
+import { expect, test } from "bun:test";
+import { completeStripeCheckoutFormV2 } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { referralPrograms } from "@tests/utils/fixtures/referralPrograms";
+import { rewards } from "@tests/utils/fixtures/rewards";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+const waitForRedemptionApplied = async ({
+	autumnV1,
+	redemptionId,
+}: {
+	autumnV1: Awaited<ReturnType<typeof initScenario>>["autumnV1"];
+	redemptionId: string;
+}) => {
+	for (let i = 0; i < 20; i++) {
+		const redemption = await autumnV1.redemptions.get(redemptionId);
+		if (redemption.triggered && redemption.applied) return redemption;
+		await timeout(1000);
+	}
+
+	return autumnV1.redemptions.get(redemptionId);
+};
+
+test.concurrent(`${chalk.yellowBright("checkout-reward-trial: exclude_trial=false applies reward on trial checkout")}`, async () => {
+	const referrerId = "checkout-reward-trial-referrer";
+	const redeemerId = "checkout-reward-trial-redeemer";
+
+	const proTrial = products.proWithTrial({
+		id: "pro-trial-reward",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+		trialDays: 7,
+		cardRequired: true,
+	});
+
+	const reward = rewards.halfOff();
+	const program = {
+		...referralPrograms.onCheckoutReferrer({
+			rewardId: reward.id,
+			productIds: [proTrial.id],
+			maxRedemptions: 1,
+		}),
+		exclude_trial: false,
+	};
+
+	const { autumnV1, redemption } = await initScenario({
+		customerId: referrerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.otherCustomers([{ id: redeemerId }]),
+			s.products({ list: [proTrial] }),
+			s.referralProgram({ reward, program }),
+		],
+		actions: [
+			s.attach({ productId: "pro-trial-reward" }),
+			s.referral.createAndRedeem({ customerId: redeemerId }),
+		],
+	});
+
+	const result = await autumnV1.billing.attach({
+		customer_id: redeemerId,
+		product_id: proTrial.id,
+	});
+
+	expect(result.payment_url).toBeDefined();
+	expect(result.payment_url).toContain("checkout.stripe.com");
+
+	await completeStripeCheckoutFormV2({ url: result.payment_url! });
+
+	const updatedRedemption = await waitForRedemptionApplied({
+		autumnV1,
+		redemptionId: redemption!.id,
+	});
+	expect(updatedRedemption.triggered).toBe(true);
+	expect(updatedRedemption.applied).toBe(true);
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes checkout reward logic to respect the referral program’s `exclude_trial` flag. Rewards are skipped during trials only when `exclude_trial` is true; otherwise they apply on trial checkout.

- **Bug Fixes**
  - Gate the trialing-subscription check behind `reward_program.exclude_trial` in `server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts`.
  - Add integration test `server/tests/integration/billing/stripe-webhooks/checkout-session-completed/checkout-reward-trial.test.ts` to ensure rewards apply on trial checkout when `exclude_trial=false`.

<sup>Written for commit c383dd2971b83fba336d54b83d01571543cd47bf. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1730?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where checkout rewards were always skipped for trialing subscriptions, regardless of the `exclude_trial` setting on the reward program. The fix gates the trial-exclusion check behind `reward_program.exclude_trial`, so rewards are only suppressed during trials when the program explicitly opts in.

- **[Bug fixes]** `grantCheckoutReward.ts`: wraps `isSubscriptionTrialing(...)` in a short-circuit check on `reward_program.exclude_trial`, fixing the regression where `exclude_trial=false` programs never granted rewards to trial subscribers.
- **[Improvements]** New integration test `checkout-reward-trial.test.ts` covers the `exclude_trial=false` path end-to-end using a Stripe test clock and a real checkout flow.
</details>

<h3>Confidence Score: 4/5</h3>

The core logic change is a minimal, correct fix. The new test validates the fixed path but leaves the exclude_trial=true path untested.

The main fix is a one-line short-circuit guard that correctly makes trial exclusion opt-in. The integration test covers the exclude_trial=false case that was broken, but there is no test confirming that exclude_trial=true still suppresses rewards during trials. A future refactor touching this branch would have no test catching a regression on the true-path.

The test file would benefit from a complementary case for exclude_trial=true.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.ts | Guards trial exclusion behind reward_program.exclude_trial flag; previously all trialing subscriptions were skipped unconditionally. |
| server/tests/integration/billing/stripe-webhooks/checkout-session-completed/checkout-reward-trial.test.ts | New integration test verifying exclude_trial=false grants reward on trial checkout; only covers the false-path, no complementary test for exclude_trial=true. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[checkout-session.completed webhook] --> B[grantCheckoutReward]
    B --> C{Customer found?}
    C -- No --> D[skip]
    C -- Yes --> E[load untriggered redemptions]
    E --> F{For each redemption}
    F --> G{trigger event == Checkout?}
    G -- No --> D
    G -- Yes --> H{Product eligible?}
    H -- No --> D
    H -- Yes --> I{reward_program.exclude_trial?}
    I -- false/null --> K{Max redemptions reached?}
    I -- true --> J{isSubscriptionTrialing?}
    J -- No --> K
    J -- Yes --> D
    K -- Yes --> D
    K -- No --> L[applyReward]
    L --> M{RewardCategory}
    M -- FreeProduct --> N[triggerFreeProduct]
    M -- Other --> O[triggerDiscount]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/billing/stripe-webhooks/checkout-session-completed/checkout-reward-trial.test.ts:28-80
**Missing complementary test for `exclude_trial=true`**

The test suite only exercises the `exclude_trial: false` path (reward should be applied). The symmetric case — `exclude_trial: true` on a trialing subscription should *not* apply the reward — is unverified. Without it, a regression that accidentally ignores the flag and always grants rewards would still pass the test suite.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/exclude-tri..."](https://github.com/useautumn/autumn/commit/793813797f272b3a04aa454f8e4d7d2cd990773e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34178424)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->