### PR TITLE
persist usage_windows via sync_balances_v2 write-through

### DIFF
--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -129,6 +129,7 @@ export const prepareFeatureDeductionV2 = ({
 		featureIds: windowFeatureIds,
 		features: ctx.features,
 		now,
+		inStatuses: orgToInStatuses({ org }),
 	});
 
 	for (const windowLimit of usageWindowLimits) {
@@ -138,7 +139,11 @@ export const prepareFeatureDeductionV2 = ({
 			);
 		}
 	}
-	if (fullSubject.entity?.spend_limits?.some((s) => s.usage_window?.enabled)) {
+	if (
+		fullSubject.entity?.spend_limits?.some(
+			(s) => s.usage_limit_interval != null,
+		)
+	) {
 		ctx.logger.warn(
 			`entity-scoped usage windows are not enforced in v1; ignored for entity ${fullSubject.entity.id}`,
 		);

--- a/server/src/internal/balances/utils/sql/syncBalancesV2.sql
+++ b/server/src/internal/balances/utils/sql/syncBalancesV2.sql
@@ -6,6 +6,7 @@
 --     - balance: number
 --     - adjustment: number
 --     - entities: jsonb (the full entities object)
+--     - usage_windows: jsonb (the full usage-window counters object)
 --     - next_reset_at: bigint/number (unix timestamp, for conflict detection)
 --     - entity_count: number (for conflict detection)
 --     - cache_version: number (if defined, skip write if DB cache_version differs)
@@ -38,6 +39,7 @@ DECLARE
   ent_balance numeric;
   ent_adjustment numeric;
   ent_entities jsonb;
+  ent_usage_windows jsonb;
   ent_next_reset_at bigint;
   ent_entity_count int;
   ent_cache_version int;
@@ -99,6 +101,7 @@ BEGIN
       ent_balance := (ent_obj->>'balance')::numeric;
       ent_adjustment := (ent_obj->>'adjustment')::numeric;
       ent_entities := ent_obj->'entities';
+      ent_usage_windows := ent_obj->'usage_windows';
       ent_next_reset_at := (ent_obj->>'next_reset_at')::bigint;
       ent_entity_count := COALESCE((ent_obj->>'entity_count')::int, 0);
       ent_cache_version := COALESCE((ent_obj->>'cache_version')::int, 0);
@@ -134,14 +137,21 @@ BEGIN
           ent_id, ent_cache_version, db_cache_version;
       END IF;
       
-      -- Update the customer_entitlement row directly
+      -- Update the customer_entitlement row directly.
+      -- usage_windows is written from the synced object, which carries the FRESH
+      -- Redis value (re-read at sync time), so this is a full replace, not a
+      -- lost-update risk: concurrent counter increments are serialized atomically
+      -- in Redis and the latest cumulative map is what reaches here. The COALESCE
+      -- only avoids wiping the column when a balance-only sync carries no
+      -- usage_windows (null). Postgres is a mirror; Redis is authoritative.
       UPDATE customer_entitlements ce
       SET
         balance = COALESCE(ent_balance, ce.balance),
         adjustment = COALESCE(ent_adjustment, ce.adjustment),
-        entities = COALESCE(ent_entities, ce.entities)
+        entities = COALESCE(ent_entities, ce.entities),
+        usage_windows = COALESCE(NULLIF(ent_usage_windows, 'null'::jsonb), ce.usage_windows)
       WHERE ce.id = ent_id;
-      
+
       -- Track update
       IF FOUND THEN
         updates_json := jsonb_set(
@@ -150,7 +160,8 @@ BEGIN
           jsonb_build_object(
             'balance', ent_balance,
             'adjustment', ent_adjustment,
-            'entities', ent_entities
+            'entities', ent_entities,
+            'usage_windows', ent_usage_windows
           )
         );
       END IF;

--- a/server/src/internal/balances/utils/sync/syncItemV4.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV4.ts
@@ -4,6 +4,7 @@ import {
 	type EntityRolloverBalance,
 	type SubjectBalance,
 	tryCatch,
+	type UsageWindows,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -76,6 +77,7 @@ export interface SyncEntry {
 	balance: number;
 	adjustment: number;
 	entities: Record<string, EntityBalance> | null;
+	usage_windows: UsageWindows | null;
 	next_reset_at: number | null;
 	entity_count: number;
 	cache_version: number | null;
@@ -98,6 +100,7 @@ const subjectBalanceToSyncEntry = ({
 	balance: subjectBalance.balance ?? 0,
 	adjustment: subjectBalance.adjustment ?? 0,
 	entities: subjectBalance.entities ?? null,
+	usage_windows: subjectBalance.usage_windows ?? null,
 	next_reset_at: subjectBalance.next_reset_at ?? null,
 	entity_count: subjectBalance.entities
 		? Object.keys(subjectBalance.entities).length

--- a/server/tests/integration/balances/track/usage-limit/track-customer-usage-limit.test.ts
+++ b/server/tests/integration/balances/track/usage-limit/track-customer-usage-limit.test.ts
@@ -10,7 +10,8 @@ import { expectCustomerFeatureCachedAndDb } from "../../utils/spend-limit-utils/
 
 type AutumnV2_1Client = Awaited<ReturnType<typeof initScenario>>["autumnV2_1"];
 
-// Arms a windowed usage cap via spend_limits[].usage_window (overage cap left off).
+// Arms a windowed usage cap via spend_limits[].usage_limit_interval (overage off).
+// `limit` is passed as the explicit usage_limit override.
 const setCustomerUsageLimit = async ({
 	autumn,
 	customerId,
@@ -29,7 +30,8 @@ const setCustomerUsageLimit = async ({
 			{
 				feature_id: featureId,
 				enabled: false,
-				usage_window: { interval, limit, enabled: true },
+				usage_limit: limit,
+				usage_limit_interval: interval,
 			},
 		],
 	};
@@ -225,10 +227,10 @@ test.concurrent(
 	},
 );
 
-// A single spend_limit entry carrying BOTH an overage_limit and a usage_window
-// must still enforce the window (the two caps are independent).
+// A single spend_limit entry carrying BOTH an overage_limit and a windowed usage
+// cap must still enforce the window (the two caps are independent).
 test.concurrent(
-	`${chalk.yellowBright("track-customer-usage-limit4: a spend_limit with both overage_limit and usage_window still enforces the window")}`,
+	`${chalk.yellowBright("track-customer-usage-limit4: a spend_limit with both overage_limit and a usage window still enforces the window")}`,
 	async () => {
 		const customerProduct = products.base({
 			id: "track-customer-compound-cap",
@@ -250,11 +252,8 @@ test.concurrent(
 					feature_id: TestFeature.Action1,
 					enabled: true,
 					overage_limit: 20,
-					usage_window: {
-						interval: EntInterval.Month,
-						limit: 5,
-						enabled: true,
-					},
+					usage_limit: 5,
+					usage_limit_interval: EntInterval.Month,
 				},
 			],
 		};

--- a/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
+++ b/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	buildUsageWindowKey,
+	CusProductStatus,
 	type DbSpendLimit,
 	EntInterval,
 	type Feature,
@@ -8,7 +9,6 @@ import {
 	type FullSubject,
 	fullSubjectToUsageWindowLimits,
 	getUsageWindowBounds,
-	SpendLimitUsageWindowSchema,
 } from "@autumn/shared";
 
 const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
@@ -30,33 +30,33 @@ const credits2ContainingAction1 = {
 	config: { schema: [{ metered_feature_id: "action1", credit_amount: 3 }] },
 } as unknown as Feature;
 
-// Test-input shape for a windowed usage cap; wrapped into a spend_limit's
-// usage_window sub-object by `toSpendLimit` (the cap config now lives there).
+// Test-input shape for a windowed usage cap. The interval arms the cap; `limit`
+// is the optional override (omit it to test inheriting from the entitlement).
 type UsageCap = {
 	feature_id: string;
-	enabled: boolean;
-	limit: number;
+	limit?: number;
 	interval: EntInterval;
 };
 
 const toSpendLimit = (cap: UsageCap): DbSpendLimit => ({
 	feature_id: cap.feature_id,
-	// Entry-level enabled gates the (absent) overage cap, not the window cap.
+	// Entry-level enabled gates the (absent) overage cap, not the usage window.
 	enabled: false,
-	usage_window: {
-		interval: cap.interval,
-		limit: cap.limit,
-		enabled: cap.enabled,
-	},
+	usage_limit: cap.limit,
+	usage_limit_interval: cap.interval,
 });
 
-// Minimal loose (product-less) customer entitlement for anchor candidate tests.
+// Minimal loose (product-less) customer entitlement for anchor/inherit tests.
+// `usageLimit` sets the entitlement's usage_limit (the inherited cap source);
+// `cycleAnchor` attaches a product with a billing-cycle anchor for cycle tests.
 const looseEntitlement = ({
 	id,
 	featureId,
+	usageLimit,
 }: {
 	id: string;
 	featureId: string;
+	usageLimit?: number;
 }) =>
 	({
 		id,
@@ -72,23 +72,71 @@ const looseEntitlement = ({
 			id: `ent_${id}`,
 			feature_id: featureId,
 			interval: EntInterval.Month,
+			usage_limit: usageLimit ?? null,
 			feature: { id: featureId, internal_id: featureId },
 		},
 		rollovers: [],
 		replaceables: [],
 	}) as unknown as FullSubject["extra_customer_entitlements"][number];
 
+// A customer product wrapping one entitlement, with an optional billing-cycle
+// anchor. Unlike loose entitlements, product-backed ones keep their
+// customer_product through fullSubjectToCustomerEntitlements, so the resolver can
+// read the cycle anchor from it.
+const customerProductWithEntitlement = ({
+	id,
+	featureId,
+	usageLimit,
+	cycleAnchor,
+}: {
+	id: string;
+	featureId: string;
+	usageLimit?: number;
+	cycleAnchor?: number;
+}) =>
+	({
+		id: `cusprod_${id}`,
+		status: CusProductStatus.Active,
+		created_at: 1000,
+		product: { is_add_on: false },
+		billing_cycle_anchor_resets_at: cycleAnchor ?? null,
+		customer_entitlements: [
+			{
+				id,
+				feature_id: featureId,
+				internal_entity_id: null,
+				internal_feature_id: featureId,
+				customer_product_id: `cusprod_${id}`,
+				entitlement_id: `ent_${id}`,
+				created_at: 1000,
+				balance: 0,
+				expires_at: null,
+				entitlement: {
+					id: `ent_${id}`,
+					feature_id: featureId,
+					interval: EntInterval.Month,
+					usage_limit: usageLimit ?? null,
+					feature: { id: featureId, internal_id: featureId },
+				},
+				rollovers: [],
+				replaceables: [],
+			},
+		],
+	}) as unknown as FullSubject["customer_products"][number];
+
 const buildSubject = ({
 	customerLimits = [],
 	entityLimits,
 	looseEntitlements = [],
 	extraCustomerSpendLimits = [],
+	customerProducts = [],
 }: {
 	customerLimits?: UsageCap[];
 	entityLimits?: UsageCap[];
 	looseEntitlements?: FullSubject["extra_customer_entitlements"];
 	// Raw spend-limit entries (e.g. overage-only or both-cap) injected as-is.
 	extraCustomerSpendLimits?: DbSpendLimit[];
+	customerProducts?: FullSubject["customer_products"];
 }): FullSubject =>
 	({
 		customer: {
@@ -97,7 +145,7 @@ const buildSubject = ({
 				...extraCustomerSpendLimits,
 			],
 		},
-		customer_products: [],
+		customer_products: customerProducts,
 		extra_customer_entitlements: looseEntitlements,
 		entity: entityLimits
 			? {
@@ -109,16 +157,11 @@ const buildSubject = ({
 	}) as unknown as FullSubject;
 
 describe("fullSubjectToUsageWindowLimits", () => {
-	test("resolves a customer-level metered-feature cap", () => {
+	test("resolves a customer-level metered-feature cap (limit overridden)", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "action1",
-						enabled: true,
-						limit: 5,
-						interval: EntInterval.Month,
-					},
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
 				],
 			}),
 			featureIds: ["action1"],
@@ -157,12 +200,7 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "credits",
-						enabled: true,
-						limit: 3,
-						interval: EntInterval.Day,
-					},
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
 				],
 			}),
 			featureIds: ["credits"],
@@ -177,37 +215,114 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		});
 	});
 
-	test("skips caps whose usage_window is disabled", () => {
+	test("inherits the limit from the feature's entitlement when no override", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				// No `limit` => inherit from the entitlement.
+				customerLimits: [{ feature_id: "credits", interval: EntInterval.Day }],
+				looseEntitlements: [
+					looseEntitlement({
+						id: "ce_credits",
+						featureId: "credits",
+						usageLimit: 7,
+					}),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			limit: 7,
+			anchor_customer_entitlement_id: "ce_credits",
+		});
+	});
+
+	test("an explicit usage_limit overrides the inherited entitlement limit", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "action1",
-						enabled: false,
-						limit: 5,
-						interval: EntInterval.Month,
-					},
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
+				],
+				looseEntitlements: [
+					looseEntitlement({
+						id: "ce_credits",
+						featureId: "credits",
+						usageLimit: 7,
+					}),
 				],
 			}),
-			featureIds: ["action1"],
-			features: [meteredAction1],
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({ limit: 3 });
+	});
+
+	test("no override and an entitlement with no usage_limit resolves nothing", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [{ feature_id: "credits", interval: EntInterval.Day }],
+				looseEntitlements: [
+					// usageLimit omitted => entitlement.usage_limit is null (unlimited).
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
 			now: NOW,
 		});
 
 		expect(limits).toHaveLength(0);
 	});
 
