### PR TITLE
chore: proxy mcp from main server

### DIFF
--- a/apps/mcp-server/Dockerfile
+++ b/apps/mcp-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM oven/bun:1.3.10 AS pruner
+WORKDIR /app
+
+COPY . .
+RUN bunx turbo@2.9.14 prune @autumn/mcp-server --docker
+
+FROM oven/bun:1.3.10
+WORKDIR /app
+
+COPY --from=pruner /app/out/json/ .
+RUN mkdir -p scripts && touch scripts/preload-env.ts
+RUN bun -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); pkg.workspaces.packages = ["shared", "apps/mcp-server", "packages/ksuid", "packages/mcp"]; delete pkg.dependencies; delete pkg.devDependencies; delete pkg.scripts; fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));'
+RUN rm bun.lock && bun install --production --ignore-scripts
+
+COPY --from=pruner /app/out/full/ .
+
+ENV NODE_ENV=production
+EXPOSE 8080
+
+CMD ["bun", "-F", "@autumn/mcp-server", "start"]

--- a/packages/mcp/src/mcp-server/oauth.ts
+++ b/packages/mcp/src/mcp-server/oauth.ts
@@ -69,12 +69,18 @@ export function getResourceUrl(
 	_flags: MCPOAuthFlags,
 	resourcePath = "/mcp",
 ): string {
-	const host = headers.get("x-forwarded-host") ?? headers.get("host");
+	const host =
+		headers.get("x-autumn-forwarded-host") ??
+		headers.get("x-forwarded-host") ??
+		headers.get("host");
 	if (!host) {
 		throw new OAuthHttpError(400, "Missing Host header", "invalid_request");
 	}
 
-	const proto = headers.get("x-forwarded-proto") ?? "http";
+	const proto =
+		headers.get("x-autumn-forwarded-proto") ??
+		headers.get("x-forwarded-proto") ??
+		"http";
 	return new URL(resourcePath, `${proto}://${host}`).href;
 }
 

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -22,6 +22,7 @@ import { cliRouter } from "./internal/dev/cli/cliRouter.js";
 import { handleOAuthCallback } from "./internal/orgs/handlers/stripeHandlers/handleOAuthCallback.js";
 import { apiRouter } from "./routers/apiRouter.js";
 import { internalRouter } from "./routers/internalRouter.js";
+import { mcpProxyRouter } from "./routers/mcpProxyRouter.js";
 import { publicRouter } from "./routers/publicRouter.js";
 import { auth } from "./utils/auth.js";
 import { isAllowedOrigin } from "./utils/corsOrigins.js";
