### PR TITLE
fix: dockerfile

### DIFF
--- a/.github/workflows/server-unit-tests.yml
+++ b/.github/workflows/server-unit-tests.yml
@@ -2,8 +2,6 @@ name: Server Unit Tests
 
 on:
   pull_request:
-    paths:
-      - "server/**"
 
 permissions:
   contents: read

--- a/.github/workflows/vite-unit-tests.yml
+++ b/.github/workflows/vite-unit-tests.yml
@@ -2,8 +2,6 @@ name: Vite Unit Tests
 
 on:
   pull_request:
-    paths:
-      - "vite/**"
 
 permissions:
   contents: read

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,33 +1,63 @@
 # syntax=docker/dockerfile:1
 
-# Shared runtime image for server + workers + cron + mcp.
+# Shared runtime image for server + workers + cron + mcp + chat.
 # Each FlightControl service runs the same image with a different command:
 #   server  -> bun start            (cwd /app/server)
 #   workers -> bun src/workers.ts   (cwd /app/server)
 #   cron    -> bun src/cron.ts      (cwd /app/server)
 #   mcp     -> cd /app/apps/mcp-server && bun start
-FROM oven/bun:1.3.10 AS pruner
+#   chat    -> cd /app/apps/chat && bun start
+FROM oven/bun:1.3.10 AS deps
 WORKDIR /app
-COPY . .
-RUN bunx turbo@2.9.14 prune @autumn/server @autumn/mcp-server autumn-js @useautumn/sdk --docker
+
+# Copy the committed lockfile + every workspace manifest. Installing against the
+# real bun.lock (not a turbo-pruned one) keeps resolution byte-for-byte identical
+# to local/CI: zod v3 stays hoisted for the server, autumn-js keeps its nested
+# zod v4. --frozen-lockfile needs every workspace manifest present, so list them
+# all (add a line here when a workspace is added). Source is copied later, so this
+# layer caches until a package.json or the lockfile changes.
+COPY package.json bun.lock bunfig.toml ./
+COPY server/package.json server/
+COPY shared/package.json shared/
+COPY vite/package.json vite/
+COPY scripts/package.json scripts/
+COPY apps/chat/package.json apps/chat/
+COPY apps/checkout/package.json apps/checkout/
+COPY apps/docs/package.json apps/docs/
+COPY apps/mcp-server/package.json apps/mcp-server/
+COPY apps/sdk-test/package.json apps/sdk-test/
+COPY apps/website/package.json apps/website/
+COPY packages/atmn/package.json packages/atmn/
+COPY packages/atmn-tests/package.json packages/atmn-tests/
+COPY packages/autumn-js/package.json packages/autumn-js/
+COPY packages/ksuid/package.json packages/ksuid/
+COPY packages/mcp/package.json packages/mcp/
+COPY packages/openapi/package.json packages/openapi/
+COPY packages/sdk/package.json packages/sdk/
+COPY packages/stripe-sync/package.json packages/stripe-sync/
+
+# bunfig.toml preloads ./scripts/preload-env.ts on every bun run; stub it so the
+# install step doesn't fail before the real source is copied.
+RUN mkdir -p scripts && touch scripts/preload-env.ts
+
+# Install only the workspaces the runtime services need (server hosts workers +
+# cron), plus their transitive workspace deps. --frozen-lockfile guarantees no
+# re-resolution; --filter skips the frontend-heavy workspaces.
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+	bun install --frozen-lockfile --ignore-scripts \
+		--filter @autumn/server \
+		--filter @autumn/mcp-server \
+		--filter @autumn/chat
 
 FROM oven/bun:1.3.10
 WORKDIR /app
