### PR TITLE
fix: slack auth

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -298,7 +298,6 @@ async function startDev() {
 					process.env.AUTUMN_MCP_URL ?? `http://localhost:${CHAT_PORT}/mcp`,
 				AUTUMN_API_URL: process.env.AUTUMN_API_URL ?? LOCAL_SERVER_URL,
 				CHAT_URL: process.env.CHAT_URL ?? LOCAL_CHAT_URL,
-				CHAT_INTERNAL_URL: process.env.CHAT_INTERNAL_URL ?? LOCAL_CHAT_URL,
 				SLACK_BOT_URL: process.env.SLACK_BOT_URL ?? LOCAL_CHAT_URL,
 				DISCORD_BOT_URL: process.env.DISCORD_BOT_URL ?? LOCAL_CHAT_URL,
 				VITE_APP_ENV: viteAppEnv,

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -56,9 +56,7 @@ const ALLOWED_HEADERS = [
 export const createHonoApp = () => {
 	const app = new Hono<HonoEnv>();
 
-	if (process.env.CHAT_INTERNAL_URL) {
-		app.route("", createChatProxyRouter());
-	}
+	app.route("", createChatProxyRouter());
 
 	// CORS configuration (must be before routes)
 	app.use(

--- a/server/src/routers/chatProxyRouter.ts
+++ b/server/src/routers/chatProxyRouter.ts
@@ -4,12 +4,12 @@ import type { HonoEnv } from "../honoUtils/HonoEnv.js";
 const bodylessMethods = new Set(["GET", "HEAD"]);
 
 const proxyChatRequest =
-	(chatInternalUrl: string) => async (c: Context<HonoEnv>) => {
+	(chatServerUrl: string) => async (c: Context<HonoEnv>) => {
 		const url = new URL(c.req.url);
 		const headers = new Headers(c.req.raw.headers);
 		headers.delete("host");
 
-		return fetch(`${chatInternalUrl}${url.pathname}${url.search}`, {
+		return fetch(`${chatServerUrl}${url.pathname}${url.search}`, {
 			body: bodylessMethods.has(c.req.raw.method) ? undefined : c.req.raw.body,
 			headers,
 			method: c.req.raw.method,
@@ -18,10 +18,13 @@ const proxyChatRequest =
 	};
 
 export const createChatProxyRouter = (
-	chatInternalUrl = process.env.CHAT_INTERNAL_URL ?? "http://localhost:3099",
+	chatServerUrl = process.env.CHAT_SERVER_URL ??
+		(process.env.NODE_ENV === "production"
+			? "https://chat.useautumn.com"
+			: "http://localhost:3099"),
 ) => {
 	const router = new Hono<HonoEnv>();
-	const proxy = proxyChatRequest(chatInternalUrl);
+	const proxy = proxyChatRequest(chatServerUrl);
 
 	router.get("/slack/oauth/callback", proxy);
 	router.post("/slack/events", proxy);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Slack OAuth and events by always enabling the chat proxy and routing Slack requests to the chat server. Switches to `CHAT_SERVER_URL` with sensible prod/dev defaults.

- **Bug Fixes**
  - Always register the chat proxy routes in the `Hono` app.
  - Proxy targets `CHAT_SERVER_URL` (prod: https://chat.useautumn.com, dev: http://localhost:3099).
  - Removed `CHAT_INTERNAL_URL` from the dev script; Slack routes `/slack/oauth/callback` and `/slack/events` now forward correctly.

<sup>Written for commit dd968e60eb2b718d7fcbde11d7dd87522910a9ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Slack OAuth by removing the `CHAT_INTERNAL_URL` environment variable guard that prevented the chat proxy router from mounting when the variable was absent, and renames it to `CHAT_SERVER_URL` with a NODE_ENV-based URL fallback.

- **[Bug fixes]** Remove the `if (process.env.CHAT_INTERNAL_URL)` guard in `initHono.ts` so the `/slack/oauth/callback`, `/slack/events`, and `/slack/interactions` proxy routes are always registered.
- **[Bug fixes, Improvements]** Rename `CHAT_INTERNAL_URL` → `CHAT_SERVER_URL` throughout `chatProxyRouter.ts` and `scripts/dev.ts`, and add a production/dev URL default when the env var is not explicitly set.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge if all production deployments explicitly set `CHAT_SERVER_URL`; the hardcoded fallback to the real chat server URL in production environments could silently misdirect Slack traffic in staging.

The unconditional proxy registration is the correct fix and the env rename is clean. The concern is the NODE_ENV-based hardcoded URL default: any staging environment running with `NODE_ENV=production` but without `CHAT_SERVER_URL` set will silently forward Slack OAuth callbacks and events to the live `chat.useautumn.com` backend instead of failing visibly.

server/src/routers/chatProxyRouter.ts — the `NODE_ENV === "production"` fallback URL logic deserves a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/routers/chatProxyRouter.ts | Renames `chatInternalUrl` → `chatServerUrl` and introduces a NODE_ENV-based hardcoded production URL fallback when `CHAT_SERVER_URL` is not set. |
| server/src/initHono.ts | Removes the `CHAT_INTERNAL_URL` environment guard so the chat proxy router is now always registered, enabling Slack OAuth routes unconditionally. |
| scripts/dev.ts | Removes `CHAT_INTERNAL_URL` env var and keeps `CHAT_SERVER_URL` as the sole variable pointing to the local chat server. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Slack
    participant Server as autumn-server
    participant ChatProxy as chatProxyRouter
    participant ChatServer as chat.useautumn.com (prod) / localhost:3099 (dev)

    Slack->>Server: GET /slack/oauth/callback
    Server->>ChatProxy: always matched (no env guard)
    ChatProxy->>ChatServer: proxied fetch (redirect: manual)
    ChatServer-->>ChatProxy: response / redirect
    ChatProxy-->>Server: raw response
    Server-->>Slack: forwarded response

    Slack->>Server: POST /slack/events
    Server->>ChatProxy: always matched
    ChatProxy->>ChatServer: proxied fetch
    ChatServer-->>ChatProxy: response
    ChatProxy-->>Server: raw response
    Server-->>Slack: forwarded response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/routers/chatProxyRouter.ts:20-25
Hardcoded fallback to `https://chat.useautumn.com` when `NODE_ENV === "production"` and `CHAT_SERVER_URL` is unset can silently route Slack traffic to the real production chat server in staging/preview deployments that run with `NODE_ENV=production`. An explicit error (or no default at all) would make misconfiguration visible immediately rather than forwarding requests to the wrong backend.

```suggestion
export const createChatProxyRouter = (
	chatServerUrl = process.env.CHAT_SERVER_URL ?? "http://localhost:3099",
) => {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/slack-auth"](https://github.com/useautumn/autumn/commit/dd968e60eb2b718d7fcbde11d7dd87522910a9ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35372427)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->