### PR TITLE
main

### DIFF
--- a/apps/mcp-server/Dockerfile
+++ b/apps/mcp-server/Dockerfile
@@ -1,0 +1,20 @@
+FROM oven/bun:1.3.10 AS pruner
+WORKDIR /app
+
+COPY . .
+RUN bunx turbo@2.9.14 prune @autumn/mcp-server --docker
+
+FROM oven/bun:1.3.10
+WORKDIR /app
+
+COPY --from=pruner /app/out/json/ .
+RUN mkdir -p scripts && touch scripts/preload-env.ts
+RUN bun -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); pkg.workspaces.packages = ["shared", "apps/mcp-server", "packages/ksuid", "packages/mcp"]; delete pkg.dependencies; delete pkg.devDependencies; delete pkg.scripts; fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));'
+RUN rm bun.lock && bun install --production --ignore-scripts
+
+COPY --from=pruner /app/out/full/ .
+
+ENV NODE_ENV=production
+EXPOSE 8080
+
+CMD ["bun", "-F", "@autumn/mcp-server", "start"]

--- a/packages/mcp/src/mcp-server/oauth.ts
+++ b/packages/mcp/src/mcp-server/oauth.ts
@@ -69,12 +69,18 @@ export function getResourceUrl(
 	_flags: MCPOAuthFlags,
 	resourcePath = "/mcp",
 ): string {
-	const host = headers.get("x-forwarded-host") ?? headers.get("host");
+	const host =
+		headers.get("x-autumn-forwarded-host") ??
+		headers.get("x-forwarded-host") ??
+		headers.get("host");
 	if (!host) {
 		throw new OAuthHttpError(400, "Missing Host header", "invalid_request");
 	}
 
-	const proto = headers.get("x-forwarded-proto") ?? "http";
+	const proto =
+		headers.get("x-autumn-forwarded-proto") ??
+		headers.get("x-forwarded-proto") ??
+		"http";
 	return new URL(resourcePath, `${proto}://${host}`).href;
 }
 

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -22,6 +22,7 @@ import { cliRouter } from "./internal/dev/cli/cliRouter.js";
 import { handleOAuthCallback } from "./internal/orgs/handlers/stripeHandlers/handleOAuthCallback.js";
 import { apiRouter } from "./routers/apiRouter.js";
 import { internalRouter } from "./routers/internalRouter.js";
+import { mcpProxyRouter } from "./routers/mcpProxyRouter.js";
 import { publicRouter } from "./routers/publicRouter.js";
 import { auth } from "./utils/auth.js";
 import { isAllowedOrigin } from "./utils/corsOrigins.js";
