### PR TITLE
add flat spend_limit usage cap config + cycle-aligned window resolver

### DIFF
--- a/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executePostgresDeductionV2.ts
@@ -116,6 +116,7 @@ export const executePostgresDeductionV2 = async ({
 				fullSubject,
 				deduction,
 				options: resolvedOptions,
+				now: Date.now(),
 			});
 
 			if (customerEntitlements.length === 0 || unlimitedFeatureIds.length > 0) {

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -2,6 +2,7 @@ import {
 	type FullCusEntWithFullCusProduct,
 	type FullSubject,
 	fullSubjectToFullCustomer,
+	notNullish,
 } from "@autumn/shared";
 import type { Redis } from "ioredis";
 import { currentRegion } from "@/external/redis/initRedis.js";
@@ -104,6 +105,10 @@ export const executeRedisDeductionV2 = async ({
 		entityId: fullSubject.entityId,
 	});
 
+	// One timestamp for the whole operation: the resolver keys windows from it
+	// and Lua receives the same value, so they never disagree on the window.
+	const usageWindowNow = Date.now();
+
 	for (const deduction of deductions) {
 		const {
 			feature,
@@ -117,6 +122,7 @@ export const executeRedisDeductionV2 = async ({
 			customerEntitlementDeductions,
 			spendLimitByFeatureId,
 			usageBasedCusEntIdsByFeatureId,
+			usageWindowLimits,
 			rollovers,
 			customerEntitlements,
 			unlimitedFeatureIds,
@@ -127,6 +133,7 @@ export const executeRedisDeductionV2 = async ({
 			fullSubject,
 			deduction,
 			options,
+			now: usageWindowNow,
 		});
 
 		if (unlimitedFeatureIds.length > 0) {
@@ -171,6 +178,16 @@ export const executeRedisDeductionV2 = async ({
 				}).redisKey
 			: null;
 
+		// Anchor features own usage-window counters and may not be in the
+		// deduction set, so their balance hash keys must be declared too.
+		const anchorFeatureIds = [
+			...new Set(
+				(usageWindowLimits ?? [])
+					.map((limit) => limit.anchor_feature_id)
+					.filter((featureId): featureId is string => featureId !== null),
+			),
+		];
+
 		const { keys, balanceKeyIndexByFeatureId } =
 			buildDeductFromSubjectBalancesKeys({
 				orgId: org.id,
@@ -181,7 +198,16 @@ export const executeRedisDeductionV2 = async ({
 				idempotencyKey: idempotencyRedisKey,
 				customerEntitlementDeductions,
 				fallbackFeatureId: feature.id,
+				anchorFeatureIds,
 			});
+
+		// Usage windows are enforced/incremented only for real positive
+		// consumption, never for target_balance set-downs or granted-balance edits.
+		const isConsumption =
+			notNullish(toDeduct) &&
+			(toDeduct as number) > 0 &&
+			!notNullish(targetBalance) &&
+			!options.alterGrantedBalance;
 
 		const luaParams = {
 			org_id: org.id,
@@ -192,6 +218,9 @@ export const executeRedisDeductionV2 = async ({
 			spend_limit_by_feature_id: spendLimitByFeatureId ?? null,
 			usage_based_cus_ent_ids_by_feature_id:
 				usageBasedCusEntIdsByFeatureId ?? null,
+			usage_window_limits: usageWindowLimits ?? null,
+			usage_window_now: usageWindowNow,
+			is_consumption: isConsumption,
 			amount_to_deduct: toDeduct ?? null,
 			target_balance: targetBalance ?? null,
 			target_entity_id: entityId || null,

--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -1,18 +1,21 @@
 import {
 	AllowanceType,
 	cusEntToStartingBalance,
+	ErrCode,
 	type FullCusEntWithFullCusProduct,
 	type FullSubject,
 	fullSubjectToCustomerEntitlements,
 	fullSubjectToOverageAllowedByFeatureId,
 	fullSubjectToSpendLimitByFeatureId,
 	fullSubjectToUsageBasedCusEntsByFeatureId,
+	fullSubjectToUsageWindowLimits,
 	getMaxOverage,
 	getRelevantFeatures,
 	isAllocatedCustomerEntitlement,
 	isFreeCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
+	RecaseError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
@@ -34,11 +37,15 @@ export const prepareFeatureDeductionV2 = ({
 	fullSubject,
 	deduction,
 	options = {},
+	now,
 }: {
 	ctx: AutumnContext;
 	fullSubject: FullSubject;
 	deduction: FeatureDeduction;
 	options?: DeductionOptions;
+	// Single timestamp shared with the Lua param so the resolved window key and
+	// the script agree on which window a boundary-crossing request lands in.
+	now: number;
 }): PreparedFeatureDeduction => {
 	const { org, env } = ctx;
 	const { feature, lock, targetBalance } = deduction;
@@ -108,6 +115,44 @@ export const prepareFeatureDeductionV2 = ({
 		fullSubject,
 		featureIds: effectiveFeatureIds,
 	});
+	// Resolve windows against the full relevant set (incl credit-system parents)
+	// even under set_usage, so a parent-feature cap can't be bypassed by set_usage
+	// on a member feature.
+	const windowFeatureIds = notNullish(targetBalance)
+		? getRelevantFeatures({
+				features: ctx.features,
+				featureId: feature.id,
+			}).map((candidate) => candidate.id)
+		: effectiveFeatureIds;
+	const usageWindowLimits = fullSubjectToUsageWindowLimits({
+		fullSubject,
+		featureIds: windowFeatureIds,
+		features: ctx.features,
+		now,
+		inStatuses: orgToInStatuses({ org }),
+	});
+
+	for (const windowLimit of usageWindowLimits) {
+		if (windowLimit.anchor_customer_entitlement_id === null) {
+			ctx.logger.warn(
+				`usage window for feature ${windowLimit.feature_id} has no eligible anchor entitlement; failing closed (rejecting). Likely a misconfigured cap with no in-status, non-entity-scoped owning entitlement.`,
+			);
+		}
+	}
+	if (fullSubject.entity?.spend_limits?.some((s) => s.usage_limit != null)) {
+		ctx.logger.warn(
+			`entity-scoped usage windows are not enforced in v1; ignored for entity ${fullSubject.entity.id}`,
+		);
+	}
+
+	// set_usage carries no window provenance, so it would silently bypass the hard
+	// cap; reject it when the feature has an enforced usage window.
+	if (notNullish(targetBalance) && usageWindowLimits.length > 0) {
+		throw new RecaseError({
+			message: `Cannot set usage for feature ${feature.id}: it has an active usage limit. Remove or adjust the limit, or record usage normally instead of using set_usage.`,
+			code: ErrCode.SetUsageNotAllowedWithUsageLimit,
+		});
+	}
 
 	const nativeUsageAllowedFeatureIds = new Set(
 		customerEntitlements
@@ -213,6 +258,8 @@ export const prepareFeatureDeductionV2 = ({
 			Object.keys(usageBasedCusEntIdsByFeatureId).length > 0
 				? usageBasedCusEntIdsByFeatureId
 				: undefined,
+		usageWindowLimits:
+			usageWindowLimits.length > 0 ? usageWindowLimits : undefined,
 		rollovers: sortedRollovers.map((rollover) => ({
 			id: rollover.id,
 			credit_cost: rollover.credit_cost,

--- a/server/src/internal/balances/utils/types/deductionTypes.ts
+++ b/server/src/internal/balances/utils/types/deductionTypes.ts
@@ -2,6 +2,7 @@ import type {
 	CustomerEntitlementFilters,
 	DbSpendLimit,
 	FullCusEntWithFullCusProduct,
+	UsageWindowLimit,
 } from "@autumn/shared";
 
 /** Behavior options for deduction */
@@ -42,6 +43,9 @@ export type PreparedFeatureDeduction = {
 	customerEntitlementDeductions: CustomerEntitlementDeduction[];
 	spendLimitByFeatureId?: Record<string, DbSpendLimit>;
 	usageBasedCusEntIdsByFeatureId?: Record<string, string[]>;
+	// Resolved windowed usage-limit caps (PR2: passed to Lua but not yet
+	// enforced; enforcement lands with the deduction-script changes).
+	usageWindowLimits?: UsageWindowLimit[];
 	// rolloverIds: string[];
 	rollovers: RolloverDeduction[];
 	unlimitedFeatureIds: string[];

--- a/server/src/internal/customers/cache/fullSubject/builders/buildDeductFromSubjectBalancesKeys.ts
+++ b/server/src/internal/customers/cache/fullSubject/builders/buildDeductFromSubjectBalancesKeys.ts
@@ -21,6 +21,7 @@ export const buildDeductFromSubjectBalancesKeys = ({
 	idempotencyKey,
 	customerEntitlementDeductions,
 	fallbackFeatureId,
+	anchorFeatureIds = [],
 }: {
 	orgId: string;
 	env: AppEnv;
@@ -30,17 +31,26 @@ export const buildDeductFromSubjectBalancesKeys = ({
 	idempotencyKey?: string | null;
 	customerEntitlementDeductions: { feature_id?: string }[];
 	fallbackFeatureId: string;
+	// Features owning a usage-window anchor counter. Their balance hash keys must
+	// be declared in KEYS[] so Lua can load the anchor even when it is not in the
+	// deduction set.
+	anchorFeatureIds?: string[];
 }) => {
 	const balanceKeysByFeatureId: Record<string, string> = {};
-	for (const deductionEntry of customerEntitlementDeductions) {
-		const targetFeatureId = deductionEntry.feature_id ?? fallbackFeatureId;
-		if (balanceKeysByFeatureId[targetFeatureId]) continue;
-		balanceKeysByFeatureId[targetFeatureId] = buildSharedFullSubjectBalanceKey({
+	const addFeatureKey = (featureId: string) => {
+		if (balanceKeysByFeatureId[featureId]) return;
+		balanceKeysByFeatureId[featureId] = buildSharedFullSubjectBalanceKey({
 			orgId,
 			env,
 			customerId,
-			featureId: targetFeatureId,
+			featureId,
 		});
+	};
+	for (const deductionEntry of customerEntitlementDeductions) {
+		addFeatureKey(deductionEntry.feature_id ?? fallbackFeatureId);
+	}
+	for (const anchorFeatureId of anchorFeatureIds) {
+		addFeatureKey(anchorFeatureId);
 	}
 
 	const balanceFeatureIds = Object.keys(balanceKeysByFeatureId);

--- a/server/src/internal/entities/handlers/handleListEntities.ts
+++ b/server/src/internal/entities/handlers/handleListEntities.ts
@@ -1,5 +1,5 @@
-import { createRoute } from "../../../honoMiddlewares/routeHandler.js";
 import { Scopes } from "@autumn/shared";
+import { createRoute } from "../../../honoMiddlewares/routeHandler.js";
 import { CusService } from "../../customers/CusService.js";
 
 export const handleListEntities = createRoute({

--- a/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
+++ b/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
@@ -1,0 +1,566 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildUsageWindowKey,
+	CusProductStatus,
+	type DbSpendLimit,
+	EntInterval,
+	type Feature,
+	FeatureType,
+	type FullSubject,
+	fullSubjectToUsageWindowLimits,
+	getUsageWindowBounds,
+} from "@autumn/shared";
+
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
+
+const meteredAction1 = { id: "action1", type: FeatureType.Metered } as Feature;
+const creditsFeature = {
+	id: "credits",
+	type: FeatureType.CreditSystem,
+} as Feature;
+// Credit system whose schema contains action1, for the membership-anchor path.
+const creditsContainingAction1 = {
+	id: "credits",
+	type: FeatureType.CreditSystem,
+	config: { schema: [{ metered_feature_id: "action1", credit_amount: 5 }] },
+} as unknown as Feature;
+const credits2ContainingAction1 = {
+	id: "credits2",
+	type: FeatureType.CreditSystem,
+	config: { schema: [{ metered_feature_id: "action1", credit_amount: 3 }] },
+} as unknown as Feature;
+
+// Test-input shape for a windowed usage cap. usage_limit arms the cap; `interval`
+// is the optional override (omit it to test inheriting from the entitlement).
+type UsageCap = {
+	feature_id: string;
+	limit: number;
+	interval?: EntInterval;
+};
+
+const toSpendLimit = (cap: UsageCap): DbSpendLimit => ({
+	feature_id: cap.feature_id,
+	// Entry-level enabled gates the (absent) overage cap, not the usage window.
+	enabled: false,
+	usage_limit: cap.limit,
+	usage_limit_interval: cap.interval,
+});
+
+// Minimal loose (product-less) customer entitlement for anchor/inherit tests.
+// `interval` is the entitlement's reset interval (the inherited window source).
+const looseEntitlement = ({
+	id,
+	featureId,
+	usageLimit,
+	interval = EntInterval.Month,
+}: {
+	id: string;
+	featureId: string;
+	usageLimit?: number;
+	interval?: EntInterval | null;
+}) =>
+	({
+		id,
+		feature_id: featureId,
+		internal_entity_id: null,
+		internal_feature_id: featureId,
+		customer_product_id: null,
+		entitlement_id: `ent_${id}`,
+		created_at: 1000,
+		balance: 0,
+		expires_at: null,
+		entitlement: {
+			id: `ent_${id}`,
+			feature_id: featureId,
+			interval,
+			usage_limit: usageLimit ?? null,
+			feature: { id: featureId, internal_id: featureId },
+		},
+		rollovers: [],
+		replaceables: [],
+	}) as unknown as FullSubject["extra_customer_entitlements"][number];
+
+// A customer product wrapping one entitlement, with an optional billing-cycle
+// anchor. Unlike loose entitlements, product-backed ones keep their
+// customer_product through fullSubjectToCustomerEntitlements, so the resolver can
+// read the cycle anchor from it.
+const customerProductWithEntitlement = ({
+	id,
+	featureId,
+	usageLimit,
+	cycleAnchor,
+}: {
+	id: string;
+	featureId: string;
+	usageLimit?: number;
+	cycleAnchor?: number;
+}) =>
+	({
+		id: `cusprod_${id}`,
+		status: CusProductStatus.Active,
+		created_at: 1000,
+		product: { is_add_on: false },
+		billing_cycle_anchor_resets_at: cycleAnchor ?? null,
+		customer_entitlements: [
+			{
+				id,
+				feature_id: featureId,
+				internal_entity_id: null,
+				internal_feature_id: featureId,
+				customer_product_id: `cusprod_${id}`,
+				entitlement_id: `ent_${id}`,
+				created_at: 1000,
+				balance: 0,
+				expires_at: null,
+				entitlement: {
+					id: `ent_${id}`,
+					feature_id: featureId,
+					interval: EntInterval.Month,
+					usage_limit: usageLimit ?? null,
+					feature: { id: featureId, internal_id: featureId },
+				},
+				rollovers: [],
+				replaceables: [],
+			},
+		],
+	}) as unknown as FullSubject["customer_products"][number];
+
+const buildSubject = ({
+	customerLimits = [],
+	entityLimits,
+	looseEntitlements = [],
+	extraCustomerSpendLimits = [],
+	customerProducts = [],
+}: {
+	customerLimits?: UsageCap[];
+	entityLimits?: UsageCap[];
+	looseEntitlements?: FullSubject["extra_customer_entitlements"];
+	// Raw spend-limit entries (e.g. overage-only or both-cap) injected as-is.
+	extraCustomerSpendLimits?: DbSpendLimit[];
+	customerProducts?: FullSubject["customer_products"];
+}): FullSubject =>
+	({
+		customer: {
+			spend_limits: [
+				...customerLimits.map(toSpendLimit),
+				...extraCustomerSpendLimits,
+			],
+		},
+		customer_products: customerProducts,
+		extra_customer_entitlements: looseEntitlements,
+		entity: entityLimits
+			? {
+					id: "ent_1",
+					internal_id: "ient_1",
+					spend_limits: entityLimits.map(toSpendLimit),
+				}
+			: undefined,
+	}) as unknown as FullSubject;
+
+describe("fullSubjectToUsageWindowLimits", () => {
+	test("resolves a customer-level metered-feature cap", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		const { windowStartAt, windowEndAt } = getUsageWindowBounds({
+			interval: EntInterval.Month,
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			feature_id: "action1",
+			dimension_type: "metered_feature",
+			dimension_feature_id: "action1",
+			scope_type: "customer",
+			entity_id: null,
+			interval: EntInterval.Month,
+			window_start_at: windowStartAt,
+			window_end_at: windowEndAt,
+			limit: 5,
+			key: buildUsageWindowKey({
+				scopeType: "customer",
+				internalEntityId: null,
+				dimensionType: "metered_feature",
+				dimensionFeatureId: "action1",
+				interval: EntInterval.Month,
+				windowStartAt,
+			}),
+		});
+	});
+
+	test("a credit-system feature resolves to the balance dimension", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			dimension_type: "balance",
+			dimension_feature_id: null,
+		});
+	});
+
+	test("inherits the interval from the anchor entitlement when no override", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				// No `interval` => inherit the entitlement's reset interval (Month).
+				customerLimits: [{ feature_id: "credits", limit: 5 }],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			limit: 5,
+			interval: EntInterval.Month,
+			anchor_customer_entitlement_id: "ce_credits",
+		});
+	});
+
+	test("an explicit usage_limit_interval overrides the inherited interval", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				// Entitlement interval is Month; the cap overrides to Day.
+				customerLimits: [
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
+				],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({ limit: 3, interval: EntInterval.Day });
+	});
+
+	test("a usage_limit with no override and a null-interval entitlement resolves nothing", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [{ feature_id: "credits", limit: 3 }],
+				looseEntitlements: [
+					looseEntitlement({
+						id: "ce_credits",
+						featureId: "credits",
+						interval: null,
+					}),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("a usage_limit of 0 is a valid hard cap (blocks all usage)", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "credits", limit: 0, interval: EntInterval.Day },
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({ limit: 0 });
+	});
+
+	test("aligns window bounds to the billing-cycle anchor when present", () => {
+		// Anchor: a non-midnight, non-first-of-month timestamp the cycle aligns to.
+		const cycleAnchor = Date.UTC(2026, 0, 9, 15, 30, 0);
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
+				],
+				customerProducts: [
+					customerProductWithEntitlement({
+						id: "ce_credits",
+						featureId: "credits",
+						cycleAnchor,
+					}),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		const aligned = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+			anchor: cycleAnchor,
+		});
+		const calendar = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0].window_start_at).toBe(aligned.windowStartAt);
+		expect(limits[0].window_end_at).toBe(aligned.windowEndAt);
+		// Sanity: the anchored window genuinely differs from calendar alignment.
+		expect(aligned.windowStartAt).not.toBe(calendar.windowStartAt);
+	});
+
+	test("a spend_limit with usage_limit_interval but no usage_limit is not armed", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				extraCustomerSpendLimits: [
+					{
+						feature_id: "action1",
+						enabled: false,
+						usage_limit_interval: EntInterval.Month,
+					},
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("ignores an overage-only spend_limit (no usage_limit)", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				extraCustomerSpendLimits: [
+					{ feature_id: "action1", enabled: true, overage_limit: 20 },
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("resolves the window when one entry carries both overage and usage caps", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				extraCustomerSpendLimits: [
+					{
+						feature_id: "action1",
+						enabled: true,
+						overage_limit: 20,
+						usage_limit: 5,
+						usage_limit_interval: EntInterval.Month,
+					},
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({ feature_id: "action1", limit: 5 });
+	});
+
+	test("ignores entity-scoped usage windows in v1; the customer cap applies", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
+				],
+				entityLimits: [
+					{ feature_id: "action1", limit: 2, interval: EntInterval.Month },
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			scope_type: "customer",
+			entity_id: null,
+			internal_entity_id: null,
+			limit: 5,
+		});
+	});
+
+	test("an entity-only usage window resolves nothing in v1", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				entityLimits: [
+					{ feature_id: "action1", limit: 2, interval: EntInterval.Month },
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("returns nothing when no cap matches the feature", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({ customerLimits: [] }),
+			featureIds: ["action1"],
+			features: [meteredAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(0);
+	});
+
+	test("returns one limit per feature when caps exist on multiple features", () => {
+		const meteredAction2 = {
+			id: "action2",
+			type: FeatureType.Metered,
+		} as Feature;
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
+					{ feature_id: "action2", limit: 9, interval: EntInterval.Day },
+				],
+			}),
+			featureIds: ["action1", "action2"],
+			features: [meteredAction1, meteredAction2],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(2);
+		expect(limits.map((limit) => limit.feature_id).sort()).toEqual([
+			"action1",
+			"action2",
+		]);
+	});
+
+	test("resolves the anchor to the owning entitlement (balance dim)", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
+				],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			anchor_customer_entitlement_id: "ce_credits",
+			anchor_feature_id: "credits",
+		});
+	});
+
+	test("metered cap with no native entitlement anchors to the containing credit system", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
+				],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1, creditsContainingAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			dimension_type: "metered_feature",
+			dimension_feature_id: "action1",
+			anchor_customer_entitlement_id: "ce_credits",
+			anchor_feature_id: "credits",
+		});
+	});
+
+	test("anchor is null when no owning entitlement exists (fail-closed signal)", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "credits", limit: 3, interval: EntInterval.Day },
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0].anchor_customer_entitlement_id).toBeNull();
+	});
+
+	test("metered cap with a containing credit system but no entitlement resolves a null anchor", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
+				],
+			}),
+			featureIds: ["action1"],
+			features: [meteredAction1, creditsContainingAction1],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0].anchor_customer_entitlement_id).toBeNull();
+	});
+
+	test("metered cap contained by two credit systems anchors deterministically", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				customerLimits: [
+					{ feature_id: "action1", limit: 5, interval: EntInterval.Month },
+				],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+					looseEntitlement({ id: "ce_credits2", featureId: "credits2" }),
+				],
+			}),
+			featureIds: ["action1"],
+			features: [
+				meteredAction1,
+				creditsContainingAction1,
+				credits2ContainingAction1,
+			],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0].anchor_customer_entitlement_id).toBe("ce_credits");
+	});
+});

