### PR TITLE
feat(server): add scope field to customer subscriptions and purchases

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 		"dw:run": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts run",
 		"dw:enable": "bun scripts/dw/index.ts enable",
 		"dw:disable": "bun scripts/dw/index.ts disable",
-		"dw:make-admin": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts make-admin",
+		"dw:admin": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts admin",
 		"d": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dev.ts",
 		"d:prod": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dev.ts --production",
 		"dx": "bun scripts/dx.ts",

--- a/scripts/dw/README.md
+++ b/scripts/dw/README.md
@@ -36,7 +36,7 @@ bun dw teardown     # full cleanup of this worktree
 bun dw teardown --all   # full cleanup of every agent worktree
 bun dw disable      # rename .env.local -> .env.local.disabled (fall back to canonical env)
 bun dw enable       # rename .env.local.disabled -> .env.local
-bun dw make-admin   # set the better-auth global role to 'admin' for every user in this worktree's DB
+bun dw admin   # set the better-auth global role to 'admin' for every user in this worktree's DB
 ```
 
 ## Subcommands
@@ -130,11 +130,11 @@ Inverse of `disable` — restores each `.env.local.disabled` to `.env.local`.
 bun dw enable
 ```
 
-### `bun dw make-admin`
+### `bun dw admin`
 Sets the better-auth **global** user role to `admin` for every row in the `user` table of this worktree's DB, granting the superuser scope locally (the `/admin` routes + impersonation). Org membership roles (`member` table) are left untouched.
 
 ```sh
-bun dw make-admin
+bun dw admin
 ```
 
 Targets `databaseUrl` from the registry entry for the current worktree, falling back to `DATABASE_URL`. **Refuses to run against production** via the shared `assertNotProductionDb` guard (connection strings containing `us-east-2`).

--- a/scripts/dw/commands/admin.ts
+++ b/scripts/dw/commands/admin.ts
@@ -1,7 +1,7 @@
-import { log, fatal, sh } from "../helpers/shell.ts";
+import { assertNotProductionDb } from "../../../server/src/db/dbUtils.ts";
 import { getCurrentWorktree } from "../helpers/git.ts";
 import { loadRegistry } from "../helpers/registry.ts";
-import { assertNotProductionDb } from "../../../server/src/db/dbUtils.ts";
+import { fatal, log, sh } from "../helpers/shell.ts";
 
 const UPDATE_SQL = `UPDATE "user" SET role = 'admin';`;
 
