### PR TITLE
add usage_limits config + usage-window resolver

### DIFF
--- a/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
@@ -116,6 +116,7 @@ export const executePostgresDeductionV2 = async ({
 				fullSubject,
 				deduction,
 				options: resolvedOptions,
+				now: Date.now(),
 			});
 
 			if (customerEntitlements.length === 0 || unlimitedFeatureIds.length > 0) {

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -2,6 +2,7 @@ import {
 	type FullCusEntWithFullCusProduct,
 	type FullSubject,
 	fullSubjectToFullCustomer,
+	notNullish,
 } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import { currentRegion } from "@/external/redis/initRedis.js";
@@ -104,6 +105,10 @@ export const executeRedisDeductionV2 = async ({
 		entityId: fullSubject.entityId,
 	});
 
+	// One timestamp for the whole operation: the resolver keys windows from it
+	// and Lua receives the same value, so they never disagree on the window.
+	const usageWindowNow = Date.now();
+
 	for (const deduction of deductions) {
 		const {
 			feature,
@@ -117,6 +122,7 @@ export const executeRedisDeductionV2 = async ({
 			customerEntitlementDeductions,
 			spendLimitByFeatureId,
 			usageBasedCusEntIdsByFeatureId,
+			usageWindowLimits,
 			rollovers,
 			customerEntitlements,
 			unlimitedFeatureIds,
@@ -127,6 +133,7 @@ export const executeRedisDeductionV2 = async ({
 			fullSubject,
 			deduction,
 			options,
+			now: usageWindowNow,
 		});
 
 		if (unlimitedFeatureIds.length > 0) {
@@ -171,6 +178,16 @@ export const executeRedisDeductionV2 = async ({
 				}).redisKey
 			: null;
 
+		// Anchor features own usage-window counters and may not be in the
+		// deduction set, so their balance hash keys must be declared too.
+		const anchorFeatureIds = [
+			...new Set(
+				(usageWindowLimits ?? [])
+					.map((limit) => limit.anchor_feature_id)
+					.filter((featureId): featureId is string => featureId !== null),
+			),
+		];
+
 		const { keys, balanceKeyIndexByFeatureId } =
 			buildDeductFromSubjectBalancesKeys({
 				orgId: org.id,
@@ -181,7 +198,16 @@ export const executeRedisDeductionV2 = async ({
 				idempotencyKey: idempotencyRedisKey,
 				customerEntitlementDeductions,
 				fallbackFeatureId: feature.id,
+				anchorFeatureIds,
 			});
+
+		// Usage windows are enforced/incremented only for real positive
+		// consumption, never for target_balance set-downs or granted-balance edits.
+		const isConsumption =
+			notNullish(toDeduct) &&
+			(toDeduct as number) > 0 &&
+			!notNullish(targetBalance) &&
+			!options.alterGrantedBalance;
 
 		const luaParams = {
 			org_id: org.id,
@@ -192,6 +218,9 @@ export const executeRedisDeductionV2 = async ({
 			spend_limit_by_feature_id: spendLimitByFeatureId ?? null,
 			usage_based_cus_ent_ids_by_feature_id:
 				usageBasedCusEntIdsByFeatureId ?? null,
+			usage_window_limits: usageWindowLimits ?? null,
+			usage_window_now: usageWindowNow,
+			is_consumption: isConsumption,
 			amount_to_deduct: toDeduct ?? null,
 			target_balance: targetBalance ?? null,
 			target_entity_id: entityId || null,

--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -1,18 +1,21 @@
 import {
 	AllowanceType,
 	cusEntToStartingBalance,
+	ErrCode,
 	type FullCusEntWithFullCusProduct,
 	type FullSubject,
 	fullSubjectToCustomerEntitlements,
 	fullSubjectToOverageAllowedByFeatureId,
 	fullSubjectToSpendLimitByFeatureId,
 	fullSubjectToUsageBasedCusEntsByFeatureId,
+	fullSubjectToUsageWindowLimits,
 	getMaxOverage,
 	getRelevantFeatures,
 	isAllocatedCustomerEntitlement,
 	isFreeCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
+	RecaseError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
@@ -34,11 +37,15 @@ export const prepareFeatureDeductionV2 = ({
 	fullSubject,
 	deduction,
 	options = {},
+	now,
 }: {
 	ctx: AutumnContext;
 	fullSubject: FullSubject;
 	deduction: FeatureDeduction;
 	options?: DeductionOptions;
+	// Single timestamp shared with the Lua param so the resolved window key and
+	// the script agree on which window a boundary-crossing request lands in.
+	now: number;
 }): PreparedFeatureDeduction => {
 	const { org, env } = ctx;
 	const { feature, lock, targetBalance } = deduction;
@@ -108,6 +115,43 @@ export const prepareFeatureDeductionV2 = ({
 		fullSubject,
 		featureIds: effectiveFeatureIds,
 	});
+	// Resolve windows against the full relevant set (incl credit-system parents)
+	// even under set_usage, so a parent-feature cap can't be bypassed by set_usage
+	// on a member feature.
+	const windowFeatureIds = notNullish(targetBalance)
+		? getRelevantFeatures({
+				features: ctx.features,
+				featureId: feature.id,
+			}).map((candidate) => candidate.id)
+		: effectiveFeatureIds;
+	const usageWindowLimits = fullSubjectToUsageWindowLimits({
+		fullSubject,
+		featureIds: windowFeatureIds,
+		features: ctx.features,
+		now,
+	});
+
+	for (const windowLimit of usageWindowLimits) {
+		if (windowLimit.anchor_customer_entitlement_id === null) {
+			ctx.logger.warn(
+				`usage window for feature ${windowLimit.feature_id} has no eligible anchor entitlement; failing closed (rejecting). Likely a misconfigured cap with no in-status, non-entity-scoped owning entitlement.`,
+			);
+		}
+	}
+	if (fullSubject.entity?.spend_limits?.some((s) => s.usage_window?.enabled)) {
+		ctx.logger.warn(
+			`entity-scoped usage windows are not enforced in v1; ignored for entity ${fullSubject.entity.id}`,
+		);
+	}
+
+	// set_usage carries no window provenance, so it would silently bypass the hard
+	// cap; reject it when the feature has an enforced usage window.
+	if (notNullish(targetBalance) && usageWindowLimits.length > 0) {
+		throw new RecaseError({
+			message: `Cannot set usage for feature ${feature.id}: it has an active usage limit. Remove or adjust the limit, or record usage normally instead of using set_usage.`,
+			code: ErrCode.SetUsageNotAllowedWithUsageLimit,
+		});
+	}
 
 	const nativeUsageAllowedFeatureIds = new Set(
 		customerEntitlements
@@ -213,6 +257,8 @@ export const prepareFeatureDeductionV2 = ({
 			Object.keys(usageBasedCusEntIdsByFeatureId).length > 0
 				? usageBasedCusEntIdsByFeatureId
 				: undefined,
+		usageWindowLimits:
+			usageWindowLimits.length > 0 ? usageWindowLimits : undefined,
 		rollovers: sortedRollovers.map((rollover) => ({
 			id: rollover.id,
 			credit_cost: rollover.credit_cost,

--- a/server/src/internal/balances/utils/types/deductionTypes.ts
+++ b/server/src/internal/balances/utils/types/deductionTypes.ts
@@ -2,6 +2,7 @@ import type {
 	CustomerEntitlementFilters,
 	DbSpendLimit,
 	FullCusEntWithFullCusProduct,
+	UsageWindowLimit,
 } from "@autumn/shared";
 
 /** Behavior options for deduction */
@@ -42,6 +43,9 @@ export type PreparedFeatureDeduction = {
 	customerEntitlementDeductions: CustomerEntitlementDeduction[];
 	spendLimitByFeatureId?: Record<string, DbSpendLimit>;
 	usageBasedCusEntIdsByFeatureId?: Record<string, string[]>;
+	// Resolved windowed usage-limit caps (PR2: passed to Lua but not yet
+	// enforced; enforcement lands with the deduction-script changes).
+	usageWindowLimits?: UsageWindowLimit[];
 	// rolloverIds: string[];
 	rollovers: RolloverDeduction[];
 	unlimitedFeatureIds: string[];

--- a/server/src/internal/customers/cache/fullSubject/builders/buildDeductFromSubjectBalancesKeys.ts
+++ b/server/src/internal/customers/cache/fullSubject/builders/buildDeductFromSubjectBalancesKeys.ts
@@ -21,6 +21,7 @@ export const buildDeductFromSubjectBalancesKeys = ({
 	idempotencyKey,
 	customerEntitlementDeductions,
 	fallbackFeatureId,
+	anchorFeatureIds = [],
 }: {
 	orgId: string;
 	env: AppEnv;
@@ -30,17 +31,26 @@ export const buildDeductFromSubjectBalancesKeys = ({
 	idempotencyKey?: string | null;
 	customerEntitlementDeductions: { feature_id?: string }[];
 	fallbackFeatureId: string;
+	// Features owning a usage-window anchor counter. Their balance hash keys must
+	// be declared in KEYS[] so Lua can load the anchor even when it is not in the
+	// deduction set.
+	anchorFeatureIds?: string[];
 }) => {
 	const balanceKeysByFeatureId: Record<string, string> = {};
-	for (const deductionEntry of customerEntitlementDeductions) {
-		const targetFeatureId = deductionEntry.feature_id ?? fallbackFeatureId;
-		if (balanceKeysByFeatureId[targetFeatureId]) continue;
-		balanceKeysByFeatureId[targetFeatureId] = buildSharedFullSubjectBalanceKey({
+	const addFeatureKey = (featureId: string) => {
+		if (balanceKeysByFeatureId[featureId]) return;
+		balanceKeysByFeatureId[featureId] = buildSharedFullSubjectBalanceKey({
 			orgId,
 			env,
 			customerId,
-			featureId: targetFeatureId,
+			featureId,
 		});
+	};
+	for (const deductionEntry of customerEntitlementDeductions) {
+		addFeatureKey(deductionEntry.feature_id ?? fallbackFeatureId);
+	}
+	for (const anchorFeatureId of anchorFeatureIds) {
+		addFeatureKey(anchorFeatureId);
 	}
 
 	const balanceFeatureIds = Object.keys(balanceKeysByFeatureId);

--- a/server/src/internal/entities/handlers/handleListEntities.ts
+++ b/server/src/internal/entities/handlers/handleListEntities.ts
@@ -1,5 +1,5 @@
-import { createRoute } from "../../../honoMiddlewares/routeHandler.js";
 import { Scopes } from "@autumn/shared";
+import { createRoute } from "../../../honoMiddlewares/routeHandler.js";
 import { CusService } from "../../customers/CusService.js";
 
 export const handleListEntities = createRoute({

--- a/server/tests/integration/db/full-subject/utils/fullSubjectScenarioBuilders.ts
+++ b/server/tests/integration/db/full-subject/utils/fullSubjectScenarioBuilders.ts
@@ -337,6 +337,7 @@ const buildCustomerEntitlement = ({
 	adjustment: 0,
 	additional_balance: 0,
 	entities: null,
+	usage_windows: null,
 	expires_at: expiresAt,
 	cache_version: 0,
 	customer_id: customer.id ?? null,

--- a/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
+++ b/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
@@ -1,0 +1,486 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildUsageWindowKey,
+	type DbSpendLimit,
+	EntInterval,
+	type Feature,
+	FeatureType,
+	type FullSubject,
+	fullSubjectToUsageWindowLimits,
+	getUsageWindowBounds,
+	SpendLimitUsageWindowSchema,
+} from "@autumn/shared";
+
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
+
+const meteredAction1 = { id: "action1", type: FeatureType.Metered } as Feature;
+const creditsFeature = {
+	id: "credits",
+	type: FeatureType.CreditSystem,
+} as Feature;
+// Credit system whose schema contains action1, for the membership-anchor path.
+const creditsContainingAction1 = {
+	id: "credits",
+	type: FeatureType.CreditSystem,
+	config: { schema: [{ metered_feature_id: "action1", credit_amount: 5 }] },
+} as unknown as Feature;
+const credits2ContainingAction1 = {
+	id: "credits2",
+	type: FeatureType.CreditSystem,
+	config: { schema: [{ metered_feature_id: "action1", credit_amount: 3 }] },
+} as unknown as Feature;
+
+// Test-input shape for a windowed usage cap; wrapped into a spend_limit's
+// usage_window sub-object by `toSpendLimit` (the cap config now lives there).
+type UsageCap = {
+	feature_id: string;
+	enabled: boolean;
+	limit: number;
+	interval: EntInterval;
+};
+
+const toSpendLimit = (cap: UsageCap): DbSpendLimit => ({
+	feature_id: cap.feature_id,
+	// Entry-level enabled gates the (absent) overage cap, not the window cap.
+	enabled: false,
+	usage_window: {
+		interval: cap.interval,
+		limit: cap.limit,
+		enabled: cap.enabled,
+	},
+});
+
+// Minimal loose (product-less) customer entitlement for anchor candidate tests.
+const looseEntitlement = ({
+	id,
+	featureId,
+}: {
+	id: string;
+	featureId: string;
+}) =>
+	({
+		id,
+		feature_id: featureId,
+		internal_entity_id: null,
+		internal_feature_id: featureId,
+		customer_product_id: null,
+		entitlement_id: `ent_${id}`,
+		created_at: 1000,
+		balance: 0,
+		expires_at: null,
+		entitlement: {
+			id: `ent_${id}`,
+			feature_id: featureId,
+			interval: EntInterval.Month,
+			feature: { id: featureId, internal_id: featureId },
+		},
+		rollovers: [],
+		replaceables: [],
+	}) as unknown as FullSubject["extra_customer_entitlements"][number];
+
+const buildSubject = ({
+	customerLimits = [],
+	entityLimits,
+	looseEntitlements = [],
+	extraCustomerSpendLimits = [],
+}: {
+	customerLimits?: UsageCap[];
+	entityLimits?: UsageCap[];
+	looseEntitlements?: FullSubject["extra_customer_entitlements"];
+	// Raw spend-limit entries (e.g. overage-only or both-cap) injected as-is.
+	extraCustomerSpendLimits?: DbSpendLimit[];
+}): FullSubject =>
+	({
+		customer: {
+			spend_limits: [
+				...customerLimits.map(toSpendLimit),
+				...extraCustomerSpendLimits,
+			],
+		},
+		customer_products: [],
+		extra_customer_entitlements: looseEntitlements,
+		entity: entityLimits
+			? {
+					id: "ent_1",
+					internal_id: "ient_1",
+					spend_limits: entityLimits.map(toSpendLimit),
+				}
+			: undefined,
+	}) as unknown as FullSubject;
+
+describe("fullSubjectToUsageWindowLimits", () => {
+	test("resolves a customer-level metered-feature cap", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						limit: 5,
+						interval: EntInterval.Month,
+					},
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		const { windowStartAt, windowEndAt } = getUsageWindowBounds({
+			interval: EntInterval.Month,
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			feature_id: "action1",
+			dimension_type: "metered_feature",
+			dimension_feature_id: "action1",
+			scope_type: "customer",
+			entity_id: null,
+			interval: EntInterval.Month,
+			window_start_at: windowStartAt,
+			window_end_at: windowEndAt,
+			limit: 5,
+			key: buildUsageWindowKey({
+				scopeType: "customer",
+				internalEntityId: null,
+				dimensionType: "metered_feature",
+				dimensionFeatureId: "action1",
+				interval: EntInterval.Month,
+				windowStartAt,
+			}),
+		});
+	});
+
+	test("a credit-system feature resolves to the balance dimension", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "credits",
+						enabled: true,
+						limit: 3,
+						interval: EntInterval.Day,
+					},
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			dimension_type: "balance",
+			dimension_feature_id: null,
+		});
+	});
+
+	test("skips caps whose usage_window is disabled", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "action1",
+						enabled: false,
+						limit: 5,
+						interval: EntInterval.Month,
+					},
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("usage_window with enabled omitted defaults to disabled and is not enforced", () => {
+		const parsed = SpendLimitUsageWindowSchema.parse({
+			interval: EntInterval.Month,
+			limit: 5,
+		});
+		expect(parsed.enabled).toBe(false);
+
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				extraCustomerSpendLimits: [
+					{ feature_id: "action1", enabled: false, usage_window: parsed },
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("ignores an overage-only spend_limit (no usage_window)", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				extraCustomerSpendLimits: [
+					{ feature_id: "action1", enabled: true, overage_limit: 20 },
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("resolves the window when one entry carries both overage and usage caps", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				extraCustomerSpendLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						overage_limit: 20,
+						usage_window: {
+							interval: EntInterval.Month,
+							limit: 5,
+							enabled: true,
+						},
+					},
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({ feature_id: "action1", limit: 5 });
+	});
+
+	test("ignores entity-scoped usage windows in v1; the customer cap applies", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						limit: 5,
+						interval: EntInterval.Month,
+					},
+				],
+				entityLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						limit: 2,
+						interval: EntInterval.Month,
+					},
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			scope_type: "customer",
+			entity_id: null,
+			internal_entity_id: null,
+			limit: 5,
+		});
+	});
+
+	test("an entity-only usage window resolves nothing in v1", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				entityLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						limit: 2,
+						interval: EntInterval.Month,
+					},
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("returns nothing when no cap matches the feature", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({ customerLimits: [] }),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("returns one limit per feature when caps exist on multiple features", () => {
+		const meteredAction2 = {
+			id: "action2",
+			type: FeatureType.Metered,
+		} as Feature;
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						limit: 5,
+						interval: EntInterval.Month,
+					},
+					{
+						feature_id: "action2",
+						enabled: true,
+						limit: 9,
+						interval: EntInterval.Day,
+					},
+				],
+			}),
+			featureIds: ["action1", "action2"],
+			features: [meteredAction1, meteredAction2],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(2);
+		expect(limits.map((limit) => limit.feature_id).sort()).toEqual([
+			"action1",
+			"action2",
+		]);
+	});
+
+	test("resolves the anchor to the owning entitlement (balance dim)", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "credits",
+						enabled: true,
+						limit: 3,
+						interval: EntInterval.Day,
+					},
+				],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			anchor_customer_entitlement_id: "ce_credits",
+			anchor_feature_id: "credits",
+		});
+	});
+
+	test("metered cap with no native entitlement anchors to the containing credit system", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						limit: 5,
+						interval: EntInterval.Month,
+					},
+				],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1, creditsContainingAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			dimension_type: "metered_feature",
+			dimension_feature_id: "action1",
+			anchor_customer_entitlement_id: "ce_credits",
+			anchor_feature_id: "credits",
+		});
+	});
+
+	test("anchor is null when no owning entitlement exists (fail-closed signal)", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "credits",
+						enabled: true,
+						limit: 3,
+						interval: EntInterval.Day,
+					},
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0].anchor_customer_entitlement_id).toBeNull();
+	});
+
+	test("metered cap with a containing credit system but no entitlement resolves a null anchor", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						limit: 5,
+						interval: EntInterval.Month,
+					},
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1, creditsContainingAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0].anchor_customer_entitlement_id).toBeNull();
+	});
+
+	test("metered cap contained by two credit systems anchors deterministically", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						limit: 5,
+						interval: EntInterval.Month,
+					},
+				],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+					looseEntitlement({ id: "ce_credits2", featureId: "credits2" }),
+				],
+			}),
+			featureIds: ["action1"],
+			features: [
+				meteredAction1,
+				creditsContainingAction1,
+				credits2ContainingAction1,
+			],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0].anchor_customer_entitlement_id).toBe("ce_credits");
+	});
+});