--- a/server/tests/unit/usage-windows/getUsageWindowBounds.test.ts
+++ b/server/tests/unit/usage-windows/getUsageWindowBounds.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { EntInterval, getUsageWindowBounds } from "@autumn/shared";
+
+// 2026-06-15T12:34:56Z (a Monday; month index 5 = June)
+const NOW = Date.UTC(2026, 5, 15, 12, 34, 56);
+
+describe("getUsageWindowBounds", () => {
+	test("day window floors to UTC midnight and spans one day", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Day, now: NOW }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 5, 15),
+			windowEndAt: Date.UTC(2026, 5, 16),
+		});
+	});
+
+	test("week window floors to Monday 00:00 UTC and spans 7 days", () => {
+		// Wednesday -> floors back to Monday June 15.
+		const wednesday = Date.UTC(2026, 5, 17, 8, 0, 0);
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Week, now: wednesday }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 5, 15),
+			windowEndAt: Date.UTC(2026, 5, 22),
+		});
+	});
+
+	test("month window floors to the 1st and spans one month", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Month, now: NOW }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 5, 1),
+			windowEndAt: Date.UTC(2026, 6, 1),
+		});
+	});
+
+	test("quarter window floors to the start of the quarter and spans 3 months", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Quarter, now: NOW }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 3, 1),
+			windowEndAt: Date.UTC(2026, 6, 1),
+		});
+	});
+
+	test("semi_annual floors to Jan 1 in the first half and spans 6 months", () => {
+		const may = Date.UTC(2026, 4, 15);
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.SemiAnnual, now: may }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 0, 1),
+			windowEndAt: Date.UTC(2026, 6, 1),
+		});
+	});
+
+	test("semi_annual floors to Jul 1 in the second half", () => {
+		const august = Date.UTC(2026, 7, 15);
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.SemiAnnual, now: august }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 6, 1),
+			windowEndAt: Date.UTC(2027, 0, 1),
+		});
+	});
+
+	test("year window floors to Jan 1 and spans one year", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Year, now: NOW }),
+		).toEqual({
+			windowStartAt: Date.UTC(2026, 0, 1),
+			windowEndAt: Date.UTC(2027, 0, 1),
+		});
+	});
+
+	test("lifetime never resets", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Lifetime, now: NOW }),
+		).toEqual({ windowStartAt: 0, windowEndAt: Number.MAX_SAFE_INTEGER });
+	});
+
+	test("is deterministic across the same window", () => {
+		expect(
+			getUsageWindowBounds({ interval: EntInterval.Month, now: NOW }),
+		).toEqual(
+			getUsageWindowBounds({ interval: EntInterval.Month, now: NOW + 1000 }),
+		);
+	});
+
+	test("aligns a day window to the anchor's time-of-day, not UTC midnight", () => {
+		const anchor = Date.UTC(2026, 0, 9, 15, 30, 0); // 15:30, not midnight
+		const { windowStartAt, windowEndAt } = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+			anchor,
+		});
+		const calendar = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+		});
+
+		// Spans one day, contains now, and rolls at the anchor's 15:30.
+		expect(windowEndAt - windowStartAt).toBe(24 * 60 * 60 * 1000);
+		expect(windowStartAt).toBeLessThanOrEqual(NOW);
+		expect(NOW).toBeLessThan(windowEndAt);
+		expect(new Date(windowStartAt).getUTCHours()).toBe(15);
+		expect(new Date(windowStartAt).getUTCMinutes()).toBe(30);
+		expect(windowStartAt).not.toBe(calendar.windowStartAt);
+	});
+
+	test("aligns a month window to the anchor's day-of-month, not the 1st", () => {
+		const anchor = Date.UTC(2026, 0, 9); // the 9th
+		const { windowStartAt } = getUsageWindowBounds({
+			interval: EntInterval.Month,
+			now: NOW, // June 15
+			anchor,
+		});
+
+		expect(new Date(windowStartAt).getUTCDate()).toBe(9);
+		expect(windowStartAt).toBeLessThanOrEqual(NOW);
+	});
+
+	test("lifetime ignores the anchor", () => {
+		expect(
+			getUsageWindowBounds({
+				interval: EntInterval.Lifetime,
+				now: NOW,
+				anchor: Date.UTC(2026, 0, 9),
+			}),
+		).toEqual({ windowStartAt: 0, windowEndAt: Number.MAX_SAFE_INTEGER });
+	});
+});