-	test("usage_window with enabled omitted defaults to disabled and is not enforced", () => {
-		const parsed = SpendLimitUsageWindowSchema.parse({
-			interval: EntInterval.Month,
-			limit: 5,
+	test("aligns window bounds to the billing-cycle anchor when present", () => {
+		// Anchor: a non-midnight, non-first-of-month timestamp the cycle aligns to.
+		const cycleAnchor = Date.UTC(2026, 0, 9, 15, 30, 0);
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
+				],
+				customerProducts: [
+					customerProductWithEntitlement({
+						id: "ce_credits",
+						featureId: "credits",
+						cycleAnchor,
+					}),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
 		});
-		expect(parsed.enabled).toBe(false);
 
+		const aligned = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+			anchor: cycleAnchor,
+		});
+		const calendar = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0].window_start_at).toBe(aligned.windowStartAt);
+		expect(limits[0].window_end_at).toBe(aligned.windowEndAt);
+		// Sanity: the anchored window genuinely differs from calendar alignment.
+		expect(aligned.windowStartAt).not.toBe(calendar.windowStartAt);
+	});
+
+	test("a usage_limit with no interval is not armed (skipped)", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				extraCustomerSpendLimits: [
-					{ feature_id: "action1", enabled: false, usage_window: parsed },
+					{ feature_id: "action1", enabled: false, usage_limit: 5 },
 				],
 			}),
 			featureIds: ["action1"],
