### PR TITLE
feat: leaf

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 #   server  -> bun start            (cwd /app/server)
 #   workers -> bun src/workers.ts   (cwd /app/server)
 #   cron    -> bun src/cron.ts      (cwd /app/server)
-#   leaf    -> cd /app/apps/leaf && bun start  (also serves the MCP routes)
+#   leaf    -> bun leaf             (cwd /app/server; serves chat + MCP routes)
 FROM oven/bun:1.3.10 AS deps
 WORKDIR /app
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Dockerfile comments to show how to run the leaf process with bun leaf from /app/server, noting it serves chat and MCP routes.

<sup>Written for commit 3a7a854ef373c8047b752bd34c2a00fb796a502c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the inline comment in the Dockerfile that documents how each FlightControl service is invoked. The `leaf` entry now reflects running `bun leaf` from `/app/server` (a package script that resolves to `bun ../apps/leaf/src/index.ts`) rather than the old `cd /app/apps/leaf && bun start` invocation, and notes that the service also serves chat routes in addition to MCP routes.

- **[Improvements]** Comment for the `leaf` service is updated to match the actual script-based invocation (`bun leaf` from `/app/server`) and to document that it serves both chat and MCP routes.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is a comment update that now accurately matches the `leaf` script defined in `server/package.json`.

This is a one-line comment change in the Dockerfile header. The new text correctly reflects how the `leaf` service is actually invoked: `bun leaf` runs from `/app/server`, and the `server/package.json` confirms the `leaf` script exists as `bun ../apps/leaf/src/index.ts`. No functional code was modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Updates the header comment for the `leaf` service from the old `cd /app/apps/leaf && bun start` invocation to the new `bun leaf` script run from `/app/server`, and expands the description to include chat routes alongside MCP routes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FlightControl: same Docker image] --> B[server\nbun start\ncwd /app/server]
    A --> C[workers\nbun src/workers.ts\ncwd /app/server]
    A --> D[cron\nbun src/cron.ts\ncwd /app/server]
    A --> E[leaf\nbun leaf\ncwd /app/server]
    E --> F["../apps/leaf/src/index.ts\n(chat + MCP routes)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["update dockerfile"](https://github.com/useautumn/autumn/commit/3a7a854ef373c8047b752bd34c2a00fb796a502c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35354419)</sub>

<!-- /greptile_comment -->