--- a/server/tests/unit/usage-windows/getUsageWindowBounds.test.ts
+++ b/server/tests/unit/usage-windows/getUsageWindowBounds.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { EntInterval, getUsageWindowBounds } from "@autumn/shared";
+
+// 2026-06-15T12:34:56Z (a Monday; month index 5 = June)
+const NOW = Date.UTC(2026, 5, 15, 12, 34, 56);
+
+describe("getUsageWindowBounds", () => {
+	test("day window floors to UTC midnight and spans one day", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Day, now: NOW }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 5, 15),
+			windowEndAt: Date.UTC(2026, 5, 16),
+		});
+	});
+
+	test("week window floors to Monday 00:00 UTC and spans 7 days", () => {
+		// Wednesday -> floors back to Monday June 15.
+		const wednesday = Date.UTC(2026, 5, 17, 8, 0, 0);
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Week, now: wednesday }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 5, 15),
+			windowEndAt: Date.UTC(2026, 5, 22),
+		});
+	});
+
+	test("month window floors to the 1st and spans one month", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Month, now: NOW }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 5, 1),
+			windowEndAt: Date.UTC(2026, 6, 1),
+		});
+	});
+
+	test("quarter window floors to the start of the quarter and spans 3 months", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Quarter, now: NOW }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 3, 1),
+			windowEndAt: Date.UTC(2026, 6, 1),
+		});
+	});
+
+	test("semi_annual floors to Jan 1 in the first half and spans 6 months", () => {
+		const may = Date.UTC(2026, 4, 15);
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.SemiAnnual, now: may }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 0, 1),
+			windowEndAt: Date.UTC(2026, 6, 1),
+		});
+	});
+
+	test("semi_annual floors to Jul 1 in the second half", () => {
+		const august = Date.UTC(2026, 7, 15);
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.SemiAnnual, now: august }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 6, 1),
+			windowEndAt: Date.UTC(2027, 0, 1),
+		});
+	});
+
+	test("year window floors to Jan 1 and spans one year", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Year, now: NOW }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 0, 1),
+			windowEndAt: Date.UTC(2027, 0, 1),
+		});
+	});
+
+	test("lifetime never resets", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Lifetime, now: NOW }),
+		).toEqual({ windowStartAt: 0, windowEndAt: Number.MAX_SAFE_INTEGER });
+	});
+
+	test("is deterministic across the same window", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Month, now: NOW }),
+		).toEqual(
+			getUsageWindowBounds({ interval: EntInterval.Month, now: NOW + 1000 }),
+		);
+	});
+});

