### PR TITLE
restore aggregate_groupable/simple rollup routing

### DIFF
--- a/server/tinybird/pipes/aggregate_groupable.pipe
+++ b/server/tinybird/pipes/aggregate_groupable.pipe
@@ -16,6 +16,7 @@ SQL >
     %
     {% set no_property_filters = (not defined(filter_key_0) or String(filter_key_0, '') == '') and (not defined(filter_key_1) or String(filter_key_1, '') == '') and (not defined(filter_key_2) or String(filter_key_2, '') == '') and (not defined(filter_key_3) or String(filter_key_3, '') == '') and (not defined(filter_key_4) or String(filter_key_4, '') == '') %}
     {% set use_no_props = (String(group_column, 'property') in ['customer_id', 'entity_id', 'plan_id']) and no_property_filters %}
+    {% set use_property_rollup = (String(group_column, 'property') == 'property') and no_property_filters %}
 
     SELECT
         {% if String(bin_size, 'day') == 'hour' %}
@@ -32,6 +33,8 @@ SQL >
         entity_id as group_value,
         {% elif String(group_column, 'property') == 'plan_id' %}
         coalesce(internal_product_id, '') as group_value,
+        {% elif use_property_rollup %}
+        property_value as group_value,
         {% else %}
         {{ column('properties.' + String(property_key, '')) }}::String as group_value,
         {% end %}
@@ -39,6 +42,8 @@ SQL >
     FROM
         {% if use_no_props %}
         events_hourly_no_properties_two_mv
+        {% elif use_property_rollup %}
+        events_property_mv
         {% else %}
         events_hourly_mv
         {% end %}
@@ -48,6 +53,9 @@ SQL >
         AND event_name IN {{ Array(event_names, 'String', default='[]') }}
         AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
         AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+        {% if use_property_rollup %}
+        AND property_key = {{ String(property_key, '') }}
+        {% end %}
         {% if defined(customer_id) and String(customer_id, '') != '' %}
         AND customer_id = {{ String(customer_id) }}
         {% end %}
