### PR TITLE
Charlie/recalculate balances

### DIFF
--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -40,6 +40,8 @@ import {
 	type Operations,
 	type OrgConfig,
 	type ProductItem,
+	type RecalculateBalanceParamsV0,
+	type RecalculateBalancePreview,
 	type RestoreParamsV1,
 	type RestoreResponse,
 	type RewardRedemption,
@@ -182,7 +184,8 @@ export class AutumnInt {
 
 			if (parsed && typeof parsed === "object") {
 				throw new AutumnError({
-					message: parsed.message ?? `request failed (status ${response.status})`,
+					message:
+						parsed.message ?? `request failed (status ${response.status})`,
 					code: parsed.code ?? ErrCode.InternalError,
 				});
 			}
@@ -1089,6 +1092,16 @@ export class AutumnInt {
 		delete: async (params: DeleteBalanceParamsV0) => {
 			const data = await this.post(`/balances.delete`, params);
 			return data;
+		},
+		recalculate: async (params: RecalculateBalanceParamsV0) => {
+			const data = await this.post(`/balances.recalculate`, params);
+			return data;
+		},
+		previewRecalculate: async (
+			params: RecalculateBalanceParamsV0,
+		): Promise<RecalculateBalancePreview> => {
+			const data = await this.post(`/balances.preview_recalculate`, params);
+			return data as RecalculateBalancePreview;
 		},
 		finalize: async (
 			params: FinalizeLockParamsV0,

--- a/server/src/internal/balances/balancesRouter.ts
+++ b/server/src/internal/balances/balancesRouter.ts
@@ -6,6 +6,8 @@ import { handleCreateBalance } from "./handlers/handleCreateBalance.js";
 import { handleDeleteBalance } from "./handlers/handleDeleteBalance.js";
 import { handleFinalizeLock } from "./handlers/handleFinalizeLock.js";
 import { handleListBalances } from "./handlers/handleListBalances.js";
+import { handleRecalculateBalance } from "./handlers/handleRecalculateBalance.js";
+import { handleRecalculateBalancePreview } from "./handlers/handleRecalculateBalancePreview.js";
 import { handleSetUsage } from "./handlers/handleSetUsage.js";
 import { handleTrack } from "./handlers/handleTrack.js";
 import { handleUpdateBalance } from "./handlers/handleUpdateBalance.js";
@@ -16,6 +18,11 @@ export const balancesRouter = new Hono<HonoEnv>();
 balancesRouter.post("/balances/create", ...handleCreateBalance);
 balancesRouter.get("/balances/list", ...handleListBalances);
 balancesRouter.post("/balances/update", ...handleUpdateBalance);
+balancesRouter.post("/balances/recalculate", ...handleRecalculateBalance);
+balancesRouter.post(
+	"/balances/preview_recalculate",
+	...handleRecalculateBalancePreview,
+);
 
 // Track
 balancesRouter.post("/events", ...handleTrack);
@@ -32,6 +39,11 @@ export const balancesRpcRouter = new Hono<HonoEnv>();
 balancesRpcRouter.post("/balances.create", ...handleCreateBalance);
 balancesRpcRouter.post("/balances.update", ...handleUpdateBalance);
 balancesRpcRouter.post("/balances.delete", ...handleDeleteBalance);
+balancesRpcRouter.post("/balances.recalculate", ...handleRecalculateBalance);
+balancesRpcRouter.post(
+	"/balances.preview_recalculate",
+	...handleRecalculateBalancePreview,
+);
 
 balancesRpcRouter.post("/balances.track", ...handleTrack);
 balancesRpcRouter.post("/balances.batch_track", ...handleBatchTrack);

--- a/server/src/internal/balances/deleteBalance/deleteBalance.ts
+++ b/server/src/internal/balances/deleteBalance/deleteBalance.ts
@@ -1,18 +1,17 @@
 import {
 	cusEntsToUsage,
 	type DeleteBalanceParamsV0,
-	findFeatureById,
 	fullCustomerToCustomerEntitlements,
 	isPaidCustomerEntitlement,
 	RecaseError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { executePostgresDeduction } from "@/internal/balances/utils/deduction/executePostgresDeduction";
 import { CusService } from "@/internal/customers/CusService";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
 import { buildCustomerEntitlementFilters } from "../utils/buildCustomerEntitlementFilters";
+import { reapplyFeatureUsageDeduction } from "../utils/reapplyFeatureUsageDeduction";
 
 export const deleteBalance = async ({
 	ctx,
@@ -93,39 +92,16 @@ export const deleteBalance = async ({
 		return;
 	}
 
-	const survivingFullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: customer_id,
-		entityId: entity_id,
-		withEntities: true,
-		withSubs: true,
-	});
-
 	const targetFeatureId = feature_id ?? customerEntitlements[0]?.feature_id;
 	if (!targetFeatureId) {
 		return;
 	}
 
-	const feature = findFeatureById({
-		features: ctx.features,
-		featureId: targetFeatureId,
-		errorOnNotFound: true,
-	});
-
-	await executePostgresDeduction({
+	await reapplyFeatureUsageDeduction({
 		ctx,
-		fullCustomer: survivingFullCustomer,
-		customerId: survivingFullCustomer.id ?? customer_id,
+		customerId: customer_id,
 		entityId: entity_id,
-		deductions: [
-			{
-				feature,
-				deduction: usageToRecalculate,
-			},
-		],
-		options: {
-			alterGrantedBalance: false,
-			overageBehaviour: "allow",
-		},
+		featureId: targetFeatureId,
+		usage: usageToRecalculate,
 	});
 };

--- a/server/src/internal/balances/handlers/handleRecalculateBalance.ts
+++ b/server/src/internal/balances/handlers/handleRecalculateBalance.ts
@@ -1,0 +1,19 @@
+import { RecalculateBalanceParamsV0Schema, Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler";
+import { recalculateBalance } from "../recalculateBalance/recalculateBalance";
+
+export const handleRecalculateBalance = createRoute({
+	scopes: [Scopes.Balances.Write],
+	body: RecalculateBalanceParamsV0Schema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const params = c.req.valid("json");
+
+		await recalculateBalance({
+			ctx,
+			params,
+		});
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/balances/handlers/handleRecalculateBalancePreview.ts
+++ b/server/src/internal/balances/handlers/handleRecalculateBalancePreview.ts
@@ -1,0 +1,19 @@
+import { RecalculateBalanceParamsV0Schema, Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler";
+import { recalculateBalancePreview } from "../recalculateBalance/recalculateBalancePreview";
+
+export const handleRecalculateBalancePreview = createRoute({
+	scopes: [Scopes.Balances.Read],
+	body: RecalculateBalanceParamsV0Schema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const params = c.req.valid("json");
+
+		const preview = await recalculateBalancePreview({
+			ctx,
+			params,
+		});
+
+		return c.json(preview);
+	},
+});

--- a/server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts
+++ b/server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts
@@ -1,0 +1,108 @@
+import {
+	cusEntsToUsage,
+	cusEntToRecalculateScopeKey,
+	cusEntToStartingBalance,
+	type FullCusEntWithFullCusProduct,
+	type FullCustomer,
+	fullCustomerToCustomerEntitlements,
+	getRecalculableScopeKeys,
+	type RecalculateBalanceParamsV0,
+	RecaseError,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { deductFromCusEntsTypescript } from "@/internal/balances/track/deductUtils/deductFromCusEntsTypescript";
+import { CusService } from "@/internal/customers/CusService";
+import { getResetBalancesUpdate } from "@/internal/customers/cusProducts/cusEnts/groupByUtils";
+import { buildCustomerEntitlementFilters } from "../utils/buildCustomerEntitlementFilters";
+
+const resetCusEntInPlace = ({
+	cusEnt,
+}: {
+	cusEnt: FullCusEntWithFullCusProduct;
+}): void => {
+	const resetUpdate = getResetBalancesUpdate({
+		cusEnt,
+		allowance: cusEntToStartingBalance({ cusEnt }) ?? undefined,
+	});
+	if ("entities" in resetUpdate) {
+		cusEnt.entities = resetUpdate.entities;
+	} else {
+		cusEnt.balance = resetUpdate.balance;
+		cusEnt.additional_balance = resetUpdate.additional_balance;
+	}
+	cusEnt.adjustment = 0;
+};
+
+/**
+ * Computes (without persisting) the result of recalculating a customer's
+ * balances for a feature: every matching entitlement is reset to its starting
+ * balance and the total usage is re-applied across them in priority order
+ * (allowing overage). Returns the original entitlements (`before`) and the
+ * recalculated clones (`after`) so callers can persist them or preview the diff.
+ */
+export const computeRecalculateBalance = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: RecalculateBalanceParamsV0;
+}): Promise<{
+	fullCustomer: FullCustomer;
+	entityId: string | undefined;
+	before: FullCusEntWithFullCusProduct[];
+	after: FullCusEntWithFullCusProduct[];
+	totalUsage: number;
+}> => {
+	const { customer_id, entity_id, feature_id } = params;
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customer_id,
+		entityId: entity_id,
+		withEntities: true,
+		withSubs: true,
+	});
+	const before = fullCustomerToCustomerEntitlements({
+		fullCustomer,
+		featureId: feature_id,
+		entity: fullCustomer.entity,
+		customerEntitlementFilters: buildCustomerEntitlementFilters({ params }),
+	});
+	if (before.length === 0) {
+		throw new RecaseError({
+			message: `Balance not found for feature ${feature_id} and customer ${customer_id}`,
+		});
+	}
+	const entityId = fullCustomer.entity?.id ?? undefined;
+	const totalUsage = cusEntsToUsage({ cusEnts: before, entityId });
+	const after = before.map((cusEnt) => structuredClone(cusEnt));
+	const recalculableScopes = getRecalculableScopeKeys({
+		cusEnts: after,
+		entityId,
+	});
+	const scopeGroups = new Map<string, FullCusEntWithFullCusProduct[]>();
+	for (const cusEnt of after) {
+		const key = cusEntToRecalculateScopeKey({ cusEnt });
+		const group = scopeGroups.get(key);
+		if (group) {
+			group.push(cusEnt);
+		} else {
+			scopeGroups.set(key, [cusEnt]);
+		}
+	}
+	for (const [key, group] of scopeGroups) {
+		if (!recalculableScopes.has(key)) {
+			continue;
+		}
+		const scopeUsage = cusEntsToUsage({ cusEnts: group, entityId });
+		for (const cusEnt of group) {
+			resetCusEntInPlace({ cusEnt });
+		}
+		deductFromCusEntsTypescript({
+			cusEnts: group,
+			amountToDeduct: scopeUsage,
+			targetEntityId: entityId,
+			allowOverage: true,
+		});
+	}
+	return { fullCustomer, entityId, before, after, totalUsage };
+};

--- a/server/src/internal/balances/recalculateBalance/recalculateBalance.ts
+++ b/server/src/internal/balances/recalculateBalance/recalculateBalance.ts
@@ -1,0 +1,45 @@
+import type { RecalculateBalanceParamsV0 } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+import { computeRecalculateBalance } from "./computeRecalculateBalance";
+
+/**
+ * Recalculates a customer's balances for a feature by resetting every matching
+ * entitlement to its starting balance and re-applying the total usage across
+ * them in priority order. This redistributes usage so a positive balance
+ * absorbs the overage of a negative one, without deleting any balance. The
+ * aggregate balance is unchanged; only the per-entitlement distribution moves.
+ */
+export const recalculateBalance = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: RecalculateBalanceParamsV0;
+}): Promise<void> => {
+	const { fullCustomer, before, after } = await computeRecalculateBalance({
+		ctx,
+		params,
+	});
+	const afterById = new Map(after.map((cusEnt) => [cusEnt.id, cusEnt]));
+	for (const cusEnt of before) {
+		const updated = afterById.get(cusEnt.id);
+		if (!updated) {
+			continue;
+		}
+		await CusEntService.update({
+			ctx,
+			id: cusEnt.id,
+			updates: {
+				balance: updated.balance ?? 0,
+				entities: updated.entities,
+				adjustment: updated.adjustment ?? 0,
+			},
+		});
+	}
+	await deleteCachedFullCustomer({
+		ctx,
+		customerId: fullCustomer.id ?? "",
+	});
+};

--- a/server/src/internal/balances/recalculateBalance/recalculateBalance.ts
+++ b/server/src/internal/balances/recalculateBalance/recalculateBalance.ts
@@ -23,21 +23,25 @@ export const recalculateBalance = async ({
 		params,
 	});
 	const afterById = new Map(after.map((cusEnt) => [cusEnt.id, cusEnt]));
-	for (const cusEnt of before) {
-		const updated = afterById.get(cusEnt.id);
-		if (!updated) {
-			continue;
+	await ctx.db.transaction(async (tx) => {
+		const txCtx = { ...ctx, db: tx as unknown as typeof ctx.db };
+		for (const cusEnt of before) {
+			const updated = afterById.get(cusEnt.id);
+			if (!updated) {
+				continue;
+			}
+			await CusEntService.update({
+				ctx: txCtx,
+				id: cusEnt.id,
+				updates: {
+					balance: updated.balance ?? 0,
+					additional_balance: updated.additional_balance ?? 0,
+					entities: updated.entities,
+					adjustment: updated.adjustment ?? 0,
+				},
+			});
 		}
-		await CusEntService.update({
-			ctx,
-			id: cusEnt.id,
-			updates: {
-				balance: updated.balance ?? 0,
-				entities: updated.entities,
-				adjustment: updated.adjustment ?? 0,
-			},
-		});
-	}
+	});
 	await deleteCachedFullCustomer({
 		ctx,
 		customerId: fullCustomer.id ?? "",

--- a/server/src/internal/balances/recalculateBalance/recalculateBalancePreview.ts
+++ b/server/src/internal/balances/recalculateBalance/recalculateBalancePreview.ts
@@ -1,0 +1,40 @@
+import {
+	cusEntsToBalance,
+	type RecalculateBalanceParamsV0,
+	type RecalculateBalancePreview,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeRecalculateBalance } from "./computeRecalculateBalance";
+
+/**
+ * Computes a preview of a balance recalculation without persisting anything,
+ * returning the remaining balance per entitlement before and after.
+ */
+export const recalculateBalancePreview = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: RecalculateBalanceParamsV0;
+}): Promise<RecalculateBalancePreview> => {
+	const { before, after, entityId, totalUsage } =
+		await computeRecalculateBalance({ ctx, params });
+	const afterById = new Map(after.map((cusEnt) => [cusEnt.id, cusEnt]));
+	const entitlements = before.map((cusEnt) => {
+		const updated = afterById.get(cusEnt.id) ?? cusEnt;
+		return {
+			customer_entitlement_id: cusEnt.id,
+			before_remaining: cusEntsToBalance({
+				cusEnts: [cusEnt],
+				entityId,
+				withRollovers: true,
+			}),
+			after_remaining: cusEntsToBalance({
+				cusEnts: [updated],
+				entityId,
+				withRollovers: true,
+			}),
+		};
+	});
+	return { total_usage: totalUsage, entitlements };
+};

--- a/server/src/internal/balances/utils/reapplyFeatureUsageDeduction.ts
+++ b/server/src/internal/balances/utils/reapplyFeatureUsageDeduction.ts
@@ -1,0 +1,51 @@
+import { findFeatureById } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { executePostgresDeduction } from "@/internal/balances/utils/deduction/executePostgresDeduction";
+import { CusService } from "@/internal/customers/CusService";
+
+/**
+ * Re-applies a feature's total usage across a customer's balances after those
+ * balances have been mutated (e.g. a balance was deleted or reset). Reloads the
+ * customer to capture the mutated state, then redistributes the usage across the
+ * remaining entitlements in priority order, allowing overage.
+ */
+export const reapplyFeatureUsageDeduction = async ({
+	ctx,
+	customerId,
+	entityId,
+	featureId,
+	usage,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	entityId?: string;
+	featureId: string;
+	usage: number;
+}): Promise<void> => {
+	if (usage === 0) {
+		return;
+	}
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		entityId,
+		withEntities: true,
+		withSubs: true,
+	});
+	const feature = findFeatureById({
+		features: ctx.features,
+		featureId,
+		errorOnNotFound: true,
+	});
+	await executePostgresDeduction({
+		ctx,
+		fullCustomer,
+		customerId: fullCustomer.id ?? customerId,
+		entityId,
+		deductions: [{ feature, deduction: usage }],
+		options: {
+			alterGrantedBalance: false,
+			overageBehaviour: "allow",
+		},
+	});
+};

--- a/server/tests/integration/balances/recalculate/recalculate-balance.test.ts
+++ b/server/tests/integration/balances/recalculate/recalculate-balance.test.ts
@@ -1,0 +1,653 @@
+import { expect, test } from "bun:test";
+import type {
+	CheckResponseV2,
+	RecalculateBalancePreview,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// Preview returns the projected remaining per entitlement; these helpers sum
+// the before/after sides so tests can assert conservation without depending on
+// per-balance ordering.
+const sumBefore = (preview: RecalculateBalancePreview) =>
+	preview.entitlements.reduce((sum, entry) => sum + entry.before_remaining, 0);
+const sumAfter = (preview: RecalculateBalancePreview) =>
+	preview.entitlements.reduce((sum, entry) => sum + entry.after_remaining, 0);
+
+// Map a check response's breakdown to { balanceId: current_balance } so tests
+// can compare distribution without depending on breakdown ordering.
+const breakdownById = (check: CheckResponseV2) =>
+	Object.fromEntries(
+		(check.balance?.breakdown ?? []).map((entry) => [
+			entry.id,
+			entry.current_balance,
+		]),
+	);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-1: An overdrawn balance is healed by redistributing its
+// usage onto a sibling balance that still has remaining.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-1: overage is redistributed onto a positive balance")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-1",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+
+		// Drive balance-a into overage (usage 130 on a grant of 100 -> -30).
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		// Preview: total usage 130, aggregate remaining conserved at 170, and the
+		// overdrawn balance recovers while no balance is left negative.
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(130);
+		expect(preview.entitlements).toHaveLength(2);
+		expect(sumBefore(preview)).toBe(170);
+		expect(sumAfter(preview)).toBe(170);
+		for (const entry of preview.entitlements) {
+			expect(entry.after_remaining).toBeGreaterThanOrEqual(0);
+		}
+		expect(
+			preview.entitlements.some(
+				(entry) => entry.after_remaining > entry.before_remaining,
+			),
+		).toBe(true);
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		// Aggregate remaining is unchanged and nothing is in overage anymore.
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(check.balance?.current_balance).toBe(170);
+		for (const entry of check.balance?.breakdown ?? []) {
+			expect(entry.current_balance).toBeGreaterThanOrEqual(0);
+		}
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-2: Recalculation nets a sibling's overage into the
+// displayed remaining, so the aggregate reflects the true
+// (granted - usage) remaining afterwards.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-2: nets overage into the displayed remaining")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-2",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		// Before: balance-a's overage is not netted against balance-b, so the
+		// displayed remaining is inflated (200 rather than the true 170).
+		const before = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		const after = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		// Recalculation reduces the inflated remaining to the true remaining.
+		expect(after.balance?.current_balance).toBeLessThan(
+			before.balance?.current_balance ?? 0,
+		);
+		expect(after.balance?.current_balance).toBe(sumAfter(preview));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-3: The preview endpoint returns the projected diff and
+// does NOT persist any changes.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-3: preview returns the diff without persisting")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-3",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		const before = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(130);
+		expect(preview.entitlements).toHaveLength(2);
+		expect(sumAfter(preview)).toBe(sumBefore(preview));
+		expect(
+			preview.entitlements.some(
+				(entry) => entry.before_remaining !== entry.after_remaining,
+			),
+		).toBe(true);
+
+		// Nothing was written: the on-disk distribution is identical.
+		const after = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(breakdownById(after)).toEqual(breakdownById(before));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-4: When balances are already distributed (no overage),
+// recalculation is a no-op and the preview reports no changes.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-4: no overage is a no-op")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-4",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+
+		const before = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(0);
+		for (const entry of preview.entitlements) {
+			expect(entry.after_remaining).toBe(entry.before_remaining);
+		}
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		const after = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(breakdownById(after)).toEqual(breakdownById(before));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-5: Recalculating a feature with no balances errors.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-5: missing balance returns an error")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-5",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await expectAutumnError({
+			func: async () => {
+				await autumnV2.balances.recalculate({
+					customer_id: customerId,
+					feature_id: TestFeature.Messages,
+				});
+			},
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-6: When total usage exceeds total grant, the residual
+// overage is consolidated onto a single balance and the aggregate is
+// still conserved.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-6: residual overage is consolidated when usage exceeds grant")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-6",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 50,
+			balance_id: "balance-b",
+		});
+		// Total grant 150, total usage 170 -> aggregate remaining -20.
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 40,
+			balance_id: "balance-b",
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(170);
+		expect(preview.entitlements).toHaveLength(2);
+		expect(sumAfter(preview)).toBe(-20);
+		expect(sumBefore(preview)).toBe(-20);
+		// The overage is consolidated onto exactly one balance.
+		expect(
+			preview.entitlements.filter((entry) => entry.after_remaining < 0),
+		).toHaveLength(1);
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		// Re-previewing the now-recalculated state shows nothing left to do.
+		const rerun = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		for (const entry of rerun.entitlements) {
+			expect(entry.after_remaining).toBe(entry.before_remaining);
+		}
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-7: Redistribution works across three balances.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-7: redistributes across three balances")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-7",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		for (const balanceId of ["balance-a", "balance-b", "balance-c"]) {
+			await autumnV2.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				included_grant: 100,
+				balance_id: balanceId,
+			});
+		}
+
+		// balance-a overdrawn to -30.
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(130);
+		expect(preview.entitlements).toHaveLength(3);
+		expect(sumBefore(preview)).toBe(170);
+		expect(sumAfter(preview)).toBe(170);
+		for (const entry of preview.entitlements) {
+			expect(entry.after_remaining).toBeGreaterThanOrEqual(0);
+		}
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(check.balance?.current_balance).toBe(170);
+		for (const entry of check.balance?.breakdown ?? []) {
+			expect(entry.current_balance).toBeGreaterThanOrEqual(0);
+		}
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-8: Recalculation is idempotent - running it again does
+// not change an already-balanced feature.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-8: recalculation is idempotent")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-8",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const first = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const second = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		expect(breakdownById(second)).toEqual(breakdownById(first));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-9: Redistribution stays within scope - a customer-level
+// overage is NOT absorbed by an entity-scoped balance.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-9: redistribution stays within entity scope")}`,
+	async () => {
+		const { customerId, autumnV2, entities } = await initScenario({
+			customerId: "recalc-9",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [],
+		});
+		const entityId = entities[0].id;
+
+		// Customer-level: one overdrawn (-30), one with remaining (200).
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "cust-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "cust-b",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "cust-a",
+		});
+
+		// Entity-scoped: partially used and positive (no overage in this scope).
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			entity_id: entityId,
+			included_grant: 100,
+			balance_id: "ent-a",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			entity_id: entityId,
+			current_balance: 60,
+			balance_id: "ent-a",
+		});
+
+		const entityBefore = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			entity_id: entityId,
+			skip_cache: true,
+		});
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		// The entity-owned balance itself is untouched - the customer-level
+		// overage was not absorbed by it. (The entity-level aggregate also
+		// reflects shared customer balances, so we target ent-a specifically.)
+		const entityAfter = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			entity_id: entityId,
+			skip_cache: true,
+		});
+		expect(breakdownById(entityAfter)["ent-a"]).toBe(
+			breakdownById(entityBefore)["ent-a"],
+		);
+		expect(breakdownById(entityAfter)["ent-a"]).toBe(60);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-10: A fully-used balance (remaining 0, not overdrawn)
+// next to positive balances is NOT recalculable - there is no overage to
+// absorb, so the preview reports no changes ("already up to date").
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-10: a fully-used balance alongside positives is a no-op")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-10",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 500,
+			balance_id: "balance-c",
+		});
+
+		// balance-a is fully used (remaining 0) but NOT overdrawn; balance-c is
+		// partially used but still positive.
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 200,
+			balance_id: "balance-c",
+		});
+
+		const before = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		// No scope has an overage, so the preview reports no changes.
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		for (const entry of preview.entitlements) {
+			expect(entry.after_remaining).toBe(entry.before_remaining);
+		}
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		const after = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(breakdownById(after)).toEqual(breakdownById(before));
+	},
+);

