### PR TITLE
fix: chat mcp start

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,8 @@
 		"start": "bun src/index.ts",
 		"workers": "bun src/workers.ts",
 		"cron": "bun src/cron.ts",
+		"mcp": "bun ../apps/mcp-server/src/index.ts",
+		"chat": "bun ../apps/chat/src/index.ts",
 		"check": "bun src/check.ts",
 		"t": "cd ../ && bun t $* && cd ./server",
 		"parallel-tests": "ENV_FILE=.env infisical run --env=dev --recursive -- bun tests/testRunner/runParallelGroupsV3.ts",


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `mcp` and `chat` scripts to `server/package.json` to start the MCP server and chat app with Bun. This fixes broken start commands and standardizes local dev.

<sup>Written for commit a2390d25f4f74d4327252bbf3d6894881f23e96c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `mcp` and `chat` convenience scripts to `server/package.json` so the MCP server and chat app can be started from the `server/` workspace without manually navigating to their directories.

- **Bug fixes** — `"mcp": "bun ../apps/mcp-server/src/index.ts"` and `"chat": "bun ../apps/chat/src/index.ts"` are wired up, mirroring the style of the existing `start`, `workers`, and `cron` scripts; both entry-point files are confirmed to exist in the monorepo.
</details>

<h3>Confidence Score: 5/5</h3>

Two-line script addition with no logic changes; both target entry points exist in the monorepo and the script style matches existing ones.

The change simply registers two new convenience scripts that point to already-present entry-point files. There is nothing to break in existing functionality, and the paths resolve correctly relative to the server/ working directory.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/package.json | Adds two new npm scripts (`mcp` and `chat`) that launch sibling monorepo apps via relative paths; both target files exist at the expected locations. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[server/package.json scripts] --> B[bun run mcp]
    A --> C[bun run chat]
    B --> D[apps/mcp-server/src/index.ts]
    C --> E[apps/chat/src/index.ts]
    style B fill:#d4edda,stroke:#28a745
    style C fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: chat-mcp-start"](https://github.com/useautumn/autumn/commit/a2390d25f4f74d4327252bbf3d6894881f23e96c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35348274)</sub>

<!-- /greptile_comment -->