### PR TITLE
chore: fix proxy

### DIFF
--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -56,7 +56,7 @@ const ALLOWED_HEADERS = [
 export const createHonoApp = () => {
 	const app = new Hono<HonoEnv>();
 
-	if (process.env.NODE_ENV === "development") {
+	if (process.env.CHAT_INTERNAL_URL) {
 		app.route("", createChatProxyRouter());
 	}
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable the chat proxy when `CHAT_INTERNAL_URL` is set instead of only in development. This ensures the proxy mounts whenever an internal chat endpoint is configured, including staging and production.

<sup>Written for commit 4a1083ce849426317e480d1272a8f4ebd7de69df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the condition that guards the chat (Slack) proxy router registration. Previously the proxy routes were only mounted when `NODE_ENV === "development"`, which prevented them from functioning in staging or production deployments even when `CHAT_INTERNAL_URL` was provided. The fix uses the presence of `CHAT_INTERNAL_URL` as the guard instead, aligning the mount condition with the env-var the proxy itself already reads.

- **Bug fixes** — Changed proxy mount guard from `NODE_ENV === "development"` to `process.env.CHAT_INTERNAL_URL`, so Slack proxy routes (`/slack/oauth/callback`, `/slack/events`, `/slack/interactions`) are now activated in any environment where `CHAT_INTERNAL_URL` is set.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line guard swap that correctly ties proxy registration to the env var it already depends on.

The only modified line swaps a NODE_ENV check for a CHAT_INTERNAL_URL presence check, which matches how createChatProxyRouter already resolves its target URL. No new routes, no new logic, and no auth or data paths are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/initHono.ts | One-line change swapping the chat proxy router's mount condition from `NODE_ENV === "development"` to the presence of the `CHAT_INTERNAL_URL` env var, allowing the Slack proxy to be active in any environment where that variable is configured. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{CHAT_INTERNAL_URL set?}
    B -- Yes --> C[Chat Proxy Router]
    C --> D{Route match?}
    D -- /slack/oauth/callback --> E[Proxy GET to CHAT_INTERNAL_URL]
    D -- /slack/events --> F[Proxy POST to CHAT_INTERNAL_URL]
    D -- /slack/interactions --> G[Proxy POST to CHAT_INTERNAL_URL]
    D -- No match --> H[Fall through to main app]
    B -- No --> H
    H --> I[CORS Middleware]
    I --> J[Auth & API routes]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix proxy"](https://github.com/useautumn/autumn/commit/4a1083ce849426317e480d1272a8f4ebd7de69df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35126953)</sub>

<!-- /greptile_comment -->