### PR TITLE
fix: update sub frontend

### DIFF
--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -10,6 +10,7 @@ import type {
 	TrialOnEnd,
 } from "@autumn/shared";
 import { useMemo } from "react";
+import { normalizeBillingRequestItems } from "@/components/forms/shared/utils/normalizeBillingRequestItems";
 import { getFreeTrial } from "@/components/forms/update-subscription-v2/utils/getFreeTrial";
 import { convertPrepaidOptionsToFeatureOptions } from "@/utils/billing/prepaidQuantityUtils";
 import type { FormCustomLineItem } from "../attachFormSchema";
@@ -103,10 +104,13 @@ export function buildAttachRequestBody({
 	}
 
 	if (items !== null) {
-		body.items = items.map((item) => ({
-			...item,
-			interval: (item.interval ?? null) as ProductItemInterval | null,
-		}));
+		const normalizedItems = normalizeBillingRequestItems({ items });
+		if (normalizedItems) {
+			body.items = normalizedItems.map((item) => ({
+				...item,
+				interval: (item.interval ?? null) as ProductItemInterval | null,
+			}));
+		}
 	}
 
 	if (version !== undefined) {

--- a/vite/src/components/forms/shared/utils/normalizeBillingRequestItems.ts
+++ b/vite/src/components/forms/shared/utils/normalizeBillingRequestItems.ts
@@ -1,0 +1,31 @@
+import type { ProductItem } from "@autumn/shared";
+
+type DraftProductItem = Omit<ProductItem, "price"> & {
+	price?: ProductItem["price"] | "";
+};
+
+const isEmptyStandalonePriceDraft = (item: DraftProductItem) =>
+	item.price === "" &&
+	item.feature_id == null &&
+	item.price_id == null &&
+	item.entitlement_id == null &&
+	item.price_config == null &&
+	!item.tiers?.length;
+
+export function normalizeBillingRequestItems({
+	items,
+}: {
+	items?: ProductItem[] | null;
+}): ProductItem[] | undefined {
+	if (!items?.length) return undefined;
+
+	const normalizedItems = (items as DraftProductItem[]).flatMap((item) => {
+		if (isEmptyStandalonePriceDraft(item)) return [];
+		if (item.price !== "") return [item as ProductItem];
+
+		const { price: _price, ...itemWithoutDraftPrice } = item;
+		return [itemWithoutDraftPrice as ProductItem];
+	});
+
+	return normalizedItems.length > 0 ? normalizedItems : undefined;
+}

--- a/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
+++ b/vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts
@@ -4,6 +4,7 @@ import type {
 	UpdateSubscriptionV0Params,
 } from "@autumn/shared";
 import { useCallback } from "react";
+import { normalizeBillingRequestItems } from "@/components/forms/shared/utils/normalizeBillingRequestItems";
 import type { UpdateSubscriptionFormContext } from "../context/UpdateSubscriptionFormProvider";
 import { getFreeTrial } from "../utils/getFreeTrial";
 import type { UseUpdateSubscriptionForm } from "./useUpdateSubscriptionForm";
@@ -181,7 +182,7 @@ export function useUpdateSubscriptionRequestBody({
 			...base,
 			options: options.length > 0 ? options : undefined,
 			free_trial: freeTrial,
-			items: items && items.length > 0 ? items : undefined,
+			items: normalizeBillingRequestItems({ items }),
 			version: version !== initialVersion ? version : undefined,
 			billing_behavior: billingBehavior || undefined,
 			billing_cycle_anchor: resetBillingCycle ? "now" : undefined,

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { type ProductV2, UsageModel } from "@autumn/shared";
+import {
+	type ProductItem,
+	ProductItemInterval,
+	type ProductV2,
+	UsageModel,
+} from "@autumn/shared";
 import { addDays } from "date-fns";
 import { buildAttachRequestBody } from "@/components/forms/attach-v2/hooks/useAttachRequestBody";
 
@@ -220,5 +225,46 @@ describe("buildAttachRequestBody — starts_at handling", () => {
 		});
 
 		expect(result?.starts_at).toBeUndefined();
+	});
+});
+
+describe("buildAttachRequestBody — items serialization", () => {
+	test("drops empty fixed-price draft rows before serialization", () => {
+		const product = makeProduct({
+			items: [{ price: 20, interval: ProductItemInterval.Month }],
+		});
+		const items = [
+			{
+				feature_id: "AI_CREDITS",
+				price: null,
+				tiers: [{ amount: 0.01, to: "inf" }],
+			},
+			{
+				price: "" as unknown as number,
+				feature_id: null,
+				price_id: null,
+				entitlement_id: null,
+				interval: ProductItemInterval.Month,
+				interval_count: 1,
+				tiers: null,
+				price_config: null,
+			},
+		] satisfies ProductItem[];
+
+		const result = buildAttachRequestBody({
+			...baseParams,
+			product,
+			prepaidOptions: {},
+			items,
+		});
+
+		expect(result?.items).toEqual([
+			{
+				feature_id: "AI_CREDITS",
+				price: null,
+				tiers: [{ amount: 0.01, to: "inf" }],
+				interval: null,
+			},
+		]);
 	});
 });

--- a/vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-options.test.ts
+++ b/vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-options.test.ts
@@ -1,5 +1,6 @@
-import { ProductItemInterval } from "@autumn/shared";
 import { describe, expect, test } from "bun:test";
