### PR TITLE
chore: fix proxy headers

### DIFF
--- a/server/src/routers/chatProxyRouter.ts
+++ b/server/src/routers/chatProxyRouter.ts
@@ -6,9 +6,12 @@ const bodylessMethods = new Set(["GET", "HEAD"]);
 const proxyChatRequest =
 	(chatInternalUrl: string) => async (c: Context<HonoEnv>) => {
 		const url = new URL(c.req.url);
+		const headers = new Headers(c.req.raw.headers);
+		headers.delete("host");
+
 		return fetch(`${chatInternalUrl}${url.pathname}${url.search}`, {
 			body: bodylessMethods.has(c.req.raw.method) ? undefined : c.req.raw.body,
-			headers: c.req.raw.headers,
+			headers,
 			method: c.req.raw.method,
 			redirect: "manual",
 		} as RequestInit & { duplex: "half" });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat proxy header forwarding by cloning headers and removing the `host` header before proxying, preventing upstream routing mismatches and failed requests.

- **Bug Fixes**
  - Create a new `Headers` from the incoming request and delete `host` before forwarding in `chatProxyRouter`.

<sup>Written for commit 52ed716b18c8137ac9fda862b98a3f10da48ea32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a proxy header issue where the original `host` header from the client request was being forwarded verbatim to the internal chat service. The router now makes a copy of the incoming headers and strips `host` before issuing the internal `fetch`, so the downstream service receives the correct host for its own URL rather than the external-facing hostname.

- **Bug fixes** — Copy incoming request headers into a new `Headers` object and `delete("host")` before forwarding to `chatInternalUrl`, preventing host-mismatch errors on the internal Slack proxy endpoints.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix with no regressions introduced.

The change copies the headers before mutating them (preserving the original request object) and removes only the `host` header, which is exactly what a well-behaved HTTP proxy should do when forwarding to an internal upstream. No logic paths are altered beyond this header strip.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/routers/chatProxyRouter.ts | Strips the incoming `host` header before forwarding requests to the internal chat service, preventing host-mismatch issues on the downstream proxy target. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ProxyRouter as chatProxyRouter (Hono)
    participant InternalChat as Internal Chat Service (CHAT_INTERNAL_URL)

    Client->>ProxyRouter: HTTP Request (host: external-domain)
    Note over ProxyRouter: Copy headers<br/>Delete "host" header
    ProxyRouter->>InternalChat: Forwarded Request (host header removed)
    InternalChat-->>ProxyRouter: Response
    ProxyRouter-->>Client: Proxied Response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix proxy headers"](https://github.com/useautumn/autumn/commit/52ed716b18c8137ac9fda862b98a3f10da48ea32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35129575)</sub>

<!-- /greptile_comment -->