### PR TITLE
fix(revenuecat): fail closed on unset webhook secret + constant-time auth check

### DIFF
--- a/server/src/external/revenueCat/revenuecatWebhookRouter.ts
+++ b/server/src/external/revenueCat/revenuecatWebhookRouter.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type {
 	Webhook,
 	WebhookBillingIssue,
@@ -42,11 +43,26 @@ revenuecatWebhookRouter.post(
 		try {
 			const webhookSecret = getRevenuecatWebhookSecret({ org, env });
 
-			if (Authorization !== webhookSecret) {
-				logger.error("Invalid authorization for RevenueCat webhook", {
-					Authorization,
-					webhookSecret,
-				});
+			// Fail closed: reject when no signing secret is configured for this
+			// org/env. Otherwise an unset (undefined) secret combined with a
+			// missing Authorization header compares `undefined !== undefined` and
+			// authenticates the request. Mirrors vercelSignatureMiddleware.
+			if (!webhookSecret) {
+				logger.error("RevenueCat webhook secret not configured", { env });
+				return c.json({ error: "Webhook secret not configured" }, 500);
+			}
+
+			// Constant-time comparison of the shared secret to avoid timing
+			// attacks (timingSafeEqual throws on length mismatch, so guard first).
+			const authBuf = Buffer.from(Authorization ?? "", "utf-8");
+			const secretBuf = Buffer.from(webhookSecret, "utf-8");
+			const authorized =
+				!!Authorization &&
+				authBuf.length === secretBuf.length &&
+				crypto.timingSafeEqual(authBuf, secretBuf);
+
+			if (!authorized) {
+				logger.error("Invalid authorization for RevenueCat webhook", { env });
 				return c.json({ error: "Unauthorized" }, 401);
 			}
 


### PR DESCRIPTION
## Summary

The RevenueCat webhook authentication compares the `Authorization` header to the org's configured webhook secret with a plain `!==`:

```ts
const webhookSecret = getRevenuecatWebhookSecret({ org, env });
if (Authorization !== webhookSecret) {
  return c.json({ error: "Unauthorized" }, 401);
}
```

`sandbox_webhook_secret` is `.optional()` in `RevenueCatProcessorConfigSchema`, so `getRevenuecatWebhookSecret` returns `undefined` for a sandbox org that has RevenueCat configured but no sandbox signing value set. If such a request also omits the `Authorization` header, the check evaluates `undefined !== undefined`, which is `false` — so it passes and the webhook is processed as authenticated (e.g. an `INITIAL_PURCHASE` granting entitlements without payment).

This is limited to the **sandbox** environment: the live `webhook_secret` is required (`z.string()`) and cannot be `undefined` for a configured org, so live entitlements are unaffected.

## Change

- **Fail closed** when no signing secret is configured for the org/env (return `500`) instead of letting an unset secret through. This mirrors `vercelSignatureMiddleware`, which already returns `500` on a missing client secret.
- Compare the shared secret with a length-guarded `crypto.timingSafeEqual` instead of `!==`.
- Stop logging the secret value and the raw `Authorization` header on failure.

Behavior for correctly-configured orgs is unchanged: a matching `Authorization` header is accepted; a missing or incorrect one is rejected with `401`.

## Testing

The change is intentionally minimal and self-contained, following the existing Vercel webhook pattern. I didn't run the full workspace suite locally (didn't install the monorepo deps in this environment) — happy to adjust the status code or log wording to your conventions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RevenueCat webhook auth to reject requests when the org/env signing secret is missing and compares secrets in constant time. Closes a sandbox-only hole where both a missing secret and missing header were treated as authenticated.

- **Bug Fixes**
  - Fail closed when the secret is unset: return 500 (mirrors `vercelSignatureMiddleware`).
  - Use length-guarded `node:crypto` `timingSafeEqual` instead of `!==` for the `Authorization` check.
  - Stop logging the secret and raw `Authorization` header on failures.

<sup>Written for commit 1cee37a95e641c68996d8e286de789f69359a18c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

