### PR TITLE
release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ on:
         default: 'manual'
 
 env:
-  AWS_REGION: us-west-2
+  # ECR region is selected per-branch in the "Extract metadata" step:
+  #   prod repo (autumn)         -> us-east-2
+  #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
   STAGING_DEPLOY_BRANCH_ALLOWLIST: fix-health-check-redis-disabled-detection feat/track-rate-limit-redis
@@ -55,17 +57,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-      
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      
       - name: Extract metadata for Docker
         id: meta
         env:
@@ -103,17 +94,30 @@ jobs:
           echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
           echo "deploy_staging_override=$DEPLOY_STAGING_OVERRIDE" >> $GITHUB_OUTPUT
           
-          # Select ECR repository based on branch
+          # Select ECR repository + region based on branch
           if [ "$BRANCH_NAME" = "dev" ] || [ "$DEPLOY_STAGING_OVERRIDE" = "true" ]; then
             echo "ecr_repo=autumn-staging" >> $GITHUB_OUTPUT
+            echo "region=us-east-1" >> $GITHUB_OUTPUT
           else
             echo "ecr_repo=autumn" >> $GITHUB_OUTPUT
+            echo "region=us-east-2" >> $GITHUB_OUTPUT
           fi
           
           # Set custom tag if provided
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.tag }}" ]; then
             echo "custom_tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
           fi
+      
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ steps.meta.outputs.region }}
+      
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
       
       - name: Set up Blacksmith Docker builder
         uses: useblacksmith/setup-docker-builder@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,8 +115,8 @@ jobs:
             echo "custom_tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
           fi
       
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Blacksmith Docker builder
+        uses: useblacksmith/setup-docker-builder@v1
       
       - name: Build and push Docker image
         env:
@@ -129,14 +129,13 @@ jobs:
           COMBINED_TAG="${IMAGE_TAG_BRANCH}-${IMAGE_TAG_SHA}"
           TAGS="${ECR_REGISTRY}/${ECR_REPOSITORY}:${COMBINED_TAG}"
           
-          # Build and push
+          # Layer + cache-mount persistence is handled by the Blacksmith sticky
+          # disk mounted at /var/lib/buildkit, so no registry cache-from/to.
           docker buildx build \
             --platform linux/amd64 \
             --push \
             --provenance=false \
             --sbom=false \
-            --cache-from type=registry,ref=${ECR_REGISTRY}/${ECR_REPOSITORY}:buildcache-${IMAGE_TAG_BRANCH} \
-            --cache-to type=registry,ref=${ECR_REGISTRY}/${ECR_REPOSITORY}:buildcache-${IMAGE_TAG_BRANCH},mode=max \
             --tag ${TAGS//,/ --tag } \
             -f docker/Dockerfile \
             .

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ supabase.sh
 tests/
 !server/tests
 !packages/mcp/tests
+!apps/chat/tests
 !vite/tests
 .secrets
 

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -16,6 +16,7 @@
 		"@chat-adapter/state-pg": "^4.29.0",
 		"@mastra/core": "^1.36.0",
 		"@mastra/mcp": "^1.8.0",
+		"@mendable/firecrawl-js": "^4.25.1",
 		"chat": "^4.29.0",
 		"date-fns": "^4.1.0",
 		"drizzle-orm": "catalog:",

--- a/apps/chat/src/agent/agent.ts
+++ b/apps/chat/src/agent/agent.ts
@@ -5,6 +5,7 @@ import {
 	createAutumnMcpClient,
 	getAutumnMcpTools,
 } from "./mcp.js";
+import { createFirecrawlTools } from "./firecrawl.js";
 import { env as chatEnv } from "../lib/env.js";
 import type { ChatContextMessage } from "../types.js";
 
@@ -19,6 +20,9 @@ const docs = [
 
 const instructions = `You are Autumn Chat.
 Use Autumn MCP tools for customer, plan, balance, schedule, and billing work.
+Use web search only for current or external web context. Never use web search for Autumn customer, plan, billing, balance, or schedule state.
+When web content influences the answer, cite the source URLs.
+Prefer searchWeb first, then scrapeUrl only for the most relevant result.
 Preview billing-impacting changes first, summarize the preview in short Slack-friendly bullets, then call the matching write tool with the same request args.
 The runtime pauses destructive tools for approval before execution, so do not ask for confirmation in plain text.`;
 
@@ -118,13 +122,17 @@ export const runChatAgent = async ({
 			}),
 			readDocs(mcp),
 		]);
