### PR TITLE
fix: leaf logs

### DIFF
--- a/firelens.conf
+++ b/firelens.conf
@@ -19,6 +19,12 @@
 [FILTER]
     Name modify
     Match *
+    Condition Key_value_matches container_name .*-leaf-.*
+    Add type leaf
+
+[FILTER]
+    Name modify
+    Match *
     Add region ${AWS_REGION}
 
 [OUTPUT]


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes misclassified leaf container logs by adding a FireLens modify filter. Logs from containers matching `.*-leaf-.*` now get `type leaf` for correct routing and indexing.

<sup>Written for commit 6bb3b25d7f8153b21228a68202052fb3ffd14b64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a new Fluent Bit log filter for "leaf" service containers so their logs are tagged with `type: leaf` before being forwarded to Axiom, matching the existing pattern used for server, workers, and cron containers.

- **Bug fixes**: Adds a missing log-type filter for `.*-leaf-.*` containers so their logs are correctly classified in the Axiom ingest pipeline.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single, minimal filter block added in a well-established pattern with no risk of disrupting existing log routing.

The change is a one-block addition that mirrors the three identical filter blocks already in the file. The regex pattern, field name, and placement (before the catch-all region filter) are all consistent with the rest of the config. No existing filter is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| firelens.conf | Adds a new Fluent Bit FILTER block to tag logs from containers matching `.*-leaf-.*` with `type: leaf`, following the same pattern as existing server/workers/cron filters. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Container Log Event] --> B{container_name matches?}
    B -->|.*-server-.*| C[Add type=server]
    B -->|.*-workers-.*| D[Add type=workers]
    B -->|.*-cron-.*| E[Add type=cron]
    B -->|.*-leaf-.*| F[Add type=leaf NEW]
    B -->|no match| G[No type added]
    C & D & E & F & G --> H[Add region=AWS_REGION]
    H --> I[OUTPUT to Axiom HTTP]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: leaf logs"](https://github.com/useautumn/autumn/commit/6bb3b25d7f8153b21228a68202052fb3ffd14b64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35354605)</sub>

<!-- /greptile_comment -->