### PR TITLE
release

### DIFF
--- a/server/src/internal/analytics/actions/listRawEvents.ts
+++ b/server/src/internal/analytics/actions/listRawEvents.ts
@@ -4,6 +4,7 @@ import type {
 	FullCustomer,
 	RawEventFromClickHouse,
 } from "@autumn/shared";
+import { UTCDate } from "@date-fns/utc";
 import {
 	getTinybirdPipes,
 	type ListEventsPaginatedPipeRow,
@@ -66,6 +67,7 @@ export type ListRawEventsParams = {
 	customer_id?: string;
 	entity_id?: string;
 	interval?: string;
+	custom_range?: { start: number; end: number };
 	customer?: FullCustomer;
 	aggregateAll?: boolean;
 	event_name?: string;
@@ -100,13 +102,15 @@ export const listRawEvents = async ({
 	// Calculate date range
 	const startDate = calculateStartDateFromInterval(intervalType);
 
-	const finalStartDate =
-		isBillingCycle && billingCycleResult?.startDate
+	const finalStartDate = params.custom_range
+		? formatJsDateToClickHouseDateTime(new UTCDate(params.custom_range.start))
+		: isBillingCycle && billingCycleResult?.startDate
 			? billingCycleResult.startDate
 			: formatJsDateToClickHouseDateTime(startDate);
 
-	const finalEndDate =
-		isBillingCycle && billingCycleResult?.endDate
+	const finalEndDate = params.custom_range
+		? formatJsDateToClickHouseDateTime(new UTCDate(params.custom_range.end))
+		: isBillingCycle && billingCycleResult?.endDate
 			? billingCycleResult.endDate
 			: formatJsDateToClickHouseDateTime(new Date());
 

--- a/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts
@@ -28,6 +28,12 @@ const STANDARD_INTERVAL_DAYS: Record<string, number> = {
 
 const InternalAggregateEventsSchema = z.object({
 	interval: z.string().nullish(),
+	custom_range: z
+		.object({ start: z.number(), end: z.number() })
+		.refine((range) => range.start < range.end, {
+			message: "custom_range.start must be before custom_range.end",
+		})
+		.optional(),
 	event_names: z.array(z.string()),
 	customer_id: z.string().optional(),
 	entity_id: z.string().optional(),
@@ -49,6 +55,7 @@ export const handleInternalAggregateEvents = createRoute({
 		const { db, org, env, features } = ctx;
 		const {
 			interval,
+			custom_range,
 			customer_id,
 			entity_id,
 			group_by,
@@ -113,6 +120,7 @@ export const handleInternalAggregateEvents = createRoute({
 			: undefined;
 		const now = new UTCDate();
 		const customRange = (() => {
+			if (custom_range) return custom_range;
 			if (standardIntervalDays === undefined) return undefined;
 			const unaligned = sub(now, { days: standardIntervalDays });
 			const aligned =

--- a/server/src/internal/analytics/internalHandlers/handleInternalListRawEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalListRawEvents.ts
@@ -7,6 +7,12 @@ import { eventActions } from "../actions/eventActions.js";
 
 const InternalListRawEventsSchema = z.object({
 	interval: z.string().nullish(),
+	custom_range: z
+		.object({ start: z.number(), end: z.number() })
+		.refine((range) => range.start < range.end, {
+			message: "custom_range.start must be before custom_range.end",
+		})
+		.optional(),
 	customer_id: z.string().nullish(),
 	entity_id: z.string().optional(),
 });
@@ -20,7 +26,8 @@ export const handleInternalListRawEvents = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, org, env } = ctx;
-		const { interval, customer_id, entity_id } = c.req.valid("json");
+		const { interval, custom_range, customer_id, entity_id } =
+			c.req.valid("json");
 
 		let aggregateAll = false;
 		let customer: FullCustomer | undefined;
@@ -52,6 +59,7 @@ export const handleInternalListRawEvents = createRoute({
 				customer_id: customer?.id ?? undefined,
 				entity_id: entity_id,
 				interval: interval ?? undefined,
+				custom_range: custom_range ?? undefined,
 				customer,
 				aggregateAll,
 			},

--- a/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
@@ -1,9 +1,22 @@
-import { memo, startTransition, useCallback, useMemo, useRef, useState } from "react";
+import {
+	memo,
+	startTransition,
+	useCallback,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
 import { cn } from "@/lib/utils";
-import { useAnalyticsContext } from "./AnalyticsContext";
 import type { Row } from "./components/analytics-types";
+import { useAnalyticsQueryState } from "./hooks/useAnalyticsQueryState";
+import {
+	CHART_MARGIN,
+	type PlotInsets,
+	Y_AXIS_WIDTH,
+} from "./utils/chartGeometry";
 import {
 	formatCompactNumber,
 	formatDateShort,
@@ -51,6 +64,7 @@ function TooltipItem({ item, label }: { item: any; label: string }) {
 export const EventsBarChart = memo(function EventsBarChart({
 	data,
 	chartConfig,
+	onGeometry,
 }: {
 	data: {
 		meta: any[];
@@ -58,12 +72,42 @@ export const EventsBarChart = memo(function EventsBarChart({
 		data: Row[];
 	};
 	chartConfig: ChartSeriesConfig[];
+	onGeometry?: (insets: PlotInsets) => void;
 }) {
-	const { selectedInterval } = useAnalyticsContext();
+	const { queryStates } = useAnalyticsQueryState();
+	const selectedInterval = queryStates.interval;
 	const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 	const [activeRow, setActiveRow] = useState<Row | null>(null);
 	const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
+
+	useLayoutEffect(() => {
+		const container = containerRef.current;
+		if (!container || !onGeometry) {
+			return;
+		}
+		const measure = () => {
+			const grid = container.querySelector(".recharts-cartesian-grid");
+			if (!grid) {
+				return;
+			}
+			const c = container.getBoundingClientRect();
+			const g = grid.getBoundingClientRect();
+			if (g.width === 0 || g.height === 0) {
+				return;
+			}
+			onGeometry({
+				left: Math.round(g.left - c.left),
+				right: Math.round(c.right - g.right),
+				top: Math.round(g.top - c.top),
+				bottom: Math.round(c.bottom - g.bottom),
+			});
+		};
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(container);
+		return () => observer.disconnect();
+	}, [onGeometry, data]);
 
 	const handleBarMouseEnter = useCallback(
 		(dataKey: string) => (entry: any) =>
@@ -144,6 +188,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 				<BarChart
 					data={data.data}
 					className="pt-3 pr-2"
+					margin={CHART_MARGIN}
 					barCategoryGap="10%"
 					style={CHART_STYLE}
 					throttleDelay="raf"
@@ -166,7 +211,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 					<YAxis
 						tickLine={false}
 						axisLine={false}
-						width={40}
+						width={Y_AXIS_WIDTH}
 						tickMargin={0}
 						tickCount={5}
 						tick={Y_TICK}
@@ -181,6 +226,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 							activeBar={false}
 							style={CHART_STYLE}
 							onMouseEnter={barHandlers[si]}
+							isAnimationActive={false}
 						/>
 					))}
 				</BarChart>

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -1,7 +1,7 @@
 import { ErrCode } from "@autumn/shared";
 import { ChartBarIcon } from "@phosphor-icons/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { PageContainer } from "@/components/general/PageContainer";
 import { useFeatureFlags } from "@/hooks/useFeatureFlags";
@@ -11,6 +11,14 @@ import { AnalyticsContext } from "./AnalyticsContext";
 import { EventsBarChart } from "./AnalyticsGraph";
 import { colors } from "./components/analytics-types";
 import { ChartLegend, type ChartLegendEntry } from "./components/ChartLegend";
+import { ChartSkeleton } from "./components/ChartSkeleton";
+import {
+	DEFAULT_PLOT_INSETS,
+	getCachedPlotInsets,
+	type PlotInsets,
+	plotInsetsEqual,
+	setCachedPlotInsets,
+} from "./utils/chartGeometry";
 import { EventsTable } from "./components/EventsTable";
 import { QueryTopbar } from "./components/QueryTopbar";
 import {
@@ -26,17 +34,23 @@ import {
 } from "./utils/transformGroupedChartData";
 
 export const AnalyticsView = () => {
-	const [searchParams] = useSearchParams();
 	const [eventNames, setEventNames] = useState<string[]>([]);
 	const [featureIds, setFeatureIds] = useState<string[]>([]);
 	const [clickHouseDisabled, setClickHouseDisabled] = useState(false);
 	const [hasCleared, setHasCleared] = useState(false);
 	const [groupFilter, setGroupFilter] = useState<string | null>(null);
 	const [planDeselected, setPlanDeselected] = useState<Set<string>>(new Set());
-	const navigate = useNavigate();
 
 	const env = useEnv();
 	const { flags, isLoading: isFeatureFlagsLoading } = useFeatureFlags();
+	const reduceMotion = useReducedMotion();
+	const [plotInsets, setPlotInsets] = useState<PlotInsets>(
+		() => getCachedPlotInsets() ?? DEFAULT_PLOT_INSETS,
+	);
+	const handlePlotGeometry = useCallback((insets: PlotInsets) => {
+		setCachedPlotInsets(insets);
+		setPlotInsets((prev) => (plotInsetsEqual(prev, insets) ? prev : insets));
+	}, []);
 
 	const {
 		customer,
@@ -183,6 +197,22 @@ export const AnalyticsView = () => {
 		return { chartData: trimmed, chartConfig: config };
 	}, [events, features, groupBy, groupFilter, planDeselected, entityNames, customerNames, planNames]);
 
+	const barFractions = useMemo(() => {
+		const rows = chartData?.data;
+		if (!rows || rows.length === 0 || !chartConfig) {
+			return null;
+		}
+		const totals = rows.map((row) =>
+			chartConfig.reduce(
+				(sum, series) =>
+					sum + Number((row as Record<string, unknown>)[series.yKey] ?? 0),
+				0,
+			),
+		);
+		const max = Math.max(...totals, 1);
+		return totals.map((total) => total / max);
+	}, [chartData, chartConfig]);
+
 	// Build legend entries (sorted desc, zero-values filtered). The
 	// width-aware overflow logic lives in ChartLegend.
 	const legendEntries: ChartLegendEntry[] = useMemo(() => {
@@ -248,35 +278,10 @@ export const AnalyticsView = () => {
 		}
 	}, [error]);
 
-	const selectedInterval = searchParams.get("interval") || "30d";
-	const selectedBinSize = searchParams.get("bin_size") || "day";
-
-	const setSelectedInterval = useCallback(
-		(interval: string) => {
-			const newParams = new URLSearchParams(searchParams);
-			newParams.set("interval", interval);
-			navigate(`${location.pathname}?${newParams.toString()}`);
-		},
-		[searchParams, navigate],
-	);
-
-	const setSelectedBinSize = useCallback(
-		(binSize: string) => {
-			const newParams = new URLSearchParams(searchParams);
-			newParams.set("bin_size", binSize);
-			navigate(`${location.pathname}?${newParams.toString()}`);
-		},
-		[searchParams, navigate],
-	);
-
 	const contextValue = useMemo(
 		() => ({
 			customer,
 			eventNames,
-			selectedInterval,
-			setSelectedInterval,
-			selectedBinSize,
-			setSelectedBinSize,
 			setEventNames,
 			featureIds,
 			setFeatureIds,
@@ -297,10 +302,6 @@ export const AnalyticsView = () => {
 		[
 			customer,
 			eventNames,
-			selectedInterval,
-			setSelectedInterval,
-			selectedBinSize,
-			setSelectedBinSize,
 			featureIds,
 			features,
 			bcExclusionFlag,
@@ -328,6 +329,11 @@ export const AnalyticsView = () => {
 		!isFeatureFlagsLoading &&
 		!flags.maintenanceModes.analytics.disableRevenueMetrics;
 
+	const hasChart =
+		!queryLoading && !!chartData && chartData.data.length > 0;
+	const isEmpty = !queryLoading && !hasChart;
+	const chartRevealDelay = reduceMotion ? 0 : 0.55;
+
 	return (
 		<AnalyticsContext.Provider value={contextValue}>
 			<PageContainer className="text-sm h-full overflow-hidden">
@@ -341,27 +347,57 @@ export const AnalyticsView = () => {
 						</div>
 						<QueryTopbar />
 					</div>
-				<div className="flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1] overflow-hidden">
-					{queryLoading && (
-						<div className="flex-1 animate-pulse" />
-					)}
-					{!queryLoading && chartData && chartData.data.length > 0 && (
-						<>
-							<ChartLegend
-								entries={legendEntries}
-								showLabels={!!groupBy || legendEntries.length <= 3}
+				<div className="relative flex flex-col bg-interactive-secondary border rounded-lg aspect-[3/1] overflow-hidden">
+					{(queryLoading || hasChart) && (
+						<div className="absolute inset-0 flex flex-col">
+							<ChartSkeleton
+								targets={hasChart ? barFractions : null}
+								geometry={plotInsets}
 							/>
-							<div className="flex-1 min-h-0">
-								<EventsBarChart
-									data={chartData as Parameters<typeof EventsBarChart>[0]["data"]}
-									chartConfig={chartConfig}
-								/>
-							</div>
-						</>
+						</div>
 					)}
-					{!queryLoading && (!chartData || chartData.data.length === 0) && (
-						<div className="flex-1 flex flex-col items-center justify-center gap-2">
-							<ChartBarIcon size={28} weight="duotone" className="text-muted-foreground/50" />
+					<AnimatePresence>
+						{hasChart && (
+							<motion.div
+								key="chart"
+								className="absolute inset-0 flex flex-col bg-interactive-secondary"
+								initial={{ opacity: 0 }}
+								animate={{
+									opacity: 1,
+									transition: {
+										duration: 0.25,
+										delay: chartRevealDelay,
+										ease: [0.23, 1, 0.32, 1],
+									},
+								}}
+								exit={{
+									opacity: 0,
+									transition: { duration: 0.2, ease: [0.23, 1, 0.32, 1] },
+								}}
+							>
+								<ChartLegend
+									entries={legendEntries}
+									showLabels={!!groupBy || legendEntries.length <= 3}
+								/>
+								<div className="flex-1 min-h-0">
+									<EventsBarChart
+										data={
+											chartData as Parameters<typeof EventsBarChart>[0]["data"]
+										}
+										chartConfig={chartConfig}
+										onGeometry={handlePlotGeometry}
+									/>
+								</div>
+							</motion.div>
+						)}
+					</AnimatePresence>
+					{isEmpty && (
+						<div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
+							<ChartBarIcon
+								size={28}
+								weight="duotone"
+								className="text-muted-foreground/50"
+							/>
 							<p className="text-muted-foreground text-sm">
 								{eventNames.length === 0
 									? "Start sending events to view usage data."

--- a/vite/src/views/customers/customer/analytics/components/ChartSkeleton.tsx
+++ b/vite/src/views/customers/customer/analytics/components/ChartSkeleton.tsx
@@ -1,0 +1,97 @@
+import { useReducedMotion } from "motion/react";
+import { useMemo } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAnalyticsQueryState } from "../hooks/useAnalyticsQueryState";
+import {
+	bandGridStyle,
+	buildSkeletonBars,
+	DEFAULT_PLOT_INSETS,
+	type PlotInsets,
+	predictBarCount,
+} from "../utils/chartGeometry";
+import { SkeletonBar } from "./SkeletonBar";
+
+const Y_POSITIONS = [0, 25, 50, 75, 100] as const;
+const X_LABELS = 7;
+
+/** Loading placeholder for the usage chart that morphs into the real chart. */
+export const ChartSkeleton = ({
+	targets,
+	geometry = DEFAULT_PLOT_INSETS,
+}: {
+	targets?: number[] | null;
+	geometry?: PlotInsets;
+}) => {
+	const { queryStates } = useAnalyticsQueryState();
+	const prefersReducedMotion = useReducedMotion();
+	const settledHeights = targets && targets.length > 0 ? targets : null;
+	const barCount =
+		settledHeights?.length ??
+		predictBarCount({
+			interval: queryStates.interval,
+			binSize: queryStates.bin_size,
+			start: queryStates.start,
+			end: queryStates.end,
+		});
+	const bars = useMemo(() => buildSkeletonBars(barCount), [barCount]);
+
+	return (
+		<div className="flex flex-1 flex-col">
+			<div className="flex h-7 shrink-0 items-center gap-4 border-b bg-card px-2">
+				{[72, 56, 64].map((width, i) => (
+					<div key={i} className="flex items-center gap-1.5">
+						<Skeleton className="size-2 rounded-sm" />
+						<Skeleton className="h-2.5 rounded-sm" style={{ width }} />
+						<Skeleton className="h-2.5 w-8 rounded-sm" />
+					</div>
+				))}
+			</div>
+
+			<div
+				className="flex min-h-0 flex-1 flex-col"
+				style={{ paddingTop: geometry.top, paddingRight: geometry.right }}
+			>
+				<div className="flex min-h-0 flex-1">
+					<div className="relative shrink-0" style={{ width: geometry.left }}>
+						{Y_POSITIONS.map((top) => (
+							<Skeleton
+								key={top}
+								className="absolute right-2 h-2 w-5 -translate-y-1/2 rounded-sm"
+								style={{ top: `${top}%` }}
+							/>
+						))}
+					</div>
+
+					<div className="relative min-w-0 flex-1" style={bandGridStyle(barCount)}>
+						<div className="pointer-events-none absolute inset-0">
+							{Y_POSITIONS.map((top) => (
+								<div
+									key={top}
+									className="absolute inset-x-0 border-t border-dashed"
+									style={{ top: `${top}%`, borderColor: "var(--chart-grid-stroke)" }}
+								/>
+							))}
+						</div>
+						{bars.map((bar, i) => (
+							<SkeletonBar
+								key={i}
+								bar={bar}
+								targetHeight={settledHeights ? settledHeights[i] : null}
+								reducedMotion={!!prefersReducedMotion}
+							/>
+						))}
+					</div>
+				</div>
+
+				<div
+					className="flex shrink-0 justify-between pt-1"
+					style={{ height: geometry.bottom, paddingLeft: geometry.left }}
+				>
+					{Array.from({ length: X_LABELS }, (_, i) => (
+						<Skeleton key={i} className="h-2 w-6 rounded-sm" />
+					))}
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -1,6 +1,8 @@
-import { CaretDownIcon } from "@phosphor-icons/react";
+import { CalendarBlankIcon, CaretDownIcon } from "@phosphor-icons/react";
+import { endOfDay, format } from "date-fns";
 import { Check } from "lucide-react";
-import { useLocation, useNavigate } from "react-router";
+import { useState } from "react";
+import type { DateRange } from "react-day-picker";
 import { IconButton } from "@/components/v2/buttons/IconButton";
 import {
 	DropdownMenu,
@@ -11,8 +13,10 @@ import {
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@/components/v2/dropdowns/DropdownMenu";
+import { Calendar } from "@/components/ui/calendar";
 
 import { useAnalyticsContext } from "../AnalyticsContext";
+import { useAnalyticsQueryState } from "../hooks/useAnalyticsQueryState";
 import { CustomerComboBox } from "./CustomerComboBox";
 import { SelectEntityDropdown } from "./SelectEntityDropdown";
 import { SelectFeatureDropdown } from "./SelectFeatureDropdown";
@@ -42,13 +46,23 @@ const BIN_SIZE_LABELS: Record<string, string> = {
 	month: "by month",
 };
 
+const CUSTOM_INTERVAL = "custom";
+
 const getDisplayLabel = ({
 	interval,
 	binSize,
+	customRange,
 }: {
 	interval: string;
 	binSize: string;
+	customRange?: DateRange;
 }) => {
+	if (interval === CUSTOM_INTERVAL) {
+		if (customRange?.from && customRange?.to) {
+			return `${format(customRange.from, "MMM d")} - ${format(customRange.to, "MMM d")}`;
+		}
+		return "Custom range";
+	}
 	if (BIN_SIZE_INTERVALS[interval] && binSize === "month") {
 		return `${ALL_INTERVALS[interval]} (by month)`;
 	}
@@ -56,39 +70,21 @@ const getDisplayLabel = ({
 };
 
 export const QueryTopbar = () => {
-	const {
-		customer,
-		selectedInterval,
-		setSelectedInterval,
-		selectedBinSize,
-		setSelectedBinSize,
-		bcExclusionFlag,
-		propertyKeys,
-	} = useAnalyticsContext();
-	const navigate = useNavigate();
-	const location = useLocation();
+	const { customer, bcExclusionFlag, propertyKeys } = useAnalyticsContext();
+	const { queryStates, setQueryStates } = useAnalyticsQueryState();
+	const [draftRange, setDraftRange] = useState<DateRange | undefined>(
+		undefined,
+	);
 
-	const updateQueryParams = ({
-		interval,
-		binSize,
-	}: {
-		interval?: string;
-		binSize?: string;
-	}) => {
-		const params = new URLSearchParams(location.search);
-		if (interval !== undefined) {
-			params.set("interval", interval);
-		}
-		if (binSize !== undefined) {
-			params.set("bin_size", binSize);
-		}
-		navigate(`${location.pathname}?${params.toString()}`);
-	};
+	const { interval: selectedInterval, start, end } = queryStates;
+	const selectedBinSize = queryStates.bin_size ?? "day";
+	const customRange =
+		selectedInterval === CUSTOM_INTERVAL && start && end
+			? { from: new Date(start), to: new Date(end) }
+			: undefined;
 
 	const handleSimpleIntervalSelect = (interval: string) => {
-		setSelectedInterval(interval);
-		setSelectedBinSize("day");
-		updateQueryParams({ interval, binSize: "day" });
+		setQueryStates({ interval, bin_size: "day", start: null, end: null });
 	};
 
 	const handleBinSizeIntervalSelect = ({
@@ -98,9 +94,20 @@ export const QueryTopbar = () => {
 		interval: string;
 		binSize: string;
 	}) => {
-		setSelectedInterval(interval);
-		setSelectedBinSize(binSize);
-		updateQueryParams({ interval, binSize });
+		setQueryStates({ interval, bin_size: binSize, start: null, end: null });
+	};
+
+	const handleCustomRangeSelect = (range: DateRange | undefined) => {
+		setDraftRange(range);
+		if (!range?.from || !range?.to) {
+			return;
+		}
+		setQueryStates({
+			interval: CUSTOM_INTERVAL,
+			bin_size: "day",
+			start: range.from.getTime(),
+			end: endOfDay(range.to).getTime(),
+		});
 	};
 
 	const shouldShowBillingCycleOptions = !bcExclusionFlag && customer;
@@ -109,7 +116,13 @@ export const QueryTopbar = () => {
 		<div className="flex items-center py-0 h-full gap-2">
 			<CustomerComboBox />
 			{customer?.entities?.length > 0 && <SelectEntityDropdown />}
-			<DropdownMenu>
+			<DropdownMenu
+				onOpenChange={(open) => {
+					if (open) {
+						setDraftRange(undefined);
+					}
+				}}
+			>
 				<DropdownMenuTrigger asChild>
 					<IconButton
 						variant="secondary"
@@ -120,6 +133,7 @@ export const QueryTopbar = () => {
 						{getDisplayLabel({
 							interval: selectedInterval,
 							binSize: selectedBinSize,
+							customRange,
 						})}
 					</IconButton>
 				</DropdownMenuTrigger>
@@ -180,6 +194,32 @@ export const QueryTopbar = () => {
 								</DropdownMenuSubContent>
 							</DropdownMenuSub>
 						))}
+
+					<DropdownMenuSub>
+						<DropdownMenuSubTrigger className="flex items-center justify-between">
+							<span className="flex items-center gap-1.5">
+								<CalendarBlankIcon
+									size={14}
+									weight="bold"
+									className="text-tertiary-foreground"
+								/>
+								Custom range
+							</span>
+							{selectedInterval === CUSTOM_INTERVAL && (
+								<Check className="mr-1 h-3 w-3 text-tertiary-foreground" />
+							)}
+						</DropdownMenuSubTrigger>
+						<DropdownMenuSubContent className="p-0">
+							<Calendar
+								mode="range"
+								numberOfMonths={2}
+								selected={draftRange}
+								onSelect={handleCustomRangeSelect}
+								defaultMonth={draftRange?.from ?? customRange?.from}
+								disabled={{ after: new Date() }}
+							/>
+						</DropdownMenuSubContent>
+					</DropdownMenuSub>
 				</DropdownMenuContent>
 			</DropdownMenu>
 			<SelectFeatureDropdown />

--- a/vite/src/views/customers/customer/analytics/components/SkeletonBar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SkeletonBar.tsx
@@ -1,0 +1,86 @@
+import { motion, type Transition } from "motion/react";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { SkeletonBarConfig } from "../utils/chartGeometry";
+
+type BarMode = "settled" | "breathing" | "static";
+
+const getMode = ({
+	settled,
+	reducedMotion,
+}: {
+	settled: boolean;
+	reducedMotion: boolean;
+}): BarMode => {
+	if (settled) {
+		return "settled";
+	}
+	if (reducedMotion) {
+		return "static";
+	}
+	return "breathing";
+};
+
+const getScaleY = ({
+	mode,
+	bar,
+	targetHeight,
+}: {
+	mode: BarMode;
+	bar: SkeletonBarConfig;
+	targetHeight: number | null;
+}): number | number[] => {
+	if (mode === "settled") {
+		return targetHeight ?? bar.peak;
+	}
+	if (mode === "breathing") {
+		return [bar.low, bar.peak, bar.low];
+	}
+	return bar.peak;
+};
+
+const getTransition = ({
+	mode,
+	bar,
+	reducedMotion,
+}: {
+	mode: BarMode;
+	bar: SkeletonBarConfig;
+	reducedMotion: boolean;
+}): Transition => {
+	if (mode === "breathing") {
+		return {
+			duration: bar.duration,
+			repeat: Number.POSITIVE_INFINITY,
+			ease: "easeInOut",
+			delay: bar.delay,
+		};
+	}
+	if (mode === "static") {
+		return { duration: 0.3 };
+	}
+	return reducedMotion
+		? { duration: 0.2 }
+		: { type: "spring", bounce: 0.1, duration: 0.55 };
+};
+
+export const SkeletonBar = ({
+	bar,
+	targetHeight,
+	reducedMotion,
+}: {
+	bar: SkeletonBarConfig;
+	targetHeight: number | null;
+	reducedMotion: boolean;
+}) => {
+	const mode = getMode({ settled: targetHeight != null, reducedMotion });
+	return (
+		<motion.div
+			className="h-full origin-bottom"
+			initial={{ scaleY: bar.low }}
+			animate={{ scaleY: getScaleY({ mode, bar, targetHeight }) }}
+			transition={getTransition({ mode, bar, reducedMotion })}
+		>
+			<Skeleton className="h-full w-full rounded-t-[2px] rounded-b-none" />
+		</motion.div>
+	);
+};

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "react-router";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useAnalyticsQueryState } from "./useAnalyticsQueryState";
 import { useEventNames } from "./useEventNames";
 
 /** Gets the user's IANA timezone (e.g., "America/New_York") */
@@ -29,12 +30,16 @@ export const useAnalyticsData = ({
 	const entityId = searchParams.get("entity_id");
 	const featureIds = searchParams.get("feature_ids")?.split(",");
 	const eventNames = searchParams.get("event_names")?.split(",");
-	const interval = searchParams.get("interval");
 	const groupBy = searchParams.get("group_by");
-	const binSize = searchParams.get("bin_size");
 	const maxGroups = Number(searchParams.get("max_groups")) || 10;
 
-	const { eventNames: cachedEventNames } = useEventNames();
+	const { queryStates } = useAnalyticsQueryState();
+	const { interval, bin_size: binSize, start, end } = queryStates;
+	const customRange =
+		interval === "custom" && start && end ? { start, end } : undefined;
+
+	const { eventNames: cachedEventNames, isLoading: eventNamesLoading } =
+		useEventNames();
 
 	const timezone = useMemo(() => getUserTimezone(), []);
 
@@ -66,7 +71,8 @@ export const useAnalyticsData = ({
 	const postBody = {
 		customer_id: customerId || undefined,
 		entity_id: entityId || undefined,
-		interval: interval || "30d",
+		interval: customRange ? undefined : interval,
+		custom_range: customRange,
 		event_names: selectedEventNames,
 		group_by: formattedGroupBy,
 		bin_size: binSize || undefined,
@@ -74,17 +80,18 @@ export const useAnalyticsData = ({
 		max_groups: formattedGroupBy ? maxGroups : undefined,
 	};
 
-	const {
-		data,
-		isLoading: queryLoading,
-		error,
-	} = useQuery({
+	const isReady = !eventNamesLoading && !featuresLoading;
+
+	const { data, isLoading, error } = useQuery({
+		enabled: isReady,
 		queryKey: buildKey([
 			"query-events",
 			customerId,
 			entityId,
-			interval || "30d",
+			interval,
 			binSize || "day",
+			String(start ?? ""),
+			String(end ?? ""),
 			...selectedEventNames.sort(),
 			groupBy,
 			timezone,
@@ -95,6 +102,8 @@ export const useAnalyticsData = ({
 			return data;
 		},
 	});
+
+	const queryLoading = !isReady || isLoading;
 
 	return {
 		customer: data?.customer,
@@ -127,7 +136,11 @@ export const useRawAnalyticsData = () => {
 	const [searchParams] = useSearchParams();
 	const customerId = searchParams.get("customer_id");
 	const entityId = searchParams.get("entity_id");
-	const interval = searchParams.get("interval");
+
+	const { queryStates } = useAnalyticsQueryState();
+	const { interval, start, end } = queryStates;
+	const customRange =
+		interval === "custom" && start && end ? { start, end } : undefined;
 
 	const { features: featuresData, isLoading: featuresLoading } =
 		useFeaturesQuery();
@@ -135,7 +148,8 @@ export const useRawAnalyticsData = () => {
 	const postBody = {
 		customer_id: customerId || undefined,
 		entity_id: entityId || undefined,
-		interval: interval || "30d",
+		interval: customRange ? undefined : interval,
+		custom_range: customRange,
 	};
 
 	const {
@@ -147,7 +161,9 @@ export const useRawAnalyticsData = () => {
 			"query-raw-events",
 			customerId,
 			entityId,
-			interval || "30d",
+			interval,
+			String(start ?? ""),
+			String(end ?? ""),
 		]),
 		queryFn: async () => {
 			const { data } = await axiosInstance.post("/query/raw", postBody);

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsQueryState.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsQueryState.tsx
@@ -1,0 +1,19 @@
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+
+/**
+ * URL-synced state for the analytics interval / custom date range controls.
+ * `start` and `end` are epoch milliseconds and are only set when
+ * `interval === "custom"`.
+ */
+export const useAnalyticsQueryState = () => {
+	const [queryStates, setQueryStates] = useQueryStates(
+		{
+			interval: parseAsString.withDefault("30d"),
+			bin_size: parseAsString,
+			start: parseAsInteger,
+			end: parseAsInteger,
+		},
+		{ history: "push" },
+	);
+	return { queryStates, setQueryStates };
+};

--- a/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
+++ b/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
@@ -1,0 +1,178 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Single source of truth for the usage chart's layout, shared between the real
+ * recharts chart (EventsBarChart) and the loading skeleton (ChartSkeleton) so
+ * the morph between them has zero shift.
+ *
+ * The values mirror what recharts reserves: the explicit BarChart `margin`, the
+ * fixed `YAxis width`, the default `XAxis height`, and the `pt-3 pr-2` padding
+ * applied to the BarChart element.
+ */
+
+export const CHART_MARGIN = { top: 5, right: 5, bottom: 5, left: 5 } as const;
+export const Y_AXIS_WIDTH = 40;
+export const X_AXIS_HEIGHT = 30;
+
+/** `pt-3 pr-2` on the BarChart element, in pixels. */
+const CHART_PAD = { top: 12, right: 8 } as const;
+
+/** Plot insets (px) from each edge of the chart body (below the legend). */
+export const LEFT_GUTTER = CHART_MARGIN.left + Y_AXIS_WIDTH;
+export const TOP_INSET = CHART_MARGIN.top + CHART_PAD.top;
+export const BOTTOM_INSET = X_AXIS_HEIGHT + CHART_MARGIN.bottom;
+export const RIGHT_INSET = CHART_MARGIN.right + CHART_PAD.right;
+
+/** `barCategoryGap="10%"` on the BarChart: bar = 90% of the band, centered. */
+export const BAR_CATEGORY_GAP = 0.1;
+
+/**
+ * CSS grid styles that reproduce recharts' band layout: each bar is 90% of its
+ * band with 5% outer padding and 10% inter-bar gaps. Percentages resolve
+ * against the plot width, so no width measurement is needed.
+ */
+export const bandGridStyle = (count: number): CSSProperties => ({
+	display: "grid",
+	gridTemplateColumns: `repeat(${count}, minmax(0, 1fr))`,
+	columnGap: `${(BAR_CATEGORY_GAP * 100) / count}%`,
+	paddingInline: `${(BAR_CATEGORY_GAP * 50) / count}%`,
+	alignItems: "end",
+});
+
+/** Per-bar geometry + timing for the loading wave. Heights are a scaleY
+ * fraction (0-1) of the full plot height. */
+export interface SkeletonBarConfig {
+	peak: number;
+	low: number;
+	duration: number;
+	delay: number;
+}
+
+/** Randomised, stable bar configs for the loading wave. */
+export const buildSkeletonBars = (count: number): SkeletonBarConfig[] =>
+	Array.from({ length: count }, () => {
+		const peak = 0.22 + Math.random() * 0.73;
+		return {
+			peak,
+			low: peak * (0.35 + Math.random() * 0.2),
+			duration: 2.6 + Math.random() * 1.8,
+			delay: Math.random() * 1.4,
+		};
+	});
+
+/** Pixel insets of the plot area from each edge of the chart body. */
+export interface PlotInsets {
+	left: number;
+	right: number;
+	top: number;
+	bottom: number;
+}
+
+/** Fallback used before the real chart has been measured once. */
+export const DEFAULT_PLOT_INSETS: PlotInsets = {
+	left: LEFT_GUTTER,
+	right: RIGHT_INSET,
+	top: TOP_INSET,
+	bottom: BOTTOM_INSET,
+};
+
+// recharts computes the exact gutter dynamically; the real chart measures its
+// plot rect and caches it here so the skeleton (which renders before the chart)
+// can mirror it exactly across loads within a session.
+let cachedPlotInsets: PlotInsets | null = null;
+
+export const getCachedPlotInsets = (): PlotInsets | null => cachedPlotInsets;
+
+export const setCachedPlotInsets = (insets: PlotInsets): void => {
+	cachedPlotInsets = insets;
+};
+
+export const plotInsetsEqual = (a: PlotInsets, b: PlotInsets): boolean =>
+	a.left === b.left &&
+	a.right === b.right &&
+	a.top === b.top &&
+	a.bottom === b.bottom;
+
+const MS_PER_HOUR = 3_600_000;
+const MS_PER_DAY = 86_400_000;
+const MIN_BARS = 6;
+const MAX_BARS = 366;
+
+const STANDARD_INTERVAL_DAYS: Record<string, number> = {
+	"24h": 1,
+	"7d": 7,
+	"30d": 30,
+	"90d": 90,
+	"1bc": 30,
+	"3bc": 90,
+};
+
+type BinSize = "hour" | "day" | "month";
+
+const resolveBinSize = ({
+	interval,
+	binSize,
+}: {
+	interval: string;
+	binSize: string | null;
+}): BinSize => {
+	if (binSize === "hour" || binSize === "day" || binSize === "month") {
+		return binSize;
+	}
+	return interval === "24h" ? "hour" : "day";
+};
+
+/** Truncates a timestamp down to the start of its bin, matching the backend. */
+const alignDown = ({ ms, binSize }: { ms: number; binSize: BinSize }): number => {
+	const date = new Date(ms);
+	if (binSize === "hour") {
+		date.setUTCMinutes(0, 0, 0);
+	} else if (binSize === "month") {
+		date.setUTCDate(1);
+		date.setUTCHours(0, 0, 0, 0);
+	} else {
+		date.setUTCHours(0, 0, 0, 0);
+	}
+	return date.getTime();
+};
+
+/**
+ * Predicts how many bars the chart will render, replicating the backend's
+ * `generateAllPeriods` (bin-aligned start, inclusive bins up to end). Used only
+ * for the pre-data loading frames; once data arrives the real count is used.
+ */
+export const predictBarCount = ({
+	interval,
+	binSize,
+	start,
+	end,
+}: {
+	interval: string;
+	binSize: string | null;
+	start: number | null;
+	end: number | null;
+}): number => {
+	const bin = resolveBinSize({ interval, binSize });
+	const rangeEnd = interval === "custom" && end ? end : Date.now();
+	const rangeStart =
+		interval === "custom" && start
+			? start
+			: rangeEnd - (STANDARD_INTERVAL_DAYS[interval] ?? 30) * MS_PER_DAY;
+
+	const alignedStart = alignDown({ ms: rangeStart, binSize: bin });
+
+	let count: number;
+	if (bin === "month") {
+		count = 0;
+		const cursor = new Date(alignedStart);
+		while (cursor.getTime() <= rangeEnd) {
+			count++;
+			cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+		}
+	} else {
+		const step = bin === "hour" ? MS_PER_HOUR : MS_PER_DAY;
+		count = Math.floor((rangeEnd - alignedStart) / step) + 1;
+	}
+
+	return Math.min(Math.max(count, MIN_BARS), MAX_BARS);
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds custom date range selection to Analytics and updates the backend to accept `custom_range`, with a new zero-jank chart skeleton that morphs into the bar chart for smoother loading.

- **New Features**
  - Custom date range in the top bar with a calendar; sets `interval=custom` plus `start`/`end` (epoch ms) and `bin_size=day`.
  - Backend accepts `custom_range` for aggregate and raw event queries, validates start < end, and uses UTC handling (`UTCDate`).
  - New `ChartSkeleton` and `SkeletonBar` animate into the final bars, respect reduced motion, and match chart layout using shared geometry.
  - Unified chart geometry in `utils/chartGeometry` (`CHART_MARGIN`, `Y_AXIS_WIDTH`, insets cache, `predictBarCount`); `EventsBarChart` measures and reports plot insets via `ResizeObserver`.

- **Refactors**
  - Introduced `useAnalyticsQueryState` (URL-synced via `nuqs`) for `interval`, `bin_size`, `start`, and `end`; removed interval/bin-size state from context.
  - Updated data hooks to send either `interval` or `custom_range` and to delay queries until prerequisites load; disabled Recharts bar animation to reduce flicker.
  - Minor UI polish: animated reveal with `motion`, improved empty state, and legend remains layout-stable during loading.

<sup>Written for commit c2e6326c4122d847ae3f3b0d36b9b5cfbd39af63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the analytics system with two features: a custom date-range picker for analytics queries (backed by epoch-ms `start`/`end` URL params via `nuqs`) and an animated chart skeleton that morphs into the real chart using geometry constants shared between recharts and the skeleton layout.

- **Improvements**: New `useAnalyticsQueryState` hook centralises interval/bin_size/start/end as URL state; `ChartSkeleton`+`SkeletonBar` implement a breathing → settled bar animation that aligns pixel-perfectly with the real chart using `chartGeometry.ts` constants.
- **Improvements**: `handleInternalAggregateEvents` and `handleInternalListRawEvents` accept `custom_range: { start, end }` (epoch ms), validated by Zod; `listRawEvents` wraps the values in `UTCDate` and short-circuits existing interval logic when a custom range is present.
- **API changes**: Both `/query/events` and `/query/raw` now accept an optional `custom_range` object; when sent, `interval` is omitted by the client.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the custom-range feature is well-guarded by Zod validation server-side and the UI prevents the invalid state in normal usage.

The core custom-range and skeleton-morph logic is solid. The only concern is that when interval=custom arrives at the server without an accompanying custom_range (reachable through URL manipulation or an unexpected navigation edge case), both aggregation actions receive interval: 'custom' with no date bounds, which may produce an empty or erroneous response.

useAnalyticsData.tsx — the fallback when interval=custom but start/end are absent; handleInternalAggregateEvents.ts — same path server-side where customRange collapses to undefined.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/internalHandlers/handleInternalAggregateEvents.ts | Accepts custom_range in the Zod schema and forwards it early in the customRange IIFE; when interval="custom" but custom_range is absent the IIFE returns undefined, which may produce unexpected query behaviour. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsQueryState.tsx | New nuqs-backed hook for URL-synced interval/bin_size/start/end; start and end default to null when absent from URL, so interval=custom without dates is a reachable edge-case invalid state. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | Migrated from raw searchParams reads to useAnalyticsQueryState; adds isReady guard to prevent premature queries and correctly omits interval when custom_range is present. |
| vite/src/views/customers/customer/analytics/components/ChartSkeleton.tsx | New component providing a bar-count-aware animated skeleton; hardcodes X_LABELS=7 for x-axis placeholders regardless of actual bar count. |
| vite/src/views/customers/customer/analytics/utils/chartGeometry.ts | New utility consolidating chart geometry constants; bandGridStyle math correctly mirrors recharts barCategoryGap="10%" layout. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant QueryTopbar
    participant useAnalyticsQueryState
    participant useAnalyticsData
    participant Server

    User->>QueryTopbar: Select custom range (calendar)
    QueryTopbar->>useAnalyticsQueryState: "setQueryStates({interval:custom, start, end})"
    useAnalyticsQueryState-->>QueryTopbar: URL updated
    QueryTopbar->>useAnalyticsData: re-render with new queryStates
    useAnalyticsData->>Server: "POST /query/events {custom_range, interval: undefined}"
    Server->>Server: custom_range present, skip STANDARD_INTERVAL_DAYS
    Server-->>useAnalyticsData: events data
    useAnalyticsData-->>QueryTopbar: "queryLoading=false, chartData ready"
    Note over QueryTopbar: ChartSkeleton settles to barFractions
    Note over QueryTopbar: motion.div fades in real chart after 0.55s
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx:38-39
**`interval=custom` without dates reaches the server**

When `start` or `end` is missing from the URL while `interval` is `"custom"` (e.g. direct URL manipulation, a browser history quirk, or a lost state transition), `customRange` is `undefined` but `postBody.interval` is still `"custom"`. The server's `STANDARD_INTERVAL_DAYS` lookup returns `undefined` for `"custom"`, so `customRange` in `handleInternalAggregateEvents` collapses to `undefined` too, and `interval: "custom"` propagates into both aggregation actions — where `getIntervalType("custom")` may fail or silently produce an empty range. The same pattern exists in `useRawAnalyticsData` at line 151. Adding a fallback (e.g. sending the default `"30d"` interval when the custom range is incomplete) would prevent this from reaching the server.

### Issue 2 of 3
vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx:110
Including `data` in the `useLayoutEffect` dependency array causes the `ResizeObserver` to be disconnected and recreated on every data update. Geometry doesn't change with data — only the chart dimensions matter — so `data` is an unnecessary dep here. Removing it means only `onGeometry` (a stable `useCallback`) triggers recreation, avoiding repeated observer churn.

```suggestion
	}, [onGeometry]);
```

### Issue 3 of 3
vite/src/views/customers/customer/analytics/components/ChartSkeleton.tsx:15
`X_LABELS` is hardcoded to 7 regardless of the actual bar count, which can range from 6 to 366. Deriving the label count from `barCount` (capped at 7) keeps the skeleton more faithful to the settled state.

```suggestion
const X_LABELS = Math.min(barCount, 7);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1779 from useautumn/..."](https://github.com/useautumn/autumn/commit/c2e6326c4122d847ae3f3b0d36b9b5cfbd39af63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35168433)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->