### PR TITLE
fix: mcp auth

### DIFF
--- a/apps/leaf/src/lib/env.ts
+++ b/apps/leaf/src/lib/env.ts
@@ -9,6 +9,7 @@ const envSchema = z
 	.object({
 		AUTUMN_MCP_URL: z.string().min(1).default("http://localhost:3099/mcp"),
 		BETTER_AUTH_SECRET: optionalString,
+		BETTER_AUTH_URL: optionalString,
 		CHAT_MODEL: z.string().min(1).default("anthropic/claude-sonnet-4-6"),
 		CHAT_NAME: z.string().min(1).default("Autumn"),
 		CHAT_STATE_DATABASE_URL: optionalString,
@@ -18,7 +19,6 @@ const envSchema = z
 		ENCRYPTION_PASSWORD: z.string().min(1),
 		FIRECRAWL_API_KEY: z.string().min(1),
 		MCP_OAUTH_ENVIRONMENT: z.enum(["live", "sandbox"]).default("sandbox"),
-		MCP_SERVER_URL: optionalString,
 		PORT: z.coerce.number().int().positive().default(3099),
 		SLACK_CLIENT_ID: z.string().min(1),
 		SLACK_CLIENT_SECRET: z.string().min(1),
@@ -32,8 +32,8 @@ const envSchema = z
 
 		return {
 			...values,
-			MCP_SERVER_URL:
-				values.MCP_SERVER_URL ??
+			BETTER_AUTH_URL:
+				values.BETTER_AUTH_URL ??
 				(process.env.NODE_ENV === "production"
 					? "https://api.useautumn.com"
 					: "http://localhost:8080"),

--- a/apps/leaf/src/main.ts
+++ b/apps/leaf/src/main.ts
@@ -21,7 +21,7 @@ app.get("/health", (c) => c.json({ ok: true }));
 registerMcpRoutes(app, {
 	"oauth-enabled": true,
 	"oauth-environment": env.MCP_OAUTH_ENVIRONMENT,
-	"server-url": env.MCP_SERVER_URL,
+	"server-url": env.BETTER_AUTH_URL,
 	logger: createConsoleLogger("info"),
 });
 

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -289,7 +289,9 @@ async function startDev() {
 				CHAT_PORT: CHAT_PORT.toString(),
 				MCP_DEBUG_PENDING_ACTIONS: process.env.MCP_DEBUG_PENDING_ACTIONS ?? "1",
 				MCP_SERVER_URL:
-					process.env.MCP_SERVER_URL ?? `http://localhost:${SERVER_PORT}`,
+					process.env.MCP_SERVER_URL ?? `http://localhost:${CHAT_PORT}`,
+				CHAT_SERVER_URL:
+					process.env.CHAT_SERVER_URL ?? `http://localhost:${CHAT_PORT}`,
 				MCP_RESOURCE_URLS:
 					process.env.MCP_RESOURCE_URLS ?? `http://localhost:${CHAT_PORT}/mcp`,
 				AUTUMN_MCP_URL:

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -65,13 +65,8 @@ const emulateGoogleUrl =
 // OAuth flow leaves and returns via a third-party host (emulate.dev), so the
 // state cookie must be SameSite=None+Secure to survive the round trip.
 const isHttpsBaseUrl = process.env.BETTER_AUTH_URL?.startsWith("https://");
-const hostedMcpResourceUrls =
-	process.env.MCP_UPSTREAM_URL && process.env.BETTER_AUTH_URL
-		? [
-				new URL("/mcp", process.env.BETTER_AUTH_URL).href,
-				new URL("/internal/mcp", process.env.BETTER_AUTH_URL).href,
-			]
-		: [];
+const isProductionAuth = process.env.NODE_ENV === "production";
+
 const parseMcpResourceUrl = (rawUrl: string) => {
 	const resourceUrl = rawUrl.trim();
 	if (!resourceUrl) return null;
@@ -83,15 +78,36 @@ const parseMcpResourceUrl = (rawUrl: string) => {
 		return null;
 	}
 };
-const mcpResourceUrls =
-	process.env.MCP_RESOURCE_URLS?.split(",")
-		.map(parseMcpResourceUrl)
-		.filter((url): url is string => Boolean(url)) ?? [];
-const internalMcpResourceUrls = mcpResourceUrls.map((resourceUrl) => {
-	const url = new URL(resourceUrl);
-	url.pathname = "/internal/mcp";
-	return url.href;
-});
+
+// Public hosts that serve OAuth-protected MCP endpoints. leaf serves both the
+// MCP server (MCP_SERVER_URL) and the chat/slackbot (CHAT_SERVER_URL); the
+// autumn server can also proxy /mcp under its own origin (BETTER_AUTH_URL).
+// The OAuth `resource` indicator is host-based, so every public host + path
+// must be a registered audience. MCP_RESOURCE_URLS is an explicit override.
+const mcpServerUrl =
+	process.env.MCP_SERVER_URL ??
+	(isProductionAuth ? "https://mcp.useautumn.com" : "http://localhost:3099");
+const chatServerUrl =
+	process.env.CHAT_SERVER_URL ??
+	(isProductionAuth ? "https://chat.useautumn.com" : "http://localhost:3099");
+
+const mcpResourcePaths = ["/mcp", "/internal/mcp"];
+const mcpResourceBases = [
+	process.env.BETTER_AUTH_URL,
+	mcpServerUrl,
+	chatServerUrl,
+].filter((base): base is string => Boolean(base));
+
+const mcpResourceUrls = [
+	...new Set([
+		...mcpResourceBases.flatMap((base) =>
+			mcpResourcePaths.map((path) => new URL(path, base).href),
+		),
+		...(process.env.MCP_RESOURCE_URLS?.split(",")
+			.map(parseMcpResourceUrl)
+			.filter((url): url is string => Boolean(url)) ?? []),
+	]),
+];
 
 /**
  * Passkey (WebAuthn) is bound to the FRONTEND origin where the browser calls
@@ -255,12 +271,9 @@ const options = {
 			// Resource-based scopes with R/W actions (plus legacy CRUDL +
 			// meta scopes — see shared/utils/scopeDefinitions.ts).
 			scopes: [...ALL_SCOPES],
-			validAudiences: [
-				process.env.BETTER_AUTH_URL,
-				...hostedMcpResourceUrls,
-				...mcpResourceUrls,
-				...internalMcpResourceUrls,
-			].filter(Boolean) as string[],
+			validAudiences: [process.env.BETTER_AUTH_URL, ...mcpResourceUrls].filter(
+				Boolean,
+			) as string[],
 			allowDynamicClientRegistration: true,
 			allowUnauthenticatedClientRegistration: true,
 			customAccessTokenClaims: ({ referenceId }) => ({


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes MCP OAuth by correctly building the valid audience list and wiring Leaf to use the Better Auth base URL. Tokens now validate for both /mcp and /internal/mcp across all public hosts in dev and prod.

- **Bug Fixes**
  - Build OAuth audiences from `BETTER_AUTH_URL`, `MCP_SERVER_URL`, and `CHAT_SERVER_URL` for both /mcp and /internal/mcp, plus `MCP_RESOURCE_URLS` overrides.
  - Simplify `validAudiences` to include the auth host and all computed MCP resource URLs.
  - Leaf now uses `BETTER_AUTH_URL` for `server-url` and drops `MCP_SERVER_URL` from its env schema.
  - Dev script aligns defaults to the chat port and adds `CHAT_SERVER_URL`.

- **Migration**
  - If Leaf previously used `MCP_SERVER_URL`, set `BETTER_AUTH_URL` instead. Defaults cover local and production.

<sup>Written for commit 5a607170e510eaa778bed5254392e3ad3d098ef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes MCP OAuth authentication by renaming the leaf app's `MCP_SERVER_URL` env var to `BETTER_AUTH_URL` and refactoring how valid OAuth audiences are computed in the auth server.

- **Bug fixes / Improvements**: Renames `MCP_SERVER_URL` to `BETTER_AUTH_URL` in the leaf (`apps/leaf`) service so that the `server-url` flag passed to `registerMcpRoutes` correctly points to the OAuth/API server (used to derive `/api/auth` endpoints) rather than the MCP server itself.
- **Bug fixes / Improvements**: In `server/src/utils/auth.ts`, replaces the previous `hostedMcpResourceUrls` guard (which required both `MCP_UPSTREAM_URL` and `BETTER_AUTH_URL`) with a richer audience derivation that automatically builds `/mcp` and `/internal/mcp` paths from all three base URLs (`BETTER_AUTH_URL`, `MCP_SERVER_URL`, `CHAT_SERVER_URL`), and uses a `Set` for deduplication.
- **Improvements**: In `scripts/dev.ts`, corrects `MCP_SERVER_URL` default from `SERVER_PORT` to `CHAT_PORT` (where the leaf MCP server actually runs) and adds `CHAT_SERVER_URL` so the auth server can register both base URLs as valid audiences.
</details>

<h3>Confidence Score: 4/5</h3>

The changes are straightforward and well-scoped: renaming an env var, fixing a dev-script port default, and broadening the OAuth audience list to cover all MCP base URLs.

The core auth logic change in server/src/utils/auth.ts drops the MCP_UPSTREAM_URL gate and always registers audiences from mcpServerUrl and chatServerUrl — their defaults are hardcoded URLs that seem correct for both dev and production, and the surrounding changes in scripts/dev.ts and the leaf env align with them. No security issues or runtime defects were found; the main remaining consideration is verifying the new audience list is complete for all deployment configurations.

server/src/utils/auth.ts deserves a second look to confirm that the hardcoded production default URLs (https://mcp.useautumn.com, https://chat.useautumn.com) match the actual deployed hostnames for the MCP and chat services.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/auth.ts | Refactors valid OAuth audience computation: drops the MCP_UPSTREAM_URL guard, adds CHAT_SERVER_URL as a base, and generates /mcp + /internal/mcp paths for all configured bases using a Set for deduplication. |
| apps/leaf/src/lib/env.ts | Renames MCP_SERVER_URL to BETTER_AUTH_URL (optional env var); defaults to http://localhost:8080 in dev and https://api.useautumn.com in prod. |
| apps/leaf/src/main.ts | Updates server-url option passed to registerMcpRoutes from env.MCP_SERVER_URL to env.BETTER_AUTH_URL, correctly pointing the MCP OAuth issuer discovery at the auth server. |
| scripts/dev.ts | Fixes MCP_SERVER_URL default to point at CHAT_PORT (where leaf runs) instead of SERVER_PORT, and adds CHAT_SERVER_URL with the same default so auth.ts can register both as valid audiences. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Leaf as leaf (CHAT_PORT :3099)
    participant Auth as autumn-server (SERVER_PORT :8080)
    participant DB as Database

    Client->>Leaf: GET /.well-known/oauth-protected-resource/mcp
    Leaf-->>Client: "{ resource, authorization_servers: [BETTER_AUTH_URL/api/auth] }"

    Client->>Auth: GET /.well-known/oauth-authorization-server
    Auth-->>Client: "{ issuer, authorization_endpoint, token_endpoint, ... }"

    Client->>Auth: POST /api/auth/oauth2/token
    Auth->>DB: validate client / scopes
    Note over Auth: validAudiences includes BETTER_AUTH_URL, MCP_SERVER_URL/mcp, CHAT_SERVER_URL/mcp, and /internal/mcp variants
    Auth-->>Client: "access_token (audience = resource URL)"

    Client->>Leaf: POST /mcp (Bearer token)
    Leaf->>Auth: introspect / validate token
    Auth-->>Leaf: token valid
    Leaf-->>Client: MCP response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: mcp auth"](https://github.com/useautumn/autumn/commit/5a607170e510eaa778bed5254392e3ad3d098ef4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35364789)</sub>

<!-- /greptile_comment -->