### PR TITLE
persist usage_windows via sync_balances_v2 write-through

### DIFF
--- a/server/src/internal/balances/utils/sql/syncBalancesV2.sql
+++ b/server/src/internal/balances/utils/sql/syncBalancesV2.sql
@@ -6,6 +6,7 @@
 --     - balance: number
 --     - adjustment: number
 --     - entities: jsonb (the full entities object)
+--     - usage_windows: jsonb (the full usage-window counters object)
 --     - next_reset_at: bigint/number (unix timestamp, for conflict detection)
 --     - entity_count: number (for conflict detection)
 --     - cache_version: number (if defined, skip write if DB cache_version differs)
@@ -38,6 +39,7 @@ DECLARE
   ent_balance numeric;
   ent_adjustment numeric;
   ent_entities jsonb;
+  ent_usage_windows jsonb;
   ent_next_reset_at bigint;
   ent_entity_count int;
   ent_cache_version int;
@@ -99,6 +101,7 @@ BEGIN
       ent_balance := (ent_obj->>'balance')::numeric;
       ent_adjustment := (ent_obj->>'adjustment')::numeric;
       ent_entities := ent_obj->'entities';
+      ent_usage_windows := ent_obj->'usage_windows';
       ent_next_reset_at := (ent_obj->>'next_reset_at')::bigint;
       ent_entity_count := COALESCE((ent_obj->>'entity_count')::int, 0);
       ent_cache_version := COALESCE((ent_obj->>'cache_version')::int, 0);
@@ -134,14 +137,21 @@ BEGIN
           ent_id, ent_cache_version, db_cache_version;
       END IF;
       
-      -- Update the customer_entitlement row directly
+      -- Update the customer_entitlement row directly.
+      -- usage_windows is written from the synced object, which carries the FRESH
+      -- Redis value (re-read at sync time), so this is a full replace, not a
+      -- lost-update risk: concurrent counter increments are serialized atomically
+      -- in Redis and the latest cumulative map is what reaches here. The COALESCE
+      -- only avoids wiping the column when a balance-only sync carries no
+      -- usage_windows (null). Postgres is a mirror; Redis is authoritative.
       UPDATE customer_entitlements ce
       SET
         balance = COALESCE(ent_balance, ce.balance),
         adjustment = COALESCE(ent_adjustment, ce.adjustment),
-        entities = COALESCE(ent_entities, ce.entities)
+        entities = COALESCE(ent_entities, ce.entities),
+        usage_windows = COALESCE(NULLIF(ent_usage_windows, 'null'::jsonb), ce.usage_windows)
       WHERE ce.id = ent_id;
-      
+
       -- Track update
       IF FOUND THEN
         updates_json := jsonb_set(
@@ -150,7 +160,8 @@ BEGIN
           jsonb_build_object(
             'balance', ent_balance,
             'adjustment', ent_adjustment,
-            'entities', ent_entities
+            'entities', ent_entities,
+            'usage_windows', ent_usage_windows
           )
         );
       END IF;