+		const firecrawlTools = createFirecrawlTools({
+			apiKey: chatEnv.FIRECRAWL_API_KEY,
+			onAction,
+		});
 		await onAction?.("Reasoning over the request");
 		const agent = new Agent({
 			id: "autumn-chat",
 			name: "Autumn Chat",
 			instructions: `${instructions}\n\nCurrent Autumn environment: ${env}.\n\n${docsText}`,
 			model: chatEnv.CHAT_MODEL,
-			tools,
+			tools: { ...tools, ...firecrawlTools },
 		});
 
 		const output = await agent.generate(message, {

--- a/apps/chat/src/agent/firecrawl.ts
+++ b/apps/chat/src/agent/firecrawl.ts
@@ -1,0 +1,89 @@
+import { createTool } from "@mastra/core/tools";
+import Firecrawl from "@mendable/firecrawl-js";
+import { z } from "zod";
+
+type FirecrawlClient = {
+	search: (
+		query: string,
+		options?: { limit?: number; sources?: ["web"] },
+	) => Promise<{ web?: unknown[] }>;
+	scrape: (
+		url: string,
+		options?: { formats?: ["markdown"] },
+	) => Promise<{
+		markdown?: string;
+		metadata?: { title?: string; sourceURL?: string };
+	}>;
+};
+
+const maxSearchResults = 5;
+const maxMarkdownLength = 12_000;
+
+const trimMarkdown = (markdown = "") =>
+	markdown
+		.replace(/\n{3,}/g, "\n\n")
+		.trim()
+		.slice(0, maxMarkdownLength);
+
+const stringField = (value: unknown, field: string) =>
+	value && typeof value === "object"
+		? (value as Record<string, unknown>)[field]
+		: undefined;
+
+export const createFirecrawlTools = ({
+	apiKey,
+	client,
+	onAction,
+}: {
+	apiKey: string;
+	client?: FirecrawlClient;
+	onAction?: (message: string) => Promise<void> | void;
+}): Record<string, ReturnType<typeof createTool>> => {
+	const firecrawl = client ?? new Firecrawl({ apiKey });
+
+	return {
+		searchWeb: createTool({
+			id: "searchWeb",
+			description:
+				"Search the public web for current or external information. Use Autumn MCP tools instead for Autumn customer, plan, billing, balance, or schedule data.",
+			inputSchema: z
+				.object({
+					query: z.string().min(1),
+					limit: z.number().int().positive().max(maxSearchResults).optional(),
+				})
+				.strict(),
+			execute: async ({ query, limit = maxSearchResults }) => {
+				await onAction?.("Searching web");
+				const results = await firecrawl.search(query, {
+					limit,
+					sources: ["web"],
+				});
+				return {
+					results: (results.web ?? []).slice(0, limit).map((result) => ({
+						title:
+							stringField(result, "title") ??
+							stringField(result, "url") ??
+							"Untitled",
+						url: stringField(result, "url"),
+						description: stringField(result, "description"),
+					})),
+				};
+			},
+		}),
+		scrapeUrl: createTool({
+			id: "scrapeUrl",
+			description:
+				"Read one public web page as markdown after searchWeb identifies a relevant URL.",
+			inputSchema: z.object({ url: z.url() }).strict(),
+			execute: async ({ url }) => {
+				await onAction?.("Reading page");
+				const page = await firecrawl.scrape(url, { formats: ["markdown"] });
+				return {
+					title: page.metadata?.title,
+					url: page.metadata?.sourceURL ?? url,
+					markdown: trimMarkdown(page.markdown),
+				};
+			},
+		}),
+	};
+};

--- a/apps/chat/src/agent/firecrawl.ts
+++ b/apps/chat/src/agent/firecrawl.ts
@@ -74,7 +74,7 @@ export const createFirecrawlTools = ({
 			id: "scrapeUrl",
 			description:
 				"Read one public web page as markdown after searchWeb identifies a relevant URL.",
-			inputSchema: z.object({ url: z.url() }).strict(),
+			inputSchema: z.object({ url: z.string().url() }).strict(),
 			execute: async ({ url }) => {
 				await onAction?.("Reading page");
 				const page = await firecrawl.scrape(url, { formats: ["markdown"] });

--- a/apps/chat/src/lib/env.ts
+++ b/apps/chat/src/lib/env.ts
@@ -16,6 +16,7 @@ const envSchema = z
 		CLIENT_URL: z.string().min(1).default("http://localhost:3000"),
 		DATABASE_URL: z.string().min(1),
 		ENCRYPTION_PASSWORD: z.string().min(1),
+		FIRECRAWL_API_KEY: z.string().min(1),
 		PORT: z.coerce.number().int().positive().default(3099),
 		SLACK_CLIENT_ID: z.string().min(1),
 		SLACK_CLIENT_SECRET: z.string().min(1),

--- a/apps/chat/tests/unit/agent/agent.test.ts
+++ b/apps/chat/tests/unit/agent/agent.test.ts
@@ -1,0 +1,127 @@
+import { AppEnv } from "@autumn/shared";
+import { describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ??= "postgresql://postgres:postgres@localhost:5432/postgres";
+process.env.ENCRYPTION_PASSWORD ??= "test";
+process.env.SLACK_CLIENT_ID ??= "test";
+process.env.SLACK_CLIENT_SECRET ??= "test";
+process.env.SLACK_SIGNING_SECRET ??= "test";
+process.env.FIRECRAWL_API_KEY ??= "fc_test";
+
+const { selectChatEnv } = await import("../../../src/agent/agent.js");
+const { createFirecrawlTools } = await import("../../../src/agent/firecrawl.js");
+
+const execute = async (
+	tool: { execute?: (...args: never[]) => Promise<unknown> } | undefined,
+	input: unknown,
+) => {
+	if (!tool?.execute) throw new Error("Tool is not executable");
+	return tool.execute(input as never, {} as never);
+};
+
+describe("chat environment selection", () => {
+	test("uses live from structured model output", async () => {
+		await expect(
+			selectChatEnv({
+				message: "list customers",
+				select: () => ({ env: AppEnv.Live }),
+			}),
+		).resolves.toBe(AppEnv.Live);
+	});
+
+	test("uses sandbox from structured model output", async () => {
+		await expect(
+			selectChatEnv({
+				message: "try this in the sandbox first",
+				select: () => ({ env: AppEnv.Sandbox }),
+			}),
+		).resolves.toBe(AppEnv.Sandbox);
+	});
+
+	test("rejects malformed model output", async () => {
+		await expect(
+			selectChatEnv({
+				message: "test mode",
+				select: () => ({ env: "test" }),
+			}),
+		).rejects.toThrow();
+	});
+});
+
+describe("Firecrawl tools", () => {
+	test("registers search and scrape tools", () => {
+		const tools = createFirecrawlTools({
+			apiKey: "fc_test",
+			client: {
+				search: async () => ({ web: [] }),
+				scrape: async () => ({}),
+			},
+		});
+
+		expect(Object.keys(tools).sort()).toEqual(["scrapeUrl", "searchWeb"]);
+	});
+
+	test("maps search results into compact output", async () => {
+		const tools = createFirecrawlTools({
+			apiKey: "fc_test",
+			client: {
+				search: async (query, options) => {
+					expect(query).toBe("autumn billing docs");
+					expect(options).toEqual({ limit: 2, sources: ["web"] });
+					return {
+						web: [
+							{
+								title: "Autumn Docs",
+								url: "https://docs.useautumn.com",
+								description: "Billing docs",
+							},
+						],
+					};
+				},
+				scrape: async () => ({}),
+			},
+		});
+
+		await expect(
+			execute(tools.searchWeb, { query: "autumn billing docs", limit: 2 }),
+		).resolves.toEqual({
+			results: [
+				{
+					title: "Autumn Docs",
+					url: "https://docs.useautumn.com",
+					description: "Billing docs",
+				},
+			],
+		});
+	});
+
+	test("scrapes one URL and bounds returned markdown", async () => {
+		const tools = createFirecrawlTools({
+			apiKey: "fc_test",
+			client: {
+				search: async () => ({ web: [] }),
+				scrape: async (url, options) => {
+					expect(url).toBe("https://example.com");
+					expect(options).toEqual({ formats: ["markdown"] });
+					return {
+						markdown: `${"a".repeat(13_000)}\n\n\nextra`,
+						metadata: {
+							title: "Example",
+							sourceURL: "https://example.com",
+						},
+					};
+				},
+			},
+		});
+
+		const result = await execute(tools.scrapeUrl, {
+			url: "https://example.com",
+		});
+
+		expect(result).toMatchObject({
+			title: "Example",
+			url: "https://example.com",
+		});
+		expect((result as { markdown: string }).markdown.length).toBe(12_000);
+	});
+});

--- a/apps/chat/tests/unit/approvals/flow.test.ts
+++ b/apps/chat/tests/unit/approvals/flow.test.ts
@@ -1,0 +1,47 @@
+import { AppEnv } from "@autumn/shared";
+import { describe, expect, test } from "bun:test";
+import { approvalRequestFromOutput } from "../../../src/approvals/request.js";
+import type { AgentOutput } from "../../../src/types.js";
+
+describe("approval flow", () => {
+	test("maps suspended destructive tool output to a pending approval request", () => {
+		const request = approvalRequestFromOutput({
+			env: AppEnv.Sandbox,
+			finishReason: "suspended",
+			runId: "run_1",
+			suspendPayload: {
+				toolCallId: "call_1",
+				toolName: "attach",
+				args: { request: { customer_id: "cus_1", plan_id: "pro" } },
+			},
+			text: "Preview ready.",
+		} satisfies AgentOutput);
+
+		expect(request).toEqual({
+			env: AppEnv.Sandbox,
+			runId: "run_1",
+			toolCallId: "call_1",
+			toolName: "attach",
+			toolArgs: { request: { customer_id: "cus_1", plan_id: "pro" } },
+			preview: "Preview ready.",
+		});
+	});
+
+	test("maps preview output to the matching write approval request", () => {
+		const request = approvalRequestFromOutput({
+			env: AppEnv.Live,
+			previewApproval: {
+				toolName: "updateSubscription",
+				toolArgs: { request: { customer_id: "cus_1", plan_id: "pro" } },
+				preview: { total: 100 },
+			},
+		} satisfies AgentOutput);
+
+		expect(request).toEqual({
+			env: AppEnv.Live,
+			toolName: "updateSubscription",
+			toolArgs: { request: { customer_id: "cus_1", plan_id: "pro" } },
+			preview: { total: 100 },
+		});
+	});
+});

--- a/apps/chat/tests/unit/providers/slack/context.test.ts
+++ b/apps/chat/tests/unit/providers/slack/context.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { getSlackWorkspaceId } from "../../../../src/providers/slack/context.js";
+
+describe("chat context", () => {
+	test("parses Slack workspace ids", () => {
+		expect(getSlackWorkspaceId({ team_id: "T123" })).toBe("T123");
+		expect(getSlackWorkspaceId({ team: { id: "T456" } })).toBe("T456");
+	});
+
+	test("rejects missing workspace ids", () => {
+		expect(() => getSlackWorkspaceId({})).toThrow();
+	});
+});

--- a/apps/chat/tests/unit/ui/blocks.test.ts
+++ b/apps/chat/tests/unit/ui/blocks.test.ts
@@ -1,0 +1,138 @@
+import { AppEnv } from "@autumn/shared";
+import { describe, expect, test } from "bun:test";
+import { approvalCard, approvalStatusCard } from "../../../src/ui/blocks.js";
+
+describe("approval card", () => {
+	test("renders billing approvals as structured cards", () => {
+		const card = approvalCard({
+			id: "approval_1",
+			env: AppEnv.Sandbox,
+			toolName: "attach",
+			toolArgs: {
+				request: {
+					customer_id: "get-full-entity-ordering",
+					plan_id: "pro_att-disc-dedup",
+				},
+			},
+			preview:
+				"I'll preview this now!Here's the billing impact preview:Plan: ProCustomer: get-full-entity-orderingTotal $20.00No discounts applied",
+		});
+
+		expect(card.title).toBe("Attach plan?");
+		expect(card.children[0]?.type).toBe("fields");
+		expect(card.children.at(-1)?.type).toBe("actions");
+		expect(JSON.stringify(card)).toContain("Sandbox");
+		expect(JSON.stringify(card)).toContain("pro_att-disc-dedup");
+		expect(JSON.stringify(card)).toContain("• Plan: Pro");
+	});
+
+	test("renders closed approvals without buttons or raw JSON", () => {
+		const card = approvalStatusCard({
+			status: "failed",
+			toolName: "attach",
+			toolArgs: {
+				request: {
+					customer_id: "cus_1",
+					plan_id: "pro",
+				},
+			},
+			result: {
+				error: true,
+				message: "Tool input validation failed.",
+				validationErrors: { fields: {} },
+			},
+		});
+
+		expect(card.title).toBe("Attach plan failed");
+		expect(card.children.at(-1)?.type).not.toBe("actions");
+		expect(JSON.stringify(card)).toContain("Tool input validation failed.");
+		expect(JSON.stringify(card)).not.toContain("validationErrors");
+	});
+
+	test("does not render raw request JSON as preview text", () => {
+		const card = approvalCard({
+			id: "approval_1",
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "charlie",
+					plan_id: "pro",
+					customize: { price: { amount: 200, interval: "month" } },
+				},
+			},
+			preview: {
+				request: {
+					customer_id: "charlie",
+					plan_id: "pro",
+				},
+			},
+		});
+
+		expect(JSON.stringify(card)).toContain("$200/month");
+		expect(JSON.stringify(card)).not.toContain('"request"');
+		expect(card.children.at(-1)?.type).toBe("actions");
+	});
+
+	test("cleans markdown and keeps decimal amounts intact", () => {
+		const card = approvalCard({
+			id: "approval_1",
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "charlie",
+					plan_id: "pro",
+					customize: { price: { amount: 400, interval: "month" } },
+				},
+			},
+			preview:
+				"Let me preview that update!\n**Immediate charge (proration)**\n- 💳 **$178.65 due now**\n- Credit for unused time: -$178.65",
+		});
+
+		const json = JSON.stringify(card);
+		expect(json).toContain("$178.65 due now");
+		expect(json).not.toContain("**");
+		expect(json).not.toContain("$178.\\n");
+		expect(json).not.toContain("Let me preview");
+	});
+
+	test("shows action progress and omits empty success text", () => {
+		const running = approvalStatusCard({
+			status: "running",
+			toolName: "updateSubscription",
+			toolArgs: { request: { customer_id: "charlie", plan_id: "pro" } },
+		});
+		const approved = approvalStatusCard({
+			status: "approved",
+			toolName: "updateSubscription",
+			toolArgs: { request: { customer_id: "charlie", plan_id: "pro" } },
+			preview: "**old preview**",
+			result: {},
+		});
+
+		expect(JSON.stringify(running)).toContain(
+			"Applying the approved action now",
+		);
+		expect(approved.title).toBe("Update subscription approved");
+		expect(JSON.stringify(approved)).not.toContain("Applied successfully.");
+		expect(JSON.stringify(approved)).not.toContain("old preview");
+	});
+
+	test("shows nested write result details", () => {
+		const card = approvalStatusCard({
+			status: "approved",
+			env: AppEnv.Live,
+			toolName: "attach",
+			result: {
+				result: {
+					status: "created",
+					checkout_url: "https://checkout.example",
+				},
+			},
+		});
+
+		const json = JSON.stringify(card);
+		expect(json).toContain("Live");
+		expect(json).toContain("Status: created");
+		expect(json).toContain("Checkout URL: https://checkout.example");
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "@chat-adapter/state-pg": "^4.29.0",
         "@mastra/core": "^1.36.0",
         "@mastra/mcp": "^1.8.0",
+        "@mendable/firecrawl-js": "^4.25.1",
         "chat": "^4.29.0",
         "date-fns": "^4.1.0",
         "drizzle-orm": "catalog:",
@@ -111,6 +112,7 @@
       "name": "@autumn/mcp-server",
       "dependencies": {
         "@autumn/mcp": "workspace:*",
+        "@autumn/shared": "workspace:*",
         "@hono/node-server": "^1.19.5",
         "hono": "4.12.7",
       },
@@ -1389,6 +1391,8 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
+
+    "@mendable/firecrawl-js": ["@mendable/firecrawl-js@4.25.1", "", { "dependencies": { "axios": "1.15.2", "firecrawl": "4.16.0", "typescript-event-target": "^1.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.0" } }, "sha512-Oo5tFCltCRMEJiaIsFOIBAzeRNq+OZ5qocrexvRcxXCnoEkqAoKunzbadSEEFZXYYayWj6yyYoGhRcGg5R14Dg=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
@@ -3716,6 +3720,8 @@
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
+    "firecrawl": ["firecrawl@4.16.0", "", { "dependencies": { "axios": "^1.13.5", "typescript-event-target": "^1.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.0" } }, "sha512-7SJ/FWhZBtW2gTCE/BsvU+gbfIpfTq+D9IH82l9MacauLVptaY6EdYAhrK3YSMC9yr5NxvxRcpZKcXG/nqjiiQ=="],
+
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
@@ -5720,6 +5726,8 @@
 
     "typescript-eslint": ["typescript-eslint@8.59.4", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.4", "@typescript-eslint/parser": "8.59.4", "@typescript-eslint/typescript-estree": "8.59.4", "@typescript-eslint/utils": "8.59.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ=="],
 
+    "typescript-event-target": ["typescript-event-target@1.1.2", "", {}, "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw=="],
+
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
@@ -6255,6 +6263,8 @@
     "@mastra/core/hono": ["hono@4.12.22", "", {}, "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw=="],
 
     "@mastra/core/p-retry": ["p-retry@7.1.1", "", { "dependencies": { "is-network-error": "^1.1.0" } }, "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w=="],
+
+    "@mendable/firecrawl-js/axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
 
     "@mermaid-js/parser/@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 FROM oven/bun:1.3.10 AS pruner
 WORKDIR /app
 COPY . .
-RUN bunx turbo@2.9.14 prune @autumn/server @autumn/mcp-server autumn-js @useautumn/sdk --docker
+RUN bunx turbo@2.9.14 prune @autumn/server @autumn/mcp-server --docker
 
 FROM oven/bun:1.3.10
 WORKDIR /app
@@ -18,7 +18,7 @@ WORKDIR /app
 # until a runtime workspace's deps change (not on every source edit).
 COPY --from=pruner /app/out/json/ .
 RUN mkdir -p scripts && touch scripts/preload-env.ts
-RUN bun -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); pkg.workspaces.packages = ["server", "shared", "apps/mcp-server", "packages/ksuid", "packages/mcp", "packages/stripe-sync", "packages/autumn-js", "packages/sdk"]; delete pkg.dependencies; delete pkg.devDependencies; delete pkg.scripts; fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));'
+RUN bun -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); pkg.workspaces.packages = ["server", "shared", "apps/mcp-server", "packages/ksuid", "packages/mcp", "packages/stripe-sync"]; delete pkg.dependencies; delete pkg.devDependencies; delete pkg.scripts; fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));'
 RUN --mount=type=cache,target=/root/.bun/install/cache \
 	rm -f bun.lock && bun install --ignore-scripts
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 FROM oven/bun:1.3.10 AS pruner
 WORKDIR /app
 COPY . .
-RUN bunx turbo@2.9.14 prune @autumn/server @autumn/mcp-server --docker
+RUN bunx turbo@2.9.14 prune @autumn/server @autumn/mcp-server autumn-js @useautumn/sdk --docker
 
 FROM oven/bun:1.3.10
 WORKDIR /app
@@ -18,7 +18,7 @@ WORKDIR /app
 # until a runtime workspace's deps change (not on every source edit).
 COPY --from=pruner /app/out/json/ .
 RUN mkdir -p scripts && touch scripts/preload-env.ts
-RUN bun -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); pkg.workspaces.packages = ["server", "shared", "apps/mcp-server", "packages/ksuid", "packages/mcp", "packages/stripe-sync"]; delete pkg.dependencies; delete pkg.devDependencies; delete pkg.scripts; fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));'
+RUN bun -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); pkg.workspaces.packages = ["server", "shared", "apps/mcp-server", "packages/ksuid", "packages/mcp", "packages/stripe-sync", "packages/autumn-js", "packages/sdk"]; delete pkg.dependencies; delete pkg.devDependencies; delete pkg.scripts; fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));'
 RUN --mount=type=cache,target=/root/.bun/install/cache \
 	rm -f bun.lock && bun install --ignore-scripts
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,35 +1,28 @@
+# syntax=docker/dockerfile:1
+
+# Shared runtime image for server + workers + cron + mcp.
+# Each FlightControl service runs the same image with a different command:
+#   server  -> bun start            (cwd /app/server)
+#   workers -> bun src/workers.ts   (cwd /app/server)
+#   cron    -> bun src/cron.ts      (cwd /app/server)
+#   mcp     -> cd /app/apps/mcp-server && bun start
+FROM oven/bun:1.3.10 AS pruner
+WORKDIR /app
+COPY . .
+RUN bunx turbo@2.9.14 prune @autumn/server @autumn/mcp-server --docker
+
 FROM oven/bun:1.3.10
 WORKDIR /app
 