@@ -218,7 +333,7 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		expect(limits).toHaveLength(0);
 	});
 
-	test("ignores an overage-only spend_limit (no usage_window)", () => {
+	test("ignores an overage-only spend_limit (no usage_limit_interval)", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				extraCustomerSpendLimits: [
@@ -241,11 +356,8 @@ describe("fullSubjectToUsageWindowLimits", () => {
 						feature_id: "action1",
 						enabled: true,
 						overage_limit: 20,
-						usage_window: {
-							interval: EntInterval.Month,
-							limit: 5,
-							enabled: true,
-						},
+						usage_limit: 5,
+						usage_limit_interval: EntInterval.Month,
 					},
 				],
 			}),
@@ -262,20 +374,10 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "action1",
-						enabled: true,
-						limit: 5,
-						interval: EntInterval.Month,
-					},
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
 				],
 				entityLimits: [
-					{
-						feature_id: "action1",
-						enabled: true,
-						limit: 2,
-						interval: EntInterval.Month,
-					},
+					{ feature_id: "action1", limit: 2, interval: EntInterval.Month },
 				],
 			}),
 			featureIds: ["action1"],
@@ -296,12 +398,7 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				entityLimits: [
-					{
-						feature_id: "action1",
-						enabled: true,
-						limit: 2,
-						interval: EntInterval.Month,
-					},
+					{ feature_id: "action1", limit: 2, interval: EntInterval.Month },
 				],
 			}),
 			featureIds: ["action1"],
