### PR TITLE
chore: mcp improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ supabase.sh
 tests/
 !server/tests
 !packages/mcp/tests
+!apps/chat/tests
 !vite/tests
 .secrets
 

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -16,6 +16,7 @@
 		"@chat-adapter/state-pg": "^4.29.0",
 		"@mastra/core": "^1.36.0",
 		"@mastra/mcp": "^1.8.0",
+		"@mendable/firecrawl-js": "^4.25.1",
 		"chat": "^4.29.0",
 		"date-fns": "^4.1.0",
 		"drizzle-orm": "catalog:",

--- a/apps/chat/src/agent/agent.ts
+++ b/apps/chat/src/agent/agent.ts
@@ -5,6 +5,7 @@ import {
 	createAutumnMcpClient,
 	getAutumnMcpTools,
 } from "./mcp.js";
+import { createFirecrawlTools } from "./firecrawl.js";
 import { env as chatEnv } from "../lib/env.js";
 import type { ChatContextMessage } from "../types.js";
 
@@ -19,6 +20,9 @@ const docs = [
 
 const instructions = `You are Autumn Chat.
 Use Autumn MCP tools for customer, plan, balance, schedule, and billing work.
+Use web search only for current or external web context. Never use web search for Autumn customer, plan, billing, balance, or schedule state.
+When web content influences the answer, cite the source URLs.
+Prefer searchWeb first, then scrapeUrl only for the most relevant result.
 Preview billing-impacting changes first, summarize the preview in short Slack-friendly bullets, then call the matching write tool with the same request args.
 The runtime pauses destructive tools for approval before execution, so do not ask for confirmation in plain text.`;
 
@@ -118,13 +122,17 @@ export const runChatAgent = async ({
 			}),
 			readDocs(mcp),
 		]);