-
-# Install from the pruned package.json set only, so this layer stays cached
-# until a runtime workspace's deps change (not on every source edit).
-COPY --from=pruner /app/out/json/ .
-RUN mkdir -p scripts && touch scripts/preload-env.ts
-RUN bun -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); pkg.workspaces.packages = ["server", "shared", "apps/mcp-server", "packages/ksuid", "packages/mcp", "packages/stripe-sync", "packages/autumn-js", "packages/sdk"]; delete pkg.dependencies; delete pkg.devDependencies; delete pkg.scripts; fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));'
-# Keep turbo's pruned bun.lock (derived from the committed lockfile) so versions
-# stay pinned and bun only reconciles the workspace-list delta. Deleting it forces
-# a full from-scratch registry resolve, which is slow and can hang.
-RUN --mount=type=cache,target=/root/.bun/install/cache \
-	bun install --ignore-scripts
-
-COPY --from=pruner /app/out/full/ .
-
 ENV NODE_ENV=production
+
+# node_modules (+ manifests) from the cached deps layer, then the source on top.
+# node_modules is .dockerignore'd, so COPY . . never clobbers the install.
+COPY --from=deps /app ./
+COPY . .
+
 EXPOSE 8080
 
 WORKDIR /app/server


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Dockerfile for deterministic Bun installs and faster builds, and adds the chat app to the shared runtime image. Also updates CI so unit tests run on all PRs.

- **Bug Fixes**
  - Install against the committed `bun.lock` and workspace manifests; removed `turbo prune`.
  - Use `bun install --frozen-lockfile` with `--filter` for `@autumn/server`, `@autumn/mcp-server`, and `@autumn/chat`.
  - Stub `scripts/preload-env.ts` to prevent preload errors during install.
  - Copy `node_modules` from the deps stage and cache until a manifest or lockfile changes.
  - Remove path filters in server and Vite unit test workflows so tests run for any PR.

<sup>Written for commit b2dfc7ec034e6c2e0087159a122153824d2969f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR rewrites the Docker build to drop the Turborepo `prune` stage in favour of copying all workspace `package.json` files explicitly and using `bun install --frozen-lockfile --filter` to install only the runtime workspaces (`@autumn/server`, `@autumn/mcp-server`, `@autumn/chat`). It also adds first-class support for the new `@autumn/chat` service.

- **Bug fixes / Improvements**: Removes the brittle `turbo prune` + inline `package.json` mutation approach; the new `deps` stage caches against the full committed `bun.lock`, ensuring resolution is byte-for-byte identical to local/CI and eliminating the previous zod v3/v4 hoisting issue.
- **Improvements**: Adds `@autumn/chat` to the set of installed/exposed services, matching the updated service comment block at the top of the file.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the build logic is correct, the .dockerignore/COPY ordering interaction is sound, and the new approach is simpler than what it replaces.

All workspace manifests are listed explicitly, the bun.lock text file exists at the repo root and matches the COPY instruction, @autumn/chat's package name matches the --filter argument, and the .dockerignore correctly excludes node_modules so the two-step COPY in the final stage works as intended. No logic errors or missing pieces were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Replaces Turborepo-prune based install with a direct bun install --filter approach, adding the @autumn/chat workspace; the deps stage, copy ordering, and .dockerignore interaction are all correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["COPY package.json + bun.lock + bunfig.toml\n+ all workspace package.json files"] --> B["RUN touch scripts/preload-env.ts\n(stub for bunfig preload)"]
    B --> C["RUN bun install --frozen-lockfile --filter\n@autumn/server\n@autumn/mcp-server\n@autumn/chat"]
    C --> D["deps stage complete\n(node_modules installed)"]

    D --> E["Final stage: COPY --from=deps /app ./\n(node_modules + manifests)"]
    E --> F["COPY . .\n(real source; node_modules excluded by .dockerignore)"]
    F --> G["EXPOSE 8080\nWORKDIR /app/server\nCMD bun start"]

    style D fill:#d4edda,stroke:#28a745
    style G fill:#cce5ff,stroke:#004085
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: dockerfile"](https://github.com/useautumn/autumn/commit/9cc8f0331a3379ef628bcade5b88ac75985c2f44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35344120)</sub>

<!-- /greptile_comment -->