### PR TITLE
fix: failopen bug

### DIFF
--- a/server/tests/unit/balances/check-v2/v12CheckChangeFailOpen.test.ts
+++ b/server/tests/unit/balances/check-v2/v12CheckChangeFailOpen.test.ts
@@ -1,0 +1,68 @@
+/**
+ * TDD test for the Redis fail-open denial bug on legacy (1.x) API versions.
+ *
+ * When Redis is not_ready, /check returns the fail-open fallback
+ * (allowed: true, balance: null). V1_2_CheckChange.transformResponse then runs
+ * for 1.x customers and, seeing a null balance, hardcoded allowed: false —
+ * wrongfully denying customers who were never actually out of balance.
+ *
+ * Red-failure mode (current behavior):
+ *  - input { allowed: true, balance: null } → output { allowed: false }
+ *
+ * Green-success criteria (after fix):
+ *  - allowed carries over: input.allowed === true with null balance stays allowed: true
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+	CheckResponseV1,
+	CheckResponseV2,
+	Feature,
+} from "@autumn/shared";
+import { V1_2_CheckChange } from "@autumn/shared/api/balances/check/changes/V1.2_CheckChange";
+import { FeatureType } from "@autumn/shared";
+
+const featureToUse = {
+	id: "google_drive_asset_ingest",
+	type: FeatureType.Metered,
+} as Feature;
+
+describe("V1_2_CheckChange fail-open", () => {
+	test("carries over allowed: true when balance is null (Redis fail-open)", () => {
+		const transform = new V1_2_CheckChange();
+		const input: CheckResponseV2 = {
+			allowed: true,
+			customer_id: "cus_mosaic",
+			entity_id: undefined,
+			required_balance: 1,
+			balance: null,
+		};
+
+		const transformed = transform.transformResponse({
+			input,
+			legacyData: { noCusEnts: false, featureToUse },
+		}) as CheckResponseV1;
+
+		expect(transformed.allowed).toBe(true);
+		expect(transformed.feature_id).toBe("google_drive_asset_ingest");
+		expect(transformed.required_balance).toBe(1);
+	});
+
+	test("still denies when balance is null and allowed is false", () => {
+		const transform = new V1_2_CheckChange();
+		const input: CheckResponseV2 = {
+			allowed: false,
+			customer_id: "cus_mosaic",
+			entity_id: undefined,
+			required_balance: 1,
+			balance: null,
+		};
+
+		const transformed = transform.transformResponse({
+			input,
+			legacyData: { noCusEnts: false, featureToUse },
+		}) as CheckResponseV1;
+
+		expect(transformed.allowed).toBe(false);
+	});
+});

--- a/shared/api/balances/check/changes/V1.2_CheckChange.ts
+++ b/shared/api/balances/check/changes/V1.2_CheckChange.ts
@@ -47,8 +47,10 @@ export const V1_2_CheckChange = defineVersionChange({
 		const { featureToUse } = legacyData;
 
 		if (!input.balance) {
+			// Redis fail-open emits allowed:true with a null balance; preserve it
+			// rather than equating "no balance object" with denial.
 			return {
-				allowed: false,
+				allowed: input.allowed,
 				code: "feature_found",
 				customer_id: input.customer_id,
 				feature_id: featureToUse.id,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes fail-open denial on legacy 1.x check responses. When Redis returns fail-open (allowed: true, balance: null), `V1_2_CheckChange` now preserves allowed: true instead of forcing a denial.

- **Bug Fixes**
  - Update `V1_2_CheckChange` to set `allowed: input.allowed` when `balance` is null.
  - Add `v12CheckChangeFailOpen.test.ts` to verify allowed:true/null balance passes and allowed:false/null balance still denies.

<sup>Written for commit 1b0c491583b0d7acb2cdacf1eab8448865efdf4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1743?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a fail-open regression in the legacy 1.x check response transformer: when Redis is unavailable and returns `allowed: true, balance: null`, `V1_2_CheckChange` was hardcoding `allowed: false`, incorrectly denying customers. The single-line fix preserves `input.allowed` in the null-balance branch, and a new test file validates both the corrected path and the intended denial path.

- **Bug fixes** — `V1_2_CheckChange.transformResponse` now returns `allowed: input.allowed` instead of `allowed: false` when `balance` is null, fixing Redis fail-open denial for legacy API consumers.
- **Improvements** — Two focused unit tests are added: one confirming that `allowed: true + balance: null` passes through correctly, and one confirming that `allowed: false + balance: null` still denies.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line correction in an isolated branch of the transformer, and both the happy path and denial path are covered by new tests.

The fix touches exactly one line in one branch of V1_2_CheckChange.transformResponse. The rest of the transformer (the non-null balance path) is unchanged. Two targeted unit tests exercise both the corrected behavior and the pre-existing denial behavior, giving good confidence that no regression was introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/balances/check/changes/V1.2_CheckChange.ts | One-line fix: null-balance branch now returns `input.allowed` instead of hardcoded `false`, correctly preserving fail-open state. |
| server/tests/unit/balances/check-v2/v12CheckChangeFailOpen.test.ts | New unit tests covering both the fixed path (allowed:true + null balance → allowed:true) and the negative case (allowed:false + null balance → allowed:false). |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Check Response V2\n(input.allowed, input.balance)"] --> B{input.balance\nnull / undefined?}
    B -- "Yes (null balance)" --> C["Before fix:\nreturn { allowed: false }"]
    B -- "Yes (null balance)" --> D["After fix:\nreturn { allowed: input.allowed }"]
    B -- "No" --> E["Transform balance via\ntransformBalanceToCusFeatureV3"]
    E --> F["Build baseData with\ninput.allowed"]
    F --> G["Validate with\nCheckResponseV1Schema.safeParse"]
    G --> H["Return V1 response"]
    D --> H
    C -.->|"Bug: fail-open\nalways denied"| X["❌ allowed: false\n(wrong)"]
    D -->|"Fix: preserves\nfail-open state"| Y["✅ allowed: true\n(correct)"]

    style C fill:#ffcccc,stroke:#cc0000
    style D fill:#ccffcc,stroke:#009900
    style X fill:#ffcccc
    style Y fill:#ccffcc
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: fail open works on previous version"](https://github.com/useautumn/autumn/commit/1b0c491583b0d7acb2cdacf1eab8448865efdf4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34417619)</sub>

<!-- /greptile_comment -->