+		const firecrawlTools = createFirecrawlTools({
+			apiKey: chatEnv.FIRECRAWL_API_KEY,
+			onAction,
+		});
 		await onAction?.("Reasoning over the request");
 		const agent = new Agent({
 			id: "autumn-chat",
 			name: "Autumn Chat",
 			instructions: `${instructions}\n\nCurrent Autumn environment: ${env}.\n\n${docsText}`,
 			model: chatEnv.CHAT_MODEL,
-			tools,
+			tools: { ...tools, ...firecrawlTools },
 		});
 
 		const output = await agent.generate(message, {

--- a/apps/chat/src/agent/firecrawl.ts
+++ b/apps/chat/src/agent/firecrawl.ts
@@ -1,0 +1,89 @@
+import { createTool } from "@mastra/core/tools";
+import Firecrawl from "@mendable/firecrawl-js";
+import { z } from "zod";
+
+type FirecrawlClient = {
+	search: (
+		query: string,
+		options?: { limit?: number; sources?: ["web"] },
+	) => Promise<{ web?: unknown[] }>;
+	scrape: (
+		url: string,
+		options?: { formats?: ["markdown"] },
+	) => Promise<{
+		markdown?: string;
+		metadata?: { title?: string; sourceURL?: string };
+	}>;
+};
+
+const maxSearchResults = 5;
+const maxMarkdownLength = 12_000;
+
+const trimMarkdown = (markdown = "") =>
+	markdown
+		.replace(/\n{3,}/g, "\n\n")
+		.trim()
+		.slice(0, maxMarkdownLength);
+
+const stringField = (value: unknown, field: string) =>
+	value && typeof value === "object"
+		? (value as Record<string, unknown>)[field]
+		: undefined;
+
+export const createFirecrawlTools = ({
+	apiKey,
+	client,
+	onAction,
+}: {
+	apiKey: string;
+	client?: FirecrawlClient;
+	onAction?: (message: string) => Promise<void> | void;
+}): Record<string, ReturnType<typeof createTool>> => {
+	const firecrawl = client ?? new Firecrawl({ apiKey });
+
+	return {
+		searchWeb: createTool({
+			id: "searchWeb",
+			description:
+				"Search the public web for current or external information. Use Autumn MCP tools instead for Autumn customer, plan, billing, balance, or schedule data.",
+			inputSchema: z
+				.object({
+					query: z.string().min(1),
+					limit: z.number().int().positive().max(maxSearchResults).optional(),
+				})
+				.strict(),
+			execute: async ({ query, limit = maxSearchResults }) => {
+				await onAction?.("Searching web");
+				const results = await firecrawl.search(query, {
+					limit,
+					sources: ["web"],
+				});
+				return {
+					results: (results.web ?? []).slice(0, limit).map((result) => ({
+						title:
+							stringField(result, "title") ??
+							stringField(result, "url") ??
+							"Untitled",
+						url: stringField(result, "url"),
+						description: stringField(result, "description"),
+					})),
+				};
+			},
+		}),
+		scrapeUrl: createTool({
+			id: "scrapeUrl",
+			description:
+				"Read one public web page as markdown after searchWeb identifies a relevant URL.",
+			inputSchema: z.object({ url: z.url() }).strict(),
+			execute: async ({ url }) => {
+				await onAction?.("Reading page");
+				const page = await firecrawl.scrape(url, { formats: ["markdown"] });
+				return {
+					title: page.metadata?.title,
+					url: page.metadata?.sourceURL ?? url,
+					markdown: trimMarkdown(page.markdown),
+				};
+			},
+		}),
+	};
+};

--- a/apps/chat/src/lib/env.ts
+++ b/apps/chat/src/lib/env.ts
@@ -16,6 +16,7 @@ const envSchema = z
 		CLIENT_URL: z.string().min(1).default("http://localhost:3000"),
 		DATABASE_URL: z.string().min(1),
 		ENCRYPTION_PASSWORD: z.string().min(1),
+		FIRECRAWL_API_KEY: z.string().min(1),
 		PORT: z.coerce.number().int().positive().default(3099),
 		SLACK_CLIENT_ID: z.string().min(1),
 		SLACK_CLIENT_SECRET: z.string().min(1),

--- a/apps/chat/tests/unit/agent/agent.test.ts
+++ b/apps/chat/tests/unit/agent/agent.test.ts
@@ -1,0 +1,127 @@
+import { AppEnv } from "@autumn/shared";
+import { describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+process.env.ENCRYPTION_PASSWORD ??= "test";
+process.env.SLACK_CLIENT_ID ??= "test";
+process.env.SLACK_CLIENT_SECRET ??= "test";
+process.env.SLACK_SIGNING_SECRET ??= "test";
+process.env.FIRECRAWL_API_KEY ??= "fc_test";
+
+const { selectChatEnv } = await import("../../../src/agent/agent.js");
+const { createFirecrawlTools } = await import("../../../src/agent/firecrawl.js");
+
+const execute = async (
+	tool: { execute?: (...args: never[]) => Promise<unknown> } | undefined,
+	input: unknown,
+) => {
+	if (!tool?.execute) throw new Error("Tool is not executable");
+	return tool.execute(input as never, {} as never);
+};
+
+describe("chat environment selection", () => {
+	test("uses live from structured model output", async () => {
+		await expect(
+			selectChatEnv({
+				message: "list customers",
+				select: () => ({ env: AppEnv.Live }),
+			}),
+		).resolves.toBe(AppEnv.Live);
+	});
+
+	test("uses sandbox from structured model output", async () => {
+		await expect(
+			selectChatEnv({
+				message: "try this in the sandbox first",
+				select: () => ({ env: AppEnv.Sandbox }),
+			}),
+		).resolves.toBe(AppEnv.Sandbox);
+	});
+
+	test("rejects malformed model output", async () => {
+		await expect(
+			selectChatEnv({
+				message: "test mode",
+				select: () => ({ env: "test" }),
+			}),
+		).rejects.toThrow();
+	});
+});
+
+describe("Firecrawl tools", () => {
+	test("registers search and scrape tools", () => {
+		const tools = createFirecrawlTools({
+			apiKey: "fc_test",
+			client: {
+				search: async () => ({ web: [] }),
+				scrape: async () => ({}),
+			},
+		});
+
+		expect(Object.keys(tools).sort()).toEqual(["scrapeUrl", "searchWeb"]);
+	});
+
+	test("maps search results into compact output", async () => {
+		const tools = createFirecrawlTools({
+			apiKey: "fc_test",
+			client: {
+				search: async (query, options) => {
+					expect(query).toBe("autumn billing docs");
+					expect(options).toEqual({ limit: 2, sources: ["web"] });
+					return {
+						web: [
+							{
+								title: "Autumn Docs",
+								url: "https://docs.useautumn.com",
+								description: "Billing docs",
+							},
+						],
+					};
+				},
+				scrape: async () => ({}),
+			},
+		});
+
+		await expect(
+			execute(tools.searchWeb, { query: "autumn billing docs", limit: 2 }),
+		).resolves.toEqual({
+			results: [
+				{
+					title: "Autumn Docs",
+					url: "https://docs.useautumn.com",
+					description: "Billing docs",
+				},
+			],
+		});
+	});
+
+	test("scrapes one URL and bounds returned markdown", async () => {
+		const tools = createFirecrawlTools({
+			apiKey: "fc_test",
+			client: {
+				search: async () => ({ web: [] }),
+				scrape: async (url, options) => {
+					expect(url).toBe("https://example.com");
+					expect(options).toEqual({ formats: ["markdown"] });
+					return {
+						markdown: `${"a".repeat(13_000)}\n\n\nextra`,
+						metadata: {
+							title: "Example",
+							sourceURL: "https://example.com",
+						},
+					};
+				},
+			},
+		});
+
+		const result = await execute(tools.scrapeUrl, {
+			url: "https://example.com",
+		});
+
+		expect(result).toMatchObject({
+			title: "Example",
+			url: "https://example.com",
+		});
+		expect((result as { markdown: string }).markdown.length).toBe(12_000);
+	});
+});

--- a/apps/chat/tests/unit/approvals/flow.test.ts
+++ b/apps/chat/tests/unit/approvals/flow.test.ts
@@ -1,0 +1,47 @@
+import { AppEnv } from "@autumn/shared";
+import { describe, expect, test } from "bun:test";
+import { approvalRequestFromOutput } from "../../../src/approvals/request.js";
+import type { AgentOutput } from "../../../src/types.js";
+
+describe("approval flow", () => {
+	test("maps suspended destructive tool output to a pending approval request", () => {
+		const request = approvalRequestFromOutput({
+			env: AppEnv.Sandbox,
+			finishReason: "suspended",
+			runId: "run_1",
+			suspendPayload: {
+				toolCallId: "call_1",
+				toolName: "attach",
+				args: { request: { customer_id: "cus_1", plan_id: "pro" } },
+			},
+			text: "Preview ready.",
+		} satisfies AgentOutput);
+
+		expect(request).toEqual({
+			env: AppEnv.Sandbox,
+			runId: "run_1",
+			toolCallId: "call_1",
+			toolName: "attach",
+			toolArgs: { request: { customer_id: "cus_1", plan_id: "pro" } },
+			preview: "Preview ready.",
+		});
+	});
+
+	test("maps preview output to the matching write approval request", () => {
+		const request = approvalRequestFromOutput({
+			env: AppEnv.Live,
+			previewApproval: {
+				toolName: "updateSubscription",
+				toolArgs: { request: { customer_id: "cus_1", plan_id: "pro" } },
+				preview: { total: 100 },
+			},
+		} satisfies AgentOutput);
+
+		expect(request).toEqual({
+			env: AppEnv.Live,
+			toolName: "updateSubscription",
+			toolArgs: { request: { customer_id: "cus_1", plan_id: "pro" } },
+			preview: { total: 100 },
+		});
+	});
+});

--- a/apps/chat/tests/unit/providers/slack/context.test.ts
+++ b/apps/chat/tests/unit/providers/slack/context.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { getSlackWorkspaceId } from "../../../../src/providers/slack/context.js";
+
+describe("chat context", () => {
+	test("parses Slack workspace ids", () => {
+		expect(getSlackWorkspaceId({ team_id: "T123" })).toBe("T123");
+		expect(getSlackWorkspaceId({ team: { id: "T456" } })).toBe("T456");
+	});
+
+	test("rejects missing workspace ids", () => {
+		expect(() => getSlackWorkspaceId({})).toThrow();
+	});
+});

--- a/apps/chat/tests/unit/ui/blocks.test.ts
+++ b/apps/chat/tests/unit/ui/blocks.test.ts
@@ -1,0 +1,138 @@
+import { AppEnv } from "@autumn/shared";
+import { describe, expect, test } from "bun:test";
+import { approvalCard, approvalStatusCard } from "../../../src/ui/blocks.js";
+
+describe("approval card", () => {
+	test("renders billing approvals as structured cards", () => {
+		const card = approvalCard({
+			id: "approval_1",
+			env: AppEnv.Sandbox,
+			toolName: "attach",
+			toolArgs: {
+				request: {
+					customer_id: "get-full-entity-ordering",
+					plan_id: "pro_att-disc-dedup",
+				},
+			},
+			preview:
+				"I'll preview this now!Here's the billing impact preview:Plan: ProCustomer: get-full-entity-orderingTotal $20.00No discounts applied",
+		});
+
+		expect(card.title).toBe("Attach plan?");
+		expect(card.children[0]?.type).toBe("fields");
+		expect(card.children.at(-1)?.type).toBe("actions");
+		expect(JSON.stringify(card)).toContain("Sandbox");
+		expect(JSON.stringify(card)).toContain("pro_att-disc-dedup");
+		expect(JSON.stringify(card)).toContain("• Plan: Pro");
+	});
+
+	test("renders closed approvals without buttons or raw JSON", () => {
+		const card = approvalStatusCard({
+			status: "failed",
+			toolName: "attach",
+			toolArgs: {
+				request: {
+					customer_id: "cus_1",
+					plan_id: "pro",
+				},
+			},
+			result: {
+				error: true,
+				message: "Tool input validation failed.",
+				validationErrors: { fields: {} },
+			},
+		});
+
+		expect(card.title).toBe("Attach plan failed");
+		expect(card.children.at(-1)?.type).not.toBe("actions");
+		expect(JSON.stringify(card)).toContain("Tool input validation failed.");
+		expect(JSON.stringify(card)).not.toContain("validationErrors");
+	});
+
+	test("does not render raw request JSON as preview text", () => {
+		const card = approvalCard({
+			id: "approval_1",
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "charlie",
+					plan_id: "pro",
+					customize: { price: { amount: 200, interval: "month" } },
+				},
+			},
+			preview: {
+				request: {
+					customer_id: "charlie",
+					plan_id: "pro",
+				},
+			},
+		});
+
+		expect(JSON.stringify(card)).toContain("$200/month");
+		expect(JSON.stringify(card)).not.toContain('"request"');
+		expect(card.children.at(-1)?.type).toBe("actions");
+	});
+
+	test("cleans markdown and keeps decimal amounts intact", () => {
+		const card = approvalCard({
+			id: "approval_1",
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "charlie",
+					plan_id: "pro",
+					customize: { price: { amount: 400, interval: "month" } },
+				},
+			},
+			preview:
+				"Let me preview that update!\n**Immediate charge (proration)**\n- 💳 **$178.65 due now**\n- Credit for unused time: -$178.65",
+		});
+
+		const json = JSON.stringify(card);
+		expect(json).toContain("$178.65 due now");
+		expect(json).not.toContain("**");
+		expect(json).not.toContain("$178.\\n");
+		expect(json).not.toContain("Let me preview");
+	});
+
+	test("shows action progress and omits empty success text", () => {
+		const running = approvalStatusCard({
+			status: "running",
+			toolName: "updateSubscription",
+			toolArgs: { request: { customer_id: "charlie", plan_id: "pro" } },
+		});
+		const approved = approvalStatusCard({
+			status: "approved",
+			toolName: "updateSubscription",
+			toolArgs: { request: { customer_id: "charlie", plan_id: "pro" } },
+			preview: "**old preview**",
+			result: {},
+		});
+
+		expect(JSON.stringify(running)).toContain(
+			"Applying the approved action now",
+		);
+		expect(approved.title).toBe("Update subscription approved");
+		expect(JSON.stringify(approved)).not.toContain("Applied successfully.");
+		expect(JSON.stringify(approved)).not.toContain("old preview");
+	});
+
+	test("shows nested write result details", () => {
+		const card = approvalStatusCard({
+			status: "approved",
+			env: AppEnv.Live,
+			toolName: "attach",
+			result: {
+				result: {
+					status: "created",
+					checkout_url: "https://checkout.example",
+				},
+			},
+		});
+
+		const json = JSON.stringify(card);
+		expect(json).toContain("Live");
+		expect(json).toContain("Status: created");
+		expect(json).toContain("Checkout URL: https://checkout.example");
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "@chat-adapter/state-pg": "^4.29.0",
         "@mastra/core": "^1.36.0",
         "@mastra/mcp": "^1.8.0",
+        "@mendable/firecrawl-js": "^4.25.1",
         "chat": "^4.29.0",
         "date-fns": "^4.1.0",
         "drizzle-orm": "catalog:",
@@ -111,6 +112,7 @@
       "name": "@autumn/mcp-server",
       "dependencies": {
         "@autumn/mcp": "workspace:*",
+        "@autumn/shared": "workspace:*",
         "@hono/node-server": "^1.19.5",
         "hono": "4.12.7",
       },
@@ -1389,6 +1391,8 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
+
+    "@mendable/firecrawl-js": ["@mendable/firecrawl-js@4.25.1", "", { "dependencies": { "axios": "1.15.2", "firecrawl": "4.16.0", "typescript-event-target": "^1.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.0" } }, "sha512-Oo5tFCltCRMEJiaIsFOIBAzeRNq+OZ5qocrexvRcxXCnoEkqAoKunzbadSEEFZXYYayWj6yyYoGhRcGg5R14Dg=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
@@ -3716,6 +3720,8 @@
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
+    "firecrawl": ["firecrawl@4.16.0", "", { "dependencies": { "axios": "^1.13.5", "typescript-event-target": "^1.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.0" } }, "sha512-7SJ/FWhZBtW2gTCE/BsvU+gbfIpfTq+D9IH82l9MacauLVptaY6EdYAhrK3YSMC9yr5NxvxRcpZKcXG/nqjiiQ=="],
+
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
@@ -5720,6 +5726,8 @@
 
     "typescript-eslint": ["typescript-eslint@8.59.4", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.4", "@typescript-eslint/parser": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/utils": "8.59.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ=="],
 
+    "typescript-event-target": ["typescript-event-target@1.1.2", "", {}, "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw=="],
+
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
@@ -6255,6 +6263,8 @@
     "@mastra/core/hono": ["hono@4.12.22", "", {}, "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw=="],
 
     "@mastra/core/p-retry": ["p-retry@7.1.1", "", { "dependencies": { "is-network-error": "^1.1.0" } }, "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w=="],
+
+    "@mendable/firecrawl-js/axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
 
     "@mermaid-js/parser/@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 

--- a/packages/mcp/src/mcp-server/agent/resources.ts
+++ b/packages/mcp/src/mcp-server/agent/resources.ts
@@ -74,6 +74,7 @@ Prefer server-side filters before local filtering:
 - subscription_status: active or scheduled subscriptions
 - processors: payment processor filters
 
+Use limit 1000 for broad scans; that is the maximum page size.
 Always paginate until next_cursor is empty when the user asks for complete results. Use getCustomer only for details not returned by listCustomers.`,
 	},
 	"autumn://docs/schedules": {

--- a/packages/mcp/src/mcp-server/agent/tools.ts
+++ b/packages/mcp/src/mcp-server/agent/tools.ts
@@ -110,6 +110,15 @@ const createBalanceMcpSchema = CreateBalanceParamsV0Schema.extend({
 	}),
 });
 
+const listCustomersMcpSchema = ListCustomersV2_3ParamsSchema.extend({
+	limit: z
+		.preprocess(
+			(value) => (typeof value === "number" && value > 1000 ? 1000 : value),
+			z.number().int().positive().max(1000).optional(),
+		)
+		.meta({ description: "Maximum customers per page. Max 1000." }),
+});
+
 const writeSchemaByTool = {
 	attach: AttachParamsV1Schema,
 	updateSubscription: UpdateSubscriptionV1ParamsSchema,
@@ -119,7 +128,7 @@ const writeSchemaByTool = {
 } as const satisfies Record<ConfirmedWriteToolName, z.ZodType>;
 
 export const schemaByTool = {
-	listCustomers: ListCustomersV2_3ParamsSchema,
+	listCustomers: listCustomersMcpSchema,
 	createCustomer: CreateCustomerParamsV1Schema,
 	getCustomer: GetCustomerParamsV1Schema,
 	listPlans: ListPlanParamsSchema,
@@ -142,8 +151,8 @@ const toolConfigs: OperationToolConfig[] = [
 	{
 		id: "listCustomers",
 		description:
-			"List Autumn customers. Use search, plans, subscription_status, and processors filters for customer-heavy queries. For queued/upcoming plan version queries, use subscription_status scheduled and omit the earliest matching version unless the user asks for all historical versions (versions 1,2,3 -> filter 2,3). 'live', 'paying', and active subscribers usually mean subscription_status active. When a plan is named, include the plans filter instead of listing broad customer sets. If listPlans returned matching versions, pass only relevant versions in plans[].versions, never guessed versions. For every/all/complete requests, paginate by calling again with start_cursor set to the previous response's next_cursor until next_cursor is empty.",
-		schema: ListCustomersV2_3ParamsSchema,
+			"List Autumn customers. Use search, plans, subscription_status, and processors filters for customer-heavy queries. limit max is 1000. For queued/upcoming plan version queries, use subscription_status scheduled and omit the earliest matching version unless the user asks for all historical versions (versions 1,2,3 -> filter 2,3). 'live', 'paying', and active subscribers usually mean subscription_status active. When a plan is named, include the plans filter instead of listing broad customer sets. If listPlans returned matching versions, pass only relevant versions in plans[].versions, never guessed versions. For every/all/complete requests, paginate by calling again with start_cursor set to the previous response's next_cursor until next_cursor is empty.",
+		schema: listCustomersMcpSchema,
 		endpoint: endpointByTool.listCustomers,
 	},
 	{

--- a/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
@@ -275,6 +275,7 @@ describe("Autumn operation tools", () => {
 		globalThis.fetch = (async (url, init) => {
 			expect(String(url)).toBe("http://localhost:8080/v1/customers.list");
 			expect(JSON.parse(init?.body as string)).toMatchObject({
+				limit: 1000,
 				search: "charlie",
 			});
 			return Response.json({ customers: [] });
@@ -286,7 +287,7 @@ describe("Autumn operation tools", () => {
 
 			await expect(
 				tool.execute(
-					{ request: { search: "charlie" } },
+					{ request: { limit: 5000, search: "charlie" } },
 					{ mcp: { extra: { authInfo: auth } } } as never,
 				),
 			).resolves.toEqual({ customers: [] });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Firecrawl web search and scraping to Autumn Chat for external context with source citations and guidance to prefer search then scrape. Also clamps MCP listCustomers page size to 1000 and documents it to prevent heavy queries.

- New Features
  - Chat agent: adds `searchWeb` and `scrapeUrl` tools via `@mendable/firecrawl-js`; limits to 5 results, trims markdown to 12k chars, emits progress messages, updates instructions to avoid web for internal data and cite URLs.
  - MCP: enforces `listCustomers.limit` max 1000 (schema clamp) and notes the max in resources; adds unit tests across agent, approvals, Slack context, and UI blocks.

- Migration
  - Set `FIRECRAWL_API_KEY` in the chat app environment.
  - Install deps to pull `@mendable/firecrawl-js`.

<sup>Written for commit 758e513d7a610a27e4b70c0b02259fae94ab6d03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Firecrawl-backed web search (`searchWeb` / `scrapeUrl`) to the Autumn Chat agent, expands MCP instruction resources with a limit-1000 guidance note, and caps the `listCustomers` `limit` parameter at 1000 via a `z.preprocess` schema extension. A suite of new unit tests for the agent, approval flow, Slack context, and UI blocks is also introduced alongside the `.gitignore` change that opts those tests into git.

- **Improvements**: `searchWeb` and `scrapeUrl` Mastra tools integrate Firecrawl into the agent, with agent instructions updated to prefer Autumn MCP tools for internal data and web search for external context. Tests mock the Firecrawl client for deterministic unit coverage.
- **Improvements**: `listCustomersMcpSchema` silently clamps `limit` values above 1000 to 1000 using `z.preprocess`, and the MCP resources doc now advises using `limit: 1000` for broad scans.
- **API changes**: `FIRECRAWL_API_KEY` is added as a required environment variable to `apps/chat`'s env schema, making web-search capability mandatory for service startup rather than opt-in.
</details>

<h3>Confidence Score: 4/5</h3>

The chat service logic is sound and well-tested, but any existing deployment without FIRECRAWL_API_KEY set will fail to start after this change is deployed.

The Firecrawl integration and schema capping are correctly implemented and covered by tests. The one concern that warrants attention before merging is that FIRECRAWL_API_KEY is now a hard required env var with no default — the chat service will refuse to start on any deployment that hasn't yet provisioned the key.

apps/chat/src/lib/env.ts — the new required FIRECRAWL_API_KEY field will break existing deployments; consider whether it should be optional to allow a graceful rollout.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/chat/src/agent/firecrawl.ts | New file introducing searchWeb and scrapeUrl Mastra tools backed by the Firecrawl API, with a local client injection point for tests. |
| apps/chat/src/agent/agent.ts | Firecrawl tools merged into the agent tool map and system prompt updated with web-search guidance; FIRECRAWL_API_KEY now consumed here unconditionally. |
| apps/chat/src/lib/env.ts | FIRECRAWL_API_KEY added as a required field with no default — the service will refuse to start if the key is absent, a hard new deployment prerequisite. |
| packages/mcp/src/mcp-server/agent/tools.ts | Adds listCustomersMcpSchema that silently caps limit > 1000 to 1000 via z.preprocess, replacing the bare ListCustomersV2_3ParamsSchema. |
| packages/mcp/src/mcp-server/agent/resources.ts | Adds guidance about using limit 1000 for broad scans to the querying-customers doc resource. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ChatAgent as Autumn Chat Agent
    participant MCP as Autumn MCP Tools
    participant Firecrawl as Firecrawl API

    User->>ChatAgent: message
    ChatAgent->>MCP: getAutumnMcpTools + readDocs
    MCP-->>ChatAgent: tools + docs text
    ChatAgent->>ChatAgent: createFirecrawlTools (searchWeb, scrapeUrl)
    ChatAgent->>ChatAgent: merge tools

    Note over ChatAgent: Agent reasons: external query to use searchWeb
    ChatAgent->>Firecrawl: search(query, limit, sources)
    Firecrawl-->>ChatAgent: web results

    opt Most relevant result
        ChatAgent->>Firecrawl: scrape(url, markdown format)
        Firecrawl-->>ChatAgent: markdown + metadata
        ChatAgent->>ChatAgent: trimMarkdown (slice 12k)
    end

    ChatAgent-->>User: Answer with cited source URLs
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/chat/src/lib/env.ts:19
`FIRECRAWL_API_KEY` is now a hard required field with no default. The `envSchema` is evaluated at module load time, so any existing deployment that hasn't yet set this key will fail to start entirely — the service throws before accepting a single request. If the intent is to let operators opt into web search, consider making the key optional (`z.string().min(1).optional()`) and only registering the Firecrawl tools in `agent.ts` when the key is present.

### Issue 2 of 3
apps/chat/src/agent/agent.ts:135
Firecrawl tools are spread after the MCP tools: `{ ...tools, ...firecrawlTools }`. If an Autumn MCP tool is ever named `searchWeb` or `scrapeUrl`, the Firecrawl tools silently win. Spreading MCP tools last (or asserting no overlap) would make the precedence explicit and prevent a silent capability loss.

### Issue 3 of 3
apps/chat/src/agent/firecrawl.ts:66-68
`stringField` returns `unknown` (specifically `Record<string, unknown>[field]`), so `url` and `description` on the returned result objects are typed as `unknown`. This passes type-checking today only because the `results` array is inferred as `unknown[]`. An explicit cast or a typed helper (e.g. `stringField` returning `string | undefined`) would prevent callers from accidentally treating these as strings without a guard.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: mcp improvements"](https://github.com/useautumn/autumn/commit/758e513d7a610a27e4b70c0b02259fae94ab6d03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35210161)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->