### PR TITLE
chore: discount upgrade fix

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
@@ -87,12 +87,10 @@ export const applyAmountOffDiscountToLineItems = ({
 		const totalDiscount =
 			existingDiscounts.reduce((sum, d) => sum + d.amountOff, 0) + itemDiscount;
 
-		// Discounts only apply to charges (refunds filtered by discountAppliesToLineItem)
-		// Cap at 0 to prevent negative charges
-		const amountAfterDiscounts = Math.max(
-			new Decimal(item.amount).minus(totalDiscount).toNumber(),
-			0,
-		);
+		const isProrationCredit = item.context.direction === "refund";
+		const amountAfterDiscounts = isProrationCredit
+			? Math.min(new Decimal(item.amount).plus(totalDiscount).toNumber(), 0)
+			: Math.max(new Decimal(item.amount).minus(totalDiscount).toNumber(), 0);
 
 		const description = item.context.discountable
 			? item.description // if discountable, stripe applies discount, don't need our own tag

--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyPercentOffDiscountToLineItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyPercentOffDiscountToLineItems.ts
@@ -70,12 +70,10 @@ export const applyPercentOffDiscountToLineItems = ({
 
 		const existingDiscounts = item.discounts ?? [];
 
-		// Discounts only apply to charges (refunds filtered by discountAppliesToLineItem)
-		// Cap at 0 to prevent negative charges
-		const amountAfterDiscounts = Math.max(
-			new Decimal(currentAmount).minus(itemDiscount).toNumber(),
-			0,
-		);
+		const isProrationCredit = item.context.direction === "refund";
+		const amountAfterDiscounts = isProrationCredit
+			? Math.min(new Decimal(currentAmount).plus(itemDiscount).toNumber(), 0)
+			: Math.max(new Decimal(currentAmount).minus(itemDiscount).toNumber(), 0);
 
 		const description = item.context.discountable
 			? item.description // if discountable, stripe applies discount, don't need our own tag

--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem.ts
@@ -1,4 +1,28 @@
-import type { LineItem, StripeDiscountWithCoupon } from "@autumn/shared";
+import { type LineItem, ms, type StripeDiscountWithCoupon } from "@autumn/shared";
+
+const discountWasActiveForCreditedPeriod = ({
+	discount,
+	lineItem,
+}: {
+	discount: StripeDiscountWithCoupon;
+	lineItem: LineItem;
+}): boolean => {
+	const discountExistedOnSubscription = Boolean(discount.id);
+	if (!discountExistedOnSubscription) {
+		return false;
+	}
+	const creditedPeriodStart = lineItem.context.billingPeriod?.start;
+	if (creditedPeriodStart === undefined) {
+		return false;
+	}
+	const discountStartedAt = ms.seconds(discount.start ?? 0);
+	if (discountStartedAt >= creditedPeriodStart) {
+		return false;
+	}
+	const discountEndedAt =
+		discount.end == null ? undefined : ms.seconds(discount.end);
+	return discountEndedAt === undefined || discountEndedAt > creditedPeriodStart;
+};
 
 /**
  * Checks if a discount applies to a specific line item based on applies_to.products
@@ -10,8 +34,11 @@ export const discountAppliesToLineItem = ({
 	discount: StripeDiscountWithCoupon;
 	lineItem: LineItem;
 }): boolean => {
-	// Discounts only apply to charges, not refunds
-	if (lineItem.context.direction === "refund") {
+	const isProrationCredit = lineItem.context.direction === "refund";
+	if (
+		isProrationCredit &&
+		!discountWasActiveForCreditedPeriod({ discount, lineItem })
+	) {
 		return false;
 	}
 

--- a/server/tests/integration/billing/attach/discounts/preview-attach-discount-carryover-upgrade.test.ts
+++ b/server/tests/integration/billing/attach/discounts/preview-attach-discount-carryover-upgrade.test.ts
@@ -1,0 +1,156 @@
+/**
+ * TDD: a discount that was active for the period being credited must also
+ * reduce the outgoing plan's proration credit on upgrade.
+ *
+ * User report: a customer is genuinely on a DISCOUNTED plan (they renew at
+ * the discounted price each cycle). When they upgrade mid-cycle:
+ *  - previewAttach shows the discount only on the previewed (new) plan in
+ *    line_items, never on the current plan.
+ *  - the current plan is credited at FULL list price — more than the customer
+ *    actually paid — so the upgrade over-refunds.
+ *
+ * Root cause: proration credits (`direction: "refund"`) were never discounted.
+ *   - server/src/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem.ts
+ *   - server/src/internal/billing/v2/providers/stripe/utils/discounts/applyPercentOffDiscountToLineItems.ts
+ *
+ * The credit must be discounted ONLY when the discount was active for the
+ * period being credited. A discount applied mid-cycle (after the period was
+ * paid at full price) correctly leaves the credit at full price — that case
+ * is covered by attach-discounts-stacking.test.ts and must stay green.
+ *
+ * Scenario (genuine discounted plan):
+ *  - Attach Pro ($20/mo) WITH a 20% forever coupon → customer pays $16/cycle.
+ *  - Renew once at the discounted price, then advance ~15 days into the cycle.
+ *  - Preview the upgrade to Premium ($50/mo) WITHOUT a discounts param — the
+ *    discount carries over from the existing subscription.
+ *
+ * Expected (green, after fix):
+ *  - Premium charge carries the 20% discount  (already correct today)
+ *  - Pro credit ALSO carries the 20% discount (smaller magnitude than the
+ *    full-price credit)
+ *  - preview.total = discounted credit + discounted charge
+ *
+ * Current buggy behavior (red, before fix):
+ *  - Pro credit has zero discounts and stays at the full-price amount,
+ *    over-refunding the customer.
+ */
+
+import { expect, test } from "bun:test";
+import type { AttachPreviewResponse } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { advanceTestClock } from "@tests/utils/stripeUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { createPercentCoupon } from "../../utils/discounts/discountTestUtils.js";
+
+const PERCENT_OFF = 20;
+const DISCOUNT_RATE = PERCENT_OFF / 100;
+
+test.concurrent(
+	`${chalk.yellowBright(
+		"preview-attach-discount-carryover-upgrade: a discount active for the credited period must reduce the outgoing plan credit, not only the new plan charge",
+	)}`,
+	async () => {
+		const customerId = "preview-disc-carryover-upgrade";
+		const proProd = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const premiumProd = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		const { autumnV1, autumnV2_2, testClockId, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: true, paymentMethod: "success" }),
+				s.products({ list: [proProd, premiumProd] }),
+			],
+			actions: [],
+		});
+
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: PERCENT_OFF,
+		});
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: `pro_${customerId}`,
+			discounts: [{ reward_id: coupon.id }],
+		});
+
+		let advancedTo = await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId as string,
+			numberOfMonths: 1,
+			waitForSeconds: 30,
+		});
+		advancedTo = await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId as string,
+			startingFrom: new Date(advancedTo),
+			numberOfDays: 15,
+			waitForSeconds: 20,
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: `premium_${customerId}`,
+		})) as AttachPreviewResponse;
+
+		const premiumLine = preview.line_items.find((li) =>
+			li.plan_id.includes("premium"),
+		);
+		const proLine = preview.line_items.find(
+			(li) => li.plan_id.includes("pro") && !li.plan_id.includes("premium"),
+		);
+
+		console.log(
+			`[preview-disc-carryover-upgrade] proLine=${JSON.stringify(
+				proLine && {
+					subtotal: proLine.subtotal,
+					total: proLine.total,
+					discounts: proLine.discounts,
+				},
+			)} premiumLine=${JSON.stringify(
+				premiumLine && {
+					subtotal: premiumLine.subtotal,
+					total: premiumLine.total,
+					discounts: premiumLine.discounts.length,
+				},
+			)} previewTotal=${preview.total}`,
+		);
+
+		expect(premiumLine).toBeDefined();
+		expect(proLine).toBeDefined();
+		expect(proLine?.subtotal).toBeLessThan(0);
+		expect(premiumLine?.subtotal).toBeGreaterThan(0);
+
+		// New plan charge is discounted — already correct today.
+		expect(premiumLine?.discounts.length).toBeGreaterThan(0);
+
+		// Outgoing credit must carry the same carried-over discount so the
+		// customer isn't refunded more than they paid.
+		expect(proLine?.discounts.length).toBe(1);
+		expect(proLine?.discounts[0]?.amount_off).toBeCloseTo(
+			Math.abs(proLine?.subtotal ?? 0) * DISCOUNT_RATE,
+			0,
+		);
+
+		// Discounted credit is smaller in magnitude than the full-price credit.
+		expect(proLine?.total).toBeGreaterThan(proLine?.subtotal ?? 0);
+		expect(Math.abs(proLine?.total ?? 0)).toBeLessThan(
+			Math.abs(proLine?.subtotal ?? 0),
+		);
+
+		// Total is the sum of the discounted credit and the discounted charge.
+		expect(preview.total).toBeCloseTo(
+			(proLine?.total ?? 0) + (premiumLine?.total ?? 0),
+			1,
+		);
+	},
+	300_000,
+);

