### PR TITLE
fix: tag billing.auto_topup_succeeded svix events with customer_id

### DIFF
--- a/server/src/internal/balances/autoTopUp/webhooks/sendAutoTopupSucceededWebhook.ts
+++ b/server/src/internal/balances/autoTopUp/webhooks/sendAutoTopupSucceededWebhook.ts
@@ -3,6 +3,7 @@ import {
 	type BillingAutoTopupSucceededInvoice,
 	type BillingResult,
 	fullCustomerToCustomerEntitlements,
+	fullCustomerToTags,
 	getApiBalance,
 	WebhookEventType,
 } from "@autumn/shared";
@@ -101,6 +102,9 @@ export const sendAutoTopupSucceededWebhook = async ({
 				invoice_mode: Boolean(autoTopupContext.invoiceMode),
 				invoice,
 			},
+			tags: fullCustomerToTags({
+				fullCustomer: autoTopupContext.fullCustomer,
+			}),
 		});
 	} catch (error) {
 		ctx.logger.error(


### PR DESCRIPTION
## Summary
- `billing.auto_topup_succeeded` Svix events were sent **without** the `customer_id`/`entity_id` tags that every other webhook caller attaches via `fullCustomerToTags`.
- As a result, these events were invisible to the Svix App Portal's search-by-customer-tag — they fired and delivered fine, but appeared "missing" when filtering by customer.
- Fix: pass `tags: fullCustomerToTags({ fullCustomer })` to the `sendSvixEvent` call in `sendAutoTopupSucceededWebhook.ts`, matching `sendProductsUpdated`, `sendBillingUpdatedWebhook`, `checkLimitReached`, `checkUsageAlerts`, and `handleThresholdReached`.

## Context
Found while investigating firecrawl customer `ebf04ec9-3a1a-4b9d-aec7-32969ddf9234`: 4 `billing.auto_topup_succeeded` events fired (5/20, 5/22, 5/25, 5/27) with zero delivery failures, but none were searchable by customer tag.

## Test plan
- [ ] Trigger an auto-topup and confirm the outgoing Svix message carries `customer_id.<id>` (and `entity_id.<id>` for entity-scoped customers).
- [ ] Confirm the event is now findable in the Svix portal via customer-tag search.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `billing.auto_topup_succeeded` Svix events to include `customer_id`/`entity_id` tags, making them searchable by customer in the Svix portal. Matches tagging used by other webhook senders via `fullCustomerToTags`.

<sup>Written for commit 9d0930f59305b675ab2ea314f1ef83dce75edf93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The `billing.auto_topup_succeeded` Svix events were emitted without the `customer_id`/`entity_id` tags that all other webhook senders attach via `fullCustomerToTags`. This made those events invisible to Svix App Portal's customer-tag search, even though delivery was fine.

- **Bug fixes** — Passes `tags: fullCustomerToTags({ fullCustomer: autoTopupContext.fullCustomer })` to `sendSvixEvent`, aligning `sendAutoTopupSucceededWebhook` with `sendBillingUpdatedWebhook`, `sendProductsUpdated`, `checkLimitReached`, `checkUsageAlerts`, and `handleThresholdReached`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, targeted addition of three lines that closes a tagging gap without touching any logic.

The change is a straightforward three-line addition of `tags: fullCustomerToTags(...)` to a single `sendSvixEvent` call. The `fullCustomerToTags` function is already exercised by five other webhook senders in the codebase, and the `fullCustomer` value passed here is the same one already used for `customerId` on the line above. There is no new logic, no data mutation, and no path that could cause a regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/webhooks/sendAutoTopupSucceededWebhook.ts | Adds `tags: fullCustomerToTags({ fullCustomer })` to the `sendSvixEvent` call, matching the pattern used by every other webhook sender and restoring customer-tag searchability in the Svix portal. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant AutoTopUp
    participant sendAutoTopupSucceededWebhook
    participant fullCustomerToTags
    participant sendSvixEvent
    participant SvixPortal

    AutoTopUp->>sendAutoTopupSucceededWebhook: billingResult, autoTopupContext
    sendAutoTopupSucceededWebhook->>fullCustomerToTags: fullCustomer
    fullCustomerToTags-->>sendAutoTopupSucceededWebhook: "["customer_id.<id>", "entity_id.<id>?"]"
    sendAutoTopupSucceededWebhook->>sendSvixEvent: eventType, data, tags
    sendSvixEvent->>SvixPortal: POST message (with customer/entity tags)
    SvixPortal-->>SvixPortal: searchable by customer_id tag ✓
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: tag billing.auto\_topup\_succeeded sv..."](https://github.com/useautumn/autumn/commit/9d0930f59305b675ab2ea314f1ef83dce75edf93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34565583)</sub>

<!-- /greptile_comment -->