--- a/server/tests/unit/usage-windows/pickAnchorCustomerEntitlementId.test.ts
+++ b/server/tests/unit/usage-windows/pickAnchorCustomerEntitlementId.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type AnchorCandidate,
+	pickAnchorCustomerEntitlementId,
+} from "@autumn/shared";
+
+const candidate = (overrides: Partial<AnchorCandidate>): AnchorCandidate => ({
+	id: "ce_1",
+	is_entity_scoped: false,
+	is_add_on: false,
+	status_rank: 0,
+	created_at: 1000,
+	...overrides,
+});
+
+describe("pickAnchorCustomerEntitlementId", () => {
+	test("returns null when there are no candidates", () => {
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [],
+				scopeType: "customer",
+			}),
+		).toBeNull();
+	});
+
+	test("customer scope excludes entity-scoped candidates", () => {
+		const id = pickAnchorCustomerEntitlementId({
+			candidates: [
+				candidate({ id: "ce_entity", is_entity_scoped: true }),
+				candidate({ id: "ce_customer", is_entity_scoped: false }),
+			],
+			scopeType: "customer",
+		});
+
+		expect(id).toBe("ce_customer");
+	});
+
+	test("customer scope returns null when only entity-scoped candidates exist (fail closed)", () => {
+		const id = pickAnchorCustomerEntitlementId({
+			candidates: [candidate({ id: "ce_entity", is_entity_scoped: true })],
+			scopeType: "customer",
+		});
+
+		expect(id).toBeNull();
+	});
+
+	test("entity scope falls back to customer-level candidates when none are entity-scoped", () => {
+		const id = pickAnchorCustomerEntitlementId({
+			candidates: [
+				candidate({ id: "ce_a", is_entity_scoped: false }),
+				candidate({ id: "ce_b", is_entity_scoped: false, created_at: 2000 }),
+			],
+			scopeType: "entity",
+		});
+
+		expect(id).toBe("ce_a");
+	});
+
+	test("entity scope prefers an entity-scoped candidate over a customer-level one", () => {
+		const id = pickAnchorCustomerEntitlementId({
+			candidates: [
+				candidate({ id: "ce_customer", is_entity_scoped: false }),
+				candidate({ id: "ce_entity", is_entity_scoped: true }),
+			],
+			scopeType: "entity",
+		});
+
+		expect(id).toBe("ce_entity");
+	});
+
+	test("prefers lower status_rank, then non-add-on, then oldest, then id", () => {
+		// All customer-scope candidates; tie-break ladder.
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [
+					candidate({ id: "ce_pastdue", status_rank: 1 }),
+					candidate({ id: "ce_active", status_rank: 0 }),
+				],
+				scopeType: "customer",
+			}),
+		).toBe("ce_active");
+
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [
+					candidate({ id: "ce_addon", is_add_on: true }),
+					candidate({ id: "ce_base", is_add_on: false }),
+				],
+				scopeType: "customer",
+			}),
+		).toBe("ce_base");
+
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [
+					candidate({ id: "ce_new", created_at: 2000 }),
+					candidate({ id: "ce_old", created_at: 1000 }),
+				],
+				scopeType: "customer",
+			}),
+		).toBe("ce_old");
+
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [candidate({ id: "ce_b" }), candidate({ id: "ce_a" })],
+				scopeType: "customer",
+			}),
+		).toBe("ce_a");
+	});
+
+	test("is deterministic regardless of input order", () => {
+		const candidates = [
+			candidate({ id: "ce_b", status_rank: 0, created_at: 1000 }),
+			candidate({ id: "ce_a", status_rank: 0, created_at: 1000 }),
+			candidate({ id: "ce_c", status_rank: 1, created_at: 500 }),
+		];
+
+		const forward = pickAnchorCustomerEntitlementId({
+			candidates,
+			scopeType: "customer",
+		});
+		const reversed = pickAnchorCustomerEntitlementId({
+			candidates: [...candidates].reverse(),
+			scopeType: "customer",
+		});
+
+		expect(forward).toBe("ce_a");
+		expect(reversed).toBe("ce_a");
+	});
+});

