### PR TITLE
apiKeyId MV for events.aggregate

### DIFF
--- a/server/tests/integration/crud/events/aggregate-group-by-api-key.test.ts
+++ b/server/tests/integration/crud/events/aggregate-group-by-api-key.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "bun:test";
+import { ApiVersion } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+/**
+ * Pins result-equivalence of the events_hourly_apikey_mv fast path: an
+ * events.aggregate grouped by properties.apiKeyId must return the same per-key
+ * totals the events_hourly_mv path produced. Guards the apiKeyId routing branch
+ * in aggregate_groupable.pipe against silent divergence (GROUP BY, the != ''
+ * filter, the ::String cast, or distinct-property-row collapse).
+ *
+ * Requires the apikey MV + materialization deployed to the test Tinybird
+ * workspace (forward materialization covers freshly-tracked events, so no
+ * backfill is needed for this test's own data).
+ */
+
+const TINYBIRD_INGEST_WAIT_MS = 4000;
+
+/** Sum every numeric value tied to each target apiKeyId, robust to the
+ *  version-transformed response shape: matches both {"<key>": n} (grouped_values)
+ *  and [{group:"<key>", messages:n}] layouts. Keys are unique long strings, so
+ *  collisions are not a concern. */
+const sumByApiKey = (
+	node: unknown,
+	keys: string[],
+	acc: Record<string, number>,
+): void => {
+	if (Array.isArray(node)) {
+		for (const el of node) sumByApiKey(el, keys, acc);
+		return;
+	}
+	if (!node || typeof node !== "object") return;
+	const obj = node as Record<string, unknown>;
+	const siblingKey = keys.find((k) => Object.values(obj).includes(k));
+	for (const [k, v] of Object.entries(obj)) {
+		if (keys.includes(k) && typeof v === "number") {
+			acc[k] = (acc[k] ?? 0) + v;
+		} else if (siblingKey && typeof v === "number") {
+			acc[siblingKey] = (acc[siblingKey] ?? 0) + v;
+		} else {
+			sumByApiKey(v, keys, acc);
+		}
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("events-aggregate-group-by-apiKeyId: per-key totals correct via events_hourly_apikey_mv")}`,
+	async () => {
+		const ts = Date.now();
+		const customerId = `agg-apikey-${ts}`;
+		const KEY_A = `tb-apikey-A-${ts}`;
+		const KEY_B = `tb-apikey-B-${ts}`;
+		const KEY_NUM = 900000 + (ts % 100000); // numeric apiKeyId → exercises ::String cast
+		const KEY_NUM_STR = String(KEY_NUM);
+		const NO_KEY_VALUE = 91737; // distinctive: must be absent (no-apiKeyId event excluded)
+
+		const messagesItem = items.free({
+			featureId: TestFeature.Messages,
+			includedUsage: 1_000_000,
+		});
+		const freeProd = products.base({ id: "free", items: [messagesItem] });
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		const track = (value: number, properties: Record<string, unknown>) =>
+			autumnV2_2.track({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value,
+				properties,
+			} as unknown as { customer_id: string });
+
+		// KEY_A: 3×10, plus one event with an extra distinct property — the apikey MV
+		// must collapse distinct other-property rows under one apiKeyId → 30 + 7 = 37.
+		await track(10, { apiKeyId: KEY_A });
+		await track(10, { apiKeyId: KEY_A });
+		await track(10, { apiKeyId: KEY_A });
+		await track(7, { apiKeyId: KEY_A, model: "gpt-4o" });
+		// KEY_B: 2×5 = 10
+		await track(5, { apiKeyId: KEY_B });
+		await track(5, { apiKeyId: KEY_B });
+		// numeric apiKeyId: 1×4 = 4
+		await track(4, { apiKeyId: KEY_NUM });
+		// no apiKeyId: must be excluded from grouped results (both paths filter != '')
+		await track(NO_KEY_VALUE, { somethingElse: "x" });
+
+		await timeout(TINYBIRD_INGEST_WAIT_MS);
+
+		const autumn = new AutumnInt({ version: ApiVersion.V2_3 });
+		const response = (await autumn.events.aggregate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			group_by: "properties.apiKeyId",
+			range: "24h",
+		} as unknown as { customer_id: string })) as unknown;
+
+		const keys = [KEY_A, KEY_B, KEY_NUM_STR];
+		const sums: Record<string, number> = {};
+		sumByApiKey(response, keys, sums);
+
+		if (sums[KEY_A] !== 37 || sums[KEY_B] !== 10 || sums[KEY_NUM_STR] !== 4) {
+			console.log(
+				chalk.red(
+					`[apikey-agg] unexpected sums ${JSON.stringify(sums)} from ${JSON.stringify(response)}`,
+				),
+			);
+		}
+
+		expect(sums[KEY_A]).toBe(37);
+		expect(sums[KEY_B]).toBe(10);
+		expect(sums[KEY_NUM_STR]).toBe(4);
+
+		// The no-apiKeyId event must not surface as a group.
+		expect(JSON.stringify(response).includes(String(NO_KEY_VALUE))).toBe(false);
+	},
+);

--- a/server/tests/integration/crud/events/aggregate-group-by-api-key.test.ts
+++ b/server/tests/integration/crud/events/aggregate-group-by-api-key.test.ts
@@ -25,7 +25,10 @@ const TINYBIRD_INGEST_WAIT_MS = 4000;
 /** Sum every numeric value tied to each target apiKeyId, robust to the
  *  version-transformed response shape: matches both {"<key>": n} (grouped_values)
  *  and [{group:"<key>", messages:n}] layouts. Keys are unique long strings, so
- *  collisions are not a concern. */
+ *  collisions are not a concern. In the sibling-object layout, only the metric
+ *  value should count — skip `period` (an epoch) and any `_`-prefixed field
+ *  (e.g. `_truncated`, a UInt8 Tinybird serializes as 0/1) so they don't inflate
+ *  the per-key total. */
 const sumByApiKey = (
 	node: unknown,
 	keys: string[],
@@ -41,7 +44,12 @@ const sumByApiKey = (
 	for (const [k, v] of Object.entries(obj)) {
 		if (keys.includes(k) && typeof v === "number") {
 			acc[k] = (acc[k] ?? 0) + v;
-		} else if (siblingKey && typeof v === "number") {
+		} else if (
+			siblingKey &&
+			typeof v === "number" &&
+			k !== "period" &&
+			!k.startsWith("_")
+		) {
 			acc[siblingKey] = (acc[siblingKey] ?? 0) + v;
 		} else {
 			sumByApiKey(v, keys, acc);

--- a/server/tinybird/copies/events_hourly_apikey_mv_backfill.pipe
+++ b/server/tinybird/copies/events_hourly_apikey_mv_backfill.pipe
@@ -1,0 +1,31 @@
+DESCRIPTION >
+    One-off chunked backfill of events_hourly_apikey_mv from the existing events datasource.
+    SQL mirrors events_hourly_apikey_mv_pipe exactly so backfilled rows are identical to
+    forward-materialized ones. Reads from `events` (already in Tinybird) — NOT from Postgres —
+    so it writes ONLY this MV, never the other six.
+
+    Seam safety: MergeTree does not dedup. Run this ONLY for [start_date, end_date) windows
+    whose hours are strictly older than the month the forward trigger went live, and let the
+    trigger own the current partial month. Half-open window so day/month chunks never overlap.
+
+NODE migrate
+SQL >
+    %
+    SELECT
+        org_id,
+        env,
+        customer_id,
+        coalesce(entity_id, '') as entity_id,
+        event_name,
+        properties.apiKeyId::String as api_key_id,
+        toStartOfHour(timestamp) as hour,
+        sum(toFloat64(coalesce(value, 1))) as total_value,
+        count() as event_count
+    FROM events
+    WHERE properties.apiKeyId::String != ''
+      AND timestamp >= {{DateTime(start_date, '2026-03-01 00:00:00')}}
+      AND timestamp < {{DateTime(end_date, '2026-06-01 00:00:00')}}
+    GROUP BY org_id, env, customer_id, entity_id, event_name, api_key_id, hour
+
+TYPE COPY
+TARGET_DATASOURCE events_hourly_apikey_mv

--- a/server/tinybird/copies/events_hourly_apikey_mv_backfill.pipe
+++ b/server/tinybird/copies/events_hourly_apikey_mv_backfill.pipe
@@ -1,12 +1,17 @@
 DESCRIPTION >
-    One-off chunked backfill of events_hourly_apikey_mv from the existing events datasource.
-    SQL mirrors events_hourly_apikey_mv_pipe exactly so backfilled rows are identical to
-    forward-materialized ones. Reads from `events` (already in Tinybird) — NOT from Postgres —
-    so it writes ONLY this MV, never the other six.
+    MANUAL FALLBACK — you usually do NOT need this. `tb deploy` (Tinybird Forward) already
+    backfills events_hourly_apikey_mv from the live events datasource at deploy time, so a
+    normal deploy populates full history on its own. Keep this pipe only to re-fill a specific
+    window (e.g. if a deploy backfill is ever incomplete).
 
-    Seam safety: MergeTree does not dedup. Run this ONLY for [start_date, end_date) windows
-    whose hours are strictly older than the month the forward trigger went live, and let the
-    trigger own the current partial month. Half-open window so day/month chunks never overlap.
+    Chunked backfill from the existing events datasource. SQL mirrors events_hourly_apikey_mv_pipe
+    exactly so backfilled rows are identical to forward-materialized ones. Reads from `events`
+    (already in Tinybird) — NOT from Postgres — so it writes ONLY this MV, never the other six.
+
+    Seam safety: MergeTree does not dedup. The default window is half-open [start, end) and ends
+    at the start of the current month, so a default run excludes the live-materializing month.
+    If you run it manually, set end_date strictly before the MV's deploy time — overlapping the
+    forward trigger's rows double-counts. Chunk by day/week (dev plan ~30s/copy limit).
 
 NODE migrate
 SQL >

--- a/server/tinybird/materializations/events_hourly_apikey_mv.datasource
+++ b/server/tinybird/materializations/events_hourly_apikey_mv.datasource
@@ -5,6 +5,12 @@ DESCRIPTION >
     to a single customer's parts. Same MergeTree + insert-time GROUP BY + query-time sum()
     pattern as events_hourly_mv. Only rows with a non-empty apiKeyId are materialized.
 
+    Sort key leads with customer_id (not hour, unlike the sibling hourly MVs) on purpose:
+    the hot path is per-customer + per-entity apiKeyId breakdowns, which always filter
+    customer_id, so leading with it prunes straight to one customer. Org-wide (aggregateAll,
+    no customer_id) apiKeyId queries scan more here — an accepted trade-off, as they are not
+    the bottleneck this MV exists to fix.
+
 SCHEMA >
     `org_id` String,
     `env` String,

--- a/server/tinybird/materializations/events_hourly_apikey_mv.datasource
+++ b/server/tinybird/materializations/events_hourly_apikey_mv.datasource
@@ -1,0 +1,21 @@
+DESCRIPTION >
+    Hourly aggregates keyed by apiKeyId, which is pre-extracted from properties into a
+    sorted String column. The apiKeyId-grouped events.aggregate path reads this column
+    instead of parsing properties JSON per row, and the customer_id-leading sort key prunes
+    to a single customer's parts. Same MergeTree + insert-time GROUP BY + query-time sum()
+    pattern as events_hourly_mv. Only rows with a non-empty apiKeyId are materialized.
+
+SCHEMA >
+    `org_id` String,
+    `env` String,
+    `customer_id` String,
+    `entity_id` String DEFAULT '',
+    `event_name` String,
+    `api_key_id` String,
+    `hour` DateTime,
+    `total_value` Float64,
+    `event_count` UInt64
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(hour)"
+ENGINE_SORTING_KEY "org_id, env, customer_id, entity_id, event_name, hour, api_key_id"

--- a/server/tinybird/materializations/events_hourly_apikey_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_hourly_apikey_mv_pipe.pipe
@@ -1,0 +1,23 @@
+DESCRIPTION >
+    Materializes events into hourly aggregates with apiKeyId extracted from properties.
+    Feeds events_hourly_apikey_mv so apiKeyId-grouped queries avoid per-row JSON parsing.
+    Only events carrying a non-empty properties.apiKeyId are kept.
+
+NODE materialize
+SQL >
+    SELECT
+        org_id,
+        env,
+        customer_id,
+        coalesce(entity_id, '') as entity_id,
+        event_name,
+        properties.apiKeyId::String as api_key_id,
+        toStartOfHour(timestamp) as hour,
+        sum(toFloat64(coalesce(value, 1))) as total_value,
+        count() as event_count
+    FROM events
+    WHERE properties.apiKeyId::String != ''
+    GROUP BY org_id, env, customer_id, entity_id, event_name, api_key_id, hour
+
+TYPE materialized
+DATASOURCE events_hourly_apikey_mv

--- a/server/tinybird/pipes/aggregate_groupable.pipe
+++ b/server/tinybird/pipes/aggregate_groupable.pipe
@@ -2,6 +2,7 @@ DESCRIPTION >
     Aggregate queries with grouping by a property key, customer_id, or entity_id.
     Routes to the smallest viable MV for the query shape:
       - events_hourly_no_properties_two_mv: customer_id/entity_id grouping with no property filters
+      - events_hourly_apikey_mv:             group by properties.apiKeyId with no property filters (apiKeyId pre-extracted to a column)
       - events_hourly_mv:                    arbitrary properties or filtered queries
     Uses PER-BIN TOP N groups + "AUTUMN_RESERVED" bucket ((N+1) max total per bin).
     N is controlled by the max_groups parameter (default 9).
@@ -16,6 +17,7 @@ SQL >
     %
     {% set no_property_filters = (not defined(filter_key_0) or String(filter_key_0, '') == '') and (not defined(filter_key_1) or String(filter_key_1, '') == '') and (not defined(filter_key_2) or String(filter_key_2, '') == '') and (not defined(filter_key_3) or String(filter_key_3, '') == '') and (not defined(filter_key_4) or String(filter_key_4, '') == '') %}
     {% set use_no_props = (String(group_column, 'property') in ['customer_id', 'entity_id', 'plan_id']) and no_property_filters %}
+    {% set use_apikey = (String(group_column, 'property') == 'property') and (String(property_key, '') == 'apiKeyId') and no_property_filters %}
 
     SELECT
         {% if String(bin_size, 'day') == 'hour' %}
@@ -32,6 +34,8 @@ SQL >
         entity_id as group_value,
         {% elif String(group_column, 'property') == 'plan_id' %}
         coalesce(internal_product_id, '') as group_value,
+        {% elif use_apikey %}
+        api_key_id as group_value,
         {% else %}
         {{ column('properties.' + String(property_key, '')) }}::String as group_value,
         {% end %}
@@ -39,6 +43,8 @@ SQL >
     FROM
         {% if use_no_props %}
         events_hourly_no_properties_two_mv
+        {% elif use_apikey %}
+        events_hourly_apikey_mv
         {% else %}
         events_hourly_mv
         {% end %}
@@ -73,6 +79,8 @@ SQL >
         {# Filter out null/empty grouping values #}
         {% if String(group_column, 'property') == 'entity_id' %}
         AND entity_id IS NOT NULL AND entity_id != ''
+        {% elif use_apikey %}
+        AND api_key_id != ''
         {% elif String(group_column, 'property') == 'property' %}
         AND {{ column('properties.' + String(property_key, '')) }}::String IS NOT NULL
         AND {{ column('properties.' + String(property_key, '')) }}::String != ''
@@ -83,7 +91,7 @@ NODE ranked
 SQL >
     SELECT
         *,
-        row_number() OVER (PARTITION BY period, event_name ORDER BY total_value DESC) as rn
+        row_number() OVER (PARTITION BY period, event_name ORDER BY total_value DESC, group_value ASC) as rn
     FROM base
 
 NODE endpoint


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `events_hourly_apikey_mv` and routes `events.aggregate` grouped by `properties.apiKeyId` (no filters) to it. This speeds up queries and preserves totals, with deterministic ordering for ties.

- New Features
  - New Tinybird datasource `events_hourly_apikey_mv` and materialized pipe storing hourly sums/counts keyed by non-empty `apiKeyId`.
  - Router update in `aggregate_groupable.pipe` to use `events_hourly_apikey_mv` when grouping by `properties.apiKeyId` with no property filters; adds stable ranking via `group_value` tie-breaker.
  - One-off backfill copy `events_hourly_apikey_mv_backfill.pipe` that mirrors the materialization SQL.
  - Integration test validates per-key totals and exclusion of empty/missing `apiKeyId`; helper updated to ignore `_truncated` and `period` fields to avoid false sums.

- Migration
  - Deploy the new datasource and materialized pipe.
  - Optional backfill with `events_hourly_apikey_mv_backfill.pipe` for windows strictly before the trigger go-live month; use non-overlapping half-open ranges and do not run for the current partial month.

<sup>Written for commit b16eda42c8197f2cc81431537e0699e01115e1c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new Tinybird materialized view (`events_hourly_apikey_mv`) that pre-extracts `apiKeyId` from the events `properties` JSON column into a dedicated `String` column, enabling `events.aggregate` grouped by `properties.apiKeyId` to skip per-row JSON parsing. The routing in `aggregate_groupable.pipe` is cleanly gated — the new path is only taken when `group_column == 'property'`, `property_key == 'apiKeyId'`, and no property filters are active; all other queries fall back to the existing MVs unchanged.

- **Improvements**: New `events_hourly_apikey_mv` MV and matching forward-materialization pipe; backfill COPY pipe with seam-safe defaults covering March–May 2026.
- **Improvements**: `aggregate_groupable.pipe` adds `group_value ASC` as a tiebreaker in the `row_number()` window to make equal-total rankings deterministic.
- **Improvements**: Integration test covers per-key sum correctness, numeric-key `::String` casting, distinct-property row collapse, and exclusion of events with no `apiKeyId`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new MV path is additive and isolated behind an exact routing condition, leaving all existing query paths untouched.

The pipeline SQL, datasource schema, and routing logic are all consistent and correct. The only callout is a fragility in the test helper that could silently produce wrong assertion values if the data set ever grows beyond max_groups, but it does not affect the correctness of the production code itself.

server/tests/integration/crud/events/aggregate-group-by-api-key.test.ts — the sumByApiKey helper's numeric-sibling accumulation could give wrong sums if _truncated ever fires.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tinybird/materializations/events_hourly_apikey_mv.datasource | New MergeTree datasource for hourly apiKeyId aggregates; schema and sorting key are well-designed for per-customer range queries. |
| server/tinybird/materializations/events_hourly_apikey_mv_pipe.pipe | Forward materialization SQL correctly extracts api_key_id from properties, filters empty values, and groups by the full composite key matching the datasource. |
| server/tinybird/copies/events_hourly_apikey_mv_backfill.pipe | Backfill COPY pipe mirrors the materialization SQL with a time-windowed WHERE clause; default date range covers March–May 2026 and is safe assuming the forward trigger went live in June. |
| server/tinybird/pipes/aggregate_groupable.pipe | Routing logic correctly gates on use_apikey (property grouping + property_key==apiKeyId + no filters); the new row_number tiebreaker (group_value ASC) improves determinism. |
| server/tests/integration/crud/events/aggregate-group-by-api-key.test.ts | Integration test covers key correctness scenarios (multi-event collapse, numeric key cast, no-apiKeyId exclusion), but the sumByApiKey helper is fragile when _truncated is returned as a numeric 0/1. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q["events.aggregate\n(group_by: properties.apiKeyId)"] --> COND{Routing in\naggregate_groupable.pipe}
    
    COND -- "group_column in\n[customer_id, entity_id, plan_id]\n+ no_property_filters" --> MV1["events_hourly_no_properties_two_mv"]
    COND -- "group_column == 'property'\n+ property_key == 'apiKeyId'\n+ no_property_filters\n[NEW]" --> MV2["events_hourly_apikey_mv\n(api_key_id column)"]
    COND -- "all other cases" --> MV3["events_hourly_mv\n(properties JSON)"]

    MV2 --> PIPE["events_hourly_apikey_mv_pipe\n(forward materialization)"]
    PIPE --> SRC["events datasource\nWHERE properties.apiKeyId != ''"]
    
    BK["events_hourly_apikey_mv_backfill.pipe\n(one-off COPY)"] --> MV2

    MV1 --> RANKED["NODE: ranked\nrow_number OVER period, event_name\nORDER BY total_value DESC, group_value ASC"]
    MV2 --> RANKED
    MV3 --> RANKED
    RANKED --> EP["NODE: endpoint\nTop-N groups + AUTUMN_RESERVED bucket"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/crud/events/aggregate-group-by-api-key.test.ts:31-46
**`sumByApiKey` accumulates all numeric siblings, including `_truncated`**

Tinybird serializes the ClickHouse `UInt8` result of `max(rn) > N` as a JSON integer (`0` or `1`), not a boolean. In `sumByApiKey`, once `siblingKey` is set for an object, every numeric value in that object — including `_truncated` — is added to `acc[siblingKey]`. For this test's 3-key / `max_groups=9` scenario `_truncated` is always `0` so the sums stay correct, but if the test data grows to trigger truncation the assertion values would each be off by `1`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["apiKeyId MV for events.aggregate"](https://github.com/useautumn/autumn/commit/27bb6be85a00e5023033f6e11d7f0600d28c3525) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34923965)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->