-# Copy root package files
-COPY package.json .
-COPY bun.lock .
+# Install from the pruned package.json set only, so this layer stays cached
+# until a runtime workspace's deps change (not on every source edit).
+COPY --from=pruner /app/out/json/ .
+RUN mkdir -p scripts && touch scripts/preload-env.ts
+RUN bun -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); pkg.workspaces.packages = ["server", "shared", "apps/mcp-server", "packages/ksuid", "packages/mcp", "packages/stripe-sync"]; delete pkg.dependencies; delete pkg.devDependencies; delete pkg.scripts; fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));'
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+	rm -f bun.lock && bun install --ignore-scripts
 
-# Copy workspace package.json files
-COPY server/package.json ./server/package.json
-COPY shared/package.json ./shared/package.json
-COPY vite/package.json ./vite/package.json
-COPY scripts/package.json ./scripts/package.json
-COPY apps/checkout/package.json ./apps/checkout/package.json
-COPY apps/mcp-server/package.json ./apps/mcp-server/package.json
-COPY apps/chat/package.json ./apps/chat/package.json
-COPY packages/autumn-js/package.json ./packages/autumn-js/package.json
-COPY packages/atmn/package.json ./packages/atmn/package.json
-COPY packages/atmn-tests/package.json ./packages/atmn-tests/package.json
-COPY packages/mcp/package.json ./packages/mcp/package.json
-COPY packages/openapi/package.json ./packages/openapi/package.json
-COPY packages/ksuid/package.json ./packages/ksuid/package.json
-COPY packages/stripe-sync/package.json ./packages/stripe-sync/package.json
-COPY packages/sdk/package.json ./packages/sdk/package.json
-COPY apps/sdk-test/package.json ./apps/sdk-test/package.json
-COPY apps/docs/package.json ./apps/docs/package.json
-COPY apps/website/package.json ./apps/website/package.json
-
-# Install dependencies
-RUN bun install --ignore-scripts
-
-# Copy rest of the code
-COPY . .
+COPY --from=pruner /app/out/full/ .
 
 ENV NODE_ENV=production
 EXPOSE 8080

--- a/packages/mcp/src/mcp-server/agent/resources.ts
+++ b/packages/mcp/src/mcp-server/agent/resources.ts
@@ -74,6 +74,7 @@ Prefer server-side filters before local filtering:
 - subscription_status: active or scheduled subscriptions
 - processors: payment processor filters
 
+Use limit 1000 for broad scans; that is the maximum page size.
 Always paginate until next_cursor is empty when the user asks for complete results. Use getCustomer only for details not returned by listCustomers.`,
 	},
 	"autumn://docs/schedules": {

--- a/packages/mcp/src/mcp-server/agent/tools.ts
+++ b/packages/mcp/src/mcp-server/agent/tools.ts
@@ -110,6 +110,15 @@ const createBalanceMcpSchema = CreateBalanceParamsV0Schema.extend({
 	}),
 });
 
+const listCustomersMcpSchema = ListCustomersV2_3ParamsSchema.extend({
+	limit: z
+		.preprocess(
+			(value) => (typeof value === "number" && value > 1000 ? 1000 : value),
+			z.number().int().positive().max(1000).optional(),
+		)
+		.meta({ description: "Maximum customers per page. Max 1000." }),
+});
+
 const writeSchemaByTool = {
 	attach: AttachParamsV1Schema,
 	updateSubscription: UpdateSubscriptionV1ParamsSchema,
@@ -119,7 +128,7 @@ const writeSchemaByTool = {
 } as const satisfies Record<ConfirmedWriteToolName, z.ZodType>;
 
 export const schemaByTool = {
-	listCustomers: ListCustomersV2_3ParamsSchema,
+	listCustomers: listCustomersMcpSchema,
 	createCustomer: CreateCustomerParamsV1Schema,
 	getCustomer: GetCustomerParamsV1Schema,
 	listPlans: ListPlanParamsSchema,
@@ -142,8 +151,8 @@ const toolConfigs: OperationToolConfig[] = [
 	{
 		id: "listCustomers",
 		description:
-			"List Autumn customers. Use search, plans, subscription_status, and processors filters for customer-heavy queries. For queued/upcoming plan version queries, use subscription_status scheduled and omit the earliest matching version unless the user asks for all historical versions (versions 1,2,3 -> filter 2,3). 'live', 'paying', and active subscribers usually mean subscription_status active. When a plan is named, include the plans filter instead of listing broad customer sets. If listPlans returned matching versions, pass only relevant versions in plans[].versions, never guessed versions. For every/all/complete requests, paginate by calling again with start_cursor set to the previous response's next_cursor until next_cursor is empty.",
-		schema: ListCustomersV2_3ParamsSchema,
+			"List Autumn customers. Use search, plans, subscription_status, and processors filters for customer-heavy queries. limit max is 1000. For queued/upcoming plan version queries, use subscription_status scheduled and omit the earliest matching version unless the user asks for all historical versions (versions 1,2,3 -> filter 2,3). 'live', 'paying', and active subscribers usually mean subscription_status active. When a plan is named, include the plans filter instead of listing broad customer sets. If listPlans returned matching versions, pass only relevant versions in plans[].versions, never guessed versions. For every/all/complete requests, paginate by calling again with start_cursor set to the previous response's next_cursor until next_cursor is empty.",
+		schema: listCustomersMcpSchema,
 		endpoint: endpointByTool.listCustomers,
 	},
 	{

--- a/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
@@ -275,6 +275,7 @@ describe("Autumn operation tools", () => {
 		globalThis.fetch = (async (url, init) => {
 			expect(String(url)).toBe("http://localhost:8080/v1/customers.list");
 			expect(JSON.parse(init?.body as string)).toMatchObject({
+				limit: 1000,
 				search: "charlie",
 			});
 			return Response.json({ customers: [] });
@@ -286,7 +287,7 @@ describe("Autumn operation tools", () => {
 
 			await expect(
 				tool.execute(
-					{ request: { search: "charlie" } },
+					{ request: { limit: 5000, search: "charlie" } },
 					{ mcp: { extra: { authInfo: auth } } } as never,
 				),
 			).resolves.toEqual({ customers: [] });

--- a/scripts/db/README.md
+++ b/scripts/db/README.md
@@ -13,7 +13,9 @@ bun db mark-applied  [--env=dev|staging|prod] # seed drizzle.__drizzle_migration
 bun db rebase                                 # auto-resolve a local migration that collided with origin/dev
 ```
 