--- a/server/tests/unit/billing/stripe/discounts/proration-credit-discount.spec.ts
+++ b/server/tests/unit/billing/stripe/discounts/proration-credit-discount.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for discounting proration credits (refund-direction line items).
+ *
+ * A discount must reduce an outgoing plan's proration credit only when it was
+ * active for the period being credited (the customer paid the discounted price
+ * for that period). A discount applied mid-cycle, after the period was paid at
+ * full price, must leave the credit untouched.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type LineItem,
+	ms,
+	msToSeconds,
+	type StripeDiscountWithCoupon,
+} from "@autumn/shared";
+import { lineItems as lineItemFixtures } from "@tests/utils/fixtures/billing/lineItems";
+import { discounts } from "@tests/utils/fixtures/db/discounts";
+import chalk from "chalk";
+import { applyPercentOffDiscountToLineItems } from "@/internal/billing/v2/providers/stripe/utils/discounts/applyPercentOffDiscountToLineItems";
+import { discountAppliesToLineItem } from "@/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem";
+
+const PERIOD_START_MS = 1_700_000_000_000;
+const PERIOD_END_MS = PERIOD_START_MS + ms.days(30);
+const ONE_DAY_MS = ms.days(1);
+
+const creditLine = ({ amount = 20 }: { amount?: number } = {}): LineItem => {
+	const lineItem = lineItemFixtures.refund({ amount });
+	lineItem.context.billingPeriod = {
+		start: PERIOD_START_MS,
+		end: PERIOD_END_MS,
+	};
+	return lineItem;
+};
+
+const establishedDiscount = ({
+	percentOff,
+	startMs,
+	endMs,
+}: {
+	percentOff: number;
+	startMs: number;
+	endMs?: number;
+}): StripeDiscountWithCoupon => ({
+	...discounts.percentOff({ percentOff }),
+	id: "di_existing",
+	start: msToSeconds(startMs),
+	end: endMs === undefined ? null : msToSeconds(endMs),
+});
+
+describe(chalk.yellowBright("proration credit discounting"), () => {
+	describe(chalk.cyan("discountAppliesToLineItem (refund)"), () => {
+		test("applies when an established discount was active before the credited period", () => {
+			const lineItem = creditLine();
+			const discount = establishedDiscount({
+				percentOff: 20,
+				startMs: PERIOD_START_MS - ONE_DAY_MS,
+			});
+
+			expect(discountAppliesToLineItem({ discount, lineItem })).toBe(true);
+		});
+
+		test("does not apply when the discount started at the credited period start (applied mid-cycle, after the period was paid at full price)", () => {
+			const lineItem = creditLine();
+			const discount = establishedDiscount({
+				percentOff: 20,
+				startMs: PERIOD_START_MS,
+			});
+
+			expect(discountAppliesToLineItem({ discount, lineItem })).toBe(false);
+		});
+
+		test("does not apply when the discount started after the credited period start", () => {
+			const lineItem = creditLine();
+			const discount = establishedDiscount({
+				percentOff: 20,
+				startMs: PERIOD_START_MS + ONE_DAY_MS,
+			});
+
+			expect(discountAppliesToLineItem({ discount, lineItem })).toBe(false);
+		});
+
+		test("does not apply for a freshly-resolved param discount (no Stripe id)", () => {
+			const lineItem = creditLine();
+			const discount = discounts.twentyPercentOff();
+
+			expect(discountAppliesToLineItem({ discount, lineItem })).toBe(false);
+		});
+
+		test("does not apply when the discount ended before the credited period", () => {
+			const lineItem = creditLine();
+			const discount = establishedDiscount({
+				percentOff: 20,
+				startMs: PERIOD_START_MS - 10 * ONE_DAY_MS,
+				endMs: PERIOD_START_MS - ONE_DAY_MS,
+			});
+
+			expect(discountAppliesToLineItem({ discount, lineItem })).toBe(false);
+		});
+	});
+
+	describe(chalk.cyan("applyPercentOffDiscountToLineItems (refund)"), () => {
+		test("shrinks the credit toward zero by the discount, never flipping sign", () => {
+			const lineItem = creditLine({ amount: 20 });
+			const discount = establishedDiscount({
+				percentOff: 20,
+				startMs: PERIOD_START_MS - ONE_DAY_MS,
+			});
+
+			const [result] = applyPercentOffDiscountToLineItems({
+				lineItems: [lineItem],
+				discount,
+			});
+
+			expect(result.amountAfterDiscounts).toBe(-16);
+			expect(result.discounts).toHaveLength(1);
+			expect(result.discounts[0].amountOff).toBe(4);
+			expect(result.discounts[0].percentOff).toBe(20);
+		});
+
+		test("leaves the credit at full price when the discount started at/after the credited period start", () => {
+			const lineItem = creditLine({ amount: 20 });
+			const discount = establishedDiscount({
+				percentOff: 20,
+				startMs: PERIOD_START_MS,
+			});
+
+			const [result] = applyPercentOffDiscountToLineItems({
+				lineItems: [lineItem],
+				discount,
+			});
+
+			expect(result.amountAfterDiscounts).toBe(-20);
+			expect(result.discounts).toHaveLength(0);
+		});
+	});
+});

