### PR TITLE
add dashboard usage-limit config sheet

### DIFF
--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -29,6 +29,8 @@ export type SheetType =
 	| "billing-auto-topup-edit"
 	| "billing-spend-limit-add"
 	| "billing-spend-limit-edit"
+	| "billing-usage-limit-add"
+	| "billing-usage-limit-edit"
 	| "billing-usage-alert-add"
 	| "billing-usage-alert-edit"
 	| "billing-overage-allowed-add"

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -2,6 +2,7 @@ import type {
 	DbOverageAllowed,
 	DbSpendLimit,
 	DbUsageAlert,
+	DbUsageLimit,
 } from "@autumn/shared";
 import type { AxiosInstance } from "axios";
 
@@ -43,6 +44,7 @@ export class CusService {
 		entityId: string;
 		billingControls: {
 			spend_limits?: DbSpendLimit[];
+			usage_limits?: DbUsageLimit[];
 			usage_alerts?: DbUsageAlert[];
 			overage_allowed?: DbOverageAllowed[];
 		};

--- a/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
+++ b/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
@@ -3,6 +3,7 @@ import type {
 	DbOverageAllowed,
 	DbSpendLimit,
 	DbUsageAlert,
+	DbUsageLimit,
 	Entity,
 	Feature,
 	FullCustomer,
@@ -150,6 +151,31 @@ const SpendLimitRow = ({
 	</button>
 );
 
+const UsageLimitRow = ({
+	usageLimit,
+	featureNameById,
+	onClick,
+}: {
+	usageLimit: DbUsageLimit;
+	featureNameById: Map<string, string>;
+	onClick: () => void;
+}) => (
+	<button type="button" className={rowClassName} onClick={onClick}>
+		<StatusPill enabled={usageLimit.enabled} />
+		<span className="truncate text-sm text-foreground font-medium">
+			{getFeatureLabel({
+				featureId: usageLimit.feature_id,
+				featureNameById,
+			})}
+		</span>
+		<div className="ml-auto flex items-center gap-1.5 shrink-0">
+			<Pill>
+				Limit: {usageLimit.limit.toLocaleString()} per {usageLimit.interval}
+			</Pill>
+		</div>
+	</button>
+);
+
 const UsageAlertRow = ({
 	usageAlert,
 	featureNameById,
@@ -246,6 +272,9 @@ export function CustomerBillingControlsSection() {
 	const spendLimits = selectedEntity
 		? (selectedEntity.spend_limits ?? [])
 		: (fullCustomer?.spend_limits ?? []);
+	const usageLimits = selectedEntity
+		? (selectedEntity.usage_limits ?? [])
+		: (fullCustomer?.usage_limits ?? []);
 	const usageAlerts = selectedEntity
 		? (selectedEntity.usage_alerts ?? [])
 		: (fullCustomer?.usage_alerts ?? []);
@@ -256,6 +285,7 @@ export function CustomerBillingControlsSection() {
 	const hasAnyControls =
 		autoTopups.length > 0 ||
 		spendLimits.length > 0 ||
+		usageLimits.length > 0 ||
 		usageAlerts.length > 0 ||
 		overageAllowed.length > 0;
 
@@ -263,6 +293,7 @@ export function CustomerBillingControlsSection() {
 		fullCustomer?.entities?.filter(
 			(entity: Entity) =>
 				(entity.spend_limits?.length ?? 0) > 0 ||
+				(entity.usage_limits?.length ?? 0) > 0 ||
 				(entity.usage_alerts?.length ?? 0) > 0 ||
 				(entity.overage_allowed?.length ?? 0) > 0,
 		).length ?? 0;
@@ -359,6 +390,11 @@ export function CustomerBillingControlsSection() {
 								Spend limit
 							</DropdownMenuItem>
 							<DropdownMenuItem
+								onClick={() => setSheet({ type: "billing-usage-limit-add" })}
+							>
+								Usage limit
+							</DropdownMenuItem>
+							<DropdownMenuItem
 								onClick={() => setSheet({ type: "billing-usage-alert-add" })}
 							>
 								Usage alert
@@ -419,6 +455,26 @@ export function CustomerBillingControlsSection() {
 											setSheet({
 												type: "billing-spend-limit-edit",
 												data: { index, item: spendLimit },
+											})
+										}
+									/>
+								))}
+							</div>
+						</BillingControlsGroup>
+					)}
+
+					{usageLimits.length > 0 && (
+						<BillingControlsGroup title="Usage limits" emptyText="" hasItems>
+							<div className="flex flex-col gap-1.5 rounded-lg">
+								{usageLimits.map((usageLimit, index) => (
+									<UsageLimitRow
+										key={`usage-limit-${usageLimit.feature_id ?? "global"}-${index}`}
+										usageLimit={usageLimit}
+										featureNameById={featureNameById}
+										onClick={() =>
+											setSheet({
+												type: "billing-usage-limit-edit",
+												data: { index, item: usageLimit },
 											})
 										}
 									/>

--- a/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
@@ -1,0 +1,258 @@
+import {
+	type DbUsageLimit,
+	EntInterval,
+	type Feature,
+	FeatureType,
+	type FullCustomer,
+} from "@autumn/shared";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/v2/buttons/Button";
+import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
+import { FormLabel } from "@/components/v2/form/FormLabel";
+import { Input } from "@/components/v2/inputs/Input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+import {
+	LayoutGroup,
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { CusService } from "@/services/customers/CusService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerContext } from "../../customer/CustomerContext";
+
+const INTERVAL_LABELS: Partial<Record<EntInterval, string>> = {
+	[EntInterval.Day]: "Day",
+	[EntInterval.Week]: "Week",
+	[EntInterval.Month]: "Month",
+	[EntInterval.Year]: "Year",
+	[EntInterval.Lifetime]: "Lifetime",
+};
+
+export function BillingUsageLimitSheet() {
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const sheetData = useSheetStore((s) => s.data);
+	const sheetType = useSheetStore((s) => s.type);
+	const { customer, refetch } = useCusQuery();
+	const { entityId } = useCustomerContext();
+	const { features } = useFeaturesQuery();
+	const axiosInstance = useAxiosInstance();
+
+	const isEdit = sheetType === "billing-usage-limit-edit";
+	const existingItem = sheetData?.item as DbUsageLimit | undefined;
+	const existingIndex = sheetData?.index as number | undefined;
+
+	const fullCustomer = customer as FullCustomer | undefined;
+	const selectedEntity = entityId
+		? fullCustomer?.entities?.find(
+				(e) => e.id === entityId || e.internal_id === entityId,
+			)
+		: null;
+
+	const [isSaving, setIsSaving] = useState(false);
+	const [featureId, setFeatureId] = useState(existingItem?.feature_id ?? "");
+	const [enabled, setEnabled] = useState(existingItem?.enabled ?? true);
+	const [limit, setLimit] = useState(existingItem?.limit?.toString() ?? "");
+	const [interval, setInterval] = useState<string>(
+		existingItem?.interval ?? EntInterval.Month,
+	);
+
+	const nonArchivedFeatures = (features ?? []).filter(
+		(f: Feature) => !f.archived && f.type !== FeatureType.Boolean,
+	);
+
+	const getCurrentUsageLimits = (): DbUsageLimit[] => {
+		if (selectedEntity) return [...(selectedEntity.usage_limits ?? [])];
+		return [...(fullCustomer?.usage_limits ?? [])];
+	};
+
+	const saveBillingControls = async (usageLimits: DbUsageLimit[]) => {
+		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
+		if (!customerId) return;
+
+		if (selectedEntity) {
+			await CusService.updateEntity({
+				axios: axiosInstance,
+				customerId,
+				entityId: selectedEntity.id || selectedEntity.internal_id,
+				billingControls: { usage_limits: usageLimits },
+			});
+		} else {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: { billing_controls: { usage_limits: usageLimits } },
+			});
+		}
+	};
+
+	const handleSave = async () => {
+		if (!featureId) {
+			toast.error("Feature is required for a usage limit");
+			return;
+		}
+		const parsedLimit = Number.parseFloat(limit);
+		if (Number.isNaN(parsedLimit) || parsedLimit < 0) {
+			toast.error("Please enter a valid limit");
+			return;
+		}
+
+		const item: DbUsageLimit = {
+			feature_id: featureId,
+			enabled,
+			limit: parsedLimit,
+			interval: interval as EntInterval,
+		};
+
+		const currentUsageLimits = getCurrentUsageLimits();
+		if (isEdit && existingIndex !== undefined) {
+			currentUsageLimits[existingIndex] = item;
+		} else {
+			currentUsageLimits.push(item);
+		}
+
+		setIsSaving(true);
+		try {
+			await saveBillingControls(currentUsageLimits);
+			await refetch();
+			closeSheet();
+			toast.success(isEdit ? "Usage limit updated" : "Usage limit added");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to save usage limit"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleDelete = async () => {
+		if (existingIndex === undefined) return;
+
+		const currentUsageLimits = getCurrentUsageLimits();
+		currentUsageLimits.splice(existingIndex, 1);
+
+		setIsSaving(true);
+		try {
+			await saveBillingControls(currentUsageLimits);
+			await refetch();
+			closeSheet();
+			toast.success("Usage limit deleted");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to delete usage limit"));
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-y-auto">
+				<SheetHeader
+					title={isEdit ? "Edit Usage Limit" : "Add Usage Limit"}
+					description="Cap how much of a feature can be used within a window, regardless of remaining balance."
+				/>
+
+				<SheetSection withSeparator>
+					<FormLabel>Feature</FormLabel>
+					{isEdit ? (
+						<div className="text-sm text-muted-foreground">
+							{nonArchivedFeatures.find((f: Feature) => f.id === featureId)
+								?.name ?? featureId}
+						</div>
+					) : (
+						<FeatureSearchDropdown
+							features={nonArchivedFeatures}
+							value={featureId || null}
+							onSelect={setFeatureId}
+						/>
+					)}
+				</SheetSection>
+
+				<SheetSection withSeparator>
+					<div className="flex flex-col gap-3">
+						<div className="flex items-center justify-between">
+							<FormLabel className="mb-0">Enabled</FormLabel>
+							<Switch checked={enabled} onCheckedChange={setEnabled} />
+						</div>
+
+						<div>
+							<FormLabel>Limit</FormLabel>
+							<Input
+								placeholder="Max usage allowed per window"
+								type="number"
+								value={limit}
+								onChange={(e) => setLimit(e.target.value)}
+							/>
+						</div>
+
+						<div>
+							<FormLabel>Window</FormLabel>
+							<Select
+								value={interval}
+								onValueChange={setInterval}
+								items={INTERVAL_LABELS as Record<string, string>}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder="Select window" />
+								</SelectTrigger>
+								<SelectContent>
+									{Object.entries(INTERVAL_LABELS).map(([value, label]) => (
+										<SelectItem key={value} value={value}>
+											{label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					</div>
+				</SheetSection>
+
+				<div className="flex-1" />
+
+				{isEdit && (
+					<div className="px-4 pb-2">
+						<Button
+							variant="ghost"
+							className="text-destructive hover:text-destructive w-full"
+							onClick={handleDelete}
+							disabled={isSaving}
+						>
+							Delete usage limit
+						</Button>
+					</div>
+				)}
+
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={closeSheet}
+						disabled={isSaving}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={handleSave}
+						isLoading={isSaving}
+						disabled={!featureId}
+					>
+						{isEdit ? "Save" : "Add"}
+					</Button>
+				</SheetFooter>
+			</div>
+		</LayoutGroup>
+	);
+}

--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -20,6 +20,7 @@ import { BillingAutoTopupSheet } from "../components/sheets/BillingAutoTopupShee
 import { BillingOverageAllowedSheet } from "../components/sheets/BillingOverageAllowedSheet";
 import { BillingSpendLimitSheet } from "../components/sheets/BillingSpendLimitSheet";
 import { BillingUsageAlertSheet } from "../components/sheets/BillingUsageAlertSheet";
+import { BillingUsageLimitSheet } from "../components/sheets/BillingUsageLimitSheet";
 import { CheckBalanceSheet } from "../components/sheets/CheckBalanceSheet";
 import { CreateScheduleSheet } from "../components/sheets/CreateScheduleSheet";
 import { InvoiceDetailSheet } from "../components/sheets/InvoiceDetailSheet";
@@ -83,6 +84,9 @@ export function CustomerSheets() {
 			case "billing-spend-limit-add":
 			case "billing-spend-limit-edit":
 				return <BillingSpendLimitSheet />;
+			case "billing-usage-limit-add":
+			case "billing-usage-limit-edit":
+				return <BillingUsageLimitSheet />;
 			case "billing-usage-alert-add":
 			case "billing-usage-alert-edit":
 				return <BillingUsageAlertSheet />;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a usage limit sheet to the customer dashboard to cap feature usage per window. Integrates usage limits into Billing Controls with add, edit, and delete flows at the customer or entity level.

- New Features
  - New `BillingUsageLimitSheet` with enable toggle, numeric limit, and window select (Day/Week/Month/Year/Lifetime), plus feature picker (excludes archived/boolean), validation, and toasts.
  - Billing Controls: “Usage limit” added to the Add menu; usage limits now list with status and “Limit per window”; click to edit; delete available in edit.
  - Wiring: Added `billing-usage-limit-add/edit` sheet types, `usage_limits` support in `CusService`, and refetch on save; persists to customer or selected entity.

<sup>Written for commit 126b2bad1c3af2f9bd05b2ed048d7533885df76b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a `BillingUsageLimitSheet` to the customer dashboard, letting operators cap feature usage per time window at the customer or entity level. The implementation closely follows the existing `BillingSpendLimitSheet` pattern for add, edit, and delete flows.

- **Improvements** — New `BillingUsageLimitSheet` with enable toggle, numeric limit input, and window selector (Day/Week/Month/Year/Lifetime); feature picker excludes archived and boolean features.
- **Improvements** — Billing Controls section gains a "Usage limit" dropdown entry and a rendered `UsageLimitRow` list with status pill and limit-per-window summary; clicking a row opens the edit sheet.
- **API changes** — `CusService.updateEntity` type extended with `usage_limits?: DbUsageLimit[]`; persists to customer or selected entity via existing update endpoints.
</details>

<h3>Confidence Score: 4/5</h3>

The change is additive and closely mirrors the existing spend-limit sheet; no existing functionality is altered.

The two findings are cosmetic: a state variable named `setInterval` that shadows the browser global, and the `UsageLimitRow` pill rendering the raw `EntInterval` enum value instead of the capitalized label used in the sheet dropdown.

Both `BillingUsageLimitSheet.tsx` and `CustomerBillingControlsSection.tsx` have the minor display inconsistency worth a quick look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx | New sheet for adding/editing usage limits; follows the existing BillingSpendLimitSheet pattern closely. Minor: `setInterval` state setter shadows the global timer function. |
| vite/src/views/customers2/components/CustomerBillingControlsSection.tsx | Adds UsageLimitRow component and wires usage_limits into the controls section. The interval pill displays the raw enum value rather than the human-readable label used in the sheet. |
| vite/src/services/customers/CusService.tsx | Adds DbUsageLimit import and usage_limits field to the updateEntity billingControls type; straightforward type extension. |
| vite/src/hooks/stores/useSheetStore.ts | Adds two new SheetType union members for billing-usage-limit-add and billing-usage-limit-edit; clean, minimal change. |
| vite/src/views/customers2/customer/CustomerSheets.tsx | Routes the two new sheet types to BillingUsageLimitSheet; follows the existing switch-case pattern exactly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant BillingControls as CustomerBillingControlsSection
    participant SheetStore as useSheetStore
    participant Sheet as BillingUsageLimitSheet
    participant CusService
    participant API

    User->>BillingControls: Click Add Usage limit
    BillingControls->>SheetStore: setSheet billing-usage-limit-add
    SheetStore-->>Sheet: Opens sheet
    User->>Sheet: Fill feature, limit, window, enabled
    User->>Sheet: Click Add
    Sheet->>Sheet: Validate featureId and limit
    Sheet->>Sheet: getCurrentUsageLimits push new item
    alt Customer level
        Sheet->>CusService: updateCustomer usage_limits
        CusService->>API: POST /v1/customers/:id
    else Entity level
        Sheet->>CusService: updateEntity usage_limits
        CusService->>API: POST /v1/entities.update
    end
    API-->>Sheet: 200 OK
    Sheet->>Sheet: refetch closeSheet toast.success
    User->>BillingControls: Click existing UsageLimitRow
    BillingControls->>SheetStore: setSheet billing-usage-limit-edit
    SheetStore-->>Sheet: Opens edit sheet
    User->>Sheet: Click Delete usage limit
    Sheet->>Sheet: splice index from list
    Sheet->>CusService: updateCustomer or updateEntity
    CusService->>API: POST
    API-->>Sheet: 200 OK
    Sheet->>Sheet: refetch closeSheet toast.success
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx:68-70
**`setInterval` shadows the global timer function**

The state setter is named `setInterval`, which shadows the browser's built-in `setInterval`. While this won't cause a bug inside this component (the scoped binding takes precedence), it makes the code misleading and could trip up developers who need to add a real timer later in this file. Consider renaming to `setWindowInterval` or `setSelectedInterval`.

### Issue 2 of 2
vite/src/views/customers2/components/CustomerBillingControlsSection.tsx:171-175
**Raw enum value displayed in the interval pill**

`usageLimit.interval` is the raw `EntInterval` enum value (likely lowercase, e.g. `"month"`). The sheet uses `INTERVAL_LABELS` to capitalize these for display, but the row pill bypasses that mapping, so users will see e.g. "Limit: 100 per month" in the list while the edit sheet shows "Month". Extract and reuse the label map here to keep the two surfaces consistent.

```suggestion
		<div className="ml-auto flex items-center gap-1.5 shrink-0">
			<Pill>
				Limit: {usageLimit.limit.toLocaleString()} per {INTERVAL_LABELS[usageLimit.interval] ?? usageLimit.interval}
			</Pill>
		</div>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add dashboard usage-limit config sheet"](https://github.com/useautumn/autumn/commit/126b2bad1c3af2f9bd05b2ed048d7533885df76b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34988408)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->