@@ -16,7 +16,7 @@ function describeTarget(url: string): string {
 // Sets the better-auth global role to 'admin' for every user in the current
 // worktree's DB, which grants the superuser scope locally. Org membership
 // roles (the `member` table) are intentionally left untouched.
-export function cmdMakeAdmin(): void {
+export function cmdAdmin(): void {
 	const cwd = getCurrentWorktree();
 	const entry = loadRegistry()[cwd];
 	const url = entry?.databaseUrl || process.env.DATABASE_URL || "";

--- a/scripts/dw/index.ts
+++ b/scripts/dw/index.ts
@@ -1,16 +1,16 @@
-import { fatal } from "./helpers/shell.ts";
-import { cmdDefault } from "./commands/default.ts";
-import { cmdSetup } from "./commands/setup.ts";
-import { cmdRun } from "./commands/run.ts";
-import { cmdTeardown } from "./commands/teardown.ts";
-import { cmdList } from "./commands/list.ts";
-import { cmdReset } from "./commands/reset.ts";
-import { cmdLogs } from "./commands/logs.ts";
+import { cmdAdmin } from "./commands/admin.ts";
 import { cmdAttach } from "./commands/attach.ts";
-import { cmdIdentify } from "./commands/identify.ts";
-import { cmdEnable } from "./commands/enable.ts";
+import { cmdDefault } from "./commands/default.ts";
 import { cmdDisable } from "./commands/disable.ts";
-import { cmdMakeAdmin } from "./commands/make-admin.ts";
+import { cmdEnable } from "./commands/enable.ts";
+import { cmdIdentify } from "./commands/identify.ts";
+import { cmdList } from "./commands/list.ts";
+import { cmdLogs } from "./commands/logs.ts";
+import { cmdReset } from "./commands/reset.ts";
+import { cmdRun } from "./commands/run.ts";
+import { cmdSetup } from "./commands/setup.ts";
+import { cmdTeardown } from "./commands/teardown.ts";
+import { fatal } from "./helpers/shell.ts";
 
 async function main(): Promise<void> {
 	const sub = process.argv[2];
@@ -49,12 +49,12 @@ async function main(): Promise<void> {
 		case "disable":
 			cmdDisable();
 			break;
-		case "make-admin":
-			cmdMakeAdmin();
+		case "admin":
+			cmdAdmin();
 			break;
 		default:
 			fatal(
-				`unknown subcommand: ${sub} (use: setup | run | teardown | list | reset | logs | attach | identify | enable | disable | make-admin)`,
+				`unknown subcommand: ${sub} (use: setup | run | teardown | list | reset | logs | attach | identify | enable | disable | admin)`,
 			);
 	}
 }

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiSubscription/getApiSubscription.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiSubscription/getApiSubscription.ts
@@ -134,6 +134,7 @@ export const getApiSubscription = async ({
 		quantity: cusProduct.quantity,
 		current_period_start: stripeSubData?.current_period_start || null,
 		current_period_end: stripeSubData?.current_period_end || null,
+		scope: cusProduct.internal_entity_id ? "entity" : "customer",
 	} satisfies ApiSubscriptionV1);
 
 	return {

--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubscription/getApiSubscriptionV2.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubscription/getApiSubscriptionV2.ts
@@ -129,11 +129,12 @@ export const getApiSubscriptionV2 = async ({
 			trial_ends_at: isCustomerProductTrialing(customerProduct)
 				? (customerProduct.trial_ends_at ?? null)
 				: null,
-			started_at: customerProduct.starts_at,
-			quantity: customerProduct.quantity,
-			current_period_start: subscriptionPeriod.current_period_start,
-			current_period_end: subscriptionPeriod.current_period_end,
-		} satisfies ApiSubscriptionV1),
+		started_at: customerProduct.starts_at,
+		quantity: customerProduct.quantity,
+		current_period_start: subscriptionPeriod.current_period_start,
+		current_period_end: subscriptionPeriod.current_period_end,
+		scope: customerProduct.internal_entity_id ? "entity" : "customer",
+	} satisfies ApiSubscriptionV1),
 		legacyData: {
 			subscription_id: subId || undefined,
 			options: customerProduct.options,

--- a/server/tests/integration/crud/customers/customer-scope.test.ts
+++ b/server/tests/integration/crud/customers/customer-scope.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	ApiCustomerV5Schema,
+} from "@shared/api/customers/apiCustomerV5";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CUSTOMER SCOPE — `scope` field on subscriptions and purchases
+//
+// Contract under test:
+//   New types/fields:
+//     - ApiSubscriptionV1.scope: "customer" | "entity"
+//     - ApiPurchaseV0.scope:    "customer" | "entity"
+//   New behaviors:
+//     - Customer-level product (internal_entity_id === null) → "customer"
+//     - Entity-level product (internal_entity_id !== null)   → "entity"
+//   Side effects: none (pure projection from existing FullCusProduct).
+//
+// Pre-impl red: scope field is undefined, schema parse rejects.
+// Post-impl green: all assertions pass.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("customer scope: customer-level subscription has scope=customer, entity-level has scope=entity")}`,
+	async () => {
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const creditsItem = items.monthlyCredits({ includedUsage: 200 });
+
+		const cusLevelProd = products.pro({
+			id: "cus-lvl-scope",
+			items: [messagesItem],
+		});
+		const entityProd = products.base({
+			id: "ent-prod-scope",
+			items: [creditsItem],
+		});
+
+		const customerId = "customer-scope-test";
+
+		const { autumnV2_2, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [cusLevelProd, entityProd] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: cusLevelProd.id }),
+				s.attach({
+					productId: entityProd.id,
+					entityIndex: 0,
+				}),
+			],
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+			keepInternalFields: true,
+		});
+		ApiCustomerV5Schema.parse(customer);
+
+		// ── Customer-level subscription ──
+		const cusSub = customer.subscriptions.find(
+			(s) => s.plan_id === cusLevelProd.id,
+		);
+		expect(cusSub).toBeDefined();
+		expect(cusSub!.scope).toBe("customer");
+
+		// ── Entity-level subscription ──
+		const entSub = customer.subscriptions.find(
+			(s) => s.plan_id === entityProd.id,
+		);
+		expect(entSub).toBeDefined();
+		expect(entSub!.scope).toBe("entity");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer scope: purchase (one-off) has scope=customer")}`,
+	async () => {
+		const oneOffItem = items.oneOffMessages({ includedUsage: 50 });
+		const oneOffProd = products.oneOff({
+			id: "one-off-scope",
+			items: [oneOffItem],
+		});
+
+		const customerId = "customer-scope-one-off";
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [oneOffProd] }),
+			],
+			actions: [s.billing.attach({ productId: oneOffProd.id })],
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+			keepInternalFields: true,
+		});
+		ApiCustomerV5Schema.parse(customer);
+
+		expect(customer.purchases.length).toBe(1);
+		expect(customer.purchases[0].scope).toBe("customer");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer scope: cached and uncached reads match")}`,
+	async () => {
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const pro = products.pro({ id: "scope-cache", items: [messagesItem] });
+
+		const customerId = "customer-scope-cache";
+
+		const { autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const cached = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expect(cached.subscriptions[0].scope).toBe("customer");
+
+		const uncached = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(uncached.subscriptions[0].scope).toBe("customer");
+	},
+);

