### PR TITLE
fix: no invoice void

### DIFF
--- a/server/src/cron/invoiceCron/runInvoiceCron.ts
+++ b/server/src/cron/invoiceCron/runInvoiceCron.ts
@@ -113,26 +113,34 @@ export const handleVoidInvoiceCron = async ({
 	}
 };
 
+export const getExpiredInvoiceMetadata = async ({
+	db,
+}: {
+	db: CronContext["db"];
+}) => {
+	return db
+		.select()
+		.from(metadata)
+		.where(
+			and(
+				or(
+					eq(metadata.type, MetadataType.InvoiceActionRequired),
+					eq(metadata.type, MetadataType.InvoiceCheckout),
+					eq(metadata.type, MetadataType.DeferredInvoice),
+				),
+				isNotNull(metadata.expires_at),
+				lt(metadata.expires_at, Date.now()),
+				isNotNull(metadata.stripe_invoice_id),
+			),
+		);
+};
+
 export const runInvoiceCron = async ({ ctx }: { ctx: CronContext }) => {
 	try {
 		console.log("Running invoice cron");
 		const { db } = ctx;
 
-		// 1. Fetch from metadata invoices
-		const invoices = await db
-			.select()
-			.from(metadata)
-			.where(
-				and(
-					or(
-						eq(metadata.type, MetadataType.InvoiceActionRequired),
-						eq(metadata.type, MetadataType.InvoiceCheckout),
-						eq(metadata.type, MetadataType.DeferredInvoice),
-					),
-					lt(metadata.expires_at, Date.now()),
-					isNotNull(metadata.stripe_invoice_id),
-				),
-			);
+		const invoices = await getExpiredInvoiceMetadata({ db });
 
 		const batchSize = 50;
 		for (let i = 0; i < invoices.length; i += batchSize) {

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeInvoiceAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeInvoiceAction.ts
@@ -4,13 +4,14 @@ import type {
 	Invoice,
 	StripeBillingPlanResult,
 } from "@autumn/shared";
-import { ms, StripeBillingStage } from "@autumn/shared";
+import { StripeBillingStage } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { shouldDeferBillingPlan } from "@/internal/billing/v2/providers/stripe/utils/common/shouldDeferBillingPlan";
 import { createInvoiceForBilling } from "@/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling";
 import { isDeferredInvoiceMode } from "@/internal/billing/v2/utils/billingContext/isDeferredInvoiceMode";
 import { invoiceActions } from "@/internal/invoices/actions";
 import { insertMetadataFromBillingPlan } from "@/internal/metadata/utils/insertMetadataFromBillingPlan";
+import { getDeferredBillingMetadataExpiresAt } from "./getDeferredBillingMetadataExpiresAt";
 
 export const executeStripeInvoiceAction = async ({
 	ctx,
@@ -59,10 +60,10 @@ export const executeStripeInvoiceAction = async ({
 			billingPlan,
 			billingContext,
 			stripeInvoice: invoice,
-			expiresAt:
-				deferredInvoiceMode || billingContext.paymentMethod?.type === "custom"
-					? Date.now() + ms.days(10)
-					: Date.now() + ms.minutes(10),
+			expiresAt: getDeferredBillingMetadataExpiresAt({
+				deferredInvoiceMode,
+				paymentMethod: billingContext.paymentMethod,
+			}),
 			resumeAfter: StripeBillingStage.InvoiceAction,
 		});
 

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts
@@ -147,9 +147,7 @@ export const executeStripeSubscriptionAction = async ({
 			billingPlan,
 			billingContext: deferredBillingContext,
 			stripeInvoice: latestStripeInvoice,
-			expiresAt: deferredInvoiceMode
-				? Date.now() + ms.days(10)
-				: Date.now() + ms.minutes(10),
+			expiresAt: deferredInvoiceMode ? null : Date.now() + ms.minutes(10),
 			resumeAfter: StripeBillingStage.SubscriptionAction,
 		});
 

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts
@@ -4,7 +4,7 @@ import type {
 	Invoice,
 	StripeBillingPlanResult,
 } from "@autumn/shared";
-import { ms, StripeBillingStage, tryCatch } from "@autumn/shared";
+import { StripeBillingStage, tryCatch } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { isStripeSubscriptionCanceled } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
 import { setStripeSubscriptionLock } from "@/external/stripe/subscriptions/utils/lockStripeSubscriptionUtils";
@@ -20,6 +20,7 @@ import { upsertSubscriptionFromBilling } from "@/internal/billing/v2/utils/upser
 import { invoiceActions } from "@/internal/invoices/actions";
 import { insertMetadataFromBillingPlan } from "@/internal/metadata/utils/insertMetadataFromBillingPlan";
 import { isDeferredInvoiceMode } from "../../../utils/billingContext/isDeferredInvoiceMode";
+import { getDeferredBillingMetadataExpiresAt } from "./getDeferredBillingMetadataExpiresAt";
 
 export const executeStripeSubscriptionAction = async ({
 	ctx,
@@ -147,7 +148,10 @@ export const executeStripeSubscriptionAction = async ({
 			billingPlan,
 			billingContext: deferredBillingContext,
 			stripeInvoice: latestStripeInvoice,
-			expiresAt: deferredInvoiceMode ? null : Date.now() + ms.minutes(10),
+			expiresAt: getDeferredBillingMetadataExpiresAt({
+				deferredInvoiceMode,
+				paymentMethod: billingContext.paymentMethod,
+			}),
 			resumeAfter: StripeBillingStage.SubscriptionAction,
 		});
 

--- a/server/src/internal/billing/v2/providers/stripe/execute/getDeferredBillingMetadataExpiresAt.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/getDeferredBillingMetadataExpiresAt.ts
@@ -1,0 +1,17 @@
+import { ms } from "@autumn/shared";
+
+export const getDeferredBillingMetadataExpiresAt = ({
+	deferredInvoiceMode,
+	paymentMethod,
+	now = Date.now(),
+}: {
+	deferredInvoiceMode: boolean;
+	paymentMethod?: { type?: string } | null;
+	now?: number;
+}) => {
+	if (deferredInvoiceMode || paymentMethod?.type === "custom") {
+		return null;
+	}
+
+	return now + ms.minutes(10);
+};

--- a/server/src/internal/metadata/utils/insertMetadataFromBillingPlan.ts
+++ b/server/src/internal/metadata/utils/insertMetadataFromBillingPlan.ts
@@ -5,7 +5,6 @@ import type {
 	StripeBillingStage,
 } from "@autumn/shared";
 import { InternalError, MetadataType } from "@autumn/shared";
-import { addDays } from "date-fns";
 import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -31,7 +30,7 @@ export const insertMetadataFromBillingPlan = async ({
 	stripeInvoice?: Stripe.Invoice;
 	stripeCheckoutSession?: Stripe.Checkout.Session;
 	resumeAfter?: StripeBillingStage;
-	expiresAt: number;
+	expiresAt: number | null;
 	/** Override the auto-detected metadata type. Used by the enable_plan_immediately checkout flow. */
 	typeOverride?: MetadataType;
 }) => {
@@ -64,7 +63,7 @@ export const insertMetadataFromBillingPlan = async ({
 			stripe_checkout_session_id: stripeCheckoutSession?.id,
 			data,
 			created_at: Date.now(),
-			expires_at: expiresAt ?? addDays(Date.now(), 10).getTime(),
+			expires_at: expiresAt,
 		},
 	});
 

--- a/server/tests/integration/billing/attach/invoice/invoice-mode-deferred-metadata-expiry.test.ts
+++ b/server/tests/integration/billing/attach/invoice/invoice-mode-deferred-metadata-expiry.test.ts
@@ -1,0 +1,162 @@
+// Contract: deferred invoice metadata is unbounded; action-required upgrade metadata keeps a short expiry.
+// Side effect: cron selection excludes null expires_at rows.
+
+import { expect, test } from "bun:test";
+import { type AttachParamsV1Input, MetadataType, ms } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	getExpiredInvoiceMetadata,
+	handleVoidInvoiceCron,
+} from "@/cron/invoiceCron/runInvoiceCron";
+import { getDeferredBillingMetadataExpiresAt } from "@/internal/billing/v2/providers/stripe/execute/getDeferredBillingMetadataExpiresAt";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+
+test(`${chalk.yellowBright("invoice-mode metadata expiry: custom payment methods are unbounded")}`, () => {
+	const now = Date.now();
+
+	expect(
+		getDeferredBillingMetadataExpiresAt({
+			deferredInvoiceMode: false,
+			paymentMethod: { type: "custom" },
+			now,
+		}),
+	).toBeNull();
+	expect(
+		getDeferredBillingMetadataExpiresAt({
+			deferredInvoiceMode: false,
+			paymentMethod: { type: "card" },
+			now,
+		}),
+	).toBe(now + ms.minutes(10));
+});
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-mode metadata expiry: deferred invoices do not auto-void")}`,
+	async () => {
+		const customerId = "invoice-mode-deferred-no-expiry";
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		const result = await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			invoice_mode: {
+				enabled: true,
+				enable_plan_immediately: false,
+				finalize: true,
+			},
+		});
+
+		expect(result.invoice?.stripe_id).toBeDefined();
+
+		const deferredMetadata = await MetadataService.getByStripeInvoiceId({
+			db: ctx.db,
+			stripeInvoiceId: result.invoice!.stripe_id,
+			type: MetadataType.DeferredInvoice,
+		});
+
+		expect(deferredMetadata).toBeDefined();
+		expect(deferredMetadata!.expires_at).toBeNull();
+
+		const expiredMetadata = await MetadataService.insert({
+			db: ctx.db,
+			data: {
+				id: `meta_invoice_mode_deferred_selector_${Date.now()}`,
+				type: MetadataType.DeferredInvoice,
+				stripe_invoice_id: "in_invoice_mode_deferred_selector",
+				created_at: Date.now(),
+				expires_at: Date.now() - ms.minutes(1),
+				data: {},
+			},
+		});
+
+		const voidableMetadata = await getExpiredInvoiceMetadata({ db: ctx.db });
+		const voidableIds = new Set(voidableMetadata.map((row) => row.id));
+
+		expect(voidableIds.has(deferredMetadata!.id)).toBe(false);
+		expect(voidableIds.has(expiredMetadata.id)).toBe(true);
+
+		await MetadataService.delete({ db: ctx.db, id: expiredMetadata.id });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-mode metadata expiry: action-required upgrades keep short expiry")}`,
+	async () => {
+		const customerId = "invoice-mode-action-required-short-expiry";
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 300 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [
+				s.attach({ productId: pro.id }),
+				s.attachPaymentMethod({ type: "authenticate" }),
+			],
+		});
+
+		const beforeAttach = Date.now();
+		await autumnV1.attach({
+			customer_id: customerId,
+			product_id: premium.id,
+		});
+
+		const customer = await autumnV1.customers.get(customerId);
+		const stripeInvoices = await ctx.stripeCli.invoices.list({
+			customer: customer.stripe_id!,
+			limit: 1,
+		});
+		const latestInvoice = stripeInvoices.data[0];
+		const metadataId = latestInvoice.metadata?.autumn_metadata_id;
+
+		expect(metadataId).toBeDefined();
+
+		const actionRequiredMetadata = await MetadataService.get({
+			db: ctx.db,
+			id: metadataId!,
+		});
+
+		expect(actionRequiredMetadata).toBeDefined();
+		expect(actionRequiredMetadata!.expires_at).toBeGreaterThanOrEqual(
+			beforeAttach,
+		);
+		expect(actionRequiredMetadata!.expires_at).toBeLessThanOrEqual(
+			beforeAttach + ms.minutes(11),
+		);
+
+		await handleVoidInvoiceCron({
+			ctx,
+			metadata: actionRequiredMetadata!,
+		});
+
+		const voidedInvoice = await ctx.stripeCli.invoices.retrieve(
+			latestInvoice.id,
+		);
+		expect(voidedInvoice.status).toBe("void");
+	},
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent auto-voiding of deferred invoices by removing metadata expiry and updating cron to ignore null expirations.

- **Bug Fixes**
  - Set `expires_at` to null for deferred invoices and for `paymentMethod.type: "custom"` across both invoice and subscription actions via `getDeferredBillingMetadataExpiresAt`; removed the old 10-day expiry.
  - Cron now uses `getExpiredInvoiceMetadata` to only select invoices with a past `expires_at`; null rows are excluded.
  - Action-required upgrade invoices keep a 10-minute expiry and are still voided when overdue.

<sup>Written for commit 159e239cb5b0d2299142df0a00cfc609caa7e3da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes unwanted invoice voiding by making deferred invoice metadata rows have no expiry (`null`), so the cron job's new `isNotNull(expires_at)` guard skips them entirely.

- **[Bug fixes]** `getDeferredBillingMetadataExpiresAt` is extracted into a shared helper that returns `null` for deferred invoice mode or custom payment methods; `insertMetadataFromBillingPlan` now accepts `number | null` and stores it directly instead of falling back to a 10-day default.
- **[Bug fixes]** `runInvoiceCron` adds `isNotNull(expires_at)` to the query so null-expiry rows are never selected for voiding; the query is extracted into a testable `getExpiredInvoiceMetadata` helper.
- **[Improvements]** New integration tests verify that deferred invoice metadata carries a null expiry, custom payment method metadata is unbounded, and action-required upgrade metadata still gets a short expiry and is correctly voided by the cron.
</details>


<h3>Confidence Score: 3/5</h3>

The invoice-action path is fully fixed, but the subscription-action path still writes a 10-minute expiry for custom payment method customers, leaving them exposed to the same premature void the PR aims to eliminate.

The subscription action path uses a bare `deferredInvoiceMode ? null : Date.now() + ms.minutes(10)` ternary instead of the new `getDeferredBillingMetadataExpiresAt` helper, so the `paymentMethod.type === "custom"` guard is silently absent. Customers on a custom payment method who go through subscription billing will have their invoices voided after 10 minutes.

server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts — the expiresAt expression needs to be updated to use getDeferredBillingMetadataExpiresAt just as executeStripeInvoiceAction.ts does.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts | Changed expiresAt to null for deferredInvoiceMode, but misses the custom payment method case that executeStripeInvoiceAction.ts handles via getDeferredBillingMetadataExpiresAt. |
| server/src/internal/billing/v2/providers/stripe/execute/getDeferredBillingMetadataExpiresAt.ts | New helper that centralises expires-at logic; returns null for deferred invoice mode or custom payment methods, 10 min otherwise. Testable by design (accepts now parameter). |
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeInvoiceAction.ts | Correctly delegates to getDeferredBillingMetadataExpiresAt, handling both deferredInvoiceMode and custom payment methods. |
| server/src/cron/invoiceCron/runInvoiceCron.ts | Adds isNotNull(expires_at) filter so deferred invoices with null expiry are excluded from auto-void cron; query extracted into testable getExpiredInvoiceMetadata helper. |
| server/src/internal/metadata/utils/insertMetadataFromBillingPlan.ts | expiresAt type widened to number | null and the implicit addDays(10) fallback removed; null is now stored directly for unbounded metadata rows. |
| server/tests/integration/billing/attach/invoice/invoice-mode-deferred-metadata-expiry.test.ts | New integration tests covering deferred invoices (null expiry, excluded from cron), custom payment methods (null expiry), and action-required upgrades (10-min expiry + void). |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Billing attach request] --> B{Which action path?}
    B --> C[executeStripeInvoiceAction]
    B --> D[executeStripeSubscriptionAction]

    C --> E[getDeferredBillingMetadataExpiresAt]
    E --> F{deferredInvoiceMode OR custom payment?}
    F -- Yes --> G[expiresAt = null]
    F -- No --> H[expiresAt = now + 10 min]

    D --> I{deferredInvoiceMode?}
    I -- Yes --> G
    I -- No --> J[expiresAt = now + 10 min ⚠️ custom payment not handled]

    G --> K[insertMetadataFromBillingPlan]
    H --> K
    J --> K

    K --> L[expires_at stored in DB]

    L --> M{Invoice Cron}
    M --> N{isNotNull AND lt now?}
    N -- expires_at IS NULL --> O[✅ Skip - never voided]
    N -- expires_at < now --> P[handleVoidInvoiceCron → void invoice]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts`, line 145-152 ([link](https://github.com/useautumn/autumn/blob/2c437db6725d204dec1c4f7d66932263c7e46da9/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts#L145-L152)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Custom payment methods are not guarded in the subscription action path. `executeStripeInvoiceAction.ts` uses `getDeferredBillingMetadataExpiresAt` (which returns `null` for `paymentMethod.type === "custom"`), but the subscription action path only checks `deferredInvoiceMode`. A customer on a custom payment method who does not trigger deferred invoice mode will get a 10-minute expiry here, and the cron will void their invoice prematurely — the exact bug this PR is meant to fix.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts
   Line: 145-152

   Comment:
   Custom payment methods are not guarded in the subscription action path. `executeStripeInvoiceAction.ts` uses `getDeferredBillingMetadataExpiresAt` (which returns `null` for `paymentMethod.type === "custom"`), but the subscription action path only checks `deferredInvoiceMode`. A customer on a custom payment method who does not trigger deferred invoice mode will get a 10-minute expiry here, and the cron will void their invoice prematurely — the exact bug this PR is meant to fix.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts:145-152
Custom payment methods are not guarded in the subscription action path. `executeStripeInvoiceAction.ts` uses `getDeferredBillingMetadataExpiresAt` (which returns `null` for `paymentMethod.type === "custom"`), but the subscription action path only checks `deferredInvoiceMode`. A customer on a custom payment method who does not trigger deferred invoice mode will get a 10-minute expiry here, and the cron will void their invoice prematurely — the exact bug this PR is meant to fix.

```suggestion
		await insertMetadataFromBillingPlan({
			ctx,
			billingPlan,
			billingContext: deferredBillingContext,
			stripeInvoice: latestStripeInvoice,
			expiresAt: getDeferredBillingMetadataExpiresAt({
				deferredInvoiceMode,
				paymentMethod: billingContext.paymentMethod,
			}),
			resumeAfter: StripeBillingStage.SubscriptionAction,
		});
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t void invoice anymore"](https://github.com/useautumn/autumn/commit/2c437db6725d204dec1c4f7d66932263c7e46da9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34917843)</sub>

<!-- /greptile_comment -->