--- a/server/src/internal/balances/utils/sync/syncItemV4.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV4.ts
@@ -4,6 +4,7 @@ import {
 	type EntityRolloverBalance,
 	type SubjectBalance,
 	tryCatch,
+	type UsageWindows,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -76,6 +77,7 @@ export interface SyncEntry {
 	balance: number;
 	adjustment: number;
 	entities: Record<string, EntityBalance> | null;
+	usage_windows: UsageWindows | null;
 	next_reset_at: number | null;
 	entity_count: number;
 	cache_version: number | null;
@@ -98,6 +100,7 @@ const subjectBalanceToSyncEntry = ({
 	balance: subjectBalance.balance ?? 0,
 	adjustment: subjectBalance.adjustment ?? 0,
 	entities: subjectBalance.entities ?? null,
+	usage_windows: subjectBalance.usage_windows ?? null,
 	next_reset_at: subjectBalance.next_reset_at ?? null,
 	entity_count: subjectBalance.entities
 		? Object.keys(subjectBalance.entities).length


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists `usage_windows` to `customer_entitlements` via `sync_balances_v2` so Postgres mirrors the latest Redis counters without risking lost updates.

- **Bug Fixes**
  - Write `usage_windows` with `COALESCE(NULLIF(ent_usage_windows, 'null'::jsonb), ce.usage_windows)`—replace when present; preserve on balance-only syncs. Redis is authoritative; Postgres mirrors.
  - Add `usage_windows` to `SyncEntry` and `subjectBalanceToSyncEntry`, include it in `updates_json`, and update SQL comments to document the field and write-through semantics.

<sup>Written for commit 09184a5c8e0d4e507b304458edc839574dc48ca8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires `usage_windows` from Redis through `sync_balances_v2` into the `customer_entitlements` table so Postgres mirrors the latest windowed-usage counters without risking lost updates.

- **Bug Fixes / Improvements**: The SQL function now extracts `ent_usage_windows` and writes it with `COALESCE(NULLIF(ent_usage_windows, 'null'::jsonb), ce.usage_windows)` — a full replace when a real value is present, a no-op when the sync carries JSON null (balance-only path). The `NULLIF` guard is the key difference from how `entities` is handled and correctly prevents balance-only syncs from wiping existing counters.
- **Improvements**: `SyncEntry` and `subjectBalanceToSyncEntry` are updated to carry `usage_windows: UsageWindows | null`, keeping the TypeScript contract in sync with what the SQL function now accepts.
- **Improvements**: `updates_json` now includes `usage_windows` in the per-entitlement change-tracking object returned by the function.
</details>


<h3>Confidence Score: 4/5</h3>

The write-through logic is sound and safe to merge; the only gap is a stale one-line doc comment.

The core SQL change (COALESCE + NULLIF) and the TypeScript wiring are both correct. The asymmetry between how entities and usage_windows handle JSON null is intentional and clearly documented in code comments. The only gap is the stale return-value comment in the SQL file.

syncBalancesV2.sql — the return-value comment (line 20) still lists only { balance, adjustment, entities } and should include usage_windows.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/sql/syncBalancesV2.sql | Adds usage_windows write-through via COALESCE(NULLIF(…, 'null'::jsonb), ce.usage_windows); logic is correct, but the return-value comment still lists only { balance, adjustment, entities }. |
| server/src/internal/balances/utils/sync/syncItemV4.ts | Adds usage_windows to SyncEntry and subjectBalanceToSyncEntry; imports UsageWindows type correctly; no issues found. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TS as syncItemV4.ts
    participant Redis
    participant SQL as sync_balances_v2()
    participant PG as customer_entitlements

    TS->>Redis: getCachedFeatureBalance()
    Redis-->>TS: SubjectBalance (incl. usage_windows)
    TS->>TS: "subjectBalanceToSyncEntry()<br/>(maps usage_windows ?? null)"
    TS->>SQL: execute sync_balances_v2(entries::jsonb)
    SQL->>PG: SELECT FOR UPDATE (lock rows)
    SQL->>SQL: "Extract ent_usage_windows via ent_obj->'usage_windows'"
    alt usage_windows present (non-null JSON)
        SQL->>PG: "UPDATE SET usage_windows = ent_usage_windows"
    else usage_windows is null / JSON null (balance-only sync)
        SQL->>PG: "UPDATE SET usage_windows = ce.usage_windows (preserve)"
    end
    SQL-->>TS: "{updates: {id -> {balance, adjustment, entities, usage_windows}}}"
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/balances/utils/sql/syncBalancesV2.sql`, line 20 ([link](https://github.com/useautumn/autumn/blob/b2fcc8985937a8a222e3a10d2351d9cdececf526/server/src/internal/balances/utils/sql/syncBalancesV2.sql#L20)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The return-value comment on line 20 lists `{ balance, adjustment, entities }` but the `updates_json` object now also carries `usage_windows`. Callers reading the returned JSON for diagnostics or tooling will have an incomplete picture from the comment alone.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/utils/sql/syncBalancesV2.sql
   Line: 20

   Comment:
   The return-value comment on line 20 lists `{ balance, adjustment, entities }` but the `updates_json` object now also carries `usage_windows`. Callers reading the returned JSON for diagnostics or tooling will have an incomplete picture from the comment alone.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/balances/utils/sql/syncBalancesV2.sql:20
The return-value comment on line 20 lists `{ balance, adjustment, entities }` but the `updates_json` object now also carries `usage_windows`. Callers reading the returned JSON for diagnostics or tooling will have an incomplete picture from the comment alone.

```suggestion
--   updates: object mapping customer_entitlement_id -> { balance, adjustment, entities, usage_windows }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["persist usage\_windows via sync\_balances\_..."](https://github.com/useautumn/autumn/commit/b2fcc8985937a8a222e3a10d2351d9cdececf526) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35203705)</sub>

<!-- /greptile_comment -->