@@ -87,6 +88,8 @@ export const createHonoApp = () => {
 	app.get("/stripe/oauth_callback", handleOAuthCallback);
 	app.get("/ready/:token", handleReadyCheck);
 	app.get("/", handleHealthCheck);
+
+	app.route("", mcpProxyRouter);
 
 	// Step 1: OTel HTTP span + base middleware + span enrichment
 	app.use(

--- a/server/src/routers/mcpProxyRouter.ts
+++ b/server/src/routers/mcpProxyRouter.ts
@@ -41,6 +41,8 @@ const proxyMcp = async (c: Context<HonoEnv>) => {
 	for (const header of hopByHopHeaders) headers.delete(header);
 
 	headers.delete("host");
+	headers.set("x-autumn-forwarded-host", forwardedHost);
+	headers.set("x-autumn-forwarded-proto", forwardedProto);
 	headers.set("x-forwarded-host", forwardedHost);
 	headers.set("x-forwarded-proto", forwardedProto);
 

--- a/server/src/routers/mcpProxyRouter.ts
+++ b/server/src/routers/mcpProxyRouter.ts
@@ -1,0 +1,69 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { HonoEnv } from "../honoUtils/HonoEnv.js";
+
+const hopByHopHeaders = [
+	"connection",
+	"keep-alive",
+	"proxy-authenticate",
+	"proxy-authorization",
+	"te",
+	"trailer",
+	"transfer-encoding",
+	"upgrade",
+];
+
+const getMcpUpstream = () => {
+	const upstream = process.env.MCP_UPSTREAM_URL;
+	if (!upstream) return null;
+
+	try {
+		return new URL(upstream);
+	} catch {
+		return null;
+	}
+};
+
+const proxyMcp = async (c: Context<HonoEnv>) => {
+	const upstream = getMcpUpstream();
+	if (!upstream) {
+		return c.json({ error: "MCP upstream not configured" }, 503);
+	}
+
+	const incomingUrl = new URL(c.req.url);
+	const targetUrl = new URL(incomingUrl.pathname + incomingUrl.search, upstream);
+	const headers = new Headers(c.req.raw.headers);
+	const forwardedHost =
+		headers.get("x-forwarded-host") ?? headers.get("host") ?? incomingUrl.host;
+	const forwardedProto =
+		headers.get("x-forwarded-proto") ?? incomingUrl.protocol.replace(":", "");
+
+	for (const header of hopByHopHeaders) headers.delete(header);
+
+	headers.delete("host");
+	headers.set("x-forwarded-host", forwardedHost);
+	headers.set("x-forwarded-proto", forwardedProto);
+
+	const hasBody = c.req.method !== "GET" && c.req.method !== "HEAD";
+	const response = await fetch(targetUrl, {
+		method: c.req.method,
+		headers,
+		body: hasBody ? c.req.raw.body : undefined,
+		duplex: hasBody ? "half" : undefined,
+	} as RequestInit & { duplex?: "half" });
+
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: response.headers,
+	});
+};
+
+export const mcpProxyRouter = new Hono<HonoEnv>();
+
+mcpProxyRouter.all("/mcp", proxyMcp);
+mcpProxyRouter.all("/mcp/*", proxyMcp);
+mcpProxyRouter.all("/internal/mcp", proxyMcp);
+mcpProxyRouter.all("/internal/mcp/*", proxyMcp);
+mcpProxyRouter.all("/.well-known/oauth-protected-resource/mcp", proxyMcp);
+mcpProxyRouter.all("/.well-known/oauth-protected-resource/internal/mcp", proxyMcp);

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -65,12 +65,13 @@ const emulateGoogleUrl =
 // OAuth flow leaves and returns via a third-party host (emulate.dev), so the
 // state cookie must be SameSite=None+Secure to survive the round trip.
 const isHttpsBaseUrl = process.env.BETTER_AUTH_URL?.startsWith("https://");
-const defaultMcpResourceUrl = process.env.BETTER_AUTH_URL
-	? new URL("/mcp", process.env.BETTER_AUTH_URL).href
-	: null;
-const defaultInternalMcpResourceUrl = process.env.BETTER_AUTH_URL
-	? new URL("/internal/mcp", process.env.BETTER_AUTH_URL).href
-	: null;
+const hostedMcpResourceUrls =
+	process.env.MCP_UPSTREAM_URL && process.env.BETTER_AUTH_URL
+		? [
+				new URL("/mcp", process.env.BETTER_AUTH_URL).href,
+				new URL("/internal/mcp", process.env.BETTER_AUTH_URL).href,
+			]
+		: [];
 const parseMcpResourceUrl = (rawUrl: string) => {
 	const resourceUrl = rawUrl.trim();
 	if (!resourceUrl) return null;
@@ -256,8 +257,7 @@ const options = {
 			scopes: [...ALL_SCOPES],
 			validAudiences: [
 				process.env.BETTER_AUTH_URL,
-				defaultMcpResourceUrl,
-				defaultInternalMcpResourceUrl,
+				...hostedMcpResourceUrls,
 				...mcpResourceUrls,
 				...internalMcpResourceUrls,
 			].filter(Boolean) as string[],


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Proxies MCP traffic through the main server and fixes OAuth URL detection behind proxies. Adds a production Dockerfile for `@autumn/mcp-server` and updates auth audiences for hosted MCP.

- New Features
  - Added `mcpProxyRouter` to forward `/mcp`, `/internal/mcp`, and related well-known paths to `MCP_UPSTREAM_URL`. Strips hop-by-hop headers, sets `x-autumn-forwarded-host` and `x-autumn-forwarded-proto`, and streams bodies.
  - Mounted the router in `initHono`.
  - Updated `getResourceUrl` to prefer `x-autumn-forwarded-*` headers, with fallbacks.
  - Extended auth valid audiences to include hosted MCP resource URLs when both `MCP_UPSTREAM_URL` and `BETTER_AUTH_URL` are set.
  - Added a Dockerfile for `@autumn/mcp-server` using Turbo prune and Bun, exposing port 8080.

- Migration
  - To enable hosted MCP via the proxy, set `MCP_UPSTREAM_URL` (and ensure `BETTER_AUTH_URL` is configured).

<sup>Written for commit 96098edca6fc0bbc80c5267cbe44aeff19751e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1742?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a reverse proxy layer in the Autumn server that forwards `/mcp`, `/internal/mcp`, and related OAuth discovery routes to a configurable upstream (`MCP_UPSTREAM_URL`), along with a new Dockerfile for the standalone MCP server. It also wires custom `x-autumn-forwarded-*` headers so the MCP server's OAuth resource URL resolution uses the original public host even when sitting behind the proxy.

- **Improvements**: `mcpProxyRouter` mounts before global middleware and correctly strips hop-by-hop *request* headers before forwarding; the MCP server's `getResourceUrl()` now prefers `x-autumn-forwarded-host/proto` over the generic `x-forwarded-*` equivalents, preventing header spoofing through the proxy chain.
- **Improvements**: `hostedMcpResourceUrls` in `auth.ts` now only registers `/mcp` and `/internal/mcp` as valid OAuth audiences when `MCP_UPSTREAM_URL` is set, keeping the audience list consistent with actual proxy availability.
- **API changes**: A new standalone `apps/mcp-server` Docker image is introduced with a Bun-based build pipeline.
</details>

<h3>Confidence Score: 3/5</h3>

The proxy is functional for happy-path requests, but forwarding upstream hop-by-hop headers on the response side is a correctness gap that can corrupt streaming (SSE) responses — the primary MCP transport.

The new mcpProxyRouter correctly handles the forwarding path for requests but leaves the response headers unfiltered. Because MCP relies heavily on Server-Sent Events, forwarding transfer-encoding: chunked or connection from the upstream response to the client can cause HTTP/1.1 clients to misinterpret the already-decoded stream. The Dockerfile also performs a non-deterministic install by removing the lock file. These two issues together on a new, untested code path warrant close review before merging to production.

server/src/routers/mcpProxyRouter.ts needs the response hop-by-hop header filtering added; apps/mcp-server/Dockerfile should use --frozen-lockfile.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/routers/mcpProxyRouter.ts | New reverse proxy for MCP routes; correctly strips hop-by-hop request headers but forwards upstream response hop-by-hop headers unfiltered, which can break SSE streams with HTTP/1.1 clients. |
| apps/mcp-server/Dockerfile | New Dockerfile for the MCP server; deletes bun.lock before install making builds non-deterministic — should use --frozen-lockfile instead. |
| packages/mcp/src/mcp-server/oauth.ts | Adds x-autumn-forwarded-host/proto header priority in getResourceUrl so the new proxy's canonical headers are preferred over generic x-forwarded-* ones. |
| server/src/utils/auth.ts | Replaces always-included defaultMcpResourceUrl/defaultInternalMcpResourceUrl with hostedMcpResourceUrls that are only populated when MCP_UPSTREAM_URL is also set, aligning validAudiences with the proxy-gated architecture. |
| server/src/initHono.ts | Mounts mcpProxyRouter before global middleware; intentional to avoid DB/OTel overhead on proxy routes, but means proxy fetch errors bypass OTel tracing. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Server as Autumn Server (Hono)
    participant Proxy as mcpProxyRouter
    participant MCP as MCP Upstream<br/>(MCP_UPSTREAM_URL)

    Client->>Server: "ANY /mcp, /internal/mcp,<br/>/.well-known/oauth-protected-resource/mcp"
    Server->>Proxy: matched before global middleware
    Proxy->>Proxy: getMcpUpstream() → parse MCP_UPSTREAM_URL
    Proxy->>Proxy: Strip hop-by-hop request headers
    Proxy->>Proxy: Set x-autumn-forwarded-host/proto
    Proxy->>MCP: "fetch(targetUrl, { method, headers, body })"
    MCP-->>Proxy: Response (status, headers, body stream)
    Proxy-->>Client: "new Response(body, { status, headers })"

    Note over Client,MCP: OAuth resource URL resolution
    Client->>MCP: Request with Authorization: Bearer token
    MCP->>MCP: "getResourceUrl() reads x-autumn-forwarded-host (priority 1),<br/>x-forwarded-host (priority 2), host (priority 3)"
    MCP->>MCP: Build resource URL for token validation
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/routers/mcpProxyRouter.ts:57-61
**Hop-by-hop response headers not stripped from upstream**

The request path correctly strips hop-by-hop headers before forwarding (`hopByHopHeaders.delete(...)` on line 41), but the response path forwards them verbatim. Passing headers like `transfer-encoding: chunked` or `connection: keep-alive` from the upstream response to the client is incorrect for a proxy: these headers describe the transport between the upstream and the proxy, not between the proxy and the client. In HTTP/1.1, if a client receives `transfer-encoding: chunked` on an already-decoded response body it can fail to parse the stream, which will affect SSE (the primary MCP transport).

### Issue 2 of 3
server/src/routers/mcpProxyRouter.ts:16-25
`getMcpUpstream()` re-parses the env var on every proxied request. Since `MCP_UPSTREAM_URL` is static at process startup, the result can be computed once at module load time.

```suggestion
const mcpUpstream = (() => {
	const upstream = process.env.MCP_UPSTREAM_URL;
	if (!upstream) return null;
	try {
		return new URL(upstream);
	} catch {
		return null;
	}
})();

const getMcpUpstream = () => mcpUpstream;
```

### Issue 3 of 3
apps/mcp-server/Dockerfile:13
**Lock file deleted before install — non-deterministic builds**

`rm bun.lock && bun install --production` discards the resolved dependency graph and lets Bun re-resolve semver ranges at build time. A new package version satisfying a range could ship in the Docker image without any code review. The `out/json/` pruner stage already emits a correctly-scoped `bun.lock`; consider keeping it and running `bun install --frozen-lockfile --production` instead.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1741 from useautumn/..."](https://github.com/useautumn/autumn/commit/96098edca6fc0bbc80c5267cbe44aeff19751e8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34400482)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->