### PR TITLE
fix: mcp oauth

### DIFF
--- a/packages/atmn/src/commands/auth/constants.ts
+++ b/packages/atmn/src/commands/auth/constants.ts
@@ -1,9 +1,10 @@
 // OAuth constants for CLI authentication
 
-/** The OAuth client ID for the CLI (public client) */
-// export const CLI_CLIENT_ID = "khicXGthBbGMIWmpgodOTDcCCJHJMDpN"; (local i think)
-// export const CLI_CLIENT_ID = "NiKwaSyAfaeEEKEvFaUYihTXdTPtIRCk" (dev i think)
-export const CLI_CLIENT_ID = "hAWUopQqLnsSwuRgeRzIBzKslwXmQUSr"; // (prod i think)
+// Historical Better Auth OAuth clients for atmn CLI environments.
+// Server auth should identify atmn from oauth_client metadata/name instead.
+export const LOCAL_CLI_CLIENT_ID = "khicXGthBbGMIWmpgodOTDcCCJHJMDpN";
+export const DEV_CLI_CLIENT_ID = "NiKwaSyAfaeEEKEvFaUYihTXdTPtIRCk";
+export const CLI_CLIENT_ID = "hAWUopQqLnsSwuRgeRzIBzKslwXmQUSr";
 
 /** Base port for the local OAuth callback server */
 export const OAUTH_PORT_BASE = 31448;

--- a/packages/mcp/src/server/auth/oauth.ts
+++ b/packages/mcp/src/server/auth/oauth.ts
@@ -1,9 +1,7 @@
-import { ms } from "@autumn/shared/unixUtils";
-import { addMilliseconds, isFuture } from "date-fns";
 import { MCP_OAUTH_SCOPES } from "../../constants.js";
 import type { AutumnMcpAuth } from "./auth.js";
 import { OAuthHttpError } from "./utils/errors.js";