--- a/shared/api/billingControls/entityBillingControls.ts
+++ b/shared/api/billingControls/entityBillingControls.ts
@@ -5,7 +5,8 @@ import { ApiUsageAlertSchema } from "./usageAlert.js";
 
 export const ApiEntityBillingControlsSchema = z.object({
 	spend_limits: z.array(ApiSpendLimitSchema).optional().meta({
-		description: "List of overage spend limits per feature.",
+		description:
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_window).",
 	}),
 	usage_alerts: z.array(ApiUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -1,34 +1,27 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1779096275848,
-      "tag": "0000_bumpy_tinkerer",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1779971507895,
-      "tag": "0001_concerned_ravenous",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1780302718193,
-      "tag": "0002_jittery_dexter_bennett",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1780310835175,
-      "tag": "0003_polite_shatterstar",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1779096275848,
+			"tag": "0000_bumpy_tinkerer",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1779971507895,
+			"tag": "0001_concerned_ravenous",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1780302718193,
+			"tag": "0002_jittery_dexter_bennett",
+			"breakpoints": true
+		}
+	]
 }

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -104,6 +104,7 @@ export const ErrCode = {
 	CreateEntitlementFailed: "create_entitlement_failed",
 	DeleteEntitlementFailed: "delete_entitlement_failed",
 	InsufficientBalance: "insufficient_balance",
+	SetUsageNotAllowedWithUsageLimit: "set_usage_not_allowed_with_usage_limit",
 
 	// Invoice
 	CreateInvoiceFailed: "create_invoice_failed",

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -211,6 +211,8 @@ export * from "./utils/cusEntUtils/balanceUtils/cusEntToUsageAllowed";
 export * from "./utils/cusEntUtils/index";
 // Utils
 export * from "./utils/usageWindowUtils/buildUsageWindowKey";
+export * from "./utils/usageWindowUtils/getUsageWindowBounds";
+export * from "./utils/usageWindowUtils/pickAnchorCustomerEntitlementId";
 export * from "./utils/displayUtils";
 export * from "./utils/fullSubjectUtils";
 export * from "./utils/index";

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -100,7 +100,8 @@ export const CustomerBillingControlsSchema = z.object({
 		description: "List of auto top-up configurations per feature.",
 	}),
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
-		description: "List of overage spend limits per feature.",
+		description:
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_window).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",
@@ -125,7 +126,8 @@ export const CustomerBillingControlsResponseSchema = z.object({
 		description: "List of auto top-up configurations per feature.",
 	}),
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
-		description: "List of overage spend limits per feature.",
+		description:
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_window).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/models/cusModels/billingControls/entityBillingControls.ts
+++ b/shared/models/cusModels/billingControls/entityBillingControls.ts
@@ -5,7 +5,8 @@ import { DbUsageAlertSchema } from "./usageAlert.js";
 
 export const EntityBillingControlsSchema = z.object({
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
-		description: "List of overage spend limits per feature.",
+		description:
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_window).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/models/cusModels/billingControls/spendLimit.ts
+++ b/shared/models/cusModels/billingControls/spendLimit.ts
@@ -1,4 +1,21 @@
 import { z } from "zod/v4";
+import { EntInterval } from "../../productModels/intervals/entitlementInterval.js";
+
+// Optional windowed usage cap on a spend limit: a hard pre-write reject on units
+// consumed per `interval` window, independent of `overage_limit` and of balance.
+export const SpendLimitUsageWindowSchema = z.object({
+	interval: z.enum(EntInterval).meta({
+		description: "The window interval the usage cap resets on.",
+	}),
+	limit: z.number().min(0).meta({
+		description:
+			"Maximum units consumable within each window. Feature units for a metered feature, or pool credits for a credit-system feature. Distinct from overage_limit's currency unit.",
+	}),
+	enabled: z.boolean().default(false).meta({
+		description:
+			"Whether the windowed usage cap is enforced. Independent of the entry-level `enabled`, which gates the overage cap.",
+	}),
+});
 
 export const DbSpendLimitSchema = z
 	.object({
@@ -6,24 +23,26 @@ export const DbSpendLimitSchema = z
 			description: "Optional feature ID this spend limit applies to.",
 		}),
 		enabled: z.boolean().default(false).meta({
-			description: "Whether this spend limit is enabled.",
+			description: "Whether the overage spend limit is enabled.",
 		}),
 		overage_limit: z.number().min(0).optional().meta({
 			description: "Maximum allowed overage spend for the target feature.",
 		}),
+		usage_window: SpendLimitUsageWindowSchema.optional().meta({
+			description:
+				"Optional windowed usage cap (hard pre-write reject), independent of the overage cap. Absent means no usage cap.",
+		}),
 	})
 	.refine(
-		(data) => {
-			if (data.overage_limit === undefined) {
-				return true;
-			}
-
-			return data.feature_id !== undefined;
-		},
+		(data) =>
+			!(data.overage_limit !== undefined || data.usage_window !== undefined) ||
+			data.feature_id !== undefined,
 		{
-			message: "feature_id is required when overage_limit is provided",
+			message:
+				"feature_id is required when overage_limit or usage_window is provided",
 			path: ["feature_id"],
 		},
 	);
 
