### PR TITLE
Add RevenueCat webhook observability

### DIFF
--- a/server/src/external/revenueCat/misc/revenueCatMiddleware.ts
+++ b/server/src/external/revenueCat/misc/revenueCatMiddleware.ts
@@ -7,6 +7,22 @@ import type { Logger } from "@/external/logtail/logtailUtils";
 import type { RevenueCatWebhookHonoEnv } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
 import { OrgService } from "@/internal/orgs/OrgService";
 import { addAppContextToLogs } from "@/utils/logging/addContextToLogs";
+import { logRevenueCatWebhookMiddlewareError } from "./revenueCatWebhookLogging";
+
+export const revenuecatIdentifyMiddleware = async (
+	c: Context<RevenueCatWebhookHonoEnv>,
+	next: Next,
+) => {
+	try {
+		const ctx = c.get("ctx");
+		ctx.authType = AuthType.Revenuecat;
+	} catch (error) {
+		logRevenueCatWebhookMiddlewareError({ c, stage: "identify", error });
+		throw error;
+	}
+
+	await next();
+};
 
 export const revenuecatSeederMiddleware = async (
 	c: Context<RevenueCatWebhookHonoEnv>,
@@ -14,39 +30,45 @@ export const revenuecatSeederMiddleware = async (
 ) => {
 	const { orgId, env } = c.req.param();
 	const ctx = c.get("ctx");
+	ctx.authType = AuthType.Revenuecat;
 
-	const result = await OrgService.getWithFeatures({
-		db: ctx.db,
-		orgId,
-		env: env as AppEnv,
-	});
+	try {
+		const result = await OrgService.getWithFeatures({
+			db: ctx.db,
+			orgId,
+			env: env as AppEnv,
+		});
 
-	if (!result) {
-		throw new Error("Organization with features not found");
+		if (!result) {
+			throw new Error("Organization with features not found");
+		}
+
+		const { org, features } = result;
+
+		if (!ctx.org && orgId) {
+			ctx.org = org;
+		}
+		if (ctx.env !== env) {
+			ctx.env = env as AppEnv;
+		}
+		if (!ctx.features && orgId) {
+			ctx.features = features;
+		}
+
+		ctx.logger = addAppContextToLogs({
+			logger: ctx.logger,
+			appContext: {
+				org_id: ctx.org?.id,
+				org_slug: ctx.org?.slug,
+				env: ctx.env,
+				auth_type: AuthType.Revenuecat,
+				api_version: ctx.apiVersion?.semver,
+			},
+		});
+	} catch (error) {
+		logRevenueCatWebhookMiddlewareError({ c, stage: "seeder", error });
+		throw error;
 	}
-
-	const { org, features } = result;
-
-	if (!ctx.org && orgId) {
-		ctx.org = org;
-	}
-	if (ctx.env !== env) {
-		ctx.env = env as AppEnv;
-	}
-	if (!ctx.features && orgId) {
-		ctx.features = features;
-	}
-
-	ctx.logger = addAppContextToLogs({
-		logger: ctx.logger,
-		appContext: {
-			org_id: ctx.org?.id,
-			org_slug: ctx.org?.slug,
-			env: ctx.env,
-			auth_type: AuthType.Revenuecat,
-			api_version: ctx.apiVersion?.semver,
-		},
-	});
 
 	await next();
 };
@@ -69,10 +91,19 @@ export const revenuecatLogMiddleware = async (
 	c: Context<RevenueCatWebhookHonoEnv>,
 	next: Next,
 ) => {
-	const { logger, org } = c.get("ctx");
-	const body = await c.req.json();
+	try {
+		const ctx = c.get("ctx");
+		const { logger, org } = ctx;
+		const body = await c.req.json();
 
-	logRevCatWebhook({ logger, org, event: body.event });
+		ctx.revenuecatEventType = body.event?.type;
+		ctx.revenuecatEventId = body.event?.id;
+
+		logRevCatWebhook({ logger, org, event: body.event });
+	} catch (error) {
+		logRevenueCatWebhookMiddlewareError({ c, stage: "log", error });
+		throw error;
+	}
 
 	await next();
 };

--- a/server/src/external/revenueCat/misc/revenueCatWebhookLogging.ts
+++ b/server/src/external/revenueCat/misc/revenueCatWebhookLogging.ts
@@ -1,0 +1,91 @@
+import type { Context } from "hono";
+import type { Logger } from "@/external/logtail/logtailUtils";
+import type { RevenueCatWebhookHonoEnv } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
+
+type RevenueCatErrorStage =
+	| "identify"
+	| "seeder"
+	| "log"
+	| "refresh"
+	| "handler";
+
+type ErrorLike = Error & {
+	code?: string;
+	statusCode?: number;
+	status?: number;
+};
+
+const serializeError = (error: unknown) => {
+	if (error instanceof Error) {
+		const errorLike = error as ErrorLike;
+		return {
+			name: error.name,
+			message: error.message,
+			stack: error.stack,
+			code: errorLike.code,
+			statusCode: errorLike.statusCode ?? errorLike.status,
+		};
+	}
+
+	return {
+		name: typeof error,
+		message: String(error),
+	};
+};
+
+const getLogger = ({
+	c,
+	fallbackLogger,
+}: {
+	c: Context<RevenueCatWebhookHonoEnv>;
+	fallbackLogger?: Logger;
+}) => {
+	try {
+		return c.get("ctx")?.logger ?? fallbackLogger;
+	} catch {
+		return fallbackLogger;
+	}
+};
+
+export const getRevenueCatWebhookDiagnosticFields = ({
+	c,
+	stage,
+}: {
+	c: Context<RevenueCatWebhookHonoEnv>;
+	stage: RevenueCatErrorStage;
+}) => {
+	const { orgId, env } = c.req.param();
+	const ctx = c.get("ctx");
+
+	return {
+		revenuecat_webhook: {
+			stage,
+			orgId,
+			env,
+			resolvedOrgId: ctx?.org?.id,
+			resolvedOrgSlug: ctx?.org?.slug,
+			eventType: ctx?.revenuecatEventType,
+			eventId: ctx?.revenuecatEventId,
+		},
+	};
+};
+
+export const logRevenueCatWebhookMiddlewareError = ({
+	c,
+	stage,
+	error,
+	fallbackLogger,
+}: {
+	c: Context<RevenueCatWebhookHonoEnv>;
+	stage: RevenueCatErrorStage;
+	error: unknown;
+	fallbackLogger?: Logger;
+}) => {
+	const logger = getLogger({ c, fallbackLogger });
+	if (!logger) return;
+
+	logger.error("RevenueCat webhook middleware error", {
+		...getRevenueCatWebhookDiagnosticFields({ c, stage }),
+		error: serializeError(error),
+	});
+};

--- a/server/src/external/revenueCat/revenuecatWebhookRouter.ts
+++ b/server/src/external/revenueCat/revenuecatWebhookRouter.ts
@@ -12,9 +12,11 @@ import { type Context, Hono } from "hono";
 import { traceEnrichMiddleware } from "@/honoMiddlewares/traceMiddleware.js";
 import { getRevenuecatWebhookSecret } from "./misc/getRevenuecatWebhookSecret";
 import {
+	revenuecatIdentifyMiddleware,
 	revenuecatLogMiddleware,
 	revenuecatSeederMiddleware,
 } from "./misc/revenueCatMiddleware";
+import { logRevenueCatWebhookMiddlewareError } from "./misc/revenueCatWebhookLogging";
 import { handleRenewal } from "./webhookHandlers/handleRevenucatRenewal";
 import { handleBillingIssue } from "./webhookHandlers/handleRevenuecatBillingIssue";
 import { handleCancellation } from "./webhookHandlers/handleRevenuecatCancellation";
@@ -29,6 +31,8 @@ export const revenuecatWebhookRouter = new Hono<RevenueCatWebhookHonoEnv>();
 
 revenuecatWebhookRouter.post(
 	"/:orgId/:env",
+	revenuecatIdentifyMiddleware,
+	traceEnrichMiddleware,
 	revenuecatSeederMiddleware,
 	revenuecatLogMiddleware,
 	revenuecatWebhookRefreshMiddleware,
@@ -37,21 +41,27 @@ revenuecatWebhookRouter.post(
 		const ctx = c.get("ctx");
 		const { logger, org, env } = ctx;
 		const Authorization = c.req.header("Authorization");
-		const body = (await c.req.json()) as Webhook;
 
 		try {
+			const body = (await c.req.json()) as Webhook;
+			ctx.revenuecatEventType = body.event.type;
+			ctx.revenuecatEventId = "id" in body.event ? body.event.id : undefined;
 			const webhookSecret = getRevenuecatWebhookSecret({ org, env });
 
 			if (Authorization !== webhookSecret) {
 				logger.error("Invalid authorization for RevenueCat webhook", {
-					Authorization,
-					webhookSecret,
+					revenuecat_webhook: {
+						orgId: c.req.param("orgId"),
+						env: c.req.param("env"),
+						resolvedOrgId: org?.id,
+						resolvedOrgSlug: org?.slug,
+						eventType: ctx.revenuecatEventType,
+						eventId: ctx.revenuecatEventId,
+					},
+					hasAuthorizationHeader: Boolean(Authorization),
 				});
 				return c.json({ error: "Unauthorized" }, 401);
 			}
-
-			// Set event type in context for logging in refresh middleware
-			ctx.revenuecatEventType = body.event.type;
 
 			switch (body.event.type) {
 				case "INITIAL_PURCHASE":
@@ -100,7 +110,7 @@ revenuecatWebhookRouter.post(
 
 			return c.json({ success: true }, 200);
 		} catch (error) {
-			logger.error(`error handling revenuecat webhook ${error}`);
+			logRevenueCatWebhookMiddlewareError({ c, stage: "handler", error });
 			return c.json({ error: `Internal server error: ${error}` }, 500);
 		}
 	},

--- a/server/src/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext.ts
+++ b/server/src/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext.ts
@@ -5,6 +5,8 @@ export type RevenueCatWebhookContext = AutumnContext & {
 	customerId?: string;
 	/** Event type for logging purposes */
 	revenuecatEventType?: string;
+	/** RevenueCat event ID for logging purposes */
+	revenuecatEventId?: string;
 };
 
 export type RevenueCatWebhookHonoEnv = Omit<HonoEnv, "Variables"> & {

--- a/server/src/external/revenueCat/webhookMiddlewares/revenuecatWebhookRefreshMiddleware.ts
+++ b/server/src/external/revenueCat/webhookMiddlewares/revenuecatWebhookRefreshMiddleware.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
+import { logRevenueCatWebhookMiddlewareError } from "../misc/revenueCatWebhookLogging.js";
 import type { RevenueCatWebhookHonoEnv } from "./revenuecatWebhookContext.js";
 
 /**
@@ -10,35 +11,36 @@ export const revenuecatWebhookRefreshMiddleware = async (
 	c: Context<RevenueCatWebhookHonoEnv>,
 	next: Next,
 ) => {
-	// Run the main handler first
-	await next();
-
-	// Post-processing: refresh cache
-	const ctx = c.get("ctx");
-	const { logger, org, env, customerId, revenuecatEventType } = ctx;
-
-	if (!customerId) {
-		logger.warn(
-			"RevenueCat webhook: No customer ID set in context, skipping cache refresh",
-		);
-		return;
-	}
-
 	try {
-		logger.info(
-			`Attempting delete cached api customer! RevenueCat ${revenuecatEventType}`,
-		);
+		// Run the main handler first
+		await next();
 
-		await deleteCachedFullCustomer({
-			customerId,
-			ctx,
-			source: `revenuecatWebhookRefreshMiddleware: ${revenuecatEventType}`,
-		});
+		// Post-processing: refresh cache
+		const ctx = c.get("ctx");
+		const { logger, customerId, revenuecatEventType } = ctx;
+
+		if (!customerId) {
+			logger.warn(
+				"RevenueCat webhook: No customer ID set in context, skipping cache refresh",
+			);
+			return;
+		}
+
+		try {
+			logger.info(
+				`Attempting delete cached api customer! RevenueCat ${revenuecatEventType}`,
+			);
+
+			await deleteCachedFullCustomer({
+				customerId,
+				ctx,
+				source: `revenuecatWebhookRefreshMiddleware: ${revenuecatEventType}`,
+			});
+		} catch (error) {
+			logRevenueCatWebhookMiddlewareError({ c, stage: "refresh", error });
+		}
 	} catch (error) {
-		logger.error(`RevenueCat webhook, error refreshing cache: ${error}`, {
-			error: {
-				message: error instanceof Error ? error.message : String(error),
-			},
-		});
+		logRevenueCatWebhookMiddlewareError({ c, stage: "refresh", error });
+		throw error;
 	}
 };

--- a/server/tests/unit/revenuecat/revenuecat-middleware-observability.test.ts
+++ b/server/tests/unit/revenuecat/revenuecat-middleware-observability.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { AppEnv, AuthType, RecaseError } from "@autumn/shared";
+import type { Context, Next } from "hono";
+import type { RevenueCatWebhookHonoEnv } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext.js";
+
+const org = { id: "org_123", slug: "acme" };
+const features = [{ id: "messages" }];
+const getWithFeatures = mock(async () => ({ org, features }));
+
+mock.module("@/internal/orgs/OrgService", () => ({
+	OrgService: {
+		getWithFeatures,
+	},
+}));
+
+const {
+	revenuecatIdentifyMiddleware,
+	revenuecatLogMiddleware,
+	revenuecatSeederMiddleware,
+} = await import("@/external/revenueCat/misc/revenueCatMiddleware.js");
+
+const createLogger = () => {
+	const logger = {
+		debug: mock(() => undefined),
+		info: mock(() => undefined),
+		warn: mock(() => undefined),
+		error: mock(() => undefined),
+		child: mock(() => logger),
+	};
+	return logger;
+};
+
+type TestRevenueCatContext = {
+	db: Record<string, never>;
+	logger: ReturnType<typeof createLogger>;
+	org?: typeof org;
+	features?: typeof features;
+	env: AppEnv;
+	authType: AuthType;
+	apiVersion: { semver: string };
+	revenuecatEventType?: string;
+	revenuecatEventId?: string;
+};
+
+const createContext = ({
+	body = { event: { type: "INITIAL_PURCHASE", id: "evt_123" } },
+}: {
+	body?: unknown;
+} = {}) => {
+	const logger = createLogger();
+	const ctx: TestRevenueCatContext = {
+		db: {},
+		logger,
+		org: undefined,
+		features: undefined,
+		env: AppEnv.Sandbox,
+		authType: AuthType.Unknown,
+		apiVersion: { semver: "1.2.0" },
+	};
+	const c = {
+		req: {
+			param: (key?: string) => {
+				const params = { orgId: "org_123", env: AppEnv.Sandbox };
+				return key ? params[key as keyof typeof params] : params;
+			},
+			json: mock(async () => body),
+		},
+		get: (key: "ctx") => {
+			if (key !== "ctx") throw new Error("unexpected key");
+			return ctx;
+		},
+	} as unknown as Context<RevenueCatWebhookHonoEnv>;
+
+	return { c, ctx, logger };
+};
+
+describe("RevenueCat webhook middleware observability", () => {
+	beforeEach(() => {
+		getWithFeatures.mockClear();
+		getWithFeatures.mockResolvedValue({ org, features });
+	});
+
+	test("identifies RevenueCat webhooks by setting ctx.authType immediately", async () => {
+		const { c, ctx } = createContext();
+		let observedAuthType: AuthType | undefined;
+		const next: Next = mock(async () => {
+			observedAuthType = ctx.authType;
+		});
+
+		await revenuecatIdentifyMiddleware(c, next);
+
+		expect(observedAuthType).toBe(AuthType.Revenuecat);
+		expect(ctx.authType).toBe(AuthType.Revenuecat);
+	});
+
+	test("seeder preserves successful setup while marking RevenueCat auth", async () => {
+		const { c, ctx, logger } = createContext();
+		const next = mock(async () => undefined);
+
+		await revenuecatSeederMiddleware(c, next);
+
+		expect(getWithFeatures).toHaveBeenCalledWith({
+			db: ctx.db,
+			orgId: "org_123",
+			env: AppEnv.Sandbox,
+		});
+		expect(ctx.authType).toBe(AuthType.Revenuecat);
+		expect(ctx.org).toBe(org);
+		expect(ctx.features).toBe(features);
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(logger.child).toHaveBeenCalled();
+	});
+
+	test("logs structured middleware errors with safe RevenueCat diagnostics", async () => {
+		const { c, ctx, logger } = createContext();
+		ctx.org = org;
+		ctx.revenuecatEventType = "RENEWAL";
+		ctx.revenuecatEventId = "evt_renewal";
+		const error = new RecaseError({
+			message: "broken setup",
+			code: "invalid_request",
+			statusCode: 422,
+		});
+		logger.info.mockImplementation(() => {
+			throw error;
+		});
+		const next = mock(async () => undefined);
+
+		await expect(revenuecatLogMiddleware(c, next)).rejects.toThrow(
+			"broken setup",
+		);
+		expect(next).not.toHaveBeenCalled();
+
+		expect(logger.error).toHaveBeenCalledTimes(1);
+		const [message, fields] = logger.error.mock.calls[0] as unknown as [
+			string,
+			{
+				revenuecat_webhook: Record<string, unknown>;
+				error: Record<string, unknown>;
+			},
+		];
+		expect(message).toBe("RevenueCat webhook middleware error");
+		expect(fields.revenuecat_webhook).toMatchObject({
+			stage: "log",
+			orgId: "org_123",
+			env: AppEnv.Sandbox,
+			resolvedOrgId: "org_123",
+			resolvedOrgSlug: "acme",
+			eventType: "INITIAL_PURCHASE",
+			eventId: "evt_123",
+		});
+		expect(fields.error).toMatchObject({
+			name: "RecaseError",
+			message: "broken setup",
+			code: "invalid_request",
+			statusCode: 422,
+		});
+		expect(JSON.stringify(fields)).not.toContain("Authorization");
+		expect(JSON.stringify(fields)).not.toContain("webhookSecret");
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});


### PR DESCRIPTION
### Motivation
- Improve diagnosability for 500s thrown before the final handler on RevenueCat webhook routes by adding structured, stage-aware middleware error logs. 
- Ensure RevenueCat requests are attributed as `auth_type: revenuecat` on the request context and OTel traces as early as possible. 
- Preserve existing webhook behavior while avoiding logging secrets or PII.

### Description
- Add `revenuecatIdentifyMiddleware` to set `ctx.authType = AuthType.Revenuecat` early and place it before `traceEnrichMiddleware` so traces show `auth_type: revenuecat` for RevenueCat requests. (changes in `misc/revenueCatMiddleware.ts` and `revenuecatWebhookRouter.ts`).
- Add a small helper `revenueCatWebhookLogging.ts` that serializes errors and emits consistent diagnostic fields including path params (`orgId`, `env`), resolved org id/slug, event type/id, middleware stage, and serialized error (name/message/stack/code/status). This helper never emits secrets. (new file `misc/revenueCatWebhookLogging.ts`).
- Wrap RevenueCat middleware bodies (`identify`, `seeder`, `log`) and the refresh middleware with try/catch that logs structured diagnostics via the helper and rethrows, preserving existing error propagation and refresh semantics. (updated `misc/revenueCatMiddleware.ts` and `webhookMiddlewares/revenuecatWebhookRefreshMiddleware.ts`).
- Stop logging raw secrets/authorization/webhook secrets on invalid auth; instead emit safe diagnostic fields and a `hasAuthorizationHeader` boolean. (updated `revenuecatWebhookRouter.ts`).
- Add `revenuecatEventId` to the webhook context and capture event type/id in middleware and the final handler for improved diagnostics. (updated `webhookMiddlewares/revenuecatWebhookContext.ts` and router).
- Add unit tests covering: early auth attribution, successful seeder setup, and that middleware errors emit structured diagnostic logs without secrets. (new test `server/tests/unit/revenuecat/revenuecat-middleware-observability.test.ts`).

### Testing
- Ran the new unit tests: `cd server && bun test tests/unit/revenuecat/revenuecat-middleware-observability.test.ts` and they passed (3 tests, 16 assertions). 
- Typechecked the server: `cd server && bun ts` and the build succeeded with no errors. 
- Ran formatter/linter/type checks: `bunx biome check` on the touched files and it passed with no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea8c017fc832b8e0aad7177c04495)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve RevenueCat webhook observability with early auth attribution and structured, stage-aware error logging to make debugging easier and traces clearer. Also removes secret leakage from logs and captures event type/id for diagnostics.

- **New Features**
  - Added `revenuecatIdentifyMiddleware` before `traceEnrichMiddleware` to set `ctx.authType = Revenuecat` so traces show `auth_type: revenuecat`.
  - Introduced `revenueCatWebhookLogging` for consistent, stage-aware error logs (includes org/env, event type/id, and serialized error).
  - Captured `revenuecatEventType` and `revenuecatEventId` in context across middleware and handler.
  - Added unit tests for early auth attribution, seeder setup, and safe structured logging.

- **Bug Fixes**
  - Removed logging of raw Authorization and webhook secrets; now logs safe diagnostics plus `hasAuthorizationHeader`.

<sup>Written for commit a88b1bc624a6dfaec12f5c7680e050621e0a09e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds observability to the RevenueCat webhook pipeline by introducing a new `revenuecatIdentifyMiddleware` that stamps `auth_type: revenuecat` on the request context early (before `traceEnrichMiddleware`), a structured logging helper (`revenueCatWebhookLogging.ts`) that emits stage-aware diagnostic fields without secrets, and try/catch wrappers around each middleware stage. It also removes raw `Authorization`/`webhookSecret` logging in the auth-failure branch and adds unit tests covering the new paths.

- **[Improvements]** `revenuecatIdentifyMiddleware` + early `traceEnrichMiddleware` placement ensures OTel traces carry `auth_type: revenuecat` from the first span, even when later middleware fails.
- **[Bug fixes]** Auth-failure log no longer emits the raw `Authorization` header or `webhookSecret`; replaced with safe diagnostic fields and a `hasAuthorizationHeader` boolean.
- **[Improvements]** `revenueCatWebhookLogging.ts` centralises error serialisation (name/message/stack/code/statusCode) and diagnostic field collection (org, env, event type/id, stage) across all middleware stages.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are additive observability wrappers that preserve existing webhook behavior and error propagation.

The core webhook flow is unchanged — middleware errors are still rethrown, cache-refresh errors are still swallowed, and the auth check path is intact. The main risk is that `getRevenueCatWebhookDiagnosticFields` lacks the same try/catch guard as `getLogger`, meaning a failure inside the logging helper could replace the original error in catch blocks. In practice Hono's `c.req.param()` and `c.get("ctx")` are stable in a valid middleware context, so this is unlikely to trigger. The redundant `ctx.authType` assignment and double event-field writes are harmless but add minor noise.

server/src/external/revenueCat/misc/revenueCatWebhookLogging.ts — the `getRevenueCatWebhookDiagnosticFields` helper should be hardened the same way `getLogger` is.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/misc/revenueCatMiddleware.ts | Adds `revenuecatIdentifyMiddleware`, wraps middleware bodies in try/catch with structured error logging, captures event type/id in log middleware; redundant `authType` assignment in `revenuecatSeederMiddleware`. |
| server/src/external/revenueCat/misc/revenueCatWebhookLogging.ts | New helper for structured error logging; `getRevenueCatWebhookDiagnosticFields` lacks a try/catch unlike `getLogger`, which can cause the original error to be swallowed if diagnostics fail. |
| server/src/external/revenueCat/revenuecatWebhookRouter.ts | Adds `revenuecatIdentifyMiddleware` + first `traceEnrichMiddleware` for early auth attribution, removes secret logging, uses structured diagnostics helper; redundant event-field assignments duplicate what `revenuecatLogMiddleware` already writes. |
| server/src/external/revenueCat/webhookMiddlewares/revenuecatWebhookRefreshMiddleware.ts | Wraps `next()` and cache-refresh in try/catch with structured logging; outer catch logs and rethrows errors from `next()`, inner catch swallows cache-refresh errors (intentional). |
| server/src/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext.ts | Adds `revenuecatEventId` field to context type; straightforward type extension. |
| server/tests/unit/revenuecat/revenuecat-middleware-observability.test.ts | New unit tests covering early auth attribution, seeder setup, and structured error logging without secret leakage; well-structured with good coverage of the new logging paths. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RC as RevenueCat
    participant ID as identifyMiddleware
    participant TE1 as traceEnrichMiddleware (1)
    participant SD as seederMiddleware
    participant LG as logMiddleware
    participant RF as refreshMiddleware
    participant TE2 as traceEnrichMiddleware (2)
    participant H as Handler

    RC->>ID: POST /:orgId/:env
    ID->>ID: "ctx.authType = Revenuecat"
    ID->>TE1: next()
    TE1->>TE1: stamp auth_type on OTel span
    TE1->>SD: next()
    SD->>SD: load org + features, enrich logger
    SD->>LG: next()
    LG->>LG: parse body, set eventType/eventId
    LG->>RF: next()
    RF->>TE2: next()
    TE2->>TE2: stamp org/env/customer on OTel span
    TE2->>H: next()
    H->>H: verify Authorization secret
    alt Auth OK
        H->>H: dispatch to event handler
        H-->>RC: 200 success
    else Auth Fail
        H-->>RC: 401 Unauthorized (no secrets logged)
    end
    H-->>RF: return
    RF->>RF: deleteCachedFullCustomer
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/external/revenueCat/misc/revenueCatWebhookLogging.ts:50-71
**Unguarded `ctx` access can swallow the original error**

`getRevenueCatWebhookDiagnosticFields` calls `c.get("ctx")` (line 58) and `c.req.param()` (line 57) without any try/catch, unlike `getLogger` which wraps its `c.get("ctx")` call in a try/catch. If either of those Hono calls unexpectedly throws while building the diagnostic payload, the exception escapes `logRevenueCatWebhookMiddlewareError` and unwinds the catch block that invoked it — the `throw error` on the next line is never reached, so the original middleware error is silently replaced by the diagnostics exception.

### Issue 2 of 3
server/src/external/revenueCat/misc/revenueCatMiddleware.ts:31-35
**Redundant `authType` assignment after `revenuecatIdentifyMiddleware`**

`revenuecatIdentifyMiddleware` runs before `revenuecatSeederMiddleware` in the router chain and already sets `ctx.authType = AuthType.Revenuecat`. The duplicate assignment here on line 33 is unreachable dead state — if `revenuecatIdentifyMiddleware` ever stops running first, this would silently paper over the missing attribution rather than surfacing the ordering problem.

```suggestion
	const { orgId, env } = c.req.param();
	const ctx = c.get("ctx");

	try {
```

### Issue 3 of 3
server/src/external/revenueCat/revenuecatWebhookRouter.ts:47-48
**`revenuecatEventType`/`revenuecatEventId` set twice with different safety assumptions**

`revenuecatLogMiddleware` already writes these fields to the context using optional chaining (`body.event?.type`, `body.event?.id`). The handler re-sets them here using direct property access (`body.event.type`, `"id" in body.event ? ...`). If the body ever arrives without an `event` key, the middleware silently sets `undefined` while the handler throws a `TypeError`. Removing the redundant assignments here and relying on what the middleware already populated would eliminate the inconsistency.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add RevenueCat webhook observability"](https://github.com/useautumn/autumn/commit/a88b1bc624a6dfaec12f5c7680e050621e0a09e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35108863)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->