--- a/shared/api/balances/index.ts
+++ b/shared/api/balances/index.ts
@@ -2,4 +2,5 @@ export * from "./common/lockParams";
 export * from "./create/index";
 export * from "./delete/index";
 export * from "./finalizeLock/index";
+export * from "./recalculate/index";
 export * from "./update/index";

--- a/shared/api/balances/recalculate/index.ts
+++ b/shared/api/balances/recalculate/index.ts
@@ -1,0 +1,2 @@
+export * from "./recalculateBalanceParams.js";
+export * from "./recalculateBalancePreview.js";

--- a/shared/api/balances/recalculate/recalculateBalanceParams.ts
+++ b/shared/api/balances/recalculate/recalculateBalanceParams.ts
@@ -1,0 +1,21 @@
+import { z } from "zod/v4";
+import { ResetInterval } from "../../..";
+export const RecalculateBalanceParamsV0Schema = z.object({
+	customer_id: z.string().meta({
+		description: "The ID of the customer.",
+	}),
+	feature_id: z.string().meta({
+		description: "The ID of the feature whose balances should be recalculated.",
+	}),
+	entity_id: z.string().optional().meta({
+		description: "The ID of the entity.",
+	}),
+	interval: z.enum(ResetInterval).optional().meta({
+		description:
+			"Target balances with a specific reset interval. Use when the customer has multiple balances for the same feature with different reset intervals.",
+	}),
+});
+
+export type RecalculateBalanceParamsV0 = z.infer<
+	typeof RecalculateBalanceParamsV0Schema
+>;