@@ -331,18 +428,8 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "action1",
-						enabled: true,
-						limit: 5,
-						interval: EntInterval.Month,
-					},
-					{
-						feature_id: "action2",
-						enabled: true,
-						limit: 9,
-						interval: EntInterval.Day,
-					},
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
+					{ feature_id: "action2", limit: 9, interval: EntInterval.Day },
 				],
 			}),
 			featureIds: ["action1", "action2"],
@@ -361,12 +448,7 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "credits",
-						enabled: true,
-						limit: 3,
-						interval: EntInterval.Day,
-					},
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
 				],
 				looseEntitlements: [
 					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
@@ -388,12 +470,7 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "action1",
-						enabled: true,
-						limit: 5,
-						interval: EntInterval.Month,
-					},
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
 				],
 				looseEntitlements: [
 					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
@@ -417,12 +494,7 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "credits",
-						enabled: true,
-						limit: 3,
-						interval: EntInterval.Day,
-					},
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
 				],
 			}),
 			featureIds: ["credits"],
@@ -438,12 +510,7 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "action1",
-						enabled: true,
-						limit: 5,
-						interval: EntInterval.Month,
-					},
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
 				],
 			}),
 			featureIds: ["action1"],
@@ -459,12 +526,7 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({
 				customerLimits: [
-					{
-						feature_id: "action1",
-						enabled: true,
-						limit: 5,
-						interval: EntInterval.Month,
-					},
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
 				],
 				looseEntitlements: [
 					looseEntitlement({ id: "ce_credits", featureId: "credits" }),

--- a/server/tests/unit/usage-windows/getUsageWindowBounds.test.ts
+++ b/server/tests/unit/usage-windows/getUsageWindowBounds.test.ts
@@ -85,4 +85,47 @@ describe("getUsageWindowBounds", () => {
 			getUsageWindowBounds({ interval: EntInterval.Month, now: NOW + 1000 }),
 		);
 	});
+
+	test("aligns a day window to the anchor's time-of-day, not UTC midnight", () => {
+		const anchor = Date.UTC(2026, 0, 9, 15, 30, 0); // 15:30, not midnight
+		const { windowStartAt, windowEndAt } = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+			anchor,
+		});
+		const calendar = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+		});
+
+		// Spans one day, contains now, and rolls at the anchor's 15:30.
+		expect(windowEndAt - windowStartAt).toBe(24 * 60 * 60 * 1000);
+		expect(windowStartAt).toBeLessThanOrEqual(NOW);
+		expect(NOW).toBeLessThan(windowEndAt);
+		expect(new Date(windowStartAt).getUTCHours()).toBe(15);
+		expect(new Date(windowStartAt).getUTCMinutes()).toBe(30);
+		expect(windowStartAt).not.toBe(calendar.windowStartAt);
+	});
+
+	test("aligns a month window to the anchor's day-of-month, not the 1st", () => {
+		const anchor = Date.UTC(2026, 0, 9); // the 9th
+		const { windowStartAt } = getUsageWindowBounds({
+			interval: EntInterval.Month,
+			now: NOW, // June 15
+			anchor,
+		});
+
+		expect(new Date(windowStartAt).getUTCDate()).toBe(9);
+		expect(windowStartAt).toBeLessThanOrEqual(NOW);
+	});
+
+	test("lifetime ignores the anchor", () => {
+		expect(
+			getUsageWindowBounds({
+				interval: EntInterval.Lifetime,
+				now: NOW,
+				anchor: Date.UTC(2026, 0, 9),
+			}),
+		).toEqual({ windowStartAt: 0, windowEndAt: Number.MAX_SAFE_INTEGER });
+	});
 });

