### PR TITLE
chore: mcp auth fix in prod

### DIFF
--- a/apps/chat/src/agent/mcp.ts
+++ b/apps/chat/src/agent/mcp.ts
@@ -25,6 +25,7 @@ type ToolOptions = {
 const withAuthFetch =
 	(apiKey: string) => (input: RequestInfo | URL, init?: RequestInit) => {
 		const headers = new Headers(init?.headers);
+		headers.set("Authorization", `Bearer ${apiKey}`);
 		headers.set("secret-key", apiKey);
 		return fetch(input, { ...init, headers });
 	};
@@ -39,7 +40,12 @@ export const createAutumnMcpClient = (
 		servers: {
 			autumn: {
 				url: new URL(env.AUTUMN_MCP_URL),
-				requestInit: { headers: { "secret-key": apiKey } },
+				requestInit: {
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+						"secret-key": apiKey,
+					},
+				},
 				eventSourceInit: { fetch: fetchWithAuth },
 				fetch: fetchWithAuth,
 				requireToolApproval: options.requireApproval

--- a/packages/mcp/src/mcp-server/oauth.ts
+++ b/packages/mcp/src/mcp-server/oauth.ts
@@ -252,6 +252,19 @@ function getOAuthPrincipalId(
 	].join(":");
 }
 
+function getStaticApiKey(headers: Headers, flags: MCPOAuthFlags) {
+	const secretKey = headers.get("secret-key");
+	if (secretKey) return secretKey;
+
+	const authorization = headers.get("authorization");
+	const bearer = authorization?.startsWith("Bearer ")
+		? authorization.slice("Bearer ".length)
+		: undefined;
+	if (bearer?.startsWith("am_")) return bearer;
+
+	return flags["oauth-enabled"] ? undefined : flags["secret-key"];
+}
+
 export async function buildAuthForRequest(
 	headers: Headers,
 	flags: MCPOAuthFlags,
@@ -271,8 +284,7 @@ export async function buildAuthForRequest(
 		"Invalid fail-open",
 	);
 	const apiKey = parseRequestOption(
-		headers.get("secret-key") ??
-			(flags["oauth-enabled"] ? undefined : flags["secret-key"]),
+		getStaticApiKey(headers, flags),
 		secretKeySchema,
 		"Invalid secret-key",
 	);

--- a/packages/mcp/tests/unit/mcp-server/oauth.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/oauth.test.ts
@@ -118,6 +118,20 @@ describe("MCP OAuth auth resolution", () => {
 		expect(auth.resource).toBe("http://localhost:2718/mcp");
 	});
 
+	test("accepts an Autumn API key bearer token when OAuth is enabled", async () => {
+		const auth = await buildAuthForRequest(
+			new Headers({
+				authorization: "Bearer am_sk_test_chat",
+				host: "localhost:2718",
+			}),
+			flags as MCPOAuthFlags,
+			logger,
+		);
+
+		expect(auth.apiKey).toBe("am_sk_test_chat");
+		expect(auth.principalId).toStartWith("secret-key:");
+	});
+
 	test("uses route-specific resource URLs", async () => {
 		const originalFetch = globalThis.fetch;
 		globalThis.fetch = (async (_url, init) => {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes MCP auth in production by sending a Bearer token from the chat client and allowing the server to accept `Authorization: Bearer am_*` API keys in addition to `secret-key`.

- **Bug Fixes**
  - Client (`apps/chat`): add `Authorization: Bearer <apiKey>` alongside `secret-key` for all MCP requests.
  - Server (`packages/mcp`): accept Autumn API keys from `Authorization` when OAuth is enabled; keep `secret-key` support; respect `oauth-enabled` fallback logic.
  - Tests: add unit test to validate Bearer token handling with OAuth enabled.

<sup>Written for commit f8cf1a0789d1b4ef80e0476d32cd469f1cb35a9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes MCP authentication in production by teaching the server to accept API keys delivered via `Authorization: Bearer` in addition to the legacy `secret-key` header, and updating the client to send both headers.

- **Bug fixes** — `getStaticApiKey` in `oauth.ts` now recognises a `Bearer` token as a static Autumn API key when it carries the `am_` prefix, letting the server authenticate requests that only supply the `Authorization` header and have no `secret-key` header.
- **Bug fixes** — `mcp.ts` (`withAuthFetch` and the static `requestInit`) now emits both `Authorization: Bearer ${apiKey}` and `secret-key: ${apiKey}`, ensuring auth works across all transport paths (SSE initial handshake, EventSource fetch, regular fetch).
- **Improvements** — A new unit test covers the `Authorization: Bearer am_sk_…` path end-to-end, complementing the existing `secret-key` header test.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds a well-understood fallback auth path with no removal of existing checks and a matching unit test.

The client-side change is additive (both headers are sent, not just the new one), so existing deployments that only check secret-key are unaffected. The server-side getStaticApiKey helper is straightforward: secret-key header wins, Bearer am_ tokens are treated as static keys, non-am_ Bearer tokens still fall through to the full OAuth exchange. The new unit test validates the Bearer path directly. No existing tests are modified or removed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/mcp/src/mcp-server/oauth.ts | New getStaticApiKey helper correctly prioritises secret-key header, then accepts Bearer tokens with the am_ prefix as static keys, then falls back to the flags value when OAuth is disabled. Logic is sound and preserves the existing OAuth exchange path for all other bearer tokens. |
| apps/chat/src/agent/mcp.ts | Both withAuthFetch and the static requestInit.headers now include Authorization: Bearer alongside secret-key, providing auth redundancy across SSE handshake, EventSource, and regular fetch transports. |
| packages/mcp/tests/unit/mcp-server/oauth.test.ts | New test exercises the Bearer am_ path end-to-end with OAuth enabled, correctly asserting apiKey and principalId prefix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client (mcp.ts)
    participant Server as MCP Server (oauth.ts)

    Note over Client: withAuthFetch / requestInit sets both headers
    Client->>Server: Request Authorization: Bearer am_sk_xxx + secret-key: am_sk_xxx

    Server->>Server: getStaticApiKey(headers, flags)
    alt secret-key header present
        Server->>Server: return headers[secret-key]
    else Authorization: Bearer am_xxx
        Server->>Server: bearer.startsWith(am_) → return bearer
    else "oauth-enabled = false"
        Server->>Server: return flags[secret-key]
    else "oauth-enabled = true"
        Server->>Server: return undefined → fall through to OAuth
    end

    alt apiKey resolved (static path)
        Server-->>Client: Auth OK (principalId: secret-key:...)
    else apiKey undefined + OAuth enabled
        Server->>Server: exchangeOAuthToken(bearer)
        Server-->>Client: Auth OK (principalId: oauth:...)
    else no key + OAuth disabled
        Server-->>Client: 401 invalid_token
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: mcp auth fix in prod"](https://github.com/useautumn/autumn/commit/f8cf1a0789d1b4ef80e0476d32cd469f1cb35a9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35136757)</sub>

<!-- /greptile_comment -->