--- a/shared/api/balances/recalculate/recalculateBalancePreview.ts
+++ b/shared/api/balances/recalculate/recalculateBalancePreview.ts
@@ -1,0 +1,10 @@
+export interface RecalculateBalanceEntitlementPreview {
+	customer_entitlement_id: string;
+	before_remaining: number;
+	after_remaining: number;
+}
+
+export interface RecalculateBalancePreview {
+	total_usage: number;
+	entitlements: RecalculateBalanceEntitlementPreview[];
+}

--- a/shared/utils/cusEntUtils/balanceUtils/recalculateScopeUtils.ts
+++ b/shared/utils/cusEntUtils/balanceUtils/recalculateScopeUtils.ts
@@ -1,0 +1,65 @@
+import type { FullCusEntWithFullCusProduct } from "../../../models/cusProductModels/cusEntModels/cusEntWithProduct";
+import { cusEntsToBalance } from "./cusEntsToBalance";
+
+export const RECALCULATE_CUSTOMER_SCOPE = "__customer__";
+
+/**
+ * Balances are only ever recalculated against siblings with the same scope: a
+ * balance owned by an entity stays within that entity, and customer-level
+ * balances stay at the customer level.
+ */
+export const cusEntToRecalculateScopeKey = ({
+	cusEnt,
+}: {
+	cusEnt: FullCusEntWithFullCusProduct;
+}): string =>
+	cusEnt.internal_entity_id ??
+	cusEnt.customer_product?.internal_entity_id ??
+	RECALCULATE_CUSTOMER_SCOPE;
+
+/**
+ * Returns the scope keys that can be recalculated - i.e. scopes that contain
+ * both an overdrawn balance and a balance with remaining to absorb it. Uses the
+ * main balance (not rollovers) because recalculation redistributes the main
+ * balance, so this matches exactly what a recalculation would change. Shared by
+ * the dashboard (to decide whether to offer the action) and the backend (to
+ * decide which scopes to redistribute) so the two never disagree.
+ */
+export const getRecalculableScopeKeys = ({
+	cusEnts,
+	entityId,
+}: {
+	cusEnts: FullCusEntWithFullCusProduct[];
+	entityId?: string;
+}): Set<string> => {
+	const scopes = new Map<
+		string,
+		{ hasNegative: boolean; hasPositive: boolean }
+	>();
+	for (const cusEnt of cusEnts) {
+		const key = cusEntToRecalculateScopeKey({ cusEnt });
+		const scope = scopes.get(key) ?? {
+			hasNegative: false,
+			hasPositive: false,
+		};
+		const remaining = cusEntsToBalance({ cusEnts: [cusEnt], entityId });
+		if (remaining < 0) scope.hasNegative = true;
+		if (remaining > 0) scope.hasPositive = true;
+		scopes.set(key, scope);
+	}
+	const recalculable = new Set<string>();
+	for (const [key, scope] of scopes) {
+		if (scope.hasNegative && scope.hasPositive) {
+			recalculable.add(key);
+		}
+	}
+	return recalculable;
+};
+
+export const hasRecalculableScope = ({
+	cusEnts,
+	entityId,
+}: {
+	cusEnts: FullCusEntWithFullCusProduct[];
+	entityId?: string;
+}): boolean => getRecalculableScopeKeys({ cusEnts, entityId }).size > 0;