--- a/shared/api/billingControls/entityBillingControls.ts
+++ b/shared/api/billingControls/entityBillingControls.ts
@@ -6,7 +6,7 @@ import { ApiUsageAlertSchema } from "./usageAlert.js";
 export const ApiEntityBillingControlsSchema = z.object({
 	spend_limits: z.array(ApiSpendLimitSchema).optional().meta({
 		description:
-			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_window).",
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_limit_interval).",
 	}),
 	usage_alerts: z.array(ApiUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -101,7 +101,7 @@ export const CustomerBillingControlsSchema = z.object({
 	}),
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
 		description:
-			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_window).",
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_limit_interval).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",
@@ -127,7 +127,7 @@ export const CustomerBillingControlsResponseSchema = z.object({
 	}),
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
 		description:
-			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_window).",
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_limit_interval).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/models/cusModels/billingControls/entityBillingControls.ts
+++ b/shared/models/cusModels/billingControls/entityBillingControls.ts
@@ -6,7 +6,7 @@ import { DbUsageAlertSchema } from "./usageAlert.js";
 export const EntityBillingControlsSchema = z.object({
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
 		description:
-			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_window).",
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_limit_interval).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/models/cusModels/billingControls/spendLimit.ts
+++ b/shared/models/cusModels/billingControls/spendLimit.ts
@@ -1,22 +1,6 @@
 import { z } from "zod/v4";
 import { EntInterval } from "../../productModels/intervals/entitlementInterval.js";
 
