### PR TITLE
chore: add entities to create balance

### DIFF
--- a/server/src/internal/balances/handlers/handleCreateBalance.ts
+++ b/server/src/internal/balances/handlers/handleCreateBalance.ts
@@ -6,6 +6,7 @@ import { validateCreateBalanceParams } from "@/internal/balances/createBalance/v
 import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
 import { CusService } from "@/internal/customers/CusService";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
 import { EntitlementService } from "@/internal/products/entitlements/EntitlementService";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 
@@ -59,6 +60,12 @@ export const handleCreateBalance = createRoute({
 		await CusEntService.insert({
 			ctx,
 			data: [newCustomerEntitlement],
+		});
+
+		await deleteCachedFullCustomer({
+			ctx,
+			customerId: fullCustomer.id ?? customer_id,
+			source: "handleCreateBalance",
 		});
 
 		return c.json({ success: true });

--- a/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
@@ -1,6 +1,7 @@
 import {
 	type Feature,
 	FeatureType,
+	type FullCustomer,
 	isContUseFeature,
 	ResetInterval,
 	type RolloverConfig,
@@ -35,6 +36,7 @@ import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { RolloverConfigForm } from "@/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm";
 import { useCustomerContext } from "../../customer/CustomerContext";
+import { EntityScopeSelector } from "./EntityScopeSelector";
 
 const RESET_INTERVAL_LABELS: Record<string, string> = {
 	[ResetInterval.Minute]: "Minute",
@@ -54,7 +56,12 @@ export function BalanceCreateSheet() {
 	const { features } = useFeaturesQuery();
 	const axiosInstance = useAxiosInstance();
 
+	const entities = (customer as FullCustomer | null)?.entities ?? [];
+
 	const [isCreating, setIsCreating] = useState(false);
+	const [scopeEntityId, setScopeEntityId] = useState<string | undefined>(
+		() => entityId ?? undefined,
+	);
 	const [featureId, setFeatureId] = useState<string>("");
 	const [balanceId, setBalanceId] = useState("");
 	const [includedGrant, setIncludedGrant] = useState("");
@@ -115,7 +122,7 @@ export function BalanceCreateSheet() {
 			feature_id: featureId,
 		};
 
-		if (entityId) params.entity_id = entityId;
+		if (scopeEntityId) params.entity_id = scopeEntityId;
 		if (balanceId.trim()) params.balance_id = balanceId.trim();
 
 		if (isMetered) {
@@ -166,6 +173,14 @@ export function BalanceCreateSheet() {
 					title="Create Balance"
 					description="Create a separate balance for this customer that is not associated with any plan."
 				/>
+
+				{entities.length > 0 && (
+					<EntityScopeSelector
+						entities={entities}
+						scopeEntityId={scopeEntityId}
+						onScopeChange={setScopeEntityId}
+					/>
+				)}
 
 				<SheetSection withSeparator>
 					<FormLabel>Feature</FormLabel>


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add entity scoping to the Create Balance flow and clear the full customer cache after creation so new balances appear immediately.

- **New Features**
  - Added `EntityScopeSelector` to Balance Create when the customer has entities.
  - Users can pick an entity; the request now sends `entity_id` (defaults to the current entity when available).

- **Bug Fixes**
  - Invalidate `fullCustomer` cache via `deleteCachedFullCustomer` in `handleCreateBalance` to avoid stale UI after creating a balance.

<sup>Written for commit 5416df3d895426d2e0c6c7eec6b87abcf49bb28c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1748?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires entity-scope support into the "Create Balance" flow: the frontend adds an `EntityScopeSelector` so users can choose which entity a new balance is scoped to, and the backend adds a cache-invalidation call after inserting the new customer entitlement.

- **[Improvements]** `BalanceCreateSheet` now reads `entities` from `FullCustomer` and renders `EntityScopeSelector` when entities are present, replacing the hard-coded `entityId` context value with user-controllable `scopeEntityId` state.
- **[Improvements]** `handleCreateBalance` calls `deleteCachedFullCustomer` after the DB writes to keep the fullCustomer/fullSubject Redis cache consistent with the newly created balance.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge after forwarding entity_id in the cache invalidation call — without it, entity-scoped balances will appear stale until the Redis TTL expires.

The server handler omits entity_id when calling deleteCachedFullCustomer, so invalidateCachedFullSubject runs without the entity identifier. Any read that hits the cache after a balance is created for a specific entity will return the pre-creation state until the entry expires naturally. The frontend changes are clean.

server/src/internal/balances/handlers/handleCreateBalance.ts — the cache-invalidation call needs entity_id forwarded.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/handlers/handleCreateBalance.ts | Cache invalidation added after balance insertion, but entity_id is not forwarded to deleteCachedFullCustomer, leaving entity-scoped fullSubject cache stale. |
| vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx | Adds entity scope selector UI when the customer has entities; initialises scopeEntityId from context entityId and uses it in the API payload correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as BalanceCreateSheet
    participant API as /v1/balances.create
    participant DB as Postgres
    participant Cache as Redis (all regions)

    UI->>UI: "render EntityScopeSelector (if entities.length > 0)"
    UI->>API: "POST /v1/balances.create { customer_id, feature_id, entity_id? }"
    API->>DB: INSERT entitlement
    API->>DB: INSERT customer_entitlement
    API->>Cache: deleteCachedFullCustomer(customerId, entityId?)
    Cache-->>API: invalidated
    API-->>UI: "{ success: true }"
    UI->>UI: refetch + closeSheet
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/balances/handlers/handleCreateBalance.ts:65-69
**Missing `entityId` in cache invalidation call**

`entity_id` is destructured from `createBalanceParams` at line 19 but is never forwarded to `deleteCachedFullCustomer`. Inside that function the `entityId` param is passed directly to `invalidateCachedFullSubject`, so omitting it means the entity-scoped fullSubject cache entry won't be invalidated when a balance is created for a specific entity — callers hitting the cache after this write will see stale data until the TTL expires.

```suggestion
		await deleteCachedFullCustomer({
			ctx,
			customerId: fullCustomer.id ?? customer_id,
			entityId: entity_id,
			source: "handleCreateBalance",
		});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add entities to create balance"](https://github.com/useautumn/autumn/commit/5416df3d895426d2e0c6c7eec6b87abcf49bb28c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34548210)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->