### PR TITLE
fix: void uncollectible invoices

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionDeleted/tasks/voidInvoicesForSubscriptionDeleted.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionDeleted/tasks/voidInvoicesForSubscriptionDeleted.ts
@@ -1,12 +1,6 @@
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import type { StripeSubscriptionDeletedContext } from "../setupStripeSubscriptionDeletedContext";
 
-/**
- * Voids invoices for a subscription that was deleted.
- *
- * When a subscription is deleted, it leaves unpaid invoices in an 'open' state.
- * We need to void these invoices to prevent customers from being charged for usage they won't receive.
- */
 export const voidInvoicesForSubscriptionDeleted = async ({
 	ctx,
 	eventContext,
@@ -28,14 +22,15 @@ export const voidInvoicesForSubscriptionDeleted = async ({
 			subscription: stripeSubscription.id,
 		});
 
-		const openInvoices = invoices.data.filter(
-			(invoice) => invoice.status === "open",
+		const voidableInvoices = invoices.data.filter(
+			(invoice) =>
+				invoice.status === "open" || invoice.status === "uncollectible",
 		);
 
 		await Promise.allSettled(
-			openInvoices.map(async (invoice) => {
+			voidableInvoices.map(async (invoice) => {
 				await stripeCli.invoices.voidInvoice(invoice.id);
-				logger.info(`[sub.deleted] Voided open invoice ${invoice.id}`);
+				logger.info(`[sub.deleted] Voided invoice ${invoice.id}`);
 			}),
 		);
 	} catch (error) {

--- a/server/tests/integration/billing/stripe-webhooks/subscription-deleted/subscription-deleted-void-invoices.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-deleted/subscription-deleted-void-invoices.test.ts
@@ -359,7 +359,144 @@ test(`${chalk.yellowBright("sub.deleted: open invoices NOT voided when config di
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// TEST 7: Only open invoices are voided (paid invoices unchanged)
+// TEST 7: Uncollectible invoices are voided
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("sub.deleted: uncollectible invoices are voided on subscription cancel")}`, async () => {
+	const customerId = "sub-deleted-void-uncollectible";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+
+	const pro = products.pro({
+		id: "pro",
+		items: [messagesItem],
+	});
+
+	const { ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const originalOrgConfig = ctx.org.config;
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: {
+				...ctx.org.config,
+				void_invoices_on_subscription_deletion: true,
+			},
+		},
+	});
+
+	try {
+		const autumnV1 = new AutumnInt({
+			version: ApiVersion.V1_2,
+			secretKey: ctx.orgSecretKey,
+		});
+
+		const customerAfterAttach =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({
+			customer: customerAfterAttach,
+			productId: pro.id,
+		});
+
+		const subscriptionId = await getSubscriptionId({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+
+		const customer = await CusService.get({
+			db: ctx.db,
+			idOrInternalId: customerId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+
+		await attachFailedPaymentMethod({
+			stripeCli: ctx.stripeCli,
+			customer: customer!,
+		});
+
+		const paymentMethods = await ctx.stripeCli.paymentMethods.list({
+			customer: customer!.processor?.id,
+		});
+		const failingPaymentMethod = paymentMethods.data[0];
+
+		await ctx.stripeCli.subscriptions.update(subscriptionId, {
+			default_payment_method: failingPaymentMethod.id,
+		});
+
+		await advanceToNextInvoice({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+		});
+
+		await timeout(4000);
+
+		const invoicesBeforeCancel = await ctx.stripeCli.invoices.list({
+			customer: customer!.processor?.id,
+			subscription: subscriptionId,
+		});
+		const openInvoiceBeforeCancel = invoicesBeforeCancel.data.find(
+			(inv) => inv.status === "open",
+		);
+		expect(openInvoiceBeforeCancel).toBeDefined();
+
+		const uncollectibleInvoice = await ctx.stripeCli.invoices.markUncollectible(
+			openInvoiceBeforeCancel!.id,
+		);
+		expect(uncollectibleInvoice.status).toBe("uncollectible");
+
+		await ctx.stripeCli.subscriptions.cancel(subscriptionId);
+
+		await timeout(8000);
+
+		const invoiceAfterCancel = await ctx.stripeCli.invoices.retrieve(
+			uncollectibleInvoice.id,
+		);
+		expect(invoiceAfterCancel.status).toBe("void");
+
+		const customerAfterCancel =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		await expectCustomerProducts({
+			customer: customerAfterCancel,
+			notPresent: [pro.id],
+			active: [free.id],
+		});
+
+		await expectNoStripeSubscription({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+	} finally {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: {
+				config: originalOrgConfig,
+			},
+		});
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 8: Only voidable invoices are voided (paid invoices unchanged)
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
@@ -376,9 +513,9 @@ test(`${chalk.yellowBright("sub.deleted: open invoices NOT voided when config di
  * - Paid invoice remains paid (unchanged)
  * - Exactly 1 voided invoice, exactly 1 paid invoice, 0 open invoices
  *
- * This verifies the feature only voids 'open' invoices, not all invoices.
+ * This verifies the feature only voids voidable invoice statuses, not all invoices.
  */
-test(`${chalk.yellowBright("sub.deleted: only open invoices voided, paid invoices unchanged")}`, async () => {
+test(`${chalk.yellowBright("sub.deleted: only voidable invoices voided, paid invoices unchanged")}`, async () => {
 	const customerId = "sub-deleted-void-multiple";
 
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });

--- a/server/tests/unit/webhooks/subscription-deleted/void-invoices-for-subscription-deleted.spec.ts
+++ b/server/tests/unit/webhooks/subscription-deleted/void-invoices-for-subscription-deleted.spec.ts
@@ -106,7 +106,7 @@ describe(chalk.yellowBright("voidInvoicesForSubscriptionDeleted"), () => {
 	});
 
 	describe(chalk.cyan("Voiding invoices"), () => {
-		test("voids only open invoices, skipping paid/draft/void statuses", async () => {
+		test("voids open and uncollectible invoices, skipping paid/draft/void statuses", async () => {
 			const mockCli = stripeClients.createMockStripeClient({
 				invoices: {
 					listResult: {
@@ -114,6 +114,10 @@ describe(chalk.yellowBright("voidInvoicesForSubscriptionDeleted"), () => {
 							stripeClients.createMockInvoice({
 								id: "inv_open",
 								status: "open",
+							}),
+							stripeClients.createMockInvoice({
+								id: "inv_uncollectible",
+								status: "uncollectible",
 							}),
 							stripeClients.createMockInvoice({
 								id: "inv_paid",
@@ -143,8 +147,9 @@ describe(chalk.yellowBright("voidInvoicesForSubscriptionDeleted"), () => {
 			});
 
 			expect(mockCli._calls.invoices.list).toHaveLength(1);
-			expect(mockCli._calls.invoices.voidInvoice).toHaveLength(1);
-			expect(mockCli._calls.invoices.voidInvoice[0]).toBe("inv_open");
+			expect(mockCli._calls.invoices.voidInvoice).toHaveLength(2);
+			expect(mockCli._calls.invoices.voidInvoice).toContain("inv_open");
+			expect(mockCli._calls.invoices.voidInvoice).toContain("inv_uncollectible");
 		});
 
 		test("voids multiple open invoices", async () => {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Void uncollectible invoices when a subscription is deleted, not just open invoices. This prevents lingering balances and accidental post-cancel charges.

- **Bug Fixes**
  - Treat `uncollectible` invoices as voidable in the subscription-deleted flow; still skip paid/draft/void.
  - Simplified log message to "Voided invoice".
  - Added tests for uncollectible cases and status filtering; respects `void_invoices_on_subscription_deletion` config.

<sup>Written for commit 81b35a11eb37311c4c9c20d35917a521b55afab9. Summary will update on new commits. <a href="https://cubic.dev/pr/useautumn/autumn/pull/1732?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the subscription-deletion invoice voiding logic to also cover `uncollectible` invoices, not just `open` ones. Both unit and integration tests are updated to cover the new case.

- **[Bug fixes]** `voidInvoicesForSubscriptionDeleted` now filters for `open || uncollectible` invoice statuses instead of only `open`, preventing uncollectible invoices from being left behind when a subscription is deleted.
- **[Improvements]** Variable renamed from `openInvoices` to `voidableInvoices` and log message updated to reflect the broader scope of the operation.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, correct expansion of the voiding filter backed by both unit and integration tests.

The change is a single-line filter addition (`|| invoice.status === "uncollectible"`) with a matching rename and log update. Stripe's API allows voiding both `open` and `uncollectible` invoices, so the new branch is valid. The new integration test drives the full cancel-with-uncollectible-invoice flow end-to-end, and the unit test confirms the filter excludes all other statuses. No regressions to pre-existing behaviour are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionDeleted/tasks/voidInvoicesForSubscriptionDeleted.ts | Extends voidable invoice filter to include `uncollectible` status in addition to `open`; variable renamed accordingly and log message updated |
| server/tests/unit/webhooks/subscription-deleted/void-invoices-for-subscription-deleted.spec.ts | Unit test updated to add `uncollectible` invoice to the mock list and assert that both `inv_open` and `inv_uncollectible` are voided |
| server/tests/integration/billing/stripe-webhooks/subscription-deleted/subscription-deleted-void-invoices.test.ts | New integration test (TEST 7) added to verify uncollectible invoices are voided on subscription cancellation; existing TEST 7 renamed to TEST 8 with updated descriptions |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sub.deleted webhook received] --> B{void_invoices_on_subscription_deletion?}
    B -- false/undefined --> C[Return early]
    B -- true --> D[List invoices for customer + subscription]
    D --> E{Filter invoices}
    E -->|status = open| F[voidableInvoices]
    E -->|status = uncollectible| F
    E -->|status = paid / draft / void| G[Skip]
    F --> H[Promise.allSettled: voidInvoice for each]
    H --> I[Log: Voided invoice]
    H -- any failure --> J[Silently settled via allSettled]
    D -- list error --> K[Warn and return]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/void-uncoll..."](https://github.com/useautumn/autumn/commit/0bda953a4c920e20ab0b57903899710d2b173f01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34227649)</sub>

<!-- /greptile_comment -->