--- a/shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts
+++ b/shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts
@@ -13,6 +13,7 @@ import type Stripe from "stripe";
  */
 export type StripeDiscountWithCoupon = {
 	id?: string;
+	start?: number;
 	end?: number | null;
 	source: { coupon: Stripe.Coupon };
 	promotionCodeId?: string;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes upgrade proration credits to respect carried-over discounts. When a customer upgrades mid-cycle, the outgoing plan credit is discounted only if the discount was active for the credited period, preventing over-refunds.

- **Bug Fixes**
  - Apply discounts to refund line items only when the discount existed and started before the credited period (`discountAppliesToLineItem`).
  - Adjust refund math to shrink credits toward zero without flipping sign (`applyPercentOffDiscountToLineItems`, `applyAmountOffDiscountToLineItems`).
  - Add `start` to `StripeDiscountWithCoupon` to evaluate discount activity.
  - Add integration and unit tests to cover discount carryover on upgrade and proration credit behavior.

<sup>Written for commit 4b5476c85886cc38952142278ff1675280a82f94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes an over-refund bug on mid-cycle plan upgrades: when a customer held an active discount, the outgoing plan's proration credit was issued at full list price instead of the lower discounted price the customer actually paid. The fix introduces a temporal guard (`discountWasActiveForCreditedPeriod`) and inverts the arithmetic for refund-direction line items so discount application moves the credit amount toward zero rather than away from it.

- **Bug fixes**: `discountAppliesToLineItem` now allows proration credits to receive a discount when the discount predates the credited period's start, and excludes newly applied discounts that weren't active when the customer paid.
- **Bug fixes**: Both `applyAmountOffDiscountToLineItems` and `applyPercentOffDiscountToLineItems` use `Math.min(amount + discount, 0)` for refund items instead of the charge-only `Math.max(amount - discount, 0)`.
- **Improvements**: `StripeDiscountWithCoupon` gains a `start?: number` field, and new unit + integration tests cover the full scenario including the boundary case where a discount starts exactly at the period boundary.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; the core bug fix is correct and well-tested, with only minor documentation and a semantic inconsistency between amount-off and percent-off discount application for the mixed charge+credit case.

The temporal guard logic and the refund arithmetic inversion are correct and match the unit-test expectations. The two concerns are: stale JSDoc/variable naming in applyAmountOffDiscountToLineItems, and the amount-off proportional-split behaviour when both a charge and a proration credit are in scope — the credit receives only a fraction of the coupon rather than the full coupon value, unlike the percent-off path. No test covers this mixed scenario, so the behaviour is unverified. Neither concern breaks the documented user-facing fix.

applyAmountOffDiscountToLineItems.ts warrants a closer look for the mixed charge+credit distribution behaviour and the outdated comment.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/discounts/discountAppliesToLineItem.ts | New discountWasActiveForCreditedPeriod guard replaces the blanket refund-exclusion: correctly checks discount.id, billingPeriod.start, and discount start/end timestamps in milliseconds. |
| server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts | Proration credits now use Math.min(amount + discount, 0) instead of the charge-only Math.max(amount - discount, 0); stale JSDoc and variable name need updating, and the proportional-split semantics differ from percent-off. |
| server/src/internal/billing/v2/providers/stripe/utils/discounts/applyPercentOffDiscountToLineItems.ts | Mirrors the amount-off change: proration credits use Math.min(currentAmount + itemDiscount, 0). Logic is correct and covered by the new unit test. |
| shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts | Adds optional start?: number field (Unix seconds) needed by the new temporal discount guard; consistent with existing end field shape. |
| server/tests/unit/billing/stripe/discounts/proration-credit-discount.spec.ts | New unit tests cover the key cases for discountAppliesToLineItem and applyPercentOffDiscountToLineItems with refund items; discount active before, at, and after period start, plus expired discounts. |
| server/tests/integration/billing/attach/discounts/preview-attach-discount-carryover-upgrade.test.ts | End-to-end integration test validates the carryover discount scenario: attaches Pro + 20% coupon, advances 1 month + 15 days, previews upgrade and asserts credit is discounted at the same rate. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Line Item] --> B{direction === refund?}
    B -- No / charge --> C[discountAppliesToLineItem product filter only]
    B -- Yes / proration credit --> D{discountWasActiveForCreditedPeriod}
    D --> E{discount.id exists?}
    E -- No --> F[return false - new param discount skip]
    E -- Yes --> G{billingPeriod.start set?}
    G -- No --> F
    G -- Yes --> H{discountStartedAt < periodStart?}
    H -- No --> F
    H -- Yes --> I{discountEndedAt > periodStart or no end?}
    I -- No --> F
    I -- Yes --> C
    C --> J{applies_to.products filter}
    J -- passes --> K[Apply discount]
    K --> L{direction === refund?}
    L -- Yes --> M[Math.min amount + discount 0 - credit moves toward zero]
    L -- No --> N[Math.max amount - discount 0 - charge moves toward zero]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts`, line 16-44 ([link](https://github.com/useautumn/autumn/blob/4b5476c85886cc38952142278ff1675280a82f94/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts#L16-L44)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale comment and variable name after proration-credit support**

   The JSDoc on line 16 still says *"Only applies to charge items (not refunds)"*, and the local variable on line 43 is still named `applicableChargeItems` — both are now incorrect because proration-credit (`direction: "refund"`) items are included when `discountWasActiveForCreditedPeriod` returns true. A future reader will be misled into thinking refund items are always excluded here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
   Line: 16-44

   Comment:
   **Stale comment and variable name after proration-credit support**

   The JSDoc on line 16 still says *"Only applies to charge items (not refunds)"*, and the local variable on line 43 is still named `applicableChargeItems` — both are now incorrect because proration-credit (`direction: "refund"`) items are included when `discountWasActiveForCreditedPeriod` returns true. A future reader will be misled into thinking refund items are always excluded here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts`, line 58-73 ([link](https://github.com/useautumn/autumn/blob/4b5476c85886cc38952142278ff1675280a82f94/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts#L58-L73)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Amount-off discount split proportionally between charge and credit — semantic mismatch with percent-off**

   When a proration credit is now included alongside a charge in the applicable set, the `discountAmountOff` budget is distributed proportionally across both (e.g. a $10 coupon on a $50 charge + $20 credit is split ~$7.14/$2.86). The `applyPercentOffDiscountToLineItems` function applies the full percentage to each item independently, so both approaches discount a credit by different effective amounts for the same underlying coupon. If the intent is that the credit reflects "what the customer actually paid", the credit should receive the same absolute discount as on a standalone charge. There is no unit test covering the mixed charge+credit scenario for `applyAmountOffDiscountToLineItems`, making this difficult to verify.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
   Line: 58-73

   Comment:
   **Amount-off discount split proportionally between charge and credit — semantic mismatch with percent-off**

   When a proration credit is now included alongside a charge in the applicable set, the `discountAmountOff` budget is distributed proportionally across both (e.g. a $10 coupon on a $50 charge + $20 credit is split ~$7.14/$2.86). The `applyPercentOffDiscountToLineItems` function applies the full percentage to each item independently, so both approaches discount a credit by different effective amounts for the same underlying coupon. If the intent is that the credit reflects "what the customer actually paid", the credit should receive the same absolute discount as on a standalone charge. There is no unit test covering the mixed charge+credit scenario for `applyAmountOffDiscountToLineItems`, making this difficult to verify.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts:16-44
**Stale comment and variable name after proration-credit support**

The JSDoc on line 16 still says *"Only applies to charge items (not refunds)"*, and the local variable on line 43 is still named `applicableChargeItems` — both are now incorrect because proration-credit (`direction: "refund"`) items are included when `discountWasActiveForCreditedPeriod` returns true. A future reader will be misled into thinking refund items are always excluded here.

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts:58-73
**Amount-off discount split proportionally between charge and credit — semantic mismatch with percent-off**

When a proration credit is now included alongside a charge in the applicable set, the `discountAmountOff` budget is distributed proportionally across both (e.g. a $10 coupon on a $50 charge + $20 credit is split ~$7.14/$2.86). The `applyPercentOffDiscountToLineItems` function applies the full percentage to each item independently, so both approaches discount a credit by different effective amounts for the same underlying coupon. If the intent is that the credit reflects "what the customer actually paid", the credit should receive the same absolute discount as on a standalone charge. There is no unit test covering the mixed charge+credit scenario for `applyAmountOffDiscountToLineItems`, making this difficult to verify.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: discount upgrade fix"](https://github.com/useautumn/autumn/commit/4b5476c85886cc38952142278ff1675280a82f94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35620886)</sub>

<!-- /greptile_comment -->