### PR TITLE
Charlie/analytics chart improvements

### DIFF
--- a/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
@@ -64,6 +64,7 @@ function TooltipItem({ item, label }: { item: any; label: string }) {
 export const EventsBarChart = memo(function EventsBarChart({
 	data,
 	chartConfig,
+	domainMax,
 	onGeometry,
 }: {
 	data: {
@@ -72,6 +73,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 		data: Row[];
 	};
 	chartConfig: ChartSeriesConfig[];
+	domainMax?: number;
 	onGeometry?: (insets: PlotInsets) => void;
 }) {
 	const { queryStates } = useAnalyticsQueryState();
@@ -214,6 +216,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 						width={Y_AXIS_WIDTH}
 						tickMargin={0}
 						tickCount={5}
+						domain={domainMax != null ? [0, domainMax] : undefined}
 						tick={Y_TICK}
 						tickFormatter={formatCompactNumber}
 					/>

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -15,6 +15,7 @@ import { ChartSkeleton } from "./components/ChartSkeleton";
 import {
 	DEFAULT_PLOT_INSETS,
 	getCachedPlotInsets,
+	niceCeil,
 	type PlotInsets,
 	plotInsetsEqual,
 	setCachedPlotInsets,
@@ -197,10 +198,10 @@ export const AnalyticsView = () => {
 		return { chartData: trimmed, chartConfig: config };
 	}, [events, features, groupBy, groupFilter, planDeselected, entityNames, customerNames, planNames]);
 
-	const barFractions = useMemo(() => {
+	const { barFractions, chartDomainMax } = useMemo(() => {
 		const rows = chartData?.data;
 		if (!rows || rows.length === 0 || !chartConfig) {
-			return null;
+			return { barFractions: null, chartDomainMax: undefined };
 		}
 		const totals = rows.map((row) =>
 			chartConfig.reduce(
@@ -209,8 +210,11 @@ export const AnalyticsView = () => {
 				0,
 			),
 		);
-		const max = Math.max(...totals, 1);
-		return totals.map((total) => total / max);
+		const domainMax = niceCeil(Math.max(...totals, 1));
+		return {
+			barFractions: totals.map((total) => total / domainMax),
+			chartDomainMax: domainMax,
+		};
 	}, [chartData, chartConfig]);
 
 	// Build legend entries (sorted desc, zero-values filtered). The
@@ -332,7 +336,7 @@ export const AnalyticsView = () => {
 	const hasChart =
 		!queryLoading && !!chartData && chartData.data.length > 0;
 	const isEmpty = !queryLoading && !hasChart;
-	const chartRevealDelay = reduceMotion ? 0 : 0.55;
+	const chartRevealDelay = reduceMotion ? 0 : 0.85;
 
 	return (
 		<AnalyticsContext.Provider value={contextValue}>
@@ -365,7 +369,7 @@ export const AnalyticsView = () => {
 								animate={{
 									opacity: 1,
 									transition: {
-										duration: 0.25,
+										duration: 0.85,
 										delay: chartRevealDelay,
 										ease: [0.23, 1, 0.32, 1],
 									},
@@ -385,6 +389,7 @@ export const AnalyticsView = () => {
 											chartData as Parameters<typeof EventsBarChart>[0]["data"]
 										}
 										chartConfig={chartConfig}
+										domainMax={chartDomainMax}
 										onGeometry={handlePlotGeometry}
 									/>
 								</div>

--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -119,7 +119,7 @@ export const QueryTopbar = () => {
 			<DropdownMenu
 				onOpenChange={(open) => {
 					if (open) {
-						setDraftRange(undefined);
+						setDraftRange(customRange);
 					}
 				}}
 			>

--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -1,5 +1,5 @@
 import { CalendarBlankIcon, CaretDownIcon } from "@phosphor-icons/react";
-import { endOfDay, format } from "date-fns";
+import { endOfDay, format, subMonths } from "date-fns";
 import { Check } from "lucide-react";
 import { useState } from "react";
 import type { DateRange } from "react-day-picker";
@@ -215,7 +215,11 @@ export const QueryTopbar = () => {
 								numberOfMonths={2}
 								selected={draftRange}
 								onSelect={handleCustomRangeSelect}
-								defaultMonth={draftRange?.from ?? customRange?.from}
+								defaultMonth={
+									draftRange?.from ??
+									customRange?.from ??
+									subMonths(new Date(), 1)
+								}
 								disabled={{ after: new Date() }}
 							/>
 						</DropdownMenuSubContent>

--- a/vite/src/views/customers/customer/analytics/components/SkeletonBar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SkeletonBar.tsx
@@ -60,7 +60,7 @@ const getTransition = ({
 	}
 	return reducedMotion
 		? { duration: 0.2 }
-		: { type: "spring", bounce: 0.1, duration: 0.55 };
+		: { type: "spring", bounce: 0, duration: 0.85 };
 };
 
 export const SkeletonBar = ({
@@ -80,7 +80,13 @@ export const SkeletonBar = ({
 			animate={{ scaleY: getScaleY({ mode, bar, targetHeight }) }}
 			transition={getTransition({ mode, bar, reducedMotion })}
 		>
-			<Skeleton className="h-full w-full rounded-t-[2px] rounded-b-none" />
+			<Skeleton
+				className="h-full w-full rounded-t-[2px] rounded-b-none"
+				style={{
+					animationDelay: `${bar.shimmerDelay}s`,
+					animationDuration: `${bar.shimmerDuration}s`,
+				}}
+			/>
 		</motion.div>
 	);
 };

--- a/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
+++ b/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
@@ -46,6 +46,8 @@ export interface SkeletonBarConfig {
 	low: number;
 	duration: number;
 	delay: number;
+	shimmerDelay: number;
+	shimmerDuration: number;
 }
 
 /** Randomised, stable bar configs for the loading wave. */
@@ -57,6 +59,8 @@ export const buildSkeletonBars = (count: number): SkeletonBarConfig[] =>
 			low: peak * (0.35 + Math.random() * 0.2),
 			duration: 2.6 + Math.random() * 1.8,
 			delay: Math.random() * 1.4,
+			shimmerDelay: -Math.random() * 3,
+			shimmerDuration: 2.6 + Math.random() * 1.6,
 		};
 	});
 
@@ -105,6 +109,29 @@ const STANDARD_INTERVAL_DAYS: Record<string, number> = {
 	"90d": 90,
 	"1bc": 30,
 	"3bc": 90,
+};
+
+/** Rounds a value up to a nice axis maximum (1/2/2.5/5/10 × 10^n), matching
+ * the headroom recharts leaves above the data so bar heights line up. */
+export const niceCeil = (value: number): number => {
+	if (!Number.isFinite(value) || value <= 0) {
+		return 1;
+	}
+	const magnitude = 10 ** Math.floor(Math.log10(value));
+	const fraction = value / magnitude;
+	const niceFraction = (() => {
+		if (fraction <= 1) {
+			return 1;
+		}
+		if (fraction <= 2) {
+			return 2;
+		}
+		if (fraction <= 5) {
+			return 5;
+		}
+		return 10;
+	})();
+	return niceFraction * magnitude;
 };
 
 type BinSize = "hour" | "day" | "month";


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved the analytics bar chart with a “nice” Y‑axis scale so bars align with ticks, plus smoother load/reveal animations. Also fixed the date picker to retain the custom range and show a sensible default month.

- **New Features**
  - Calculate a “nice” Y-axis max with `niceCeil` and pass `domainMax` to the chart for consistent bar heights and headroom; `barFractions` now scale to this max.
  - Smoother chart and skeleton animations: increased durations to 0.85s, removed bounce, and added per-bar shimmer delay/duration.

- **Bug Fixes**
  - Date picker restores the previous custom range when reopened and defaults the calendar to last month if none is set.

<sup>Written for commit 9fa707a6c352cc9b9befba5a9acaa075475a7367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the analytics chart by aligning skeleton loading bars with the actual chart domain, fixing a calendar draft-range reset bug in the custom date picker, and polishing animation timings and shimmer effects.

- **[Improvements]** Introduces `niceCeil` to compute a "nice" Y-axis ceiling shared between the chart (`domain` prop on `YAxis`) and the skeleton bar fractions, so the loading skeleton and the real chart bars occupy the same proportional heights.
- **[Bug fixes]** `QueryTopbar`: draft range is now seeded from `customRange` when the calendar reopens instead of being reset to `undefined`, preserving a previously applied custom range selection. Adds a `subMonths(new Date(), 1)` fallback for `defaultMonth` so the calendar always opens at a sensible month.
- **[Improvements]** Skeleton bars receive staggered `animationDelay`/`animationDuration` CSS properties (via new `shimmerDelay`/`shimmerDuration` fields) for offset shimmer effects; spring animation is tuned to `bounce: 0` with longer durations for smoother reveal.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are scoped to the analytics chart UI with no backend or data-flow risk.

The domain-alignment logic is self-consistent (skeleton and chart always share the same domainMax), the calendar bug fix is straightforward, and the animation tweaks are purely cosmetic. The only finding is a minor mismatch between niceCeil's docstring (which lists 2.5 as a possible output) and its implementation (which never produces 2.5 × 10^n).

chartGeometry.ts — the niceCeil docstring overstates the possible outputs, which could confuse future readers of that function.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/utils/chartGeometry.ts | Adds niceCeil utility and shimmer timing fields to SkeletonBarConfig; niceCeil is functionally correct but its docstring incorrectly lists 2.5 as a valid output when 2.5 × 10^n is never returned. |
| vite/src/views/customers/customer/analytics/AnalyticsView.tsx | Replaces raw-max barFraction calculation with niceCeil-based domainMax, then threads that domainMax into EventsBarChart so skeleton and chart bars share the same scale; logic is correct and well-structured. |
| vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx | Bug fix: draft range now seeds from the current customRange on open instead of resetting to undefined, so a previously applied custom range is preserved when the calendar is reopened. Adds subMonths(new Date(), 1) fallback for defaultMonth. |
| vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx | Adds optional domainMax prop wired to the recharts YAxis domain, correctly guarded with a != null check before applying. |
| vite/src/views/customers/customer/analytics/components/SkeletonBar.tsx | Passes shimmerDelay/shimmerDuration as inline CSS animation properties on the Skeleton element to stagger shimmer effects; also tunes spring animation settings for smoother motion. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[chartData + chartConfig] --> B["useMemo: compute row totals"]
    B --> C["Math.max(totals, 1)"]
    C --> D["niceCeil(max) → domainMax"]
    D --> E["barFractions = totals / domainMax"]
    D --> F["chartDomainMax"]

    E --> G[ChartSkeleton\nSkeletonBar heights]
    F --> H["EventsBarChart\nYAxis domain={[0, domainMax]}"]

    G -.->|"same scale"| H
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers/customer/analytics/utils/chartGeometry.ts:114-115
**Docstring lists 2.5 as a possible output, but it is never returned**

The comment says the function produces ceilings at `1/2/2.5/5/10 × 10^n`, but the implementation jumps directly from `2` to `5`. Any value between `2 × 10^n` and `5 × 10^n` (e.g. a data max of 21 → `domainMax = 50` rather than the described 25) will land on the `5` branch, producing a ceiling that is up to 2× higher than advertised. This doesn't break alignment (skeleton and chart both use the same `domainMax`), but the comment misleads readers about the range of possible outputs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: improve analytics chart"](https://github.com/useautumn/autumn/commit/9fa707a6c352cc9b9befba5a9acaa075475a7367) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35336689)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->