+import { type ProductItem, ProductItemInterval } from "@autumn/shared";
+import { normalizeBillingRequestItems } from "@/components/forms/shared/utils/normalizeBillingRequestItems";
 import { buildUpdateSubscriptionOptions } from "@/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody";
 
 describe("buildUpdateSubscriptionOptions — included usage handling", () => {
@@ -219,5 +220,100 @@ describe("buildUpdateSubscriptionOptions — included usage handling", () => {
 		});
 
 		expect(result).toEqual([]);
+	});
+});
+
+describe("normalizeBillingRequestItems", () => {
+	test("drops empty fixed-price draft rows before serialization", () => {
+		const items = [
+			{
+				feature_id: "AI_CREDITS",
+				price: null,
+				tiers: [{ amount: 0.01, to: "inf" }],
+			},
+			{
+				price: "" as unknown as number,
+				feature_id: null,
+				price_id: null,
+				entitlement_id: null,
+				interval: ProductItemInterval.Month,
+				interval_count: 1,
+				tiers: null,
+				billing_units: null,
+				usage_model: null,
+				included_usage: null,
+				config: null,
+				feature_type: null,
+				entity_feature_id: null,
+				price_config: null,
+			},
+			{
+				price: "" as unknown as number,
+				feature_id: null,
+				price_id: null,
+				entitlement_id: null,
+				interval: ProductItemInterval.Month,
+				interval_count: 1,
+				tiers: null,
+				billing_units: null,
+				usage_model: null,
+				included_usage: null,
+				config: null,
+				feature_type: null,
+				entity_feature_id: null,
+				price_config: null,
+			},
+			{
+				feature_id: "SSO",
+				price: null,
+			},
+		] satisfies ProductItem[];
+
+		expect(normalizeBillingRequestItems({ items })).toEqual([
+			items[0],
+			items[3],
+		]);
+	});
+
+	test("omits draft string prices from non-empty items", () => {
+		const items = [
+			{
+				feature_id: "seats",
+				price: "" as unknown as number,
+				included_usage: 10,
+				interval: ProductItemInterval.Month,
+			},
+		] satisfies ProductItem[];
+
+		expect(normalizeBillingRequestItems({ items })).toEqual([
+			{
+				feature_id: "seats",
+				included_usage: 10,
+				interval: ProductItemInterval.Month,
+			},
+		]);
+	});
+
+	test("returns undefined when only empty draft rows are present", () => {
+		const items = [
+			{
+				price: "" as unknown as number,
+				feature_id: null,
+				price_id: null,
+				entitlement_id: null,
+				interval: ProductItemInterval.Month,
+				interval_count: 1,
+				tiers: null,
+				billing_units: null,
+				usage_model: null,
+				included_usage: null,
+				config: null,
+				feature_type: null,
+				entity_feature_id: null,
+				price_config: null,
+			},
+		] satisfies ProductItem[];
+
+		expect(normalizeBillingRequestItems({ items })).toBeUndefined();
 	});
 });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalized billing request `items` in attach and update subscription forms to drop empty fixed-price draft rows and strip draft string prices. This cleans up request bodies and prevents sending invalid item data to the backend.

- **Bug Fixes**
  - Added `normalizeBillingRequestItems` to remove empty draft rows and omit draft string prices from `items`.
  - Integrated into `useAttachRequestBody` and `useUpdateSubscriptionRequestBody` to omit `items` when nothing valid remains, with new tests covering serialization and normalization.

<sup>Written for commit 0b08f3cc278f188a50bae22cc52c29bc1b4fb90d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where empty fixed-price draft rows from the UI form state were being serialized and sent to the server in both the attach and update-subscription API calls. A new shared `normalizeBillingRequestItems` utility is introduced to filter out these draft rows and strip empty-string `price` fields before the request body is built.

- **[Bug fixes]** Adds `normalizeBillingRequestItems` to drop "empty standalone price draft" items (where `price === ""` and all identifying fields are null) and strip `""` price from items that still carry other meaningful fields like `feature_id`.
- **[Improvements]** Both `useAttachRequestBody` and `useUpdateSubscriptionRequestBody` now share this normalizer, so the filtering logic is defined once and covered by dedicated unit tests in both consumers.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-tested bug fix with no structural risk.

The normalization utility is small and its three branching paths are each covered by dedicated unit tests. Both callers integrate the utility consistently, and the behavior difference (omitting empty draft rows instead of forwarding them to the server) is exactly what the fix intends.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/shared/utils/normalizeBillingRequestItems.ts | New utility function that filters empty draft price rows and strips "" price strings; logic is correct and well-covered by tests. |
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Uses normalizeBillingRequestItems before mapping items; correctly guards body.items assignment on the return value being truthy. |
| vite/src/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionRequestBody.ts | Replaces manual length-check with normalizeBillingRequestItems; fixes the previously unguarded pass-through of draft rows. |
| vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts | Adds a test verifying empty draft rows are dropped and the remaining item gets interval: null applied correctly. |
| vite/tests/components/forms/update-subscription-v2/hooks/build-update-subscription-options.test.ts | Adds three focused tests for normalizeBillingRequestItems covering drop-all-drafts, strip-empty-price, and return-undefined cases. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[items from form state] --> B{items null or empty?}
    B -- yes --> C[return undefined]
    B -- no --> D[cast to DraftProductItem array]
    D --> E{for each item}
    E --> F{isEmptyStandalonePriceDraft?\nprice='' AND feature_id/price_id/\nentitlement_id/price_config null\nAND no tiers}
    F -- yes --> G[drop item]
    F -- no --> H{price === ''}
    H -- no --> I[include item as-is]
    H -- yes --> J[strip price field, include rest]
    G --> K[collect normalizedItems]
    I --> K
    J --> K
    K --> L{normalizedItems.length > 0?}
    L -- yes --> M[return normalizedItems]
    L -- no --> C
    M --> N[caller sets body.items]
    C --> O[caller skips body.items]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: normalize billing request items"](https://github.com/useautumn/autumn/commit/0b08f3cc278f188a50bae22cc52c29bc1b4fb90d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34977775)</sub>

<!-- /greptile_comment -->