### PR TITLE
fix: org config overwrites

### DIFF
--- a/server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts
+++ b/server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts
@@ -1,10 +1,13 @@
 import { type OrgConfig, OrgConfigSchema, Scopes } from "@autumn/shared";
 import { sql } from "drizzle-orm";
+import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { clearOrgCache } from "../orgUtils/clearOrgCache.js";
 
 const validKeys = new Set(Object.keys(OrgConfigSchema.shape));
-const bodySchema = OrgConfigSchema.partial();
+// Not `OrgConfigSchema.partial()`: its `.default()`s expand a single-field
+// request into the full object, clobbering other flags on merge.
+const bodySchema = z.record(z.string(), z.unknown());
 
 export const handleUpdateOrgConfig = createRoute({
 	scopes: [Scopes.Organisation.Write],
@@ -13,18 +16,25 @@ export const handleUpdateOrgConfig = createRoute({
 		const { db, org } = c.get("ctx");
 		const raw = c.req.valid("json");
 
-		const updates = Object.fromEntries(
-			Object.entries(raw).filter(
-				([k, v]) => validKeys.has(k) && v !== undefined,
-			),
-		) as Partial<OrgConfig>;
+		// Known config keys present in the request body.
+		const sentKeys = Object.keys(raw).filter((k) => validKeys.has(k));
 
-		if (Object.keys(updates).length === 0) {
+		if (sentKeys.length === 0) {
 			return c.json({
 				success: true,
 				config: OrgConfigSchema.parse(org.config),
 			});
 		}
+
+		// Validate sent values, then read back only the sent keys so the
+		// defaults `.partial()` fills for omitted keys are never merged.
+		const validated = OrgConfigSchema.partial().parse(raw) as Record<
+			string,
+			unknown
+		>;
+		const updates = Object.fromEntries(
+			sentKeys.map((k) => [k, validated[k]]),
+		) as Partial<OrgConfig>;
 
 		const rows = await db.execute<{ config: OrgConfig }>(
 			sql`UPDATE organizations

--- a/server/tests/integration/org-config/update-org-config-handler.test.ts
+++ b/server/tests/integration/org-config/update-org-config-handler.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression: PATCH /organization/config must merge, not replace. A prior
+ * `OrgConfigSchema.partial()` body schema filled every field's default, so each
+ * save overwrote previously-set flags. These tests drive the real HTTP handler.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type DbUsageAlert,
+	type OrgConfig,
+	OrgConfigSchema,
+	organizations,
+} from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+test(`${chalk.yellowBright("org config handler: second save preserves first save")}`, async () => {
+	const { ctx } = await initScenario({ setup: [], actions: [] });
+	const { db, org } = ctx;
+	const originalConfig = org.config;
+
+	const readDbConfig = async (): Promise<OrgConfig> => {
+		const [row] = await db
+			.select({ config: organizations.config })
+			.from(organizations)
+			.where(eq(organizations.id, org.id))
+			.limit(1);
+		return OrgConfigSchema.parse(row?.config ?? {});
+	};
+
+	try {
+		// Known empty starting state.
+		await db
+			.update(organizations)
+			.set({ config: {} as OrgConfig })
+			.where(eq(organizations.id, org.id));
+
+		const autumn = new AutumnInt({ secretKey: ctx.orgSecretKey });
+
+		// First save: one toggle.
+		const firstResponse = (await autumn.patch("/organization/config", {
+			automatic_tax: true,
+		})) as { success: boolean; config: OrgConfig };
+		expect(firstResponse.config.automatic_tax).toBe(true);
+
+		// Second save: a different toggle.
+		const secondResponse = (await autumn.patch("/organization/config", {
+			cancel_on_past_due: true,
+		})) as { success: boolean; config: OrgConfig };
+
+		// The regression assertions: the first field must survive the second save.
+		expect(secondResponse.config.automatic_tax).toBe(true);
+		expect(secondResponse.config.cancel_on_past_due).toBe(true);
+
+		const persisted = await readDbConfig();
+		expect(persisted.automatic_tax).toBe(true);
+		expect(persisted.cancel_on_past_due).toBe(true);
+	} finally {
+		await db
+			.update(organizations)
+			.set({ config: originalConfig })
+			.where(eq(organizations.id, org.id));
+	}
+});
+
+/**
+ * Guards the mixed-type path: `usage_alerts` (an array) is saved through the
+ * same endpoint and must coexist with previously-set boolean flags.
+ */
+test(`${chalk.yellowBright("org config handler: array field (usage_alerts) merges with boolean flags")}`, async () => {
+	const { ctx } = await initScenario({ setup: [], actions: [] });
+	const { db, org } = ctx;
+	const originalConfig = org.config;
+
+	const readDbConfig = async (): Promise<OrgConfig> => {
+		const [row] = await db
+			.select({ config: organizations.config })
+			.from(organizations)
+			.where(eq(organizations.id, org.id))
+			.limit(1);
+		return OrgConfigSchema.parse(row?.config ?? {});
+	};
+
+	const alert: DbUsageAlert = {
+		enabled: true,
+		threshold: 80,
+		threshold_type: "usage_percentage",
+	};
+
+	try {
+		await db
+			.update(organizations)
+			.set({ config: {} as OrgConfig })
+			.where(eq(organizations.id, org.id));
+
+		const autumn = new AutumnInt({ secretKey: ctx.orgSecretKey });
+
+		// Boolean toggle first.
+		await autumn.patch("/organization/config", { automatic_tax: true });
+
+		// Then an array field through the same endpoint.
+		const response = (await autumn.patch("/organization/config", {
+			usage_alerts: [alert],
+		})) as { success: boolean; config: OrgConfig };
+
+		expect(response.config.automatic_tax).toBe(true);
+		expect(response.config.usage_alerts).toHaveLength(1);
+		expect(response.config.usage_alerts?.[0]?.threshold).toBe(80);
+
+		const persisted = await readDbConfig();
+		expect(persisted.automatic_tax).toBe(true);
+		expect(persisted.usage_alerts).toHaveLength(1);
+	} finally {
+		await db
+			.update(organizations)
+			.set({ config: originalConfig })
+			.where(eq(organizations.id, org.id));
+	}
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes org config overwrites on PATCH by merging only the keys sent in the request. Adds integration tests to ensure earlier flags and array fields (like usage_alerts) persist across saves.

- **Bug Fixes**
  - Replaced `OrgConfigSchema.partial()` as the body schema with `z.record(...)` to avoid default expansion that clobbered existing flags.
  - Validate with `OrgConfigSchema.partial()` but only merge the keys actually sent; ignore unknown keys and return early if none are valid.
  - Added integration tests covering: second save preserves first save; array field `usage_alerts` merges with existing boolean flags.

<sup>Written for commit 14eab089e28d41cbe7c9ff2c2fb64e945e67fc8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1747?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `PATCH /organization/config` was overwriting the entire org config instead of merging, because `OrgConfigSchema.partial()` as the body schema would fill in Zod defaults for all omitted fields, causing every field to be written on each save.

- **[Bug fixes]** Replaces `OrgConfigSchema.partial()` as the body schema with `z.record(z.string(), z.unknown())`, then applies a two-phase validation: filter to known keys present in the request (`sentKeys`), run `OrgConfigSchema.partial().parse(raw)` for value validation, and re-extract only `sentKeys` so no default-filled fields leak into the SQL merge.
- **[Improvements]** Adds two integration tests driving the real HTTP handler — one for consecutive boolean-toggle PATCHes, one for a boolean + array-field combination — both asserting that previously saved values survive a subsequent partial update.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-tested fix to a merge-vs-overwrite bug with no regressions on other code paths.

The two-phase validation approach (raw record in, selective key re-extraction out) correctly prevents Zod defaults from leaking into the SQL merge. The SQL update itself is unchanged. Both changed files are well-reasoned and the new integration tests directly exercise the regression path end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/orgs/handlers/handleUpdateOrgConfig.ts | Fixes config-overwrite bug by splitting body validation into two phases: raw record acceptance + selective key re-extraction after schema validation, so defaults for omitted fields are never merged into the database. |
| server/tests/integration/org-config/update-org-config-handler.test.ts | New integration tests covering the regression: two test cases verify that a second PATCH call preserves flags set by the first (boolean-boolean and boolean-array combinations). Both tests restore original config in finally blocks. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as handleUpdateOrgConfig
    participant Zod as OrgConfigSchema.partial()
    participant DB as PostgreSQL

    Client->>Handler: "PATCH /organization/config { automatic_tax: true }"
    Handler->>Handler: "sentKeys = keys(raw) ∩ validKeys → ["automatic_tax"]"
    Handler->>Zod: parse(raw) → validated (all defaults filled)
    Zod-->>Handler: "{ automatic_tax: true, cancel_on_past_due: false, ... }"
    Handler->>Handler: "updates = pick(validated, sentKeys) → { automatic_tax: true }"
    Handler->>DB: "config = COALESCE(config,'{}') || '{"automatic_tax":true}'"
    DB-->>Handler: merged config
    Handler-->>Client: "{ success: true, config: merged }"

    Client->>Handler: "PATCH /organization/config { cancel_on_past_due: true }"
    Handler->>Handler: "sentKeys = ["cancel_on_past_due"]"
    Handler->>Zod: parse(raw) → validated (all defaults filled)
    Zod-->>Handler: "{ automatic_tax: false, cancel_on_past_due: true, ... }"
    Handler->>Handler: "updates = pick(validated, sentKeys) → { cancel_on_past_due: true }"
    Handler->>DB: "config = COALESCE(config,'{}') || '{"cancel_on_past_due":true}'"
    Note over DB: automatic_tax: true is preserved ✓
    DB-->>Handler: merged config
    Handler-->>Client: "{ success: true, config: merged }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: org config overwrites"](https://github.com/useautumn/autumn/commit/14eab089e28d41cbe7c9ff2c2fb64e945e67fc8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34543762)</sub>

<!-- /greptile_comment -->