### PR TITLE
release

### DIFF
--- a/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx
@@ -64,6 +64,7 @@ function TooltipItem({ item, label }: { item: any; label: string }) {
 export const EventsBarChart = memo(function EventsBarChart({
 	data,
 	chartConfig,
+	domainMax,
 	onGeometry,
 }: {
 	data: {
@@ -72,6 +73,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 		data: Row[];
 	};
 	chartConfig: ChartSeriesConfig[];
+	domainMax?: number;
 	onGeometry?: (insets: PlotInsets) => void;
 }) {
 	const { queryStates } = useAnalyticsQueryState();
@@ -214,6 +216,7 @@ export const EventsBarChart = memo(function EventsBarChart({
 						width={Y_AXIS_WIDTH}
 						tickMargin={0}
 						tickCount={5}
+						domain={domainMax != null ? [0, domainMax] : undefined}
 						tick={Y_TICK}
 						tickFormatter={formatCompactNumber}
 					/>

--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -15,6 +15,7 @@ import { ChartSkeleton } from "./components/ChartSkeleton";
 import {
 	DEFAULT_PLOT_INSETS,
 	getCachedPlotInsets,
+	niceCeil,
 	type PlotInsets,
 	plotInsetsEqual,
 	setCachedPlotInsets,
@@ -197,10 +198,10 @@ export const AnalyticsView = () => {
 		return { chartData: trimmed, chartConfig: config };
 	}, [events, features, groupBy, groupFilter, planDeselected, entityNames, customerNames, planNames]);
 
-	const barFractions = useMemo(() => {
+	const { barFractions, chartDomainMax } = useMemo(() => {
 		const rows = chartData?.data;
 		if (!rows || rows.length === 0 || !chartConfig) {
-			return null;
+			return { barFractions: null, chartDomainMax: undefined };
 		}
 		const totals = rows.map((row) =>
 			chartConfig.reduce(
@@ -209,8 +210,11 @@ export const AnalyticsView = () => {
 				0,
 			),
 		);
-		const max = Math.max(...totals, 1);
-		return totals.map((total) => total / max);
+		const domainMax = niceCeil(Math.max(...totals, 1));
+		return {
+			barFractions: totals.map((total) => total / domainMax),
+			chartDomainMax: domainMax,
+		};
 	}, [chartData, chartConfig]);
 
 	// Build legend entries (sorted desc, zero-values filtered). The
@@ -332,7 +336,7 @@ export const AnalyticsView = () => {
 	const hasChart =
 		!queryLoading && !!chartData && chartData.data.length > 0;
 	const isEmpty = !queryLoading && !hasChart;
-	const chartRevealDelay = reduceMotion ? 0 : 0.55;
+	const chartRevealDelay = reduceMotion ? 0 : 0.85;
 
 	return (
 		<AnalyticsContext.Provider value={contextValue}>
@@ -365,7 +369,7 @@ export const AnalyticsView = () => {
 								animate={{
 									opacity: 1,
 									transition: {
-										duration: 0.25,
+										duration: 0.85,
 										delay: chartRevealDelay,
 										ease: [0.23, 1, 0.32, 1],
 									},
@@ -385,6 +389,7 @@ export const AnalyticsView = () => {
 											chartData as Parameters<typeof EventsBarChart>[0]["data"]
 										}
 										chartConfig={chartConfig}
+										domainMax={chartDomainMax}
 										onGeometry={handlePlotGeometry}
 									/>
 								</div>

--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -119,7 +119,7 @@ export const QueryTopbar = () => {
 			<DropdownMenu
 				onOpenChange={(open) => {
 					if (open) {
-						setDraftRange(undefined);
+						setDraftRange(customRange);
 					}
 				}}
 			>

--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -1,5 +1,5 @@
 import { CalendarBlankIcon, CaretDownIcon } from "@phosphor-icons/react";
-import { endOfDay, format } from "date-fns";
+import { endOfDay, format, subMonths } from "date-fns";
 import { Check } from "lucide-react";
 import { useState } from "react";
 import type { DateRange } from "react-day-picker";
@@ -215,7 +215,11 @@ export const QueryTopbar = () => {
 								numberOfMonths={2}
 								selected={draftRange}
 								onSelect={handleCustomRangeSelect}
-								defaultMonth={draftRange?.from ?? customRange?.from}
+								defaultMonth={
+									draftRange?.from ??
+									customRange?.from ??
+									subMonths(new Date(), 1)
+								}
 								disabled={{ after: new Date() }}
 							/>
 						</DropdownMenuSubContent>

--- a/vite/src/views/customers/customer/analytics/components/SkeletonBar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/SkeletonBar.tsx
@@ -60,7 +60,7 @@ const getTransition = ({
 	}
 	return reducedMotion
 		? { duration: 0.2 }
-		: { type: "spring", bounce: 0.1, duration: 0.55 };
+		: { type: "spring", bounce: 0, duration: 0.85 };
 };
 
 export const SkeletonBar = ({
@@ -80,7 +80,13 @@ export const SkeletonBar = ({
 			animate={{ scaleY: getScaleY({ mode, bar, targetHeight }) }}
 			transition={getTransition({ mode, bar, reducedMotion })}
 		>
-			<Skeleton className="h-full w-full rounded-t-[2px] rounded-b-none" />
+			<Skeleton
+				className="h-full w-full rounded-t-[2px] rounded-b-none"
+				style={{
+					animationDelay: `${bar.shimmerDelay}s`,
+					animationDuration: `${bar.shimmerDuration}s`,
+				}}
+			/>
 		</motion.div>
 	);
 };

--- a/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
+++ b/vite/src/views/customers/customer/analytics/utils/chartGeometry.ts
@@ -46,6 +46,8 @@ export interface SkeletonBarConfig {
 	low: number;
 	duration: number;
 	delay: number;
+	shimmerDelay: number;
+	shimmerDuration: number;
 }
 
 /** Randomised, stable bar configs for the loading wave. */
@@ -57,6 +59,8 @@ export const buildSkeletonBars = (count: number): SkeletonBarConfig[] =>
 			low: peak * (0.35 + Math.random() * 0.2),
 			duration: 2.6 + Math.random() * 1.8,
 			delay: Math.random() * 1.4,
+			shimmerDelay: -Math.random() * 3,
+			shimmerDuration: 2.6 + Math.random() * 1.6,
 		};
 	});
 
@@ -105,6 +109,29 @@ const STANDARD_INTERVAL_DAYS: Record<string, number> = {
 	"90d": 90,
 	"1bc": 30,
 	"3bc": 90,
+};
+
+/** Rounds a value up to a nice axis maximum (1/2/2.5/5/10 × 10^n), matching
+ * the headroom recharts leaves above the data so bar heights line up. */
+export const niceCeil = (value: number): number => {
+	if (!Number.isFinite(value) || value <= 0) {
+		return 1;
+	}
+	const magnitude = 10 ** Math.floor(Math.log10(value));
+	const fraction = value / magnitude;
+	const niceFraction = (() => {
+		if (fraction <= 1) {
+			return 1;
+		}
+		if (fraction <= 2) {
+			return 2;
+		}
+		if (fraction <= 5) {
+			return 5;
+		}
+		return 10;
+	})();
+	return niceFraction * magnitude;
 };
 
 type BinSize = "hour" | "day" | "month";


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved analytics chart scaling and loading animations, and fixed the date picker’s default month. Bars now align with the y-axis, and the date range dropdown remembers your custom selection.

- **Refactors**
  - Compute a “nice” y-axis max with `niceCeil` and pass it as `domainMax` to `EventsBarChart` so bar heights line up with axis ticks.
  - Derive `barFractions` from the rounded domain for consistent scaling.
  - Smoother animations: longer chart reveal (0.85s), no spring bounce, and per-bar shimmer delay/duration.

- **Bug Fixes**
  - Date range picker reopens with the current custom range.
  - If no range is set, the calendar defaults to last month via `subMonths` from `date-fns`.

<sup>Written for commit 47c42b6fc80fcbe13946372e7b8c204ab79a4711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release aligns the analytics loading skeleton with the real chart by introducing a shared Y-axis ceiling (`niceCeil`) and passing an explicit `domain` to Recharts, so skeleton bars morph into chart bars without a height jump. It also fixes the custom date-range calendar resetting its selection when re-opened.

- **[Bug fixes]** `QueryTopbar`: calendar now initialises `draftRange` from the active custom range on re-open (instead of `undefined`), preserving the visible selection; a `subMonths(new Date(), 1)` fallback ensures the calendar always opens on a sensible month.
- **[Improvements]** `niceCeil` rounds the data max to a `1/2/5/10 × 10^n` ceiling shared by both `barFractions` (skeleton) and the explicit `YAxis domain` (chart), eliminating the skeleton-to-chart height mismatch.
- **[Improvements]** Skeleton bars receive per-bar `shimmerDelay`/`shimmerDuration` styles (including negative delays to pre-phase the animation) for a staggered shimmer; spring bounce and fade-in timings are adjusted to 0.85 s for a smoother transition.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are UI-only and touch the analytics chart skeleton/real-chart alignment and date-picker UX.

The `niceCeil` function's comment advertises a 2.5 × 10^n nice step that the code does not implement. For data peaks in the range (2, 5) × 10^n this doubles the domain ceiling (e.g. 21 events → ceiling of 50 instead of 25), leaving bars visually shorter than intended against the axis. Both skeleton and chart use the same ceiling so they still align with each other, but the axis headroom is more generous than the comment implies. No data loss or security concerns; the rest of the changes are straightforward animation and date-picker fixes.

`chartGeometry.ts` — the missing 2.5 nice step in `niceCeil` is the only item that warrants a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/utils/chartGeometry.ts | Adds `niceCeil` function (1/2/5/10 × 10^n rounding) and shimmer timing fields to `SkeletonBarConfig`; comment mentions 2.5 as a nice step but code omits it |
| vite/src/views/customers/customer/analytics/AnalyticsView.tsx | Wires `niceCeil`-based domain max through to both skeleton bar fractions and the chart's explicit Y-axis domain so they stay aligned; animation timings extended |
| vite/src/views/customers/customer/analytics/AnalyticsGraph.tsx | Accepts optional `domainMax` prop and applies it as an explicit `domain` on the Recharts `YAxis` to lock the axis ceiling |
| vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx | Bug fix: calendar now re-opens with the current custom range pre-selected instead of clearing; adds a sensible `defaultMonth` fallback via `subMonths` |
| vite/src/views/customers/customer/analytics/components/SkeletonBar.tsx | Passes per-bar `shimmerDelay`/`shimmerDuration` as inline CSS to stagger the Skeleton shimmer animation across bars |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant AV as AnalyticsView
    participant CG as chartGeometry (niceCeil)
    participant SK as ChartSkeleton
    participant EBC as EventsBarChart (Recharts)

    AV->>AV: useMemo — compute totals from chartData
    AV->>CG: niceCeil(max(totals, 1))
    CG-->>AV: domainMax

    AV->>AV: "barFractions = totals.map(t => t / domainMax)"
    AV->>SK: "targets={barFractions} (skeleton bar heights)"
    AV->>EBC: "domainMax={chartDomainMax}"

    EBC->>EBC: "YAxis domain=[0, domainMax]"
    Note over SK,EBC: Bar heights now share the same scale ceiling
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers/customer/analytics/utils/chartGeometry.ts:114-135
The JSDoc says the nice steps are `1/2/2.5/5/10 × 10^n`, but the implementation only covers `1/2/5/10`. The 2.5 bracket (`fraction <= 2.5`) is missing, so any data max between `2 × 10^n` (exclusive) and `5 × 10^n` (inclusive) gets ceiled all the way to `5 × 10^n` instead of `2.5 × 10^n`. For example, a peak of 21 events yields a domain ceiling of 50 rather than 25, making all bars appear roughly half-height. Either add the 2.5 step or update the comment to match the intended four-step ladder.

```suggestion
/** Rounds a value up to a nice axis maximum (1/2/2.5/5/10 × 10^n), matching
 * the headroom recharts leaves above the data so bar heights line up. */
export const niceCeil = (value: number): number => {
	if (!Number.isFinite(value) || value <= 0) {
		return 1;
	}
	const magnitude = 10 ** Math.floor(Math.log10(value));
	const fraction = value / magnitude;
	const niceFraction = (() => {
		if (fraction <= 1) {
			return 1;
		}
		if (fraction <= 2) {
			return 2;
		}
		if (fraction <= 2.5) {
			return 2.5;
		}
		if (fraction <= 5) {
			return 5;
		}
		return 10;
	})();
	return niceFraction * magnitude;
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1791 from useautumn/..."](https://github.com/useautumn/autumn/commit/47c42b6fc80fcbe13946372e7b8c204ab79a4711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35337793)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->