### PR TITLE
cut over to us east tinybird

### DIFF
--- a/server/src/external/tinybird/initClickhouse.ts
+++ b/server/src/external/tinybird/initClickhouse.ts
@@ -1,12 +1,8 @@
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
 
-// ClickHouse URL is different from API URL
-// API: https://api.europe-west2.gcp.tinybird.co
-// ClickHouse: https://europe-west2.gcp.clickhouse.tinybird.co
-const TINYBIRD_CLICKHOUSE_URL = process.env.TINYBIRD_CLICKHOUSE_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
+const TINYBIRD_CLICKHOUSE_URL = process.env.TINYBIRD_US_EAST_CLICKHOUSE_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
 
-// Debug logging
 if (TINYBIRD_CLICKHOUSE_URL && TINYBIRD_TOKEN) {
 	console.log(
 		`[Tinybird ClickHouse] Configured with URL: ${TINYBIRD_CLICKHOUSE_URL}`,

--- a/server/src/external/tinybird/initTinybirdV2.ts
+++ b/server/src/external/tinybird/initTinybirdV2.ts
@@ -4,9 +4,9 @@ const TINYBIRD_SECONDARY_API_URL = process.env.TINYBIRD_API_URL;
 const TINYBIRD_SECONDARY_TOKEN = process.env.TINYBIRD_TOKEN;
 
 /** Secondary Tinybird API client for dual-write safety net during region cutover.
- *  Reads from the legacy TINYBIRD_API_URL / TINYBIRD_TOKEN env vars, which point
- *  at the prior region (us-west). Once us-east is stable, delete this file +
- *  the dual-write logic in sendEvents.ts. */
+ *  Reads from the legacy TINYBIRD_API_URL / TINYBIRD_TOKEN env vars (europe-west2
+ *  GCP). Once us-east is stable, delete this file + the dual-write logic in
+ *  sendEvents.ts. */
 export const tinybirdSecondaryApi =
 	TINYBIRD_SECONDARY_API_URL && TINYBIRD_SECONDARY_TOKEN
 		? createTinybirdApi({

--- a/server/src/external/tinybird/initTinybirdV2.ts
+++ b/server/src/external/tinybird/initTinybirdV2.ts
@@ -1,19 +1,22 @@
 import { createTinybirdApi } from "@tinybirdco/sdk";
 
-const TINYBIRD_US_EAST_API_URL = process.env.TINYBIRD_US_EAST_API_URL;
-const TINYBIRD_US_EAST_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
+const TINYBIRD_SECONDARY_API_URL = process.env.TINYBIRD_API_URL;
+const TINYBIRD_SECONDARY_TOKEN = process.env.TINYBIRD_TOKEN;
 
-/** Secondary Tinybird API client (us-east region) for dual-write during migration. */
-export const tinybirdUsEastApi =
-	TINYBIRD_US_EAST_API_URL && TINYBIRD_US_EAST_TOKEN
+/** Secondary Tinybird API client for dual-write safety net during region cutover.
+ *  Reads from the legacy TINYBIRD_API_URL / TINYBIRD_TOKEN env vars, which point
+ *  at the prior region (us-west). Once us-east is stable, delete this file +
+ *  the dual-write logic in sendEvents.ts. */
+export const tinybirdSecondaryApi =
+	TINYBIRD_SECONDARY_API_URL && TINYBIRD_SECONDARY_TOKEN
 		? createTinybirdApi({
-				baseUrl: TINYBIRD_US_EAST_API_URL,
-				token: TINYBIRD_US_EAST_TOKEN,
+				baseUrl: TINYBIRD_SECONDARY_API_URL,
+				token: TINYBIRD_SECONDARY_TOKEN,
 			})
 		: null;
 
-if (tinybirdUsEastApi) {
+if (tinybirdSecondaryApi) {
 	console.log(
-		`[Tinybird] us-east dual-write configured with URL: ${TINYBIRD_US_EAST_API_URL}`,
+		`[Tinybird] secondary dual-write configured with URL: ${TINYBIRD_SECONDARY_API_URL}`,
 	);
 }

--- a/server/src/external/tinybird/sendEvents/sendEvents.ts
+++ b/server/src/external/tinybird/sendEvents/sendEvents.ts
@@ -3,7 +3,7 @@ import type { EventInsert } from "@autumn/shared";
 import * as Sentry from "@sentry/bun";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { tinybirdIngest } from "../initTinybird.js";
-import { tinybirdUsEastApi } from "../initTinybirdV2.js";
+import { tinybirdSecondaryApi } from "../initTinybirdV2.js";
 import { isTinybirdConfigured } from "../tinybirdUtils.js";
 import { mapToTinybirdEvent } from "./mapEvent.js";
 
@@ -35,7 +35,7 @@ export const sendEventsToTinybird = async ({
 
 	const tinybirdEvents = events.map(mapToTinybirdEvent);
 
-	const reportFailure = (error: unknown, region: "primary" | "us-east") => {
+	const reportFailure = (error: unknown, region: "primary" | "secondary") => {
 		const errorId = generateErrorId();
 		const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -81,24 +81,21 @@ export const sendEventsToTinybird = async ({
 		})
 		.catch((error: unknown) => reportFailure(error, "primary"));
 
-	const usEastWrite = tinybirdUsEastApi
-		? tinybirdUsEastApi
+	const secondaryWrite = tinybirdSecondaryApi
+		? tinybirdSecondaryApi
 				.ingestBatch("events", tinybirdEvents)
 				.then((result) => {
-					logger?.info(
-						`Sent ${events.length} events to Tinybird (us-east)`,
-						{
-							data: {
-								region: "us-east",
-								eventCount: events.length,
-								successfulRows: result?.successful_rows,
-								quarantinedRows: result?.quarantined_rows,
-							},
+					logger?.info(`Sent ${events.length} events to Tinybird (secondary)`, {
+						data: {
+							region: "secondary",
+							eventCount: events.length,
+							successfulRows: result?.successful_rows,
+							quarantinedRows: result?.quarantined_rows,
 						},
-					);
+					});
 				})
-				.catch((error: unknown) => reportFailure(error, "us-east"))
+				.catch((error: unknown) => reportFailure(error, "secondary"))
 		: Promise.resolve();
 
-	await Promise.all([primaryWrite, usEastWrite]);
+	await Promise.all([primaryWrite, secondaryWrite]);
 };

--- a/server/src/external/tinybird/tinybirdUtils.ts
+++ b/server/src/external/tinybird/tinybirdUtils.ts
@@ -1,8 +1,8 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 
-const TINYBIRD_API_URL = process.env.TINYBIRD_API_URL;
-const TINYBIRD_TOKEN = process.env.TINYBIRD_TOKEN;
+const TINYBIRD_API_URL = process.env.TINYBIRD_US_EAST_API_URL;
+const TINYBIRD_TOKEN = process.env.TINYBIRD_US_EAST_TOKEN;
 
 export type TinybirdConfig = {
 	baseUrl: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut over Tinybird primary region to us-east and keep optional dual-write to the legacy region as a safety net. Primary ingest and ClickHouse now read US East env vars; secondary client uses legacy envs.

- **Refactors**
  - Primary Tinybird now uses `TINYBIRD_US_EAST_API_URL`/`TINYBIRD_US_EAST_TOKEN` and `TINYBIRD_US_EAST_CLICKHOUSE_URL`.
  - Secondary dual-write client renamed to `tinybirdSecondaryApi` and reads `TINYBIRD_API_URL`/`TINYBIRD_TOKEN`; logs/labels updated to "secondary".
  - Fixed comment to correctly note the secondary region is europe-west2 (GCP).

- **Migration**
  - Set `TINYBIRD_US_EAST_API_URL`, `TINYBIRD_US_EAST_TOKEN`, and `TINYBIRD_US_EAST_CLICKHOUSE_URL` in all environments.
  - Keep `TINYBIRD_API_URL` and `TINYBIRD_TOKEN` only if dual-write is needed; remove once us-east is stable.

<sup>Written for commit 477df225fc3f190f32c758fcd7e7ebb9934c3863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes the cutover of the primary Tinybird integration to the US East region by swapping which env vars are treated as primary (`TINYBIRD_US_EAST_*`) vs secondary/dual-write (`TINYBIRD_API_URL` / `TINYBIRD_TOKEN`), and renames the previously "us-east" secondary client to "secondary" to reflect the inverted role.

- **[Improvements]** `tinybirdUtils.ts` and `initClickhouse.ts` now read `TINYBIRD_US_EAST_API_URL`, `TINYBIRD_US_EAST_TOKEN`, and `TINYBIRD_US_EAST_CLICKHOUSE_URL` as the primary credentials, making US East the authoritative region.
- **[Improvements]** `initTinybirdV2.ts` is repurposed as the dual-write safety net pointing at the legacy region using the old `TINYBIRD_API_URL` / `TINYBIRD_TOKEN` vars; the comment correctly notes these should be deleted once US East is stable.
- **[Improvements]** `tinybirdUsEastApi` is renamed to `tinybirdSecondaryApi` and updated consistently throughout `sendEvents.ts`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; all env-var wiring and rename changes are consistent across the four affected files.

The cutover logic is straightforward and the rename is applied consistently — no leftover references to the old exported name or old env vars were found in other files. The only issue is a stale region label in a comment (us-west instead of europe-west2 GCP), which has no runtime effect but could mislead operators investigating secondary-write failures.

initTinybirdV2.ts has a mislabeled region in its comment; all other files are clean.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/tinybird/tinybirdUtils.ts | Swaps primary env vars from TINYBIRD_API_URL/TOKEN to TINYBIRD_US_EAST_API_URL/TOKEN; drives isTinybirdConfigured() and tinybirdConfig for the whole primary write path. |
| server/src/external/tinybird/initClickhouse.ts | Switches ClickHouse client credentials to TINYBIRD_US_EAST_CLICKHOUSE_URL and TINYBIRD_US_EAST_TOKEN; also removes stale comment about GCP europe-west2 URLs. |
| server/src/external/tinybird/initTinybirdV2.ts | Repurposed from a us-east secondary writer to a legacy-region safety net; now reads the old TINYBIRD_API_URL/TOKEN. Comment says 'us-west' but removed code hinted at 'europe-west2.gcp'. |
| server/src/external/tinybird/sendEvents/sendEvents.ts | Mechanical rename from tinybirdUsEastApi/usEastWrite to tinybirdSecondaryApi/secondaryWrite; no logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant sendEvents
    participant Primary as Primary (US East) TINYBIRD_US_EAST_*
    participant Secondary as Secondary (Legacy Region) TINYBIRD_API_URL / TINYBIRD_TOKEN

    App->>sendEvents: sendEventsToTinybird(events)
    sendEvents->>sendEvents: isTinybirdConfigured()?
    alt not configured
        sendEvents-->>App: return (debug log only)
    else configured
        par Dual Write
            sendEvents->>Primary: tinybirdIngest.events(events)
            Primary-->>sendEvents: result / error
        and
            sendEvents->>Secondary: tinybirdSecondaryApi.ingestBatch(events)
            Secondary-->>sendEvents: result / error
        end
        sendEvents-->>App: void
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/external/tinybird/initTinybirdV2.ts:6-9
The comment says the prior region is "us-west", but the code that was removed from `initClickhouse.ts` in this same PR explicitly referenced `europe-west2.gcp` as the legacy region. This mislabels the dual-write target, which could cause confusion when diagnosing failures or deciding when to retire the secondary.

```suggestion
/** Secondary Tinybird API client for dual-write safety net during region cutover.
 *  Reads from the legacy TINYBIRD_API_URL / TINYBIRD_TOKEN env vars, which point
 *  at the prior region (europe-west2 GCP). Once us-east is stable, delete this file +
 *  the dual-write logic in sendEvents.ts. */
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["cut over to us east"](https://github.com/useautumn/autumn/commit/efd61a46c4ac97311456acc75821287b5b925792) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34879350)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->