--- a/server/tests/unit/usage-windows/pickAnchorCustomerEntitlementId.test.ts
+++ b/server/tests/unit/usage-windows/pickAnchorCustomerEntitlementId.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type AnchorCandidate,
+	pickAnchorCustomerEntitlementId,
+} from "@autumn/shared";
+
+const candidate = (overrides: Partial<AnchorCandidate>): AnchorCandidate => ({
+	id: "ce_1",
+	is_entity_scoped: false,
+	is_add_on: false,
+	status_rank: 0,
+	created_at: 1000,
+	...overrides,
+});
+
+describe("pickAnchorCustomerEntitlementId", () => {
+	test("returns null when there are no candidates", () => {
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [],
+				scopeType: "customer",
+			}),
+		).toBeNull();
+	});
+
+	test("customer scope excludes entity-scoped candidates", () => {
+		const id = pickAnchorCustomerEntitlementId({
+			candidates: [
+				candidate({ id: "ce_entity", is_entity_scoped: true }),
+				candidate({ id: "ce_customer", is_entity_scoped: false }),
+			],
+			scopeType: "customer",
+		});
+
+		expect(id).toBe("ce_customer");
+	});
+
+	test("customer scope returns null when only entity-scoped candidates exist (fail closed)", () => {
+		const id = pickAnchorCustomerEntitlementId({
+			candidates: [candidate({ id: "ce_entity", is_entity_scoped: true })],
+			scopeType: "customer",
+		});
+
+		expect(id).toBeNull();
+	});
+
+	test("entity scope falls back to customer-level candidates when none are entity-scoped", () => {
+		const id = pickAnchorCustomerEntitlementId({
+			candidates: [
+				candidate({ id: "ce_a", is_entity_scoped: false }),
+				candidate({ id: "ce_b", is_entity_scoped: false, created_at: 2000 }),
+			],
+			scopeType: "entity",
+		});
+
+		expect(id).toBe("ce_a");
+	});
+
+	test("entity scope prefers an entity-scoped candidate over a customer-level one", () => {
+		const id = pickAnchorCustomerEntitlementId({
+			candidates: [
+				candidate({ id: "ce_customer", is_entity_scoped: false }),
+				candidate({ id: "ce_entity", is_entity_scoped: true }),
+			],
+			scopeType: "entity",
+		});
+
+		expect(id).toBe("ce_entity");
+	});
+
+	test("prefers lower status_rank, then non-add-on, then oldest, then id", () => {
+		// All customer-scope candidates; tie-break ladder.
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [
+					candidate({ id: "ce_pastdue", status_rank: 1 }),
+					candidate({ id: "ce_active", status_rank: 0 }),
+				],
+				scopeType: "customer",
+			}),
+		).toBe("ce_active");
+
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [
+					candidate({ id: "ce_addon", is_add_on: true }),
+					candidate({ id: "ce_base", is_add_on: false }),
+				],
+				scopeType: "customer",
+			}),
+		).toBe("ce_base");
+
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [
+					candidate({ id: "ce_new", created_at: 2000 }),
+					candidate({ id: "ce_old", created_at: 1000 }),
+				],
+				scopeType: "customer",
+			}),
+		).toBe("ce_old");
+
+		expect(
+			pickAnchorCustomerEntitlementId({
+				candidates: [candidate({ id: "ce_b" }), candidate({ id: "ce_a" })],
+				scopeType: "customer",
+			}),
+		).toBe("ce_a");
+	});
+
+	test("is deterministic regardless of input order", () => {
+		const candidates = [
+			candidate({ id: "ce_b", status_rank: 0, created_at: 1000 }),
+			candidate({ id: "ce_a", status_rank: 0, created_at: 1000 }),
+			candidate({ id: "ce_c", status_rank: 1, created_at: 500 }),
+		];
+
+		const forward = pickAnchorCustomerEntitlementId({
+			candidates,
+			scopeType: "customer",
+		});
+		const reversed = pickAnchorCustomerEntitlementId({
+			candidates: [...candidates].reverse(),
+			scopeType: "customer",
+		});
+
+		expect(forward).toBe("ce_a");
+		expect(reversed).toBe("ce_a");
+	});
+});