-// Optional windowed usage cap on a spend limit: a hard pre-write reject on units
-// consumed per `interval` window, independent of `overage_limit` and of balance.
-export const SpendLimitUsageWindowSchema = z.object({
-	interval: z.enum(EntInterval).meta({
-		description: "The window interval the usage cap resets on.",
-	}),
-	limit: z.number().min(0).meta({
-		description:
-			"Maximum units consumable within each window. Feature units for a metered feature, or pool credits for a credit-system feature. Distinct from overage_limit's currency unit.",
-	}),
-	enabled: z.boolean().default(false).meta({
-		description:
-			"Whether the windowed usage cap is enforced. Independent of the entry-level `enabled`, which gates the overage cap.",
-	}),
-});
-
 export const DbSpendLimitSchema = z
 	.object({
 		feature_id: z.string().optional().meta({
@@ -28,21 +12,26 @@ export const DbSpendLimitSchema = z
 		overage_limit: z.number().min(0).optional().meta({
 			description: "Maximum allowed overage spend for the target feature.",
 		}),
-		usage_window: SpendLimitUsageWindowSchema.optional().meta({
+		usage_limit: z.number().min(0).optional().meta({
 			description:
-				"Optional windowed usage cap (hard pre-write reject), independent of the overage cap. Absent means no usage cap.",
+				"Optional override for the windowed usage cap. When omitted, the cap inherits the feature entitlement's usage_limit. Only meaningful with usage_limit_interval set.",
+		}),
+		usage_limit_interval: z.enum(EntInterval).optional().meta({
+			description:
+				"Interval the windowed usage cap resets on, aligned to the customer's billing cycle. Its presence arms the usage cap (hard pre-write reject); absent means no usage cap.",
 		}),
 	})
 	.refine(
 		(data) =>
-			!(data.overage_limit !== undefined || data.usage_window !== undefined) ||
-			data.feature_id !== undefined,
+			!(
+				data.overage_limit !== undefined ||
+				data.usage_limit_interval !== undefined
+			) || data.feature_id !== undefined,
 		{
 			message:
-				"feature_id is required when overage_limit or usage_window is provided",
+				"feature_id is required when overage_limit or usage_limit_interval is provided",
 			path: ["feature_id"],
 		},
 	);
 
-export type SpendLimitUsageWindow = z.infer<typeof SpendLimitUsageWindowSchema>;
 export type DbSpendLimit = z.infer<typeof DbSpendLimitSchema>;

--- a/shared/models/cusProductModels/cusEntModels/usageWindowModels.ts
+++ b/shared/models/cusProductModels/cusEntModels/usageWindowModels.ts
@@ -51,8 +51,9 @@ export type UsageWindows = z.infer<typeof UsageWindowsSchema>;
 
 /**
  * A resolved, enforceable usage-window limit: the runtime input handed to the
- * deduction script. Built each deduction from the `usage_window` sub-object on a
- * `spend_limit` billing control plus the current window bounds (NOT stored).
+ * deduction script. Built each deduction from the windowed usage cap
+ * (`usage_limit_interval` + inherited/override limit) on a `spend_limit` billing
+ * control plus the current window bounds (NOT stored).
  * Carries the resolved `limit` and `key`/window so Lua can find-or-create the
  * matching counter.
  */

--- a/shared/utils/fullSubjectUtils/fullSubjectToUsageWindowLimits.ts
+++ b/shared/utils/fullSubjectUtils/fullSubjectToUsageWindowLimits.ts
@@ -52,43 +52,66 @@ const toAnchorCandidate = (
 
 /**
  * Resolves the enforceable usage-window limits for the requested features from a
- * FullSubject. The windowed cap is configured as the optional `usage_window`
- * sub-object on a `spend_limit` entry (same JSON as the overage cap; the two
- * caps are independent). v1 reads ONLY customer-scoped spend_limits; entity
- * usage windows are out of scope. Only `usage_window.enabled` entries are
- * enforced (independent of the entry-level `enabled`, which gates the overage cap).
+ * FullSubject. A windowed cap is armed by setting `usage_limit_interval` on a
+ * customer `spend_limit` entry (flat config; the interval's presence is the
+ * switch, independent of the entry-level `enabled` which gates the overage cap).
+ * v1 reads ONLY customer-scoped spend_limits; entity usage windows are out of scope.
  *
- * A cap on a credit-system feature targets the credit pool (`balance`
- * dimension); a cap on any other feature targets that feature's usage
- * (`metered_feature` dimension). Window bounds + key are computed from `now`.
+ * The cap value is the entry's `usage_limit` if set, else inherited from the
+ * capped feature's OWN entitlement (`entitlement.usage_limit`) - so you usually
+ * set only the interval. No resolvable limit (e.g. an unlimited entitlement and no
+ * override) means no enforceable cap, so the feature is skipped.
  *
- * Each limit also gets a single owning `anchor_customer_entitlement_id`,
- * resolved deduction-order-independently so one counter never splits across
- * pools. Null anchor means no eligible owner; the enforcement layer fails closed.
+ * A cap on a credit-system feature targets the credit pool (`balance` dimension);
+ * a cap on any other feature targets that feature's usage (`metered_feature`).
+ * Window bounds align to the customer's billing cycle (the anchor entitlement's
+ * `billing_cycle_anchor_resets_at`), falling back to UTC calendar when absent.
+ *
+ * Each limit gets a single owning `anchor_customer_entitlement_id`, resolved
+ * deduction-order-independently so one counter never splits across pools. Null
+ * anchor means no eligible owner; the enforcement layer fails closed.
  */
 export const fullSubjectToUsageWindowLimits = ({
 	fullSubject,
 	featureIds,
 	features,
 	now,
+	inStatuses,
 }: {
 	fullSubject: FullSubject;
 	featureIds: string[];
 	features: Feature[];
 	now: number;
+	// Status filter for entitlement lookups; pass the caller's orgToInStatuses so
+	// the cap's value/anchor resolution matches what the deduction can act on.
+	inStatuses?: CusProductStatus[];
 }): UsageWindowLimit[] => {
 	// v1: customer-scoped caps only; entity-scoped usage windows are out of scope.
 	const customerSpendLimits = fullSubject.customer.spend_limits ?? [];
 	const limits: UsageWindowLimit[] = [];
 
 	for (const featureId of [...new Set(featureIds)]) {
+		// Presence of usage_limit_interval arms the cap; there is no separate enabled.
 		const spendLimit = customerSpendLimits.find(
 			(candidate) =>
 				candidate.feature_id === featureId &&
-				candidate.usage_window?.enabled === true,
+				candidate.usage_limit_interval != null,
 		);
-		const usageWindow = spendLimit?.usage_window;
-		if (!usageWindow) continue;
+		const interval = spendLimit?.usage_limit_interval;
+		if (spendLimit == null || interval == null) continue;
+
+		// Cap value: explicit override, else inherited from the capped feature's OWN
+		// entitlement (NOT the anchor, which may be a containing credit system in a
+		// different unit). No resolvable limit => no enforceable cap, skip.
+		const featureCustomerEntitlement = fullSubjectToCustomerEntitlements({
+			fullSubject,
+			featureIds: [featureId],
+			inStatuses,
+		})[0];
+		const limit =
+			spendLimit.usage_limit ??
+			featureCustomerEntitlement?.entitlement.usage_limit;
+		if (limit == null) continue;
 
 		const scopeType = "customer" as const;
 		const entityId = null;
@@ -117,28 +140,36 @@ export const fullSubjectToUsageWindowLimits = ({
 
 		let anchorId: string | null = null;
 		let anchorFeatureId: string | null = null;
+		let anchorCustomerEntitlement: FullCusEntWithFullCusProduct | undefined;
 		for (const ownerFeatureIds of ownerFeatureIdsByPreference) {
 			if (ownerFeatureIds.length === 0) continue;
 			const candidateEntitlements = fullSubjectToCustomerEntitlements({
 				fullSubject,
 				featureIds: ownerFeatureIds,
+				inStatuses,
 			});
 			anchorId = pickAnchorCustomerEntitlementId({
 				candidates: candidateEntitlements.map(toAnchorCandidate),
 				scopeType,
 			});
 			if (anchorId) {
-				anchorFeatureId =
-					candidateEntitlements.find(
-						(customerEntitlement) => customerEntitlement.id === anchorId,
-					)?.feature_id ?? null;
+				anchorCustomerEntitlement = candidateEntitlements.find(
+					(customerEntitlement) => customerEntitlement.id === anchorId,
+				);
+				anchorFeatureId = anchorCustomerEntitlement?.feature_id ?? null;
 				break;
 			}
 		}
 
+		// Align window bounds to the customer's billing cycle when the anchor has a
+		// cycle anchor; otherwise getUsageWindowBounds falls back to UTC calendar.
+		const cycleAnchor =
+			anchorCustomerEntitlement?.customer_product
+				?.billing_cycle_anchor_resets_at ?? null;
 		const { windowStartAt, windowEndAt } = getUsageWindowBounds({
-			interval: usageWindow.interval,
+			interval,
 			now,
+			anchor: cycleAnchor,
 		});
 
 		limits.push({
@@ -148,7 +179,7 @@ export const fullSubjectToUsageWindowLimits = ({
 				internalEntityId,
 				dimensionType,
 				dimensionFeatureId,
-				interval: usageWindow.interval,
+				interval,
 				windowStartAt,
 			}),
 			dimension_type: dimensionType,
@@ -156,10 +187,10 @@ export const fullSubjectToUsageWindowLimits = ({
 			scope_type: scopeType,
 			entity_id: entityId,
 			internal_entity_id: internalEntityId,
-			interval: usageWindow.interval,
+			interval,
 			window_start_at: windowStartAt,
 			window_end_at: windowEndAt,
-			limit: usageWindow.limit,
+			limit,
 			anchor_customer_entitlement_id: anchorId,
 			anchor_feature_id: anchorFeatureId,
 		});

--- a/shared/utils/usageWindowUtils/getUsageWindowBounds.ts
+++ b/shared/utils/usageWindowUtils/getUsageWindowBounds.ts
@@ -9,13 +9,15 @@ import {
 	startOfYear,
 } from "date-fns";
 import { EntInterval } from "../../models/productModels/intervals/entitlementInterval.js";
+import { getCycleEnd } from "../billingUtils/cycleUtils/getCycleEnd.js";
+import { getCycleStart } from "../billingUtils/cycleUtils/getCycleStart.js";
 import { addInterval } from "../billingUtils/intervalUtils/intervalArithmetic.js";
 
 const LIFETIME_WINDOW_END = Number.MAX_SAFE_INTEGER;
 
-// UTC-calendar-aligned start of the interval containing `now`. Alignment keeps
-// the window (and therefore its key) deterministic from `now` alone, so the TS
-// and Lua sides never disagree on which window a track lands in.
+// UTC-calendar-aligned start of the interval containing `now`. Used only as the
+// fallback when no billing-cycle anchor is available; alignment keeps the window
+// (and its key) deterministic from `now` alone so TS and Lua never disagree.
 const startOfWindow = ({
 	interval,
 	now,
@@ -56,19 +58,37 @@ const startOfWindow = ({
 };
 
 /**
- * Current usage-window bounds for an interval, aligned to the UTC calendar.
- * `lifetime` never resets. Each window spans exactly one interval (sub-interval
- * counts are intentionally not supported yet; they need non-overlapping tiling).
+ * Current usage-window bounds for an interval. When a billing-cycle `anchor` is
+ * given, bounds align to the customer's cycle (so a "daily" cap rolls on their
+ * billing time-of-day, not UTC midnight). Without an anchor, falls back to UTC
+ * calendar alignment. `lifetime` never resets. Each window spans one interval.
  */
 export const getUsageWindowBounds = ({
 	interval,
 	now,
+	anchor,
 }: {
 	interval: EntInterval;
 	now: number;
+	anchor?: number | null;
 }): { windowStartAt: number; windowEndAt: number } => {
 	if (interval === EntInterval.Lifetime) {
 		return { windowStartAt: 0, windowEndAt: LIFETIME_WINDOW_END };
+	}
+
+	if (anchor != null && Number.isFinite(anchor)) {
+		const cycleStartAt = getCycleStart({ anchor, interval, now });
+		const cycleEndAt = getCycleEnd({ anchor, interval, now });
+		// Only trust cycle bounds that are finite and actually bracket `now`; a bad
+		// billing anchor must fall back to calendar, never poison the deduction.
+		if (
+			Number.isFinite(cycleStartAt) &&
+			Number.isFinite(cycleEndAt) &&
+			cycleStartAt <= now &&
+			now < cycleEndAt
+		) {
+			return { windowStartAt: cycleStartAt, windowEndAt: cycleEndAt };
+		}
 	}
 
 	const windowStartAt = startOfWindow({ interval, now });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists `usage_windows` via `sync_balances_v2` and enforces windowed usage caps aligned to each customer's billing cycle. Caps are armed by `usage_limit_interval` with an optional `usage_limit` override (falls back to the feature entitlement); v1 ignores entity-scoped windows.

- **New Features**
  - Write-through: `sync_balances_v2` writes `usage_windows` with `COALESCE(NULLIF(...))` and returns it in `updates_json`; `SyncEntry` and Lua carry and merge it.
  - Enforcement: arm via `usage_limit_interval`; limit comes from `usage_limit` or the feature’s `entitlement.usage_limit`; window bounds align to `billing_cycle_anchor_resets_at` via `getUsageWindowBounds` (falls back to UTC).
  - Anchoring: resolve a single owning `anchor_customer_entitlement_id` (incl. credit parents) and pass `inStatuses` from `prepareFeatureDeductionV2` for consistent resolution.
  - Behavior: epsilon-tolerant checks; prune closed windows and mark anchors dirty even without consumption; block `set_usage` while a window is active; fail closed on missing anchors.
  - Safety: validate usage-window key segments to prevent aliasing; Redis stays authoritative with Postgres mirroring.

- **Migration**
  - Replace `spend_limits[].usage_window` with flat fields: `usage_limit_interval` (arms the cap) and `usage_limit` (optional override).
  - Entry-level `enabled` still gates `overage_limit`; no boolean is needed for the windowed cap.
  - If `usage_limit` is omitted, the cap inherits the feature entitlement’s `usage_limit`; if that is null, no cap is enforced.
  - API models/schemas and docs updated to reference `usage_limit_interval`.

<sup>Written for commit f4f8afcb86863a894aa1999097e091193e3fceca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires `usage_windows` counters through the `sync_balances_v2` write path so they are persisted to the DB on every balance sync, matching how `entities` is already handled.

- **[Bug fixes / Improvements]** SQL: declares `ent_usage_windows jsonb`, extracts it from the input object, and applies `COALESCE(ent_usage_windows, ce.usage_windows)` on `UPDATE`; also appends the value to the `updates_json` tracking object returned to the caller.
- **[Improvements]** TypeScript: adds `UsageWindows | null` to the `SyncEntry` interface and maps it from `SubjectBalance.usage_windows` using the existing `?? null` fallback pattern in `subjectBalanceToSyncEntry`.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a straightforward extension of the existing entities write-through pattern.

The SQL and TypeScript changes are minimal, consistent with the established COALESCE pattern for nullable JSONB fields, and touch only the sync path. The only outstanding item is an outdated doc comment in the SQL header.

No files require special attention beyond the minor doc comment fix in syncBalancesV2.sql.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/sql/syncBalancesV2.sql | Adds ent_usage_windows variable, reads it from input JSON, persists it with COALESCE on UPDATE, and includes it in updates_json tracking; return-value doc comment omits usage_windows |
| server/src/internal/balances/utils/sync/syncItemV4.ts | Adds UsageWindows import, usage_windows field to SyncEntry interface, and maps it from SubjectBalance in subjectBalanceToSyncEntry using the same ?? null pattern as other nullable fields |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Redis as Redis Cache
    participant TS as syncItemV4.ts
    participant PG as sync_balances_v2 (PG)
    participant DB as customer_entitlements

    TS->>Redis: getCachedFeatureBalance (SubjectBalance[])
    Redis-->>TS: SubjectBalance[] (incl. usage_windows)
    TS->>TS: subjectBalanceToSyncEntry() maps usage_windows ?? null → SyncEntry
    TS->>PG: sync_balances_v2(entries as jsonb)
    PG->>DB: SELECT next_reset_at, entity_count, cache_version FOR UPDATE
    DB-->>PG: current row values
    Note over PG: Conflict guards (reset_at, entity_count, cache_version)
    PG->>DB: "UPDATE SET balance, adjustment, entities, usage_windows = COALESCE(ent_usage_windows, ce.usage_windows)"
    PG-->>TS: "{ updates: {id → {balance, adjustment, entities, usage_windows}} }"
    TS->>TS: logSyncItem (updateCount)
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/balances/utils/sql/syncBalancesV2.sql`, line 20 ([link](https://github.com/useautumn/autumn/blob/4db67117e16ee68ebc50e2ec4f0b288eea2f640a/server/src/internal/balances/utils/sql/syncBalancesV2.sql#L20)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The return-value doc comment at the top of the file still describes the `updates` map as `{ balance, adjustment, entities }`, but `usage_windows` is now also included in every `updates_json` entry. A caller reading only the header comment would not know the field is present in the response.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/utils/sql/syncBalancesV2.sql
   Line: 20

   Comment:
   The return-value doc comment at the top of the file still describes the `updates` map as `{ balance, adjustment, entities }`, but `usage_windows` is now also included in every `updates_json` entry. A caller reading only the header comment would not know the field is present in the response.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/balances/utils/sql/syncBalancesV2.sql:20
The return-value doc comment at the top of the file still describes the `updates` map as `{ balance, adjustment, entities }`, but `usage_windows` is now also included in every `updates_json` entry. A caller reading only the header comment would not know the field is present in the response.

```suggestion
--   updates: object mapping customer_entitlement_id -> { balance, adjustment, entities, usage_windows }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["persist usage\_windows via sync\_balances\_..."](https://github.com/useautumn/autumn/commit/4db67117e16ee68ebc50e2ec4f0b288eea2f640a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34988393)</sub>

<!-- /greptile_comment -->