-`migrate` and `migrate:dry` also run a safety check that **refuses to apply any pending migration containing `CREATE INDEX`, `DROP INDEX`, or `REINDEX` without `CONCURRENTLY`**. Those DDL statements take an ACCESS EXCLUSIVE lock and can block reads/writes on busy tables. To get through the check: either rewrite the SQL with `CONCURRENTLY` and apply manually + `mark-applied`, or add `.concurrently()` to the index in your schema and regenerate.
+`migrate` applies pending migrations directly via `pg` (using drizzle's own `readMigrationFiles` for parsing + hashing), so the tracking table stays compatible with drizzle and `mark-applied`. Unlike drizzle's built-in `migrate()` — which wraps every migration in a single transaction — our executor runs any statement containing `CONCURRENTLY` in autocommit, so `CREATE INDEX CONCURRENTLY` migrations apply normally. Everything else still runs in a per-migration transaction.
+
+`migrate` and `migrate:dry` also run a safety check that **refuses to apply any pending migration containing `CREATE INDEX`, `DROP INDEX`, or `REINDEX` without `CONCURRENTLY`**. Those DDL statements take an ACCESS EXCLUSIVE lock and can block reads/writes on busy tables. To get through the check, make the index concurrent: rewrite the SQL with `CONCURRENTLY`, or add `.concurrently()` to the index in your schema and regenerate. Concurrent index migrations then apply through `bun db migrate` with no manual step.
 
 `--env` defaults to `dev`. `generate` and `rebase` never touch a DB and don't take `--env`.
 
@@ -133,17 +135,20 @@ scripts/db/
 ├── commands/
 │   ├── help.ts
 │   ├── generate.ts        # passthrough to `bun -F @autumn/shared db:generate`
-│   ├── migrate.ts         # passthrough to `bun -F @autumn/shared db:migrate`
+│   ├── migrate.ts         # applies pending migrations (CONCURRENTLY-aware executor)
 │   ├── markApplied.ts     # seeds drizzle.__drizzle_migrations
 │   └── rebase.ts          # auto-resolves duplicate-idx conflicts
 ├── helpers/
+│   ├── applyMigrations.ts # per-migration executor: autocommit for CONCURRENTLY, tx otherwise
 │   ├── env.ts             # --env parsing + infisical wrap + DATABASE_URL host extraction
+│   ├── pendingMigrations.ts # computes pending set from _journal.json vs tracking table
+│   ├── safetyCheck.ts     # flags non-CONCURRENTLY index DDL
 │   ├── paths.ts           # canonical paths to shared/drizzle/ and meta/
 │   └── spawn.ts           # thin child_process.spawn wrapper
 └── pull.ts                # unrelated — customer data pull (legacy)
 ```
 
-`shared/package.json` still owns the implementation of `db:generate` and `db:migrate` (which are what the CLI shells out to under the hood). The unified `bun db` interface lives at the repo root.
+`shared/package.json` still owns `db:generate` (which `generate` shells out to). `migrate` no longer delegates to drizzle-kit — it reads the committed migrations with drizzle's `readMigrationFiles` and applies them itself so `CONCURRENTLY` works. The unified `bun db` interface lives at the repo root.
 
 ---
 

--- a/scripts/db/commands/migrate.ts
+++ b/scripts/db/commands/migrate.ts
@@ -1,7 +1,8 @@
+import { readMigrationFiles } from "drizzle-orm/migrator";
 import pg from "pg";
-import { run } from "../helpers/spawn.ts";
-import { REPO_ROOT } from "../helpers/paths.ts";
+import { MIGRATIONS_DIR } from "../helpers/paths.ts";
 import { type Env, targetHost, wrapInInfisical } from "../helpers/env.ts";
+import { applyMigration } from "../helpers/applyMigrations.ts";
 import {
 	getPendingMigrations,
 	type PendingMigration,
@@ -82,10 +83,41 @@ export async function cmdMigrate(
 		process.exit(1);
 	}
 
-	const { code } = await run("bun", ["-F", "@autumn/shared", "db:migrate"], {
-		cwd: REPO_ROOT,
-	});
-	process.exit(code);
+	await applyPending(databaseUrl, pending);
+}
+
+/**
+ * Applies pending migrations using drizzle's own readMigrationFiles (so hashes
+ * match the tracking table drizzle/mark-applied write) but our own executor,
+ * which — unlike drizzle's migrate() — can run CONCURRENTLY outside a transaction.
+ */
+async function applyPending(
+	databaseUrl: string,
+	pending: PendingMigration[],
+): Promise<void> {
+	const pendingByMillis = new Map(pending.map((m) => [m.when, m.tag]));
+	const toApply = readMigrationFiles({ migrationsFolder: MIGRATIONS_DIR })
+		.filter((m) => pendingByMillis.has(m.folderMillis))
+		.sort((a, b) => a.folderMillis - b.folderMillis);
+
+	const client = new pg.Client({ connectionString: databaseUrl });
+	await client.connect();
+	try {
+		for (const migration of toApply) {
+			const tag = pendingByMillis.get(migration.folderMillis) ?? "migration";
+			const { transactional } = await applyMigration(client, migration);
+			console.log(`  applied ${tag}${transactional ? "" : " (concurrent)"}`);
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.error(`\nmigration failed: ${message}`);
+		process.exitCode = 1;
+		return;
+	} finally {
+		await client.end();
+	}
+
+	console.log(`done — applied ${toApply.length} migration(s)`);
 }
 
 type FlaggedBlocker = {

--- a/scripts/db/helpers/applyMigrations.ts
+++ b/scripts/db/helpers/applyMigrations.ts
@@ -1,0 +1,60 @@
+import type { MigrationMeta } from "drizzle-orm/migrator";
+import type pg from "pg";
+
+// CONCURRENTLY (e.g. CREATE INDEX CONCURRENTLY) cannot run inside a transaction
+// block. drizzle's own migrate() wraps everything in one transaction, so those
+// statements are applied here in autocommit instead.
+const NON_TRANSACTIONAL = /\bCONCURRENTLY\b/i;
+
+const TRACKING_TABLE = `"drizzle"."__drizzle_migrations"`;
+
+async function recordApplied(
+	client: pg.Client,
+	migration: MigrationMeta,
+): Promise<void> {
+	await client.query(
+		`INSERT INTO ${TRACKING_TABLE} ("hash", "created_at") VALUES ($1, $2)`,
+		[migration.hash, migration.folderMillis],
+	);
+}
+
+export type ApplyResult = { transactional: boolean };
+
+/**
+ * Applies one migration's statements. If any statement is non-transactional
+ * (CONCURRENTLY), the whole migration runs in autocommit; otherwise it's wrapped
+ * in a single transaction so DDL + tracking row commit atomically — matching
+ * drizzle's own per-migration semantics.
+ */
+export async function applyMigration(
+	client: pg.Client,
+	migration: MigrationMeta,
+): Promise<ApplyResult> {
+	const statements = migration.sql
+		.map((statement) => statement.trim())
+		.filter(Boolean);
+	const nonTransactional = statements.some((statement) =>
+		NON_TRANSACTIONAL.test(statement),
+	);
+
+	if (nonTransactional) {
+		for (const statement of statements) {
+			await client.query(statement);
+		}
+		await recordApplied(client, migration);
+		return { transactional: false };
+	}
+
+	await client.query("BEGIN");
+	try {
+		for (const statement of statements) {
+			await client.query(statement);
+		}
+		await recordApplied(client, migration);
+		await client.query("COMMIT");
+	} catch (err) {
+		await client.query("ROLLBACK");
+		throw err;
+	}
+	return { transactional: true };
+}

--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -40,6 +40,8 @@ import {
 	type Operations,
 	type OrgConfig,
 	type ProductItem,
+	type RecalculateBalanceParamsV0,
+	type RecalculateBalancePreview,
 	type RestoreParamsV1,
 	type RestoreResponse,
 	type RewardRedemption,
@@ -182,7 +184,8 @@ export class AutumnInt {
 
 			if (parsed && typeof parsed === "object") {
 				throw new AutumnError({
-					message: parsed.message ?? `request failed (status ${response.status})`,
+					message:
+						parsed.message ?? `request failed (status ${response.status})`,
 					code: parsed.code ?? ErrCode.InternalError,
 				});
 			}
@@ -1089,6 +1092,16 @@ export class AutumnInt {
 		delete: async (params: DeleteBalanceParamsV0) => {
 			const data = await this.post(`/balances.delete`, params);
 			return data;
+		},
+		recalculate: async (params: RecalculateBalanceParamsV0) => {
+			const data = await this.post(`/balances.recalculate`, params);
+			return data;
+		},
+		previewRecalculate: async (
+			params: RecalculateBalanceParamsV0,
+		): Promise<RecalculateBalancePreview> => {
+			const data = await this.post(`/balances.preview_recalculate`, params);
+			return data as RecalculateBalancePreview;
 		},
 		finalize: async (
 			params: FinalizeLockParamsV0,

--- a/server/src/internal/balances/balancesRouter.ts
+++ b/server/src/internal/balances/balancesRouter.ts
@@ -6,6 +6,8 @@ import { handleCreateBalance } from "./handlers/handleCreateBalance.js";
 import { handleDeleteBalance } from "./handlers/handleDeleteBalance.js";
 import { handleFinalizeLock } from "./handlers/handleFinalizeLock.js";
 import { handleListBalances } from "./handlers/handleListBalances.js";
+import { handleRecalculateBalance } from "./handlers/handleRecalculateBalance.js";
+import { handleRecalculateBalancePreview } from "./handlers/handleRecalculateBalancePreview.js";
 import { handleSetUsage } from "./handlers/handleSetUsage.js";
 import { handleTrack } from "./handlers/handleTrack.js";
 import { handleUpdateBalance } from "./handlers/handleUpdateBalance.js";
@@ -16,6 +18,11 @@ export const balancesRouter = new Hono<HonoEnv>();
 balancesRouter.post("/balances/create", ...handleCreateBalance);
 balancesRouter.get("/balances/list", ...handleListBalances);
 balancesRouter.post("/balances/update", ...handleUpdateBalance);
+balancesRouter.post("/balances/recalculate", ...handleRecalculateBalance);
+balancesRouter.post(
+	"/balances/preview_recalculate",
+	...handleRecalculateBalancePreview,
+);
 
 // Track
 balancesRouter.post("/events", ...handleTrack);
@@ -32,6 +39,11 @@ export const balancesRpcRouter = new Hono<HonoEnv>();
 balancesRpcRouter.post("/balances.create", ...handleCreateBalance);
 balancesRpcRouter.post("/balances.update", ...handleUpdateBalance);
 balancesRpcRouter.post("/balances.delete", ...handleDeleteBalance);
+balancesRpcRouter.post("/balances.recalculate", ...handleRecalculateBalance);
+balancesRpcRouter.post(
+	"/balances.preview_recalculate",
+	...handleRecalculateBalancePreview,
+);
 
 balancesRpcRouter.post("/balances.track", ...handleTrack);
 balancesRpcRouter.post("/balances.batch_track", ...handleBatchTrack);

--- a/server/src/internal/balances/deleteBalance/deleteBalance.ts
+++ b/server/src/internal/balances/deleteBalance/deleteBalance.ts
@@ -1,18 +1,17 @@
 import {
 	cusEntsToUsage,
 	type DeleteBalanceParamsV0,
-	findFeatureById,
 	fullCustomerToCustomerEntitlements,
 	isPaidCustomerEntitlement,
 	RecaseError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { executePostgresDeduction } from "@/internal/balances/utils/deduction/executePostgresDeduction";
 import { CusService } from "@/internal/customers/CusService";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
 import { buildCustomerEntitlementFilters } from "../utils/buildCustomerEntitlementFilters";
+import { reapplyFeatureUsageDeduction } from "../utils/reapplyFeatureUsageDeduction";
 
 export const deleteBalance = async ({
 	ctx,
@@ -93,39 +92,16 @@ export const deleteBalance = async ({
 		return;
 	}
 
-	const survivingFullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: customer_id,
-		entityId: entity_id,
-		withEntities: true,
-		withSubs: true,
-	});
-
 	const targetFeatureId = feature_id ?? customerEntitlements[0]?.feature_id;
 	if (!targetFeatureId) {
 		return;
 	}
 
-	const feature = findFeatureById({
-		features: ctx.features,
-		featureId: targetFeatureId,
-		errorOnNotFound: true,
-	});
-
-	await executePostgresDeduction({
+	await reapplyFeatureUsageDeduction({
 		ctx,
-		fullCustomer: survivingFullCustomer,
-		customerId: survivingFullCustomer.id ?? customer_id,
+		customerId: customer_id,
 		entityId: entity_id,
-		deductions: [
-			{
-				feature,
-				deduction: usageToRecalculate,
-			},
-		],
-		options: {
-			alterGrantedBalance: false,
-			overageBehaviour: "allow",
-		},
+		featureId: targetFeatureId,
+		usage: usageToRecalculate,
 	});
 };

--- a/server/src/internal/balances/handlers/handleRecalculateBalance.ts
+++ b/server/src/internal/balances/handlers/handleRecalculateBalance.ts
@@ -1,0 +1,19 @@
+import { RecalculateBalanceParamsV0Schema, Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler";
+import { recalculateBalance } from "../recalculateBalance/recalculateBalance";
+
+export const handleRecalculateBalance = createRoute({
+	scopes: [Scopes.Balances.Write],
+	body: RecalculateBalanceParamsV0Schema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const params = c.req.valid("json");
+
+		await recalculateBalance({
+			ctx,
+			params,
+		});
+
+		return c.json({ success: true });
+	},
+});

--- a/server/src/internal/balances/handlers/handleRecalculateBalancePreview.ts
+++ b/server/src/internal/balances/handlers/handleRecalculateBalancePreview.ts
@@ -1,0 +1,19 @@
+import { RecalculateBalanceParamsV0Schema, Scopes } from "@autumn/shared";
+import { createRoute } from "@/honoMiddlewares/routeHandler";
+import { recalculateBalancePreview } from "../recalculateBalance/recalculateBalancePreview";
+
+export const handleRecalculateBalancePreview = createRoute({
+	scopes: [Scopes.Balances.Read],
+	body: RecalculateBalanceParamsV0Schema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const params = c.req.valid("json");
+
+		const preview = await recalculateBalancePreview({
+			ctx,
+			params,
+		});
+
+		return c.json(preview);
+	},
+});

--- a/server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts
+++ b/server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts
@@ -1,0 +1,108 @@
+import {
+	cusEntsToUsage,
+	cusEntToRecalculateScopeKey,
+	cusEntToStartingBalance,
+	type FullCusEntWithFullCusProduct,
+	type FullCustomer,
+	fullCustomerToCustomerEntitlements,
+	getRecalculableScopeKeys,
+	type RecalculateBalanceParamsV0,
+	RecaseError,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { deductFromCusEntsTypescript } from "@/internal/balances/track/deductUtils/deductFromCusEntsTypescript";
+import { CusService } from "@/internal/customers/CusService";
+import { getResetBalancesUpdate } from "@/internal/customers/cusProducts/cusEnts/groupByUtils";
+import { buildCustomerEntitlementFilters } from "../utils/buildCustomerEntitlementFilters";
+
+const resetCusEntInPlace = ({
+	cusEnt,
+}: {
+	cusEnt: FullCusEntWithFullCusProduct;
+}): void => {
+	const resetUpdate = getResetBalancesUpdate({
+		cusEnt,
+		allowance: cusEntToStartingBalance({ cusEnt }) ?? undefined,
+	});
+	if ("entities" in resetUpdate) {
+		cusEnt.entities = resetUpdate.entities;
+	} else {
+		cusEnt.balance = resetUpdate.balance;
+		cusEnt.additional_balance = resetUpdate.additional_balance;
+	}
+	cusEnt.adjustment = 0;
+};
+
+/**
+ * Computes (without persisting) the result of recalculating a customer's
+ * balances for a feature: every matching entitlement is reset to its starting
+ * balance and the total usage is re-applied across them in priority order
+ * (allowing overage). Returns the original entitlements (`before`) and the
+ * recalculated clones (`after`) so callers can persist them or preview the diff.
+ */
+export const computeRecalculateBalance = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: RecalculateBalanceParamsV0;
+}): Promise<{
+	fullCustomer: FullCustomer;
+	entityId: string | undefined;
+	before: FullCusEntWithFullCusProduct[];
+	after: FullCusEntWithFullCusProduct[];
+	totalUsage: number;
+}> => {
+	const { customer_id, entity_id, feature_id } = params;
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customer_id,
+		entityId: entity_id,
+		withEntities: true,
+		withSubs: true,
+	});
+	const before = fullCustomerToCustomerEntitlements({
+		fullCustomer,
+		featureId: feature_id,
+		entity: fullCustomer.entity,
+		customerEntitlementFilters: buildCustomerEntitlementFilters({ params }),
+	});
+	if (before.length === 0) {
+		throw new RecaseError({
+			message: `Balance not found for feature ${feature_id} and customer ${customer_id}`,
+		});
+	}
+	const entityId = fullCustomer.entity?.id ?? undefined;
+	const totalUsage = cusEntsToUsage({ cusEnts: before, entityId });
+	const after = before.map((cusEnt) => structuredClone(cusEnt));
+	const recalculableScopes = getRecalculableScopeKeys({
+		cusEnts: after,
+		entityId,
+	});
+	const scopeGroups = new Map<string, FullCusEntWithFullCusProduct[]>();
+	for (const cusEnt of after) {
+		const key = cusEntToRecalculateScopeKey({ cusEnt });
+		const group = scopeGroups.get(key);
+		if (group) {
+			group.push(cusEnt);
+		} else {
+			scopeGroups.set(key, [cusEnt]);
+		}
+	}
+	for (const [key, group] of scopeGroups) {
+		if (!recalculableScopes.has(key)) {
+			continue;
+		}
+		const scopeUsage = cusEntsToUsage({ cusEnts: group, entityId });
+		for (const cusEnt of group) {
+			resetCusEntInPlace({ cusEnt });
+		}
+		deductFromCusEntsTypescript({
+			cusEnts: group,
+			amountToDeduct: scopeUsage,
+			targetEntityId: entityId,
+			allowOverage: true,
+		});
+	}
+	return { fullCustomer, entityId, before, after, totalUsage };
+};

--- a/server/src/internal/balances/recalculateBalance/recalculateBalance.ts
+++ b/server/src/internal/balances/recalculateBalance/recalculateBalance.ts
@@ -1,0 +1,45 @@
+import type { RecalculateBalanceParamsV0 } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+import { computeRecalculateBalance } from "./computeRecalculateBalance";
+
+/**
+ * Recalculates a customer's balances for a feature by resetting every matching
+ * entitlement to its starting balance and re-applying the total usage across
+ * them in priority order. This redistributes usage so a positive balance
+ * absorbs the overage of a negative one, without deleting any balance. The
+ * aggregate balance is unchanged; only the per-entitlement distribution moves.
+ */
+export const recalculateBalance = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: RecalculateBalanceParamsV0;
+}): Promise<void> => {
+	const { fullCustomer, before, after } = await computeRecalculateBalance({
+		ctx,
+		params,
+	});
+	const afterById = new Map(after.map((cusEnt) => [cusEnt.id, cusEnt]));
+	for (const cusEnt of before) {
+		const updated = afterById.get(cusEnt.id);
+		if (!updated) {
+			continue;
+		}
+		await CusEntService.update({
+			ctx,
+			id: cusEnt.id,
+			updates: {
+				balance: updated.balance ?? 0,
+				entities: updated.entities,
+				adjustment: updated.adjustment ?? 0,
+			},
+		});
+	}
+	await deleteCachedFullCustomer({
+		ctx,
+		customerId: fullCustomer.id ?? "",
+	});
+};

--- a/server/src/internal/balances/recalculateBalance/recalculateBalance.ts
+++ b/server/src/internal/balances/recalculateBalance/recalculateBalance.ts
@@ -23,21 +23,25 @@ export const recalculateBalance = async ({
 		params,
 	});
 	const afterById = new Map(after.map((cusEnt) => [cusEnt.id, cusEnt]));
-	for (const cusEnt of before) {
-		const updated = afterById.get(cusEnt.id);
-		if (!updated) {
-			continue;
+	await ctx.db.transaction(async (tx) => {
+		const txCtx = { ...ctx, db: tx as unknown as typeof ctx.db };
+		for (const cusEnt of before) {
+			const updated = afterById.get(cusEnt.id);
+			if (!updated) {
+				continue;
+			}
+			await CusEntService.update({
+				ctx: txCtx,
+				id: cusEnt.id,
+				updates: {
+					balance: updated.balance ?? 0,
+					additional_balance: updated.additional_balance ?? 0,
+					entities: updated.entities,
+					adjustment: updated.adjustment ?? 0,
+				},
+			});
 		}
-		await CusEntService.update({
-			ctx,
-			id: cusEnt.id,
-			updates: {
-				balance: updated.balance ?? 0,
-				entities: updated.entities,
-				adjustment: updated.adjustment ?? 0,
-			},
-		});
-	}
+	});
 	await deleteCachedFullCustomer({
 		ctx,
 		customerId: fullCustomer.id ?? "",

--- a/server/src/internal/balances/recalculateBalance/recalculateBalancePreview.ts
+++ b/server/src/internal/balances/recalculateBalance/recalculateBalancePreview.ts
@@ -1,0 +1,40 @@
+import {
+	cusEntsToBalance,
+	type RecalculateBalanceParamsV0,
+	type RecalculateBalancePreview,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeRecalculateBalance } from "./computeRecalculateBalance";
+
+/**
+ * Computes a preview of a balance recalculation without persisting anything,
+ * returning the remaining balance per entitlement before and after.
+ */
+export const recalculateBalancePreview = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: RecalculateBalanceParamsV0;
+}): Promise<RecalculateBalancePreview> => {
+	const { before, after, entityId, totalUsage } =
+		await computeRecalculateBalance({ ctx, params });
+	const afterById = new Map(after.map((cusEnt) => [cusEnt.id, cusEnt]));
+	const entitlements = before.map((cusEnt) => {
+		const updated = afterById.get(cusEnt.id) ?? cusEnt;
+		return {
+			customer_entitlement_id: cusEnt.id,
+			before_remaining: cusEntsToBalance({
+				cusEnts: [cusEnt],
+				entityId,
+				withRollovers: true,
+			}),
+			after_remaining: cusEntsToBalance({
+				cusEnts: [updated],
+				entityId,
+				withRollovers: true,
+			}),
+		};
+	});
+	return { total_usage: totalUsage, entitlements };
+};

--- a/server/src/internal/balances/utils/reapplyFeatureUsageDeduction.ts
+++ b/server/src/internal/balances/utils/reapplyFeatureUsageDeduction.ts
@@ -1,0 +1,51 @@
+import { findFeatureById } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { executePostgresDeduction } from "@/internal/balances/utils/deduction/executePostgresDeduction";
+import { CusService } from "@/internal/customers/CusService";
+
+/**
+ * Re-applies a feature's total usage across a customer's balances after those
+ * balances have been mutated (e.g. a balance was deleted or reset). Reloads the
+ * customer to capture the mutated state, then redistributes the usage across the
+ * remaining entitlements in priority order, allowing overage.
+ */
+export const reapplyFeatureUsageDeduction = async ({
+	ctx,
+	customerId,
+	entityId,
+	featureId,
+	usage,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	entityId?: string;
+	featureId: string;
+	usage: number;
+}): Promise<void> => {
+	if (usage === 0) {
+		return;
+	}
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		entityId,
+		withEntities: true,
+		withSubs: true,
+	});
+	const feature = findFeatureById({
+		features: ctx.features,
+		featureId,
+		errorOnNotFound: true,
+	});
+	await executePostgresDeduction({
+		ctx,
+		fullCustomer,
+		customerId: fullCustomer.id ?? customerId,
+		entityId,
+		deductions: [{ feature, deduction: usage }],
+		options: {
+			alterGrantedBalance: false,
+			overageBehaviour: "allow",
+		},
+	});
+};

--- a/server/tests/integration/balances/recalculate/recalculate-balance.test.ts
+++ b/server/tests/integration/balances/recalculate/recalculate-balance.test.ts
@@ -1,0 +1,653 @@
+import { expect, test } from "bun:test";
+import type {
+	CheckResponseV2,
+	RecalculateBalancePreview,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// Preview returns the projected remaining per entitlement; these helpers sum
+// the before/after sides so tests can assert conservation without depending on
+// per-balance ordering.
+const sumBefore = (preview: RecalculateBalancePreview) =>
+	preview.entitlements.reduce((sum, entry) => sum + entry.before_remaining, 0);
+const sumAfter = (preview: RecalculateBalancePreview) =>
+	preview.entitlements.reduce((sum, entry) => sum + entry.after_remaining, 0);
+
+// Map a check response's breakdown to { balanceId: current_balance } so tests
+// can compare distribution without depending on breakdown ordering.
+const breakdownById = (check: CheckResponseV2) =>
+	Object.fromEntries(
+		(check.balance?.breakdown ?? []).map((entry) => [
+			entry.id,
+			entry.current_balance,
+		]),
+	);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-1: An overdrawn balance is healed by redistributing its
+// usage onto a sibling balance that still has remaining.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-1: overage is redistributed onto a positive balance")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-1",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+
+		// Drive balance-a into overage (usage 130 on a grant of 100 -> -30).
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		// Preview: total usage 130, aggregate remaining conserved at 170, and the
+		// overdrawn balance recovers while no balance is left negative.
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(130);
+		expect(preview.entitlements).toHaveLength(2);
+		expect(sumBefore(preview)).toBe(170);
+		expect(sumAfter(preview)).toBe(170);
+		for (const entry of preview.entitlements) {
+			expect(entry.after_remaining).toBeGreaterThanOrEqual(0);
+		}
+		expect(
+			preview.entitlements.some(
+				(entry) => entry.after_remaining > entry.before_remaining,
+			),
+		).toBe(true);
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		// Aggregate remaining is unchanged and nothing is in overage anymore.
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(check.balance?.current_balance).toBe(170);
+		for (const entry of check.balance?.breakdown ?? []) {
+			expect(entry.current_balance).toBeGreaterThanOrEqual(0);
+		}
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-2: Recalculation nets a sibling's overage into the
+// displayed remaining, so the aggregate reflects the true
+// (granted - usage) remaining afterwards.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-2: nets overage into the displayed remaining")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-2",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		// Before: balance-a's overage is not netted against balance-b, so the
+		// displayed remaining is inflated (200 rather than the true 170).
+		const before = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		const after = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		// Recalculation reduces the inflated remaining to the true remaining.
+		expect(after.balance?.current_balance).toBeLessThan(
+			before.balance?.current_balance ?? 0,
+		);
+		expect(after.balance?.current_balance).toBe(sumAfter(preview));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-3: The preview endpoint returns the projected diff and
+// does NOT persist any changes.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-3: preview returns the diff without persisting")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-3",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		const before = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(130);
+		expect(preview.entitlements).toHaveLength(2);
+		expect(sumAfter(preview)).toBe(sumBefore(preview));
+		expect(
+			preview.entitlements.some(
+				(entry) => entry.before_remaining !== entry.after_remaining,
+			),
+		).toBe(true);
+
+		// Nothing was written: the on-disk distribution is identical.
+		const after = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(breakdownById(after)).toEqual(breakdownById(before));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-4: When balances are already distributed (no overage),
+// recalculation is a no-op and the preview reports no changes.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-4: no overage is a no-op")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-4",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+
+		const before = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(0);
+		for (const entry of preview.entitlements) {
+			expect(entry.after_remaining).toBe(entry.before_remaining);
+		}
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		const after = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(breakdownById(after)).toEqual(breakdownById(before));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-5: Recalculating a feature with no balances errors.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-5: missing balance returns an error")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-5",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await expectAutumnError({
+			func: async () => {
+				await autumnV2.balances.recalculate({
+					customer_id: customerId,
+					feature_id: TestFeature.Messages,
+				});
+			},
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-6: When total usage exceeds total grant, the residual
+// overage is consolidated onto a single balance and the aggregate is
+// still conserved.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-6: residual overage is consolidated when usage exceeds grant")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-6",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 50,
+			balance_id: "balance-b",
+		});
+		// Total grant 150, total usage 170 -> aggregate remaining -20.
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 40,
+			balance_id: "balance-b",
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(170);
+		expect(preview.entitlements).toHaveLength(2);
+		expect(sumAfter(preview)).toBe(-20);
+		expect(sumBefore(preview)).toBe(-20);
+		// The overage is consolidated onto exactly one balance.
+		expect(
+			preview.entitlements.filter((entry) => entry.after_remaining < 0),
+		).toHaveLength(1);
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		// Re-previewing the now-recalculated state shows nothing left to do.
+		const rerun = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		for (const entry of rerun.entitlements) {
+			expect(entry.after_remaining).toBe(entry.before_remaining);
+		}
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-7: Redistribution works across three balances.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-7: redistributes across three balances")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-7",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		for (const balanceId of ["balance-a", "balance-b", "balance-c"]) {
+			await autumnV2.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				included_grant: 100,
+				balance_id: balanceId,
+			});
+		}
+
+		// balance-a overdrawn to -30.
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(130);
+		expect(preview.entitlements).toHaveLength(3);
+		expect(sumBefore(preview)).toBe(170);
+		expect(sumAfter(preview)).toBe(170);
+		for (const entry of preview.entitlements) {
+			expect(entry.after_remaining).toBeGreaterThanOrEqual(0);
+		}
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(check.balance?.current_balance).toBe(170);
+		for (const entry of check.balance?.breakdown ?? []) {
+			expect(entry.current_balance).toBeGreaterThanOrEqual(0);
+		}
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-8: Recalculation is idempotent - running it again does
+// not change an already-balanced feature.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-8: recalculation is idempotent")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-8",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "balance-a",
+		});
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const first = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const second = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		expect(breakdownById(second)).toEqual(breakdownById(first));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-9: Redistribution stays within scope - a customer-level
+// overage is NOT absorbed by an entity-scoped balance.
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-9: redistribution stays within entity scope")}`,
+	async () => {
+		const { customerId, autumnV2, entities } = await initScenario({
+			customerId: "recalc-9",
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [],
+		});
+		const entityId = entities[0].id;
+
+		// Customer-level: one overdrawn (-30), one with remaining (200).
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "cust-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "cust-b",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 130,
+			balance_id: "cust-a",
+		});
+
+		// Entity-scoped: partially used and positive (no overage in this scope).
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			entity_id: entityId,
+			included_grant: 100,
+			balance_id: "ent-a",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			entity_id: entityId,
+			current_balance: 60,
+			balance_id: "ent-a",
+		});
+
+		const entityBefore = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			entity_id: entityId,
+			skip_cache: true,
+		});
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		// The entity-owned balance itself is untouched - the customer-level
+		// overage was not absorbed by it. (The entity-level aggregate also
+		// reflects shared customer balances, so we target ent-a specifically.)
+		const entityAfter = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			entity_id: entityId,
+			skip_cache: true,
+		});
+		expect(breakdownById(entityAfter)["ent-a"]).toBe(
+			breakdownById(entityBefore)["ent-a"],
+		);
+		expect(breakdownById(entityAfter)["ent-a"]).toBe(60);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// RECALCULATE-10: A fully-used balance (remaining 0, not overdrawn)
+// next to positive balances is NOT recalculable - there is no overage to
+// absorb, so the preview reports no changes ("already up to date").
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("recalculate-10: a fully-used balance alongside positives is a no-op")}`,
+	async () => {
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "recalc-10",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 200,
+			balance_id: "balance-b",
+		});
+		await autumnV2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 500,
+			balance_id: "balance-c",
+		});
+
+		// balance-a is fully used (remaining 0) but NOT overdrawn; balance-c is
+		// partially used but still positive.
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 100,
+			balance_id: "balance-a",
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			usage: 200,
+			balance_id: "balance-c",
+		});
+
+		const before = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+
+		// No scope has an overage, so the preview reports no changes.
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		for (const entry of preview.entitlements) {
+			expect(entry.after_remaining).toBe(entry.before_remaining);
+		}
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		const after = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(breakdownById(after)).toEqual(breakdownById(before));
+	},
+);

--- a/shared/api/balances/index.ts
+++ b/shared/api/balances/index.ts
@@ -2,4 +2,5 @@ export * from "./common/lockParams";
 export * from "./create/index";
 export * from "./delete/index";
 export * from "./finalizeLock/index";
+export * from "./recalculate/index";
 export * from "./update/index";

--- a/shared/api/balances/recalculate/index.ts
+++ b/shared/api/balances/recalculate/index.ts
@@ -1,0 +1,2 @@
+export * from "./recalculateBalanceParams.js";
+export * from "./recalculateBalancePreview.js";

--- a/shared/api/balances/recalculate/recalculateBalanceParams.ts
+++ b/shared/api/balances/recalculate/recalculateBalanceParams.ts
@@ -1,0 +1,21 @@
+import { z } from "zod/v4";
+import { ResetInterval } from "../../..";
+export const RecalculateBalanceParamsV0Schema = z.object({
+	customer_id: z.string().meta({
+		description: "The ID of the customer.",
+	}),
+	feature_id: z.string().meta({
+		description: "The ID of the feature whose balances should be recalculated.",
+	}),
+	entity_id: z.string().optional().meta({
+		description: "The ID of the entity.",
+	}),
+	interval: z.enum(ResetInterval).optional().meta({
+		description:
+			"Target balances with a specific reset interval. Use when the customer has multiple balances for the same feature with different reset intervals.",
+	}),
+});
+
+export type RecalculateBalanceParamsV0 = z.infer<
+	typeof RecalculateBalanceParamsV0Schema
+>;

--- a/shared/api/balances/recalculate/recalculateBalancePreview.ts
+++ b/shared/api/balances/recalculate/recalculateBalancePreview.ts
@@ -1,0 +1,10 @@
+export interface RecalculateBalanceEntitlementPreview {
+	customer_entitlement_id: string;
+	before_remaining: number;
+	after_remaining: number;
+}
+
+export interface RecalculateBalancePreview {
+	total_usage: number;
+	entitlements: RecalculateBalanceEntitlementPreview[];
+}

--- a/shared/utils/cusEntUtils/balanceUtils/recalculateScopeUtils.ts
+++ b/shared/utils/cusEntUtils/balanceUtils/recalculateScopeUtils.ts
@@ -1,0 +1,65 @@
+import type { FullCusEntWithFullCusProduct } from "../../../models/cusProductModels/cusEntModels/cusEntWithProduct";
+import { cusEntsToBalance } from "./cusEntsToBalance";
+
+export const RECALCULATE_CUSTOMER_SCOPE = "__customer__";
+
+/**
+ * Balances are only ever recalculated against siblings with the same scope: a
+ * balance owned by an entity stays within that entity, and customer-level
+ * balances stay at the customer level.
+ */
+export const cusEntToRecalculateScopeKey = ({
+	cusEnt,
+}: {
+	cusEnt: FullCusEntWithFullCusProduct;
+}): string =>
+	cusEnt.internal_entity_id ??
+	cusEnt.customer_product?.internal_entity_id ??
+	RECALCULATE_CUSTOMER_SCOPE;
+
+/**
+ * Returns the scope keys that can be recalculated - i.e. scopes that contain
+ * both an overdrawn balance and a balance with remaining to absorb it. Uses the
+ * main balance (not rollovers) because recalculation redistributes the main
+ * balance, so this matches exactly what a recalculation would change. Shared by
+ * the dashboard (to decide whether to offer the action) and the backend (to
+ * decide which scopes to redistribute) so the two never disagree.
+ */
+export const getRecalculableScopeKeys = ({
+	cusEnts,
+	entityId,
+}: {
+	cusEnts: FullCusEntWithFullCusProduct[];
+	entityId?: string;
+}): Set<string> => {
+	const scopes = new Map<
+		string,
+		{ hasNegative: boolean; hasPositive: boolean }
+	>();
+	for (const cusEnt of cusEnts) {
+		const key = cusEntToRecalculateScopeKey({ cusEnt });
+		const scope = scopes.get(key) ?? {
+			hasNegative: false,
+			hasPositive: false,
+		};
+		const remaining = cusEntsToBalance({ cusEnts: [cusEnt], entityId });
+		if (remaining < 0) scope.hasNegative = true;
+		if (remaining > 0) scope.hasPositive = true;
+		scopes.set(key, scope);
+	}
+	const recalculable = new Set<string>();
+	for (const [key, scope] of scopes) {
+		if (scope.hasNegative && scope.hasPositive) {
+			recalculable.add(key);
+		}
+	}
+	return recalculable;
+};
+
+export const hasRecalculableScope = ({
+	cusEnts,
+	entityId,
+}: {
+	cusEnts: FullCusEntWithFullCusProduct[];
+	entityId?: string;
+}): boolean => getRecalculableScopeKeys({ cusEnts, entityId }).size > 0;

--- a/shared/utils/cusEntUtils/index.ts
+++ b/shared/utils/cusEntUtils/index.ts
@@ -19,6 +19,7 @@ export * from "./balanceUtils/customerEntitlementToBalancePrice";
 export * from "./balanceUtils/grantedBalanceUtils/cusEntsToAdjustment";
 export * from "./balanceUtils/grantedBalanceUtils/cusEntsToAllowance";
 export * from "./balanceUtils/grantedBalanceUtils/cusEntsToGrantedBalance";
+export * from "./balanceUtils/recalculateScopeUtils";
 export * from "./balanceUtils/rollovers/cusEntsToRolloverBalance";
 export * from "./balanceUtils/rollovers/cusEntsToRolloverGranted";
 export * from "./balanceUtils/rollovers/cusEntsToRolloverUsage";

--- a/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/InvoiceDetailSheet.tsx
@@ -142,7 +142,19 @@ export function InvoiceDetailSheet({
 
 			const productId = productKey === "__unknown__" ? null : productKey;
 			const product = products?.find((p) => p.id === productId);
-			const productName = product?.name ?? productId ?? "Unknown Product";
+			const invoiceProductId =
+				!productId && invoice?.product_ids?.length === 1
+					? invoice.product_ids[0]
+					: null;
+			const invoiceProduct = invoiceProductId
+				? products?.find((p) => p.id === invoiceProductId)
+				: undefined;
+			const productName =
+				product?.name ??
+				invoiceProduct?.name ??
+				productId ??
+				invoiceProductId ??
+				"Custom Item";
 
 			result.push({
 				productId,
@@ -152,7 +164,7 @@ export function InvoiceDetailSheet({
 		}
 
 		return result;
-	}, [lineItems, features, products]);
+	}, [lineItems, features, products, invoice?.product_ids]);
 
 	if (!invoice) return null;
 

--- a/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
@@ -137,11 +137,19 @@ export function BalanceRecalculateDialog({
 					</div>
 				)}
 
-				{!preview.isFetching && changedRows.length === 0 && (
-					<p className="text-sm text-tertiary-foreground">
-						These balances are already up to date.
+				{!preview.isFetching && preview.isError && (
+					<p className="text-sm text-red-600 dark:text-red-400">
+						Couldn't load the preview. Please try again.
 					</p>
 				)}
+
+				{!preview.isFetching &&
+					!preview.isError &&
+					changedRows.length === 0 && (
+						<p className="text-sm text-tertiary-foreground">
+							These balances are already up to date.
+						</p>
+					)}
 
 				<DialogFooter>
 					<ShortcutButton

--- a/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx
@@ -1,0 +1,161 @@
+import {
+	type Entity,
+	type FullCusEntWithFullCusProduct,
+	fullCustomerToCustomerEntitlements,
+	numberWithCommas,
+} from "@autumn/shared";
+import { UserIcon } from "@phosphor-icons/react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ShortcutButton } from "@/components/v2/buttons/ShortcutButton";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/v2/dialogs/Dialog";
+import { cn } from "@/lib/utils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { getCustomerBalanceSourceParts } from "./customerBalanceUtils";
+import { useRecalculateBalancePreview } from "./useRecalculateBalancePreview";
+import { useRecalculateBalances } from "./useRecalculateBalances";
+
+export function BalanceRecalculateDialog({
+	balance,
+	entityId,
+	open,
+	onOpenChange,
+}: {
+	balance: FullCusEntWithFullCusProduct | null;
+	entityId: string | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const { customer } = useCusQuery();
+	const preview = useRecalculateBalancePreview({
+		balance,
+		entityId,
+		enabled: open,
+	});
+	const { mutate, isPending } = useRecalculateBalances({ entityId });
+
+	const entities: Entity[] = customer?.entities ?? [];
+	const selectedEntity = entities.find(
+		(entity) => entity.id === entityId || entity.internal_id === entityId,
+	);
+	const ents =
+		balance && customer
+			? fullCustomerToCustomerEntitlements({
+					fullCustomer: customer,
+					featureId: balance.entitlement.feature.id,
+					entity: selectedEntity,
+				})
+			: [];
+	const entById = new Map(ents.map((ent) => [ent.id, ent]));
+	const changedRows = (preview.data?.entitlements ?? []).filter(
+		(row) => row.before_remaining !== row.after_remaining,
+	);
+	const featureName = balance?.entitlement.feature.name ?? "this feature";
+
+	const handleConfirm = () => {
+		if (!balance) return;
+		mutate({ balance }, { onSuccess: () => onOpenChange(false) });
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>Recalculate {featureName}</DialogTitle>
+					<DialogDescription>
+						Usage is redistributed so balances with remaining absorb the
+						overage. The total stays the same.
+					</DialogDescription>
+				</DialogHeader>
+
+				{preview.isFetching && (
+					<div className="divide-y divide-border/60 overflow-hidden rounded-lg border border-border/60">
+						<div className="flex items-center justify-between gap-4 px-3 py-2">
+							<Skeleton className="h-4 w-40" />
+							<Skeleton className="h-4 w-12" />
+						</div>
+						<div className="flex items-center justify-between gap-4 px-3 py-2">
+							<Skeleton className="h-4 w-28" />
+							<Skeleton className="h-4 w-12" />
+						</div>
+					</div>
+				)}
+
+				{!preview.isFetching && changedRows.length > 0 && (
+					<div className="divide-y divide-border/60 overflow-hidden rounded-lg border border-border/60">
+						{changedRows.map((row) => {
+							const ent = entById.get(row.customer_entitlement_id);
+							const parts = ent
+								? getCustomerBalanceSourceParts({ balance: ent, entities })
+								: null;
+							const label = parts
+								? [parts.productName, parts.intervalLabel]
+										.filter(Boolean)
+										.join(" · ")
+								: row.customer_entitlement_id;
+							const isIncrease = row.after_remaining > row.before_remaining;
+							return (
+								<div
+									key={row.customer_entitlement_id}
+									className="flex items-center justify-between gap-4 px-3 py-2"
+								>
+									<div className="flex min-w-0 items-center gap-2">
+										<span className="truncate text-sm text-muted-foreground">
+											{label}
+										</span>
+										{parts?.entityName && (
+											<span className="text-tiny-id inline-flex shrink-0 items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-muted-foreground">
+												<UserIcon size={10} weight="bold" />
+												{parts.entityName}
+											</span>
+										)}
+									</div>
+									<div className="flex shrink-0 items-center gap-2 text-sm tabular-nums">
+										<span className="text-tertiary-foreground line-through">
+											{numberWithCommas(row.before_remaining)}
+										</span>
+										<span
+											className={cn(
+												"font-medium",
+												isIncrease
+													? "text-emerald-600 dark:text-emerald-400"
+													: "text-red-600 dark:text-red-400",
+											)}
+										>
+											{numberWithCommas(row.after_remaining)}
+										</span>
+									</div>
+								</div>
+							);
+						})}
+					</div>
+				)}
+
+				{!preview.isFetching && changedRows.length === 0 && (
+					<p className="text-sm text-tertiary-foreground">
+						These balances are already up to date.
+					</p>
+				)}
+
+				<DialogFooter>
+					<ShortcutButton
+						variant="primary"
+						metaShortcut="enter"
+						onClick={handleConfirm}
+						isLoading={isPending}
+						disabled={preview.isFetching || changedRows.length === 0}
+						className="w-full"
+					>
+						Recalculate
+					</ShortcutButton>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTable.tsx
@@ -6,6 +6,7 @@ import { useCustomerBalanceSheetStore } from "@/hooks/stores/useCustomerBalanceS
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCustomerTable } from "@/views/customers2/hooks/useCustomerTable";
+import { BalanceRecalculateDialog } from "./BalanceRecalculateDialog";
 import { CustomerBalanceTableColumns } from "./CustomerBalanceTableColumns";
 
 export type CustomerBalanceRowData = FullCusEntWithFullCusProduct & {
@@ -34,6 +35,9 @@ export function CustomerBalanceTable({
 	const selectedFeatureId = useCustomerBalanceSheetStore((s) => s.featureId);
 
 	const [expanded, setExpanded] = useState<ExpandedState>({});
+	const [recalcBalance, setRecalcBalance] =
+		useState<FullCusEntWithFullCusProduct | null>(null);
+	const [recalcOpen, setRecalcOpen] = useState(false);
 
 	const rowData: CustomerBalanceRowData[] = useMemo(() => {
 		return allEnts.map((ent) => {
@@ -75,6 +79,10 @@ export function CustomerBalanceTable({
 							featureName: balance.entitlement.feature.name,
 						},
 					}),
+				onRecalculateClick: (balance) => {
+					setRecalcBalance(balance);
+					setRecalcOpen(true);
+				},
 			}),
 		[customer, entityId, setSheet],
 	);
@@ -134,22 +142,30 @@ export function CustomerBalanceTable({
 	};
 
 	return (
-		<Table.Provider
-			config={{
-				table,
-				numberOfColumns: columns.length,
-				enableSorting: false,
-				isLoading,
-				onRowClick: handleRowClick,
-				flexibleTableColumns: true,
-				selectedItemId: getSelectedRowId(),
-			}}
-		>
-			<Table.Container>
-				<Table.Content>
-					<Table.Body />
-				</Table.Content>
-			</Table.Container>
-		</Table.Provider>
+		<>
+			<Table.Provider
+				config={{
+					table,
+					numberOfColumns: columns.length,
+					enableSorting: false,
+					isLoading,
+					onRowClick: handleRowClick,
+					flexibleTableColumns: true,
+					selectedItemId: getSelectedRowId(),
+				}}
+			>
+				<Table.Container>
+					<Table.Content>
+						<Table.Body />
+					</Table.Content>
+				</Table.Container>
+			</Table.Provider>
+			<BalanceRecalculateDialog
+				balance={recalcBalance}
+				entityId={entityId}
+				open={recalcOpen}
+				onOpenChange={setRecalcOpen}
+			/>
+		</>
 	);
 }

--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -14,6 +14,7 @@ import {
 	nullish,
 } from "@autumn/shared";
 import {
+	ArrowsClockwiseIcon,
 	BoxArrowDownIcon,
 	BracketsSquareIcon,
 	CaretRightIcon,
@@ -45,6 +46,7 @@ import { FeatureBalanceDisplay } from "../customer-feature-usage/FeatureBalanceD
 import type { CustomerBalanceRowData } from "./CustomerBalanceTable";
 import {
 	canDeleteCustomerBalance,
+	canRecalculateCustomerBalances,
 	getCustomerBalanceSourceParts,
 } from "./customerBalanceUtils";
 
@@ -360,22 +362,37 @@ function BarCell({
 
 function BalanceActionsCell({
 	row,
+	fullCustomer,
+	entityId,
 	onDeleteClick,
 	onRecordUsageClick,
 	onCheckBalanceClick,
+	onRecalculateClick,
 }: {
 	row: Row<CustomerBalanceRowData>;
+	fullCustomer: FullCustomer | null | undefined;
+	entityId: string | null;
 	onDeleteClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onRecordUsageClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
+	onRecalculateClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) {
 	const isParentRow = row.depth === 0;
 	const canDelete =
 		!row.getCanExpand() && canDeleteCustomerBalance({ balance: row.original });
 	const canRecordUsage = isParentRow && !!onRecordUsageClick;
 	const canCheckBalance = isParentRow && !!onCheckBalanceClick;
+	const canRecalculate =
+		isParentRow &&
+		!!onRecalculateClick &&
+		canRecalculateCustomerBalances({
+			fullCustomer,
+			featureId: row.original.entitlement.feature.id,
+			entityId,
+		});
 
-	if (!canDelete && !canRecordUsage && !canCheckBalance) return null;
+	if (!canDelete && !canRecordUsage && !canCheckBalance && !canRecalculate)
+		return null;
 
 	return (
 		<div className="flex justify-end">
@@ -410,7 +427,26 @@ function BalanceActionsCell({
 						>
 							<div className="flex w-full items-center justify-between gap-2 text-sm">
 								Check balance
-								<BracketsSquareIcon size={12} className="text-tertiary-foreground" />
+								<BracketsSquareIcon
+									size={12}
+									className="text-tertiary-foreground"
+								/>
+							</div>
+						</DropdownMenuItem>
+					)}
+					{canRecalculate && (
+						<DropdownMenuItem
+							onClick={(event) => {
+								event.stopPropagation();
+								onRecalculateClick(row.original);
+							}}
+						>
+							<div className="flex w-full items-center justify-between gap-2 text-sm">
+								Recalculate balances
+								<ArrowsClockwiseIcon
+									size={12}
+									className="text-tertiary-foreground"
+								/>
 							</div>
 						</DropdownMenuItem>
 					)}
@@ -442,6 +478,7 @@ export const CustomerBalanceTableColumns = ({
 	onDeleteClick,
 	onRecordUsageClick,
 	onCheckBalanceClick,
+	onRecalculateClick,
 }: {
 	fullCustomer: FullCustomer | null | undefined;
 	entityId: string | null;
@@ -449,6 +486,7 @@ export const CustomerBalanceTableColumns = ({
 	onDeleteClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onRecordUsageClick?: (balance: FullCusEntWithFullCusProduct) => void;
 	onCheckBalanceClick?: (balance: FullCusEntWithFullCusProduct) => void;
+	onRecalculateClick?: (balance: FullCusEntWithFullCusProduct) => void;
 }) => [
 	{
 		header: "Feature",
@@ -477,7 +515,9 @@ export const CustomerBalanceTableColumns = ({
 									entities,
 								})}
 							>
-								<span className="text-tertiary-foreground truncate text-xs">{metaParts}</span>
+								<span className="text-tertiary-foreground truncate text-xs">
+									{metaParts}
+								</span>
 							</AdminHover>
 						</div>
 					);
@@ -498,7 +538,9 @@ export const CustomerBalanceTableColumns = ({
 								</span>
 							</AdminHover>
 						</div>
-						<span className="text-tertiary-foreground text-xs truncate pl-5.5">{metaParts}</span>
+						<span className="text-tertiary-foreground text-xs truncate pl-5.5">
+							{metaParts}
+						</span>
 					</div>
 				);
 			}
@@ -568,9 +610,12 @@ export const CustomerBalanceTableColumns = ({
 		cell: ({ row }: { row: Row<CustomerBalanceRowData> }) => (
 			<BalanceActionsCell
 				row={row}
+				fullCustomer={fullCustomer}
+				entityId={entityId}
 				onDeleteClick={onDeleteClick}
 				onRecordUsageClick={onRecordUsageClick}
 				onCheckBalanceClick={onCheckBalanceClick}
+				onRecalculateClick={onRecalculateClick}
 			/>
 		),
 	},

--- a/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/customerBalanceUtils.ts
@@ -4,7 +4,11 @@ import {
 	EntInterval,
 	type Entity,
 	type FullCusEntWithFullCusProduct,
+	type FullCustomer,
+	fullCustomerToCustomerEntitlements,
+	hasRecalculableScope,
 	isPaidCustomerEntitlement,
+	type RecalculateBalanceParamsV0,
 } from "@autumn/shared";
 
 export const getCustomerBalanceId = ({
@@ -79,6 +83,44 @@ export const getCustomerBalanceRemaining = ({
 		entityId: entityId ?? undefined,
 		withRollovers: true,
 	});
+
+export const canRecalculateCustomerBalances = ({
+	fullCustomer,
+	featureId,
+	entityId,
+}: {
+	fullCustomer: FullCustomer | null | undefined;
+	featureId: string;
+	entityId: string | null;
+}) => {
+	if (!fullCustomer) return false;
+	const entity = entityId
+		? fullCustomer.entities?.find(
+				(candidate) =>
+					candidate.id === entityId || candidate.internal_id === entityId,
+			)
+		: undefined;
+	const cusEnts = fullCustomerToCustomerEntitlements({
+		fullCustomer,
+		featureId,
+		entity,
+	});
+	return hasRecalculableScope({ cusEnts, entityId: entity?.id ?? undefined });
+};
+
+export const getRecalculateBalanceParams = ({
+	balance,
+	customerId,
+	entityId,
+}: {
+	balance: FullCusEntWithFullCusProduct;
+	customerId: string;
+	entityId: string | null;
+}): RecalculateBalanceParamsV0 => ({
+	customer_id: customerId,
+	feature_id: balance.entitlement.feature.id,
+	entity_id: entityId ?? undefined,
+});
 
 export const getDeleteBalanceParams = ({
 	balance,

--- a/vite/src/views/customers2/components/table/customer-balance/useRecalculateBalancePreview.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/useRecalculateBalancePreview.ts
@@ -1,0 +1,39 @@
+import type {
+	FullCusEntWithFullCusProduct,
+	RecalculateBalancePreview,
+} from "@autumn/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { getRecalculateBalanceParams } from "./customerBalanceUtils";
+
+export const useRecalculateBalancePreview = ({
+	balance,
+	entityId,
+	enabled,
+}: {
+	balance: FullCusEntWithFullCusProduct | null;
+	entityId: string | null;
+	enabled: boolean;
+}) => {
+	const axiosInstance = useAxiosInstance();
+	const { customer } = useCusQuery();
+	const customerId = customer?.id || customer?.internal_id;
+	const featureId = balance?.entitlement.feature.id;
+	return useQuery({
+		queryKey: ["recalculate-balance-preview", customerId, featureId, entityId],
+		enabled: enabled && !!customerId && !!balance,
+		staleTime: 0,
+		gcTime: 0,
+		queryFn: async (): Promise<RecalculateBalancePreview> => {
+			if (!customerId || !balance) {
+				throw new Error("Customer not found");
+			}
+			const { data } = await axiosInstance.post(
+				"/v1/balances.preview_recalculate",
+				getRecalculateBalanceParams({ balance, customerId, entityId }),
+			);
+			return data;
+		},
+	});
+};

--- a/vite/src/views/customers2/components/table/customer-balance/useRecalculateBalances.ts
+++ b/vite/src/views/customers2/components/table/customer-balance/useRecalculateBalances.ts
@@ -1,0 +1,47 @@
+import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { getRecalculateBalanceParams } from "./customerBalanceUtils";
+
+export const useRecalculateBalances = ({
+	entityId,
+}: {
+	entityId: string | null;
+}) => {
+	const axiosInstance = useAxiosInstance();
+	const { customer, refetch } = useCusQuery();
+	const queryClient = useQueryClient();
+	const buildQueryKey = useQueryKeyFactory();
+	const customerId = customer?.id || customer?.internal_id;
+	return useMutation({
+		mutationFn: async ({
+			balance,
+		}: {
+			balance: FullCusEntWithFullCusProduct;
+		}) => {
+			if (!customerId) {
+				throw new Error("Customer not found");
+			}
+			await axiosInstance.post(
+				"/v1/balances.recalculate",
+				getRecalculateBalanceParams({ balance, customerId, entityId }),
+			);
+		},
+		onSuccess: async () => {
+			toast.success("Balances recalculated");
+			await Promise.all([
+				refetch(),
+				queryClient.invalidateQueries({
+					queryKey: buildQueryKey(["customer", customerId]),
+				}),
+			]);
+		},
+		onError: (error) => {
+			toast.error(getBackendErr(error, "Failed to recalculate balances"));
+		},
+	});
+};

--- a/vite/src/views/customers2/components/table/customer-invoices/getInvoiceProductNames.ts
+++ b/vite/src/views/customers2/components/table/customer-invoices/getInvoiceProductNames.ts
@@ -5,7 +5,7 @@ import type {
 	ProductV2,
 } from "@autumn/shared";
 
-const UNKNOWN_PRODUCT_LABEL = "Unknown Product";
+const UNKNOWN_PRODUCT_LABEL = "Custom Item";
 
 type ProductGroup = {
 	productName: string;
@@ -29,11 +29,13 @@ const getFallbackNames = ({
 const resolveProductName = ({
 	productId,
 	products,
+	invoiceFallback,
 }: {
 	productId: string | null;
 	products: ProductV2[];
+	invoiceFallback?: string;
 }): string => {
-	if (!productId) return UNKNOWN_PRODUCT_LABEL;
+	if (!productId) return invoiceFallback ?? UNKNOWN_PRODUCT_LABEL;
 	return products.find((p) => p.id === productId)?.name ?? productId;
 };
 
@@ -54,6 +56,11 @@ export const getInvoiceProductNames = ({
 	features: Feature[];
 }): string => {
 	if (lineItems.length === 0) return getFallbackNames({ invoice, products });
+	const invoiceFallback =
+		invoice.product_ids.length === 1
+			? (products.find((p) => p.id === invoice.product_ids[0])?.name ??
+				invoice.product_ids[0])
+			: undefined;
 	const groups = new Map<string, ProductGroup>();
 	for (const item of lineItems) {
 		const key = item.product_id ?? "__unknown__";
@@ -63,6 +70,7 @@ export const getInvoiceProductNames = ({
 				productName: resolveProductName({
 					productId: item.product_id,
 					products,
+					invoiceFallback,
 				}),
 				featureNames: new Set<string>(),
 			} satisfies ProductGroup);


### PR DESCRIPTION
## Summary
Release of current `dev` onto `main`, excluding the `fix: dockerfile` change.

- Mirrors PR #1788 (`dev` → `main`) but drops the `fix: dockerfile` commit (e5a6d21) — reverted here so the `docker/Dockerfile` tweak from that commit is not part of this release.
- The `Merge branch 'dev'` commit (aa8acdd) only carried the recalculate-balances content, which is retained.

## Notes
- All other dev work is included: recalculate balances, invoice label fixes, mcp improvements, db migrate, improve docker build, fix: regions, etc.
- Built from `origin/dev` with the single `fix: dockerfile` change reverted (DAG history made a clean curated cherry-pick onto main risky, so a revert was used to guarantee an identical tree minus the Dockerfile change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release includes balance recalculation with preview/apply, chat web search via Firecrawl, and safer DB migration + build pipeline updates.

- **New Features**
  - Recalculate balances for a feature with preview: adds `/balances.recalculate` and `/balances.preview_recalculate` (and RPC equivalents). Totals stay the same; usage is redistributed within the same scope. Dashboard adds a “Recalculate balances” dialog in the customer balance table.
  - Chat web search: added `searchWeb` and `scrapeUrl` tools using `@mendable/firecrawl-js`. Requires `FIRECRAWL_API_KEY`. Instructions discourage web for Autumn data and enforce source citation. Includes unit tests.
  - MCP: `listCustomers` clamps `limit` to 1000 and docs note the max. Tools/tests updated.

- **Refactors**
  - DB migrations: new executor applies `CONCURRENTLY` statements outside transactions; safety check blocks non-concurrent index DDL. CLI runs pending migrations directly via drizzle file hashes.
  - CI/build: ECR region picked per branch; switched to Blacksmith Docker builder with sticky build cache; Dockerfile rebuilt with Turbo prune for smaller, faster builds.
  - UI polish: clearer invoice product labels (“Custom Item” fallback and single-product inference); balance table adds Recalculate action; various test additions (chat, approvals, UI).

<sup>Written for commit eef5c0124d670be344e2c17e035c1e943800c5ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release merges the current `dev` branch onto `main`, deliberately excluding only the `fix: dockerfile` commit. The bulk of the changes are new balance-recalculation functionality spanning API, server logic, shared utilities, and a dashboard dialog, plus Firecrawl web-search integration in the chat agent, a custom CONCURRENTLY-aware DB migration executor, MCP `listCustomers` limit clamping, invoice product-name improvements, and a multi-stage Docker build.

- **[Improvements, API changes]** New `balances.recalculate` / `balances.preview_recalculate` endpoints redistribute per-entitlement usage across sibling balances within scope, preserving the aggregate; backed by 10 integration tests and a dashboard dialog with a before/after preview.
- **[Improvements]** Custom DB migration executor runs `CREATE INDEX CONCURRENTLY` migrations in autocommit so they no longer need manual steps.
- **[Improvements]** Chat agent gains `searchWeb` and `scrapeUrl` tools via Firecrawl, adding `FIRECRAWL_API_KEY` as a new required env variable.
- **[Bug fixes]** Invoice line items now fall back to the invoice's `product_ids` when a line item has no explicit product, fixing \"Unknown Product\" labels.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with the caveat that FIRECRAWL_API_KEY must be set in all chat service environments before deploying, otherwise the service will fail to start.

The recalculate-balance feature is well-structured with a clean compute/persist split, comprehensive integration tests, and correct scope-based grouping. The two P2 gaps in the migration tooling are low-probability edge cases. The only meaningful deployment risk is the required FIRECRAWL_API_KEY in the chat service: existing deployments without this variable will fail to start immediately.

apps/chat/src/lib/env.ts — FIRECRAWL_API_KEY must be provisioned in every environment before rollout. scripts/db/helpers/applyMigrations.ts and scripts/db/commands/migrate.ts have minor correctness gaps worth a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/chat/src/lib/env.ts | Adds required FIRECRAWL_API_KEY env var; no default or optional — existing chat deployments without this key will fail to start |
| scripts/db/helpers/applyMigrations.ts | New custom migration executor that runs CONCURRENTLY statements in autocommit; atomicity gap between DDL execution and tracking-row insert is not handled or documented |
| scripts/db/commands/migrate.ts | Replaces drizzle-kit delegate with a custom applyPending; silently skips journal entries whose SQL files are not found by readMigrationFiles |
| server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts | Core balance recalculation logic: resets entitlements to starting balance per scope group and re-applies total usage with overage allowed |
| server/src/internal/balances/recalculateBalance/recalculateBalance.ts | Persists recalculate results in a DB transaction then invalidates the customer cache |
| docker/Dockerfile | Multi-stage Dockerfile using turborepo prune for a minimal dependency layer |
| vite/src/views/customers2/components/table/customer-balance/BalanceRecalculateDialog.tsx | New dialog showing before/after preview per entitlement before confirming recalculation |
| server/tests/integration/balances/recalculate/recalculate-balance.test.ts | 10 concurrent integration tests covering overage redistribution, idempotency, entity scope isolation, and preview-only mode |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dashboard as Dashboard (Vite)
    participant API as Server API
    participant Compute as computeRecalculateBalance
    participant DB as Database
    participant Cache as Customer Cache

    Dashboard->>API: POST /balances.preview_recalculate
    API->>Compute: computeRecalculateBalance(params)
    Compute->>DB: CusService.getFull(customer_id)
    DB-->>Compute: fullCustomer + entitlements
    Compute->>Compute: group by scope key
    Compute->>Compute: reset + re-apply usage per scope
    Compute-->>API: before[], after[], totalUsage
    API-->>Dashboard: RecalculateBalancePreview

    Dashboard->>Dashboard: Show before/after diff dialog
    Dashboard->>API: POST /balances.recalculate
    API->>Compute: computeRecalculateBalance(params)
    Compute->>DB: CusService.getFull(customer_id)
    DB-->>Compute: fullCustomer + entitlements
    Compute-->>API: before[], after[]
    API->>DB: transaction: UPDATE each cusEnt
    DB-->>API: committed
    API->>Cache: deleteCachedFullCustomer
    API-->>Dashboard: success: true
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/db/commands/migrate.ts`, line 880-882 ([link](https://github.com/useautumn/autumn/blob/eef5c0124d670be344e2c17e035c1e943800c5ca/scripts/db/commands/migrate.ts#L880-L882)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent skip for unresolvable pending migrations**

   `toApply` is built by intersecting the pending set against whatever `readMigrationFiles` finds on disk. If a journal entry has no matching SQL file (e.g., the file was deleted but the journal wasn't updated), that migration is silently skipped. The final `done — applied N migration(s)` log line will show a count lower than the number of pending entries, but no warning is emitted. A missing-file check before the loop would surface this unambiguously.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/db/commands/migrate.ts
   Line: 880-882

   Comment:
   **Silent skip for unresolvable pending migrations**

   `toApply` is built by intersecting the pending set against whatever `readMigrationFiles` finds on disk. If a journal entry has no matching SQL file (e.g., the file was deleted but the journal wasn't updated), that migration is silently skipped. The final `done — applied N migration(s)` log line will show a count lower than the number of pending entries, but no warning is emitted. A missing-file check before the loop would surface this unambiguously.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `scripts/db/helpers/applyMigrations.ts`, line 950-955 ([link](https://github.com/useautumn/autumn/blob/eef5c0124d670be344e2c17e035c1e943800c5ca/scripts/db/helpers/applyMigrations.ts#L950-L955)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Atomicity gap in CONCURRENTLY migrations**

   When a migration contains `CONCURRENTLY`, the DDL statements run in autocommit and then `recordApplied` is called separately. If the process crashes or the connection drops between the last DDL statement and the `recordApplied` insert, the index will exist in the database but the migration will still appear as pending on the next run. The next invocation will attempt to re-run `CREATE INDEX CONCURRENTLY`, which will fail with "index already exists" and require manual intervention (`bun db mark-applied`). The README describes this path as fully automated, so this scenario is worth documenting explicitly.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/db/helpers/applyMigrations.ts
   Line: 950-955

   Comment:
   **Atomicity gap in CONCURRENTLY migrations**

   When a migration contains `CONCURRENTLY`, the DDL statements run in autocommit and then `recordApplied` is called separately. If the process crashes or the connection drops between the last DDL statement and the `recordApplied` insert, the index will exist in the database but the migration will still appear as pending on the next run. The next invocation will attempt to re-run `CREATE INDEX CONCURRENTLY`, which will fail with "index already exists" and require manual intervention (`bun db mark-applied`). The README describes this path as fully automated, so this scenario is worth documenting explicitly.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/chat/src/lib/env.ts:19
FIRECRAWL_API_KEY is required with no default or optional fallback. Any existing chat service deployment that doesn't have this variable pre-configured will fail at startup immediately after this release. Consider making it optional and conditionally registering the Firecrawl tools only when the key is present, or ensure all environments are updated before deploying.

```suggestion
		FIRECRAWL_API_KEY: z.string().min(1).optional(),
```

### Issue 2 of 3
scripts/db/commands/migrate.ts:880-882
**Silent skip for unresolvable pending migrations**

`toApply` is built by intersecting the pending set against whatever `readMigrationFiles` finds on disk. If a journal entry has no matching SQL file (e.g., the file was deleted but the journal wasn't updated), that migration is silently skipped. The final `done — applied N migration(s)` log line will show a count lower than the number of pending entries, but no warning is emitted. A missing-file check before the loop would surface this unambiguously.

### Issue 3 of 3
scripts/db/helpers/applyMigrations.ts:950-955
**Atomicity gap in CONCURRENTLY migrations**

When a migration contains `CONCURRENTLY`, the DDL statements run in autocommit and then `recordApplied` is called separately. If the process crashes or the connection drops between the last DDL statement and the `recordApplied` insert, the index will exist in the database but the migration will still appear as pending on the next run. The next invocation will attempt to re-run `CREATE INDEX CONCURRENTLY`, which will fail with "index already exists" and require manual intervention (`bun db mark-applied`). The README describes this path as fully automated, so this scenario is worth documenting explicitly.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix: dockerfile&quot;"](https://github.com/useautumn/autumn/commit/eef5c0124d670be344e2c17e035c1e943800c5ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35225830)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->