--- a/shared/api/billingControls/entityBillingControls.ts
+++ b/shared/api/billingControls/entityBillingControls.ts
@@ -5,7 +5,8 @@ import { ApiUsageAlertSchema } from "./usageAlert.js";
 
 export const ApiEntityBillingControlsSchema = z.object({
 	spend_limits: z.array(ApiSpendLimitSchema).optional().meta({
-		description: "List of overage spend limits per feature.",
+		description:
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_limit).",
 	}),
 	usage_alerts: z.array(ApiUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -104,6 +104,7 @@ export const ErrCode = {
 	CreateEntitlementFailed: "create_entitlement_failed",
 	DeleteEntitlementFailed: "delete_entitlement_failed",
 	InsufficientBalance: "insufficient_balance",
+	SetUsageNotAllowedWithUsageLimit: "set_usage_not_allowed_with_usage_limit",
 
 	// Invoice
 	CreateInvoiceFailed: "create_invoice_failed",

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -211,6 +211,8 @@ export * from "./utils/cusEntUtils/balanceUtils/cusEntToUsageAllowed";
 export * from "./utils/cusEntUtils/index";
 // Utils
 export * from "./utils/usageWindowUtils/buildUsageWindowKey";
+export * from "./utils/usageWindowUtils/getUsageWindowBounds";
+export * from "./utils/usageWindowUtils/pickAnchorCustomerEntitlementId";
 export * from "./utils/displayUtils";
 export * from "./utils/fullSubjectUtils";
 export * from "./utils/index";

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -100,7 +100,8 @@ export const CustomerBillingControlsSchema = z.object({
 		description: "List of auto top-up configurations per feature.",
 	}),
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
-		description: "List of overage spend limits per feature.",
+		description:
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_limit).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",
@@ -125,7 +126,8 @@ export const CustomerBillingControlsResponseSchema = z.object({
 		description: "List of auto top-up configurations per feature.",
 	}),
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
-		description: "List of overage spend limits per feature.",
+		description:
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_limit).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/models/cusModels/billingControls/entityBillingControls.ts
+++ b/shared/models/cusModels/billingControls/entityBillingControls.ts
@@ -5,7 +5,8 @@ import { DbUsageAlertSchema } from "./usageAlert.js";
 
 export const EntityBillingControlsSchema = z.object({
 	spend_limits: z.array(DbSpendLimitSchema).optional().meta({
-		description: "List of overage spend limits per feature.",
+		description:
+			"List of spend limits per feature. Each entry caps overage (overage_limit) and/or windowed usage (usage_limit).",
 	}),
 	usage_alerts: z.array(DbUsageAlertSchema).optional().meta({
 		description: "List of usage alert configurations per feature.",

--- a/shared/models/cusModels/billingControls/spendLimit.ts
+++ b/shared/models/cusModels/billingControls/spendLimit.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { EntInterval } from "../../productModels/intervals/entitlementInterval.js";
 
 export const DbSpendLimitSchema = z
 	.object({
@@ -6,22 +7,27 @@ export const DbSpendLimitSchema = z
 			description: "Optional feature ID this spend limit applies to.",
 		}),
 		enabled: z.boolean().default(false).meta({
-			description: "Whether this spend limit is enabled.",
+			description: "Whether the overage spend limit is enabled.",
 		}),
 		overage_limit: z.number().min(0).optional().meta({
 			description: "Maximum allowed overage spend for the target feature.",
 		}),
+		usage_limit: z.number().min(0).optional().meta({
+			description:
+				"Windowed usage cap: max units allowed per window. Its presence arms the cap (hard pre-write reject); absent means no usage cap.",
+		}),
+		usage_limit_interval: z.enum(EntInterval).optional().meta({
+			description:
+				"Optional window/reset interval for the usage cap, aligned to the customer's billing cycle. When omitted, defaults to the feature entitlement's own reset interval. Only meaningful with usage_limit set.",
+		}),
 	})
 	.refine(
-		(data) => {
-			if (data.overage_limit === undefined) {
-				return true;
-			}
-
-			return data.feature_id !== undefined;
-		},
+		(data) =>
+			!(data.overage_limit !== undefined || data.usage_limit !== undefined) ||
+			data.feature_id !== undefined,
 		{
-			message: "feature_id is required when overage_limit is provided",
+			message:
+				"feature_id is required when overage_limit or usage_limit is provided",
 			path: ["feature_id"],
 		},
 	);

--- a/shared/models/cusModels/entityModels/entityTable.ts
+++ b/shared/models/cusModels/entityModels/entityTable.ts
@@ -65,11 +65,7 @@ export const entities = pgTable(
 			table.internal_customer_id,
 			sql`${table.internal_id} DESC`,
 		),
-		index("idx_entities_org_env_id").on(
-			table.org_id,
-			table.env,
-			table.id,
-		),
+		index("idx_entities_org_env_id").on(table.org_id, table.env, table.id),
 		index("idx_entities_cursor").on(
 			table.org_id,
 			table.env,

--- a/shared/models/cusProductModels/cusEntModels/usageWindowModels.ts
+++ b/shared/models/cusProductModels/cusEntModels/usageWindowModels.ts
@@ -52,7 +52,7 @@ export type UsageWindows = z.infer<typeof UsageWindowsSchema>;
 /**
  * A resolved, enforceable usage-window limit: the runtime input handed to the
  * deduction script. Built each deduction from the windowed usage cap
- * (`usage_limit_interval` + inherited/override limit) on a `spend_limit` billing
+ * (`usage_limit` + optional `usage_limit_interval` override) on a `spend_limit` billing
  * control plus the current window bounds (NOT stored).
  * Carries the resolved `limit` and `key`/window so Lua can find-or-create the
  * matching counter.

--- a/shared/utils/fullSubjectUtils/fullSubjectToUsageWindowLimits.ts
+++ b/shared/utils/fullSubjectUtils/fullSubjectToUsageWindowLimits.ts
@@ -1,0 +1,191 @@
+import type { FullSubject } from "../../models/cusModels/fullSubject/fullSubjectModel.js";
+import type { FullCusEntWithFullCusProduct } from "../../models/cusProductModels/cusEntModels/cusEntWithProduct.js";
+import type {
+	UsageWindowDimension,
+	UsageWindowLimit,
+} from "../../models/cusProductModels/cusEntModels/usageWindowModels.js";
+import { CusProductStatus } from "../../models/cusProductModels/cusProductEnums.js";
+import { FeatureType } from "../../models/featureModels/featureEnums.js";
+import type { Feature } from "../../models/featureModels/featureModels.js";
+import { getRelevantFeatures } from "../featureUtils.js";
+import { buildUsageWindowKey } from "../usageWindowUtils/buildUsageWindowKey.js";
+import { getUsageWindowBounds } from "../usageWindowUtils/getUsageWindowBounds.js";
+import {
+	type AnchorCandidate,
+	pickAnchorCustomerEntitlementId,
+} from "../usageWindowUtils/pickAnchorCustomerEntitlementId.js";
+import { fullSubjectToCustomerEntitlements } from "./fullSubjectToCustomerEntitlements.js";
+
+// Lower rank wins in the anchor tie-break. Loose entitlements (no product) are
+// treated as active grants.
+const customerProductStatusToAnchorRank = (
+	status: CusProductStatus | undefined,
+): number => {
+	switch (status) {
+		case undefined:
+		case CusProductStatus.Active:
+			return 0;
+		case CusProductStatus.PastDue:
+			return 1;
+		case CusProductStatus.Scheduled:
+			return 2;
+		case CusProductStatus.Trialing:
+			return 3;
+		default:
+			return 999;
+	}
+};
+
+const toAnchorCandidate = (
+	customerEntitlement: FullCusEntWithFullCusProduct,
+): AnchorCandidate => ({
+	id: customerEntitlement.id,
+	is_entity_scoped: customerEntitlement.internal_entity_id !== null,
+	is_add_on: customerEntitlement.customer_product?.product.is_add_on ?? false,
+	status_rank: customerProductStatusToAnchorRank(
+		customerEntitlement.customer_product?.status,
+	),
+	created_at:
+		customerEntitlement.customer_product?.created_at ??
+		customerEntitlement.created_at,
+});
+
+/**
+ * Resolves the enforceable usage-window limits for the requested features from a
+ * FullSubject. A windowed cap is armed by setting `usage_limit` on a customer
+ * `spend_limit` entry (flat config; its presence is the switch, independent of the
+ * entry-level `enabled` which gates the overage cap).
+ * v1 reads ONLY customer-scoped spend_limits; entity usage windows are out of scope.
+ *
+ * The window interval is the entry's `usage_limit_interval` if set, else inherited
+ * from the anchor entitlement's reset interval (`entitlement.interval`) - so a cap
+ * defaults to the billing cycle and you usually set only `usage_limit`. No
+ * resolvable interval (e.g. a boolean entitlement with no interval and no override)
+ * means no enforceable cap, so the feature is skipped.
+ *
+ * A cap on a credit-system feature targets the credit pool (`balance` dimension);
+ * a cap on any other feature targets that feature's usage (`metered_feature`).
+ * Window bounds align to the customer's billing cycle (the anchor entitlement's
+ * `billing_cycle_anchor_resets_at`), falling back to UTC calendar when absent.
+ *
+ * Each limit gets a single owning `anchor_customer_entitlement_id`, resolved
+ * deduction-order-independently so one counter never splits across pools. Null
+ * anchor means no eligible owner; the enforcement layer fails closed.
+ */
+export const fullSubjectToUsageWindowLimits = ({
+	fullSubject,
+	featureIds,
+	features,
+	now,
+	inStatuses,
+}: {
+	fullSubject: FullSubject;
+	featureIds: string[];
+	features: Feature[];
+	now: number;
+	// Status filter for entitlement lookups; pass the caller's orgToInStatuses so
+	// the cap's value/anchor resolution matches what the deduction can act on.
+	inStatuses?: CusProductStatus[];
+}): UsageWindowLimit[] => {
+	// v1: customer-scoped caps only; entity-scoped usage windows are out of scope.
+	const customerSpendLimits = fullSubject.customer.spend_limits ?? [];
+	const limits: UsageWindowLimit[] = [];
+
+	for (const featureId of [...new Set(featureIds)]) {
+		const spendLimit = customerSpendLimits.find(
+			(candidate) =>
+				candidate.feature_id === featureId && candidate.usage_limit != null,
+		);
+		const limit = spendLimit?.usage_limit;
+		if (spendLimit == null || limit == null) continue;
+
+		const scopeType = "customer" as const;
+		const entityId = null;
+		const internalEntityId = null;
+
+		const isCreditSystem =
+			features.find((feature) => feature.id === featureId)?.type ===
+			FeatureType.CreditSystem;
+		const dimensionType: UsageWindowDimension = isCreditSystem
+			? "balance"
+			: "metered_feature";
+		const dimensionFeatureId = isCreditSystem ? null : featureId;
+
+		// Balance dim is owned by the credit-system entitlement. Metered dim
+		// prefers the member feature's own entitlement, then falls back to a
+		// credit system that contains it.
+		const containingCreditSystemFeatureIds = getRelevantFeatures({
+			features,
+			featureId,
+		})
+			.map((feature) => feature.id)
+			.filter((relevantFeatureId) => relevantFeatureId !== featureId);
+		const ownerFeatureIdsByPreference = isCreditSystem
+			? [[featureId]]
+			: [[featureId], containingCreditSystemFeatureIds];
+
+		let anchorId: string | null = null;
+		let anchorFeatureId: string | null = null;
+		let anchorCustomerEntitlement: FullCusEntWithFullCusProduct | undefined;
+		for (const ownerFeatureIds of ownerFeatureIdsByPreference) {
+			if (ownerFeatureIds.length === 0) continue;
+			const candidateEntitlements = fullSubjectToCustomerEntitlements({
+				fullSubject,
+				featureIds: ownerFeatureIds,
+				inStatuses,
+			});
+			anchorId = pickAnchorCustomerEntitlementId({
+				candidates: candidateEntitlements.map(toAnchorCandidate),
+				scopeType,
+			});
+			if (anchorId) {
+				anchorCustomerEntitlement = candidateEntitlements.find(
+					(customerEntitlement) => customerEntitlement.id === anchorId,
+				);
+				anchorFeatureId = anchorCustomerEntitlement?.feature_id ?? null;
+				break;
+			}
+		}
+
+		const interval =
+			spendLimit.usage_limit_interval ??
+			anchorCustomerEntitlement?.entitlement.interval;
+		if (interval == null) continue;
+
+		// Align window bounds to the customer's billing cycle when the anchor has a
+		// cycle anchor; otherwise getUsageWindowBounds falls back to UTC calendar.
+		const cycleAnchor =
+			anchorCustomerEntitlement?.customer_product
+				?.billing_cycle_anchor_resets_at ?? null;
+		const { windowStartAt, windowEndAt } = getUsageWindowBounds({
+			interval,
+			now,
+			anchor: cycleAnchor,
+		});
+
+		limits.push({
+			feature_id: featureId,
+			key: buildUsageWindowKey({
+				scopeType,
+				internalEntityId,
+				dimensionType,
+				dimensionFeatureId,
+				interval,
+				windowStartAt,
+			}),
+			dimension_type: dimensionType,
+			dimension_feature_id: dimensionFeatureId,
+			scope_type: scopeType,
+			entity_id: entityId,
+			internal_entity_id: internalEntityId,
+			interval,
+			window_start_at: windowStartAt,
+			window_end_at: windowEndAt,
+			limit,
+			anchor_customer_entitlement_id: anchorId,
+			anchor_feature_id: anchorFeatureId,
+		});
+	}
+
+	return limits;
+};

--- a/shared/utils/fullSubjectUtils/index.ts
+++ b/shared/utils/fullSubjectUtils/index.ts
@@ -9,6 +9,7 @@ export {
 	fullSubjectToSpendLimitByFeatureId,
 	fullSubjectToUsageBasedCusEntsByFeatureId,
 } from "./fullSubjectToSpendLimit.js";
+export { fullSubjectToUsageWindowLimits } from "./fullSubjectToUsageWindowLimits.js";
 export { logFullSubject } from "./logFullSubject.js";
 export { mergeCustomerBillingControlsForCheck } from "./mergeCustomerBillingControlsForCheck.js";
 export { normalizedToFullSubject } from "./normalizedToFullSubject.js";

--- a/shared/utils/usageWindowUtils/getUsageWindowBounds.ts
+++ b/shared/utils/usageWindowUtils/getUsageWindowBounds.ts
@@ -1,0 +1,98 @@
+import { UTCDate } from "@date-fns/utc";
+import {
+	startOfDay,
+	startOfHour,
+	startOfMinute,
+	startOfMonth,
+	startOfQuarter,
+	startOfWeek,
+	startOfYear,
+} from "date-fns";
+import { EntInterval } from "../../models/productModels/intervals/entitlementInterval.js";
+import { getCycleEnd } from "../billingUtils/cycleUtils/getCycleEnd.js";
+import { getCycleStart } from "../billingUtils/cycleUtils/getCycleStart.js";
+import { addInterval } from "../billingUtils/intervalUtils/intervalArithmetic.js";
+
+const LIFETIME_WINDOW_END = Number.MAX_SAFE_INTEGER;
+
+// UTC-calendar-aligned start of the interval containing `now`. Used only as the
+// fallback when no billing-cycle anchor is available; alignment keeps the window
+// (and its key) deterministic from `now` alone so TS and Lua never disagree.
+const startOfWindow = ({
+	interval,
+	now,
+}: {
+	interval: EntInterval;
+	now: number;
+}): number => {
+	const from = new UTCDate(now);
+
+	switch (interval) {
+		case EntInterval.Minute:
+			return startOfMinute(from).getTime();
+		case EntInterval.Hour:
+			return startOfHour(from).getTime();
+		case EntInterval.Day:
+			return startOfDay(from).getTime();
+		case EntInterval.Week:
+			return startOfWeek(from, { weekStartsOn: 1 }).getTime();
+		case EntInterval.Month:
+			return startOfMonth(from).getTime();
+		case EntInterval.Quarter:
+			return startOfQuarter(from).getTime();
+		case EntInterval.SemiAnnual: {
+			const yearStart = startOfYear(from).getTime();
+			return from.getUTCMonth() < 6
+				? yearStart
+				: addInterval({
+						from: yearStart,
+						interval: EntInterval.Month,
+						intervalCount: 6,
+					});
+		}
+		case EntInterval.Year:
+			return startOfYear(from).getTime();
+		default:
+			return now;
+	}
+};
+
+/**
+ * Current usage-window bounds for an interval. When a billing-cycle `anchor` is
+ * given, bounds align to the customer's cycle (so a "daily" cap rolls on their
+ * billing time-of-day, not UTC midnight). Without an anchor, falls back to UTC
+ * calendar alignment. `lifetime` never resets. Each window spans one interval.
+ */
+export const getUsageWindowBounds = ({
+	interval,
+	now,
+	anchor,
+}: {
+	interval: EntInterval;
+	now: number;
+	anchor?: number | null;
+}): { windowStartAt: number; windowEndAt: number } => {
+	if (interval === EntInterval.Lifetime) {
+		return { windowStartAt: 0, windowEndAt: LIFETIME_WINDOW_END };
+	}
+
+	if (anchor != null && Number.isFinite(anchor)) {
+		const cycleStartAt = getCycleStart({ anchor, interval, now });
+		const cycleEndAt = getCycleEnd({ anchor, interval, now });
+		// Only trust cycle bounds that are finite and actually bracket `now`; a bad
+		// billing anchor must fall back to calendar, never poison the deduction.
+		if (
+			Number.isFinite(cycleStartAt) &&
+			Number.isFinite(cycleEndAt) &&
+			cycleStartAt <= now &&
+			now < cycleEndAt
+		) {
+			return { windowStartAt: cycleStartAt, windowEndAt: cycleEndAt };
+		}
+	}
+
+	const windowStartAt = startOfWindow({ interval, now });
+	const windowEndAt = addInterval({ from: windowStartAt, interval });
+
+	return { windowStartAt, windowEndAt };
+};

--- a/shared/utils/usageWindowUtils/pickAnchorCustomerEntitlementId.ts
+++ b/shared/utils/usageWindowUtils/pickAnchorCustomerEntitlementId.ts
@@ -1,0 +1,55 @@
+import type { UsageWindowScope } from "../../models/cusProductModels/cusEntModels/usageWindowModels.js";
+
+/**
+ * A candidate customer entitlement for owning a usage-window counter, reduced to
+ * just the fields the canonical pick depends on. Deliberately decoupled from the
+ * deduction set and its ordering so the chosen anchor is stable regardless of
+ * deduction order, filters, or reverse_deduction_order.
+ */
+export type AnchorCandidate = {
+	id: string;
+	is_entity_scoped: boolean;
+	is_add_on: boolean;
+	// Lower rank = higher priority (e.g. active before past_due).
+	status_rank: number;
+	created_at: number;
+};
+
+/**
+ * Deterministically picks the single customer entitlement that owns a usage
+ * window, so one logical counter is never split across entitlements.
+ *
+ * Customer-scope counters must live on a customer-level entitlement (returns
+ * null if only entity-scoped ones exist, so the caller can fail closed rather
+ * than split the cap per entity). Entity-scope prefers an entity-owned one.
+ */
+export const pickAnchorCustomerEntitlementId = ({
+	candidates,
+	scopeType,
+}: {
+	candidates: AnchorCandidate[];
+	scopeType: UsageWindowScope;
+}): string | null => {
+	let eligible: AnchorCandidate[];
+	if (scopeType === "customer") {
+		eligible = candidates.filter((candidate) => !candidate.is_entity_scoped);
+	} else {
+		const entityScoped = candidates.filter(
+			(candidate) => candidate.is_entity_scoped,
+		);
+		eligible = entityScoped.length > 0 ? entityScoped : candidates;
+	}
+
+	if (eligible.length === 0) {
+		return null;
+	}
+
+	const sorted = [...eligible].sort((a, b) => {
+		if (a.status_rank !== b.status_rank) return a.status_rank - b.status_rank;
+		if (a.is_add_on !== b.is_add_on) return a.is_add_on ? 1 : -1;
+		if (a.created_at !== b.created_at) return a.created_at - b.created_at;
+		return a.id < b.id ? -1 : 1;
+	});
+
+	return sorted[0].id;
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cycle-aligned usage-window caps via customer `spend_limits` (`usage_limit` with optional `usage_limit_interval`). Resolves per-feature limits anchored to entitlements, passes deterministic windows with a shared timestamp, and rejects `set_usage` when a cap exists.

- **New Features**
  - Add `usage_limit` and `usage_limit_interval` to spend-limit schemas; require `feature_id` when `overage_limit` or `usage_limit` is set; update API descriptions to cover overage and windowed usage caps.
  - New `fullSubjectToUsageWindowLimits` resolver aligns windows to the customer’s billing cycle; exports `getUsageWindowBounds` and `pickAnchorCustomerEntitlementId`; add unit tests for resolver, bounds, and anchor selection.
  - Pass resolved limits, a single operation timestamp, and an `is_consumption` flag through Redis/Postgres to Lua; declare anchor feature keys in `buildDeductFromSubjectBalancesKeys`; extend types to include `usageWindowLimits`.
  - Reject `set_usage` on capped features with `ErrCode.SetUsageNotAllowedWithUsageLimit`; entity-scoped usage windows are logged and ignored in v1.

- **Migration**
  - To enable a cap, add a customer `spend_limits[]` entry with `feature_id` and `usage_limit`; optionally set `usage_limit_interval` (otherwise inherit the entitlement interval).
  - No behavior change unless `usage_limit` is set.
  - `set_usage` is rejected for capped features; record usage normally instead.
  - Entity-level usage windows are currently ignored.

<sup>Written for commit 8eab888024d35cb472913b8265361c15896f3cff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds flat `spend_limit` configuration fields (`usage_limit`, `usage_limit_interval`) to customer/entity billing controls and wires them into a new cycle-aligned usage-window resolver (`fullSubjectToUsageWindowLimits`). The resolver computes per-feature enforceable caps anchored to the customer's billing cycle and rejects `set_usage` calls on capped features; actual Lua deduction-script enforcement is deferred to a follow-up PR.

- **New Features | API changes** — Adds `usage_limit` and `usage_limit_interval` to `DbSpendLimitSchema` (and `ApiSpendLimitSchema` via re-export); updates the `feature_id` `refine` check to require it for either overage or windowed caps.
- **New Features | Improvements** — New `fullSubjectToUsageWindowLimits` resolver with deterministic anchor selection (`pickAnchorCustomerEntitlementId`) and billing-cycle-aligned window bounds (`getUsageWindowBounds`); passes resolved limits + anchor feature keys into both Redis and Postgres deduction paths.
- **New Features** — `set_usage` is rejected with `SetUsageNotAllowedWithUsageLimit` when any relevant feature (including credit-system parents) carries an active usage-window cap; entity-scoped usage windows are logged and ignored in v1.
</details>


<h3>Confidence Score: 3/5</h3>

The set_usage rejection and limit resolution are correct, but the null-anchor warning misleads operators about whether a deduction was rejected, and enforcement is intentionally deferred to a follow-up PR — meaning no cap is actually applied to normal deductions yet.

The core resolver and set_usage guard work correctly, and the design is well-documented. The main concern is the warning message that says 'failing closed (rejecting)' when no rejection occurs for normal deductions in the current code — an operator or on-call engineer reading logs could incorrectly conclude that traffic is being blocked when it is not.

prepareFeatureDeductionV2.ts — contains the misleading warning and the opaque error message that references the wrong feature ID when a parent cap triggers rejection.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts | Adds usage-window resolution and set_usage rejection; warning message 'failing closed (rejecting)' is misleading as enforcement is deferred; error message for inherited parent-cap rejection may confuse users. |
| shared/utils/fullSubjectUtils/fullSubjectToUsageWindowLimits.ts | New resolver correctly computes per-feature usage-window limits with billing-cycle alignment and deterministic anchor selection; only customer-scoped caps enforced in v1. |
| shared/utils/usageWindowUtils/getUsageWindowBounds.ts | Correct window-bound computation with safe anchor fallback; default case in startOfWindow returns raw now for unrecognized intervals (no practical risk since EntInterval is an enum). |
| shared/utils/usageWindowUtils/pickAnchorCustomerEntitlementId.ts | Deterministic anchor selection with well-tested tie-break ordering; correctly returns null for customer-scope caps with only entity-scoped candidates. |
| shared/models/cusModels/billingControls/spendLimit.ts | Adds usage_limit and usage_limit_interval fields; refine validation correctly updated to require feature_id for either overage or windowed caps. |
| server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts | Correctly captures a single operation timestamp for window alignment, computes isConsumption guard, and passes window limits + anchor feature keys to Lua. |
| server/src/internal/customers/cache/fullSubject/builders/buildDeductFromSubjectBalancesKeys.ts | Refactored to accept anchorFeatureIds so that balance hash keys for anchor features are declared in KEYS[] even when not in the deduction set. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant prepareFeatureDeductionV2
    participant fullSubjectToUsageWindowLimits
    participant getUsageWindowBounds
    participant pickAnchorCustomerEntitlementId
    participant executeRedisDeductionV2
    participant LuaScript

    Caller->>executeRedisDeductionV2: deductions (featureId, toDeduct / targetBalance)
    executeRedisDeductionV2->>executeRedisDeductionV2: "capture usageWindowNow = Date.now()"
    loop per deduction
        executeRedisDeductionV2->>prepareFeatureDeductionV2: "{fullSubject, deduction, now: usageWindowNow}"
        prepareFeatureDeductionV2->>fullSubjectToUsageWindowLimits: "{featureIds, features, now, inStatuses}"
        fullSubjectToUsageWindowLimits->>getUsageWindowBounds: "{interval, now, anchor?}"
        getUsageWindowBounds-->>fullSubjectToUsageWindowLimits: "{windowStartAt, windowEndAt}"
        fullSubjectToUsageWindowLimits->>pickAnchorCustomerEntitlementId: "{candidates, scopeType}"
        pickAnchorCustomerEntitlementId-->>fullSubjectToUsageWindowLimits: "anchorId | null"
        fullSubjectToUsageWindowLimits-->>prepareFeatureDeductionV2: UsageWindowLimit[]
        alt "targetBalance set AND limits.length > 0"
            prepareFeatureDeductionV2-->>Caller: throw SetUsageNotAllowedWithUsageLimit
        else normal deduction
            prepareFeatureDeductionV2-->>executeRedisDeductionV2: PreparedFeatureDeduction
        end
        executeRedisDeductionV2->>LuaScript: "luaParams {usage_window_limits, usage_window_now, is_consumption}"
        Note over LuaScript: Enforcement deferred to PR2
        LuaScript-->>executeRedisDeductionV2: DeductionResult
    end
    executeRedisDeductionV2-->>Caller: "{updates, mutationLogs}"
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts`, line 135-165 ([link](https://github.com/useautumn/autumn/blob/b4a05af05b836c96f669c5de1f645ad5748a0f9b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts#L135-L165)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Warning claims rejection that doesn't happen yet**

   The warning message at line 138 says `"failing closed (rejecting)"`, implying the in-flight deduction is being rejected, but no exception is thrown for the null-anchor case in a normal (non-`set_usage`) deduction. With Lua enforcement deferred to PR2, a cap whose `anchor_customer_entitlement_id` resolves to `null` is currently passed through unenforceable to the Lua script. An operator seeing this log entry in production would reasonably believe the deduction was rejected, but the usage is silently allowed. The message should reflect the actual current behavior — e.g. `"will fail closed once Lua enforcement lands (PR2)"` — so the gap between the log and the real behaviour is explicit.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
   Line: 135-165

   Comment:
   **Warning claims rejection that doesn't happen yet**

   The warning message at line 138 says `"failing closed (rejecting)"`, implying the in-flight deduction is being rejected, but no exception is thrown for the null-anchor case in a normal (non-`set_usage`) deduction. With Lua enforcement deferred to PR2, a cap whose `anchor_customer_entitlement_id` resolves to `null` is currently passed through unenforceable to the Lua script. An operator seeing this log entry in production would reasonably believe the deduction was rejected, but the usage is silently allowed. The message should reflect the actual current behavior — e.g. `"will fail closed once Lua enforcement lands (PR2)"` — so the gap between the log and the real behaviour is explicit.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts`, line 179-184 ([link](https://github.com/useautumn/autumn/blob/b4a05af05b836c96f669c5de1f645ad5748a0f9b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts#L179-L184)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Error message may be unclear when rejection is triggered by a parent credit-system cap**

   When `set_usage` on a metered feature (e.g. `action1`) is rejected because its containing credit system (e.g. `credits`) has a `usage_limit_interval` cap, the error message references `feature.id` (`action1`) as if that feature itself has the limit. The limit actually lives on the parent. A user who sees this message and checks their spend_limits for `action1` directly will find nothing, making the error hard to act on. Including which feature's cap triggered the rejection would improve debuggability.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
   Line: 179-184

   Comment:
   **Error message may be unclear when rejection is triggered by a parent credit-system cap**

   When `set_usage` on a metered feature (e.g. `action1`) is rejected because its containing credit system (e.g. `credits`) has a `usage_limit_interval` cap, the error message references `feature.id` (`action1`) as if that feature itself has the limit. The limit actually lives on the parent. A user who sees this message and checks their spend_limits for `action1` directly will find nothing, making the error hard to act on. Including which feature's cap triggered the rejection would improve debuggability.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts:135-165
**Warning claims rejection that doesn't happen yet**

The warning message at line 138 says `"failing closed (rejecting)"`, implying the in-flight deduction is being rejected, but no exception is thrown for the null-anchor case in a normal (non-`set_usage`) deduction. With Lua enforcement deferred to PR2, a cap whose `anchor_customer_entitlement_id` resolves to `null` is currently passed through unenforceable to the Lua script. An operator seeing this log entry in production would reasonably believe the deduction was rejected, but the usage is silently allowed. The message should reflect the actual current behavior — e.g. `"will fail closed once Lua enforcement lands (PR2)"` — so the gap between the log and the real behaviour is explicit.

### Issue 2 of 2
server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts:179-184
**Error message may be unclear when rejection is triggered by a parent credit-system cap**

When `set_usage` on a metered feature (e.g. `action1`) is rejected because its containing credit system (e.g. `credits`) has a `usage_limit_interval` cap, the error message references `feature.id` (`action1`) as if that feature itself has the limit. The limit actually lives on the parent. A user who sees this message and checks their spend_limits for `action1` directly will find nothing, making the error hard to act on. Including which feature's cap triggered the rejection would improve debuggability.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add flat spend\_limit usage cap config + ..."](https://github.com/useautumn/autumn/commit/b4a05af05b836c96f669c5de1f645ad5748a0f9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35203695)</sub>

<!-- /greptile_comment -->