### PR TITLE
fix(vercel): 🐛 resolve free plan resource provisioning

### DIFF
--- a/server/src/external/vercel/handlers/resources/handleCreateResource.ts
+++ b/server/src/external/vercel/handlers/resources/handleCreateResource.ts
@@ -1,7 +1,10 @@
 import {
 	AppEnv,
+	findActiveCustomerProductById,
 	type FullCusProduct,
+	type FullCustomer,
 	type FullProduct,
+	isFreeProduct,
 	RecaseError,
 	Scopes,
 } from "@autumn/shared";
@@ -30,13 +33,24 @@ import { productToBillingPlan } from "../handleListBillingPlans.js";
 
 const findInstallationCusProduct = async ({
 	ctx,
+	fullCustomer,
 	stripeCustomer,
 	integrationConfigurationId,
+	freeProduct,
 }: {
 	ctx: AutumnContext;
+	fullCustomer: FullCustomer;
 	stripeCustomer: Stripe.Customer;
 	integrationConfigurationId: string;
+	freeProduct?: FullProduct;
 }): Promise<FullCusProduct | undefined> => {
+	if (freeProduct) {
+		return findActiveCustomerProductById({
+			fullCus: fullCustomer,
+			productId: freeProduct.id,
+		});
+	}
+
 	const { db, org, env } = ctx;
 
 	const existingSub = stripeCustomer.subscriptions?.data.find(
@@ -162,6 +176,11 @@ export const handleCreateResource = createRoute({
 		});
 
 		try {
+			const requestedProduct = await loadProduct(billingPlanId);
+			const freeProduct = isFreeProduct({ prices: requestedProduct.prices })
+				? requestedProduct
+				: undefined;
+
 			const existing = await VercelResourceService.getByInstallationAndName({
 				db,
 				installationId: integrationConfigurationId,
@@ -172,14 +191,16 @@ export const handleCreateResource = createRoute({
 
 			const installationCusProduct = await findInstallationCusProduct({
 				ctx,
+				fullCustomer: customer,
 				stripeCustomer,
 				integrationConfigurationId,
+				freeProduct,
 			});
 
 			if (existing) {
 				const product = installationCusProduct
 					? await loadProduct(installationCusProduct.product_id)
-					: await loadProduct(billingPlanId);
+					: requestedProduct;
 				return c.json(
 					buildResourceResponse({ resourceId: existing.id, product }),
 				);
@@ -214,14 +235,16 @@ export const handleCreateResource = createRoute({
 				if (!winner) throw error;
 				const product = installationCusProduct
 					? await loadProduct(installationCusProduct.product_id)
-					: await loadProduct(billingPlanId);
+					: requestedProduct;
 				return c.json(
 					buildResourceResponse({ resourceId: winner.id, product }),
 				);
 			}
 
 			const product = installationCusProduct
-				? await loadProduct(installationCusProduct.product_id)
+				? installationCusProduct.product_id === billingPlanId
+					? requestedProduct
+					: await loadProduct(installationCusProduct.product_id)
 				: (
 						await provisionVercelCusProduct({
 							ctx,

--- a/server/src/external/vercel/handlers/resources/handleCreateResource.ts
+++ b/server/src/external/vercel/handlers/resources/handleCreateResource.ts
@@ -44,13 +44,6 @@ const findInstallationCusProduct = async ({
 	integrationConfigurationId: string;
 	freeProduct?: FullProduct;
 }): Promise<FullCusProduct | undefined> => {
-	if (freeProduct) {
-		return findActiveCustomerProductById({
-			fullCus: fullCustomer,
-			productId: freeProduct.id,
-		});
-	}
-
 	const { db, org, env } = ctx;
 
 	const existingSub = stripeCustomer.subscriptions?.data.find(
@@ -60,26 +53,33 @@ const findInstallationCusProduct = async ({
 			s.status !== "canceled",
 	);
 
-	if (!existingSub) {
-		return undefined;
+	if (existingSub) {
+		const existingCusProducts = await customerProductRepo.getByStripeSubId({
+			db,
+			stripeSubId: existingSub.id,
+			orgId: org.id,
+			env,
+		});
+
+		if (existingCusProducts.length > 0) {
+			return existingCusProducts[0];
+		}
+
+		throw new RecaseError({
+			message: "Vercel subscription is still being provisioned. Retry shortly.",
+			code: "vercel_provisioning_in_flight",
+			statusCode: StatusCodes.CONFLICT,
+		});
 	}
 
-	const existingCusProducts = await customerProductRepo.getByStripeSubId({
-		db,
-		stripeSubId: existingSub.id,
-		orgId: org.id,
-		env,
-	});
-
-	if (existingCusProducts.length > 0) {
-		return existingCusProducts[0];
+	if (freeProduct) {
+		return findActiveCustomerProductById({
+			fullCus: fullCustomer,
+			productId: freeProduct.id,
+		});
 	}
 
-	throw new RecaseError({
-		message: "Vercel subscription is still being provisioned. Retry shortly.",
-		code: "vercel_provisioning_in_flight",
-		statusCode: StatusCodes.CONFLICT,
-	});
+	return undefined;
 };
 
 export const handleCreateResource = createRoute({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vercel resource provisioning on the free plan. Detects zero-price products, reuses the customer’s active free product, and returns the correct plan without needing a Stripe subscription.

- **Bug Fixes**
  - Detect free products with `isFreeProduct` and add a free-product path that avoids Stripe.
  - Resolve the customer’s active free product with `findActiveCustomerProductById` using `fullCustomer`.
  - Pass `fullCustomer` and optional `freeProduct` into `findInstallationCusProduct`.
  - Hoist `loadProduct(billingPlanId)` and reuse `requestedProduct` in early returns; short-circuit when IDs match to avoid extra loads.
  - Paid plans remain unchanged.

<sup>Written for commit 3e320389966c18faa5a6cee86ffbbfd9ef97057a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where free-plan resources could not be provisioned correctly through the Vercel integration. Free products have no Stripe subscriptions, so the previous subscription-based lookup in `findInstallationCusProduct` always returned `undefined`, causing the handler to attempt re-provisioning an already-active free customer product on every request.

- **Bug fixes**: Adds a `freeProduct` path in `findInstallationCusProduct` that bypasses the Stripe subscription lookup entirely and resolves the customer product directly from the in-memory `FullCustomer` object using `findActiveCustomerProductById`, preventing duplicate provisioning calls for free plans.
- **Improvements**: Hoists `loadProduct(billingPlanId)` before the `existing`-resource check so `requestedProduct` is available in all branches, and adds a short-circuit (`product_id === billingPlanId`) in the main path to avoid re-fetching an already-loaded product.
</details>


<h3>Confidence Score: 4/5</h3>

The fix is narrowly scoped to free-plan detection and in-memory customer product lookup — no database writes, no auth changes, and the paid-plan path is unchanged.

The core fix correctly routes free-product requests away from the Stripe subscription lookup that would always miss them. The only rough edges are two early-return branches that still call loadProduct redundantly when the product is already in scope.

handleCreateResource.ts — the existing-resource and race-condition retry branches could reuse requestedProduct the same way the main provisioning path does.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/vercel/handlers/resources/handleCreateResource.ts | Adds free-plan awareness to resource provisioning: detects zero-price products upfront and resolves the customer product directly from in-memory customer data instead of searching Stripe subscriptions (which don't exist for free plans). Logic is correct; minor inconsistency in reusing the already-loaded requestedProduct across all early-return branches. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /resources] --> B[Load requestedProduct]
    B --> C{isFreeProduct?}
    C -- Yes --> D[freeProduct = requestedProduct]
    C -- No --> E[freeProduct = undefined]
    D & E --> F[findInstallationCusProduct]
    F --> G{freeProduct set?}
    G -- Yes --> H[findActiveCustomerProductById from fullCustomer]
    G -- No --> I[Find Stripe subscription by vercel_installation_id]
    I --> J{existingSub found?}
    J -- No --> K[return undefined]
    J -- Yes --> L[getByStripeSubId]
    H & L --> M[installationCusProduct]
    M --> N{existing resource?}
    N -- Yes --> O[return existing resource with product]
    N -- No --> P[Create new resource record]
    P --> Q{installationCusProduct exists?}
    Q -- Yes --> R[Reuse existing cus_product]
    Q -- No --> S[provisionVercelCusProduct]
    R & S --> T[Send Svix event]
    T --> U[Return resource response]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/external/vercel/handlers/resources/handleCreateResource.ts`, line 200-207 ([link](https://github.com/useautumn/autumn/blob/d416d37407431d44d425a2e69c9c264025a4e8d4/server/src/external/vercel/handlers/resources/handleCreateResource.ts#L200-L207)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `installationCusProduct.product_id === billingPlanId` short-circuit to reuse `requestedProduct` was only added to the main provisioning path. The `existing` resource early-return path still always calls `loadProduct(installationCusProduct.product_id)`, which is an unnecessary round-trip when the IDs are equal and `requestedProduct` is already in scope. Consistent with the optimization already applied further below.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/external/vercel/handlers/resources/handleCreateResource.ts
   Line: 200-207

   Comment:
   The `installationCusProduct.product_id === billingPlanId` short-circuit to reuse `requestedProduct` was only added to the main provisioning path. The `existing` resource early-return path still always calls `loadProduct(installationCusProduct.product_id)`, which is an unnecessary round-trip when the IDs are equal and `requestedProduct` is already in scope. Consistent with the optimization already applied further below.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/vercel/handlers/resources/handleCreateResource.ts:200-207
The `installationCusProduct.product_id === billingPlanId` short-circuit to reuse `requestedProduct` was only added to the main provisioning path. The `existing` resource early-return path still always calls `loadProduct(installationCusProduct.product_id)`, which is an unnecessary round-trip when the IDs are equal and `requestedProduct` is already in scope. Consistent with the optimization already applied further below.

```suggestion
			if (existing) {
				const product = installationCusProduct
					? installationCusProduct.product_id === billingPlanId
						? requestedProduct
						: await loadProduct(installationCusProduct.product_id)
					: requestedProduct;
				return c.json(
					buildResourceResponse({ resourceId: existing.id, product }),
				);
			}
```

### Issue 2 of 2
server/src/external/vercel/handlers/resources/handleCreateResource.ts:236-238
Same inconsistency as the `existing` path: `loadProduct(installationCusProduct.product_id)` is called unconditionally when `installationCusProduct` is set, even though `requestedProduct` is already in scope and could be reused when `installationCusProduct.product_id === billingPlanId`. The main provisioning path just below applies that check correctly.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(vercel): 🐛 resolve free plan resour..."](https://github.com/useautumn/autumn/commit/d416d37407431d44d425a2e69c9c264025a4e8d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34567661)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->