### PR TITLE
chore: schedule entities check

### DIFF
--- a/shared/utils/cusProductUtils/getCusProductFromCustomer.ts
+++ b/shared/utils/cusProductUtils/getCusProductFromCustomer.ts
@@ -167,6 +167,14 @@ export const getTargetSubscriptionScheduleCusProduct = ({
 		return hasSubscriptionSchedule;
 	});
 
+	if (cusProductId) {
+		const targetCusProduct = cusProducts.find((cp) => cp.id === cusProductId);
+		const targetExists = fullCus.customer_products.some(
+			(cp) => cp.id === cusProductId,
+		);
+		if (targetExists && !targetCusProduct) return undefined;
+	}
+
 	// Sort by merge order:
 	// 1. Entity match (highest priority)
 	// 2. Main product (add-ons lowest priority)

--- a/vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx
+++ b/vite/src/components/forms/create-schedule/components/CreateScheduleSheetContent.tsx
@@ -29,7 +29,7 @@ export function CreateScheduleSheetContent() {
 	const { form, formValues, entityId, handleAddPhase, error, onScopeChange } =
 		useCreateScheduleFormContext();
 	const { closeSheet, setSheet } = useSheetStore();
-	const hasSchedule = useHasSchedule();
+	const hasSchedule = useHasSchedule({ entityId });
 	const { customer } = useCusQuery();
 	const entities = (customer as FullCustomer | null)?.entities ?? [];
 
@@ -136,10 +136,10 @@ function getConfirmLabel({
 }
 
 export function CreateScheduleReviewContent() {
-	const { handleSubmit, isPending, isPreviewLoading, preview, error } =
+	const { handleSubmit, isPending, isPreviewLoading, preview, error, entityId } =
 		useCreateScheduleFormContext();
 	const { setSheet } = useSheetStore();
-	const hasSchedule = useHasSchedule();
+	const hasSchedule = useHasSchedule({ entityId });
 
 	const confirmLabel = getConfirmLabel({ preview });
 	const isZeroAmount = preview && preview.total <= 0;

--- a/vite/src/components/forms/create-schedule/components/ScheduledPlanGuard.tsx
+++ b/vite/src/components/forms/create-schedule/components/ScheduledPlanGuard.tsx
@@ -5,8 +5,14 @@ import { Button } from "@/components/v2/buttons/Button";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useHasSchedule } from "../hooks/useHasSchedule";
 
-export function ScheduledPlanGuard({ children }: { children: ReactNode }) {
-	const hasSchedule = useHasSchedule();
+export function ScheduledPlanGuard({
+	children,
+	entityId,
+}: {
+	children: ReactNode;
+	entityId?: string | null;
+}) {
+	const hasSchedule = useHasSchedule({ entityId });
 	const { setSheet } = useSheetStore();
 
 	if (!hasSchedule) return <>{children}</>;

--- a/vite/src/components/forms/create-schedule/hooks/useHasSchedule.ts
+++ b/vite/src/components/forms/create-schedule/hooks/useHasSchedule.ts
@@ -1,6 +1,14 @@
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 
-export function useHasSchedule() {
+export function useHasSchedule({
+	entityId,
+}: { entityId?: string | null } = {}) {
 	const { schedule, customer } = useCusQuery({ schedule: true });
-	return !!schedule || !!customer?.entities?.some((entity) => entity.schedule);
+	if (entityId) {
+		const entity = customer?.entities?.find(
+			(e) => e.id === entityId || e.internal_id === entityId,
+		);
+		return !!entity?.schedule;
+	}
+	return !!schedule;
 }

--- a/vite/src/views/customers2/components/sheets/SubscriptionCancelSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionCancelSheet.tsx
@@ -140,7 +140,7 @@ export function SubscriptionCancelSheet() {
 	}
 
 	return (
-		<ScheduledPlanGuard>
+		<ScheduledPlanGuard entityId={cusProduct.entity_id ?? undefined}>
 			<UpdateSubscriptionFormProvider
 				formContext={formContext}
 				originalItems={undefined}

--- a/vite/src/views/customers2/components/table/customer-products/AttachProductSheetTrigger.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/AttachProductSheetTrigger.tsx
@@ -15,12 +15,14 @@ import {
 	useIsAttachingProduct,
 	useSheetStore,
 } from "@/hooks/stores/useSheetStore";
+import { useEntity } from "@/hooks/stores/useSubscriptionStore";
 import { cn } from "@/lib/utils";
 
 export function AttachProductSheetTrigger() {
 	const { setSheet } = useSheetStore();
 	const isAttachingProduct = useIsAttachingProduct();
-	const hasSchedule = useHasSchedule();
+	const { entityId } = useEntity();
+	const hasSchedule = useHasSchedule({ entityId });
 
 	const handleAttachClick = () => {
 		setSheet({ type: "attach-product" });


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scope schedule checks to the specific entity to prevent creating or modifying plans when that entity already has a schedule. Also handle a cusProduct lookup edge case to avoid selecting the wrong product.

- **Bug Fixes**
  - `useHasSchedule` now accepts `entityId` and returns the schedule state for that entity (falls back to customer schedule if no `entityId`).
  - Passed `entityId` through `CreateScheduleSheetContent`, `CreateScheduleReviewContent`, `ScheduledPlanGuard`, `AttachProductSheetTrigger`, and `SubscriptionCancelSheet` for correct guard behavior.
  - In `getCusProductFromCustomer`, if the requested `cusProductId` exists on the customer but not in the filtered list, return `undefined` to avoid mismatched selections.

<sup>Written for commit 31448e9f7cbb85b82d4c832090cc77ac130c284d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes schedule checks entity-aware across the UI and server-side billing utilities, fixing an over-broad guard that previously blocked operations whenever *any* entity had an active schedule, regardless of which entity the current product belonged to.

- **Bug fixes** — `useHasSchedule` now accepts an optional `entityId` and scopes its check to that specific entity's schedule (or the customer-level schedule when no entity is given), replacing the old catch-all `entities.some(e => e.schedule)` that could incorrectly block unrelated entities.
- **Bug fixes** — `ScheduledPlanGuard` and `SubscriptionCancelSheet` propagate `entity_id` from the customer product so cancellation is blocked only when the *same* entity's schedule is active.
- **Improvements** — `getTargetSubscriptionScheduleCusProduct` gains an early-return guard: when a specific `cusProductId` is targeted, exists on the customer, but has no subscription schedule, the function returns `undefined` instead of falling back to a different entity/product's schedule.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes correctly narrow schedule checks from customer-wide to entity-scoped, and all call sites have been updated accordingly.

The logic in useHasSchedule and getTargetSubscriptionScheduleCusProduct is straightforward and well-contained. The server-side caller handles the new undefined return gracefully via optional chaining. All six call sites of useHasSchedule now pass entityId, so the removal of the entities.some fallback is complete. No dangling callers or missing propagation were found.

getCusProductFromCustomer.ts and useHasSchedule.ts carry the core behavioral changes and are worth a second look in the context of any future multi-entity billing paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/cusProductUtils/getCusProductFromCustomer.ts | Adds an early-return guard in getTargetSubscriptionScheduleCusProduct: when a specific cusProductId is provided that exists in the customer's products but lacks a subscription schedule, return undefined instead of falling back to a different product's schedule. |
| vite/src/components/forms/create-schedule/hooks/useHasSchedule.ts | Refactored to accept an optional entityId. When provided it checks only that entity's schedule; when absent it checks the customer-level schedule. Removes the previous catch-all of checking all entities for a schedule. |
| vite/src/components/forms/create-schedule/components/ScheduledPlanGuard.tsx | Now accepts an optional entityId prop and forwards it to useHasSchedule, enabling entity-scoped schedule blocking. |
| vite/src/views/customers2/components/sheets/SubscriptionCancelSheet.tsx | Passes cusProduct.entity_id to ScheduledPlanGuard so that cancellation is blocked only when the specific product's entity has an active schedule. |
| vite/src/views/customers2/components/table/customer-products/AttachProductSheetTrigger.tsx | Imports useEntity to read the current entity from the URL query param and passes it to useHasSchedule, making the Create/Update Schedule dropdown label entity-aware. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useHasSchedule called] --> B{entityId provided?}
    B -- Yes --> C[Find entity in customer.entities by id or internal_id]
    C --> D{entity found?}
    D -- Yes --> E[return !!entity.schedule]
    D -- No --> F[return false]
    B -- No --> G[return !!schedule customer-level only]

    H[getTargetSubscriptionScheduleCusProduct] --> I[Filter: products with subscription schedules]
    I --> J{cusProductId provided?}
    J -- Yes --> K{Product exists in customer_products?}
    K -- Yes --> L{Product in schedule-filtered list?}
    L -- No --> M[return undefined - do not fall back to another product]
    L -- Yes --> N[Sort + return best match]
    K -- No --> N
    J -- No --> N
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: schedule entities check"](https://github.com/useautumn/autumn/commit/31448e9f7cbb85b82d4c832090cc77ac130c284d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35600947)</sub>

<!-- /greptile_comment -->