@@ -87,6 +88,8 @@ export const createHonoApp = () => {
 	app.get("/stripe/oauth_callback", handleOAuthCallback);
 	app.get("/ready/:token", handleReadyCheck);
 	app.get("/", handleHealthCheck);
+
+	app.route("", mcpProxyRouter);
 
 	// Step 1: OTel HTTP span + base middleware + span enrichment
 	app.use(

--- a/server/src/routers/mcpProxyRouter.ts
+++ b/server/src/routers/mcpProxyRouter.ts
@@ -41,6 +41,8 @@ const proxyMcp = async (c: Context<HonoEnv>) => {
 	for (const header of hopByHopHeaders) headers.delete(header);
 
 	headers.delete("host");
+	headers.set("x-autumn-forwarded-host", forwardedHost);
+	headers.set("x-autumn-forwarded-proto", forwardedProto);
 	headers.set("x-forwarded-host", forwardedHost);
 	headers.set("x-forwarded-proto", forwardedProto);
 

--- a/server/src/routers/mcpProxyRouter.ts
+++ b/server/src/routers/mcpProxyRouter.ts
@@ -1,0 +1,69 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { HonoEnv } from "../honoUtils/HonoEnv.js";
+
+const hopByHopHeaders = [
+	"connection",
+	"keep-alive",
+	"proxy-authenticate",
+	"proxy-authorization",
+	"te",
+	"trailer",
+	"transfer-encoding",
+	"upgrade",
+];
+
+const getMcpUpstream = () => {
+	const upstream = process.env.MCP_UPSTREAM_URL;
+	if (!upstream) return null;
+
+	try {
+		return new URL(upstream);
+	} catch {
+		return null;
+	}
+};
+
+const proxyMcp = async (c: Context<HonoEnv>) => {
+	const upstream = getMcpUpstream();
+	if (!upstream) {
+		return c.json({ error: "MCP upstream not configured" }, 503);
+	}
+
+	const incomingUrl = new URL(c.req.url);
+	const targetUrl = new URL(incomingUrl.pathname + incomingUrl.search, upstream);
+	const headers = new Headers(c.req.raw.headers);
+	const forwardedHost =
+		headers.get("x-forwarded-host") ?? headers.get("host") ?? incomingUrl.host;
+	const forwardedProto =
+		headers.get("x-forwarded-proto") ?? incomingUrl.protocol.replace(":", "");
+
+	for (const header of hopByHopHeaders) headers.delete(header);
+
+	headers.delete("host");
+	headers.set("x-forwarded-host", forwardedHost);
+	headers.set("x-forwarded-proto", forwardedProto);
+
+	const hasBody = c.req.method !== "GET" && c.req.method !== "HEAD";
+	const response = await fetch(targetUrl, {
+		method: c.req.method,
+		headers,
+		body: hasBody ? c.req.raw.body : undefined,
+		duplex: hasBody ? "half" : undefined,
+	} as RequestInit & { duplex?: "half" });
+
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: response.headers,
+	});
+};
+
+export const mcpProxyRouter = new Hono<HonoEnv>();
+
+mcpProxyRouter.all("/mcp", proxyMcp);
+mcpProxyRouter.all("/mcp/*", proxyMcp);
+mcpProxyRouter.all("/internal/mcp", proxyMcp);
+mcpProxyRouter.all("/internal/mcp/*", proxyMcp);
+mcpProxyRouter.all("/.well-known/oauth-protected-resource/mcp", proxyMcp);
+mcpProxyRouter.all("/.well-known/oauth-protected-resource/internal/mcp", proxyMcp);

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -65,12 +65,13 @@ const emulateGoogleUrl =
 // OAuth flow leaves and returns via a third-party host (emulate.dev), so the
 // state cookie must be SameSite=None+Secure to survive the round trip.
 const isHttpsBaseUrl = process.env.BETTER_AUTH_URL?.startsWith("https://");
-const defaultMcpResourceUrl = process.env.BETTER_AUTH_URL
-	? new URL("/mcp", process.env.BETTER_AUTH_URL).href
-	: null;
-const defaultInternalMcpResourceUrl = process.env.BETTER_AUTH_URL
-	? new URL("/internal/mcp", process.env.BETTER_AUTH_URL).href
-	: null;
+const hostedMcpResourceUrls =
+	process.env.MCP_UPSTREAM_URL && process.env.BETTER_AUTH_URL
+		? [
+				new URL("/mcp", process.env.BETTER_AUTH_URL).href,
+				new URL("/internal/mcp", process.env.BETTER_AUTH_URL).href,
+			]
+		: [];
 const parseMcpResourceUrl = (rawUrl: string) => {
 	const resourceUrl = rawUrl.trim();
 	if (!resourceUrl) return null;
@@ -256,8 +257,7 @@ const options = {
 			scopes: [...ALL_SCOPES],
 			validAudiences: [
 				process.env.BETTER_AUTH_URL,
-				defaultMcpResourceUrl,
-				defaultInternalMcpResourceUrl,
+				...hostedMcpResourceUrls,
 				...mcpResourceUrls,
 				...internalMcpResourceUrls,
 			].filter(Boolean) as string[],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MCP reverse proxy to the main server so `/mcp` endpoints are served under the same domain with unified auth. Ships a production Docker image for `@autumn/mcp-server` and adds proxy headers so OAuth builds correct resource URLs behind the proxy.

- **New Features**
  - Added `mcpProxyRouter` to forward `/mcp`, `/internal/mcp`, and related `.well-known` paths to `MCP_UPSTREAM_URL`.
  - Preserves streaming bodies, strips hop-by-hop headers, and sets `x-forwarded-*` plus `x-autumn-forwarded-host/proto`.
  - Updated MCP OAuth to prefer `x-autumn-forwarded-*` for resource URLs; valid audiences now include hosted MCP URLs when `MCP_UPSTREAM_URL` is set.

- **Migration**
  - Set `MCP_UPSTREAM_URL` in the main server environment.
  - Optionally deploy the new `@autumn/mcp-server` Docker image (port 8080).

<sup>Written for commit 999f9dcbe8e2ef0265aee6440353ff9223cac6e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1741?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a reverse proxy in the main Hono server that forwards `/mcp`, `/internal/mcp`, and their `/.well-known/oauth-protected-resource/…` counterparts to a configurable `MCP_UPSTREAM_URL`, eliminating the need to expose the MCP server directly. It also ships a Dockerfile for the MCP server and tightens the OAuth audience list so the hosted MCP URLs are only registered as valid audiences when the proxy is actually configured.

- **Improvements**: `mcpProxyRouter` mounts before the OTel/base middleware and correctly strips hop-by-hop headers from outgoing requests; CORS still applies since that middleware is registered earlier.
- **Improvements**: `auth.ts` cleans up two nullable variables into a single conditional array spread, making the valid-audience list slightly clearer.
- **API changes**: The Dockerfile for `@autumn/mcp-server` uses Turborepo pruning to produce a lean production image.
</details>

<h3>Confidence Score: 3/5</h3>

The proxy is functional when the upstream is reachable, but unhandled network failures route through the wrong error branch, producing misleading 500 responses and leaking the internal upstream URL into Sentry.

The proxy has no error boundary around the upstream fetch call. When MCP_UPSTREAM_URL is configured but the upstream is temporarily down, any MCP request throws an unhandled TypeError that bypasses normal request context and falls into the Sentry-capturing fallback of errorMiddleware. The auth.ts audience change is clean and intentional, and the Dockerfile is straightforward.

server/src/routers/mcpProxyRouter.ts needs a try/catch around the upstream fetch call

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/routers/mcpProxyRouter.ts | New MCP reverse-proxy router; `fetch()` has no try/catch so upstream network failures surface as 500 instead of 502/504, and the raw upstream URL is captured in Sentry |
| server/src/utils/auth.ts | Consolidates two nullable MCP resource URL vars into a single conditional array; valid audience list for `/mcp` and `/internal/mcp` is now only populated when `MCP_UPSTREAM_URL` is also set |
| server/src/initHono.ts | Mounts `mcpProxyRouter` before OTel/base middleware; CORS is applied correctly since that middleware is registered first |
| apps/mcp-server/Dockerfile | New multi-stage Dockerfile for the MCP server using Turborepo pruning and a production Bun image; looks correct |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant MainServer as Main Server (Hono)
    participant MCPProxy as mcpProxyRouter
    participant MCPUpstream as MCP Upstream (MCP_UPSTREAM_URL)

    Client->>MainServer: "ANY /mcp, /mcp/*, /internal/mcp/*, /.well-known/oauth-protected-resource/mcp"

    alt MCP_UPSTREAM_URL not set
        MainServer-->>Client: 503 error MCP upstream not configured
    else MCP_UPSTREAM_URL set
        MainServer->>MCPProxy: route matched before OTel/baseMiddleware
        Note over MCPProxy: Strip hop-by-hop headers, set x-forwarded-host / x-forwarded-proto
        MCPProxy->>MCPUpstream: "fetch(targetUrl, {method, headers, body})"
        alt Upstream reachable
            MCPUpstream-->>MCPProxy: response (status, headers, body)
            MCPProxy-->>Client: proxy response (streamed body)
        else Upstream unreachable (no try/catch)
            MCPProxy-->>MainServer: TypeError thrown
            MainServer-->>Client: 500 Internal Server Error via errorMiddleware fallback
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/routers/mcpProxyRouter.ts:48-59
**Unhandled upstream network errors produce 500 instead of 502/504**

The `fetch()` call throws a `TypeError` when the MCP upstream is unreachable (ECONNREFUSED, DNS failure, timeout). Because `mcpProxyRouter` is mounted _before_ `baseMiddleware`, the Hono `ctx` is never populated when MCP requests go through. The `errorMiddleware` fallback therefore fires, logs the raw `TypeError` (which includes the internal upstream URL string) to Sentry, and returns a generic `{"message":"Internal server error","code":"internal_error"}` 500 — instead of a protocol-appropriate 502/504 that signals upstream unavailability. Wrapping the fetch in a try/catch and returning a `502`/`504` would give callers the correct signal and keep internal topology out of Sentry noise.

### Issue 2 of 3
server/src/routers/mcpProxyRouter.ts:16-25
`getMcpUpstream()` re-parses `process.env.MCP_UPSTREAM_URL` and allocates a new `URL` object on every proxied request. Since the env var is static at startup, a module-level constant is clearer and avoids repeated work on hot paths (SSE keep-alive pings, etc.).

```suggestion
const getMcpUpstream = (() => {
	const upstream = process.env.MCP_UPSTREAM_URL;
	if (!upstream) return null;
	try {
		return new URL(upstream);
	} catch {
		return null;
	}
})();
```

### Issue 3 of 3
server/src/routers/mcpProxyRouter.ts:43-45
The `X-Forwarded-For` header is not sanitized or reset before forwarding. A client can send `X-Forwarded-For: 1.2.3.4` and the proxy will relay it verbatim to the MCP upstream, allowing IP spoofing from the upstream's perspective. The proxy should append the real client IP rather than forwarding the client-supplied value.

```suggestion
	headers.delete("host");
	headers.set("x-forwarded-host", forwardedHost);
	headers.set("x-forwarded-proto", forwardedProto);

	const clientIp =
		c.req.header("cf-connecting-ip") ??
		c.req.header("x-real-ip") ??
		c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
		"";
	if (clientIp) headers.set("x-forwarded-for", clientIp);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: proxy mcp from main server"](https://github.com/useautumn/autumn/commit/86ebeaa64a08594e8cbb965d793ea4b59c68ef32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34399149)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->