--- a/shared/utils/cusEntUtils/index.ts
+++ b/shared/utils/cusEntUtils/index.ts
@@ -19,6 +19,7 @@ export * from "./balanceUtils/customerEntitlementToBalancePrice";
 export * from "./balanceUtils/grantedBalanceUtils/cusEntsToAdjustment";
 export * from "./balanceUtils/grantedBalanceUtils/cusEntsToAllowance";
 export * from "./balanceUtils/grantedBalanceUtils/cusEntsToGrantedBalance";
+export * from "./balanceUtils/recalculateScopeUtils";
 export * from "./balanceUtils/rollovers/cusEntsToRolloverBalance";
 export * from "./balanceUtils/rollovers/cusEntsToRolloverGranted";
 export * from "./balanceUtils/rollovers/cusEntsToRolloverUsage";

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -142,7 +142,19 @@ export function InvoiceDetailSheet({
 
 			const productId = productKey === "__unknown__" ? null : productKey;
 			const product = products?.find((p) => p.id === productId);
-			const productName = product?.name ?? productId ?? "Unknown Product";
+			const invoiceProductId =
+				!productId && invoice?.product_ids?.length === 1
+					? invoice.product_ids[0]
+					: null;
+			const invoiceProduct = invoiceProductId
+				? products?.find((p) => p.id === invoiceProductId)
+				: undefined;
+			const productName =
+				product?.name ??
+				invoiceProduct?.name ??
+				productId ??
+				invoiceProductId ??
+				"Custom Item";
 
 			result.push({
 				productId,
@@ -152,7 +164,7 @@ export function InvoiceDetailSheet({
 		}
 
 		return result;
-	}, [lineItems, features, products]);
+	}, [lineItems, features, products, invoice?.product_ids]);
 
 	if (!invoice) return null;
 

--- a/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
@@ -137,11 +137,19 @@ export function BalanceRecalculateDialog({
 					</div>
 				)}
 
-				{!preview.isFetching && changedRows.length === 0 && (
-					<p className="text-sm text-tertiary-foreground">
-						These balances are already up to date.
+				{!preview.isFetching && preview.isError && (
+					<p className="text-sm text-red-600 dark:text-red-400">
+						Couldn't load the preview. Please try again.
 					</p>
 				)}
+
+				{!preview.isFetching &&
+					!preview.isError &&
+					changedRows.length === 0 && (
+						<p className="text-sm text-tertiary-foreground">
+							These balances are already up to date.
+						</p>
+					)}
 
 				<DialogFooter>
 					<ShortcutButton

--- a/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
@@ -1,0 +1,161 @@
+import {
+	type Entity,
+	type FullCusEntWithFullCusProduct,
+	fullCustomerToCustomerEntitlements,
+	numberWithCommas,
+} from "@autumn/shared";
+import { UserIcon } from "@phosphor-icons/react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ShortcutButton } from "@/components/v2/buttons/ShortcutButton";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { cn } from "@/lib/utils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { getCustomerBalanceSourceParts } from "./customerBalanceUtils";
+import { useRecalculateBalancePreview } from "./useRecalculateBalancePreview";
+import { useRecalculateBalances } from "./useRecalculateBalances";
+
+export function BalanceRecalculateDialog({
+	balance,
+	entityId,
+	open,
+	onOpenChange,
+}: {
+	balance: FullCusEntWithFullCusProduct | null;
+	entityId: string | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const { customer } = useCusQuery();
+	const preview = useRecalculateBalancePreview({
+		balance,
+		entityId,
+		enabled: open,
+	});
+	const { mutate, isPending } = useRecalculateBalances({ entityId });
+
+	const entities: Entity[] = customer?.entities ?? [];
+	const selectedEntity = entities.find(
+		(entity) => entity.id === entityId || entity.internal_id === entityId,
+	);
+	const ents =
+		balance && customer
+			? fullCustomerToCustomerEntitlements({
+					fullCustomer: customer,
+					featureId: balance.entitlement.feature.id,
+					entity: selectedEntity,
+				})
+			: [];
+	const entById = new Map(ents.map((ent) => [ent.id, ent]));
+	const changedRows = (preview.data?.entitlements ?? []).filter(
+		(row) => row.before_remaining !== row.after_remaining,
+	);
+	const featureName = balance?.entitlement.feature.name ?? "this feature";
+
+	const handleConfirm = () => {
+		if (!balance) return;
+		mutate({ balance }, { onSuccess: () => onOpenChange(false) });
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>Recalculate {featureName}</DialogTitle>
+					<DialogDescription>
+						Usage is redistributed so balances with remaining absorb the
+						overage. The total stays the same.
+					</DialogDescription>
+				</DialogHeader>
+
+				{preview.isFetching && (
+					<div className="divide-y divide-border/60 overflow-hidden rounded-lg border border-border/60">
+						<div className="flex items-center justify-between gap-4 px-3 py-2">
+							<Skeleton className="h-4 w-40" />
+							<Skeleton className="h-4 w-12" />
+						</div>
+						<div className="flex items-center justify-between gap-4 px-3 py-2">
+							<Skeleton className="h-4 w-28" />
+							<Skeleton className="h-4 w-12" />
+						</div>
+					</div>
+				)}
+
+				{!preview.isFetching && changedRows.length > 0 && (
+					<div className="divide-y divide-border/60 overflow-hidden rounded-lg border border-border/60">
+						{changedRows.map((row) => {
+							const ent = entById.get(row.customer_entitlement_id);
+							const parts = ent
+								? getCustomerBalanceSourceParts({ balance: ent, entities })
+								: null;
+							const label = parts
+								? [parts.productName, parts.intervalLabel]
+										.filter(Boolean)
+										.join(" · ")
+								: row.customer_entitlement_id;
+							const isIncrease = row.after_remaining > row.before_remaining;
+							return (
+								<div
+									key={row.customer_entitlement_id}
+									className="flex items-center justify-between gap-4 px-3 py-2"
+								>
+									<div className="flex min-w-0 items-center gap-2">
+										<span className="truncate text-sm text-muted-foreground">
+											{label}
+										</span>
+										{parts?.entityName && (
+											<span className="text-tiny-id inline-flex shrink-0 items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-muted-foreground">
+												<UserIcon size={10} weight="bold" />
+												{parts.entityName}
+											</span>
+										)}
+									</div>
+									<div className="flex shrink-0 items-center gap-2 text-sm tabular-nums">
+										<span className="text-tertiary-foreground line-through">
+											{numberWithCommas(row.before_remaining)}
+										</span>
+										<span
+											className={cn(
+												"font-medium",
+												isIncrease
+													? "text-emerald-600 dark:text-emerald-400"
+													: "text-red-600 dark:text-red-400",
+											)}
+										>
+											{numberWithCommas(row.after_remaining)}
+										</span>
+									</div>
+								</div>
+							);
+						})}
+					</div>
+				)}
+
+				{!preview.isFetching && changedRows.length === 0 && (
+					<p className="text-sm text-tertiary-foreground">
+						These balances are already up to date.
+					</p>
+				)}
+
+				<DialogFooter>
+					<ShortcutButton
+						variant="primary"
+						metaShortcut="enter"
+						onClick={handleConfirm}
+						isLoading={isPending}
+						disabled={preview.isFetching || changedRows.length === 0}
+						className="w-full"
+					>
+						Recalculate
+					</ShortcutButton>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -6,6 +6,7 @@ import { useCustomerBalanceSheetStore } from "@/hooks/stores/useCustomerBalanceS
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
+import { BalanceRecalculateDialog } from "./BalanceRecalculateDialog";
 import { CustomerBalanceTableColumns } from "./CustomerBalanceTableColumns";
 
 export type CustomerBalanceRowData = FullCusEntWithFullCusProduct & {
@@ -34,6 +35,9 @@ export function CustomerBalanceTable({
 	const selectedFeatureId = useCustomerBalanceSheetStore((s) => s.featureId);
 
 	const [expanded, setExpanded] = useState<ExpandedState>({});
+	const [recalcBalance, setRecalcBalance] =
+		useState<FullCusEntWithFullCusProduct | null>(null);
+	const [recalcOpen, setRecalcOpen] = useState(false);
 
 	const rowData: CustomerBalanceRowData[] = useMemo(() => {
 		return allEnts.map((ent) => {
@@ -75,6 +79,10 @@ export function CustomerBalanceTable({
 							featureName: balance.entitlement.feature.name,
 						},
 					}),
+				onRecalculateClick: (balance) => {
+					setRecalcBalance(balance);
+					setRecalcOpen(true);
+				},
 			}),
 		[customer, entityId, setSheet],
 	);
@@ -134,22 +142,30 @@ export function CustomerBalanceTable({
 	};
 
 	return (
-		<Table.Provider
-			config={{
-				table,
-				numberOfColumns: columns.length,
-				enableSorting: false,
-				isLoading,
-				onRowClick: handleRowClick,
-				flexibleTableColumns: true,
-				selectedItemId: getSelectedRowId(),
-			}}
-		>
-			<Table.Container>
-				<Table.Content>
-					<Table.Body />
-				</Table.Content>
-			</Table.Container>
-		</Table.Provider>
+		<>
+			<Table.Provider
+				config={{
+					table,
+					numberOfColumns: columns.length,
+					enableSorting: false,
+					isLoading,
+					onRowClick: handleRowClick,
+					flexibleTableColumns: true,
+					selectedItemId: getSelectedRowId(),
+				}}
+			>
+				<Table.Container>
+					<Table.Content>
+						<Table.Body />
+					</Table.Content>
+				</Table.Container>
+			</Table.Provider>
+			<BalanceRecalculateDialog
+				balance={recalcBalance}
+				entityId={entityId}
+				open={recalcOpen}
+				onOpenChange={setRecalcOpen}
+			/>
+		</>
 	);
 }

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -14,6 +14,7 @@ import {
 	nullish,
 } from "@autumn/shared";
 import {
+	ArrowsClockwiseIcon,
 	BoxArrowDownIcon,
 	BracketsSquareIcon,
 	CaretRightIcon,
@@ -45,6 +46,7 @@ import { FeatureBalanceDisplay } from "../customer-feature-usage/FeatureBalanceD
 import type { CustomerBalanceRowData } from "./CustomerBalanceTable";
 import {
 	canDeleteCustomerBalance,
+	canRecalculateCustomerBalances,
 	getCustomerBalanceSourceParts,
 } from "./customerBalanceUtils";
 
@@ -360,22 +362,37 @@ function BarCell({
 
 function BalanceActionsCell({
 	row,
+	fullCustomer,
+	entityId,
 	onDeleteClick,
 	onRecordUsageClick,
 	onCheckBalanceClick,
+	onRecalculateClick,
 }: {
 	row: Row<CustomerBalanceRowData>;
+	fullCustomer: FullCustomer | null | undefined;
+	entityId: string | null;
 	onDeleteClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onRecordUsageClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
+	onRecalculateClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) {
 	const isParentRow = row.depth === 0;
 	const canDelete =
 		!row.getCanExpand() && canDeleteCustomerBalance({ balance: row.original });
 	const canRecordUsage = isParentRow && !!onRecordUsageClick;
 	const canCheckBalance = isParentRow && !!onCheckBalanceClick;
+	const canRecalculate =
+		isParentRow &&
+		!!onRecalculateClick &&
+		canRecalculateCustomerBalances({
+			fullCustomer,
+			featureId: row.original.entitlement.feature.id,
+			entityId,
+		});
 
-	if (!canDelete && !canRecordUsage && !canCheckBalance) return null;
+	if (!canDelete && !canRecordUsage && !canCheckBalance && !canRecalculate)
+		return null;
 
 	return (
 		<div className="flex justify-end">
@@ -410,7 +427,26 @@ function BalanceActionsCell({
 						>
 							<div className="flex w-full items-center justify-between gap-2 text-sm">
 								Check balance
-								<BracketsSquareIcon size={12} className="text-tertiary-foreground" />
+								<BracketsSquareIcon
+									size={12}
+									className="text-tertiary-foreground"
+								/>
+							</div>
+						</DropdownMenuItem>
+					)}
+					{canRecalculate && (
+						<DropdownMenuItem
+							onClick={(event) => {
+								event.stopPropagation();
+								onRecalculateClick(row.original);
+							}}
+						>
+							<div className="flex w-full items-center justify-between gap-2 text-sm">
+								Recalculate balances
+								<ArrowsClockwiseIcon
+									size={12}
+									className="text-tertiary-foreground"
+								/>
 							</div>
 						</DropdownMenuItem>
 					)}
@@ -442,6 +478,7 @@ export const CustomerBalanceTableColumns = ({
 	onDeleteClick,
 	onRecordUsageClick,
 	onCheckBalanceClick,
+	onRecalculateClick,
 }: {
 	fullCustomer: FullCustomer | null | undefined;
 	entityId: string | null;
@@ -449,6 +486,7 @@ export const CustomerBalanceTableColumns = ({
 	onDeleteClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onRecordUsageClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
+	onRecalculateClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) => [
 	{
 		header: "Feature",
@@ -477,7 +515,9 @@ export const CustomerBalanceTableColumns = ({
 									entities,
 								})}
 							>
-								<span className="text-tertiary-foreground truncate text-xs">{metaParts}</span>
+								<span className="text-tertiary-foreground truncate text-xs">
+									{metaParts}
+								</span>
 							</AdminHover>
 						</div>
 					);
@@ -498,7 +538,9 @@ export const CustomerBalanceTableColumns = ({
 								</span>
 							</AdminHover>
 						</div>
-						<span className="text-tertiary-foreground text-xs truncate pl-5.5">{metaParts}</span>
+						<span className="text-tertiary-foreground text-xs truncate pl-5.5">
+							{metaParts}
+						</span>
 					</div>
 				);
 			}
@@ -568,9 +610,12 @@ export const CustomerBalanceTableColumns = ({
 		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => (
 			<BalanceActionsCell
 				row={row}
+				fullCustomer={fullCustomer}
+				entityId={entityId}
 				onDeleteClick={onDeleteClick}
 				onRecordUsageClick={onRecordUsageClick}
 				onCheckBalanceClick={onCheckBalanceClick}
+				onRecalculateClick={onRecalculateClick}
 			/>
 		),
 	},

--- a/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
@@ -4,7 +4,11 @@ import {
 	EntInterval,
 	type Entity,
 	type FullCusEntWithFullCusProduct,
+	type FullCustomer,
+	fullCustomerToCustomerEntitlements,
+	hasRecalculableScope,
 	isPaidCustomerEntitlement,
+	type RecalculateBalanceParamsV0,
 } from "@autumn/shared";
 
 export const getCustomerBalanceId = ({
@@ -79,6 +83,44 @@ export const getCustomerBalanceRemaining = ({
 		entityId: entityId ?? undefined,
 		withRollovers: true,
 	});
+
+export const canRecalculateCustomerBalances = ({
+	fullCustomer,
+	featureId,
+	entityId,
+}: {
+	fullCustomer: FullCustomer | null | undefined;
+	featureId: string;
+	entityId: string | null;
+}) => {
+	if (!fullCustomer) return false;
+	const entity = entityId
+		? fullCustomer.entities?.find(
+				(candidate) =>
+					candidate.id === entityId || candidate.internal_id === entityId,
+			)
+		: undefined;
+	const cusEnts = fullCustomerToCustomerEntitlements({
+		fullCustomer,
+		featureId,
+		entity,
+	});
+	return hasRecalculableScope({ cusEnts, entityId: entity?.id ?? undefined });
+};
+
+export const getRecalculateBalanceParams = ({
+	balance,
+	customerId,
+	entityId,
+}: {
+	balance: FullCusEntWithFullCusProduct;
+	customerId: string;
+	entityId: string | null;
+}): RecalculateBalanceParamsV0 => ({
+	customer_id: customerId,
+	feature_id: balance.entitlement.feature.id,
+	entity_id: entityId ?? undefined,
+});
 
 export const getDeleteBalanceParams = ({
 	balance,

--- a/vite/src/views/customers2/components/table/customer-balance/useRecalculateBalancePreview.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/useRecalculateBalancePreview.ts
@@ -1,0 +1,39 @@
+import type {
+	FullCusEntWithFullCusProduct,
+	RecalculateBalancePreview,
+} from "@autumn/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { getRecalculateBalanceParams } from "./customerBalanceUtils";
+
+export const useRecalculateBalancePreview = ({
+	balance,
+	entityId,
+	enabled,
+}: {
+	balance: FullCusEntWithFullCusProduct | null;
+	entityId: string | null;
+	enabled: boolean;
+}) => {
+	const axiosInstance = useAxiosInstance();
+	const { customer } = useCusQuery();
+	const customerId = customer?.id || customer?.internal_id;
+	const featureId = balance?.entitlement.feature.id;
+	return useQuery({
+		queryKey: ["recalculate-balance-preview", customerId, featureId, entityId],
+		enabled: enabled && !!customerId && !!balance,
+		staleTime: 0,
+		gcTime: 0,
+		queryFn: async (): Promise<RecalculateBalancePreview> => {
+			if (!customerId || !balance) {
+				throw new Error("Customer not found");
+			}
+			const { data } = await axiosInstance.post(
+				"/v1/balances.preview_recalculate",
+				getRecalculateBalanceParams({ balance, customerId, entityId }),
+			);
+			return data;
+		},
+	});
+};

--- a/vite/src/views/customers2/components/table/customer-balance/useRecalculateBalances.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/useRecalculateBalances.ts
@@ -1,0 +1,47 @@
+import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { getRecalculateBalanceParams } from "./customerBalanceUtils";
+
+export const useRecalculateBalances = ({
+	entityId,
+}: {
+	entityId: string | null;
+}) => {
+	const axiosInstance = useAxiosInstance();
+	const { customer, refetch } = useCusQuery();
+	const queryClient = useQueryClient();
+	const buildQueryKey = useQueryKeyFactory();
+	const customerId = customer?.id || customer?.internal_id;
+	return useMutation({
+		mutationFn: async ({
+			balance,
+		}: {
+			balance: FullCusEntWithFullCusProduct;
+		}) => {
+			if (!customerId) {
+				throw new Error("Customer not found");
+			}
+			await axiosInstance.post(
+				"/v1/balances.recalculate",
+				getRecalculateBalanceParams({ balance, customerId, entityId }),
+			);
+		},
+		onSuccess: async () => {
+			toast.success("Balances recalculated");
+			await Promise.all([
+				refetch(),
+				queryClient.invalidateQueries({
+					queryKey: buildQueryKey(["customer", customerId]),
+				}),
+			]);
+		},
+		onError: (error) => {
+			toast.error(getBackendErr(error, "Failed to recalculate balances"));
+		},
+	});
+};

--- a/vite/src/views/customers2/components/table/customer-invoices/getInvoiceProductNames.ts
+++ b/vite/src/views/customers2/components/table/customer-invoices/getInvoiceProductNames.ts
@@ -5,7 +5,7 @@ import type {
 	ProductV2,
 } from "@autumn/shared";
 
-const UNKNOWN_PRODUCT_LABEL = "Unknown Product";
+const UNKNOWN_PRODUCT_LABEL = "Custom Item";
 
 type ProductGroup = {
 	productName: string;
@@ -29,11 +29,13 @@ const getFallbackNames = ({
 const resolveProductName = ({
 	productId,
 	products,
+	invoiceFallback,
 }: {
 	productId: string | null;
 	products: ProductV2[];
+	invoiceFallback?: string;
 }): string => {
-	if (!productId) return UNKNOWN_PRODUCT_LABEL;
+	if (!productId) return invoiceFallback ?? UNKNOWN_PRODUCT_LABEL;
 	return products.find((p) => p.id === productId)?.name ?? productId;
 };
 
@@ -54,6 +56,11 @@ export const getInvoiceProductNames = ({
 	features: Feature[];
 }): string => {
 	if (lineItems.length === 0) return getFallbackNames({ invoice, products });
+	const invoiceFallback =
+		invoice.product_ids.length === 1
+			? (products.find((p) => p.id === invoice.product_ids[0])?.name ??
+				invoice.product_ids[0])
+			: undefined;
 	const groups = new Map<string, ProductGroup>();
 	for (const item of lineItems) {
 		const key = item.product_id ?? "__unknown__";
@@ -63,6 +70,7 @@ export const getInvoiceProductNames = ({
 				productName: resolveProductName({
 					productId: item.product_id,
 					products,
+					invoiceFallback,
 				}),
 				featureNames: new Set<string>(),
 			} satisfies ProductGroup);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds balance recalculation to redistribute feature usage across a customer’s balances without changing the total remaining. Includes a preview API and a UI dialog in the Customer Balance table.

- **New Features**
  - Server: added `balances.recalculate` and `balances.preview_recalculate` routes (REST and RPC). Logic resets matching entitlements, then reapplies total usage in priority order within the same scope (customer vs. entity), allowing overage. Updates are persisted in a single DB transaction and include `additional_balance`. Preview returns per-entitlement before/after and total usage. Autumn client adds `recalculate` and `previewRecalculate`. Shared API types and recalculation utils exported from `@autumn/shared`.
  - UI: “Recalculate balances” action appears only when redistribution is possible. Dialog previews changed rows, shows a clear error state on preview failure, and applies on confirm. New hooks for preview/mutation.
  - Tests: comprehensive integration tests for redistribution, conservation, idempotency, scope isolation, residual overage, and no-op cases.

- **Refactors**
  - `deleteBalance` now re-applies feature usage via `reapplyFeatureUsageDeduction` to ensure remaining balances reflect true usage.
  - Invoice product naming improved: fallback label changed to “Custom Item” and uses `invoice.product_ids` when available.

<sup>Written for commit e7163f6dfd13ba64ec3564227919e6d060811b9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `recalculate` endpoint (and a side-effect-free `preview_recalculate` counterpart) that redistributes a customer's feature usage across their balances so that overdrawn ones are healed by absorbing from siblings with remaining capacity. A matching dashboard dialog surfaces the preview diff before the user commits.

- **[Improvements]** New `computeRecalculateBalance` shared core (reset → re-deduct in-memory) with a clean preview/apply split; 10-scenario integration test suite covering overage redistribution, idempotency, scope isolation, and error cases.
- **[Improvements]** `deleteBalance` simplified by extracting the reload-and-reapply pattern into the new `reapplyFeatureUsageDeduction` helper.
- **[API changes]** Two new RPC endpoints (`/balances.recalculate`, `/balances.preview_recalculate`) with corresponding `RecalculateBalanceParamsV0` schema and `RecalculateBalancePreview` response type; both are registered on the public router and exposed via `AutumnInt`.
</details>

<h3>Confidence Score: 3/5</h3>

The recalculate write path has two correctness gaps in its persist step that could silently corrupt balance aggregates for customers with rollovers or if any update in the batch fails.

The persist loop in `recalculateBalance.ts` runs N sequential non-transactional DB writes. A mid-flight failure leaves some balances redistributed and others at their original values, breaking the invariant that recalculation is aggregate-neutral. Separately, `resetCusEntInPlace` explicitly sets `additional_balance` as part of the reset computation, but the `CusEntService.update` call omits that field; for any entitlement carrying rollover or manual-adjustment credits, the post-recalculation DB total will be higher than what the computation intended. Both issues are on the hot path for every recalculate call.

`server/src/internal/balances/recalculateBalance/recalculateBalance.ts` needs the most attention — both the missing transaction wrapper and the `additional_balance` omission are there.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/recalculateBalance/recalculateBalance.ts | Core persist step: omits `additional_balance` from updates and runs sequential non-transactional DB writes — two distinct correctness issues. |
| server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts | New pure-compute entry point: resets each entitlement in-memory then redistributes scope usage via structuredClone + in-memory deduction. Logic looks correct; scope isolation and idempotency are well-handled. |
| server/src/internal/balances/utils/buildCustomerEntitlementFilters.ts | Function is called with `RecalculateBalanceParamsV0` but its type signature only accepts `UpdateBalanceParamsV0 | DeleteBalanceParamsV0` — type mismatch. |
| shared/utils/cusEntUtils/balanceUtils/recalculateScopeUtils.ts | New shared scope-key and recalculability utilities; clean logic reused correctly by both backend and frontend. |
| vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx | New dialog renders before/after preview rows but does not distinguish the preview error state from the genuine no-op state. |
| server/src/internal/balances/utils/reapplyFeatureUsageDeduction.ts | Clean extraction of the reload-and-reapply deduction pattern; correctly guards the zero-usage early return. |
| server/tests/integration/balances/recalculate/recalculate-balance.test.ts | Comprehensive 10-scenario integration test suite covering overage redistribution, preview-only semantics, idempotency, entity scope isolation, and error cases. |
| server/src/internal/balances/deleteBalance/deleteBalance.ts | Refactored to delegate post-delete reapplication to the new helper, reducing duplication without changing behavior. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Dashboard UI
    participant API as Balances API
    participant DB as Database
    participant Cache as Customer Cache

    UI->>API: POST /balances.preview_recalculate
    API->>DB: CusService.getFull (customer + entitlements)
    DB-->>API: fullCustomer
    API->>API: computeRecalculateBalance (reset, re-deduct in-memory)
    API-->>UI: RecalculateBalancePreview

    UI->>API: POST /balances.recalculate
    API->>DB: CusService.getFull (customer + entitlements)
    DB-->>API: fullCustomer
    API->>API: computeRecalculateBalance (reset, re-deduct in-memory)
    loop for each cusEnt in before (sequential, no tx)
        API->>DB: CusEntService.update balance, entities, adjustment
    end
    API->>Cache: deleteCachedFullCustomer
    API-->>UI: success true
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/balances/recalculateBalance/recalculateBalance.ts:26-40
**Non-transactional sequential DB updates**

The N sequential `await CusEntService.update()` calls have no wrapping transaction. If any one of them fails partway through (network blip, DB timeout, etc.), the already-committed updates are not rolled back, leaving a mix of redistributed and un-redistributed balances in the DB. The aggregate balance across the scope would then be wrong — the invariant "aggregate is unchanged" would be violated until the next successful recalculation or another write restores it.

### Issue 2 of 3
server/src/internal/balances/recalculateBalance/recalculateBalance.ts:34-38
**`additional_balance` excluded from the persisted update**

`resetCusEntInPlace` explicitly sets `cusEnt.additional_balance = resetUpdate.additional_balance` (resetting it to the starting value, which is typically 0 for the main grant). After `deductFromCusEntsTypescript` runs against the zeroed `additional_balance`, the computed result in `after` reflects that zero. But the `CusEntService.update` call only writes `balance`, `entities`, and `adjustment` — `additional_balance` is omitted.

For any entitlement that has a non-zero `additional_balance` in the DB (e.g. a rollover credit), the DB ends up with the recalculated `balance` but the **original** (non-reset) `additional_balance`. The aggregate for that scope will be over-reported by exactly `sum(original additional_balances)`, quietly breaking the invariant that recalculation is balance-neutral.

### Issue 3 of 3
vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx:140-145
**Preview error state is silently swallowed**

When `preview.isError` is `true`, `preview.data` is `undefined`, so `changedRows` becomes `[]`. The dialog then renders "These balances are already up to date." and a disabled Recalculate button — indistinguishable from the genuine no-op state. A user whose preview fetch failed (e.g. a 500 from the server) will think there is nothing to do and close the dialog without realising the check never succeeded.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update invoice labels"](https://github.com/useautumn/autumn/commit/e4f6dc0c72ab7c50a6f701ad5009a18ea6c12fb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35203502)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->