+export type SpendLimitUsageWindow = z.infer<typeof SpendLimitUsageWindowSchema>;
 export type DbSpendLimit = z.infer<typeof DbSpendLimitSchema>;

--- a/shared/models/cusModels/entityModels/entityTable.ts
+++ b/shared/models/cusModels/entityModels/entityTable.ts
@@ -65,11 +65,7 @@ export const entities = pgTable(
 			table.internal_customer_id,
 			sql`${table.internal_id} DESC`,
 		),
-		index("idx_entities_org_env_id").on(
-			table.org_id,
-			table.env,
-			table.id,
-		),
+		index("idx_entities_org_env_id").on(table.org_id, table.env, table.id),
 		index("idx_entities_cursor").on(
 			table.org_id,
 			table.env,

--- a/shared/utils/fullSubjectUtils/fullSubjectToUsageWindowLimits.ts
+++ b/shared/utils/fullSubjectUtils/fullSubjectToUsageWindowLimits.ts
@@ -1,0 +1,169 @@
+import type { FullSubject } from "../../models/cusModels/fullSubject/fullSubjectModel.js";
+import type { FullCusEntWithFullCusProduct } from "../../models/cusProductModels/cusEntModels/cusEntWithProduct.js";
+import type {
+	UsageWindowDimension,
+	UsageWindowLimit,
+} from "../../models/cusProductModels/cusEntModels/usageWindowModels.js";
+import { CusProductStatus } from "../../models/cusProductModels/cusProductEnums.js";
+import { FeatureType } from "../../models/featureModels/featureEnums.js";
+import type { Feature } from "../../models/featureModels/featureModels.js";
+import { getRelevantFeatures } from "../featureUtils.js";
+import { buildUsageWindowKey } from "../usageWindowUtils/buildUsageWindowKey.js";
+import { getUsageWindowBounds } from "../usageWindowUtils/getUsageWindowBounds.js";
+import {
+	type AnchorCandidate,
+	pickAnchorCustomerEntitlementId,
+} from "../usageWindowUtils/pickAnchorCustomerEntitlementId.js";
+import { fullSubjectToCustomerEntitlements } from "./fullSubjectToCustomerEntitlements.js";
+
+// Lower rank wins in the anchor tie-break. Loose entitlements (no product) are
+// treated as active grants.
+const customerProductStatusToAnchorRank = (
+	status: CusProductStatus | undefined,
+): number => {
+	switch (status) {
+		case undefined:
+		case CusProductStatus.Active:
+			return 0;
+		case CusProductStatus.PastDue:
+			return 1;
+		case CusProductStatus.Scheduled:
+			return 2;
+		case CusProductStatus.Trialing:
+			return 3;
+		default:
+			return 999;
+	}
+};
+
+const toAnchorCandidate = (
+	customerEntitlement: FullCusEntWithFullCusProduct,
+): AnchorCandidate => ({
+	id: customerEntitlement.id,
+	is_entity_scoped: customerEntitlement.internal_entity_id !== null,
+	is_add_on: customerEntitlement.customer_product?.product.is_add_on ?? false,
+	status_rank: customerProductStatusToAnchorRank(
+		customerEntitlement.customer_product?.status,
+	),
+	created_at:
+		customerEntitlement.customer_product?.created_at ??
+		customerEntitlement.created_at,
+});
+
+/**
+ * Resolves the enforceable usage-window limits for the requested features from a
+ * FullSubject. The windowed cap is configured as the optional `usage_window`
+ * sub-object on a `spend_limit` entry (same JSON as the overage cap; the two
+ * caps are independent). v1 reads ONLY customer-scoped spend_limits; entity
+ * usage windows are out of scope. Only `usage_window.enabled` entries are
+ * enforced (independent of the entry-level `enabled`, which gates the overage cap).
+ *
+ * A cap on a credit-system feature targets the credit pool (`balance`
+ * dimension); a cap on any other feature targets that feature's usage
+ * (`metered_feature` dimension). Window bounds + key are computed from `now`.
+ *
+ * Each limit also gets a single owning `anchor_customer_entitlement_id`,
+ * resolved deduction-order-independently so one counter never splits across
+ * pools. Null anchor means no eligible owner; the enforcement layer fails closed.
+ */
+export const fullSubjectToUsageWindowLimits = ({
+	fullSubject,
+	featureIds,
+	features,
+	now,
+}: {
+	fullSubject: FullSubject;
+	featureIds: string[];
+	features: Feature[];
+	now: number;
+}): UsageWindowLimit[] => {
+	// v1: customer-scoped caps only; entity-scoped usage windows are out of scope.
+	const customerSpendLimits = fullSubject.customer.spend_limits ?? [];
+	const limits: UsageWindowLimit[] = [];
+
+	for (const featureId of [...new Set(featureIds)]) {
+		const spendLimit = customerSpendLimits.find(
+			(candidate) =>
+				candidate.feature_id === featureId &&
+				candidate.usage_window?.enabled === true,
+		);
+		const usageWindow = spendLimit?.usage_window;
+		if (!usageWindow) continue;
+
+		const scopeType = "customer" as const;
+		const entityId = null;
+		const internalEntityId = null;
+
+		const isCreditSystem =
+			features.find((feature) => feature.id === featureId)?.type ===
+			FeatureType.CreditSystem;
+		const dimensionType: UsageWindowDimension = isCreditSystem
+			? "balance"
+			: "metered_feature";
+		const dimensionFeatureId = isCreditSystem ? null : featureId;
+
+		// Balance dim is owned by the credit-system entitlement. Metered dim
+		// prefers the member feature's own entitlement, then falls back to a
+		// credit system that contains it.
+		const containingCreditSystemFeatureIds = getRelevantFeatures({
+			features,
+			featureId,
+		})
+			.map((feature) => feature.id)
+			.filter((relevantFeatureId) => relevantFeatureId !== featureId);
+		const ownerFeatureIdsByPreference = isCreditSystem
+			? [[featureId]]
+			: [[featureId], containingCreditSystemFeatureIds];
+
+		let anchorId: string | null = null;
+		let anchorFeatureId: string | null = null;
+		for (const ownerFeatureIds of ownerFeatureIdsByPreference) {
+			if (ownerFeatureIds.length === 0) continue;
+			const candidateEntitlements = fullSubjectToCustomerEntitlements({
+				fullSubject,
+				featureIds: ownerFeatureIds,
+			});
+			anchorId = pickAnchorCustomerEntitlementId({
+				candidates: candidateEntitlements.map(toAnchorCandidate),
+				scopeType,
+			});
+			if (anchorId) {
+				anchorFeatureId =
+					candidateEntitlements.find(
+						(customerEntitlement) => customerEntitlement.id === anchorId,
+					)?.feature_id ?? null;
+				break;
+			}
+		}
+
+		const { windowStartAt, windowEndAt } = getUsageWindowBounds({
+			interval: usageWindow.interval,
+			now,
+		});
+
+		limits.push({
+			feature_id: featureId,
+			key: buildUsageWindowKey({
+				scopeType,
+				internalEntityId,
+				dimensionType,
+				dimensionFeatureId,
+				interval: usageWindow.interval,
+				windowStartAt,
+			}),
+			dimension_type: dimensionType,
+			dimension_feature_id: dimensionFeatureId,
+			scope_type: scopeType,
+			entity_id: entityId,
+			internal_entity_id: internalEntityId,
+			interval: usageWindow.interval,
+			window_start_at: windowStartAt,
+			window_end_at: windowEndAt,
+			limit: usageWindow.limit,
+			anchor_customer_entitlement_id: anchorId,
+			anchor_feature_id: anchorFeatureId,
+		});
+	}
+
+	return limits;
+};

--- a/shared/utils/fullSubjectUtils/index.ts
+++ b/shared/utils/fullSubjectUtils/index.ts
@@ -9,6 +9,7 @@ export {
 	fullSubjectToSpendLimitByFeatureId,
 	fullSubjectToUsageBasedCusEntsByFeatureId,
 } from "./fullSubjectToSpendLimit.js";
+export { fullSubjectToUsageWindowLimits } from "./fullSubjectToUsageWindowLimits.js";
 export { logFullSubject } from "./logFullSubject.js";
 export { mergeCustomerBillingControlsForCheck } from "./mergeCustomerBillingControlsForCheck.js";
 export { normalizedToFullSubject } from "./normalizedToFullSubject.js";

--- a/shared/utils/usageWindowUtils/getUsageWindowBounds.ts
+++ b/shared/utils/usageWindowUtils/getUsageWindowBounds.ts
@@ -1,0 +1,78 @@
+import { UTCDate } from "@date-fns/utc";
+import {
+	startOfDay,
+	startOfHour,
+	startOfMinute,
+	startOfMonth,
+	startOfQuarter,
+	startOfWeek,
+	startOfYear,
+} from "date-fns";
+import { EntInterval } from "../../models/productModels/intervals/entitlementInterval.js";
+import { addInterval } from "../billingUtils/intervalUtils/intervalArithmetic.js";
+
+const LIFETIME_WINDOW_END = Number.MAX_SAFE_INTEGER;
+
+// UTC-calendar-aligned start of the interval containing `now`. Alignment keeps
+// the window (and therefore its key) deterministic from `now` alone, so the TS
+// and Lua sides never disagree on which window a track lands in.
+const startOfWindow = ({
+	interval,
+	now,
+}: {
+	interval: EntInterval;
+	now: number;
+}): number => {
+	const from = new UTCDate(now);
+
+	switch (interval) {
+		case EntInterval.Minute:
+			return startOfMinute(from).getTime();
+		case EntInterval.Hour:
+			return startOfHour(from).getTime();
+		case EntInterval.Day:
+			return startOfDay(from).getTime();
+		case EntInterval.Week:
+			return startOfWeek(from, { weekStartsOn: 1 }).getTime();
+		case EntInterval.Month:
+			return startOfMonth(from).getTime();
+		case EntInterval.Quarter:
+			return startOfQuarter(from).getTime();
+		case EntInterval.SemiAnnual: {
+			const yearStart = startOfYear(from).getTime();
+			return from.getUTCMonth() < 6
+				? yearStart
+				: addInterval({
+						from: yearStart,
+						interval: EntInterval.Month,
+						intervalCount: 6,
+					});
+		}
+		case EntInterval.Year:
+			return startOfYear(from).getTime();
+		default:
+			return now;
+	}
+};
+
+/**
+ * Current usage-window bounds for an interval, aligned to the UTC calendar.
+ * `lifetime` never resets. Each window spans exactly one interval (sub-interval
+ * counts are intentionally not supported yet; they need non-overlapping tiling).
+ */
+export const getUsageWindowBounds = ({
+	interval,
+	now,
+}: {
+	interval: EntInterval;
+	now: number;
+}): { windowStartAt: number; windowEndAt: number } => {
+	if (interval === EntInterval.Lifetime) {
+		return { windowStartAt: 0, windowEndAt: LIFETIME_WINDOW_END };
+	}
+
+	const windowStartAt = startOfWindow({ interval, now });
+	const windowEndAt = addInterval({ from: windowStartAt, interval });
+
+	return { windowStartAt, windowEndAt };
+};

--- a/shared/utils/usageWindowUtils/pickAnchorCustomerEntitlementId.ts
+++ b/shared/utils/usageWindowUtils/pickAnchorCustomerEntitlementId.ts
@@ -1,0 +1,55 @@
+import type { UsageWindowScope } from "../../models/cusProductModels/cusEntModels/usageWindowModels.js";
+
+/**
+ * A candidate customer entitlement for owning a usage-window counter, reduced to
+ * just the fields the canonical pick depends on. Deliberately decoupled from the
+ * deduction set and its ordering so the chosen anchor is stable regardless of
+ * deduction order, filters, or reverse_deduction_order.
+ */
+export type AnchorCandidate = {
+	id: string;
+	is_entity_scoped: boolean;
+	is_add_on: boolean;
+	// Lower rank = higher priority (e.g. active before past_due).
+	status_rank: number;
+	created_at: number;
+};
+
+/**
+ * Deterministically picks the single customer entitlement that owns a usage
+ * window, so one logical counter is never split across entitlements.
+ *
+ * Customer-scope counters must live on a customer-level entitlement (returns
+ * null if only entity-scoped ones exist, so the caller can fail closed rather
+ * than split the cap per entity). Entity-scope prefers an entity-owned one.
+ */
+export const pickAnchorCustomerEntitlementId = ({
+	candidates,
+	scopeType,
+}: {
+	candidates: AnchorCandidate[];
+	scopeType: UsageWindowScope;
+}): string | null => {
+	let eligible: AnchorCandidate[];
+	if (scopeType === "customer") {
+		eligible = candidates.filter((candidate) => !candidate.is_entity_scoped);
+	} else {
+		const entityScoped = candidates.filter(
+			(candidate) => candidate.is_entity_scoped,
+		);
+		eligible = entityScoped.length > 0 ? entityScoped : candidates;
+	}
+
+	if (eligible.length === 0) {
+		return null;
+	}
+
+	const sorted = [...eligible].sort((a, b) => {
+		if (a.status_rank !== b.status_rank) return a.status_rank - b.status_rank;
+		if (a.is_add_on !== b.is_add_on) return a.is_add_on ? 1 : -1;
+		if (a.created_at !== b.created_at) return a.created_at - b.created_at;
+		return a.id < b.id ? -1 : 1;
+	});
+
+	return sorted[0].id;
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds windowed usage caps via a new `usage_window` on `spend_limits`. Windows are UTC-aligned with stable anchors and flow through the deduction pipeline; Lua enforcement lands next.

- **New Features**
  - Added `usage_window { interval, limit, enabled }` to `spend_limits` for customers/entities; default disabled. Validation now requires `feature_id` when `overage_limit` or `usage_window` is provided. Updated API/schema docs to clarify overage vs windowed caps.
  - Introduced in `@autumn/shared`: `fullSubjectToUsageWindowLimits` (resolves dimension: `balance` for credit systems, `metered_feature` otherwise; computes keys/bounds; picks deterministic anchor via `pickAnchorCustomerEntitlementId`; v1 ignores entity-scoped caps), plus `getUsageWindowBounds`.
  - Deduction prep rejects `set_usage`/`target_balance` when a feature has an active window cap (`ErrCode.SetUsageNotAllowedWithUsageLimit`). Redis path captures one `usage_window_now`, declares anchor feature balance keys via `buildDeductFromSubjectBalancesKeys`, and passes `usage_window_limits`, `usage_window_now`, and `is_consumption` to Lua.
  - Added unit tests for the resolver, window bounds, and anchor selection.

<sup>Written for commit 97b838bf118de6acffee7ec9df9ad955375c08d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces windowed usage limits (`usage_limits`) as a new billing control for customers and entities, backed by a new JSONB column migration. A resolver (`fullSubjectToUsageWindowLimits`) computes UTC-aligned window bounds, selects a deterministic anchor entitlement, and produces `UsageWindowLimit` objects that are passed through the deduction pipeline to Redis/Lua. Enforcement in Lua is deferred to a follow-up PR.

- **[API changes, Improvements]** New `usage_limits` field on `CustomerBillingControlsSchema` and `EntityBillingControlsSchema`, with per-`feature_id` uniqueness validation; exposed on all create/read/update paths for customers and entities.
- **[Improvements]** New shared utilities: `getUsageWindowBounds` (UTC-calendar-aligned window bounds), `pickAnchorCustomerEntitlementId` (stable, deduction-order-independent anchor selection), and `fullSubjectToUsageWindowLimits` (resolver tying them together).
- **[Improvements]** Deduction pipeline now captures a single `usageWindowNow` timestamp for each Redis operation and passes `usage_window_limits`, `usage_window_now`, and `is_consumption` to Lua; anchor feature balance keys are pre-declared even when not part of the current deduction set.
</details>


<h3>Confidence Score: 3/5</h3>

Safe to merge with a small fix: the Postgres fallback path needs a shared timestamp hoisted out of the deduction loop before it can correctly enforce window limits at calendar boundaries.

The Redis path correctly captures one timestamp before the loop — the comment even explains why this matters. The Postgres path calls `Date.now()` fresh on every deduction, so a multi-deduction request that crosses a window boundary (e.g. midnight for a daily cap) will produce mismatched window keys across deductions, splitting the counter and making enforcement ineffective. Since Lua enforcement is still coming in the next PR, the practical impact is limited right now, but the mismatch will be baked in once enforcement lands.

server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts needs a single `usageWindowNow` hoisted before the deduction loop, mirroring the Redis path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts | Passes `now: Date.now()` inside the deduction loop — unlike the Redis path which uses one shared timestamp — causing window-key inconsistency for multi-deduction operations at window boundaries. |
| server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts | Captures a single `usageWindowNow` before the deduction loop and passes it plus `usage_window_limits` and `is_consumption` to Lua; correctly deduplicates anchor feature keys. |
| shared/utils/fullSubjectUtils/fullSubjectToUsageWindowLimits.ts | Core resolver: entity cap wins over customer, credit-system maps to balance dimension, anchor is picked deterministically. Logic is sound and well-tested. |
| shared/utils/usageWindowUtils/getUsageWindowBounds.ts | UTC-aligned window bounds with all intervals handled; Lifetime returns a fixed sentinel range; clean and well-covered by tests. |
| shared/utils/usageWindowUtils/pickAnchorCustomerEntitlementId.ts | Deterministic anchor selection: customer-scope filters out entity-scoped entitlements; sorted by status rank, add-on flag, creation time, then ID. Logic is correct. |
| shared/models/cusModels/billingControls/usageLimit.ts | New `DbUsageLimitSchema` with `enabled` defaulting to `false` (opt-in enforcement); clean Zod schema definition. |
| shared/drizzle/0003_polite_shatterstar.sql | Adds nullable JSONB `usage_limits` to `customers` and `entities`; no backfill needed. |
| server/src/internal/customers/cache/fullSubject/builders/buildDeductFromSubjectBalancesKeys.ts | Refactored to accept `anchorFeatureIds`; extracted `addFeatureKey` helper avoids duplicating the key-building logic. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API
    participant prepareFeatureDeductionV2
    participant fullSubjectToUsageWindowLimits
    participant getUsageWindowBounds
    participant pickAnchorCustomerEntitlementId
    participant buildDeductFromSubjectBalancesKeys
    participant RedisLua as Redis / Lua

    API->>prepareFeatureDeductionV2: deduction + now (single timestamp)
    prepareFeatureDeductionV2->>fullSubjectToUsageWindowLimits: featureIds + now
    fullSubjectToUsageWindowLimits->>getUsageWindowBounds: interval + now
    fullSubjectToUsageWindowLimits->>pickAnchorCustomerEntitlementId: candidates + scopeType
    fullSubjectToUsageWindowLimits-->>prepareFeatureDeductionV2: UsageWindowLimit[]
    prepareFeatureDeductionV2-->>API: PreparedFeatureDeduction
    API->>buildDeductFromSubjectBalancesKeys: deductions + anchorFeatureIds
    buildDeductFromSubjectBalancesKeys-->>API: keys[]
    API->>RedisLua: keys[], usage_window_limits, usage_window_now, is_consumption
    Note over RedisLua: Enforcement deferred to next PR
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts`, line 96-120 ([link](https://github.com/useautumn/autumn/blob/d93557d5a85151056d9e8ecdd80dc8ee92b935ef/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts#L96-L120)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The Postgres path calls `Date.now()` fresh on every iteration of the deduction loop, while the Redis path deliberately captures a single `usageWindowNow` before the loop so "the resolver keys windows from it and [the script] receives the same value, so they never disagree on the window." In a multi-deduction request that straddles a calendar boundary (e.g. midnight for a daily limit), earlier deductions would be keyed to the old window and later ones to the new window, splitting usage across two counters and making it impossible to enforce the cap correctly. `usageWindowNow` should be hoisted above the loop, as done in the Redis executor.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
   Line: 96-120

   Comment:
   The Postgres path calls `Date.now()` fresh on every iteration of the deduction loop, while the Redis path deliberately captures a single `usageWindowNow` before the loop so "the resolver keys windows from it and [the script] receives the same value, so they never disagree on the window." In a multi-deduction request that straddles a calendar boundary (e.g. midnight for a daily limit), earlier deductions would be keyed to the old window and later ones to the new window, splitting usage across two counters and making it impossible to enforce the cap correctly. `usageWindowNow` should be hoisted above the loop, as done in the Redis executor.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts:96-120
The Postgres path calls `Date.now()` fresh on every iteration of the deduction loop, while the Redis path deliberately captures a single `usageWindowNow` before the loop so "the resolver keys windows from it and [the script] receives the same value, so they never disagree on the window." In a multi-deduction request that straddles a calendar boundary (e.g. midnight for a daily limit), earlier deductions would be keyed to the old window and later ones to the new window, splitting usage across two counters and making it impossible to enforce the cap correctly. `usageWindowNow` should be hoisted above the loop, as done in the Redis executor.

```suggestion
		const usageWindowNow = Date.now();

		for (const deduction of deductions) {
			const {
				feature,
				deduction: toDeduct,
				targetBalance,
				lockReceipt,
				unwindValue,
			} = deduction;

			const {
				customerEntitlementDeductions,
				spendLimitByFeatureId,
				usageBasedCusEntIdsByFeatureId,
				rollovers,
				customerEntitlements,
				unlimitedFeatureIds,
				unlimitedCusEnt,
				lock: preparedLock,
			} = prepareFeatureDeductionV2({
				ctx,
				fullSubject,
				deduction,
				options: resolvedOptions,
				now: usageWindowNow,
			});
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add usage\_limits config + usage-window r..."](https://github.com/useautumn/autumn/commit/d93557d5a85151056d9e8ecdd80dc8ee92b935ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34988384)</sub>

<!-- /greptile_comment -->