### PR TITLE
chore: add events table filtering

### DIFF
--- a/server/src/internal/analytics/actions/listRawEvents.ts
+++ b/server/src/internal/analytics/actions/listRawEvents.ts
@@ -71,6 +71,7 @@ export type ListRawEventsParams = {
 	customer?: FullCustomer;
 	aggregateAll?: boolean;
 	event_name?: string;
+	event_names?: string[];
 	limit?: number;
 };
 
@@ -114,6 +115,16 @@ export const listRawEvents = async ({
 			? billingCycleResult.endDate
 			: formatJsDateToClickHouseDateTime(new Date());
 
+	const eventNameFilter = (() => {
+		if (params.event_names && params.event_names.length > 0) {
+			return params.event_names;
+		}
+		if (params.event_name) {
+			return [params.event_name];
+		}
+		return undefined;
+	})();
+
 	const pipeParams = {
 		org_id: org.id,
 		env,
@@ -121,7 +132,7 @@ export const listRawEvents = async ({
 		end_date: finalEndDate,
 		customer_id: params.aggregateAll ? undefined : params.customer_id,
 		entity_id: params.entity_id,
-		event_names: params.event_name ? [params.event_name] : undefined,
+		event_names: eventNameFilter,
 		limit: params.limit ?? DEFAULT_LIMIT,
 		offset: 0,
 	};

--- a/server/src/internal/analytics/internalHandlers/handleInternalListRawEvents.ts
+++ b/server/src/internal/analytics/internalHandlers/handleInternalListRawEvents.ts
@@ -13,6 +13,7 @@ const InternalListRawEventsSchema = z.object({
 			message: "custom_range.start must be before custom_range.end",
 		})
 		.optional(),
+	event_names: z.array(z.string()).optional(),
 	customer_id: z.string().nullish(),
 	entity_id: z.string().optional(),
 });
@@ -26,7 +27,7 @@ export const handleInternalListRawEvents = createRoute({
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, org, env } = ctx;
-		const { interval, custom_range, customer_id, entity_id } =
+		const { interval, custom_range, event_names, customer_id, entity_id } =
 			c.req.valid("json");
 
 		let aggregateAll = false;
@@ -60,6 +61,7 @@ export const handleInternalListRawEvents = createRoute({
 				entity_id: entity_id,
 				interval: interval ?? undefined,
 				custom_range: custom_range ?? undefined,
+				event_names: event_names?.filter((name) => name !== ""),
 				customer,
 				aggregateAll,
 			},

--- a/vite/src/views/customers/customer/analytics/components/ChartSkeleton.tsx
+++ b/vite/src/views/customers/customer/analytics/components/ChartSkeleton.tsx
@@ -36,7 +36,7 @@ export const ChartSkeleton = ({
 	const bars = useMemo(() => buildSkeletonBars(barCount), [barCount]);
 
 	return (
-		<div className="flex flex-1 flex-col">
+		<div className="relative flex flex-1 flex-col">
 			<div className="flex h-7 shrink-0 items-center gap-4 border-b bg-card px-2">
 				{[72, 56, 64].map((width, i) => (
 					<div key={i} className="flex items-center gap-1.5">
@@ -92,6 +92,8 @@ export const ChartSkeleton = ({
 					))}
 				</div>
 			</div>
+
+			<div className="bg-white/40 dark:bg-black/40 pointer-events-none absolute inset-0" />
 		</div>
 	);
 };

--- a/vite/src/views/customers/customer/analytics/components/EventsTable.tsx
+++ b/vite/src/views/customers/customer/analytics/components/EventsTable.tsx
@@ -2,7 +2,6 @@ import { CaretLeftIcon, CaretRightIcon, DatabaseIcon } from "@phosphor-icons/rea
 import { memo, useState } from "react";
 import { Table } from "@/components/general/table";
 import { IconButton } from "@/components/v2/buttons/IconButton";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
 	Select,
 	SelectContent,
@@ -11,31 +10,14 @@ import {
 	SelectValue,
 } from "@/components/v2/selects/Select";
 import { cn } from "@/lib/utils";
-import type { ColumnDef } from "@tanstack/react-table";
 import type { IRow } from "./analytics-types";
 import { createEventsColumns } from "./EventsColumns";
 import { RowClickDialog } from "./RowClickDialog";
 import { useEventsTable } from "../hooks/useEventsTable";
 
 const PAGE_SIZE_OPTIONS = [100, 500, 1000] as const;
+
 const columns = createEventsColumns();
-
-const SKELETON_CELL_WIDTHS = ["w-28", "w-20", "w-8", "w-40"] as const;
-
-const skeletonColumns: ColumnDef<IRow, unknown>[] = columns.map((col, i) => ({
-	...col,
-	cell: () => <Skeleton className={cn("h-3 rounded-sm", SKELETON_CELL_WIDTHS[i])} />,
-}));
-
-const PLACEHOLDER_ROWS: IRow[] = Array.from({ length: 15 }, (_, i) => ({
-	timestamp: "",
-	event_name: "",
-	value: 0,
-	properties: "",
-	idempotency_key: String(i),
-	entity_id: "",
-	customer_id: "",
-}));
 
 export const EventsTable = memo(function EventsTable({
 	data,
@@ -51,9 +33,7 @@ export const EventsTable = memo(function EventsTable({
 	const [selectedEvent, setSelectedEvent] = useState<IRow | null>(null);
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-	const tableData = isLoading ? PLACEHOLDER_ROWS : data;
-	const activeColumns = isLoading ? skeletonColumns : columns;
-	const table = useEventsTable({ data: tableData, columns: activeColumns });
+	const table = useEventsTable({ data, columns });
 
 	const { pageIndex, pageSize } = table.getState().pagination;
 	const totalPages = table.getPageCount();
@@ -130,8 +110,8 @@ export const EventsTable = memo(function EventsTable({
 				<Table.Provider
 					config={{
 						table,
-						numberOfColumns: activeColumns.length,
-						isLoading: false,
+						numberOfColumns: columns.length,
+						isLoading,
 						enableSorting: !isLoading,
 						onRowClick: handleRowClick,
 						rowClassName: "h-8",

--- a/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx
@@ -1,12 +1,11 @@
-import { ErrCode, FeatureType } from "@autumn/shared";
+import { ErrCode } from "@autumn/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
-import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { useAnalyticsQueryState } from "./useAnalyticsQueryState";
-import { useEventNames } from "./useEventNames";
+import { useSelectedEventNames } from "./useSelectedEventNames";
 
 /** Gets the user's IANA timezone (e.g., "America/New_York") */
 const getUserTimezone = (): string => {
@@ -28,8 +27,6 @@ export const useAnalyticsData = ({
 	const [searchParams] = useSearchParams();
 	const customerId = searchParams.get("customer_id");
 	const entityId = searchParams.get("entity_id");
-	const featureIds = searchParams.get("feature_ids")?.split(",");
-	const eventNames = searchParams.get("event_names")?.split(",");
 	const groupBy = searchParams.get("group_by");
 	const maxGroups = Number(searchParams.get("max_groups")) || 10;
 
@@ -38,35 +35,16 @@ export const useAnalyticsData = ({
 	const customRange =
 		interval === "custom" && start && end ? { start, end } : undefined;
 
-	const { eventNames: cachedEventNames, isLoading: eventNamesLoading } =
-		useEventNames();
+	const { selectedEventNames, featuresData, featuresLoading, eventNamesLoading } =
+		useSelectedEventNames();
 
 	const timezone = useMemo(() => getUserTimezone(), []);
-
-	const { features: featuresData, isLoading: featuresLoading } =
-		useFeaturesQuery();
 
 	const formattedGroupBy = groupBy
 		? groupBy === "customer_id" || groupBy === "entity_id" || groupBy === "plan_id"
 			? groupBy
 			: `properties.${groupBy}`
 		: undefined;
-
-	const featureLinkedEventNames = useMemo(() => {
-		if (!featuresData?.length) return cachedEventNames;
-		return cachedEventNames.filter((e) =>
-			featuresData.some(
-				(f) =>
-					(f.type === FeatureType.Metered || f.type === FeatureType.CreditSystem) &&
-					(f.event_names?.includes(e.event_name) || f.id === e.event_name),
-			),
-		);
-	}, [cachedEventNames, featuresData]);
-
-	const selectedEventNames =
-		eventNames || featureIds
-			? [...(eventNames || []), ...(featureIds || [])]
-			: featureLinkedEventNames.slice(0, 3).map((e) => e.event_name);
 
 	const postBody = {
 		customer_id: customerId || undefined,
@@ -142,21 +120,21 @@ export const useRawAnalyticsData = () => {
 	const customRange =
 		interval === "custom" && start && end ? { start, end } : undefined;
 
-	const { features: featuresData, isLoading: featuresLoading } =
-		useFeaturesQuery();
+	const { selectedEventNames, featuresData, featuresLoading, eventNamesLoading } =
+		useSelectedEventNames();
+
+	const isReady = !eventNamesLoading && !featuresLoading;
 
 	const postBody = {
 		customer_id: customerId || undefined,
 		entity_id: entityId || undefined,
 		interval: customRange ? undefined : interval,
 		custom_range: customRange,
+		event_names: selectedEventNames,
 	};
 
-	const {
-		data,
-		isLoading: queryLoading,
-		error,
-	} = useQuery({
+	const { data, isLoading, error } = useQuery({
+		enabled: isReady,
 		queryKey: buildKey([
 			"query-raw-events",
 			customerId,
@@ -164,12 +142,15 @@ export const useRawAnalyticsData = () => {
 			interval,
 			String(start ?? ""),
 			String(end ?? ""),
+			...selectedEventNames.sort(),
 		]),
 		queryFn: async () => {
 			const { data } = await axiosInstance.post("/query/raw", postBody);
 			return data;
 		},
 	});
+
+	const queryLoading = !isReady || isLoading;
 
 	return {
 		customer: data?.customer,

--- a/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx
@@ -1,0 +1,48 @@
+import { FeatureType } from "@autumn/shared";
+import { parseAsArrayOf, parseAsString, useQueryStates } from "nuqs";
+import { useMemo } from "react";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { type EventNameWithCount, useEventNames } from "./useEventNames";
+
+/** Resolves the event names the analytics views filter by: explicit URL
+ * selection (event_names / feature_ids) or the top metered events by default.
+ * Shared by the chart and the events table so they stay in sync. */
+export const useSelectedEventNames = () => {
+	const [{ feature_ids: featureIds, event_names: eventNames }] = useQueryStates({
+		feature_ids: parseAsArrayOf(parseAsString),
+		event_names: parseAsArrayOf(parseAsString),
+	});
+
+	const { eventNames: cachedEventNames, isLoading: eventNamesLoading } =
+		useEventNames();
+	const { features: featuresData, isLoading: featuresLoading } =
+		useFeaturesQuery();
+
+	const featureLinkedEventNames = useMemo(() => {
+		if (!featuresData?.length) {
+			return cachedEventNames;
+		}
+		return cachedEventNames.filter((e: EventNameWithCount) =>
+			featuresData.some(
+				(f) =>
+					(f.type === FeatureType.Metered ||
+						f.type === FeatureType.CreditSystem) &&
+					(f.event_names?.includes(e.event_name) || f.id === e.event_name),
+			),
+		);
+	}, [cachedEventNames, featuresData]);
+
+	const selectedEventNames =
+		eventNames || featureIds
+			? [...(eventNames || []), ...(featureIds || [])]
+			: featureLinkedEventNames
+					.slice(0, 3)
+					.map((e: EventNameWithCount) => e.event_name);
+
+	return {
+		selectedEventNames,
+		featuresData,
+		featuresLoading,
+		eventNamesLoading,
+	};
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds multi-event filtering to the Analytics Events table and raw events API so the table stays in sync with the chart and URL filters. Also improves loading states in the chart and table.

- **New Features**
  - Server: raw events API now accepts `event_names: string[]` (preferred over single `event_name`) and ignores empty values.
  - Client: chart and table share selection via a new `useSelectedEventNames` hook, deriving from URL `event_names`/`feature_ids` or defaulting to top metered events.
  - Client: raw events requests include `event_names`, and the query key includes the selected events for correct caching.

- **Refactors**
  - Removed custom placeholder rows/skeleton columns in the events table; use `Table.Provider` `isLoading` instead.
  - Simplified analytics data hooks by delegating event-name selection to the shared hook.
  - Added a lightweight overlay to `ChartSkeleton` for clearer loading feedback.

<sup>Written for commit fa3084284bdd3abac0fd09a801a002ab75eba8e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires multi-event filtering through the full analytics stack — from a new `useSelectedEventNames` hook that reads URL state via `nuqs` down to the raw events API that now accepts an `event_names: string[]` parameter — so the Events table stays in sync with the chart's selection. It also cleans up loading states by delegating to `Table.Provider`'s `isLoading` prop and adds a translucent overlay to `ChartSkeleton`.

- **Improvements**: New `useSelectedEventNames` hook centralises event-name derivation (URL params → top metered events fallback) and is shared by both analytics data hooks, keeping chart and table in sync; `EventsTable` loading state is simplified by removing bespoke skeleton rows/columns in favour of `Table.Provider`'s `isLoading`; `ChartSkeleton` gains a translucent overlay for clearer visual feedback.
- **API changes**: `handleInternalListRawEvents` schema extended with `event_names: string[]`; `listRawEvents` resolves priority between the new array field and the legacy `event_name` string, filtering empty values before forwarding.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are well-scoped to the analytics feature with no data-writing paths affected.

The logic is straightforward and the fallback chain (URL params → metered events → all events) handles edge cases gracefully. The only callout is `selectedEventNames.sort()` mutating the shared array in-place in the query-key construction of both analytics hooks — harmless in practice because the arrays are always freshly created, but worth tidying up.

vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx — the in-place `.sort()` call on `selectedEventNames` when building query keys.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/hooks/useSelectedEventNames.tsx | New shared hook that derives selected event names from URL params (nuqs) or defaults to top-3 metered events; logic is clean and matches the chart's prior behaviour. |
| vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx | Both analytics hooks now delegate event-name resolution to useSelectedEventNames; in-place .sort() on the selectedEventNames array is a minor style concern. |
| server/src/internal/analytics/actions/listRawEvents.ts | Added event_names[] parameter with a clean IIFE-based priority resolver; correctly falls back to the legacy single event_name field. |
| server/src/internal/analytics/internalHandlers/handleInternalListRawEvents.ts | Schema extended to accept event_names string array; empty strings are filtered before forwarding to the action. |
| vite/src/views/customers/customer/analytics/components/EventsTable.tsx | Removed custom skeleton row/column setup in favour of the Table.Provider isLoading prop — simplification is correct and reduces duplication. |
| vite/src/views/customers/customer/analytics/components/ChartSkeleton.tsx | Adds a translucent overlay div to provide clearer visual feedback during loading; the parent is now relative-positioned to contain it. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant URL as URL (nuqs)
    participant Hook as useSelectedEventNames
    participant Chart as useAnalyticsData
    participant Table as useRawAnalyticsData
    participant Server as /query/raw (handleInternalListRawEvents)
    participant Action as listRawEvents

    URL->>Hook: event_names[], feature_ids[]
    Hook->>Hook: fallback to top-3 metered events
    Hook-->>Chart: selectedEventNames
    Hook-->>Table: selectedEventNames

    Chart->>Server: "POST /query/events {event_names}"
    Table->>Server: "POST /query/raw {event_names}"
    Server->>Server: filter empty strings
    Server->>Action: event_names (cleaned)
    Action->>Action: "resolve eventNameFilter (array > single > undefined)"
    Action-->>Server: ClickHouseResult
    Server-->>Table: rawEvents
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx:145
**In-place sort mutates shared array reference**

`selectedEventNames.sort()` sorts the array in-place and also mutates `postBody.event_names`, which holds a reference to the same array. While the sort order doesn't affect filter semantics (the server treats `event_names` as an OR set), mutating the array that was passed to `postBody` before the query key is built is a subtle side-effect. Using `[...selectedEventNames].sort()` makes the intent explicit and avoids relying on the fact that both the chart and raw-events hooks always create a fresh array.

### Issue 2 of 2
vite/src/views/customers/customer/analytics/hooks/useAnalyticsData.tsx:138-146
Same in-place `.sort()` concern applies here in `useRawAnalyticsData`. Using a copy keeps the mutation isolated to the query-key construction and makes the intent clearer.

```suggestion
		queryKey: buildKey([
			"query-raw-events",
			customerId,
			entityId,
			interval,
			String(start ?? ""),
			String(end ?? ""),
			...[...selectedEventNames].sort(),
		]),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add events table filtering"](https://github.com/useautumn/autumn/commit/fa3084284bdd3abac0fd09a801a002ab75eba8e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35396156)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->