-import { getOAuthPrincipalId, principalFromSecret } from "./utils/principal.js";
+import { principalFromSecret } from "./utils/principal.js";
 import {
 	getEnvironment,
 	getStaticApiKey,
@@ -13,11 +11,9 @@ import {
 	failOpenSchema,
 	type MCPOAuthFlags,
 	secretKeySchema,
-	tokenExchangeSchema,
 	xApiVersionSchema,
 } from "./utils/schemas.js";
 import {
-	getApiKeyUrl,
 	getIssuerUrl,
 	getResourceUrl,
 	getWWWAuthenticate,
@@ -28,75 +24,8 @@ export { MCP_OAUTH_SCOPES } from "../../constants.js";
 export { OAuthHttpError } from "./utils/errors.js";
 export type { MCPOAuthFlags, OAuthEnvironment } from "./utils/schemas.js";
 
-type ExchangedToken = {
-	key: string;
-	orgId?: string | undefined;
-	userId?: string | undefined;
-	clientId?: string | undefined;
-	scopes?: string[] | undefined;
-};
-
 type AuthLogger = {
 	warning: (message: string, data?: Record<string, unknown>) => void;
-};
-
-const apiKeyCache = new Map<string, ExchangedToken & { expiresAt: Date }>();
-
-const exchangeOAuthToken = async ({
-	headers,
-	flags,
-	resource,
-	token,
-}: {
-	headers: Headers;
-	flags: MCPOAuthFlags;
-	resource: string;
-	token: string;
-}): Promise<ExchangedToken> => {
-	const env = getEnvironment({ headers, flags });
-	const cacheKey = `${token}:${resource}:${env}`;
-	const cached = apiKeyCache.get(cacheKey);
-	if (cached && isFuture(cached.expiresAt)) return cached;
-
-	const response = await fetch(getApiKeyUrl(flags), {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${token}`,
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({ resource, scopes: MCP_OAUTH_SCOPES }),
-	});
-
-	if (!response.ok) {
-		throw new OAuthHttpError(
-			response.status === 403 ? 403 : 401,
-			await response.text(),
-			response.status === 403 ? "insufficient_scope" : "invalid_token",
-			response.status === 403
-				? undefined
-				: getWWWAuthenticate({ resourceUrl: resource, error: "invalid_token" }),
-		);
-	}
-
-	const data = tokenExchangeSchema.parse(await response.json());
-	const key = env === "live" ? data.prod_key : data.sandbox_key;
-	if (!key) {
-		throw new OAuthHttpError(
-			502,
-			"OAuth key exchange did not return an API key",
-		);
-	}
-
-	const exchanged = {
-		key,
-		orgId: data.org_id,
-		userId: data.user_id,
-		clientId: data.client_id,
-		scopes: data.scopes,
-		expiresAt: addMilliseconds(new Date(), ms.minutes(1)),
-	};
-	apiKeyCache.set(cacheKey, exchanged);
-	return exchanged;
 };
 
 export const getProtectedResourceMetadata = (
@@ -170,34 +99,12 @@ export const buildAuthForRequest = async (
 	}
 
 	if (flags["oauth-enabled"]) {
-		const authHeader = headers.get("authorization");
-		if (!authHeader?.startsWith("Bearer ")) {
-			throw new OAuthHttpError(
-				401,
-				"Missing Authorization bearer token",
-				"invalid_token",
-				getWWWAuthenticate({ resourceUrl: resource }),
-			);
-		}
-
-		const token = authHeader.slice("Bearer ".length);
-		const exchanged = await exchangeOAuthToken({
-			headers,
-			flags,
-			resource,
-			token,
-		});
-		return {
-			apiKey: exchanged.key,
-			env,
-			resource,
-			principalId: getOAuthPrincipalId({ token, exchanged }),
-			scopes: exchanged.scopes ?? [...MCP_OAUTH_SCOPES],
-			orgId: exchanged.orgId,
-			serverURL: flags["server-url"],
-			xApiVersion,
-			failOpen,
-		};
+		throw new OAuthHttpError(
+			401,
+			"Missing Autumn API key bearer token",
+			"invalid_token",
+			getWWWAuthenticate({ resourceUrl: resource, error: "invalid_token" }),
+		);
 	}
 
 	logger.warning("Missing secret-key for MCP request");

--- a/packages/mcp/src/server/auth/utils/principal.ts
+++ b/packages/mcp/src/server/auth/utils/principal.ts
@@ -15,33 +15,3 @@ export const principalFromSecret = ({
 	kind: string;
 	value: string;
 }) => `${kind}:${hash(value)}`;
-
-type ExchangedIdentity = {
-	orgId?: string | undefined;
-	userId?: string | undefined;
-	clientId?: string | undefined;
-};
-
-/**
- * Derives a principal id for an OAuth session. When the token exchange returned
- * an org we build a human-readable `oauth:<org>:<user>:<client>` id; otherwise we
- * fall back to a hashed token so unidentified callers still group consistently.
- */
-export const getOAuthPrincipalId = ({
-	token,
-	exchanged,
-}: {
-	token: string;
-	exchanged: ExchangedIdentity;
-}) => {
-	if (!exchanged.orgId) {
-		return principalFromSecret({ kind: "oauth", value: token });
-	}
-
-	return [
-		"oauth",
-		exchanged.orgId,
-		exchanged.userId ?? "unknown-user",
-		exchanged.clientId ?? "unknown-client",
-	].join(":");
-};

--- a/packages/mcp/src/server/auth/utils/schemas.ts
+++ b/packages/mcp/src/server/auth/utils/schemas.ts
@@ -16,15 +16,6 @@ export const failOpenSchema = z
 
 export const secretKeySchema = z.string().min(1).optional();
 
-export const tokenExchangeSchema = z.object({
-	sandbox_key: z.string().optional(),
-	prod_key: z.string().optional(),
-	org_id: z.string().optional(),
-	user_id: z.string().optional(),
-	client_id: z.string().optional(),
-	scopes: z.array(z.string()).optional(),
-});
-
 export interface MCPOAuthFlags extends MCPServerFlags {
 	readonly "oauth-enabled"?: boolean | undefined;
 	readonly "oauth-environment"?: OAuthEnvironment | undefined;

--- a/packages/mcp/src/server/auth/utils/urls.ts
+++ b/packages/mcp/src/server/auth/utils/urls.ts
@@ -45,9 +45,6 @@ export const getIssuerUrl = (flags: MCPOAuthFlags): string =>
 		new URL("/api/auth", flags["server-url"] ?? DEFAULT_AUTUMN_API_URL).href,
 	);
 
-export const getApiKeyUrl = (flags: MCPOAuthFlags): string =>
-	new URL("/cli/api-keys", getIssuerUrl(flags)).href;
-
 export const getWWWAuthenticate = ({
 	resourceUrl,
 	error,

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -6,6 +6,7 @@ import { type AutumnMcpAuth, getAutumnAuth } from "../server/auth/auth.js";
 import { balances } from "./balances.js";
 import { billing } from "./billing.js";
 import { customers } from "./customers.js";
+import { orgTools } from "./org.js";
 import { plans } from "./plans.js";
 import { callAutumn } from "./utils/client.js";
 import { dateToEpochMillisecondsTool } from "./utils/dates.js";
@@ -72,7 +73,8 @@ export const createRawAutumnOperationTools = () =>
 			),
 			...toTools(localPreviews, rawLocalPreviewTool),
 			...toTools(confirmedWrites, operationTool),
-		}),
+			...orgTools,
+		} as Record<string, ReturnType<typeof createTool>>),
 		surface: "mcp",
 	});
 

--- a/packages/mcp/src/tools/org.ts
+++ b/packages/mcp/src/tools/org.ts
@@ -1,0 +1,34 @@
+import { createTool } from "@mastra/core/tools";
+import * as z from "zod/v4";
+import { getAutumnAuth } from "../server/auth/auth.js";
+import { mcpAnnotations } from "./utils/annotations.js";
+import { callAutumnGet } from "./utils/client.js";
+
+const organizationMeSchema = z
+	.object({
+		name: z.string(),
+		slug: z.string(),
+		env: z.string(),
+	})
+	.strict();
+
+const signalOf = (context: { mcp?: { extra?: { signal?: AbortSignal } } }) =>
+	context?.mcp?.extra?.signal;
+
+export const orgTools = {
+	getCurrentOrganization: createTool({
+		id: "getCurrentOrganization",
+		description:
+			"Fetch the current Autumn organization name, slug, and environment.",
+		inputSchema: z.object({}).strict(),
+		mcp: { annotations: mcpAnnotations() },
+		execute: async (_input, context) =>
+			organizationMeSchema.parse(
+				await callAutumnGet({
+					auth: getAutumnAuth(context),
+					endpoint: "/v1/organization/me",
+					signal: signalOf(context),
+				}),
+			),
+	}),
+} as const;

--- a/packages/mcp/src/tools/utils/client.ts
+++ b/packages/mcp/src/tools/utils/client.ts
@@ -43,3 +43,32 @@ export const callAutumn = async ({
 	}
 	return body;
 };
+
+export const callAutumnGet = async ({
+	auth,
+	endpoint,
+	signal,
+}: {
+	auth: AutumnMcpAuth;
+	endpoint: string;
+	signal?: AbortSignal | undefined;
+}) => {
+	const client = createAutumnClient(auth);
+	const init: RequestInit = {
+		method: "GET",
+		headers: client.headers,
+	};
+	if (signal) init.signal = signal;
+
+	const response = await fetch(new URL(endpoint, client.baseUrl), init);
+	const text = await response.text();
+	const body = text ? parseBody(text) : null;
+	if (!response.ok) {
+		throw new Error(
+			`Autumn API request failed (${response.status}): ${
+				typeof body === "string" ? body : JSON.stringify(body)
+			}`,
+		);
+	}
+	return body;
+};

--- a/packages/mcp/tests/unit/mcp-server/agent/server.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/agent/server.test.ts
@@ -21,6 +21,7 @@ describe("Autumn MCP server", () => {
 			"attach",
 			"updateSubscription",
 			"createSchedule",
+			"getCurrentOrganization",
 		]);
 		expect(tools.tools.map((tool) => tool.name)).not.toContain("ask_autumn");
 		expect(tools.tools.map((tool) => tool.name)).not.toContain(

--- a/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
@@ -43,6 +43,7 @@ describe("Autumn operation tools", () => {
 		expect(tools.previewCreateBalance.description).toContain("Does not mutate");
 		expect(tools.createSchedule.description).toContain("starts_at");
 		expect(tools.previewCreateSchedule.description).toContain("billing impact");
+		expect(tools.getCurrentOrganization.description).toContain("organization");
 	});
 
 	test("write tools are annotated as destructive", () => {
@@ -67,6 +68,7 @@ describe("Autumn operation tools", () => {
 			"previewUpdateSubscription",
 			"previewCreateSchedule",
 			"previewCreateBalance",
+			"getCurrentOrganization",
 		] as const) {
 			expect(tools[name].mcp?.annotations?.destructiveHint).toBe(false);
 		}
@@ -307,6 +309,40 @@ describe("Autumn operation tools", () => {
 					} as never,
 				),
 			).resolves.toEqual({ customers: [] });
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("raw getCurrentOrganization calls the organization me endpoint", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (url, init) => {
+			expect(String(url)).toBe("http://localhost:8080/v1/organization/me");
+			expect(init?.method).toBe("GET");
+			expect(init?.body).toBeUndefined();
+			return Response.json({
+				name: "Unit Tests",
+				slug: "unit-tests",
+				env: "sandbox",
+			});
+		}) as typeof fetch;
+
+		try {
+			const tool = createRawAutumnOperationTools().getCurrentOrganization;
+			if (!tool.execute) {
+				throw new Error("getCurrentOrganization is not executable");
+			}
+
+			await expect(
+				tool.execute(
+					{ intent: "check which Autumn organization is connected" },
+					{ mcp: { extra: { authInfo: auth } } } as never,
+				),
+			).resolves.toEqual({
+				name: "Unit Tests",
+				slug: "unit-tests",
+				env: "sandbox",
+			});
 		} finally {
 			globalThis.fetch = originalFetch;
 		}

--- a/packages/mcp/tests/unit/mcp-server/oauth.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/oauth.test.ts
@@ -41,7 +41,7 @@ describe("MCP OAuth auth resolution", () => {
 			status: 401,
 			error: "invalid_token",
 			wwwAuthenticate:
-				'Bearer resource_metadata="http://localhost:2718/.well-known/oauth-protected-resource/mcp"',
+				'Bearer resource_metadata="http://localhost:2718/.well-known/oauth-protected-resource/mcp", error="invalid_token"',
 		} satisfies Partial<OAuthHttpError>);
 	});
 
@@ -57,47 +57,34 @@ describe("MCP OAuth auth resolution", () => {
 			status: 401,
 			error: "invalid_token",
 			wwwAuthenticate:
-				'Bearer resource_metadata="http://localhost:2718/.well-known/oauth-protected-resource/internal/mcp"',
+				'Bearer resource_metadata="http://localhost:2718/.well-known/oauth-protected-resource/internal/mcp", error="invalid_token"',
 		} satisfies Partial<OAuthHttpError>);
 	});
 
-	test("exchanges a bearer token for Autumn API credentials", async () => {
+	test("rejects opaque bearer tokens without exchanging them", async () => {
 		const originalFetch = globalThis.fetch;
-		globalThis.fetch = (async (_url, init) => {
-			expect(init?.headers).toEqual({
-				Authorization: "Bearer oauth_token",
-				"Content-Type": "application/json",
-			});
-			expect(JSON.parse(init?.body as string)).toEqual({
-				resource: "http://localhost:2718/mcp",
-				scopes: MCP_OAUTH_SCOPES,
-			});
-			return Response.json({
-				sandbox_key: "sk_sandbox",
-				prod_key: "sk_live",
-				org_id: "org_123",
-				user_id: "user_123",
-				client_id: "client_123",
-				scopes: MCP_OAUTH_SCOPES,
-			});
-		}) as typeof fetch;
+		let fetchCalled = false;
+		const mockFetch = (async () => {
+			fetchCalled = true;
+			return Response.json({});
+		}) as unknown as typeof fetch;
+		globalThis.fetch = mockFetch;
 
 		try {
-			const auth = await buildAuthForRequest(
-				new Headers({
-					authorization: "Bearer oauth_token",
-					host: "localhost:2718",
-				}),
-				flags as MCPOAuthFlags,
-				logger,
-			);
-
-			expect(auth.apiKey).toBe("sk_sandbox");
-			expect(auth.env).toBe("sandbox");
-			expect(auth.resource).toBe("http://localhost:2718/mcp");
-			expect(auth.principalId).toBe("oauth:org_123:user_123:client_123");
-			expect(auth.scopes).toEqual([...MCP_OAUTH_SCOPES]);
-			expect(auth.orgId).toBe("org_123");
+			await expect(
+				buildAuthForRequest(
+					new Headers({
+						authorization: "Bearer oauth_token",
+						host: "localhost:2718",
+					}),
+					flags as MCPOAuthFlags,
+					logger,
+				),
+			).rejects.toMatchObject({
+				status: 401,
+				error: "invalid_token",
+			} satisfies Partial<OAuthHttpError>);
+			expect(fetchCalled).toBe(false);
 		} finally {
 			globalThis.fetch = originalFetch;
 		}
@@ -133,40 +120,24 @@ describe("MCP OAuth auth resolution", () => {
 	});
 
 	test("uses route-specific resource URLs", async () => {
-		const originalFetch = globalThis.fetch;
-		globalThis.fetch = (async (_url, init) => {
-			expect(JSON.parse(init?.body as string)).toMatchObject({
-				resource: "http://localhost:2718/internal/mcp",
-			});
-			return Response.json({
-				sandbox_key: "sk_sandbox",
-				org_id: "org_123",
-				scopes: MCP_OAUTH_SCOPES,
-			});
-		}) as typeof fetch;
+		const auth = await buildAuthForRequest(
+			new Headers({
+				authorization: "Bearer am_sk_test_chat",
+				host: "localhost:2718",
+			}),
+			flags as MCPOAuthFlags,
+			logger,
+			"/internal/mcp",
+		);
 
-		try {
-			const auth = await buildAuthForRequest(
-				new Headers({
-					authorization: "Bearer internal_oauth_token",
-					host: "localhost:2718",
-				}),
+		expect(auth.resource).toBe("http://localhost:2718/internal/mcp");
+		expect(
+			getProtectedResourceMetadata(
+				new Headers({ host: "localhost:2718" }),
 				flags as MCPOAuthFlags,
-				logger,
 				"/internal/mcp",
-			);
-
-			expect(auth.resource).toBe("http://localhost:2718/internal/mcp");
-			expect(
-				getProtectedResourceMetadata(
-					new Headers({ host: "localhost:2718" }),
-					flags as MCPOAuthFlags,
-					"/internal/mcp",
-				).resource,
-			).toBe("http://localhost:2718/internal/mcp");
-		} finally {
-			globalThis.fetch = originalFetch;
-		}
+			).resource,
+		).toBe("http://localhost:2718/internal/mcp");
 	});
 
 	test("missing static secret-key returns the auth error path", async () => {

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -1,10 +1,4 @@
-import { oauthClient } from "@autumn/shared";
-import {
-	oauthProviderAuthServerMetadata,
-	oauthProviderOpenIdConfigMetadata,
-} from "@better-auth/oauth-provider";
 import { httpInstrumentationMiddleware } from "@hono/otel";
-import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { autumnWebhookRouter } from "./external/autumn/autumnWebhookRouter.js";
@@ -19,6 +13,7 @@ import type { HonoEnv } from "./honoUtils/HonoEnv.js";
 import { handleHealthCheck } from "./honoUtils/handleHealthCheck.js";
 import { handleReadyCheck } from "./honoUtils/handleReadyCheck.js";
 import { handleListAuthOrganizations } from "./internal/auth/handleListAuthOrganizations.js";
+import { oauthRouter } from "./internal/auth/oauth/oauthRouter.js";
 import { cliRouter } from "./internal/dev/cli/cliRouter.js";
 import { handleOAuthCallback } from "./internal/orgs/handlers/stripeHandlers/handleOAuthCallback.js";
 import { apiRouter } from "./routers/apiRouter.js";
@@ -70,21 +65,7 @@ export const createHonoApp = () => {
 		}),
 	);
 
-	app.get("/api/auth/.well-known/openid-configuration", (c) => {
-		return oauthProviderOpenIdConfigMetadata(auth)(c.req.raw);
-	});
-
-	app.get("/.well-known/oauth-authorization-server", (c) => {
-		return oauthProviderAuthServerMetadata(auth)(c.req.raw);
-	});
-
-	app.get("/api/auth/.well-known/oauth-authorization-server", (c) => {
-		return oauthProviderAuthServerMetadata(auth)(c.req.raw);
-	});
-
-	app.get("/.well-known/oauth-authorization-server/api/auth", (c) => {
-		return oauthProviderAuthServerMetadata(auth)(c.req.raw);
-	});
+	app.route("", oauthRouter);
 
 	// Better Auth's joined Drizzle query defaults to 100 memberships.
 	app.get("/api/auth/organization/list", handleListAuthOrganizations);
@@ -110,33 +91,6 @@ export const createHonoApp = () => {
 	);
 	app.use("*", baseMiddleware);
 	app.use("*", replicaDbMiddleware);
-
-	// Public endpoint to get OAuth client name (for consent page)
-	app.get("/oauth/client/:client_id", async (c) => {
-		const clientId = c.req.param("client_id");
-		if (!clientId) {
-			return c.json({ error: "client_id is required" }, 400);
-		}
-
-		const db = c.get("ctx").db;
-		const client = await db
-			.select({
-				name: oauthClient.name,
-				clientId: oauthClient.clientId,
-			})
-			.from(oauthClient)
-			.where(eq(oauthClient.clientId, clientId))
-			.limit(1);
-
-		if (!client.length) {
-			return c.json({ error: "Client not found" }, 404);
-		}
-
-		return c.json({
-			client_id: client[0].clientId,
-			name: client[0].name || "Unknown Application",
-		});
-	});
 
 	// CLI routes (uses Bearer token auth, not session auth)
 	app.route("/cli", cliRouter);

--- a/server/src/internal/admin/handleListOAuthClients.ts
+++ b/server/src/internal/admin/handleListOAuthClients.ts
@@ -1,5 +1,5 @@
-import { oauthClient, Scopes } from "@autumn/shared";
-import { desc } from "drizzle-orm";
+import { Scopes } from "@autumn/shared";
+import { oauthClientRepo } from "@/internal/auth/repos/index.js";
 import { createRoute } from "../../honoMiddlewares/routeHandler";
 
 export const handleListOAuthClients = createRoute({
@@ -8,24 +8,7 @@ export const handleListOAuthClients = createRoute({
 		const ctx = c.get("ctx");
 		const { db } = ctx;
 
-		const clients = await db
-			.select({
-				id: oauthClient.id,
-				clientId: oauthClient.clientId,
-				name: oauthClient.name,
-				redirectUris: oauthClient.redirectUris,
-				public: oauthClient.public,
-				disabled: oauthClient.disabled,
-				skipConsent: oauthClient.skipConsent,
-				scopes: oauthClient.scopes,
-				tokenEndpointAuthMethod: oauthClient.tokenEndpointAuthMethod,
-				grantTypes: oauthClient.grantTypes,
-				responseTypes: oauthClient.responseTypes,
-				createdAt: oauthClient.createdAt,
-				updatedAt: oauthClient.updatedAt,
-			})
-			.from(oauthClient)
-			.orderBy(desc(oauthClient.createdAt));
+		const clients = await oauthClientRepo.listForAdmin({ db });
 
 		return c.json({
 			clients: clients.map((client) => ({

--- a/server/src/internal/auth/actions/index.ts
+++ b/server/src/internal/auth/actions/index.ts
@@ -1,0 +1,4 @@
+export {
+	isSafeOAuthRedirectUri,
+	registerMcpOAuthClient,
+} from "./registerMcpOAuthClient.js";

--- a/server/src/internal/auth/actions/registerMcpOAuthClient.ts
+++ b/server/src/internal/auth/actions/registerMcpOAuthClient.ts
@@ -236,12 +236,13 @@ export const registerMcpOAuthClient = async ({
 		return { error: "unsupported_mcp_client", status: 400 };
 	}
 
-	const cacheKey = `${info.type}:${[...redirectUris].sort().join("|")}`;
+	const requestedScopes = getRequestedScopes(scope);
+	const scopeKey = [...requestedScopes].sort().join(" ");
+	const cacheKey = `${info.type}:${[...redirectUris].sort().join("|")}:${scopeKey}`;
 	const cached = getCachedRegistration(cacheKey);
 	if (cached)
 		return { body: cached as RegistrationResponse["body"], status: 200 };
 
-	const requestedScopes = getRequestedScopes(scope);
 	const clients = await oauthClientRepo.list({ db });
 	const existingClient =
 		clients.find((client) => clientMatches({ client, info, redirectUris })) ??

--- a/server/src/internal/auth/actions/registerMcpOAuthClient.ts
+++ b/server/src/internal/auth/actions/registerMcpOAuthClient.ts
@@ -1,0 +1,315 @@
+import { ALL_SCOPES } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { generateId } from "@/utils/genUtils.js";
+import { type OAuthClientRecord, oauthClientRepo } from "../repos/index.js";
+
+const MCP_CLIENT_KIND = "mcp_client";
+const REGISTER_CACHE_TTL_MS = 5 * 60 * 1000;
+const DANGEROUS_REDIRECT_SCHEMES = new Set([
+	"javascript:",
+	"data:",
+	"vbscript:",
+]);
+
+type MpcClientType = "claude" | "codex" | "cursor" | "opencode" | "slack";
+
+type MpcClientInfo = {
+	type: MpcClientType;
+	name: string;
+	clientId: string;
+};
+
+type McpMetadata = {
+	kind?: string;
+	mcpClientType?: string;
+	redirectNames?: Record<string, string>;
+};
+
+type RegistrationResponse = {
+	body: {
+		client_id: string;
+		client_id_issued_at: number;
+		client_name: string | null;
+		redirect_uris: string[];
+		scope: string;
+		token_endpoint_auth_method: "none";
+		grant_types: ["authorization_code", "refresh_token"];
+		response_types: ["code"];
+		public: true;
+		type: "native";
+	};
+	status: 200 | 201;
+};
+
+const registerCache = new Map<string, { expiresAt: number; body: unknown }>();
+
+const parseMetadata = (metadata: unknown): McpMetadata => {
+	if (!metadata) return {};
+	if (typeof metadata === "string") {
+		try {
+			const parsed = JSON.parse(metadata);
+			return parsed && typeof parsed === "object" ? parsed : {};
+		} catch {
+			return {};
+		}
+	}
+
+	return typeof metadata === "object" ? metadata : {};
+};
+
+const isLocalhost = (hostname: string) =>
+	hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+
+export const isSafeOAuthRedirectUri = (redirectUri: string) => {
+	if (!URL.canParse(redirectUri)) return false;
+
+	const url = new URL(redirectUri);
+	if (DANGEROUS_REDIRECT_SCHEMES.has(url.protocol)) return false;
+	if (url.protocol === "http:") return isLocalhost(url.hostname);
+
+	return true;
+};
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+const classifyMcpClient = ({
+	clientName,
+	redirectUris,
+}: {
+	clientName: unknown;
+	redirectUris: string[];
+}): MpcClientInfo | null => {
+	const haystack = [
+		typeof clientName === "string" ? clientName : "",
+		...redirectUris,
+	]
+		.join(" ")
+		.toLowerCase();
+
+	if (haystack.includes("cursor")) {
+		return { type: "cursor", name: "Cursor", clientId: "autumn_mcp_cursor" };
+	}
+	if (haystack.includes("claude")) {
+		return { type: "claude", name: "Claude", clientId: "autumn_mcp_claude" };
+	}
+	if (
+		haystack.includes("opencode") ||
+		haystack.includes("open-code") ||
+		haystack.includes("open code")
+	) {
+		return {
+			type: "opencode",
+			name: "OpenCode",
+			clientId: "autumn_mcp_opencode",
+		};
+	}
+	if (haystack.includes("codex")) {
+		return { type: "codex", name: "Codex", clientId: "autumn_mcp_codex" };
+	}
+	if (haystack.includes("slack")) {
+		return { type: "slack", name: "Slack", clientId: "autumn_mcp_slack" };
+	}
+
+	return null;
+};
+
+const getRequestedScopes = (scope: unknown) => {
+	if (typeof scope !== "string" || !scope.trim()) return [...ALL_SCOPES];
+	const allowed = new Set(ALL_SCOPES);
+	return scope.split(" ").filter((scope) => allowed.has(scope as never));
+};
+
+const mergeMetadata = ({
+	client,
+	info,
+	redirectUris,
+}: {
+	client: OAuthClientRecord | null;
+	info: MpcClientInfo;
+	redirectUris: string[];
+}) => {
+	const existing = parseMetadata(client?.metadata);
+	const redirectNames = { ...(existing.redirectNames ?? {}) };
+	for (const redirectUri of redirectUris) {
+		redirectNames[redirectUri] = info.name;
+	}
+
+	return {
+		...existing,
+		kind: MCP_CLIENT_KIND,
+		mcpClientType: info.type,
+		redirectNames,
+	};
+};
+
+const clientMatches = ({
+	client,
+	info,
+	redirectUris,
+}: {
+	client: OAuthClientRecord;
+	info: MpcClientInfo;
+	redirectUris: string[];
+}) => {
+	const metadata = parseMetadata(client.metadata);
+	if (
+		metadata.kind === MCP_CLIENT_KIND &&
+		metadata.mcpClientType === info.type
+	) {
+		return true;
+	}
+	if (client.clientId === info.clientId) return true;
+
+	const requested = new Set(redirectUris);
+	const hasMatchingRedirectUri = client.redirectUris.some((redirectUri) =>
+		requested.has(redirectUri),
+	);
+	if (!hasMatchingRedirectUri) return false;
+
+	if (normalize(client.name ?? "") === normalize(info.name)) return true;
+	return (
+		classifyMcpClient({
+			clientName: client.name,
+			redirectUris: client.redirectUris,
+		})?.type === info.type
+	);
+};
+
+const getCachedRegistration = (cacheKey: string) => {
+	const cached = registerCache.get(cacheKey);
+	if (!cached || cached.expiresAt < Date.now()) {
+		registerCache.delete(cacheKey);
+		return null;
+	}
+
+	return cached.body;
+};
+
+const setCachedRegistration = (cacheKey: string, body: unknown) => {
+	registerCache.set(cacheKey, {
+		expiresAt: Date.now() + REGISTER_CACHE_TTL_MS,
+		body,
+	});
+};
+
+const getRegistrationResponse = (
+	client: OAuthClientRecord,
+	status: 200 | 201,
+): RegistrationResponse => ({
+	body: {
+		client_id: client.clientId,
+		client_id_issued_at: client.createdAt
+			? Math.floor(client.createdAt.getTime() / 1000)
+			: Math.floor(Date.now() / 1000),
+		client_name: client.name,
+		redirect_uris: client.redirectUris,
+		scope: client.scopes?.join(" ") ?? "",
+		token_endpoint_auth_method: "none",
+		grant_types: ["authorization_code", "refresh_token"],
+		response_types: ["code"],
+		public: true,
+		type: "native",
+	},
+	status,
+});
+
+export const registerMcpOAuthClient = async ({
+	db,
+	clientName,
+	redirectUris,
+	scope,
+}: {
+	db: DrizzleCli;
+	clientName: unknown;
+	redirectUris: string[];
+	scope: unknown;
+}): Promise<RegistrationResponse | { error: string; status: 400 }> => {
+	if (redirectUris.length === 0) {
+		return { error: "redirect_uris is required", status: 400 };
+	}
+	if (!redirectUris.every(isSafeOAuthRedirectUri)) {
+		return { error: "invalid_redirect_uri", status: 400 };
+	}
+
+	const info = classifyMcpClient({ clientName, redirectUris });
+	if (!info) {
+		return { error: "unsupported_mcp_client", status: 400 };
+	}
+
+	const cacheKey = `${info.type}:${[...redirectUris].sort().join("|")}`;
+	const cached = getCachedRegistration(cacheKey);
+	if (cached)
+		return { body: cached as RegistrationResponse["body"], status: 200 };
+
+	const requestedScopes = getRequestedScopes(scope);
+	const clients = await oauthClientRepo.list({ db });
+	const existingClient =
+		clients.find((client) => clientMatches({ client, info, redirectUris })) ??
+		null;
+	const now = new Date();
+
+	if (existingClient) {
+		const mergedRedirectUris = [
+			...new Set([...existingClient.redirectUris, ...redirectUris]),
+		];
+		const mergedScopes = [
+			...new Set([...(existingClient.scopes ?? []), ...requestedScopes]),
+		];
+
+		const updatedClient = await oauthClientRepo.updateById({
+			db,
+			id: existingClient.id,
+			updates: {
+				name: info.name,
+				redirectUris: mergedRedirectUris,
+				scopes: mergedScopes,
+				tokenEndpointAuthMethod: "none",
+				grantTypes: ["authorization_code", "refresh_token"],
+				responseTypes: ["code"],
+				public: true,
+				type: "native",
+				metadata: mergeMetadata({ client: existingClient, info, redirectUris }),
+				updatedAt: now,
+			},
+		});
+
+		const response = getRegistrationResponse(updatedClient!, 200);
+		setCachedRegistration(cacheKey, response.body);
+		return response;
+	}
+
+	const client = await oauthClientRepo.upsert({
+		db,
+		insert: {
+			id: generateId("oauth_client"),
+			clientId: info.clientId,
+			name: info.name,
+			redirectUris,
+			scopes: requestedScopes,
+			tokenEndpointAuthMethod: "none",
+			grantTypes: ["authorization_code", "refresh_token"],
+			responseTypes: ["code"],
+			public: true,
+			type: "native",
+			metadata: mergeMetadata({ client: null, info, redirectUris }),
+			createdAt: now,
+			updatedAt: now,
+		},
+		update: {
+			name: info.name,
+			redirectUris,
+			scopes: requestedScopes,
+			tokenEndpointAuthMethod: "none",
+			grantTypes: ["authorization_code", "refresh_token"],
+			responseTypes: ["code"],
+			public: true,
+			type: "native",
+			metadata: mergeMetadata({ client: null, info, redirectUris }),
+			updatedAt: now,
+		},
+	});
+
+	const response = getRegistrationResponse(client!, 201);
+	setCachedRegistration(cacheKey, response.body);
+	return response;
+};

--- a/server/src/internal/auth/oauth/atmnOAuthClients.ts
+++ b/server/src/internal/auth/oauth/atmnOAuthClients.ts
@@ -1,0 +1,60 @@
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { oauthClientRepo } from "../repos/index.js";
+
+const ATMN_OAUTH_CLIENT_NAMES = new Set(["atmn", "autumn cli"]);
+
+const configuredAtmnClientIds = () =>
+	new Set(
+		(process.env.ATMN_OAUTH_CLIENT_IDS ?? "")
+			.split(",")
+			.map((id) => id.trim())
+			.filter(Boolean),
+	);
+
+const metadataMarksAtmn = (metadata: unknown) => {
+	if (!metadata) return false;
+	let metadataObject = metadata;
+	if (typeof metadata === "string") {
+		try {
+			metadataObject = JSON.parse(metadata);
+		} catch {
+			return false;
+		}
+	}
+
+	if (!metadataObject || typeof metadataObject !== "object") return false;
+
+	const values = Object.values(metadataObject as Record<string, unknown>);
+	return values.some(
+		(value) =>
+			typeof value === "string" && ["atmn", "autumn-cli"].includes(value),
+	);
+};
+
+export const isAtmnOAuthClientRecord = ({
+	clientId,
+	name,
+	metadata,
+}: {
+	clientId: string | null | undefined;
+	name: string | null | undefined;
+	metadata?: unknown;
+}) => {
+	if (clientId && configuredAtmnClientIds().has(clientId)) return true;
+	if (metadataMarksAtmn(metadata)) return true;
+
+	const normalizedName = name?.trim().toLowerCase();
+	return !!normalizedName && ATMN_OAUTH_CLIENT_NAMES.has(normalizedName);
+};
+
+export const isAtmnOAuthClientId = async ({
+	db,
+	clientId,
+}: {
+	db: DrizzleCli;
+	clientId: string;
+}) => {
+	const client = await oauthClientRepo.getByClientId({ db, clientId });
+
+	return isAtmnOAuthClientRecord(client ?? { clientId, name: null });
+};

--- a/server/src/internal/auth/oauth/atmnOAuthClients.ts
+++ b/server/src/internal/auth/oauth/atmnOAuthClients.ts
@@ -24,10 +24,13 @@ const metadataMarksAtmn = (metadata: unknown) => {
 
 	if (!metadataObject || typeof metadataObject !== "object") return false;
 
-	const values = Object.values(metadataObject as Record<string, unknown>);
-	return values.some(
-		(value) =>
-			typeof value === "string" && ["atmn", "autumn-cli"].includes(value),
+	const metadataRecord = metadataObject as Record<string, unknown>;
+	return (
+		metadataRecord.kind === "atmn" ||
+		metadataRecord.client === "atmn" ||
+		metadataRecord.clientType === "atmn" ||
+		metadataRecord.client_type === "atmn" ||
+		metadataRecord.source === "autumn-cli"
 	);
 };
 

--- a/server/src/internal/auth/oauth/handleGetOAuthClient.ts
+++ b/server/src/internal/auth/oauth/handleGetOAuthClient.ts
@@ -20,15 +20,18 @@ export const handleGetOAuthClient = async (c: Context) => {
 		return c.json({ error: "Client not found" }, 404);
 	}
 
-	const internalMcpName = getInternalMcpDisplayName({
-		metadata: client.metadata,
-		redirectUri,
-	});
+	const isInternalMcp = isInternalMcpOAuthClientRecord(client);
+	const internalMcpName = isInternalMcp
+		? getInternalMcpDisplayName({
+				metadata: client.metadata,
+				redirectUri,
+			})
+		: null;
 
 	return c.json({
 		client_id: client.clientId,
 		name: internalMcpName || client.name || "Unknown Application",
 		is_atmn: isAtmnOAuthClientRecord(client),
-		is_internal_mcp: isInternalMcpOAuthClientRecord(client),
+		is_internal_mcp: isInternalMcp,
 	});
 };

--- a/server/src/internal/auth/oauth/handleGetOAuthClient.ts
+++ b/server/src/internal/auth/oauth/handleGetOAuthClient.ts
@@ -1,0 +1,34 @@
+import type { Context } from "hono";
+import { db } from "@/db/initDrizzle.js";
+import { oauthClientRepo } from "../repos/index.js";
+import { isAtmnOAuthClientRecord } from "./atmnOAuthClients.js";
+import {
+	getInternalMcpDisplayName,
+	isInternalMcpOAuthClientRecord,
+} from "./internalMcpOAuthClients.js";
+
+export const handleGetOAuthClient = async (c: Context) => {
+	const clientId = c.req.param("client_id");
+	const redirectUri = c.req.query("redirect_uri");
+	if (!clientId) {
+		return c.json({ error: "client_id is required" }, 400);
+	}
+
+	const client = await oauthClientRepo.getByClientId({ db, clientId });
+
+	if (!client) {
+		return c.json({ error: "Client not found" }, 404);
+	}
+
+	const internalMcpName = getInternalMcpDisplayName({
+		metadata: client.metadata,
+		redirectUri,
+	});
+
+	return c.json({
+		client_id: client.clientId,
+		name: internalMcpName || client.name || "Unknown Application",
+		is_atmn: isAtmnOAuthClientRecord(client),
+		is_internal_mcp: isInternalMcpOAuthClientRecord(client),
+	});
+};

--- a/server/src/internal/auth/oauth/handleMcpOAuthRegistration.ts
+++ b/server/src/internal/auth/oauth/handleMcpOAuthRegistration.ts
@@ -1,0 +1,35 @@
+import type { Context } from "hono";
+import { db } from "@/db/initDrizzle.js";
+import { registerMcpOAuthClient } from "../actions/index.js";
+
+type RegisterBody = {
+	redirect_uris?: unknown;
+	client_name?: unknown;
+	scope?: unknown;
+};
+
+const parseJsonObject = async (request: Request) => {
+	const body = await request.json().catch(() => null);
+	return body && typeof body === "object" ? (body as RegisterBody) : {};
+};
+
+const getRedirectUris = (value: unknown) =>
+	Array.isArray(value)
+		? value.filter((uri): uri is string => typeof uri === "string" && !!uri)
+		: [];
+
+export const handleMcpOAuthRegistration = async (c: Context) => {
+	const body = await parseJsonObject(c.req.raw);
+	const result = await registerMcpOAuthClient({
+		db,
+		clientName: body.client_name,
+		redirectUris: getRedirectUris(body.redirect_uris),
+		scope: body.scope,
+	});
+
+	if ("error" in result) {
+		return c.json({ error: result.error }, result.status);
+	}
+
+	return c.json(result.body, result.status);
+};

--- a/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
+++ b/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
@@ -1,0 +1,98 @@
+import { AppEnv } from "@autumn/shared";
+import type { Context } from "hono";
+import { db } from "@/db/initDrizzle.js";
+import { auth } from "@/utils/auth.js";
+import { oauthConsentRepo } from "../repos/index.js";
+import { isAtmnOAuthClientId } from "./atmnOAuthClients.js";
+
+type RequestFields = Record<string, unknown>;
+
+const parseRequestFields = async (request: Request) => {
+	const contentType = request.headers.get("content-type") ?? "";
+	const rawBody = await request.text();
+	if (!rawBody) return {};
+
+	if (contentType.includes("application/json")) {
+		try {
+			const body = JSON.parse(rawBody);
+			return body && typeof body === "object" ? (body as RequestFields) : {};
+		} catch {
+			return {};
+		}
+	}
+
+	const params = new URLSearchParams(rawBody);
+	return Object.fromEntries(params.entries());
+};
+
+const getString = (value: unknown) =>
+	typeof value === "string" && value.length > 0 ? value : null;
+
+const parseEnv = (value: unknown) => {
+	if (value === AppEnv.Live || value === AppEnv.Sandbox) return value;
+	return null;
+};
+
+const acceptedConsent = (value: unknown) => value === true || value === "true";
+
+const getNestedOAuthField = (value: unknown, key: string) => {
+	if (!value) return null;
+
+	if (typeof value === "string") {
+		try {
+			return getString(JSON.parse(value)?.[key]);
+		} catch {
+			return new URLSearchParams(value).get(key);
+		}
+	}
+
+	if (typeof value === "object") {
+		return getString((value as Record<string, unknown>)[key]);
+	}
+
+	return null;
+};
+
+const getClientIdFromFields = (fields: RequestFields) =>
+	getString(fields.client_id) ??
+	getNestedOAuthField(fields.oauth_query, "client_id");
+
+const getRedirectUriFromFields = (fields: RequestFields) =>
+	getString(fields.redirect_uri) ??
+	getString(fields.redirectUri) ??
+	getNestedOAuthField(fields.oauth_query, "redirect_uri");
+
+export const handleOAuthConsentWithEnv = async (c: Context) => {
+	const fields = await parseRequestFields(c.req.raw.clone());
+	const response = await auth.handler(c.req.raw);
+
+	if (!response.ok || !acceptedConsent(fields.accept)) {
+		return response;
+	}
+
+	const clientId = getClientIdFromFields(fields);
+	const redirectUri = getRedirectUriFromFields(fields);
+	const env = parseEnv(fields.env);
+	if (!clientId || !env || (await isAtmnOAuthClientId({ db, clientId }))) {
+		return response;
+	}
+
+	const session = await auth.api.getSession({
+		headers: c.req.raw.headers,
+	});
+
+	const userId = session?.user?.id;
+	const orgId = session?.session?.activeOrganizationId;
+	if (!userId || !orgId) return response;
+
+	await oauthConsentRepo.updateEnv({
+		db,
+		clientId,
+		userId,
+		referenceId: orgId,
+		env,
+		redirectUri,
+	});
+
+	return response;
+};

--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -1,0 +1,82 @@
+import { RecaseError } from "@autumn/shared";
+import type { Context } from "hono";
+import { db } from "@/db/initDrizzle.js";
+import { auth } from "@/utils/auth.js";
+import {
+	getExternalOAuthApiKeyForToken,
+	getOAuthAccessTokenRecord,
+	scopesFromOAuthScopeString,
+} from "./oauthAccessTokenApiKey.js";
+
+const getString = (value: unknown) =>
+	typeof value === "string" && value.length > 0 ? value : null;
+
+const getResourceFromTokenRequest = async (request: Request) => {
+	const contentType = request.headers.get("content-type") ?? "";
+	const rawBody = await request.text();
+	if (!rawBody) return null;
+
+	if (contentType.includes("application/json")) {
+		try {
+			const body = JSON.parse(rawBody) as Record<string, unknown>;
+			const resource = body.resource;
+			if (Array.isArray(resource)) return getString(resource[0]);
+			return getString(resource);
+		} catch {
+			return null;
+		}
+	}
+
+	const params = new URLSearchParams(rawBody);
+	return params.getAll("resource")[0] ?? null;
+};
+
+export const handleOAuthTokenWithApiKey = async (c: Context) => {
+	const resource = await getResourceFromTokenRequest(c.req.raw.clone());
+	const response = await auth.handler(c.req.raw);
+	if (!response.ok) return response;
+
+	let body: Record<string, unknown>;
+	try {
+		body = (await response.clone().json()) as Record<string, unknown>;
+	} catch {
+		return response;
+	}
+
+	const accessToken = getString(body.access_token);
+	if (!accessToken) return response;
+
+	const requestedScopes = scopesFromOAuthScopeString(body.scope);
+	let apiKeyResult: Awaited<ReturnType<typeof getExternalOAuthApiKeyForToken>>;
+	try {
+		const tokenRecord = await getOAuthAccessTokenRecord({
+			db,
+			accessToken,
+			resource,
+			requestedScopes,
+		});
+		apiKeyResult = await getExternalOAuthApiKeyForToken({
+			db,
+			tokenRecord,
+			requestedScopes,
+		});
+	} catch (error) {
+		if (error instanceof RecaseError) {
+			return c.json(
+				{
+					error: "invalid_grant",
+					error_description: error.message,
+				},
+				error.statusCode as 400 | 401 | 403,
+			);
+		}
+		throw error;
+	}
+	if (!apiKeyResult) return response;
+
+	return c.json({
+		...body,
+		access_token: apiKeyResult.apiKey,
+		scope: apiKeyResult.scopes.join(" "),
+	});
+};

--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -11,6 +11,66 @@ import {
 const getString = (value: unknown) =>
 	typeof value === "string" && value.length > 0 ? value : null;
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getTokenPayload = (body: Record<string, unknown>) => {
+	const response = body.response;
+	if (isRecord(response)) return response;
+	return body;
+};
+
+const rewriteTokenBody = ({
+	apiKey,
+	body,
+	scopes,
+}: {
+	apiKey: string;
+	body: Record<string, unknown>;
+	scopes: string[];
+}) => {
+	const response = body.response;
+	if (isRecord(response)) {
+		return {
+			...body,
+			response: {
+				...response,
+				access_token: apiKey,
+				scope: scopes.join(" "),
+			},
+		};
+	}
+
+	return {
+		...body,
+		access_token: apiKey,
+		scope: scopes.join(" "),
+	};
+};
+
+const tokenResponseHeaders = (response?: Response) => {
+	const headers = new Headers(response?.headers);
+	headers.set("Content-Type", "application/json");
+	headers.set("Cache-Control", "no-store");
+	headers.set("Pragma", "no-cache");
+	headers.delete("Content-Length");
+	return headers;
+};
+
+const jsonTokenResponse = ({
+	body,
+	response,
+	status,
+}: {
+	body: unknown;
+	response?: Response;
+	status: number;
+}) =>
+	new Response(JSON.stringify(body), {
+		status,
+		headers: tokenResponseHeaders(response),
+	});
+
 const getResourceFromTokenRequest = async (request: Request) => {
 	const contentType = request.headers.get("content-type") ?? "";
 	const rawBody = await request.text();
@@ -43,10 +103,11 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 		return response;
 	}
 
-	const accessToken = getString(body.access_token);
+	const tokenPayload = getTokenPayload(body);
+	const accessToken = getString(tokenPayload.access_token);
 	if (!accessToken) return response;
 
-	const requestedScopes = scopesFromOAuthScopeString(body.scope);
+	const requestedScopes = scopesFromOAuthScopeString(tokenPayload.scope);
 	let apiKeyResult: Awaited<ReturnType<typeof getExternalOAuthApiKeyForToken>>;
 	try {
 		const tokenRecord = await getOAuthAccessTokenRecord({
@@ -62,21 +123,25 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 		});
 	} catch (error) {
 		if (error instanceof RecaseError) {
-			return c.json(
-				{
+			return jsonTokenResponse({
+				body: {
 					error: "invalid_grant",
 					error_description: error.message,
 				},
-				error.statusCode as 400 | 401 | 403,
-			);
+				status: error.statusCode,
+			});
 		}
 		throw error;
 	}
 	if (!apiKeyResult) return response;
 
-	return c.json({
-		...body,
-		access_token: apiKeyResult.apiKey,
-		scope: apiKeyResult.scopes.join(" "),
+	return jsonTokenResponse({
+		body: rewriteTokenBody({
+			apiKey: apiKeyResult.apiKey,
+			body,
+			scopes: apiKeyResult.scopes,
+		}),
+		response,
+		status: response.status,
 	});
 };

--- a/server/src/internal/auth/oauth/internalMcpOAuthClients.ts
+++ b/server/src/internal/auth/oauth/internalMcpOAuthClients.ts
@@ -1,0 +1,103 @@
+import type { Context } from "hono";
+import { type DrizzleCli, db } from "@/db/initDrizzle.js";
+import { auth } from "@/utils/auth.js";
+import { oauthClientRepo } from "../repos/index.js";
+
+const INTERNAL_MCP_CLIENT_ID = process.env.INTERNAL_MCP_OAUTH_CLIENT_ID;
+const INTERNAL_MCP_CLIENT_NAME = "Autumn internal-mcp";
+const INTERNAL_MCP_CLIENT_NAME_NORMALIZED =
+	INTERNAL_MCP_CLIENT_NAME.toLowerCase();
+const INTERNAL_MCP_KIND = "internal_mcp";
+const MCP_CLIENT_KIND = "mcp_client";
+
+type InternalMcpMetadata = {
+	kind?: string;
+	mcpClientType?: string;
+	redirectNames?: Record<string, string>;
+};
+
+const parseMetadata = (metadata: unknown): InternalMcpMetadata => {
+	if (!metadata) return {};
+	if (typeof metadata === "string") {
+		try {
+			const parsed = JSON.parse(metadata);
+			return parsed && typeof parsed === "object" ? parsed : {};
+		} catch {
+			return {};
+		}
+	}
+
+	return typeof metadata === "object" ? metadata : {};
+};
+
+const inferClientNameFromRedirectUri = (redirectUri: string) => {
+	const normalized = redirectUri.toLowerCase();
+	if (normalized.includes("cursor")) return "Cursor";
+	if (normalized.includes("claude")) return "Claude";
+	if (normalized.includes("opencode")) return "OpenCode";
+	if (normalized.includes("open-code")) return "OpenCode";
+	if (normalized.includes("slack")) return "Slack";
+	if (normalized.includes("codex")) return "Codex";
+	return "MCP client";
+};
+
+export const isInternalMcpOAuthClientRecord = ({
+	clientId,
+	name,
+	metadata,
+}: {
+	clientId: string | null | undefined;
+	name: string | null | undefined;
+	metadata?: unknown;
+}) => {
+	if (INTERNAL_MCP_CLIENT_ID && clientId === INTERNAL_MCP_CLIENT_ID)
+		return true;
+	if (name?.trim().toLowerCase() === INTERNAL_MCP_CLIENT_NAME_NORMALIZED) {
+		return true;
+	}
+	const parsedMetadata = parseMetadata(metadata);
+	return [INTERNAL_MCP_KIND, MCP_CLIENT_KIND].includes(
+		parsedMetadata.kind ?? "",
+	);
+};
+
+export const getInternalMcpDisplayName = ({
+	metadata,
+	redirectUri,
+}: {
+	metadata: unknown;
+	redirectUri: string | null | undefined;
+}) => {
+	if (!redirectUri) return null;
+	const metadataObject = parseMetadata(metadata);
+	return (
+		metadataObject.redirectNames?.[redirectUri] ??
+		inferClientNameFromRedirectUri(redirectUri)
+	);
+};
+
+export const isInternalMcpOAuthClientId = async ({
+	db,
+	clientId,
+}: {
+	db: DrizzleCli;
+	clientId: string;
+}) => {
+	const client = await oauthClientRepo.getByClientId({ db, clientId });
+
+	return isInternalMcpOAuthClientRecord(client ?? { clientId, name: null });
+};
+
+export const handleInternalMcpOAuthAuthorize = async (c: Context) => {
+	const url = new URL(c.req.raw.url);
+	const clientId = url.searchParams.get("client_id");
+	if (!clientId || !(await isInternalMcpOAuthClientId({ db, clientId }))) {
+		return auth.handler(c.req.raw);
+	}
+
+	const prompts = new Set(url.searchParams.get("prompt")?.split(" ") ?? []);
+	prompts.add("consent");
+	url.searchParams.set("prompt", [...prompts].filter(Boolean).join(" "));
+
+	return auth.handler(new Request(url, c.req.raw));
+};

--- a/server/src/internal/auth/oauth/oauthAccessTokenApiKey.ts
+++ b/server/src/internal/auth/oauth/oauthAccessTokenApiKey.ts
@@ -1,0 +1,174 @@
+import {
+	AppEnv,
+	checkScopes,
+	ErrCode,
+	RecaseError,
+	type ScopeString,
+} from "@autumn/shared";
+import { verifyAccessToken } from "better-auth/oauth2";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	parseRequestedScopes,
+	type ResourceAccessTokenRecord,
+	tokenRecordFromResourceToken,
+} from "@/internal/dev/cli/oauthApiKeyUtils.js";
+import { hashOAuthToken } from "@/utils/oauthUtils.js";
+import { oauthAccessTokenRepo, oauthConsentRepo } from "../repos/index.js";
+import { isAtmnOAuthClientId } from "./atmnOAuthClients.js";
+import { getOrCreateOAuthConsentApiKey } from "./oauthConsentApiKey.js";
+
+const getOAuthIssuer = () =>
+	`${process.env.BETTER_AUTH_URL?.replace(/\/$/, "") ?? ""}/api/auth`;
+
+const verifyResourceAccessToken = async ({
+	accessToken,
+	resource,
+	requestedScopes,
+}: {
+	accessToken: string;
+	resource: string | null;
+	requestedScopes: ScopeString[] | null;
+}) => {
+	if (!resource) return null;
+
+	const issuer = getOAuthIssuer();
+	try {
+		const payload = await verifyAccessToken(accessToken, {
+			jwksUrl: `${issuer}/jwks`,
+			verifyOptions: {
+				audience: resource,
+				issuer,
+			},
+			scopes: requestedScopes ?? undefined,
+		});
+
+		return tokenRecordFromResourceToken(payload as Record<string, unknown>);
+	} catch {
+		return null;
+	}
+};
+
+export const getOAuthAccessTokenRecord = async ({
+	db,
+	accessToken,
+	resource,
+	requestedScopes,
+}: {
+	db: DrizzleCli;
+	accessToken: string;
+	resource: string | null;
+	requestedScopes: ScopeString[] | null;
+}) => {
+	const hashedToken = await hashOAuthToken(accessToken);
+	const tokenValues = [...new Set([hashedToken, accessToken])];
+	const tokenRecord =
+		(await oauthAccessTokenRepo.getValidByTokenValues({ db, tokenValues })) ??
+		(await verifyResourceAccessToken({
+			accessToken,
+			resource,
+			requestedScopes,
+		}));
+
+	if (!tokenRecord) {
+		throw new RecaseError({
+			message: "Invalid or expired access token",
+			code: ErrCode.InvalidRequest,
+			statusCode: 401,
+		});
+	}
+
+	if (requestedScopes) {
+		const { allowed, missing } = checkScopes(
+			requestedScopes,
+			tokenRecord.scopes,
+		);
+		if (!allowed) {
+			throw new RecaseError({
+				message: `Insufficient scopes. Missing: ${missing.join(", ")}`,
+				code: ErrCode.InsufficientScopes,
+				statusCode: 403,
+			});
+		}
+	}
+
+	const userId = tokenRecord.userId;
+	if (!userId) {
+		throw new RecaseError({
+			message: "Token missing user information",
+			code: ErrCode.InvalidRequest,
+			statusCode: 401,
+		});
+	}
+
+	const orgId = tokenRecord.referenceId;
+	if (!orgId) {
+		throw new RecaseError({
+			message: "No organization found. Please select an organization.",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	return tokenRecord as ResourceAccessTokenRecord & {
+		userId: string;
+		referenceId: string;
+	};
+};
+
+export const getExternalOAuthApiKeyForToken = async ({
+	db,
+	tokenRecord,
+	requestedScopes,
+}: {
+	db: DrizzleCli;
+	tokenRecord: ResourceAccessTokenRecord & {
+		userId: string;
+		referenceId: string;
+	};
+	requestedScopes: ScopeString[] | null;
+}) => {
+	const isAtmnClient = await isAtmnOAuthClientId({
+		db,
+		clientId: tokenRecord.clientId,
+	});
+	if (isAtmnClient) return null;
+
+	const consent = await oauthConsentRepo.getForClientUserOrg({
+		db,
+		clientId: tokenRecord.clientId,
+		userId: tokenRecord.userId,
+		referenceId: tokenRecord.referenceId,
+	});
+
+	if (!consent) {
+		throw new RecaseError({
+			message: "OAuth consent not found",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+
+	const env = consent.env ?? AppEnv.Sandbox;
+	const scopes = requestedScopes ?? (tokenRecord.scopes as ScopeString[]);
+	const apiKey = await getOrCreateOAuthConsentApiKey({
+		db,
+		consent,
+		tokenRecord,
+		env,
+		scopes,
+	});
+
+	return {
+		apiKey,
+		env,
+		orgId: tokenRecord.referenceId,
+		userId: tokenRecord.userId,
+		clientId: tokenRecord.clientId,
+		scopes,
+	};
+};
+
+export const scopesFromOAuthScopeString = (scope: unknown) => {
+	if (typeof scope !== "string") return null;
+	return parseRequestedScopes(scope.split(/\s+/).filter(Boolean));
+};

--- a/server/src/internal/auth/oauth/oauthAccessTokenApiKey.ts
+++ b/server/src/internal/auth/oauth/oauthAccessTokenApiKey.ts
@@ -15,7 +15,7 @@ import {
 import { hashOAuthToken } from "@/utils/oauthUtils.js";
 import { oauthAccessTokenRepo, oauthConsentRepo } from "../repos/index.js";
 import { isAtmnOAuthClientId } from "./atmnOAuthClients.js";
-import { getOrCreateOAuthConsentApiKey } from "./oauthConsentApiKey.js";
+import { rotateOAuthConsentApiKey } from "./oauthConsentApiKey.js";
 
 const getOAuthIssuer = () =>
 	`${process.env.BETTER_AUTH_URL?.replace(/\/$/, "") ?? ""}/api/auth`;
@@ -150,7 +150,7 @@ export const getExternalOAuthApiKeyForToken = async ({
 
 	const env = consent.env ?? AppEnv.Sandbox;
 	const scopes = requestedScopes ?? (tokenRecord.scopes as ScopeString[]);
-	const apiKey = await getOrCreateOAuthConsentApiKey({
+	const apiKey = await rotateOAuthConsentApiKey({
 		db,
 		consent,
 		tokenRecord,

--- a/server/src/internal/auth/oauth/oauthConsentApiKey.ts
+++ b/server/src/internal/auth/oauth/oauthConsentApiKey.ts
@@ -6,7 +6,6 @@ import {
 	hashApiKey,
 } from "@/internal/dev/api-keys/apiKeyUtils.js";
 import type { ResourceAccessTokenRecord } from "@/internal/dev/cli/oauthApiKeyUtils.js";
-import { decryptData, encryptData } from "@/utils/encryptUtils.js";
 import {
 	type OAuthConsentApiKeyRecord,
 	oauthApiKeyRepo,
@@ -14,9 +13,9 @@ import {
 	oauthConsentRepo,
 } from "../repos/index.js";
 
-const isKeyForEnv = (apiKey: string, env: AppEnv) => {
-	const prefix = env === AppEnv.Live ? ApiKeyPrefix.Live : ApiKeyPrefix.Sandbox;
-	return apiKey.startsWith(`${prefix}_`);
+type OAuthApiKeyTokenRecord = ResourceAccessTokenRecord & {
+	userId: string;
+	referenceId: string;
 };
 
 const getOAuthClientApiKeyName = async ({
@@ -40,7 +39,7 @@ const createConsentApiKey = async ({
 }: {
 	db: DrizzleCli;
 	consent: OAuthConsentApiKeyRecord;
-	tokenRecord: ResourceAccessTokenRecord;
+	tokenRecord: OAuthApiKeyTokenRecord;
 	env: AppEnv;
 	scopes: ScopeString[];
 }) => {
@@ -53,7 +52,7 @@ const createConsentApiKey = async ({
 		db,
 		env,
 		name: keyName,
-		orgId: tokenRecord.referenceId!,
+		orgId: tokenRecord.referenceId,
 		userId: tokenRecord.userId ?? undefined,
 		prefix,
 		meta: {
@@ -69,18 +68,21 @@ const createConsentApiKey = async ({
 
 	const hashedKey = hashApiKey(apiKey);
 	const apiKeyId = await oauthApiKeyRepo.getIdByHashedKey({ db, hashedKey });
+	if (!apiKeyId) {
+		throw new Error("OAuth API key was not persisted");
+	}
+
 	await oauthConsentRepo.updateApiKey({
 		db,
 		consentId: consent.id,
 		env,
 		oauthApiKeyId: apiKeyId,
-		oauthApiKey: encryptData(apiKey),
 	});
 
-	return apiKey;
+	return { apiKey, apiKeyId };
 };
 
-export const getOrCreateOAuthConsentApiKey = async ({
+export const rotateOAuthConsentApiKey = async ({
 	db,
 	consent,
 	tokenRecord,
@@ -89,48 +91,31 @@ export const getOrCreateOAuthConsentApiKey = async ({
 }: {
 	db: DrizzleCli;
 	consent: OAuthConsentApiKeyRecord;
-	tokenRecord: ResourceAccessTokenRecord;
+	tokenRecord: OAuthApiKeyTokenRecord;
 	env: AppEnv;
 	scopes: ScopeString[];
 }) => {
-	let existingApiKey: string | null = null;
-
-	if (consent.oauthApiKey) {
-		try {
-			existingApiKey = decryptData(consent.oauthApiKey);
-		} catch {
-			existingApiKey = null;
-		}
-	}
-
-	if (existingApiKey && isKeyForEnv(existingApiKey, env)) {
-		const keyName = await getOAuthClientApiKeyName({
-			db,
-			clientId: tokenRecord.clientId,
-		});
-		const apiKeyId = await oauthApiKeyRepo.updateLinkedScopes({
-			db,
-			apiKeyId: consent.oauthApiKeyId,
-			apiKey: existingApiKey,
-			scopes,
-			name: keyName,
-		});
-
-		if (apiKeyId) {
-			await oauthConsentRepo.updateApiKeyId({
-				db,
-				consentId: consent.id,
-				oauthApiKeyId: apiKeyId,
-			});
-			return existingApiKey;
-		}
-	}
-
-	await oauthApiKeyRepo.deleteLinked({
+	const previousApiKeyId = consent.oauthApiKeyId;
+	const { apiKey, apiKeyId } = await createConsentApiKey({
 		db,
-		apiKeyId: consent.oauthApiKeyId,
-		apiKey: existingApiKey,
+		consent,
+		tokenRecord,
+		env,
+		scopes,
 	});
 
-	return createConsentApiKey({ db, consent, tokenRecord, env, scopes });
+	if (previousApiKeyId && previousApiKeyId !== apiKeyId) {
+		await oauthApiKeyRepo.deleteConsentLinked({
+			db,
+			apiKeyId: previousApiKeyId,
+			consentId: consent.id,
+			clientId: tokenRecord.clientId,
+			redirectUri: consent.redirectUri,
+			orgId: tokenRecord.referenceId,
+			userId: tokenRecord.userId,
+			env,
+		});
+	}
+
+	return apiKey;
 };

--- a/server/src/internal/auth/oauth/oauthConsentApiKey.ts
+++ b/server/src/internal/auth/oauth/oauthConsentApiKey.ts
@@ -1,0 +1,136 @@
+import { AppEnv, type ScopeString } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	ApiKeyPrefix,
+	createKey,
+	hashApiKey,
+} from "@/internal/dev/api-keys/apiKeyUtils.js";
+import type { ResourceAccessTokenRecord } from "@/internal/dev/cli/oauthApiKeyUtils.js";
+import { decryptData, encryptData } from "@/utils/encryptUtils.js";
+import {
+	type OAuthConsentApiKeyRecord,
+	oauthApiKeyRepo,
+	oauthClientRepo,
+	oauthConsentRepo,
+} from "../repos/index.js";
+
+const isKeyForEnv = (apiKey: string, env: AppEnv) => {
+	const prefix = env === AppEnv.Live ? ApiKeyPrefix.Live : ApiKeyPrefix.Sandbox;
+	return apiKey.startsWith(`${prefix}_`);
+};
+
+const getOAuthClientApiKeyName = async ({
+	db,
+	clientId,
+}: {
+	db: DrizzleCli;
+	clientId: string;
+}) => {
+	const client = await oauthClientRepo.getByClientId({ db, clientId });
+
+	return `OAuth Key - ${client?.name || clientId.slice(0, 8)}`;
+};
+
+const createConsentApiKey = async ({
+	db,
+	consent,
+	tokenRecord,
+	env,
+	scopes,
+}: {
+	db: DrizzleCli;
+	consent: OAuthConsentApiKeyRecord;
+	tokenRecord: ResourceAccessTokenRecord;
+	env: AppEnv;
+	scopes: ScopeString[];
+}) => {
+	const prefix = env === AppEnv.Live ? ApiKeyPrefix.Live : ApiKeyPrefix.Sandbox;
+	const keyName = await getOAuthClientApiKeyName({
+		db,
+		clientId: tokenRecord.clientId,
+	});
+	const apiKey = await createKey({
+		db,
+		env,
+		name: keyName,
+		orgId: tokenRecord.referenceId!,
+		userId: tokenRecord.userId ?? undefined,
+		prefix,
+		meta: {
+			oauth_consent_id: consent.id,
+			oauth_client_id: tokenRecord.clientId,
+			oauth_redirect_uri: consent.redirectUri,
+			created_via: "oauth",
+			generatedAt: new Date().toISOString(),
+			env,
+		},
+		scopes,
+	});
+
+	const hashedKey = hashApiKey(apiKey);
+	const apiKeyId = await oauthApiKeyRepo.getIdByHashedKey({ db, hashedKey });
+	await oauthConsentRepo.updateApiKey({
+		db,
+		consentId: consent.id,
+		env,
+		oauthApiKeyId: apiKeyId,
+		oauthApiKey: encryptData(apiKey),
+	});
+
+	return apiKey;
+};
+
+export const getOrCreateOAuthConsentApiKey = async ({
+	db,
+	consent,
+	tokenRecord,
+	env,
+	scopes,
+}: {
+	db: DrizzleCli;
+	consent: OAuthConsentApiKeyRecord;
+	tokenRecord: ResourceAccessTokenRecord;
+	env: AppEnv;
+	scopes: ScopeString[];
+}) => {
+	let existingApiKey: string | null = null;
+
+	if (consent.oauthApiKey) {
+		try {
+			existingApiKey = decryptData(consent.oauthApiKey);
+		} catch {
+			existingApiKey = null;
+		}
+	}
+
+	if (existingApiKey && isKeyForEnv(existingApiKey, env)) {
+		const keyName = await getOAuthClientApiKeyName({
+			db,
+			clientId: tokenRecord.clientId,
+		});
+		const apiKeyId = await oauthApiKeyRepo.updateLinkedScopes({
+			db,
+			apiKeyId: consent.oauthApiKeyId,
+			apiKey: existingApiKey,
+			scopes,
+			name: keyName,
+		});
+
+		if (apiKeyId) {
+			await oauthConsentRepo.updateApiKeyId({
+				db,
+				consentId: consent.id,
+				oauthApiKeyId: apiKeyId,
+			});
+			return existingApiKey;
+		}
+	}
+
+	await oauthApiKeyRepo.deleteLinked({
+		db,
+		apiKeyId: consent.oauthApiKeyId,
+		apiKey: existingApiKey,
+	});
+
+	return createConsentApiKey({ db, consent, tokenRecord, env, scopes });
+};

--- a/server/src/internal/auth/oauth/oauthRouter.ts
+++ b/server/src/internal/auth/oauth/oauthRouter.ts
@@ -1,0 +1,55 @@
+import {
+	oauthProviderAuthServerMetadata,
+	oauthProviderOpenIdConfigMetadata,
+} from "@better-auth/oauth-provider";
+import { type Context, Hono } from "hono";
+import { rateLimiter } from "hono-rate-limiter";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { auth } from "@/utils/auth.js";
+import { handleGetOAuthClient } from "./handleGetOAuthClient.js";
+import { handleMcpOAuthRegistration } from "./handleMcpOAuthRegistration.js";
+import { handleOAuthConsentWithEnv } from "./handleOAuthConsentWithEnv.js";
+import { handleOAuthTokenWithApiKey } from "./handleOAuthTokenWithApiKey.js";
+import { handleInternalMcpOAuthAuthorize } from "./internalMcpOAuthClients.js";
+
+export const oauthRouter = new Hono<HonoEnv>();
+
+const getClientLookupRateLimitKey = (c: Context<HonoEnv>) =>
+	c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+	c.req.header("x-real-ip") ??
+	c.req.header("cf-connecting-ip") ??
+	"unknown";
+
+const oauthClientLookupLimiter = rateLimiter<HonoEnv>({
+	windowMs: 60 * 1000,
+	limit: process.env.NODE_ENV === "development" ? 1000 : 60,
+	standardHeaders: "draft-6",
+	keyGenerator: getClientLookupRateLimitKey,
+});
+
+oauthRouter.get("/api/auth/.well-known/openid-configuration", (c) => {
+	return oauthProviderOpenIdConfigMetadata(auth)(c.req.raw);
+});
+
+oauthRouter.get("/.well-known/oauth-authorization-server", (c) => {
+	return oauthProviderAuthServerMetadata(auth)(c.req.raw);
+});
+
+oauthRouter.get("/api/auth/.well-known/oauth-authorization-server", (c) => {
+	return oauthProviderAuthServerMetadata(auth)(c.req.raw);
+});
+
+oauthRouter.get("/.well-known/oauth-authorization-server/api/auth", (c) => {
+	return oauthProviderAuthServerMetadata(auth)(c.req.raw);
+});
+
+oauthRouter.post("/api/auth/oauth2/consent", handleOAuthConsentWithEnv);
+oauthRouter.post("/api/auth/oauth2/token", handleOAuthTokenWithApiKey);
+oauthRouter.get("/api/auth/oauth2/authorize", handleInternalMcpOAuthAuthorize);
+oauthRouter.post("/api/auth/oauth2/register", handleMcpOAuthRegistration);
+
+oauthRouter.get(
+	"/oauth/client/:client_id",
+	oauthClientLookupLimiter,
+	handleGetOAuthClient,
+);

--- a/server/src/internal/auth/repos/index.ts
+++ b/server/src/internal/auth/repos/index.ts
@@ -1,0 +1,11 @@
+export { oauthAccessTokenRepo } from "./oauthAccessTokenRepo.js";
+export { oauthApiKeyRepo } from "./oauthApiKeyRepo.js";
+export {
+	type OAuthClientRecord,
+	oauthClientRepo,
+} from "./oauthClientRepo.js";
+export {
+	type OAuthConsentApiKeyRecord,
+	oauthConsentRepo,
+} from "./oauthConsentRepo.js";
+export { oauthRefreshTokenRepo } from "./oauthRefreshTokenRepo.js";

--- a/server/src/internal/auth/repos/oauthAccessTokenRepo.ts
+++ b/server/src/internal/auth/repos/oauthAccessTokenRepo.ts
@@ -1,0 +1,49 @@
+import { oauthAccessToken } from "@autumn/shared";
+import { and, eq, gt, inArray, isNull } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export const getValidOAuthAccessTokenByTokenValues = async ({
+	db,
+	tokenValues,
+}: {
+	db: DrizzleCli;
+	tokenValues: string[];
+}) => {
+	const [token] = await db
+		.select()
+		.from(oauthAccessToken)
+		.where(
+			and(
+				inArray(oauthAccessToken.token, tokenValues),
+				gt(oauthAccessToken.expiresAt, new Date()),
+			),
+		)
+		.limit(1);
+
+	return token ?? null;
+};
+
+export const deleteOAuthAccessTokensByClientAndReference = async ({
+	db,
+	clientId,
+	referenceId,
+}: {
+	db: DrizzleCli;
+	clientId: string;
+	referenceId: string | null;
+}) =>
+	db
+		.delete(oauthAccessToken)
+		.where(
+			and(
+				eq(oauthAccessToken.clientId, clientId),
+				referenceId
+					? eq(oauthAccessToken.referenceId, referenceId)
+					: isNull(oauthAccessToken.referenceId),
+			),
+		);
+
+export const oauthAccessTokenRepo = {
+	getValidByTokenValues: getValidOAuthAccessTokenByTokenValues,
+	deleteByClientAndReference: deleteOAuthAccessTokensByClientAndReference,
+};

--- a/server/src/internal/auth/repos/oauthApiKeyRepo.ts
+++ b/server/src/internal/auth/repos/oauthApiKeyRepo.ts
@@ -1,0 +1,107 @@
+import { apiKeys } from "@autumn/shared";
+import { eq, or, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { hashApiKey } from "@/internal/dev/api-keys/apiKeyUtils.js";
+import { clearSecretKeyCache } from "@/internal/dev/api-keys/cacheApiKeyUtils.js";
+
+export const deleteOAuthLinkedApiKey = async ({
+	db,
+	apiKeyId,
+	apiKey,
+}: {
+	db: DrizzleCli;
+	apiKeyId: string | null;
+	apiKey: string | null;
+}) => {
+	const hashedKey = apiKey ? hashApiKey(apiKey) : null;
+	const conditions = [
+		apiKeyId ? eq(apiKeys.id, apiKeyId) : null,
+		hashedKey ? eq(apiKeys.hashed_key, hashedKey) : null,
+	].filter((condition) => condition !== null);
+
+	if (conditions.length > 0) {
+		await db.delete(apiKeys).where(or(...conditions));
+	}
+
+	if (hashedKey) {
+		await clearSecretKeyCache({ hashedKey });
+	}
+};
+
+export const listOAuthApiKeysByConsentId = async ({
+	db,
+	consentId,
+}: {
+	db: DrizzleCli;
+	consentId: string;
+}) =>
+	db
+		.select({
+			id: apiKeys.id,
+			prefix: apiKeys.prefix,
+			env: apiKeys.env,
+			name: apiKeys.name,
+			hashed_key: apiKeys.hashed_key,
+		})
+		.from(apiKeys)
+		.where(sql`${apiKeys.meta}->>'oauth_consent_id' = ${consentId}`);
+
+export const deleteOAuthApiKeyById = async ({
+	db,
+	apiKeyId,
+}: {
+	db: DrizzleCli;
+	apiKeyId: string;
+}) => db.delete(apiKeys).where(eq(apiKeys.id, apiKeyId));
+
+export const updateOAuthLinkedApiKeyScopes = async ({
+	db,
+	apiKeyId,
+	apiKey,
+	scopes,
+	name,
+}: {
+	db: DrizzleCli;
+	apiKeyId: string | null;
+	apiKey: string;
+	scopes: string[];
+	name: string;
+}) => {
+	const hashedKey = hashApiKey(apiKey);
+	const conditions = [
+		apiKeyId ? eq(apiKeys.id, apiKeyId) : null,
+		eq(apiKeys.hashed_key, hashedKey),
+	].filter((condition) => condition !== null);
+
+	const [updatedKey] = await db
+		.update(apiKeys)
+		.set({ name, scopes })
+		.where(or(...conditions))
+		.returning({ id: apiKeys.id });
+
+	return updatedKey?.id ?? null;
+};
+
+export const getApiKeyIdByHashedKey = async ({
+	db,
+	hashedKey,
+}: {
+	db: DrizzleCli;
+	hashedKey: string;
+}) => {
+	const [keyRecord] = await db
+		.select({ id: apiKeys.id })
+		.from(apiKeys)
+		.where(eq(apiKeys.hashed_key, hashedKey))
+		.limit(1);
+
+	return keyRecord?.id ?? null;
+};
+
+export const oauthApiKeyRepo = {
+	listByConsentId: listOAuthApiKeysByConsentId,
+	deleteById: deleteOAuthApiKeyById,
+	deleteLinked: deleteOAuthLinkedApiKey,
+	updateLinkedScopes: updateOAuthLinkedApiKeyScopes,
+	getIdByHashedKey: getApiKeyIdByHashedKey,
+};

--- a/server/src/internal/auth/repos/oauthApiKeyRepo.ts
+++ b/server/src/internal/auth/repos/oauthApiKeyRepo.ts
@@ -1,31 +1,109 @@
-import { apiKeys } from "@autumn/shared";
-import { eq, or, sql } from "drizzle-orm";
+import { type AppEnv, apiKeys } from "@autumn/shared";
+import { eq, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
-import { hashApiKey } from "@/internal/dev/api-keys/apiKeyUtils.js";
 import { clearSecretKeyCache } from "@/internal/dev/api-keys/cacheApiKeyUtils.js";
 
-export const deleteOAuthLinkedApiKey = async ({
+type OAuthApiKeyRecord = {
+	id: string;
+	orgId: string | null;
+	userId: string | null;
+	env: string | null;
+	hashedKey: string | null;
+	meta: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const isOAuthConsentLinkedApiKey = ({
+	apiKey,
+	consentId,
+	clientId,
+	redirectUri,
+	orgId,
+	userId,
+	env,
+}: {
+	apiKey: OAuthApiKeyRecord;
+	consentId: string;
+	clientId: string;
+	redirectUri: string | null;
+	orgId: string;
+	userId: string;
+	env: AppEnv;
+}) => {
+	if (
+		apiKey.orgId !== orgId ||
+		apiKey.userId !== userId ||
+		apiKey.env !== env ||
+		!isRecord(apiKey.meta)
+	) {
+		return false;
+	}
+
+	return (
+		apiKey.meta.created_via === "oauth" &&
+		apiKey.meta.oauth_consent_id === consentId &&
+		apiKey.meta.oauth_client_id === clientId &&
+		apiKey.meta.oauth_redirect_uri === redirectUri &&
+		apiKey.meta.env === env
+	);
+};
+
+export const deleteOAuthConsentLinkedApiKey = async ({
 	db,
 	apiKeyId,
-	apiKey,
+	consentId,
+	clientId,
+	redirectUri,
+	orgId,
+	userId,
+	env,
 }: {
 	db: DrizzleCli;
-	apiKeyId: string | null;
-	apiKey: string | null;
+	apiKeyId: string;
+	consentId: string;
+	clientId: string;
+	redirectUri: string | null;
+	orgId: string;
+	userId: string;
+	env: AppEnv;
 }) => {
-	const hashedKey = apiKey ? hashApiKey(apiKey) : null;
-	const conditions = [
-		apiKeyId ? eq(apiKeys.id, apiKeyId) : null,
-		hashedKey ? eq(apiKeys.hashed_key, hashedKey) : null,
-	].filter((condition) => condition !== null);
+	const [apiKey] = await db
+		.select({
+			id: apiKeys.id,
+			orgId: apiKeys.org_id,
+			userId: apiKeys.user_id,
+			env: apiKeys.env,
+			hashedKey: apiKeys.hashed_key,
+			meta: apiKeys.meta,
+		})
+		.from(apiKeys)
+		.where(eq(apiKeys.id, apiKeyId))
+		.limit(1);
 
-	if (conditions.length > 0) {
-		await db.delete(apiKeys).where(or(...conditions));
+	if (!apiKey) return { deleted: false, reason: "not_found" as const };
+
+	if (
+		!isOAuthConsentLinkedApiKey({
+			apiKey,
+			consentId,
+			clientId,
+			redirectUri,
+			orgId,
+			userId,
+			env,
+		})
+	) {
+		return { deleted: false, reason: "guard_failed" as const };
 	}
 
-	if (hashedKey) {
-		await clearSecretKeyCache({ hashedKey });
-	}
+	await db.delete(apiKeys).where(eq(apiKeys.id, apiKeyId));
+
+	if (apiKey.hashedKey)
+		await clearSecretKeyCache({ hashedKey: apiKey.hashedKey });
+
+	return { deleted: true, reason: null };
 };
 
 export const listOAuthApiKeysByConsentId = async ({
@@ -54,34 +132,6 @@ export const deleteOAuthApiKeyById = async ({
 	apiKeyId: string;
 }) => db.delete(apiKeys).where(eq(apiKeys.id, apiKeyId));
 
-export const updateOAuthLinkedApiKeyScopes = async ({
-	db,
-	apiKeyId,
-	apiKey,
-	scopes,
-	name,
-}: {
-	db: DrizzleCli;
-	apiKeyId: string | null;
-	apiKey: string;
-	scopes: string[];
-	name: string;
-}) => {
-	const hashedKey = hashApiKey(apiKey);
-	const conditions = [
-		apiKeyId ? eq(apiKeys.id, apiKeyId) : null,
-		eq(apiKeys.hashed_key, hashedKey),
-	].filter((condition) => condition !== null);
-
-	const [updatedKey] = await db
-		.update(apiKeys)
-		.set({ name, scopes })
-		.where(or(...conditions))
-		.returning({ id: apiKeys.id });
-
-	return updatedKey?.id ?? null;
-};
-
 export const getApiKeyIdByHashedKey = async ({
 	db,
 	hashedKey,
@@ -101,7 +151,6 @@ export const getApiKeyIdByHashedKey = async ({
 export const oauthApiKeyRepo = {
 	listByConsentId: listOAuthApiKeysByConsentId,
 	deleteById: deleteOAuthApiKeyById,
-	deleteLinked: deleteOAuthLinkedApiKey,
-	updateLinkedScopes: updateOAuthLinkedApiKeyScopes,
+	deleteConsentLinked: deleteOAuthConsentLinkedApiKey,
 	getIdByHashedKey: getApiKeyIdByHashedKey,
 };

--- a/server/src/internal/auth/repos/oauthClientRepo.ts
+++ b/server/src/internal/auth/repos/oauthClientRepo.ts
@@ -1,0 +1,141 @@
+import { oauthClient } from "@autumn/shared";
+import { desc, eq } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export type OAuthClientRecord = {
+	id: string;
+	clientId: string;
+	name: string | null;
+	redirectUris: string[];
+	scopes: string[] | null;
+	metadata: unknown;
+	createdAt: Date | null;
+};
+
+const oauthClientSelect = {
+	id: oauthClient.id,
+	clientId: oauthClient.clientId,
+	name: oauthClient.name,
+	redirectUris: oauthClient.redirectUris,
+	scopes: oauthClient.scopes,
+	metadata: oauthClient.metadata,
+	createdAt: oauthClient.createdAt,
+};
+
+export const listOAuthClients = async ({ db }: { db: DrizzleCli }) =>
+	db.select(oauthClientSelect).from(oauthClient);
+
+export const listOAuthClientsForAdmin = async ({ db }: { db: DrizzleCli }) =>
+	db
+		.select({
+			id: oauthClient.id,
+			clientId: oauthClient.clientId,
+			name: oauthClient.name,
+			redirectUris: oauthClient.redirectUris,
+			public: oauthClient.public,
+			disabled: oauthClient.disabled,
+			skipConsent: oauthClient.skipConsent,
+			scopes: oauthClient.scopes,
+			tokenEndpointAuthMethod: oauthClient.tokenEndpointAuthMethod,
+			grantTypes: oauthClient.grantTypes,
+			responseTypes: oauthClient.responseTypes,
+			createdAt: oauthClient.createdAt,
+			updatedAt: oauthClient.updatedAt,
+		})
+		.from(oauthClient)
+		.orderBy(desc(oauthClient.createdAt));
+
+export const getOAuthClientByClientId = async ({
+	db,
+	clientId,
+}: {
+	db: DrizzleCli;
+	clientId: string;
+}) => {
+	const [client] = await db
+		.select(oauthClientSelect)
+		.from(oauthClient)
+		.where(eq(oauthClient.clientId, clientId))
+		.limit(1);
+
+	return client ?? null;
+};
+
+export const updateOAuthClientById = async ({
+	db,
+	id,
+	updates,
+}: {
+	db: DrizzleCli;
+	id: string;
+	updates: {
+		name: string;
+		redirectUris: string[];
+		scopes: string[];
+		tokenEndpointAuthMethod: string;
+		grantTypes: string[];
+		responseTypes: string[];
+		public: boolean;
+		type: string;
+		metadata: unknown;
+		updatedAt: Date;
+	};
+}) => {
+	const [client] = await db
+		.update(oauthClient)
+		.set(updates)
+		.where(eq(oauthClient.id, id))
+		.returning(oauthClientSelect);
+
+	return client ?? null;
+};
+
+export const upsertOAuthClient = async ({
+	db,
+	insert,
+	update,
+}: {
+	db: DrizzleCli;
+	insert: {
+		id: string;
+		clientId: string;
+		name: string;
+		redirectUris: string[];
+		scopes: string[];
+		tokenEndpointAuthMethod: string;
+		grantTypes: string[];
+		responseTypes: string[];
+		public: boolean;
+		type: string;
+		metadata: unknown;
+		createdAt: Date;
+		updatedAt: Date;
+	};
+	update: {
+		name: string;
+		redirectUris: string[];
+		scopes: string[];
+		tokenEndpointAuthMethod: string;
+		grantTypes: string[];
+		responseTypes: string[];
+		public: boolean;
+		type: string;
+		metadata: unknown;
+		updatedAt: Date;
+	};
+}) => {
+	await db.insert(oauthClient).values(insert).onConflictDoUpdate({
+		target: oauthClient.clientId,
+		set: update,
+	});
+
+	return getOAuthClientByClientId({ db, clientId: insert.clientId });
+};
+
+export const oauthClientRepo = {
+	list: listOAuthClients,
+	listForAdmin: listOAuthClientsForAdmin,
+	getByClientId: getOAuthClientByClientId,
+	updateById: updateOAuthClientById,
+	upsert: upsertOAuthClient,
+};

--- a/server/src/internal/auth/repos/oauthConsentRepo.ts
+++ b/server/src/internal/auth/repos/oauthConsentRepo.ts
@@ -1,0 +1,164 @@
+import { type AppEnv, oauthConsent } from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export type OAuthConsentApiKeyRecord = {
+	id: string;
+	env: AppEnv | null;
+	oauthApiKeyId: string | null;
+	oauthApiKey: string | null;
+	redirectUri: string | null;
+};
+
+export const listOAuthConsentsByReferenceId = async ({
+	db,
+	referenceId,
+}: {
+	db: DrizzleCli;
+	referenceId: string;
+}) =>
+	db
+		.select({
+			id: oauthConsent.id,
+			clientId: oauthConsent.clientId,
+			userId: oauthConsent.userId,
+			referenceId: oauthConsent.referenceId,
+			scopes: oauthConsent.scopes,
+			createdAt: oauthConsent.createdAt,
+			updatedAt: oauthConsent.updatedAt,
+		})
+		.from(oauthConsent)
+		.where(eq(oauthConsent.referenceId, referenceId));
+
+export const getOAuthConsentOwner = async ({
+	db,
+	consentId,
+}: {
+	db: DrizzleCli;
+	consentId: string;
+}) => {
+	const [consent] = await db
+		.select({
+			id: oauthConsent.id,
+			clientId: oauthConsent.clientId,
+			referenceId: oauthConsent.referenceId,
+		})
+		.from(oauthConsent)
+		.where(eq(oauthConsent.id, consentId))
+		.limit(1);
+
+	return consent ?? null;
+};
+
+export const updateOAuthConsentEnv = async ({
+	db,
+	clientId,
+	userId,
+	referenceId,
+	env,
+	redirectUri,
+}: {
+	db: DrizzleCli;
+	clientId: string;
+	userId: string;
+	referenceId: string;
+	env: AppEnv;
+	redirectUri: string | null;
+}) =>
+	db
+		.update(oauthConsent)
+		.set({ env, redirectUri, updatedAt: new Date() })
+		.where(
+			and(
+				eq(oauthConsent.clientId, clientId),
+				eq(oauthConsent.userId, userId),
+				eq(oauthConsent.referenceId, referenceId),
+			),
+		);
+
+export const getOAuthConsentForClientUserOrg = async ({
+	db,
+	clientId,
+	userId,
+	referenceId,
+}: {
+	db: DrizzleCli;
+	clientId: string;
+	userId: string;
+	referenceId: string;
+}) => {
+	const [consent] = await db
+		.select({
+			id: oauthConsent.id,
+			env: oauthConsent.env,
+			oauthApiKeyId: oauthConsent.oauthApiKeyId,
+			oauthApiKey: oauthConsent.oauthApiKey,
+			redirectUri: oauthConsent.redirectUri,
+		})
+		.from(oauthConsent)
+		.where(
+			and(
+				eq(oauthConsent.clientId, clientId),
+				eq(oauthConsent.userId, userId),
+				eq(oauthConsent.referenceId, referenceId),
+			),
+		)
+		.limit(1);
+
+	return consent ?? null;
+};
+
+export const updateOAuthConsentApiKey = async ({
+	db,
+	consentId,
+	env,
+	oauthApiKeyId,
+	oauthApiKey,
+}: {
+	db: DrizzleCli;
+	consentId: string;
+	env: AppEnv;
+	oauthApiKeyId: string | null;
+	oauthApiKey: string;
+}) =>
+	db
+		.update(oauthConsent)
+		.set({
+			env,
+			oauthApiKeyId,
+			oauthApiKey,
+			updatedAt: new Date(),
+		})
+		.where(eq(oauthConsent.id, consentId));
+
+export const updateOAuthConsentApiKeyId = async ({
+	db,
+	consentId,
+	oauthApiKeyId,
+}: {
+	db: DrizzleCli;
+	consentId: string;
+	oauthApiKeyId: string;
+}) =>
+	db
+		.update(oauthConsent)
+		.set({ oauthApiKeyId, updatedAt: new Date() })
+		.where(eq(oauthConsent.id, consentId));
+
+export const deleteOAuthConsentById = async ({
+	db,
+	consentId,
+}: {
+	db: DrizzleCli;
+	consentId: string;
+}) => db.delete(oauthConsent).where(eq(oauthConsent.id, consentId));
+
+export const oauthConsentRepo = {
+	listByReferenceId: listOAuthConsentsByReferenceId,
+	getOwner: getOAuthConsentOwner,
+	updateEnv: updateOAuthConsentEnv,
+	getForClientUserOrg: getOAuthConsentForClientUserOrg,
+	updateApiKey: updateOAuthConsentApiKey,
+	updateApiKeyId: updateOAuthConsentApiKeyId,
+	deleteById: deleteOAuthConsentById,
+};

--- a/server/src/internal/auth/repos/oauthConsentRepo.ts
+++ b/server/src/internal/auth/repos/oauthConsentRepo.ts
@@ -6,7 +6,6 @@ export type OAuthConsentApiKeyRecord = {
 	id: string;
 	env: AppEnv | null;
 	oauthApiKeyId: string | null;
-	oauthApiKey: string | null;
 	redirectUri: string | null;
 };
 
@@ -92,7 +91,6 @@ export const getOAuthConsentForClientUserOrg = async ({
 			id: oauthConsent.id,
 			env: oauthConsent.env,
 			oauthApiKeyId: oauthConsent.oauthApiKeyId,
-			oauthApiKey: oauthConsent.oauthApiKey,
 			redirectUri: oauthConsent.redirectUri,
 		})
 		.from(oauthConsent)
@@ -113,36 +111,19 @@ export const updateOAuthConsentApiKey = async ({
 	consentId,
 	env,
 	oauthApiKeyId,
-	oauthApiKey,
 }: {
 	db: DrizzleCli;
 	consentId: string;
 	env: AppEnv;
 	oauthApiKeyId: string | null;
-	oauthApiKey: string;
 }) =>
 	db
 		.update(oauthConsent)
 		.set({
 			env,
 			oauthApiKeyId,
-			oauthApiKey,
 			updatedAt: new Date(),
 		})
-		.where(eq(oauthConsent.id, consentId));
-
-export const updateOAuthConsentApiKeyId = async ({
-	db,
-	consentId,
-	oauthApiKeyId,
-}: {
-	db: DrizzleCli;
-	consentId: string;
-	oauthApiKeyId: string;
-}) =>
-	db
-		.update(oauthConsent)
-		.set({ oauthApiKeyId, updatedAt: new Date() })
 		.where(eq(oauthConsent.id, consentId));
 
 export const deleteOAuthConsentById = async ({
@@ -159,6 +140,5 @@ export const oauthConsentRepo = {
 	updateEnv: updateOAuthConsentEnv,
 	getForClientUserOrg: getOAuthConsentForClientUserOrg,
 	updateApiKey: updateOAuthConsentApiKey,
-	updateApiKeyId: updateOAuthConsentApiKeyId,
 	deleteById: deleteOAuthConsentById,
 };

--- a/server/src/internal/auth/repos/oauthRefreshTokenRepo.ts
+++ b/server/src/internal/auth/repos/oauthRefreshTokenRepo.ts
@@ -1,0 +1,27 @@
+import { oauthRefreshToken } from "@autumn/shared";
+import { and, eq, isNull } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export const deleteOAuthRefreshTokensByClientAndReference = async ({
+	db,
+	clientId,
+	referenceId,
+}: {
+	db: DrizzleCli;
+	clientId: string;
+	referenceId: string | null;
+}) =>
+	db
+		.delete(oauthRefreshToken)
+		.where(
+			and(
+				eq(oauthRefreshToken.clientId, clientId),
+				referenceId
+					? eq(oauthRefreshToken.referenceId, referenceId)
+					: isNull(oauthRefreshToken.referenceId),
+			),
+		);
+
+export const oauthRefreshTokenRepo = {
+	deleteByClientAndReference: deleteOAuthRefreshTokensByClientAndReference,
+};

--- a/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
+++ b/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
@@ -4,6 +4,7 @@ import {
 	getExternalOAuthApiKeyForToken,
 	getOAuthAccessTokenRecord,
 } from "@/internal/auth/oauth/oauthAccessTokenApiKey.js";
+import { oauthConsentRepo } from "@/internal/auth/repos/index.js";
 import { ApiKeyPrefix, createKey } from "../../api-keys/apiKeyUtils.js";
 import {
 	type OAuthApiKeyRequestBody,
@@ -97,9 +98,17 @@ export const handleCreateOAuthApiKeys = createRoute({
 			});
 		}
 
-		// Build meta with consent linkage
+		const consent = await oauthConsentRepo.getForClientUserOrg({
+			db,
+			clientId,
+			userId,
+			referenceId: orgId,
+		});
+
 		const meta = {
-			oauth_consent_id: null,
+			oauth_consent_id: consent?.id ?? null,
+			oauth_client_id: clientId,
+			oauth_redirect_uri: consent?.redirectUri ?? null,
 			created_via: "oauth",
 			generatedAt: new Date().toISOString(),
 		};

--- a/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
+++ b/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
@@ -1,27 +1,15 @@
-import {
-	AppEnv,
-	checkScopes,
-	ErrCode,
-	oauthAccessToken,
-	oauthConsent,
-	RecaseError,
-	type ScopeString,
-	Scopes,
-} from "@autumn/shared";
-import { verifyAccessToken } from "better-auth/oauth2";
-import { and, eq, gt } from "drizzle-orm";
+import { AppEnv, ErrCode, RecaseError, Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
-import { hashOAuthToken } from "@/utils/oauthUtils.js";
+import {
+	getExternalOAuthApiKeyForToken,
+	getOAuthAccessTokenRecord,
+} from "@/internal/auth/oauth/oauthAccessTokenApiKey.js";
 import { ApiKeyPrefix, createKey } from "../../api-keys/apiKeyUtils.js";
 import {
 	type OAuthApiKeyRequestBody,
 	OAuthApiKeyRequestBodySchema,
 	parseRequestedScopes,
-	tokenRecordFromResourceToken,
 } from "../oauthApiKeyUtils.js";
-
-const getOAuthIssuer = () =>
-	`${process.env.BETTER_AUTH_URL?.replace(/\/$/, "") ?? ""}/api/auth`;
 
 const parseBody = (rawBody: string): OAuthApiKeyRequestBody => {
 	let body: unknown = {};
@@ -45,34 +33,6 @@ const parseBody = (rawBody: string): OAuthApiKeyRequestBody => {
 		code: ErrCode.InvalidRequest,
 		statusCode: 400,
 	});
-};
-
-const verifyResourceAccessToken = async ({
-	accessToken,
-	resource,
-	requestedScopes,
-}: {
-	accessToken: string;
-	resource: string | null;
-	requestedScopes: ScopeString[] | null;
-}) => {
-	if (!resource) return null;
-
-	const issuer = getOAuthIssuer();
-	try {
-		const payload = await verifyAccessToken(accessToken, {
-			jwksUrl: `${issuer}/jwks`,
-			verifyOptions: {
-				audience: resource,
-				issuer,
-			},
-			scopes: requestedScopes ?? undefined,
-		});
-
-		return tokenRecordFromResourceToken(payload as Record<string, unknown>);
-	} catch {
-		return null;
-	}
 };
 
 /**
@@ -105,90 +65,41 @@ export const handleCreateOAuthApiKeys = createRoute({
 
 		const accessToken = authHeader.substring(7);
 
-		// Better-auth stores opaque tokens as SHA-256 hashes in base64url format
-		const hashedToken = await hashOAuthToken(accessToken);
-
-		// Look up the token in the oauth_access_token table
-		const tokenRecords = await db
-			.select()
-			.from(oauthAccessToken)
-			.where(
-				and(
-					eq(oauthAccessToken.token, hashedToken),
-					gt(oauthAccessToken.expiresAt, new Date()),
-				),
-			)
-			.limit(1);
-
-		const tokenRecord =
-			tokenRecords[0] ??
-			(await verifyResourceAccessToken({
-				accessToken,
-				resource,
-				requestedScopes,
-			}));
-
-		if (!tokenRecord) {
-			throw new RecaseError({
-				message: "Invalid or expired access token",
-				code: ErrCode.InvalidRequest,
-				statusCode: 401,
-			});
-		}
-
-		if (requestedScopes) {
-			const { allowed, missing } = checkScopes(
-				requestedScopes,
-				tokenRecord.scopes,
-			);
-			if (!allowed) {
-				throw new RecaseError({
-					message: `Insufficient scopes. Missing: ${missing.join(", ")}`,
-					code: ErrCode.InsufficientScopes,
-					statusCode: 403,
-				});
-			}
-		}
-
+		const tokenRecord = await getOAuthAccessTokenRecord({
+			db,
+			accessToken,
+			resource,
+			requestedScopes,
+		});
 		const userId = tokenRecord.userId;
-		if (!userId) {
-			throw new RecaseError({
-				message: "Token missing user information",
-				code: ErrCode.InvalidRequest,
-				statusCode: 401,
-			});
-		}
-
-		// Get the org ID from the referenceId field (set by consentReferenceId)
 		const orgId = tokenRecord.referenceId;
-		if (!orgId) {
-			throw new RecaseError({
-				message: "No organization found. Please select an organization.",
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-
 		const clientId = tokenRecord.clientId;
 
-		// Look up the OAuth consent to get its ID for linking API keys
-		const consentRecords = await db
-			.select({ id: oauthConsent.id })
-			.from(oauthConsent)
-			.where(
-				and(
-					eq(oauthConsent.clientId, clientId),
-					eq(oauthConsent.userId, userId),
-					eq(oauthConsent.referenceId, orgId),
-				),
-			)
-			.limit(1);
-
-		const consentId = consentRecords[0]?.id || null;
+		const externalApiKey = await getExternalOAuthApiKeyForToken({
+			db,
+			tokenRecord,
+			requestedScopes,
+		});
+		if (externalApiKey) {
+			return c.json({
+				sandbox_key:
+					externalApiKey.env === AppEnv.Sandbox
+						? externalApiKey.apiKey
+						: undefined,
+				prod_key:
+					externalApiKey.env === AppEnv.Live
+						? externalApiKey.apiKey
+						: undefined,
+				org_id: orgId,
+				user_id: userId,
+				client_id: clientId,
+				scopes: externalApiKey.scopes,
+			});
+		}
 
 		// Build meta with consent linkage
 		const meta = {
-			oauth_consent_id: consentId,
+			oauth_consent_id: null,
 			created_via: "oauth",
 			generatedAt: new Date().toISOString(),
 		};

--- a/server/src/internal/misc/consent/handlers/handleGetConsentApiKeys.ts
+++ b/server/src/internal/misc/consent/handlers/handleGetConsentApiKeys.ts
@@ -1,7 +1,10 @@
-import { apiKeys, oauthConsent, Scopes } from "@autumn/shared";
-import { eq, sql } from "drizzle-orm";
+import { Scopes } from "@autumn/shared";
 import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	oauthApiKeyRepo,
+	oauthConsentRepo,
+} from "@/internal/auth/repos/index.js";
 
 /**
  * Get API keys linked to a specific OAuth consent.
@@ -26,35 +29,28 @@ export const handleGetConsentApiKeys = createRoute({
 			return c.json({ error: "No organization found" }, 400);
 		}
 
-		// First verify the consent belongs to this org
-		const consentRecords = await db
-			.select({ id: oauthConsent.id, referenceId: oauthConsent.referenceId })
-			.from(oauthConsent)
-			.where(eq(oauthConsent.id, consent_id))
-			.limit(1);
+		const consent = await oauthConsentRepo.getOwner({
+			db,
+			consentId: consent_id,
+		});
 
-		if (consentRecords.length === 0) {
+		if (!consent) {
 			return c.json({ error: "Consent not found" }, 404);
 		}
 
-		if (consentRecords[0].referenceId !== org.id) {
+		if (consent.referenceId !== org.id) {
 			return c.json(
 				{ error: "Consent does not belong to this organization" },
 				403,
 			);
 		}
 
-		// Query API keys where meta->>'oauth_consent_id' = consent_id
-		// Only return prefix, env, name - NOT the hashed key
-		const keys = await db
-			.select({
-				id: apiKeys.id,
-				prefix: apiKeys.prefix,
-				env: apiKeys.env,
-				name: apiKeys.name,
+		const keys = (
+			await oauthApiKeyRepo.listByConsentId({
+				db,
+				consentId: consent_id,
 			})
-			.from(apiKeys)
-			.where(sql`${apiKeys.meta}->>'oauth_consent_id' = ${consent_id}`);
+		).map(({ hashed_key: _hashedKey, ...key }) => key);
 
 		return c.json({ apiKeys: keys });
 	},

--- a/server/src/internal/misc/consent/handlers/handleGetOrgConsents.ts
+++ b/server/src/internal/misc/consent/handlers/handleGetOrgConsents.ts
@@ -1,6 +1,6 @@
-import { ErrCode, oauthConsent, RecaseError, Scopes } from "@autumn/shared";
-import { eq } from "drizzle-orm";
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { oauthConsentRepo } from "@/internal/auth/repos/index.js";
 
 /**
  * Get OAuth consents for the current organization.
@@ -26,19 +26,10 @@ export const handleGetOrgConsents = createRoute({
 			});
 		}
 
-		// Query consents where referenceId matches the current org
-		const consents = await db
-			.select({
-				id: oauthConsent.id,
-				clientId: oauthConsent.clientId,
-				userId: oauthConsent.userId,
-				referenceId: oauthConsent.referenceId,
-				scopes: oauthConsent.scopes,
-				createdAt: oauthConsent.createdAt,
-				updatedAt: oauthConsent.updatedAt,
-			})
-			.from(oauthConsent)
-			.where(eq(oauthConsent.referenceId, org.id));
+		const consents = await oauthConsentRepo.listByReferenceId({
+			db,
+			referenceId: org.id,
+		});
 
 		return c.json({ consents });
 	},

--- a/server/src/internal/misc/consent/handlers/handleRevokeConsent.ts
+++ b/server/src/internal/misc/consent/handlers/handleRevokeConsent.ts
@@ -1,15 +1,12 @@
-import {
-	apiKeys,
-	ErrCode,
-	oauthAccessToken,
-	oauthConsent,
-	oauthRefreshToken,
-	RecaseError,
-	Scopes,
-} from "@autumn/shared";
-import { and, eq, sql } from "drizzle-orm";
+import { ErrCode, RecaseError, Scopes } from "@autumn/shared";
 import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import {
+	oauthAccessTokenRepo,
+	oauthApiKeyRepo,
+	oauthConsentRepo,
+	oauthRefreshTokenRepo,
+} from "@/internal/auth/repos/index.js";
 import { clearSecretKeyCache } from "../../../dev/api-keys/cacheApiKeyUtils.js";
 
 /**
@@ -42,26 +39,17 @@ export const handleRevokeConsent = createRoute({
 			});
 		}
 
-		// 1. Get the consent and verify it belongs to this org
-		const consentRecords = await db
-			.select({
-				id: oauthConsent.id,
-				clientId: oauthConsent.clientId,
-				referenceId: oauthConsent.referenceId,
-			})
-			.from(oauthConsent)
-			.where(eq(oauthConsent.id, consent_id))
-			.limit(1);
-
-		if (consentRecords.length === 0) {
+		const consent = await oauthConsentRepo.getOwner({
+			db,
+			consentId: consent_id,
+		});
+		if (!consent) {
 			throw new RecaseError({
 				message: "Consent not found",
 				code: "not_found",
 				statusCode: 404,
 			});
 		}
-
-		const consent = consentRecords[0];
 
 		if (consent.referenceId !== org.id) {
 			throw new RecaseError({
@@ -73,51 +61,38 @@ export const handleRevokeConsent = createRoute({
 
 		const { clientId, referenceId } = consent;
 
-		// 2. Get API keys linked to this consent (for cache invalidation and response)
-		const linkedKeys = await db
-			.select({
-				id: apiKeys.id,
-				prefix: apiKeys.prefix,
-				hashed_key: apiKeys.hashed_key,
-			})
-			.from(apiKeys)
-			.where(sql`${apiKeys.meta}->>'oauth_consent_id' = ${consent_id}`);
+		const linkedKeys = await oauthApiKeyRepo.listByConsentId({
+			db,
+			consentId: consent_id,
+		});
 
 		const deletedKeyPrefixes = linkedKeys.map((k) => k.prefix).filter(Boolean);
 
 		// 3. Delete API keys and invalidate their cache
 		for (const key of linkedKeys) {
-			// Delete from database
-			await db.delete(apiKeys).where(eq(apiKeys.id, key.id));
+			await oauthApiKeyRepo.deleteById({ db, apiKeyId: key.id });
 
-			// Invalidate cache
 			if (key.hashed_key) {
 				await clearSecretKeyCache({ hashedKey: key.hashed_key });
 			}
 		}
 
 		// 4. Delete access tokens for this client + org
-		await db
-			.delete(oauthAccessToken)
-			.where(
-				and(
-					eq(oauthAccessToken.clientId, clientId),
-					eq(oauthAccessToken.referenceId, referenceId),
-				),
-			);
+		await oauthAccessTokenRepo.deleteByClientAndReference({
+			db,
+			clientId,
+			referenceId,
+		});
 
 		// 5. Delete refresh tokens for this client + org
-		await db
-			.delete(oauthRefreshToken)
-			.where(
-				and(
-					eq(oauthRefreshToken.clientId, clientId),
-					eq(oauthRefreshToken.referenceId, referenceId),
-				),
-			);
+		await oauthRefreshTokenRepo.deleteByClientAndReference({
+			db,
+			clientId,
+			referenceId,
+		});
 
 		// 6. Delete the consent
-		await db.delete(oauthConsent).where(eq(oauthConsent.id, consent_id));
+		await oauthConsentRepo.deleteById({ db, consentId: consent_id });
 
 		return c.json({
 			success: true,

--- a/server/tests/unit/auth/atmnOAuthClients.test.ts
+++ b/server/tests/unit/auth/atmnOAuthClients.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { isAtmnOAuthClientRecord } from "@/internal/auth/oauth/atmnOAuthClients.js";
+
+describe("isAtmnOAuthClientRecord", () => {
+	test("does not classify arbitrary metadata values as atmn", () => {
+		expect(
+			isAtmnOAuthClientRecord({
+				clientId: "client_123",
+				name: "Third Party App",
+				metadata: { description: "connects to atmn projects" },
+			}),
+		).toBe(false);
+	});
+
+	test("classifies explicit atmn metadata and names", () => {
+		expect(
+			isAtmnOAuthClientRecord({
+				clientId: "client_123",
+				name: "Third Party App",
+				metadata: { kind: "atmn" },
+			}),
+		).toBe(true);
+
+		expect(
+			isAtmnOAuthClientRecord({
+				clientId: "client_123",
+				name: "atmn",
+			}),
+		).toBe(true);
+	});
+});

--- a/server/tests/unit/auth/oauthApiKeyRepo.test.ts
+++ b/server/tests/unit/auth/oauthApiKeyRepo.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import { isOAuthConsentLinkedApiKey } from "@/internal/auth/repos/oauthApiKeyRepo.js";
+
+type GuardApiKey = Parameters<typeof isOAuthConsentLinkedApiKey>[0]["apiKey"];
+
+const oauthMeta = {
+	created_via: "oauth",
+	oauth_consent_id: "consent_123",
+	oauth_client_id: "autumn_mcp_cursor",
+	oauth_redirect_uri: "cursor://oauth/callback",
+	env: AppEnv.Sandbox,
+};
+
+const baseApiKey: GuardApiKey = {
+	id: "key_123",
+	orgId: "org_123",
+	userId: "user_123",
+	env: AppEnv.Sandbox,
+	hashedKey: "hashed",
+	meta: oauthMeta,
+};
+
+const matchesConsent = (apiKey: GuardApiKey) =>
+	isOAuthConsentLinkedApiKey({
+		apiKey,
+		consentId: "consent_123",
+		clientId: "autumn_mcp_cursor",
+		redirectUri: "cursor://oauth/callback",
+		orgId: "org_123",
+		userId: "user_123",
+		env: AppEnv.Sandbox,
+	});
+
+describe("isOAuthConsentLinkedApiKey", () => {
+	test("accepts an OAuth-created key linked to the same consent", () => {
+		expect(matchesConsent(baseApiKey)).toBe(true);
+	});
+
+	test("rejects a user-created key even if it is the stored api key id", () => {
+		expect(
+			matchesConsent({
+				...baseApiKey,
+				meta: { created_via: "dashboard" },
+			}),
+		).toBe(false);
+	});
+
+	test("rejects an OAuth key linked to a different consent", () => {
+		expect(
+			matchesConsent({
+				...baseApiKey,
+				meta: {
+					...oauthMeta,
+					oauth_consent_id: "consent_other",
+				},
+			}),
+		).toBe(false);
+	});
+
+	test("rejects an OAuth key linked to a different redirect URI", () => {
+		expect(
+			isOAuthConsentLinkedApiKey({
+				apiKey: baseApiKey,
+				consentId: "consent_123",
+				clientId: "autumn_mcp_cursor",
+				redirectUri: "cursor://oauth/other-callback",
+				orgId: "org_123",
+				userId: "user_123",
+				env: AppEnv.Sandbox,
+			}),
+		).toBe(false);
+	});
+
+	test("rejects an OAuth key with different ownership or env", () => {
+		expect(matchesConsent({ ...baseApiKey, orgId: "org_other" })).toBe(false);
+		expect(matchesConsent({ ...baseApiKey, userId: "user_other" })).toBe(false);
+		expect(matchesConsent({ ...baseApiKey, env: AppEnv.Live })).toBe(false);
+	});
+});

--- a/shared/db/auth-schema.ts
+++ b/shared/db/auth-schema.ts
@@ -9,6 +9,7 @@ import {
 	text,
 	timestamp,
 } from "drizzle-orm/pg-core";
+import type { AppEnv } from "../models/genModels/genEnums.js";
 import {
 	type Organization,
 	organizations,
@@ -246,6 +247,10 @@ export const oauthConsent = pgTable("oauth_consent", {
 	userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
 	referenceId: text("reference_id"),
 	scopes: text("scopes").array().notNull(),
+	env: text("env").$type<AppEnv>(),
+	redirectUri: text("redirect_uri"),
+	oauthApiKeyId: text("oauth_api_key_id"),
+	oauthApiKey: text("oauth_api_key"),
 	createdAt: timestamp("created_at", { withTimezone: true }),
 	updatedAt: timestamp("updated_at", { withTimezone: true }),
 }).enableRLS();

--- a/shared/db/auth-schema.ts
+++ b/shared/db/auth-schema.ts
@@ -250,7 +250,6 @@ export const oauthConsent = pgTable("oauth_consent", {
 	env: text("env").$type<AppEnv>(),
 	redirectUri: text("redirect_uri"),
 	oauthApiKeyId: text("oauth_api_key_id"),
-	oauthApiKey: text("oauth_api_key"),
 	createdAt: timestamp("created_at", { withTimezone: true }),
 	updatedAt: timestamp("updated_at", { withTimezone: true }),
 }).enableRLS();

--- a/shared/drizzle/0006_sad_madrox.sql
+++ b/shared/drizzle/0006_sad_madrox.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "oauth_consent" ADD COLUMN "env" text;--> statement-breakpoint
+ALTER TABLE "oauth_consent" ADD COLUMN "redirect_uri" text;--> statement-breakpoint
+ALTER TABLE "oauth_consent" ADD COLUMN "oauth_api_key_id" text;--> statement-breakpoint
+ALTER TABLE "oauth_consent" ADD COLUMN "oauth_api_key" text;

--- a/shared/drizzle/0006_sad_madrox.sql
+++ b/shared/drizzle/0006_sad_madrox.sql
@@ -1,4 +1,3 @@
 ALTER TABLE "oauth_consent" ADD COLUMN "env" text;--> statement-breakpoint
 ALTER TABLE "oauth_consent" ADD COLUMN "redirect_uri" text;--> statement-breakpoint
-ALTER TABLE "oauth_consent" ADD COLUMN "oauth_api_key_id" text;--> statement-breakpoint
-ALTER TABLE "oauth_consent" ADD COLUMN "oauth_api_key" text;
+ALTER TABLE "oauth_consent" ADD COLUMN "oauth_api_key_id" text;

--- a/shared/drizzle/meta/0006_snapshot.json
+++ b/shared/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,7383 @@
+{
+  "id": "eadc8c95-3f6f-4643-abc3-e90cd56d5ed1",
+  "prevId": "3ee43a45-bd02-43e2-a2d1-2080d51b5674",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_actions_on_internal_entity_id": {
+          "name": "idx_actions_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_org_id_fkey": {
+          "name": "actions_org_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_customer_id_fkey": {
+          "name": "actions_customer_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_entity_id_fkey": {
+          "name": "actions_entity_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_org_id_fkey": {
+          "name": "api_keys_org_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_key": {
+          "name": "api_keys_hashed_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_topup_limit_states": {
+      "name": "auto_topup_limit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_window_ends_at": {
+          "name": "purchase_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt_window_ends_at": {
+          "name": "attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_attempt_window_ends_at": {
+          "name": "failed_attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempt_count": {
+          "name": "failed_attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_attempt_at": {
+          "name": "last_failed_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "auto_topup_limits_org_env_internal_customer_feature_unique": {
+          "name": "auto_topup_limits_org_env_internal_customer_feature_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_topup_limits_org_id_fkey": {
+          "name": "auto_topup_limits_org_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_topup_limits_internal_customer_id_fkey": {
+          "name": "auto_topup_limits_internal_customer_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_approvals": {
+      "name": "chat_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_provider_user_id": {
+          "name": "decided_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_approvals_org_id_fkey": {
+          "name": "chat_approvals_org_id_fkey",
+          "tableFrom": "chat_approvals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_installations": {
+      "name": "chat_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_env": {
+          "name": "default_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_api_key_id": {
+          "name": "sandbox_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_api_key": {
+          "name": "sandbox_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key_id": {
+          "name": "live_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key": {
+          "name": "live_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_provider_user_id": {
+          "name": "installed_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_installations_org_id_fkey": {
+          "name": "chat_installations_org_id_fkey",
+          "tableFrom": "chat_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_installations_org_provider_key": {
+          "name": "chat_installations_org_provider_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "provider"
+          ]
+        },
+        "chat_installations_provider_workspace_key": {
+          "name": "chat_installations_provider_workspace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_results": {
+      "name": "chat_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.checkouts": {
+      "name": "checkouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_version": {
+          "name": "params_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_checkouts_stripe_invoice_id": {
+          "name": "idx_checkouts_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_entitlements": {
+      "name": "customer_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_reset_at": {
+          "name": "next_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_allowed": {
+          "name": "usage_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "adjustment": {
+          "name": "adjustment",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_balance": {
+          "name": "additional_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_version": {
+          "name": "cache_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_entitlements_product_id": {
+          "name": "idx_customer_entitlements_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id": {
+          "name": "idx_customer_entitlements_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id_btree": {
+          "name": "idx_customer_entitlements_internal_customer_id_btree",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_entitlement_id": {
+          "name": "idx_customer_entitlements_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_entity_id": {
+          "name": "idx_customer_entitlements_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_on_next_reset_at": {
+          "name": "idx_customer_entitlements_on_next_reset_at",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_loose_customer_expires": {
+          "name": "idx_customer_entitlements_loose_customer_expires",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_internal_entity_id_fkey": {
+          "name": "customer_entitlements_internal_entity_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_customer_product_id_fkey": {
+          "name": "customer_entitlements_customer_product_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_entitlements_entitlement_id_fkey": {
+          "name": "customer_entitlements_entitlement_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_prices": {
+      "name": "customer_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_prices_product_id": {
+          "name": "idx_customer_prices_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_price_id": {
+          "name": "idx_customer_prices_price_id",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_internal_customer_id": {
+          "name": "idx_customer_prices_internal_customer_id",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_prices_customer_product_id_fkey": {
+          "name": "customer_prices_customer_product_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_internal_customer_id_fkey": {
+          "name": "customer_prices_internal_customer_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_price_id_fkey": {
+          "name": "customer_prices_price_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_products": {
+      "name": "customer_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_starts_at": {
+          "name": "access_starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_trial_id": {
+          "name": "free_trial_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_resets_at": {
+          "name": "billing_cycle_anchor_resets_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_method": {
+          "name": "collection_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'charge_automatically'"
+        },
+        "subscription_ids": {
+          "name": "subscription_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_ids": {
+          "name": "scheduled_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_version": {
+          "name": "billing_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_semver": {
+          "name": "api_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_customer_product_id": {
+          "name": "previous_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_trial_end": {
+          "name": "on_trial_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_products_customer_status": {
+          "name": "idx_customer_products_customer_status",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_entity_id": {
+          "name": "idx_customer_products_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_product_id": {
+          "name": "idx_customer_products_on_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_subscription_ids": {
+          "name": "idx_customer_products_subscription_ids",
+          "columns": [
+            {
+              "expression": "subscription_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_scheduled_ids": {
+          "name": "idx_customer_products_scheduled_ids",
+          "columns": [
+            {
+              "expression": "scheduled_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_stripe_checkout_session_id": {
+          "name": "idx_customer_products_stripe_checkout_session_id",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_revenuecat_processor": {
+          "name": "idx_customer_products_revenuecat_processor",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_products_free_trial_id_fkey": {
+          "name": "customer_products_free_trial_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "free_trials",
+          "columnsFrom": [
+            "free_trial_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_customer_id_fkey": {
+          "name": "customer_products_internal_customer_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_products_internal_product_id_fkey": {
+          "name": "customer_products_internal_product_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_entity_id_fkey": {
+          "name": "customer_products_internal_entity_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processors": {
+          "name": "processors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "send_email_receipts": {
+          "name": "send_email_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "customers_email_null_id_unique": {
+          "name": "customers_email_null_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_fingerprint": {
+          "name": "idx_customers_org_env_fingerprint",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"fingerprint\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processor_id": {
+          "name": "idx_customers_processor_id",
+          "columns": [
+            {
+              "expression": "(\"processor\" ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_composite": {
+          "name": "idx_customers_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_internal_id": {
+          "name": "idx_customers_org_env_internal_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_email_trgm": {
+          "name": "idx_customers_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_name_trgm": {
+          "name": "idx_customers_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_id_trgm": {
+          "name": "idx_customers_id_trgm",
+          "columns": [
+            {
+              "expression": "\"id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_org_id_env_created_at": {
+          "name": "idx_customers_org_id_env_created_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_cursor": {
+          "name": "idx_customers_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat": {
+          "name": "idx_customers_processors_revenuecat",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'revenuecat')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_vercel": {
+          "name": "idx_customers_processors_vercel",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'vercel')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_org_id_fkey": {
+          "name": "customers_org_id_fkey",
+          "tableFrom": "customers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cus_id_constraint": {
+          "name": "cus_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entities_internal_customer_id": {
+          "name": "idx_entities_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_internal_desc": {
+          "name": "idx_entities_customer_internal_desc",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_org_env_id": {
+          "name": "idx_entities_org_env_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_cursor": {
+          "name": "idx_entities_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_internal_customer_id_fkey": {
+          "name": "entities_internal_customer_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_internal_feature_id_fkey": {
+          "name": "entities_internal_feature_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_org_id_fkey": {
+          "name": "entities_org_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_id_constraint": {
+          "name": "entity_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "internal_customer_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlements": {
+      "name": "entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowance_type": {
+          "name": "allowance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowance": {
+          "name": "allowance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "carry_from_previous": {
+          "name": "carry_from_previous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_feature_id": {
+          "name": "entity_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_duration": {
+          "name": "expiry_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_length": {
+          "name": "expiry_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover": {
+          "name": "rollover",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entitlements_internal_product_id": {
+          "name": "idx_entitlements_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id": {
+          "name": "idx_entitlements_internal_reward_id",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_reward_feature": {
+          "name": "idx_entitlements_reward_feature",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id_c_partial": {
+          "name": "idx_entitlements_internal_reward_id_c_partial",
+          "columns": [
+            {
+              "expression": "\"internal_reward_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_internal_product_id_fkey": {
+          "name": "entitlements_internal_product_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "entitlements_internal_reward_id_fkey": {
+          "name": "entitlements_internal_reward_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entitlements_id_key": {
+          "name": "entitlements_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_usage": {
+          "name": "set_usage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductions": {
+          "name": "deductions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_internal_customer_id": {
+          "name": "idx_events_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_internal_entity_id": {
+          "name": "idx_events_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_customer_non_usage_ts": {
+          "name": "idx_events_customer_non_usage_ts",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"timestamp\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"set_usage\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_internal_customer_id_fkey": {
+          "name": "events_internal_customer_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_constraint": {
+          "name": "unique_event_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "customer_id",
+            "event_name",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.features": {
+      "name": "features",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_names": {
+          "name": "event_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "features_org_id_fkey": {
+          "name": "features_org_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_id_constraint": {
+          "name": "feature_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_trials": {
+      "name": "free_trials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'day'"
+        },
+        "length": {
+          "name": "length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_fingerprint": {
+          "name": "unique_fingerprint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "card_required": {
+          "name": "card_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "on_end": {
+          "name": "on_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_free_trials_internal_product_id": {
+          "name": "idx_free_trials_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_trials_internal_product_id_fkey": {
+          "name": "free_trials_internal_product_id_fkey",
+          "tableFrom": "free_trials",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organizations_id_fk": {
+          "name": "invitation_organization_id_organizations_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_item_id": {
+          "name": "stripe_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_discountable": {
+          "name": "stripe_discountable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_after_discounts": {
+          "name": "amount_after_discounts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_quantity": {
+          "name": "stripe_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_timing": {
+          "name": "billing_timing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorated": {
+          "name": "prorated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_price_ids": {
+          "name": "customer_price_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_entitlement_ids": {
+          "name": "customer_entitlement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_start": {
+          "name": "effective_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_end": {
+          "name": "effective_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_fkey": {
+          "name": "invoice_line_items_invoice_id_fkey",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_line_items_stripe_id_unique": {
+          "name": "invoice_line_items_stripe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_templates": {
+      "name": "invoice_templates",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_terms_days": {
+          "name": "net_terms_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invoice_templates_org_id": {
+          "name": "idx_invoice_templates_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_templates_org_id_fkey": {
+          "name": "invoice_templates_org_id_fkey",
+          "tableFrom": "invoice_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_templates_id_unique": {
+          "name": "invoice_templates_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_product_ids": {
+          "name": "internal_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_type": {
+          "name": "processor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoices_customer_created": {
+          "name": "idx_invoices_customer_created",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_internal_entity_id": {
+          "name": "idx_invoices_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_internal_customer_id_fkey": {
+          "name": "invoices_internal_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_internal_entity_id_fkey": {
+          "name": "invoices_internal_entity_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_stripe_id_key": {
+          "name": "invoices_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organizations_id_fk": {
+          "name": "member_organization_id_organizations_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_errors": {
+      "name": "migration_errors",
+      "schema": "",
+      "columns": {
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_job_id": {
+          "name": "migration_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_customers_internal_customer_id_fkey": {
+          "name": "migration_customers_internal_customer_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_customers_migration_job_id_fkey": {
+          "name": "migration_customers_migration_job_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "migration_jobs",
+          "columnsFrom": [
+            "migration_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "migration_errors_pkey": {
+          "name": "migration_errors_pkey",
+          "columns": [
+            "internal_customer_id",
+            "migration_job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_item_runs": {
+      "name": "migration_item_runs",
+      "schema": "",
+      "columns": {
+        "migration_item_run_id": {
+          "name": "migration_item_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_run_id": {
+          "name": "migration_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_item_runs_live_unique": {
+          "name": "migration_item_runs_live_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_dry_run_unique": {
+          "name": "migration_item_runs_dry_run_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "migration_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_customer_recent_idx": {
+          "name": "migration_item_runs_customer_recent_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_jobs": {
+      "name": "migration_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_internal_product_id": {
+          "name": "from_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_internal_product_id": {
+          "name": "to_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_details": {
+          "name": "step_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_jobs_from_internal_product_id_fkey": {
+          "name": "migration_jobs_from_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "from_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_org_id_fkey": {
+          "name": "migration_jobs_org_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_to_internal_product_id_fkey": {
+          "name": "migration_jobs_to_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "to_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lazy_run": {
+          "name": "lazy_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_ids": {
+          "name": "only_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_limit": {
+          "name": "target_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_per_migration_unique": {
+          "name": "migration_runs_active_per_migration_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_migration_internal_id_fkey": {
+          "name": "migration_runs_migration_internal_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "migrations",
+          "columnsFrom": [
+            "migration_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_org_id_fkey": {
+          "name": "migration_runs_org_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migrations": {
+      "name": "migrations",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_state": {
+          "name": "prepared_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_billing_changes": {
+          "name": "no_billing_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_failed": {
+          "name": "retry_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migrations_org_env_id_unique": {
+          "name": "migrations_org_env_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migrations_org_id_fkey": {
+          "name": "migrations_org_id_fkey",
+          "tableFrom": "migrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_api_key_id": {
+          "name": "oauth_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_api_key": {
+          "name": "oauth_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'usd'"
+        },
+        "stripe_connected": {
+          "name": "stripe_connected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stripe_config": {
+          "name": "stripe_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_stripe_connect": {
+          "name": "test_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "live_stripe_connect": {
+          "name": "live_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "processor_configs": {
+          "name": "processor_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_pkey": {
+          "name": "test_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_pkey": {
+          "name": "live_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svix_config": {
+          "name": "svix_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded": {
+          "name": "onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deployed": {
+          "name": "deployed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "redis_config": {
+          "name": "redis_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_name_trgm": {
+          "name": "idx_organizations_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_slug_trgm": {
+          "name": "idx_organizations_slug_trgm",
+          "columns": [
+            {
+              "expression": "\"slug\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_created_at_id": {
+          "name": "idx_organizations_created_at_id",
+          "columns": [
+            {
+              "expression": "\"createdAt\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_test_pkey_key": {
+          "name": "organizations_test_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_pkey"
+          ]
+        },
+        "organizations_live_pkey_key": {
+          "name": "organizations_live_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "live_pkey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialId_idx": {
+          "name": "passkey_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_behavior": {
+          "name": "tier_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "proration_config": {
+          "name": "proration_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_prices_internal_product_id": {
+          "name": "idx_prices_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_entitlement_id": {
+          "name": "idx_prices_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prices_entitlement_id_fkey": {
+          "name": "prices_entitlement_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prices_internal_product_id_fkey": {
+          "name": "prices_internal_product_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prices_id_key": {
+          "name": "prices_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_add_on": {
+          "name": "is_add_on",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "base_variant_id": {
+          "name": "base_variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_products_org_env_id_version": {
+          "name": "idx_products_org_env_id_version",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_org_id_fkey": {
+          "name": "products_org_id_fkey",
+          "tableFrom": "products",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_product": {
+          "name": "unique_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_referral_codes_internal_customer_id": {
+          "name": "idx_referral_codes_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "referral_codes_internal_customer_id_fkey": {
+          "name": "referral_codes_internal_customer_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_internal_reward_program_id_fkey": {
+          "name": "referral_codes_internal_reward_program_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_org_id_fkey": {
+          "name": "referral_codes_org_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "referral_codes_pkey": {
+          "name": "referral_codes_pkey",
+          "columns": [
+            "code",
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "referral_codes_id_key": {
+          "name": "referral_codes_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replaceables": {
+      "name": "replaceables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_next_cycle": {
+          "name": "delete_next_cycle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_replaceables_cus_ent_id": {
+          "name": "idx_replaceables_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replaceables_cus_ent_id_fkey": {
+          "name": "replaceables_cus_ent_id_fkey",
+          "tableFrom": "replaceables",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.revenuecat_mappings": {
+      "name": "revenuecat_mappings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autumn_product_id": {
+          "name": "autumn_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenuecat_product_ids": {
+          "name": "revenuecat_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "revenuecat_mappings_org_id_fkey": {
+          "name": "revenuecat_mappings_org_id_fkey",
+          "tableFrom": "revenuecat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "revenuecat_mappings_pkey": {
+          "name": "revenuecat_mappings_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "autumn_product_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_programs": {
+      "name": "reward_programs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlimited_redemptions": {
+          "name": "unlimited_redemptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when": {
+          "name": "when",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'immediately'"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"\"}'"
+        },
+        "exclude_trial": {
+          "name": "exclude_trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reward_triggers_internal_reward_id_fkey": {
+          "name": "reward_triggers_internal_reward_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_triggers_org_id_fkey": {
+          "name": "reward_triggers_org_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_redemptions": {
+      "name": "reward_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered": {
+          "name": "triggered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "redeemer_applied": {
+          "name": "redeemer_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_internal_id": {
+          "name": "reward_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code": {
+          "name": "promo_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reward_redemptions_referral_code_id": {
+          "name": "idx_reward_redemptions_referral_code_id",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_reward_internal_id": {
+          "name": "idx_reward_redemptions_reward_internal_id",
+          "columns": [
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_customer_reward": {
+          "name": "idx_reward_redemptions_customer_reward",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reward_redemptions_internal_customer_id_fkey": {
+          "name": "reward_redemptions_internal_customer_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_internal_reward_program_id_fkey": {
+          "name": "reward_redemptions_internal_reward_program_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_referral_code_id_fkey": {
+          "name": "reward_redemptions_referral_code_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "referral_codes",
+          "columnsFrom": [
+            "referral_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_config": {
+          "name": "discount_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_config": {
+          "name": "free_product_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_id": {
+          "name": "free_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_codes": {
+          "name": "promo_codes",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coupons_org_id_fkey": {
+          "name": "coupons_org_id_fkey",
+          "tableFrom": "rewards",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollovers": {
+      "name": "rollovers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_rollovers_cus_ent_id": {
+          "name": "idx_rollovers_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rollovers_cus_ent_expires": {
+          "name": "idx_rollovers_cus_ent_expires",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rollover_cus_ent_id_fkey": {
+          "name": "rollover_cus_ent_id_fkey",
+          "tableFrom": "rollovers",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.phases": {
+      "name": "phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phases_schedule_id_fkey": {
+          "name": "phases_schedule_id_fkey",
+          "tableFrom": "phases",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phases_schedule_id_starts_at_key": {
+          "name": "phases_schedule_id_starts_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "starts_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "schedules_customer_scope_unique": {
+          "name": "schedules_customer_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_entity_scope_unique": {
+          "name": "schedules_entity_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_customer_id": {
+          "name": "idx_schedules_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_entity_id": {
+          "name": "idx_schedules_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_org_id_fkey": {
+          "name": "schedules_org_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_customer_id_fkey": {
+          "name": "schedules_internal_customer_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_entity_id_fkey": {
+          "name": "schedules_internal_entity_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "usage_features": {
+          "name": "usage_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_org_id_fkey": {
+          "name": "subscriptions_org_id_fkey",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_id_key": {
+          "name": "subscriptions_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_name_trgm": {
+          "name": "idx_user_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_email_trgm": {
+          "name": "idx_user_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_created_at_id": {
+          "name": "idx_user_created_at_id",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_created_by_fkey": {
+          "name": "user_created_by_fkey",
+          "tableFrom": "user",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_resources": {
+      "name": "vercel_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "vercel_resources_installation_name_unique_idx": {
+          "name": "vercel_resources_installation_name_unique_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status <> 'uninstalled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_resources_org_id_fkey": {
+          "name": "vercel_resources_org_id_fkey",
+          "tableFrom": "vercel_resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/drizzle/meta/0006_snapshot.json
+++ b/shared/drizzle/meta/0006_snapshot.json
@@ -1,7383 +1,6987 @@
 {
-  "id": "eadc8c95-3f6f-4643-abc3-e90cd56d5ed1",
-  "prevId": "3ee43a45-bd02-43e2-a2d1-2080d51b5674",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.account": {
-      "name": "account",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "account_id": {
-          "name": "account_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider_id": {
-          "name": "provider_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id_token": {
-          "name": "id_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "access_token_expires_at": {
-          "name": "access_token_expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token_expires_at": {
-          "name": "refresh_token_expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scope": {
-          "name": "scope",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "account_userId_idx": {
-          "name": "account_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "account_user_id_user_id_fk": {
-          "name": "account_user_id_user_id_fk",
-          "tableFrom": "account",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.actions": {
-      "name": "actions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "request_id": {
-          "name": "request_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_slug": {
-          "name": "org_slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "entity_id": {
-          "name": "entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "auth_type": {
-          "name": "auth_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "method": {
-          "name": "method",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "path": {
-          "name": "path",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "properties": {
-          "name": "properties",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_actions_on_internal_entity_id": {
-          "name": "idx_actions_on_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "actions_org_id_fkey": {
-          "name": "actions_org_id_fkey",
-          "tableFrom": "actions",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "actions_customer_id_fkey": {
-          "name": "actions_customer_id_fkey",
-          "tableFrom": "actions",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "actions_entity_id_fkey": {
-          "name": "actions_entity_id_fkey",
-          "tableFrom": "actions",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.api_keys": {
-      "name": "api_keys",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "prefix": {
-          "name": "prefix",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hashed_key": {
-          "name": "hashed_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "meta": {
-          "name": "meta",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "api_keys_org_id_fkey": {
-          "name": "api_keys_org_id_fkey",
-          "tableFrom": "api_keys",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "api_keys_hashed_key_key": {
-          "name": "api_keys_hashed_key_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "hashed_key"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.auto_topup_limit_states": {
-      "name": "auto_topup_limit_states",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "purchase_window_ends_at": {
-          "name": "purchase_window_ends_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "purchase_count": {
-          "name": "purchase_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "attempt_window_ends_at": {
-          "name": "attempt_window_ends_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "attempt_count": {
-          "name": "attempt_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "failed_attempt_window_ends_at": {
-          "name": "failed_attempt_window_ends_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "failed_attempt_count": {
-          "name": "failed_attempt_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "last_attempt_at": {
-          "name": "last_attempt_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_failed_attempt_at": {
-          "name": "last_failed_attempt_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "auto_topup_limits_org_env_internal_customer_feature_unique": {
-          "name": "auto_topup_limits_org_env_internal_customer_feature_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "auto_topup_limits_org_id_fkey": {
-          "name": "auto_topup_limits_org_id_fkey",
-          "tableFrom": "auto_topup_limit_states",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "auto_topup_limits_internal_customer_id_fkey": {
-          "name": "auto_topup_limits_internal_customer_id_fkey",
-          "tableFrom": "auto_topup_limit_states",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.chat_approvals": {
-      "name": "chat_approvals",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "workspace_id": {
-          "name": "workspace_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "message_ts": {
-          "name": "message_ts",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "provider_user_id": {
-          "name": "provider_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "run_id": {
-          "name": "run_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tool_call_id": {
-          "name": "tool_call_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tool_name": {
-          "name": "tool_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "tool_args": {
-          "name": "tool_args",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "preview": {
-          "name": "preview",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decided_at": {
-          "name": "decided_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "decided_by_provider_user_id": {
-          "name": "decided_by_provider_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "chat_approvals_org_id_fkey": {
-          "name": "chat_approvals_org_id_fkey",
-          "tableFrom": "chat_approvals",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.chat_installations": {
-      "name": "chat_installations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "workspace_id": {
-          "name": "workspace_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "workspace_name": {
-          "name": "workspace_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "bot_user_id": {
-          "name": "bot_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "bot_access_token": {
-          "name": "bot_access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "default_env": {
-          "name": "default_env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sandbox_api_key_id": {
-          "name": "sandbox_api_key_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sandbox_api_key": {
-          "name": "sandbox_api_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "live_api_key_id": {
-          "name": "live_api_key_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "live_api_key": {
-          "name": "live_api_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "installed_by_user_id": {
-          "name": "installed_by_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "installed_by_provider_user_id": {
-          "name": "installed_by_provider_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "chat_installations_org_id_fkey": {
-          "name": "chat_installations_org_id_fkey",
-          "tableFrom": "chat_installations",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "chat_installations_org_provider_key": {
-          "name": "chat_installations_org_provider_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "provider"
-          ]
-        },
-        "chat_installations_provider_workspace_key": {
-          "name": "chat_installations_provider_workspace_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "provider",
-            "workspace_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.chat_results": {
-      "name": "chat_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "data": {
-          "name": "data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.checkouts": {
-      "name": "checkouts",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "action": {
-          "name": "action",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "params": {
-          "name": "params",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "params_version": {
-          "name": "params_version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "response": {
-          "name": "response",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_invoice_id": {
-          "name": "stripe_invoice_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "completed_at": {
-          "name": "completed_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_checkouts_stripe_invoice_id": {
-          "name": "idx_checkouts_stripe_invoice_id",
-          "columns": [
-            {
-              "expression": "stripe_invoice_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customer_entitlements": {
-      "name": "customer_entitlements",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "customer_product_id": {
-          "name": "customer_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "entitlement_id": {
-          "name": "entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "unlimited": {
-          "name": "unlimited",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "balance": {
-          "name": "balance",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "next_reset_at": {
-          "name": "next_reset_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_allowed": {
-          "name": "usage_allowed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "adjustment": {
-          "name": "adjustment",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "additional_balance": {
-          "name": "additional_balance",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "entities": {
-          "name": "entities",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cache_version": {
-          "name": "cache_version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 0
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "external_id": {
-          "name": "external_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_customer_entitlements_product_id": {
-          "name": "idx_customer_entitlements_product_id",
-          "columns": [
-            {
-              "expression": "customer_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_internal_customer_id": {
-          "name": "idx_customer_entitlements_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "hash",
-          "with": {}
-        },
-        "idx_customer_entitlements_internal_customer_id_btree": {
-          "name": "idx_customer_entitlements_internal_customer_id_btree",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_entitlement_id": {
-          "name": "idx_customer_entitlements_entitlement_id",
-          "columns": [
-            {
-              "expression": "entitlement_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_internal_entity_id": {
-          "name": "idx_customer_entitlements_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "hash",
-          "with": {}
-        },
-        "idx_customer_entitlements_on_next_reset_at": {
-          "name": "idx_customer_entitlements_on_next_reset_at",
-          "columns": [
-            {
-              "expression": "next_reset_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_loose_customer_expires": {
-          "name": "idx_customer_entitlements_loose_customer_expires",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "entitlements_internal_feature_id_fkey": {
-          "name": "entitlements_internal_feature_id_fkey",
-          "tableFrom": "customer_entitlements",
-          "tableTo": "features",
-          "columnsFrom": [
-            "internal_feature_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_entitlements_internal_entity_id_fkey": {
-          "name": "customer_entitlements_internal_entity_id_fkey",
-          "tableFrom": "customer_entitlements",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_entitlements_customer_product_id_fkey": {
-          "name": "customer_entitlements_customer_product_id_fkey",
-          "tableFrom": "customer_entitlements",
-          "tableTo": "customer_products",
-          "columnsFrom": [
-            "customer_product_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        },
-        "customer_entitlements_entitlement_id_fkey": {
-          "name": "customer_entitlements_entitlement_id_fkey",
-          "tableFrom": "customer_entitlements",
-          "tableTo": "entitlements",
-          "columnsFrom": [
-            "entitlement_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customer_prices": {
-      "name": "customer_prices",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "price_id": {
-          "name": "price_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "options": {
-          "name": "options",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "customer_product_id": {
-          "name": "customer_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_customer_prices_product_id": {
-          "name": "idx_customer_prices_product_id",
-          "columns": [
-            {
-              "expression": "customer_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_prices_price_id": {
-          "name": "idx_customer_prices_price_id",
-          "columns": [
-            {
-              "expression": "price_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_prices_internal_customer_id": {
-          "name": "idx_customer_prices_internal_customer_id",
-          "columns": [
-            {
-              "expression": "\"internal_customer_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "customer_prices_customer_product_id_fkey": {
-          "name": "customer_prices_customer_product_id_fkey",
-          "tableFrom": "customer_prices",
-          "tableTo": "customer_products",
-          "columnsFrom": [
-            "customer_product_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_prices_internal_customer_id_fkey": {
-          "name": "customer_prices_internal_customer_id_fkey",
-          "tableFrom": "customer_prices",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_prices_price_id_fkey": {
-          "name": "customer_prices_price_id_fkey",
-          "tableFrom": "customer_prices",
-          "tableTo": "prices",
-          "columnsFrom": [
-            "price_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customer_products": {
-      "name": "customer_products",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "processor": {
-          "name": "processor",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "canceled": {
-          "name": "canceled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "canceled_at": {
-          "name": "canceled_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ended_at": {
-          "name": "ended_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "starts_at": {
-          "name": "starts_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "access_starts_at": {
-          "name": "access_starts_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "options": {
-          "name": "options",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "product_id": {
-          "name": "product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "free_trial_id": {
-          "name": "free_trial_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "trial_ends_at": {
-          "name": "trial_ends_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "billing_cycle_anchor_resets_at": {
-          "name": "billing_cycle_anchor_resets_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "collection_method": {
-          "name": "collection_method",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'charge_automatically'"
-        },
-        "subscription_ids": {
-          "name": "subscription_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scheduled_ids": {
-          "name": "scheduled_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "quantity": {
-          "name": "quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 1
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "entity_id": {
-          "name": "entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "billing_version": {
-          "name": "billing_version",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "api_version": {
-          "name": "api_version",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "api_semver": {
-          "name": "api_semver",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "external_id": {
-          "name": "external_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_checkout_session_id": {
-          "name": "stripe_checkout_session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "previous_customer_product_id": {
-          "name": "previous_customer_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "on_trial_end": {
-          "name": "on_trial_end",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_customer_products_customer_status": {
-          "name": "idx_customer_products_customer_status",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "status",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_on_internal_entity_id": {
-          "name": "idx_customer_products_on_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_on_internal_product_id": {
-          "name": "idx_customer_products_on_internal_product_id",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_subscription_ids": {
-          "name": "idx_customer_products_subscription_ids",
-          "columns": [
-            {
-              "expression": "subscription_ids",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customer_products_scheduled_ids": {
-          "name": "idx_customer_products_scheduled_ids",
-          "columns": [
-            {
-              "expression": "scheduled_ids",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customer_products_stripe_checkout_session_id": {
-          "name": "idx_customer_products_stripe_checkout_session_id",
-          "columns": [
-            {
-              "expression": "stripe_checkout_session_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_revenuecat_processor": {
-          "name": "idx_customer_products_revenuecat_processor",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "customer_products_free_trial_id_fkey": {
-          "name": "customer_products_free_trial_id_fkey",
-          "tableFrom": "customer_products",
-          "tableTo": "free_trials",
-          "columnsFrom": [
-            "free_trial_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "customer_products_internal_customer_id_fkey": {
-          "name": "customer_products_internal_customer_id_fkey",
-          "tableFrom": "customer_products",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        },
-        "customer_products_internal_product_id_fkey": {
-          "name": "customer_products_internal_product_id_fkey",
-          "tableFrom": "customer_products",
-          "tableTo": "products",
-          "columnsFrom": [
-            "internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "customer_products_internal_entity_id_fkey": {
-          "name": "customer_products_internal_entity_id_fkey",
-          "tableFrom": "customer_products",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customers": {
-      "name": "customers",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "fingerprint": {
-          "name": "fingerprint",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "processor": {
-          "name": "processor",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "processors": {
-          "name": "processors",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "send_email_receipts": {
-          "name": "send_email_receipts",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "auto_topups": {
-          "name": "auto_topups",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "spend_limits": {
-          "name": "spend_limits",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_alerts": {
-          "name": "usage_alerts",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "overage_allowed": {
-          "name": "overage_allowed",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        }
-      },
-      "indexes": {
-        "customers_email_null_id_unique": {
-          "name": "customers_email_null_id_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "lower(\"email\")",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_org_env_fingerprint": {
-          "name": "idx_customers_org_env_fingerprint",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "fingerprint",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customers\".\"fingerprint\" IS NOT NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_processor_id": {
-          "name": "idx_customers_processor_id",
-          "columns": [
-            {
-              "expression": "(\"processor\" ->> 'id')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_composite": {
-          "name": "idx_customers_composite",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_org_env_internal_id": {
-          "name": "idx_customers_org_env_internal_id",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"internal_id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_email_trgm": {
-          "name": "idx_customers_email_trgm",
-          "columns": [
-            {
-              "expression": "\"email\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customers\".\"email\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customers_name_trgm": {
-          "name": "idx_customers_name_trgm",
-          "columns": [
-            {
-              "expression": "\"name\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customers\".\"name\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customers_id_trgm": {
-          "name": "idx_customers_id_trgm",
-          "columns": [
-            {
-              "expression": "\"id\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customers\".\"id\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customers_org_id_env_created_at": {
-          "name": "idx_customers_org_id_env_created_at",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_cursor": {
-          "name": "idx_customers_cursor",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_processors_revenuecat": {
-          "name": "idx_customers_processors_revenuecat",
-          "columns": [
-            {
-              "expression": "(\"processors\" ->> 'revenuecat')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_processors_vercel": {
-          "name": "idx_customers_processors_vercel",
-          "columns": [
-            {
-              "expression": "(\"processors\" ->> 'vercel')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "customers_org_id_fkey": {
-          "name": "customers_org_id_fkey",
-          "tableFrom": "customers",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cus_id_constraint": {
-          "name": "cus_id_constraint",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "id",
-            "env"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.entities": {
-      "name": "entities",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted": {
-          "name": "deleted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "spend_limits": {
-          "name": "spend_limits",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_alerts": {
-          "name": "usage_alerts",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "overage_allowed": {
-          "name": "overage_allowed",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_entities_internal_customer_id": {
-          "name": "idx_entities_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_customer_internal_desc": {
-          "name": "idx_entities_customer_internal_desc",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"internal_id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_org_env_id": {
-          "name": "idx_entities_org_env_id",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_cursor": {
-          "name": "idx_entities_cursor",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "entities_internal_customer_id_fkey": {
-          "name": "entities_internal_customer_id_fkey",
-          "tableFrom": "entities",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "entities_internal_feature_id_fkey": {
-          "name": "entities_internal_feature_id_fkey",
-          "tableFrom": "entities",
-          "tableTo": "features",
-          "columnsFrom": [
-            "internal_feature_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "entities_org_id_fkey": {
-          "name": "entities_org_id_fkey",
-          "tableFrom": "entities",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "entity_id_constraint": {
-          "name": "entity_id_constraint",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "env",
-            "internal_customer_id",
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.entitlements": {
-      "name": "entitlements",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_reward_id": {
-          "name": "internal_reward_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "allowance_type": {
-          "name": "allowance_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "allowance": {
-          "name": "allowance",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interval": {
-          "name": "interval",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interval_count": {
-          "name": "interval_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 1
-        },
-        "carry_from_previous": {
-          "name": "carry_from_previous",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "entity_feature_id": {
-          "name": "entity_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_limit": {
-          "name": "usage_limit",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expiry_duration": {
-          "name": "expiry_duration",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expiry_length": {
-          "name": "expiry_length",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "rollover": {
-          "name": "rollover",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_entitlements_internal_product_id": {
-          "name": "idx_entitlements_internal_product_id",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entitlements_internal_reward_id": {
-          "name": "idx_entitlements_internal_reward_id",
-          "columns": [
-            {
-              "expression": "internal_reward_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entitlements_reward_feature": {
-          "name": "idx_entitlements_reward_feature",
-          "columns": [
-            {
-              "expression": "internal_reward_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entitlements_internal_reward_id_c_partial": {
-          "name": "idx_entitlements_internal_reward_id_c_partial",
-          "columns": [
-            {
-              "expression": "\"internal_reward_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "entitlements_internal_feature_id_fkey": {
-          "name": "entitlements_internal_feature_id_fkey",
-          "tableFrom": "entitlements",
-          "tableTo": "features",
-          "columnsFrom": [
-            "internal_feature_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "entitlements_internal_product_id_fkey": {
-          "name": "entitlements_internal_product_id_fkey",
-          "tableFrom": "entitlements",
-          "tableTo": "products",
-          "columnsFrom": [
-            "internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        },
-        "entitlements_internal_reward_id_fkey": {
-          "name": "entitlements_internal_reward_id_fkey",
-          "tableFrom": "entitlements",
-          "tableTo": "rewards",
-          "columnsFrom": [
-            "internal_reward_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "entitlements_id_key": {
-          "name": "entitlements_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.events": {
-      "name": "events",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_slug": {
-          "name": "org_slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "event_name": {
-          "name": "event_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "idempotency_key": {
-          "name": "idempotency_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "value": {
-          "name": "value",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "set_usage": {
-          "name": "set_usage",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "entity_id": {
-          "name": "entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "properties": {
-          "name": "properties",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deductions": {
-          "name": "deductions",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_events_internal_customer_id": {
-          "name": "idx_events_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_events_internal_entity_id": {
-          "name": "idx_events_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_events_customer_non_usage_ts": {
-          "name": "idx_events_customer_non_usage_ts",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"timestamp\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"events\".\"set_usage\" = false",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "events_internal_customer_id_fkey": {
-          "name": "events_internal_customer_id_fkey",
-          "tableFrom": "events",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "unique_event_constraint": {
-          "name": "unique_event_constraint",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "env",
-            "customer_id",
-            "event_name",
-            "idempotency_key"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.features": {
-      "name": "features",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "display": {
-          "name": "display",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "archived": {
-          "name": "archived",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "event_names": {
-          "name": "event_names",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "features_org_id_fkey": {
-          "name": "features_org_id_fkey",
-          "tableFrom": "features",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "feature_id_constraint": {
-          "name": "feature_id_constraint",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "id",
-            "env"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.free_trials": {
-      "name": "free_trials",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration": {
-          "name": "duration",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'day'"
-        },
-        "length": {
-          "name": "length",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "unique_fingerprint": {
-          "name": "unique_fingerprint",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "card_required": {
-          "name": "card_required",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "on_end": {
-          "name": "on_end",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_free_trials_internal_product_id": {
-          "name": "idx_free_trials_internal_product_id",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "free_trials_internal_product_id_fkey": {
-          "name": "free_trials_internal_product_id_fkey",
-          "tableFrom": "free_trials",
-          "tableTo": "products",
-          "columnsFrom": [
-            "internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.invitation": {
-      "name": "invitation",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "role": {
-          "name": "role",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "inviter_id": {
-          "name": "inviter_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "invitation_organizationId_idx": {
-          "name": "invitation_organizationId_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "invitation_email_idx": {
-          "name": "invitation_email_idx",
-          "columns": [
-            {
-              "expression": "email",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "invitation_organization_id_organizations_id_fk": {
-          "name": "invitation_organization_id_organizations_id_fk",
-          "tableFrom": "invitation",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "invitation_inviter_id_user_id_fk": {
-          "name": "invitation_inviter_id_user_id_fk",
-          "tableFrom": "invitation",
-          "tableTo": "user",
-          "columnsFrom": [
-            "inviter_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.invoice_line_items": {
-      "name": "invoice_line_items",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "invoice_id": {
-          "name": "invoice_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_id": {
-          "name": "stripe_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_invoice_id": {
-          "name": "stripe_invoice_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_invoice_item_id": {
-          "name": "stripe_invoice_item_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_subscription_item_id": {
-          "name": "stripe_subscription_item_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_product_id": {
-          "name": "stripe_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_price_id": {
-          "name": "stripe_price_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_discountable": {
-          "name": "stripe_discountable",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "amount": {
-          "name": "amount",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "amount_after_discounts": {
-          "name": "amount_after_discounts",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "currency": {
-          "name": "currency",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'usd'"
-        },
-        "stripe_quantity": {
-          "name": "stripe_quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total_quantity": {
-          "name": "total_quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "paid_quantity": {
-          "name": "paid_quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description_source": {
-          "name": "description_source",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "direction": {
-          "name": "direction",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "billing_timing": {
-          "name": "billing_timing",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "prorated": {
-          "name": "prorated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "price_id": {
-          "name": "price_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "customer_product_ids": {
-          "name": "customer_product_ids",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "customer_price_ids": {
-          "name": "customer_price_ids",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "customer_entitlement_ids": {
-          "name": "customer_entitlement_ids",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "product_id": {
-          "name": "product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "effective_period_start": {
-          "name": "effective_period_start",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "effective_period_end": {
-          "name": "effective_period_end",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "discounts": {
-          "name": "discounts",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "invoice_line_items_invoice_id_fkey": {
-          "name": "invoice_line_items_invoice_id_fkey",
-          "tableFrom": "invoice_line_items",
-          "tableTo": "invoices",
-          "columnsFrom": [
-            "invoice_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "invoice_line_items_stripe_id_unique": {
-          "name": "invoice_line_items_stripe_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "stripe_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.invoice_templates": {
-      "name": "invoice_templates",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "footer": {
-          "name": "footer",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "memo": {
-          "name": "memo",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "net_terms_days": {
-          "name": "net_terms_days",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_invoice_templates_org_id": {
-          "name": "idx_invoice_templates_org_id",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "invoice_templates_org_id_fkey": {
-          "name": "invoice_templates_org_id_fkey",
-          "tableFrom": "invoice_templates",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "invoice_templates_id_unique": {
-          "name": "invoice_templates_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.invoices": {
-      "name": "invoices",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "product_ids": {
-          "name": "product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "internal_product_ids": {
-          "name": "internal_product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_id": {
-          "name": "stripe_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "processor_type": {
-          "name": "processor_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'draft'"
-        },
-        "hosted_invoice_url": {
-          "name": "hosted_invoice_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total": {
-          "name": "total",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "amount_paid": {
-          "name": "amount_paid",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refunded_amount": {
-          "name": "refunded_amount",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "currency": {
-          "name": "currency",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'usd'"
-        },
-        "discounts": {
-          "name": "discounts",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "items": {
-          "name": "items",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        }
-      },
-      "indexes": {
-        "idx_invoices_customer_created": {
-          "name": "idx_invoices_customer_created",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_invoices_internal_entity_id": {
-          "name": "idx_invoices_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "invoices_internal_customer_id_fkey": {
-          "name": "invoices_internal_customer_id_fkey",
-          "tableFrom": "invoices",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "invoices_internal_entity_id_fkey": {
-          "name": "invoices_internal_entity_id_fkey",
-          "tableFrom": "invoices",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "invoices_stripe_id_key": {
-          "name": "invoices_stripe_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "stripe_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.jwks": {
-      "name": "jwks",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "public_key": {
-          "name": "public_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "private_key": {
-          "name": "private_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.member": {
-      "name": "member",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "role": {
-          "name": "role",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'member'"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "member_organizationId_idx": {
-          "name": "member_organizationId_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "member_userId_idx": {
-          "name": "member_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "member_organization_id_organizations_id_fk": {
-          "name": "member_organization_id_organizations_id_fk",
-          "tableFrom": "member",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "member_user_id_user_id_fk": {
-          "name": "member_user_id_user_id_fk",
-          "tableFrom": "member",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.metadata": {
-      "name": "metadata",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "data": {
-          "name": "data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_invoice_id": {
-          "name": "stripe_invoice_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_checkout_session_id": {
-          "name": "stripe_checkout_session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migration_errors": {
-      "name": "migration_errors",
-      "schema": "",
-      "columns": {
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "migration_job_id": {
-          "name": "migration_job_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "data": {
-          "name": "data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "message": {
-          "name": "message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "code": {
-          "name": "code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "migration_customers_internal_customer_id_fkey": {
-          "name": "migration_customers_internal_customer_id_fkey",
-          "tableFrom": "migration_errors",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "migration_customers_migration_job_id_fkey": {
-          "name": "migration_customers_migration_job_id_fkey",
-          "tableFrom": "migration_errors",
-          "tableTo": "migration_jobs",
-          "columnsFrom": [
-            "migration_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "migration_errors_pkey": {
-          "name": "migration_errors_pkey",
-          "columns": [
-            "internal_customer_id",
-            "migration_job_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migration_item_runs": {
-      "name": "migration_item_runs",
-      "schema": "",
-      "columns": {
-        "migration_item_run_id": {
-          "name": "migration_item_run_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "migration_internal_id": {
-          "name": "migration_internal_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "migration_run_id": {
-          "name": "migration_run_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "dry_run": {
-          "name": "dry_run",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "item_kind": {
-          "name": "item_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "item_id": {
-          "name": "item_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "migration_item_runs_live_unique": {
-          "name": "migration_item_runs_live_unique",
-          "columns": [
-            {
-              "expression": "migration_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"migration_item_runs\".\"dry_run\" = false",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "migration_item_runs_dry_run_unique": {
-          "name": "migration_item_runs_dry_run_unique",
-          "columns": [
-            {
-              "expression": "migration_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "migration_run_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"migration_item_runs\".\"dry_run\" = true",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "migration_item_runs_customer_recent_idx": {
-          "name": "migration_item_runs_customer_recent_idx",
-          "columns": [
-            {
-              "expression": "item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"updated_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migration_jobs": {
-      "name": "migration_jobs",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_step": {
-          "name": "current_step",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "from_internal_product_id": {
-          "name": "from_internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "to_internal_product_id": {
-          "name": "to_internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "step_details": {
-          "name": "step_details",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "migration_jobs_from_internal_product_id_fkey": {
-          "name": "migration_jobs_from_internal_product_id_fkey",
-          "tableFrom": "migration_jobs",
-          "tableTo": "products",
-          "columnsFrom": [
-            "from_internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "migration_jobs_org_id_fkey": {
-          "name": "migration_jobs_org_id_fkey",
-          "tableFrom": "migration_jobs",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "migration_jobs_to_internal_product_id_fkey": {
-          "name": "migration_jobs_to_internal_product_id_fkey",
-          "tableFrom": "migration_jobs",
-          "tableTo": "products",
-          "columnsFrom": [
-            "to_internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migration_runs": {
-      "name": "migration_runs",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "migration_internal_id": {
-          "name": "migration_internal_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "dry_run": {
-          "name": "dry_run",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lazy_run": {
-          "name": "lazy_run",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "trigger_run_id": {
-          "name": "trigger_run_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "error_message": {
-          "name": "error_message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "only_ids": {
-          "name": "only_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_limit": {
-          "name": "target_limit",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "finished_at": {
-          "name": "finished_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "migration_runs_active_per_migration_unique": {
-          "name": "migration_runs_active_per_migration_unique",
-          "columns": [
-            {
-              "expression": "migration_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "migration_runs_migration_internal_id_fkey": {
-          "name": "migration_runs_migration_internal_id_fkey",
-          "tableFrom": "migration_runs",
-          "tableTo": "migrations",
-          "columnsFrom": [
-            "migration_internal_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "migration_runs_org_id_fkey": {
-          "name": "migration_runs_org_id_fkey",
-          "tableFrom": "migration_runs",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migrations": {
-      "name": "migrations",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "filter": {
-          "name": "filter",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "operations": {
-          "name": "operations",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "prepared_state": {
-          "name": "prepared_state",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "no_billing_changes": {
-          "name": "no_billing_changes",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "retry_failed": {
-          "name": "retry_failed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "migrations_org_env_id_unique": {
-          "name": "migrations_org_env_id_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "migrations_org_id_fkey": {
-          "name": "migrations_org_id_fkey",
-          "tableFrom": "migrations",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_access_token": {
-      "name": "oauth_access_token",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_id": {
-          "name": "refresh_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_access_token_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_session_id_session_id_fk": {
-          "name": "oauth_access_token_session_id_session_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "session",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_user_id_user_id_fk": {
-          "name": "oauth_access_token_user_id_user_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
-          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_refresh_token",
-          "columnsFrom": [
-            "refresh_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_access_token_token_unique": {
-          "name": "oauth_access_token_token_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.oauth_client": {
-      "name": "oauth_client",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "client_secret": {
-          "name": "client_secret",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "disabled": {
-          "name": "disabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "skip_consent": {
-          "name": "skip_consent",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "enable_end_session": {
-          "name": "enable_end_session",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "uri": {
-          "name": "uri",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "icon": {
-          "name": "icon",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "contacts": {
-          "name": "contacts",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tos": {
-          "name": "tos",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "policy": {
-          "name": "policy",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_id": {
-          "name": "software_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_version": {
-          "name": "software_version",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_statement": {
-          "name": "software_statement",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "redirect_uris": {
-          "name": "redirect_uris",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "post_logout_redirect_uris": {
-          "name": "post_logout_redirect_uris",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "token_endpoint_auth_method": {
-          "name": "token_endpoint_auth_method",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "grant_types": {
-          "name": "grant_types",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "response_types": {
-          "name": "response_types",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "public": {
-          "name": "public",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_client_user_id_user_id_fk": {
-          "name": "oauth_client_user_id_user_id_fk",
-          "tableFrom": "oauth_client",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_client_client_id_unique": {
-          "name": "oauth_client_client_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "client_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.oauth_consent": {
-      "name": "oauth_consent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "redirect_uri": {
-          "name": "redirect_uri",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "oauth_api_key_id": {
-          "name": "oauth_api_key_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "oauth_api_key": {
-          "name": "oauth_api_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_consent_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_consent",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_consent_user_id_user_id_fk": {
-          "name": "oauth_consent_user_id_user_id_fk",
-          "tableFrom": "oauth_consent",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.oauth_refresh_token": {
-      "name": "oauth_refresh_token",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "revoked": {
-          "name": "revoked",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "auth_time": {
-          "name": "auth_time",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_session_id_session_id_fk": {
-          "name": "oauth_refresh_token_session_id_session_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "session",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_user_id_user_id_fk": {
-          "name": "oauth_refresh_token_user_id_user_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.organizations": {
-      "name": "organizations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "slug": {
-          "name": "slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "logo": {
-          "name": "logo",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "default_currency": {
-          "name": "default_currency",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'usd'"
-        },
-        "stripe_connected": {
-          "name": "stripe_connected",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "stripe_config": {
-          "name": "stripe_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "test_stripe_connect": {
-          "name": "test_stripe_connect",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "live_stripe_connect": {
-          "name": "live_stripe_connect",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "processor_configs": {
-          "name": "processor_configs",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "test_pkey": {
-          "name": "test_pkey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "live_pkey": {
-          "name": "live_pkey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "svix_config": {
-          "name": "svix_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "onboarded": {
-          "name": "onboarded",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "deployed": {
-          "name": "deployed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "redis_config": {
-          "name": "redis_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_organizations_name_trgm": {
-          "name": "idx_organizations_name_trgm",
-          "columns": [
-            {
-              "expression": "\"name\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"organizations\".\"name\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_organizations_slug_trgm": {
-          "name": "idx_organizations_slug_trgm",
-          "columns": [
-            {
-              "expression": "\"slug\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"organizations\".\"slug\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_organizations_created_at_id": {
-          "name": "idx_organizations_created_at_id",
-          "columns": [
-            {
-              "expression": "\"createdAt\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "organizations_slug_unique": {
-          "name": "organizations_slug_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
-        },
-        "organizations_test_pkey_key": {
-          "name": "organizations_test_pkey_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "test_pkey"
-          ]
-        },
-        "organizations_live_pkey_key": {
-          "name": "organizations_live_pkey_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "live_pkey"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.passkey": {
-      "name": "passkey",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "public_key": {
-          "name": "public_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "credential_id": {
-          "name": "credential_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "counter": {
-          "name": "counter",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "device_type": {
-          "name": "device_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "backed_up": {
-          "name": "backed_up",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "transports": {
-          "name": "transports",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "aaguid": {
-          "name": "aaguid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "passkey_userId_idx": {
-          "name": "passkey_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "passkey_credentialId_idx": {
-          "name": "passkey_credentialId_idx",
-          "columns": [
-            {
-              "expression": "credential_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "passkey_user_id_user_id_fk": {
-          "name": "passkey_user_id_user_id_fk",
-          "tableFrom": "passkey",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "passkey_credential_id_unique": {
-          "name": "passkey_credential_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "credential_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.prices": {
-      "name": "prices",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "billing_type": {
-          "name": "billing_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tier_behavior": {
-          "name": "tier_behavior",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "entitlement_id": {
-          "name": "entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "proration_config": {
-          "name": "proration_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        }
-      },
-      "indexes": {
-        "idx_prices_internal_product_id": {
-          "name": "idx_prices_internal_product_id",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_prices_entitlement_id": {
-          "name": "idx_prices_entitlement_id",
-          "columns": [
-            {
-              "expression": "entitlement_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "prices_entitlement_id_fkey": {
-          "name": "prices_entitlement_id_fkey",
-          "tableFrom": "prices",
-          "tableTo": "entitlements",
-          "columnsFrom": [
-            "entitlement_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "prices_internal_product_id_fkey": {
-          "name": "prices_internal_product_id_fkey",
-          "tableFrom": "prices",
-          "tableTo": "products",
-          "columnsFrom": [
-            "internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "prices_id_key": {
-          "name": "prices_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.products": {
-      "name": "products",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "is_add_on": {
-          "name": "is_add_on",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "is_default": {
-          "name": "is_default",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "group": {
-          "name": "group",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "''"
-        },
-        "version": {
-          "name": "version",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "processor": {
-          "name": "processor",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "base_variant_id": {
-          "name": "base_variant_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "archived": {
-          "name": "archived",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        }
-      },
-      "indexes": {
-        "idx_products_org_env_id_version": {
-          "name": "idx_products_org_env_id_version",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "version",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "products_org_id_fkey": {
-          "name": "products_org_id_fkey",
-          "tableFrom": "products",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "unique_product": {
-          "name": "unique_product",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "id",
-            "env",
-            "version"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.referral_codes": {
-      "name": "referral_codes",
-      "schema": "",
-      "columns": {
-        "code": {
-          "name": "code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_reward_program_id": {
-          "name": "internal_reward_program_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_referral_codes_internal_customer_id": {
-          "name": "idx_referral_codes_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "referral_codes_internal_customer_id_fkey": {
-          "name": "referral_codes_internal_customer_id_fkey",
-          "tableFrom": "referral_codes",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "referral_codes_internal_reward_program_id_fkey": {
-          "name": "referral_codes_internal_reward_program_id_fkey",
-          "tableFrom": "referral_codes",
-          "tableTo": "reward_programs",
-          "columnsFrom": [
-            "internal_reward_program_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "referral_codes_org_id_fkey": {
-          "name": "referral_codes_org_id_fkey",
-          "tableFrom": "referral_codes",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "referral_codes_pkey": {
-          "name": "referral_codes_pkey",
-          "columns": [
-            "code",
-            "org_id",
-            "env"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "referral_codes_id_key": {
-          "name": "referral_codes_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.replaceables": {
-      "name": "replaceables",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "cus_ent_id": {
-          "name": "cus_ent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "from_entity_id": {
-          "name": "from_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "delete_next_cycle": {
-          "name": "delete_next_cycle",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {
-        "idx_replaceables_cus_ent_id": {
-          "name": "idx_replaceables_cus_ent_id",
-          "columns": [
-            {
-              "expression": "cus_ent_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "replaceables_cus_ent_id_fkey": {
-          "name": "replaceables_cus_ent_id_fkey",
-          "tableFrom": "replaceables",
-          "tableTo": "customer_entitlements",
-          "columnsFrom": [
-            "cus_ent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.revenuecat_mappings": {
-      "name": "revenuecat_mappings",
-      "schema": "",
-      "columns": {
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "autumn_product_id": {
-          "name": "autumn_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "revenuecat_product_ids": {
-          "name": "revenuecat_product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "revenuecat_mappings_org_id_fkey": {
-          "name": "revenuecat_mappings_org_id_fkey",
-          "tableFrom": "revenuecat_mappings",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "revenuecat_mappings_pkey": {
-          "name": "revenuecat_mappings_pkey",
-          "columns": [
-            "org_id",
-            "env",
-            "autumn_product_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reward_programs": {
-      "name": "reward_programs",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_reward_id": {
-          "name": "internal_reward_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "max_redemptions": {
-          "name": "max_redemptions",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "unlimited_redemptions": {
-          "name": "unlimited_redemptions",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "when": {
-          "name": "when",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'immediately'"
-        },
-        "product_ids": {
-          "name": "product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{\"\"}'"
-        },
-        "exclude_trial": {
-          "name": "exclude_trial",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "received_by": {
-          "name": "received_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "reward_triggers_internal_reward_id_fkey": {
-          "name": "reward_triggers_internal_reward_id_fkey",
-          "tableFrom": "reward_programs",
-          "tableTo": "rewards",
-          "columnsFrom": [
-            "internal_reward_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "reward_triggers_org_id_fkey": {
-          "name": "reward_triggers_org_id_fkey",
-          "tableFrom": "reward_programs",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reward_redemptions": {
-      "name": "reward_redemptions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "triggered": {
-          "name": "triggered",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_reward_program_id": {
-          "name": "internal_reward_program_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applied": {
-          "name": "applied",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "redeemer_applied": {
-          "name": "redeemer_applied",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "referral_code_id": {
-          "name": "referral_code_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reward_internal_id": {
-          "name": "reward_internal_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "promo_code": {
-          "name": "promo_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_reward_redemptions_referral_code_id": {
-          "name": "idx_reward_redemptions_referral_code_id",
-          "columns": [
-            {
-              "expression": "referral_code_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_reward_redemptions_reward_internal_id": {
-          "name": "idx_reward_redemptions_reward_internal_id",
-          "columns": [
-            {
-              "expression": "reward_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_reward_redemptions_customer_reward": {
-          "name": "idx_reward_redemptions_customer_reward",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "reward_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "reward_redemptions_internal_customer_id_fkey": {
-          "name": "reward_redemptions_internal_customer_id_fkey",
-          "tableFrom": "reward_redemptions",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "reward_redemptions_internal_reward_program_id_fkey": {
-          "name": "reward_redemptions_internal_reward_program_id_fkey",
-          "tableFrom": "reward_redemptions",
-          "tableTo": "reward_programs",
-          "columnsFrom": [
-            "internal_reward_program_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "reward_redemptions_referral_code_id_fkey": {
-          "name": "reward_redemptions_referral_code_id_fkey",
-          "tableFrom": "reward_redemptions",
-          "tableTo": "referral_codes",
-          "columnsFrom": [
-            "referral_code_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rewards": {
-      "name": "rewards",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "discount_config": {
-          "name": "discount_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "free_product_config": {
-          "name": "free_product_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "free_product_id": {
-          "name": "free_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "promo_codes": {
-          "name": "promo_codes",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "coupons_org_id_fkey": {
-          "name": "coupons_org_id_fkey",
-          "tableFrom": "rewards",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rollovers": {
-      "name": "rollovers",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "cus_ent_id": {
-          "name": "cus_ent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "balance": {
-          "name": "balance",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage": {
-          "name": "usage",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "entities": {
-          "name": "entities",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        }
-      },
-      "indexes": {
-        "idx_rollovers_cus_ent_id": {
-          "name": "idx_rollovers_cus_ent_id",
-          "columns": [
-            {
-              "expression": "cus_ent_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_rollovers_cus_ent_expires": {
-          "name": "idx_rollovers_cus_ent_expires",
-          "columns": [
-            {
-              "expression": "cus_ent_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "rollover_cus_ent_id_fkey": {
-          "name": "rollover_cus_ent_id_fkey",
-          "tableFrom": "rollovers",
-          "tableTo": "customer_entitlements",
-          "columnsFrom": [
-            "cus_ent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.phases": {
-      "name": "phases",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "schedule_id": {
-          "name": "schedule_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "starts_at": {
-          "name": "starts_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_product_ids": {
-          "name": "customer_product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "phases_schedule_id_fkey": {
-          "name": "phases_schedule_id_fkey",
-          "tableFrom": "phases",
-          "tableTo": "schedules",
-          "columnsFrom": [
-            "schedule_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "phases_schedule_id_starts_at_key": {
-          "name": "phases_schedule_id_starts_at_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "schedule_id",
-            "starts_at"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.schedules": {
-      "name": "schedules",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "entity_id": {
-          "name": "entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "schedules_customer_scope_unique": {
-          "name": "schedules_customer_scope_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"schedules\".\"internal_entity_id\" IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "schedules_entity_scope_unique": {
-          "name": "schedules_entity_scope_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_schedules_internal_customer_id": {
-          "name": "idx_schedules_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_schedules_internal_entity_id": {
-          "name": "idx_schedules_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "schedules_org_id_fkey": {
-          "name": "schedules_org_id_fkey",
-          "tableFrom": "schedules",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "schedules_internal_customer_id_fkey": {
-          "name": "schedules_internal_customer_id_fkey",
-          "tableFrom": "schedules",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "schedules_internal_entity_id_fkey": {
-          "name": "schedules_internal_entity_id_fkey",
-          "tableFrom": "schedules",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.session": {
-      "name": "session",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "impersonated_by": {
-          "name": "impersonated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "active_organization_id": {
-          "name": "active_organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "city": {
-          "name": "city",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "country": {
-          "name": "country",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "session_userId_idx": {
-          "name": "session_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "session_user_id_user_id_fk": {
-          "name": "session_user_id_user_id_fk",
-          "tableFrom": "session",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "session_token_unique": {
-          "name": "session_token_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.subscriptions": {
-      "name": "subscriptions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stripe_id": {
-          "name": "stripe_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_schedule_id": {
-          "name": "stripe_schedule_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "usage_features": {
-          "name": "usage_features",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_period_start": {
-          "name": "current_period_start",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_period_end": {
-          "name": "current_period_end",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "subscriptions_org_id_fkey": {
-          "name": "subscriptions_org_id_fkey",
-          "tableFrom": "subscriptions",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "subscriptions_stripe_id_key": {
-          "name": "subscriptions_stripe_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "stripe_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.user": {
-      "name": "user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "image": {
-          "name": "image",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "role": {
-          "name": "role",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "banned": {
-          "name": "banned",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ban_reason": {
-          "name": "ban_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ban_expires": {
-          "name": "ban_expires",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_active_at": {
-          "name": "last_active_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_user_name_trgm": {
-          "name": "idx_user_name_trgm",
-          "columns": [
-            {
-              "expression": "\"name\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"user\".\"name\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_user_email_trgm": {
-          "name": "idx_user_email_trgm",
-          "columns": [
-            {
-              "expression": "\"email\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"user\".\"email\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_user_created_at_id": {
-          "name": "idx_user_created_at_id",
-          "columns": [
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "user_created_by_fkey": {
-          "name": "user_created_by_fkey",
-          "tableFrom": "user",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "created_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "user_email_unique": {
-          "name": "user_email_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vercel_resources": {
-      "name": "vercel_resources",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "installation_id": {
-          "name": "installation_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        }
-      },
-      "indexes": {
-        "vercel_resources_installation_name_unique_idx": {
-          "name": "vercel_resources_installation_name_unique_idx",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "installation_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "status <> 'uninstalled'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vercel_resources_org_id_fkey": {
-          "name": "vercel_resources_org_id_fkey",
-          "tableFrom": "vercel_resources",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.verification": {
-      "name": "verification",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "identifier": {
-          "name": "identifier",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "verification_identifier_idx": {
-          "name": "verification_identifier_idx",
-          "columns": [
-            {
-              "expression": "identifier",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    }
-  },
-  "enums": {},
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "eadc8c95-3f6f-4643-abc3-e90cd56d5ed1",
+	"prevId": "3ee43a45-bd02-43e2-a2d1-2080d51b5674",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.actions": {
+			"name": "actions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_slug": {
+					"name": "org_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"auth_type": {
+					"name": "auth_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"method": {
+					"name": "method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"path": {
+					"name": "path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"properties": {
+					"name": "properties",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_actions_on_internal_entity_id": {
+					"name": "idx_actions_on_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"actions_org_id_fkey": {
+					"name": "actions_org_id_fkey",
+					"tableFrom": "actions",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"actions_customer_id_fkey": {
+					"name": "actions_customer_id_fkey",
+					"tableFrom": "actions",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"actions_entity_id_fkey": {
+					"name": "actions_entity_id_fkey",
+					"tableFrom": "actions",
+					"tableTo": "entities",
+					"columnsFrom": ["internal_entity_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.api_keys": {
+			"name": "api_keys",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prefix": {
+					"name": "prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hashed_key": {
+					"name": "hashed_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"meta": {
+					"name": "meta",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"api_keys_org_id_fkey": {
+					"name": "api_keys_org_id_fkey",
+					"tableFrom": "api_keys",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"api_keys_hashed_key_key": {
+					"name": "api_keys_hashed_key_key",
+					"nullsNotDistinct": false,
+					"columns": ["hashed_key"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.auto_topup_limit_states": {
+			"name": "auto_topup_limit_states",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"purchase_window_ends_at": {
+					"name": "purchase_window_ends_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"purchase_count": {
+					"name": "purchase_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempt_window_ends_at": {
+					"name": "attempt_window_ends_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt_count": {
+					"name": "attempt_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"failed_attempt_window_ends_at": {
+					"name": "failed_attempt_window_ends_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"failed_attempt_count": {
+					"name": "failed_attempt_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"last_attempt_at": {
+					"name": "last_attempt_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_failed_attempt_at": {
+					"name": "last_failed_attempt_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"auto_topup_limits_org_env_internal_customer_feature_unique": {
+					"name": "auto_topup_limits_org_env_internal_customer_feature_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"auto_topup_limits_org_id_fkey": {
+					"name": "auto_topup_limits_org_id_fkey",
+					"tableFrom": "auto_topup_limit_states",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"auto_topup_limits_internal_customer_id_fkey": {
+					"name": "auto_topup_limits_internal_customer_id_fkey",
+					"tableFrom": "auto_topup_limit_states",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.chat_approvals": {
+			"name": "chat_approvals",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"message_ts": {
+					"name": "message_ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_user_id": {
+					"name": "provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_call_id": {
+					"name": "tool_call_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_name": {
+					"name": "tool_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tool_args": {
+					"name": "tool_args",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"preview": {
+					"name": "preview",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decided_at": {
+					"name": "decided_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decided_by_provider_user_id": {
+					"name": "decided_by_provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"chat_approvals_org_id_fkey": {
+					"name": "chat_approvals_org_id_fkey",
+					"tableFrom": "chat_approvals",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.chat_installations": {
+			"name": "chat_installations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_name": {
+					"name": "workspace_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"bot_user_id": {
+					"name": "bot_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"bot_access_token": {
+					"name": "bot_access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"default_env": {
+					"name": "default_env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sandbox_api_key_id": {
+					"name": "sandbox_api_key_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_api_key": {
+					"name": "sandbox_api_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"live_api_key_id": {
+					"name": "live_api_key_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"live_api_key": {
+					"name": "live_api_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"installed_by_user_id": {
+					"name": "installed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"installed_by_provider_user_id": {
+					"name": "installed_by_provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"chat_installations_org_id_fkey": {
+					"name": "chat_installations_org_id_fkey",
+					"tableFrom": "chat_installations",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"chat_installations_org_provider_key": {
+					"name": "chat_installations_org_provider_key",
+					"nullsNotDistinct": false,
+					"columns": ["org_id", "provider"]
+				},
+				"chat_installations_provider_workspace_key": {
+					"name": "chat_installations_provider_workspace_key",
+					"nullsNotDistinct": false,
+					"columns": ["provider", "workspace_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.chat_results": {
+			"name": "chat_results",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.checkouts": {
+			"name": "checkouts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_version": {
+					"name": "params_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"response": {
+					"name": "response",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_invoice_id": {
+					"name": "stripe_invoice_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_checkouts_stripe_invoice_id": {
+					"name": "idx_checkouts_stripe_invoice_id",
+					"columns": [
+						{
+							"expression": "stripe_invoice_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customer_entitlements": {
+			"name": "customer_entitlements",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"customer_product_id": {
+					"name": "customer_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"entitlement_id": {
+					"name": "entitlement_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"unlimited": {
+					"name": "unlimited",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"balance": {
+					"name": "balance",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_reset_at": {
+					"name": "next_reset_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_allowed": {
+					"name": "usage_allowed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"adjustment": {
+					"name": "adjustment",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"additional_balance": {
+					"name": "additional_balance",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"entities": {
+					"name": "entities",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cache_version": {
+					"name": "cache_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"external_id": {
+					"name": "external_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_customer_entitlements_product_id": {
+					"name": "idx_customer_entitlements_product_id",
+					"columns": [
+						{
+							"expression": "customer_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_entitlements_internal_customer_id": {
+					"name": "idx_customer_entitlements_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hash",
+					"with": {}
+				},
+				"idx_customer_entitlements_internal_customer_id_btree": {
+					"name": "idx_customer_entitlements_internal_customer_id_btree",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_entitlements_entitlement_id": {
+					"name": "idx_customer_entitlements_entitlement_id",
+					"columns": [
+						{
+							"expression": "entitlement_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_entitlements_internal_entity_id": {
+					"name": "idx_customer_entitlements_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hash",
+					"with": {}
+				},
+				"idx_customer_entitlements_on_next_reset_at": {
+					"name": "idx_customer_entitlements_on_next_reset_at",
+					"columns": [
+						{
+							"expression": "next_reset_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_entitlements_loose_customer_expires": {
+					"name": "idx_customer_entitlements_loose_customer_expires",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"entitlements_internal_feature_id_fkey": {
+					"name": "entitlements_internal_feature_id_fkey",
+					"tableFrom": "customer_entitlements",
+					"tableTo": "features",
+					"columnsFrom": ["internal_feature_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"customer_entitlements_internal_entity_id_fkey": {
+					"name": "customer_entitlements_internal_entity_id_fkey",
+					"tableFrom": "customer_entitlements",
+					"tableTo": "entities",
+					"columnsFrom": ["internal_entity_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"customer_entitlements_customer_product_id_fkey": {
+					"name": "customer_entitlements_customer_product_id_fkey",
+					"tableFrom": "customer_entitlements",
+					"tableTo": "customer_products",
+					"columnsFrom": ["customer_product_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"customer_entitlements_entitlement_id_fkey": {
+					"name": "customer_entitlements_entitlement_id_fkey",
+					"tableFrom": "customer_entitlements",
+					"tableTo": "entitlements",
+					"columnsFrom": ["entitlement_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customer_prices": {
+			"name": "customer_prices",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"price_id": {
+					"name": "price_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"customer_product_id": {
+					"name": "customer_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_customer_prices_product_id": {
+					"name": "idx_customer_prices_product_id",
+					"columns": [
+						{
+							"expression": "customer_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_prices_price_id": {
+					"name": "idx_customer_prices_price_id",
+					"columns": [
+						{
+							"expression": "price_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_prices_internal_customer_id": {
+					"name": "idx_customer_prices_internal_customer_id",
+					"columns": [
+						{
+							"expression": "\"internal_customer_id\" COLLATE \"C\"",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
+					"concurrently": true,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"customer_prices_customer_product_id_fkey": {
+					"name": "customer_prices_customer_product_id_fkey",
+					"tableFrom": "customer_prices",
+					"tableTo": "customer_products",
+					"columnsFrom": ["customer_product_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"customer_prices_internal_customer_id_fkey": {
+					"name": "customer_prices_internal_customer_id_fkey",
+					"tableFrom": "customer_prices",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"customer_prices_price_id_fkey": {
+					"name": "customer_prices_price_id_fkey",
+					"tableFrom": "customer_prices",
+					"tableTo": "prices",
+					"columnsFrom": ["price_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customer_products": {
+			"name": "customer_products",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"processor": {
+					"name": "processor",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"canceled": {
+					"name": "canceled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"canceled_at": {
+					"name": "canceled_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"starts_at": {
+					"name": "starts_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_starts_at": {
+					"name": "access_starts_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"product_id": {
+					"name": "product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"free_trial_id": {
+					"name": "free_trial_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trial_ends_at": {
+					"name": "trial_ends_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"billing_cycle_anchor_resets_at": {
+					"name": "billing_cycle_anchor_resets_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"collection_method": {
+					"name": "collection_method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'charge_automatically'"
+				},
+				"subscription_ids": {
+					"name": "subscription_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scheduled_ids": {
+					"name": "scheduled_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 1
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"billing_version": {
+					"name": "billing_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"api_version": {
+					"name": "api_version",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"api_semver": {
+					"name": "api_semver",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"external_id": {
+					"name": "external_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_checkout_session_id": {
+					"name": "stripe_checkout_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"previous_customer_product_id": {
+					"name": "previous_customer_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"on_trial_end": {
+					"name": "on_trial_end",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_customer_products_customer_status": {
+					"name": "idx_customer_products_customer_status",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_products_on_internal_entity_id": {
+					"name": "idx_customer_products_on_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_products_on_internal_product_id": {
+					"name": "idx_customer_products_on_internal_product_id",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_products_subscription_ids": {
+					"name": "idx_customer_products_subscription_ids",
+					"columns": [
+						{
+							"expression": "subscription_ids",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_customer_products_scheduled_ids": {
+					"name": "idx_customer_products_scheduled_ids",
+					"columns": [
+						{
+							"expression": "scheduled_ids",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_customer_products_stripe_checkout_session_id": {
+					"name": "idx_customer_products_stripe_checkout_session_id",
+					"columns": [
+						{
+							"expression": "stripe_checkout_session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customer_products_revenuecat_processor": {
+					"name": "idx_customer_products_revenuecat_processor",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"customer_products_free_trial_id_fkey": {
+					"name": "customer_products_free_trial_id_fkey",
+					"tableFrom": "customer_products",
+					"tableTo": "free_trials",
+					"columnsFrom": ["free_trial_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"customer_products_internal_customer_id_fkey": {
+					"name": "customer_products_internal_customer_id_fkey",
+					"tableFrom": "customer_products",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"customer_products_internal_product_id_fkey": {
+					"name": "customer_products_internal_product_id_fkey",
+					"tableFrom": "customer_products",
+					"tableTo": "products",
+					"columnsFrom": ["internal_product_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"customer_products_internal_entity_id_fkey": {
+					"name": "customer_products_internal_entity_id_fkey",
+					"tableFrom": "customer_products",
+					"tableTo": "entities",
+					"columnsFrom": ["internal_entity_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customers": {
+			"name": "customers",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fingerprint": {
+					"name": "fingerprint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"processor": {
+					"name": "processor",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"processors": {
+					"name": "processors",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"send_email_receipts": {
+					"name": "send_email_receipts",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"auto_topups": {
+					"name": "auto_topups",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spend_limits": {
+					"name": "spend_limits",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_alerts": {
+					"name": "usage_alerts",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overage_allowed": {
+					"name": "overage_allowed",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"customers_email_null_id_unique": {
+					"name": "customers_email_null_id_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customers_org_env_fingerprint": {
+					"name": "idx_customers_org_env_fingerprint",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fingerprint",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"customers\".\"fingerprint\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customers_processor_id": {
+					"name": "idx_customers_processor_id",
+					"columns": [
+						{
+							"expression": "(\"processor\" ->> 'id')",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customers_composite": {
+					"name": "idx_customers_composite",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customers_org_env_internal_id": {
+					"name": "idx_customers_org_env_internal_id",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"internal_id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customers_email_trgm": {
+					"name": "idx_customers_email_trgm",
+					"columns": [
+						{
+							"expression": "\"email\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"customers\".\"email\" IS NOT NULL",
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_customers_name_trgm": {
+					"name": "idx_customers_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"customers\".\"name\" IS NOT NULL",
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_customers_id_trgm": {
+					"name": "idx_customers_id_trgm",
+					"columns": [
+						{
+							"expression": "\"id\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"customers\".\"id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_customers_org_id_env_created_at": {
+					"name": "idx_customers_org_id_env_created_at",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customers_cursor": {
+					"name": "idx_customers_cursor",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customers_processors_revenuecat": {
+					"name": "idx_customers_processors_revenuecat",
+					"columns": [
+						{
+							"expression": "(\"processors\" ->> 'revenuecat')",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_customers_processors_vercel": {
+					"name": "idx_customers_processors_vercel",
+					"columns": [
+						{
+							"expression": "(\"processors\" ->> 'vercel')",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"customers_org_id_fkey": {
+					"name": "customers_org_id_fkey",
+					"tableFrom": "customers",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cus_id_constraint": {
+					"name": "cus_id_constraint",
+					"nullsNotDistinct": false,
+					"columns": ["org_id", "id", "env"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.entities": {
+			"name": "entities",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"deleted": {
+					"name": "deleted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spend_limits": {
+					"name": "spend_limits",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_alerts": {
+					"name": "usage_alerts",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overage_allowed": {
+					"name": "overage_allowed",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_entities_internal_customer_id": {
+					"name": "idx_entities_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_entities_customer_internal_desc": {
+					"name": "idx_entities_customer_internal_desc",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"internal_id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_entities_org_env_id": {
+					"name": "idx_entities_org_env_id",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_entities_cursor": {
+					"name": "idx_entities_cursor",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"entities_internal_customer_id_fkey": {
+					"name": "entities_internal_customer_id_fkey",
+					"tableFrom": "entities",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"entities_internal_feature_id_fkey": {
+					"name": "entities_internal_feature_id_fkey",
+					"tableFrom": "entities",
+					"tableTo": "features",
+					"columnsFrom": ["internal_feature_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"entities_org_id_fkey": {
+					"name": "entities_org_id_fkey",
+					"tableFrom": "entities",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"entity_id_constraint": {
+					"name": "entity_id_constraint",
+					"nullsNotDistinct": false,
+					"columns": ["org_id", "env", "internal_customer_id", "id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.entitlements": {
+			"name": "entitlements",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_reward_id": {
+					"name": "internal_reward_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"allowance_type": {
+					"name": "allowance_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"allowance": {
+					"name": "allowance",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval": {
+					"name": "interval",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_count": {
+					"name": "interval_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 1
+				},
+				"carry_from_previous": {
+					"name": "carry_from_previous",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"entity_feature_id": {
+					"name": "entity_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_limit": {
+					"name": "usage_limit",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expiry_duration": {
+					"name": "expiry_duration",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expiry_length": {
+					"name": "expiry_length",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rollover": {
+					"name": "rollover",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_entitlements_internal_product_id": {
+					"name": "idx_entitlements_internal_product_id",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_entitlements_internal_reward_id": {
+					"name": "idx_entitlements_internal_reward_id",
+					"columns": [
+						{
+							"expression": "internal_reward_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_entitlements_reward_feature": {
+					"name": "idx_entitlements_reward_feature",
+					"columns": [
+						{
+							"expression": "internal_reward_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_entitlements_internal_reward_id_c_partial": {
+					"name": "idx_entitlements_internal_reward_id_c_partial",
+					"columns": [
+						{
+							"expression": "\"internal_reward_id\" COLLATE \"C\"",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"entitlements_internal_feature_id_fkey": {
+					"name": "entitlements_internal_feature_id_fkey",
+					"tableFrom": "entitlements",
+					"tableTo": "features",
+					"columnsFrom": ["internal_feature_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"entitlements_internal_product_id_fkey": {
+					"name": "entitlements_internal_product_id_fkey",
+					"tableFrom": "entitlements",
+					"tableTo": "products",
+					"columnsFrom": ["internal_product_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				},
+				"entitlements_internal_reward_id_fkey": {
+					"name": "entitlements_internal_reward_id_fkey",
+					"tableFrom": "entitlements",
+					"tableTo": "rewards",
+					"columnsFrom": ["internal_reward_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"entitlements_id_key": {
+					"name": "entitlements_id_key",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_slug": {
+					"name": "org_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_name": {
+					"name": "event_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"value": {
+					"name": "value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"set_usage": {
+					"name": "set_usage",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"properties": {
+					"name": "properties",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"deductions": {
+					"name": "deductions",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_events_internal_customer_id": {
+					"name": "idx_events_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_events_internal_entity_id": {
+					"name": "idx_events_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_events_customer_non_usage_ts": {
+					"name": "idx_events_customer_non_usage_ts",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"timestamp\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"events\".\"set_usage\" = false",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"events_internal_customer_id_fkey": {
+					"name": "events_internal_customer_id_fkey",
+					"tableFrom": "events",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_event_constraint": {
+					"name": "unique_event_constraint",
+					"nullsNotDistinct": false,
+					"columns": [
+						"org_id",
+						"env",
+						"customer_id",
+						"event_name",
+						"idempotency_key"
+					]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.features": {
+			"name": "features",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display": {
+					"name": "display",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"archived": {
+					"name": "archived",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"event_names": {
+					"name": "event_names",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"features_org_id_fkey": {
+					"name": "features_org_id_fkey",
+					"tableFrom": "features",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"feature_id_constraint": {
+					"name": "feature_id_constraint",
+					"nullsNotDistinct": false,
+					"columns": ["org_id", "id", "env"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.free_trials": {
+			"name": "free_trials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'day'"
+				},
+				"length": {
+					"name": "length",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unique_fingerprint": {
+					"name": "unique_fingerprint",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"card_required": {
+					"name": "card_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"on_end": {
+					"name": "on_end",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_free_trials_internal_product_id": {
+					"name": "idx_free_trials_internal_product_id",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"free_trials_internal_product_id_fkey": {
+					"name": "free_trials_internal_product_id_fkey",
+					"tableFrom": "free_trials",
+					"tableTo": "products",
+					"columnsFrom": ["internal_product_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invitation": {
+			"name": "invitation",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"inviter_id": {
+					"name": "inviter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"invitation_organizationId_idx": {
+					"name": "invitation_organizationId_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"invitation_email_idx": {
+					"name": "invitation_email_idx",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"invitation_organization_id_organizations_id_fk": {
+					"name": "invitation_organization_id_organizations_id_fk",
+					"tableFrom": "invitation",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"invitation_inviter_id_user_id_fk": {
+					"name": "invitation_inviter_id_user_id_fk",
+					"tableFrom": "invitation",
+					"tableTo": "user",
+					"columnsFrom": ["inviter_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.invoice_line_items": {
+			"name": "invoice_line_items",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"invoice_id": {
+					"name": "invoice_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_id": {
+					"name": "stripe_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_invoice_id": {
+					"name": "stripe_invoice_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_invoice_item_id": {
+					"name": "stripe_invoice_item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_subscription_item_id": {
+					"name": "stripe_subscription_item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_product_id": {
+					"name": "stripe_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_price_id": {
+					"name": "stripe_price_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_discountable": {
+					"name": "stripe_discountable",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount_after_discounts": {
+					"name": "amount_after_discounts",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"currency": {
+					"name": "currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'usd'"
+				},
+				"stripe_quantity": {
+					"name": "stripe_quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_quantity": {
+					"name": "total_quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"paid_quantity": {
+					"name": "paid_quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description_source": {
+					"name": "description_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"direction": {
+					"name": "direction",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"billing_timing": {
+					"name": "billing_timing",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prorated": {
+					"name": "prorated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"price_id": {
+					"name": "price_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"customer_product_ids": {
+					"name": "customer_product_ids",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"customer_price_ids": {
+					"name": "customer_price_ids",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"customer_entitlement_ids": {
+					"name": "customer_entitlement_ids",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"product_id": {
+					"name": "product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"effective_period_start": {
+					"name": "effective_period_start",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"effective_period_end": {
+					"name": "effective_period_end",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"discounts": {
+					"name": "discounts",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"invoice_line_items_invoice_id_fkey": {
+					"name": "invoice_line_items_invoice_id_fkey",
+					"tableFrom": "invoice_line_items",
+					"tableTo": "invoices",
+					"columnsFrom": ["invoice_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"invoice_line_items_stripe_id_unique": {
+					"name": "invoice_line_items_stripe_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["stripe_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invoice_templates": {
+			"name": "invoice_templates",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"footer": {
+					"name": "footer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"memo": {
+					"name": "memo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"net_terms_days": {
+					"name": "net_terms_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_invoice_templates_org_id": {
+					"name": "idx_invoice_templates_org_id",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"invoice_templates_org_id_fkey": {
+					"name": "invoice_templates_org_id_fkey",
+					"tableFrom": "invoice_templates",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"invoice_templates_id_unique": {
+					"name": "invoice_templates_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invoices": {
+			"name": "invoices",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"product_ids": {
+					"name": "product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"internal_product_ids": {
+					"name": "internal_product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_id": {
+					"name": "stripe_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"processor_type": {
+					"name": "processor_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"hosted_invoice_url": {
+					"name": "hosted_invoice_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total": {
+					"name": "total",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"amount_paid": {
+					"name": "amount_paid",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refunded_amount": {
+					"name": "refunded_amount",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"currency": {
+					"name": "currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'usd'"
+				},
+				"discounts": {
+					"name": "discounts",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"items": {
+					"name": "items",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				}
+			},
+			"indexes": {
+				"idx_invoices_customer_created": {
+					"name": "idx_invoices_customer_created",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_invoices_internal_entity_id": {
+					"name": "idx_invoices_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
+					"concurrently": true,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"invoices_internal_customer_id_fkey": {
+					"name": "invoices_internal_customer_id_fkey",
+					"tableFrom": "invoices",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"invoices_internal_entity_id_fkey": {
+					"name": "invoices_internal_entity_id_fkey",
+					"tableFrom": "invoices",
+					"tableTo": "entities",
+					"columnsFrom": ["internal_entity_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"invoices_stripe_id_key": {
+					"name": "invoices_stripe_id_key",
+					"nullsNotDistinct": false,
+					"columns": ["stripe_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.jwks": {
+			"name": "jwks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"public_key": {
+					"name": "public_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"private_key": {
+					"name": "private_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.member": {
+			"name": "member",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'member'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"member_organizationId_idx": {
+					"name": "member_organizationId_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"member_userId_idx": {
+					"name": "member_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"member_organization_id_organizations_id_fk": {
+					"name": "member_organization_id_organizations_id_fk",
+					"tableFrom": "member",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"member_user_id_user_id_fk": {
+					"name": "member_user_id_user_id_fk",
+					"tableFrom": "member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.metadata": {
+			"name": "metadata",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_invoice_id": {
+					"name": "stripe_invoice_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_checkout_session_id": {
+					"name": "stripe_checkout_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migration_errors": {
+			"name": "migration_errors",
+			"schema": "",
+			"columns": {
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"migration_job_id": {
+					"name": "migration_job_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"migration_customers_internal_customer_id_fkey": {
+					"name": "migration_customers_internal_customer_id_fkey",
+					"tableFrom": "migration_errors",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"migration_customers_migration_job_id_fkey": {
+					"name": "migration_customers_migration_job_id_fkey",
+					"tableFrom": "migration_errors",
+					"tableTo": "migration_jobs",
+					"columnsFrom": ["migration_job_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"migration_errors_pkey": {
+					"name": "migration_errors_pkey",
+					"columns": ["internal_customer_id", "migration_job_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migration_item_runs": {
+			"name": "migration_item_runs",
+			"schema": "",
+			"columns": {
+				"migration_item_run_id": {
+					"name": "migration_item_run_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"migration_internal_id": {
+					"name": "migration_internal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"migration_run_id": {
+					"name": "migration_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dry_run": {
+					"name": "dry_run",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"item_kind": {
+					"name": "item_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_id": {
+					"name": "item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"migration_item_runs_live_unique": {
+					"name": "migration_item_runs_live_unique",
+					"columns": [
+						{
+							"expression": "migration_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"migration_item_runs\".\"dry_run\" = false",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"migration_item_runs_dry_run_unique": {
+					"name": "migration_item_runs_dry_run_unique",
+					"columns": [
+						{
+							"expression": "migration_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "migration_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"migration_item_runs\".\"dry_run\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"migration_item_runs_customer_recent_idx": {
+					"name": "migration_item_runs_customer_recent_idx",
+					"columns": [
+						{
+							"expression": "item_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"updated_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migration_jobs": {
+			"name": "migration_jobs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"from_internal_product_id": {
+					"name": "from_internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"to_internal_product_id": {
+					"name": "to_internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"step_details": {
+					"name": "step_details",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"migration_jobs_from_internal_product_id_fkey": {
+					"name": "migration_jobs_from_internal_product_id_fkey",
+					"tableFrom": "migration_jobs",
+					"tableTo": "products",
+					"columnsFrom": ["from_internal_product_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"migration_jobs_org_id_fkey": {
+					"name": "migration_jobs_org_id_fkey",
+					"tableFrom": "migration_jobs",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"migration_jobs_to_internal_product_id_fkey": {
+					"name": "migration_jobs_to_internal_product_id_fkey",
+					"tableFrom": "migration_jobs",
+					"tableTo": "products",
+					"columnsFrom": ["to_internal_product_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migration_runs": {
+			"name": "migration_runs",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"migration_internal_id": {
+					"name": "migration_internal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dry_run": {
+					"name": "dry_run",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lazy_run": {
+					"name": "lazy_run",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"trigger_run_id": {
+					"name": "trigger_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"only_ids": {
+					"name": "only_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"target_limit": {
+					"name": "target_limit",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"migration_runs_active_per_migration_unique": {
+					"name": "migration_runs_active_per_migration_unique",
+					"columns": [
+						{
+							"expression": "migration_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"migration_runs_migration_internal_id_fkey": {
+					"name": "migration_runs_migration_internal_id_fkey",
+					"tableFrom": "migration_runs",
+					"tableTo": "migrations",
+					"columnsFrom": ["migration_internal_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"migration_runs_org_id_fkey": {
+					"name": "migration_runs_org_id_fkey",
+					"tableFrom": "migration_runs",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migrations": {
+			"name": "migrations",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"filter": {
+					"name": "filter",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"operations": {
+					"name": "operations",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prepared_state": {
+					"name": "prepared_state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"no_billing_changes": {
+					"name": "no_billing_changes",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retry_failed": {
+					"name": "retry_failed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"migrations_org_env_id_unique": {
+					"name": "migrations_org_env_id_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"migrations_org_id_fkey": {
+					"name": "migrations_org_id_fkey",
+					"tableFrom": "migrations",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_access_token": {
+			"name": "oauth_access_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_id": {
+					"name": "refresh_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_access_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_session_id_session_id_fk": {
+					"name": "oauth_access_token_session_id_session_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "session",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_user_id_user_id_fk": {
+					"name": "oauth_access_token_user_id_user_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+					"name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "oauth_refresh_token",
+					"columnsFrom": ["refresh_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_access_token_token_unique": {
+					"name": "oauth_access_token_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.oauth_client": {
+			"name": "oauth_client",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_secret": {
+					"name": "client_secret",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"disabled": {
+					"name": "disabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"skip_consent": {
+					"name": "skip_consent",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enable_end_session": {
+					"name": "enable_end_session",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"uri": {
+					"name": "uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contacts": {
+					"name": "contacts",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tos": {
+					"name": "tos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_id": {
+					"name": "software_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_version": {
+					"name": "software_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_statement": {
+					"name": "software_statement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"redirect_uris": {
+					"name": "redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"post_logout_redirect_uris": {
+					"name": "post_logout_redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_endpoint_auth_method": {
+					"name": "token_endpoint_auth_method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"grant_types": {
+					"name": "grant_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"response_types": {
+					"name": "response_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_client_user_id_user_id_fk": {
+					"name": "oauth_client_user_id_user_id_fk",
+					"tableFrom": "oauth_client",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_client_client_id_unique": {
+					"name": "oauth_client_client_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["client_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.oauth_consent": {
+			"name": "oauth_consent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"redirect_uri": {
+					"name": "redirect_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"oauth_api_key_id": {
+					"name": "oauth_api_key_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_consent_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_consent_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_consent",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_consent_user_id_user_id_fk": {
+					"name": "oauth_consent_user_id_user_id_fk",
+					"tableFrom": "oauth_consent",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.oauth_refresh_token": {
+			"name": "oauth_refresh_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked": {
+					"name": "revoked",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auth_time": {
+					"name": "auth_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_refresh_token_session_id_session_id_fk": {
+					"name": "oauth_refresh_token_session_id_session_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "session",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"oauth_refresh_token_user_id_user_id_fk": {
+					"name": "oauth_refresh_token_user_id_user_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"logo": {
+					"name": "logo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_currency": {
+					"name": "default_currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'usd'"
+				},
+				"stripe_connected": {
+					"name": "stripe_connected",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"stripe_config": {
+					"name": "stripe_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"test_stripe_connect": {
+					"name": "test_stripe_connect",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"live_stripe_connect": {
+					"name": "live_stripe_connect",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"processor_configs": {
+					"name": "processor_configs",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"test_pkey": {
+					"name": "test_pkey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"live_pkey": {
+					"name": "live_pkey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"svix_config": {
+					"name": "svix_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"onboarded": {
+					"name": "onboarded",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"deployed": {
+					"name": "deployed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"redis_config": {
+					"name": "redis_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_organizations_name_trgm": {
+					"name": "idx_organizations_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"organizations\".\"name\" IS NOT NULL",
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_organizations_slug_trgm": {
+					"name": "idx_organizations_slug_trgm",
+					"columns": [
+						{
+							"expression": "\"slug\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"organizations\".\"slug\" IS NOT NULL",
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_organizations_created_at_id": {
+					"name": "idx_organizations_created_at_id",
+					"columns": [
+						{
+							"expression": "\"createdAt\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				},
+				"organizations_test_pkey_key": {
+					"name": "organizations_test_pkey_key",
+					"nullsNotDistinct": false,
+					"columns": ["test_pkey"]
+				},
+				"organizations_live_pkey_key": {
+					"name": "organizations_live_pkey_key",
+					"nullsNotDistinct": false,
+					"columns": ["live_pkey"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.passkey": {
+			"name": "passkey",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public_key": {
+					"name": "public_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"counter": {
+					"name": "counter",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device_type": {
+					"name": "device_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"backed_up": {
+					"name": "backed_up",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transports": {
+					"name": "transports",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"aaguid": {
+					"name": "aaguid",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"passkey_userId_idx": {
+					"name": "passkey_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"passkey_credentialId_idx": {
+					"name": "passkey_credentialId_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"passkey_user_id_user_id_fk": {
+					"name": "passkey_user_id_user_id_fk",
+					"tableFrom": "passkey",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"passkey_credential_id_unique": {
+					"name": "passkey_credential_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["credential_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.prices": {
+			"name": "prices",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"billing_type": {
+					"name": "billing_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tier_behavior": {
+					"name": "tier_behavior",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"entitlement_id": {
+					"name": "entitlement_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"proration_config": {
+					"name": "proration_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				}
+			},
+			"indexes": {
+				"idx_prices_internal_product_id": {
+					"name": "idx_prices_internal_product_id",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_prices_entitlement_id": {
+					"name": "idx_prices_entitlement_id",
+					"columns": [
+						{
+							"expression": "entitlement_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"prices_entitlement_id_fkey": {
+					"name": "prices_entitlement_id_fkey",
+					"tableFrom": "prices",
+					"tableTo": "entitlements",
+					"columnsFrom": ["entitlement_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"prices_internal_product_id_fkey": {
+					"name": "prices_internal_product_id_fkey",
+					"tableFrom": "prices",
+					"tableTo": "products",
+					"columnsFrom": ["internal_product_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"prices_id_key": {
+					"name": "prices_id_key",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.products": {
+			"name": "products",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_add_on": {
+					"name": "is_add_on",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_default": {
+					"name": "is_default",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"group": {
+					"name": "group",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "''"
+				},
+				"version": {
+					"name": "version",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"processor": {
+					"name": "processor",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"base_variant_id": {
+					"name": "base_variant_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"archived": {
+					"name": "archived",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"idx_products_org_env_id_version": {
+					"name": "idx_products_org_env_id_version",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"products_org_id_fkey": {
+					"name": "products_org_id_fkey",
+					"tableFrom": "products",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_product": {
+					"name": "unique_product",
+					"nullsNotDistinct": false,
+					"columns": ["org_id", "id", "env", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.referral_codes": {
+			"name": "referral_codes",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_reward_program_id": {
+					"name": "internal_reward_program_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_referral_codes_internal_customer_id": {
+					"name": "idx_referral_codes_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"referral_codes_internal_customer_id_fkey": {
+					"name": "referral_codes_internal_customer_id_fkey",
+					"tableFrom": "referral_codes",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"referral_codes_internal_reward_program_id_fkey": {
+					"name": "referral_codes_internal_reward_program_id_fkey",
+					"tableFrom": "referral_codes",
+					"tableTo": "reward_programs",
+					"columnsFrom": ["internal_reward_program_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"referral_codes_org_id_fkey": {
+					"name": "referral_codes_org_id_fkey",
+					"tableFrom": "referral_codes",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"referral_codes_pkey": {
+					"name": "referral_codes_pkey",
+					"columns": ["code", "org_id", "env"]
+				}
+			},
+			"uniqueConstraints": {
+				"referral_codes_id_key": {
+					"name": "referral_codes_id_key",
+					"nullsNotDistinct": false,
+					"columns": ["id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.replaceables": {
+			"name": "replaceables",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"cus_ent_id": {
+					"name": "cus_ent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"from_entity_id": {
+					"name": "from_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"delete_next_cycle": {
+					"name": "delete_next_cycle",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {
+				"idx_replaceables_cus_ent_id": {
+					"name": "idx_replaceables_cus_ent_id",
+					"columns": [
+						{
+							"expression": "cus_ent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"replaceables_cus_ent_id_fkey": {
+					"name": "replaceables_cus_ent_id_fkey",
+					"tableFrom": "replaceables",
+					"tableTo": "customer_entitlements",
+					"columnsFrom": ["cus_ent_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.revenuecat_mappings": {
+			"name": "revenuecat_mappings",
+			"schema": "",
+			"columns": {
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"autumn_product_id": {
+					"name": "autumn_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revenuecat_product_ids": {
+					"name": "revenuecat_product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"revenuecat_mappings_org_id_fkey": {
+					"name": "revenuecat_mappings_org_id_fkey",
+					"tableFrom": "revenuecat_mappings",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"revenuecat_mappings_pkey": {
+					"name": "revenuecat_mappings_pkey",
+					"columns": ["org_id", "env", "autumn_product_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.reward_programs": {
+			"name": "reward_programs",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_reward_id": {
+					"name": "internal_reward_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_redemptions": {
+					"name": "max_redemptions",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unlimited_redemptions": {
+					"name": "unlimited_redemptions",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"when": {
+					"name": "when",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'immediately'"
+				},
+				"product_ids": {
+					"name": "product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{\"\"}'"
+				},
+				"exclude_trial": {
+					"name": "exclude_trial",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"received_by": {
+					"name": "received_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"reward_triggers_internal_reward_id_fkey": {
+					"name": "reward_triggers_internal_reward_id_fkey",
+					"tableFrom": "reward_programs",
+					"tableTo": "rewards",
+					"columnsFrom": ["internal_reward_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"reward_triggers_org_id_fkey": {
+					"name": "reward_triggers_org_id_fkey",
+					"tableFrom": "reward_programs",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.reward_redemptions": {
+			"name": "reward_redemptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"triggered": {
+					"name": "triggered",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_reward_program_id": {
+					"name": "internal_reward_program_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applied": {
+					"name": "applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"redeemer_applied": {
+					"name": "redeemer_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"referral_code_id": {
+					"name": "referral_code_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reward_internal_id": {
+					"name": "reward_internal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"promo_code": {
+					"name": "promo_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_reward_redemptions_referral_code_id": {
+					"name": "idx_reward_redemptions_referral_code_id",
+					"columns": [
+						{
+							"expression": "referral_code_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_reward_redemptions_reward_internal_id": {
+					"name": "idx_reward_redemptions_reward_internal_id",
+					"columns": [
+						{
+							"expression": "reward_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_reward_redemptions_customer_reward": {
+					"name": "idx_reward_redemptions_customer_reward",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reward_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"reward_redemptions_internal_customer_id_fkey": {
+					"name": "reward_redemptions_internal_customer_id_fkey",
+					"tableFrom": "reward_redemptions",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"reward_redemptions_internal_reward_program_id_fkey": {
+					"name": "reward_redemptions_internal_reward_program_id_fkey",
+					"tableFrom": "reward_redemptions",
+					"tableTo": "reward_programs",
+					"columnsFrom": ["internal_reward_program_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"reward_redemptions_referral_code_id_fkey": {
+					"name": "reward_redemptions_referral_code_id_fkey",
+					"tableFrom": "reward_redemptions",
+					"tableTo": "referral_codes",
+					"columnsFrom": ["referral_code_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.rewards": {
+			"name": "rewards",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"discount_config": {
+					"name": "discount_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"free_product_config": {
+					"name": "free_product_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"free_product_id": {
+					"name": "free_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"promo_codes": {
+					"name": "promo_codes",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"coupons_org_id_fkey": {
+					"name": "coupons_org_id_fkey",
+					"tableFrom": "rewards",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.rollovers": {
+			"name": "rollovers",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"cus_ent_id": {
+					"name": "cus_ent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"balance": {
+					"name": "balance",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage": {
+					"name": "usage",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"entities": {
+					"name": "entities",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"idx_rollovers_cus_ent_id": {
+					"name": "idx_rollovers_cus_ent_id",
+					"columns": [
+						{
+							"expression": "cus_ent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_rollovers_cus_ent_expires": {
+					"name": "idx_rollovers_cus_ent_expires",
+					"columns": [
+						{
+							"expression": "cus_ent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"rollover_cus_ent_id_fkey": {
+					"name": "rollover_cus_ent_id_fkey",
+					"tableFrom": "rollovers",
+					"tableTo": "customer_entitlements",
+					"columnsFrom": ["cus_ent_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.phases": {
+			"name": "phases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"starts_at": {
+					"name": "starts_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_product_ids": {
+					"name": "customer_product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"phases_schedule_id_fkey": {
+					"name": "phases_schedule_id_fkey",
+					"tableFrom": "phases",
+					"tableTo": "schedules",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"phases_schedule_id_starts_at_key": {
+					"name": "phases_schedule_id_starts_at_key",
+					"nullsNotDistinct": false,
+					"columns": ["schedule_id", "starts_at"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.schedules": {
+			"name": "schedules",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"schedules_customer_scope_unique": {
+					"name": "schedules_customer_scope_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"schedules\".\"internal_entity_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"schedules_entity_scope_unique": {
+					"name": "schedules_entity_scope_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedules_internal_customer_id": {
+					"name": "idx_schedules_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedules_internal_entity_id": {
+					"name": "idx_schedules_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"schedules_org_id_fkey": {
+					"name": "schedules_org_id_fkey",
+					"tableFrom": "schedules",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"schedules_internal_customer_id_fkey": {
+					"name": "schedules_internal_customer_id_fkey",
+					"tableFrom": "schedules",
+					"tableTo": "customers",
+					"columnsFrom": ["internal_customer_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"schedules_internal_entity_id_fkey": {
+					"name": "schedules_internal_entity_id_fkey",
+					"tableFrom": "schedules",
+					"tableTo": "entities",
+					"columnsFrom": ["internal_entity_id"],
+					"columnsTo": ["internal_id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"active_organization_id": {
+					"name": "active_organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"city": {
+					"name": "city",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.subscriptions": {
+			"name": "subscriptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_id": {
+					"name": "stripe_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_schedule_id": {
+					"name": "stripe_schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"usage_features": {
+					"name": "usage_features",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_period_start": {
+					"name": "current_period_start",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_period_end": {
+					"name": "current_period_end",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"subscriptions_org_id_fkey": {
+					"name": "subscriptions_org_id_fkey",
+					"tableFrom": "subscriptions",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"subscriptions_stripe_id_key": {
+					"name": "subscriptions_stripe_id_key",
+					"nullsNotDistinct": false,
+					"columns": ["stripe_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_active_at": {
+					"name": "last_active_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_user_name_trgm": {
+					"name": "idx_user_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"user\".\"name\" IS NOT NULL",
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_user_email_trgm": {
+					"name": "idx_user_email_trgm",
+					"columns": [
+						{
+							"expression": "\"email\" gin_trgm_ops",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"user\".\"email\" IS NOT NULL",
+					"concurrently": false,
+					"method": "gin",
+					"with": {}
+				},
+				"idx_user_created_at_id": {
+					"name": "idx_user_created_at_id",
+					"columns": [
+						{
+							"expression": "\"created_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_created_by_fkey": {
+					"name": "user_created_by_fkey",
+					"tableFrom": "user",
+					"tableTo": "organizations",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.vercel_resources": {
+			"name": "vercel_resources",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"installation_id": {
+					"name": "installation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"vercel_resources_installation_name_unique_idx": {
+					"name": "vercel_resources_installation_name_unique_idx",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "installation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "status <> 'uninstalled'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"vercel_resources_org_id_fkey": {
+					"name": "vercel_resources_org_id_fkey",
+					"tableFrom": "vercel_resources",
+					"tableTo": "organizations",
+					"columnsFrom": ["org_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1780582242747,
       "tag": "0005_fresh_runaways",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1780584591419,
+      "tag": "0006_sad_madrox",
+      "breakpoints": true
     }
   ]
 }

--- a/vite/src/views/auth/Consent.tsx
+++ b/vite/src/views/auth/Consent.tsx
@@ -1,27 +1,31 @@
-import { type GroupedPermission, groupAndFormatScopes } from "@autumn/shared";
 import {
-	Check,
-	ChevronDown,
-	Clock,
-	ExternalLink,
-	Shield,
-	X,
-} from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+	AppEnv,
+	type GroupedPermission,
+	groupAndFormatScopes,
+} from "@autumn/shared";
+import { Check, Clock, ExternalLink, Shield, X } from "lucide-react";
+import { useEffect, useId, useState } from "react";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { CustomToaster } from "@/components/general/CustomToaster";
 import { Button } from "@/components/v2/buttons/Button";
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/v2/selects/Select";
+import {
 	authClient,
 	useListOrganizations,
 	useSession,
 } from "@/lib/auth-client";
-import { cn } from "@/lib/utils";
 
 interface ClientInfo {
 	client_id: string;
 	client_name?: string;
+	is_atmn?: boolean;
 	client_uri?: string;
 	logo_uri?: string;
 	policy_uri?: string;
@@ -90,11 +94,11 @@ const OrgLogo = ({ org }: { org: { name: string; logo?: string | null } }) => {
 	const firstLetter = org?.name?.charAt(0).toUpperCase() || "A";
 
 	return (
-		<div className="rounded-md overflow-hidden flex items-center justify-center bg-zinc-200 dark:bg-zinc-700 w-6 h-6 min-w-6 min-h-6">
+		<div className="rounded-md overflow-hidden flex items-center justify-center bg-zinc-200 dark:bg-zinc-700 w-5 h-5 min-w-5 min-h-5">
 			{org.logo ? (
 				<img src={org.logo} alt={org.name} className="w-full h-full" />
 			) : (
-				<span className="w-6 h-6 flex items-center justify-center bg-linear-to-r from-purple-600 via-purple-500 to-purple-400 text-white text-xs font-medium">
+				<span className="w-5 h-5 flex items-center justify-center bg-linear-to-r from-purple-600 via-purple-500 to-purple-400 text-white text-[10px] font-medium">
 					{firstLetter}
 				</span>
 			)}
@@ -102,11 +106,43 @@ const OrgLogo = ({ org }: { org: { name: string; logo?: string | null } }) => {
 	);
 };
 
+const getConsentRedirectUrl = (data: unknown) => {
+	if (!data || typeof data !== "object") return null;
+	const response = data as Record<string, unknown>;
+
+	return [response.url, response.uri, response.redirectTo].find(
+		(value): value is string => typeof value === "string" && value.length > 0,
+	);
+};
+
+const isExternalAppRedirect = (redirectUrl: string) => {
+	if (!URL.canParse(redirectUrl)) return false;
+	const protocol = new URL(redirectUrl).protocol;
+	return protocol !== "http:" && protocol !== "https:";
+};
+
+const openConsentRedirect = ({
+	onExternalRedirectFallback,
+	redirectUrl,
+}: {
+	onExternalRedirectFallback: () => void;
+	redirectUrl: string;
+}) => {
+	const shouldShowFallback = isExternalAppRedirect(redirectUrl);
+	window.location.href = redirectUrl;
+
+	if (shouldShowFallback) {
+		window.setTimeout(onExternalRedirectFallback, 1200);
+	}
+};
+
 export const Consent = () => {
 	const [searchParams] = useSearchParams();
 	const { data: session } = useSession();
 	const { data: orgs } = useListOrganizations();
 	const { data: activeOrganization } = authClient.useActiveOrganization();
+	const errorIconMaskId = useId();
+	const consentIconMaskId = useId();
 
 	const [clientInfo, setClientInfo] = useState<ClientInfo | null>(null);
 	const [groupedPermissions, setGroupedPermissions] = useState<
@@ -115,30 +151,18 @@ export const Consent = () => {
 	const [jokeScope] = useState(() => getRandomJokeScope());
 	const [isLoading, setIsLoading] = useState(true);
 	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [orgDropdownOpen, setOrgDropdownOpen] = useState(false);
+	const [pendingRedirectUrl, setPendingRedirectUrl] = useState<string | null>(
+		null,
+	);
+	const [selectedEnv, setSelectedEnv] = useState<AppEnv>(AppEnv.Live);
 	const [switchingOrg, setSwitchingOrg] = useState(false);
-	const orgDropdownRef = useRef<HTMLDivElement>(null);
 
 	const clientId = searchParams.get("client_id");
+	const redirectUri = searchParams.get("redirect_uri");
 	const requestedScopes = searchParams.get("scope")?.split(" ") || [];
 
 	// Get the current org (active or first available)
 	const currentOrg = activeOrganization || orgs?.[0];
-
-	// Close dropdown when clicking outside
-	useEffect(() => {
-		const handleClickOutside = (event: MouseEvent) => {
-			if (
-				orgDropdownRef.current &&
-				!orgDropdownRef.current.contains(event.target as Node)
-			) {
-				setOrgDropdownOpen(false);
-			}
-		};
-
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => document.removeEventListener("mousedown", handleClickOutside);
-	}, []);
 
 	const handleSwitchOrg = async (orgId: string) => {
 		setSwitchingOrg(true);
@@ -163,15 +187,21 @@ export const Consent = () => {
 
 			try {
 				// Fetch client name from our own endpoint
-				const response = await fetch(
+				const clientInfoUrl = new URL(
 					`${import.meta.env.VITE_BACKEND_URL}/oauth/client/${encodeURIComponent(clientId)}`,
 				);
+				if (redirectUri) {
+					clientInfoUrl.searchParams.set("redirect_uri", redirectUri);
+				}
+
+				const response = await fetch(clientInfoUrl.toString());
 
 				if (response.ok) {
 					const data = await response.json();
 					setClientInfo({
 						client_id: clientId,
 						client_name: data.name || "Unknown Application",
+						is_atmn: data.is_atmn === true,
 					});
 				} else {
 					console.error("Error fetching client info:", response.status);
@@ -179,6 +209,7 @@ export const Consent = () => {
 					setClientInfo({
 						client_id: clientId,
 						client_name: "External Application",
+						is_atmn: false,
 					});
 				}
 			} catch (error) {
@@ -187,6 +218,7 @@ export const Consent = () => {
 				setClientInfo({
 					client_id: clientId,
 					client_name: "External Application",
+					is_atmn: false,
 				});
 			}
 
@@ -197,10 +229,11 @@ export const Consent = () => {
 		}
 
 		fetchClientInfo();
-	}, [clientId, requestedScopes.join(",")]);
+	}, [clientId, redirectUri, requestedScopes.join(",")]);
 
 	const handleAuthorize = async () => {
 		setIsSubmitting(true);
+		setPendingRedirectUrl(null);
 		try {
 			// Use the original requested scopes
 			const grantedScopes = requestedScopes.join(" ");
@@ -208,6 +241,13 @@ export const Consent = () => {
 			const { data, error } = await authClient.oauth2.consent({
 				accept: true,
 				scope: grantedScopes,
+				client_id: clientId,
+				redirect_uri: redirectUri,
+				env: clientInfo.is_atmn ? undefined : selectedEnv,
+			} as Parameters<typeof authClient.oauth2.consent>[0] & {
+				client_id: string | null;
+				redirect_uri: string | null;
+				env?: AppEnv;
 			});
 
 			if (error) {
@@ -216,12 +256,20 @@ export const Consent = () => {
 				return;
 			}
 
-			// Handle redirect - server returns { redirect: true, uri: "..." }
-			if (data?.uri) {
-				window.location.href = data.uri;
-			} else if (data?.redirectTo) {
-				window.location.href = data.redirectTo;
+			const redirectUrl = getConsentRedirectUrl(data);
+			if (redirectUrl) {
+				if (isExternalAppRedirect(redirectUrl)) {
+					setPendingRedirectUrl(redirectUrl);
+				}
+				openConsentRedirect({
+					redirectUrl,
+					onExternalRedirectFallback: () => setIsSubmitting(false),
+				});
+				return;
 			}
+
+			toast.error("Authorization failed");
+			setIsSubmitting(false);
 		} catch (error) {
 			console.error("Authorization error:", error);
 			toast.error("Authorization failed. Please try again.");
@@ -231,6 +279,7 @@ export const Consent = () => {
 
 	const handleCancel = async () => {
 		setIsSubmitting(true);
+		setPendingRedirectUrl(null);
 		try {
 			const { data, error } = await authClient.oauth2.consent({
 				accept: false,
@@ -242,16 +291,30 @@ export const Consent = () => {
 				return;
 			}
 
-			if (data?.uri) {
-				window.location.href = data.uri;
-			} else if (data?.redirectTo) {
-				window.location.href = data.redirectTo;
+			const redirectUrl = getConsentRedirectUrl(data);
+			if (redirectUrl) {
+				if (isExternalAppRedirect(redirectUrl)) {
+					setPendingRedirectUrl(redirectUrl);
+				}
+				openConsentRedirect({
+					redirectUrl,
+					onExternalRedirectFallback: () => setIsSubmitting(false),
+				});
+				return;
 			}
+
+			toast.error("Failed to cancel. Please close this window.");
+			setIsSubmitting(false);
 		} catch (error) {
 			console.error("Cancel error:", error);
 			toast.error("Failed to cancel. Please close this window.");
 			setIsSubmitting(false);
 		}
+	};
+
+	const handleOpenPendingRedirect = () => {
+		if (!pendingRedirectUrl) return;
+		window.location.href = pendingRedirectUrl;
 	};
 
 	if (isLoading) {
@@ -271,12 +334,27 @@ export const Consent = () => {
 				<CustomToaster />
 				<div className="text-center space-y-4">
 					<div className="flex justify-center">
-						<svg width="48" height="48" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-							<mask id="icon-cutout-err">
-								<rect width="28" height="28" fill="white"/>
-								<path d="M10.7139 9.06887C9.77726 11.211 8.84052 13.3532 7.90386 15.4953C8.63795 16.4465 9.37205 17.3984 10.1061 18.3496C12.2827 15.537 14.4599 12.7244 16.637 9.91183L9.27077 22.9514C12.9161 20.7518 16.5615 18.5529 20.2069 16.3534V4.85034L10.7139 9.06887Z" fill="black"/>
+						<svg
+							width="48"
+							height="48"
+							viewBox="0 0 28 28"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+							aria-hidden="true"
+						>
+							<mask id={errorIconMaskId}>
+								<rect width="28" height="28" fill="white" />
+								<path
+									d="M10.7139 9.06887C9.77726 11.211 8.84052 13.3532 7.90386 15.4953C8.63795 16.4465 9.37205 17.3984 10.1061 18.3496C12.2827 15.537 14.4599 12.7244 16.637 9.91183L9.27077 22.9514C12.9161 20.7518 16.5615 18.5529 20.2069 16.3534V4.85034L10.7139 9.06887Z"
+									fill="black"
+								/>
 							</mask>
-							<rect width="28" height="28" fill="currentColor" mask="url(#icon-cutout-err)"/>
+							<rect
+								width="28"
+								height="28"
+								fill="currentColor"
+								mask={`url(#${errorIconMaskId})`}
+							/>
 						</svg>
 					</div>
 					<h1 className="text-lg font-semibold text-foreground">
@@ -296,12 +374,27 @@ export const Consent = () => {
 			<div className="w-full max-w-[420px] space-y-6 max-h-full overflow-y-auto">
 				{/* Logo */}
 				<div className="flex justify-center">
-					<svg width="48" height="48" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-						<mask id="icon-cutout-consent">
-							<rect width="28" height="28" fill="white"/>
-							<path d="M10.7139 9.06887C9.77726 11.211 8.84052 13.3532 7.90386 15.4953C8.63795 16.4465 9.37205 17.3984 10.1061 18.3496C12.2827 15.537 14.4599 12.7244 16.637 9.91183L9.27077 22.9514C12.9161 20.7518 16.5615 18.5529 20.2069 16.3534V4.85034L10.7139 9.06887Z" fill="black"/>
+					<svg
+						width="48"
+						height="48"
+						viewBox="0 0 28 28"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						aria-hidden="true"
+					>
+						<mask id={consentIconMaskId}>
+							<rect width="28" height="28" fill="white" />
+							<path
+								d="M10.7139 9.06887C9.77726 11.211 8.84052 13.3532 7.90386 15.4953C8.63795 16.4465 9.37205 17.3984 10.1061 18.3496C12.2827 15.537 14.4599 12.7244 16.637 9.91183L9.27077 22.9514C12.9161 20.7518 16.5615 18.5529 20.2069 16.3534V4.85034L10.7139 9.06887Z"
+								fill="black"
+							/>
 						</mask>
-						<rect width="28" height="28" fill="currentColor" mask="url(#icon-cutout-consent)"/>
+						<rect
+							width="28"
+							height="28"
+							fill="currentColor"
+							mask={`url(#${consentIconMaskId})`}
+						/>
 					</svg>
 				</div>
 
@@ -323,70 +416,62 @@ export const Consent = () => {
 					)}
 				</div>
 
-				{/* Organization Selector */}
-				{currentOrg && (
-					<div
-						ref={orgDropdownRef}
-						className="border border-border rounded-xl bg-card"
-					>
-						<div className="px-4 py-2 border-b border-border bg-muted/30">
-							<p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-								Organization
-							</p>
-						</div>
-						<div className="relative">
-							<button
-								type="button"
-								onClick={() => setOrgDropdownOpen(!orgDropdownOpen)}
-								disabled={switchingOrg || !orgs || orgs.length < 2}
-								className={cn(
-									"w-full flex items-center justify-between gap-3 px-4 py-3 text-left transition-colors",
-									orgs &&
-										orgs.length >= 2 &&
-										"hover:bg-muted/50 cursor-pointer",
-									switchingOrg && "opacity-50",
-								)}
-							>
-								<div className="flex items-center gap-3">
-									<OrgLogo org={currentOrg} />
-									<span className="text-sm font-medium text-foreground">
-										{currentOrg.name}
-									</span>
-								</div>
-								{orgs && orgs.length >= 2 && (
-									<ChevronDown
-										className={cn(
-											"w-4 h-4 text-muted-foreground transition-transform",
-											orgDropdownOpen && "rotate-180",
-										)}
-									/>
-								)}
-							</button>
-
-							{/* Dropdown */}
-							{orgDropdownOpen && orgs && orgs.length >= 2 && (
-								<div className="absolute top-full left-0 right-0 z-50 mt-1 border border-border rounded-lg bg-card shadow-lg max-h-64 overflow-y-auto">
-									{orgs
-										.filter((org) => org.id !== currentOrg.id)
-										.map((org) => (
-											<button
-												key={org.id}
-												type="button"
-												onClick={() => {
-													setOrgDropdownOpen(false);
-													handleSwitchOrg(org.id);
-												}}
-												className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-muted/50 transition-colors border-b border-border last:border-b-0"
-											>
+				{/* Account context: organization + environment */}
+				{(currentOrg || !clientInfo.is_atmn) && (
+					<div className="border border-border rounded-xl bg-card overflow-hidden divide-y divide-border">
+						{currentOrg && (
+							<div className="flex items-center justify-between gap-3 px-4 py-3">
+								<span className="text-sm text-muted-foreground shrink-0">
+									Organization
+								</span>
+								<Select
+									value={currentOrg.id}
+									onValueChange={handleSwitchOrg}
+									disabled={switchingOrg || !orgs || orgs.length < 2}
+								>
+									<SelectTrigger className="w-[200px]">
+										<SelectValue>
+											<span className="flex items-center gap-2 min-w-0">
+												<OrgLogo org={currentOrg} />
+												<span className="truncate">{currentOrg.name}</span>
+											</span>
+										</SelectValue>
+									</SelectTrigger>
+									<SelectContent>
+										{orgs?.map((org) => (
+											<SelectItem key={org.id} value={org.id}>
 												<OrgLogo org={org} />
-												<span className="text-sm text-foreground">
-													{org.name}
-												</span>
-											</button>
+												<span className="truncate">{org.name}</span>
+											</SelectItem>
 										))}
-								</div>
-							)}
-						</div>
+									</SelectContent>
+								</Select>
+							</div>
+						)}
+
+						{!clientInfo.is_atmn && (
+							<div className="flex items-center justify-between gap-3 px-4 py-3">
+								<span className="text-sm text-muted-foreground shrink-0">
+									Environment
+								</span>
+								<Select
+									value={selectedEnv}
+									onValueChange={(value) => setSelectedEnv(value as AppEnv)}
+									items={{
+										[AppEnv.Sandbox]: "Sandbox",
+										[AppEnv.Live]: "Production",
+									}}
+								>
+									<SelectTrigger className="w-[200px]">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value={AppEnv.Sandbox}>Sandbox</SelectItem>
+										<SelectItem value={AppEnv.Live}>Production</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+						)}
 					</div>
 				)}
 
@@ -494,6 +579,11 @@ export const Consent = () => {
 				</div>
 
 				{/* Action Buttons */}
+				{pendingRedirectUrl && !isSubmitting && (
+					<p className="text-xs text-muted-foreground text-center">
+						If {clientInfo.client_name} did not open, use the button below.
+					</p>
+				)}
 				<div className="flex gap-3">
 					<Button
 						variant="secondary"
@@ -505,11 +595,15 @@ export const Consent = () => {
 					</Button>
 					<Button
 						variant="primary"
-						onClick={handleAuthorize}
+						onClick={
+							pendingRedirectUrl ? handleOpenPendingRedirect : handleAuthorize
+						}
 						isLoading={isSubmitting}
 						className="flex-1"
 					>
-						Authorize
+						{pendingRedirectUrl
+							? `Open ${clientInfo.client_name}`
+							: "Authorize"}
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked MCP OAuth so the token endpoint returns Autumn API keys for external apps, and the MCP server now requires an Autumn API key instead of exchanging OAuth tokens. Added consent-aware env selection, safer redirects, better client naming, and linked OAuth-created API keys to consents so revocation reliably cleans them up.

- **New Features**
  - Dedicated OAuth router with:
    - `POST /api/auth/oauth2/register` for MCP client registration (validates redirect URIs, auto-classifies Cursor/Claude/OpenCode/Slack/Codex).
    - `POST /api/auth/oauth2/consent` captures `env` and `redirect_uri` (skips `env` for atmn).
    - `POST /api/auth/oauth2/token` rewrites `access_token` to an Autumn API key for non-atmn clients; `GET /api/auth/oauth2/authorize` forces `prompt=consent` for internal MCP.
    - `GET /oauth/client/:client_id?redirect_uri=...` returns client name plus `is_atmn`/`is_internal_mcp` (rate-limited).
  - New repos for OAuth clients, consents, access tokens, refresh tokens, and API keys; consent revocation deletes linked OAuth-created API keys and invalidates cache.
  - MCP server: removed token exchange; OAuth-enabled routes now return 401 `invalid_token` unless an Autumn API key is provided.
  - MCP tools: added `getCurrentOrganization` and `callAutumnGet`.
  - Consent UI: org and environment selectors (non-atmn only), safer native-app redirects with a fallback button, and better client naming.
  - DB: added `env`, `redirect_uri`, and `oauth_api_key_id` to `oauth_consent` (migration `0006_sad_madrox`).
  - CLI: added `LOCAL_CLI_CLIENT_ID` and `DEV_CLI_CLIENT_ID` alongside `CLI_CLIENT_ID`.

- **Migration**
  - External MCP OAuth clients should call `POST /api/auth/oauth2/token` and use the returned Autumn API key as the Bearer for MCP requests; opaque OAuth tokens are rejected with `invalid_token`.
  - Register MCP clients via `POST /api/auth/oauth2/register` with `redirect_uris` and optional `client_name`.
  - Configure detection with `ATMN_OAUTH_CLIENT_IDS` and `INTERNAL_MCP_OAUTH_CLIENT_ID`.

<sup>Written for commit 1769bb26c417316d10e335f2b47f7105a8f6c697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR overhauls MCP OAuth by moving the OAuth-token-to-API-key exchange from the MCP client (which previously called `/cli/api-keys`) to the server side, where the token endpoint now replaces `access_token` with an Autumn API key directly. A new dedicated `oauthRouter` collects all OAuth-related routes, and the consent UI gains an environment selector (Sandbox/Production) for third-party MCP clients.

- **Bug fixes / Improvements**: Server-side token exchange — `handleOAuthTokenWithApiKey` intercepts `/api/auth/oauth2/token` and returns an Autumn API key as `access_token`, removing the round-trip call from the MCP server.
- **Improvements**: New `registerMcpOAuthClient` action auto-registers known MCP clients (Claude, Cursor, Codex, OpenCode, Slack) via a whitelist with safe redirect-URI validation; consent revocation and API-key repos are extracted into dedicated repo modules.
- **Bug fixes**: Consent page now uses `useId` for SVG mask IDs, replaces a bespoke org-dropdown with a `Select` component, and adds a deep-link fallback button for native-app redirects.
</details>

<h3>Confidence Score: 3/5</h3>

Two defects in the credential lifecycle mean this PR could leave active credentials in the system that users believe they have revoked.

The core new flow is well-structured, but the consent-API-key creation path is not atomic and the CLI key-revocation link is silently dropped — both leave valid credentials behind after a revocation.

server/src/internal/auth/oauth/oauthConsentApiKey.ts (race condition) and server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts (consent ID removed from meta)

<details open><summary><h3>Security Review</h3></summary>

- **CLI API keys survive consent revocation** (`handleCreateOAuthApiKeys.ts`): `oauth_consent_id` is now hardcoded to `null` for atmn-CLI clients, decoupling those keys from the consent revocation lifecycle.
- **Orphaned valid API keys** (`oauthConsentApiKey.ts`): a race between two simultaneous token requests can produce an API key that is registered in `apiKeys` but not referenced by the consent record, surviving revocation.
- **Encrypted API key stored in `oauth_consent`**: `oauth_api_key` persists an application-encrypted copy of the full Autumn API key, raising the sensitivity of the table.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/auth/oauth/oauthConsentApiKey.ts | New module that creates/reuses encrypted API keys linked to OAuth consents; contains a race condition where concurrent token requests can both create independent API keys for the same consent, leaving orphaned credentials in the system. |
| server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts | Refactored to delegate token-to-API-key exchange to shared utilities, but now hardcodes `oauth_consent_id: null` for the atmn-CLI path, breaking consent-revocation cleanup of CLI-issued API keys. |
| server/src/internal/auth/actions/registerMcpOAuthClient.ts | New whitelist-based MCP client auto-registration; correctly validates redirect URIs and classifies known clients, but uses a full table scan for matching and has non-null assertions on DB results. |
| server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts | Intercepts the OAuth token endpoint and replaces the access_token with an Autumn API key for non-atmn clients; request/response bodies are cloned correctly before reading. |
| server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts | Intercepts the consent endpoint to capture environment and redirect_uri selection; request body is cloned correctly before auth handler consumes it. |
| server/src/internal/auth/oauth/internalMcpOAuthClients.ts | New module classifying internal MCP OAuth clients and injecting a forced consent prompt; duplicates the MCP_CLIENT_KIND string constant from registerMcpOAuthClient.ts. |
| server/src/internal/auth/oauth/oauthRouter.ts | Extracts OAuth-related routes from initHono.ts into a dedicated router; rate limiting added on the client-lookup endpoint. |
| shared/db/auth-schema.ts | Adds env, redirect_uri, oauth_api_key_id, and oauth_api_key columns to oauth_consent; migration is paired correctly. |
| packages/mcp/src/server/auth/oauth.ts | Removes the server-side token exchange loop from the MCP client; the oauth-enabled path now always returns 401, shifting exchange responsibility to the server token endpoint. |
| vite/src/views/auth/Consent.tsx | Adds environment selector (Sandbox/Production) for non-atmn clients, replaces bespoke org dropdown with shadcn Select, and handles deep-link redirects with a fallback Open App button. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant MCP as MCP Client
    participant BA as Better Auth
    participant Srv as handleOAuthTokenWithApiKey
    participant DB as Database
    participant Keys as Autumn API Keys
    MCP->>BA: POST /api/auth/oauth2/token
    BA-->>Srv: JWT access_token
    Srv->>DB: getOAuthAccessTokenRecord
    DB-->>Srv: token record
    Srv->>DB: getForClientUserOrg
    DB-->>Srv: consent with env
    Srv->>Keys: getOrCreateOAuthConsentApiKey
    Keys-->>Srv: sk_live_... or sk_sandbox_...
    Srv-->>MCP: "access_token = Autumn API key"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts:84-93
**CLI API keys no longer linked to consent on revocation**

The `oauth_consent_id` in meta is now hardcoded to `null` for the atmn-CLI code path. Previously the handler looked up the consent record and set `oauth_consent_id: consentId`, which caused `oauthApiKeyRepo.listByConsentId` (used in `handleRevokeConsent`) to find and delete these keys when the consent was revoked. With `oauth_consent_id: null`, consent revocation still deletes the access/refresh tokens but leaves the corresponding CLI API key alive and usable. An attacker (or a user who wants to invalidate their credentials) who revokes consent will find that their CLI key continues to work against the Autumn API.

### Issue 2 of 5
server/src/internal/auth/oauth/oauthConsentApiKey.ts:93-136
**Race condition creates orphaned API keys**

`getOrCreateOAuthConsentApiKey` is not atomic. Two simultaneous token requests for the same consent can both observe `consent.oauthApiKey = null`, both call `deleteLinked` (a no-op when both IDs are null), and both enter `createConsentApiKey`. Each call creates a distinct key in the `apiKeys` table tagged with `oauth_consent_id = consent.id`. The second `updateApiKey` wins and overwrites the consent row, so the first key becomes permanently orphaned — it is valid and has full org-level access, but is no longer reachable via `listByConsentId`, so it will survive any subsequent consent revocation until manually discovered.

To fix, guard the creation path with a DB-level unique constraint or an advisory lock, or use an `ON CONFLICT DO UPDATE` upsert on the consent row so that only one key can be "current" at a time.

### Issue 3 of 5
server/src/internal/auth/actions/registerMcpOAuthClient.ts:276-281
Both `updateById` and `upsert` return `null` when the DB row is missing (e.g. concurrent delete or unexpected conflict), making the non-null assertions `updatedClient!` and `client!` a potential runtime crash. Returning an error response is safer here.

```suggestion
		if (!updatedClient) {
			return { error: "client_update_failed", status: 400 };
		}
		const response = getRegistrationResponse(updatedClient, 200);
		setCachedRegistration(cacheKey, response.body);
		return response;
	}

	const client = await oauthClientRepo.upsert({
```

### Issue 4 of 5
server/src/internal/auth/actions/registerMcpOAuthClient.ts:264-272
**`oauthClientRepo.list` loads every OAuth client on every registration cache-miss**

`registerMcpOAuthClient` calls `oauthClientRepo.list({ db })` which selects all rows from `oauth_client` with no filter. The result is iterated in-process with `Array.find`. Since the in-memory `registerCache` expires every 5 minutes and is not shared across server instances, this full-table scan will run frequently in multi-replica deployments. A targeted `getByClientId` call (since known clients have deterministic IDs like `autumn_mcp_cursor`) or a DB-level query filtered by `metadata->>'kind' = 'mcp_client'` would avoid the full scan.

### Issue 5 of 5
server/src/internal/auth/oauth/internalMcpOAuthClients.ts:11
**`MCP_CLIENT_KIND` constant is duplicated**

`MCP_CLIENT_KIND = "mcp_client"` is defined independently in both `registerMcpOAuthClient.ts` and this file. `isInternalMcpOAuthClientRecord` relies on this value matching what `registerMcpOAuthClient` writes into `metadata.kind`. If they ever diverge the classification will silently break. Extract the constant to a shared location (e.g. a `oauthClientKinds.ts` file) and import it in both places.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: mcp oauth"](https://github.com/useautumn/autumn/commit/b9bfe213f707886e913b7424ff2f619cc78f910e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35649656)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->