--- a/shared/api/customers/cusPlans/apiSubscriptionV1.ts
+++ b/shared/api/customers/cusPlans/apiSubscriptionV1.ts
@@ -52,6 +52,10 @@ export const ApiSubscriptionV1Schema = z.object({
 	quantity: z.number().meta({
 		description: "Number of units of this subscription (for per-seat plans).",
 	}),
+	scope: z.enum(["customer", "entity"]).optional().meta({
+		description:
+			"Whether this subscription is attached at the customer level or entity level.",
+	}),
 });
 
 export const ApiPurchaseV0Schema = z.object({
@@ -70,6 +74,10 @@ export const ApiPurchaseV0Schema = z.object({
 	}),
 	quantity: z.number().meta({
 		description: "Number of units purchased.",
+	}),
+	scope: z.enum(["customer", "entity"]).optional().meta({
+		description:
+			"Whether this purchase is attached at the customer level or entity level.",
 	}),
 });
 

--- a/shared/api/customers/cusPlans/mappers/apiSubscriptionV1ToPurchaseV0.ts
+++ b/shared/api/customers/cusPlans/mappers/apiSubscriptionV1ToPurchaseV0.ts
@@ -13,5 +13,6 @@ export function apiSubscriptionV1ToPurchaseV0({
 		expires_at: input.expires_at,
 		started_at: input.started_at,
 		quantity: input.quantity,
+		scope: input.scope,
 	};
 }


### PR DESCRIPTION
Adds a new `scope` field (`customer` | `entity`) to subscriptions and purchases in the customer API response. Pure projection from existing `internal_entity_id` — no extra DB calls or cache changes.

### Changes
- `ApiSubscriptionV1Schema` / `ApiPurchaseV0Schema` — add `scope` field
- `getApiSubscriptionV2.ts` — derive `scope` from `customerProduct.internal_entity_id`
- `apiSubscriptionV1ToPurchaseV0.ts` — pass `scope` through to purchases
- `customer-scope.test.ts` — integration test covering customer-level, entity-level, and purchase scope

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `scope` field to subscriptions and purchases to show if they’re customer- or entity-level, derived from existing data with no DB/cache changes. Also rename the dev-worktree admin command to `dw:admin`.

- **New Features**
  - Add optional `scope` on `ApiSubscriptionV1` and `ApiPurchaseV0` (`"customer"` | `"entity"`).
  - Populate in both `getApiSubscription` and `getApiSubscriptionV2` from `internal_entity_id`; pass through the purchase mapper.
  - Integration tests cover customer-level, entity-level, one-off purchases, and cached vs. uncached reads.

- **Refactors**
  - Rename `bun dw make-admin` → `bun dw admin` and update the package script to `dw:admin` and docs.