@@ -73,6 +81,8 @@ SQL >
         {# Filter out null/empty grouping values #}
         {% if String(group_column, 'property') == 'entity_id' %}
         AND entity_id IS NOT NULL AND entity_id != ''
+        {% elif use_property_rollup %}
+        AND property_value != ''
         {% elif String(group_column, 'property') == 'property' %}
         AND {{ column('properties.' + String(property_key, '')) }}::String IS NOT NULL
         AND {{ column('properties.' + String(property_key, '')) }}::String != ''

--- a/server/tinybird/pipes/aggregate_simple.pipe
+++ b/server/tinybird/pipes/aggregate_simple.pipe
@@ -8,6 +8,8 @@ NODE endpoint
 TYPE endpoint
 SQL >
     %
+    {% set no_property_filters = (not defined(filter_key_0) or String(filter_key_0, '') == '') and (not defined(filter_key_1) or String(filter_key_1, '') == '') and (not defined(filter_key_2) or String(filter_key_2, '') == '') and (not defined(filter_key_3) or String(filter_key_3, '') == '') and (not defined(filter_key_4) or String(filter_key_4, '') == '') %}
+    {% set use_org_rollup = no_property_filters and (not defined(customer_id) or String(customer_id, '') == '') and (not defined(entity_id) or String(entity_id, '') == '') %}
     SELECT
         {% if String(bin_size, 'day') == 'hour' %}
         formatDateTime(hour, '%F %T') as period,
@@ -18,17 +20,17 @@ SQL >
         {% end %}
         event_name,
         sum(total_value) as total_value
-    FROM {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}events_hourly_mv{% elif defined(filter_key_1) and String(filter_key_1, '') != '' %}events_hourly_mv{% elif defined(filter_key_2) and String(filter_key_2, '') != '' %}events_hourly_mv{% elif defined(filter_key_3) and String(filter_key_3, '') != '' %}events_hourly_mv{% elif defined(filter_key_4) and String(filter_key_4, '') != '' %}events_hourly_mv{% else %}events_hourly_no_properties_two_mv{% end %}
+    FROM {% if not no_property_filters %}events_hourly_mv{% elif use_org_rollup %}events_org_hourly_mv{% else %}events_hourly_no_properties_two_mv{% end %}
     WHERE
         org_id = {{ String(org_id, '') }}
         AND env = {{ String(env, 'test') }}
         AND event_name IN {{ Array(event_names, 'String', default='[]') }}
         AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
         AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
-        {% if defined(customer_id) and String(customer_id, '') != '' %}
+        {% if not use_org_rollup and defined(customer_id) and String(customer_id, '') != '' %}
         AND customer_id = {{ String(customer_id) }}
         {% end %}
-        {% if defined(entity_id) and String(entity_id, '') != '' %}
+        {% if not use_org_rollup and defined(entity_id) and String(entity_id, '') != '' %}
         AND entity_id = {{ String(entity_id) }}
         {% end %}
         {% if defined(filter_key_0) and String(filter_key_0, '') != '' %}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores rollup routing in Tinybird aggregate endpoints to use the correct materialized views for hourly, org, and property groupings. Prevents mis-aggregation and incorrect filters when no property filters are present.

- **Bug Fixes**
  - aggregate_groupable: Added property rollup path to route to events_property_mv when grouping by property with no property filters; applies property_key and skips empty property_value; keeps no-props path to events_hourly_no_properties_two_mv.
  - aggregate_simple: Introduced no_property_filters and use_org_rollup flags; selects events_org_hourly_mv for org-level rollups, otherwise uses events_hourly_mv or events_hourly_no_properties_two_mv; avoids applying customer_id/entity_id filters during org rollup.

<sup>Written for commit b2bf1ca5e502ccd3d56a8b2b9da5c6d300a59651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores intentional MV routing that was previously removed from two Tinybird aggregate pipes. `aggregate_groupable` now routes `group_column=property` queries with no filter keys to the pre-aggregated `events_property_mv` (keyed by `property_key`/`property_value`) instead of the full `events_hourly_mv`. `aggregate_simple` adds an org-level rollup path via `events_org_hourly_mv` for queries that carry no customer, entity, or property filters, and collapses the previous five redundant `elif` branches into a single `not no_property_filters` guard.

- **Bug fixes / Improvements**: `aggregate_groupable` — adds `use_property_rollup` flag to select `property_value as group_value` from `events_property_mv` and applies a `property_key` equality filter.
- **Bug fixes / Improvements**: `aggregate_simple` — introduces `no_property_filters` and `use_org_rollup` template variables; `customer_id`/`entity_id` WHERE conditions are correctly gated by `not use_org_rollup` to avoid referencing columns absent from the org-grain rollup table.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — routing logic is correct, table schemas match column references, and filter guards are properly scoped.

Both routing paths were validated against the materialized-view schemas and all column references are correct. The subtle edge case of a caller passing group_column=property without a property_key silently getting zero rows, and the stale DESCRIPTION comment, are the only issues found.

server/tinybird/pipes/aggregate_groupable.pipe — the DESCRIPTION comment and the implicit empty-property_key behaviour deserve a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/tinybird/pipes/aggregate_groupable.pipe | Adds use_property_rollup flag to route property-grouping queries (with no filter keys) to events_property_mv; schema and column references match the MV definition; DESCRIPTION comment now slightly stale |
| server/tinybird/pipes/aggregate_simple.pipe | Consolidates 5 redundant filter-key branches into no_property_filters; adds use_org_rollup to route org-level queries to events_org_hourly_mv; customer_id/entity_id filter guards are correct |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Query arrives] --> B{aggregate_groupable or aggregate_simple?}
    B -->|aggregate_groupable| C{group_column?}
    C -->|customer_id/entity_id/plan_id AND no_property_filters| D[events_hourly_no_properties_two_mv]
    C -->|property AND no_property_filters| E[events_property_mv]
    C -->|property with filters or other| F[events_hourly_mv]
    B -->|aggregate_simple| G{no_property_filters?}
    G -->|No| F
    G -->|Yes| H{no customer_id AND no entity_id?}
    H -->|Yes| I[events_org_hourly_mv]
    H -->|No| D
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/tinybird/pipes/aggregate_groupable.pipe`, line 3-5 ([link](https://github.com/useautumn/autumn/blob/b2bf1ca5e502ccd3d56a8b2b9da5c6d300a59651/server/tinybird/pipes/aggregate_groupable.pipe#L3-L5)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The DESCRIPTION comment lists only two routing targets but there are now three. The new `events_property_mv` path for property-column grouping with no property filters should be documented here so the routing logic stays self-consistent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/tinybird/pipes/aggregate_groupable.pipe
   Line: 3-5

   Comment:
   The DESCRIPTION comment lists only two routing targets but there are now three. The new `events_property_mv` path for property-column grouping with no property filters should be documented here so the routing logic stays self-consistent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tinybird/pipes/aggregate_groupable.pipe:3-5
The DESCRIPTION comment lists only two routing targets but there are now three. The new `events_property_mv` path for property-column grouping with no property filters should be documented here so the routing logic stays self-consistent.

```suggestion
    Routes to the smallest viable MV for the query shape:
      - events_hourly_no_properties_two_mv: customer_id/entity_id/plan_id grouping with no property filters
      - events_property_mv:                  property grouping with no property filters (low-cardinality values only)
      - events_hourly_mv:                    arbitrary properties or filtered queries
```

### Issue 2 of 2
server/tinybird/pipes/aggregate_groupable.pipe:56-58
**Empty `property_key` silently returns zero rows**

When `use_property_rollup` is `true` but `property_key` is not supplied, `String(property_key, '')` evaluates to `''`, so the filter becomes `AND property_key = ''`. Because `events_property_mv` is built via `ARRAY JOIN` on `JSONExtractKeysAndValues`, no row will ever have `property_key = ''`, so the entire query returns nothing with no error. Consider adding a guard or surfacing a clear error when the key is absent.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["restore aggregate\_groupable/simple rollu..."](https://github.com/useautumn/autumn/commit/b2bf1ca5e502ccd3d56a8b2b9da5c6d300a59651) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35476310)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->