<sup>Written for commit 08d39309a69cb2ff16a324345b590341e1f38435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `scope` field (`"customer" | "entity"`) to the customer API's subscription and purchase objects, derived purely from the existing `internal_entity_id` on `FullCusProduct` — no new DB queries or cache changes. It also renames the `dw make-admin` developer-worktree command to `dw admin`, updating the script, imports, switch-case, package.json script, and README in lockstep.

- **[API changes]** `ApiSubscriptionV1Schema` and `ApiPurchaseV0Schema` gain an optional `scope` enum field; `getApiSubscriptionV2` always populates it; `apiSubscriptionV1ToPurchaseV0` passes it through to purchases.
- **[Improvements]** Three integration tests cover customer-level subscriptions (`scope=customer`), entity-level subscriptions (`scope=entity`), one-off purchases, and cached vs. uncached read parity.
- **[Improvements]** `dw make-admin` → `dw admin` rename propagated consistently across the scripts package.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the scope derivation is a read-only projection with no side effects and is covered by integration tests.

The only code change worth noting is a minor indentation regression in getApiSubscriptionV2.ts where four fields were accidentally de-dented when scope was added. TypeScript is whitespace-insensitive so this has no runtime impact, but it leaves the file inconsistent.

getApiSubscriptionV2.ts — minor indentation inconsistency introduced alongside the new scope field.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubscription/getApiSubscriptionV2.ts | Adds scope field derivation from internal_entity_id; introduces an indentation inconsistency where four fields lost one tab level compared to the surrounding object literal. |
| shared/api/customers/cusPlans/apiSubscriptionV1.ts | Adds scope as an optional "customer" | "entity" enum field to both ApiSubscriptionV1Schema and ApiPurchaseV0Schema; no logic issues. |
| shared/api/customers/cusPlans/mappers/apiSubscriptionV1ToPurchaseV0.ts | Passes scope through from subscription to purchase; straightforward one-line addition with no issues. |
| server/tests/integration/crud/customers/customer-scope.test.ts | New integration test covering customer-level subscriptions, entity-level subscriptions, one-off purchases, and cached/uncached read parity; well-structured with clear contract comments. |
| scripts/dw/commands/admin.ts | Renames make-admin.ts → admin.ts and cmdMakeAdmin → cmdAdmin; import order alphabetised; no functional changes. |
| scripts/dw/index.ts | Updates switch-case from make-admin to admin and adjusts all imports to match the rename; import list now alphabetised. |
| package.json | Updates dw:make-admin npm script to dw:admin to match the command rename. |
| scripts/dw/README.md | Updates docs to reflect the make-admin → admin rename; no content changes beyond identifiers. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant CustomerAPI
    participant getApiSubscriptionV2
    participant FullCusProduct

    Client->>CustomerAPI: GET /customers/:id
    CustomerAPI->>getApiSubscriptionV2: customerProduct
    getApiSubscriptionV2->>FullCusProduct: read internal_entity_id
    FullCusProduct-->>getApiSubscriptionV2: "string | null | undefined"
    Note over getApiSubscriptionV2: scope = internal_entity_id ? "entity" : "customer"
    getApiSubscriptionV2-->>CustomerAPI: "ApiSubscriptionV1 { ..., scope }"
    Note over CustomerAPI: one-off? apiSubscriptionV1ToPurchaseV0 passes scope through
    CustomerAPI-->>Client: "{ subscriptions: [..., { scope }], purchases: [..., { scope }] }"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubscription/getApiSubscriptionV2.ts:132-137
Four fields lost one level of indentation when `scope` was added, making them inconsistent with the rest of the object literal passed to `ApiSubscriptionV1Schema.parse()`.

```suggestion
			started_at: customerProduct.starts_at,
			quantity: customerProduct.quantity,
			current_period_start: subscriptionPeriod.current_period_start,
			current_period_end: subscriptionPeriod.current_period_end,
			scope: customerProduct.internal_entity_id ? "entity" : "customer",
		} satisfies ApiSubscriptionV1),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(scripts): 🤖 rename dw:make-admin ..."](https://github.com/useautumn/autumn/commit/6402cc213b4d17587213c30b219e10b034548038) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35445761)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->