### PR TITLE
fix: rollovers

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleInvoiceCreated/handlePrepaidPrices.ts
+++ b/server/src/external/stripe/webhookHandlers/handleInvoiceCreated/handlePrepaidPrices.ts
@@ -79,7 +79,7 @@ export const handlePrepaidPrices = async ({
 
 	const rolloverUpdate = getRolloverUpdates({
 		cusEnt,
-		nextResetAt: end * 1000,
+		nextResetAt: start * 1000,
 	});
 
 	if (notNullish(options?.upcoming_quantity)) {

--- a/server/src/external/stripe/webhookHandlers/handleInvoiceCreated/handleUsagePrices.ts
+++ b/server/src/external/stripe/webhookHandlers/handleInvoiceCreated/handleUsagePrices.ts
@@ -149,7 +149,7 @@ export const handleUsagePrices = async ({
 		allowance: ent.interval === EntInterval.Lifetime ? 0 : ent.allowance!,
 	});
 
-	const { end } = subToPeriodStartEnd({ sub: usageSub });
+	const { start, end } = subToPeriodStartEnd({ sub: usageSub });
 	await CusEntService.update({
 		ctx,
 		id: relatedCusEnt.id,
@@ -162,7 +162,7 @@ export const handleUsagePrices = async ({
 
 	const rolloverUpdate = getRolloverUpdates({
 		cusEnt: relatedCusEnt,
-		nextResetAt: end * 1000,
+		nextResetAt: start * 1000,
 	});
 
 	if (rolloverUpdate?.toInsert && rolloverUpdate.toInsert.length > 0) {

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processConsumablePricesForInvoiceCreated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processConsumablePricesForInvoiceCreated.ts
@@ -9,9 +9,9 @@ import { eventContextToArrearLineItems } from "@/external/stripe/webhookHandlers
 import { lineItemsToCreateInvoiceItemsParams } from "@/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams";
 import { createStripeInvoiceItems } from "@/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
-import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
 import { RolloverService } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/RolloverService";
 import { getRolloverUpdates } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
 import { parseSkipOverageSubmissionFlag } from "@/internal/misc/featureFlags/parseSkipOverageSubmission";
 import type { StripeWebhookContext } from "../../../webhookMiddlewares/stripeWebhookContext";
 import type { InvoiceCreatedContext } from "../setupInvoiceCreatedContext";
@@ -116,7 +116,7 @@ export const processConsumablePricesForInvoiceCreated = async ({
 	updateCustomerEntitlements.forEach(async (update) => {
 		const rolloverUpdates = getRolloverUpdates({
 			cusEnt: update.customerEntitlement,
-			nextResetAt: Date.now(),
+			nextResetAt: invoicePeriodEndMs,
 		});
 
 		const fullCusEnt: FullCusEntWithProduct = {

--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processPrepaidPricesForInvoiceCreated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processPrepaidPricesForInvoiceCreated.ts
@@ -41,8 +41,7 @@ const processPrepaidPrice = async ({
 
 	const customerProduct = customerEntitlement.customer_product;
 
-	const { stripeSubscription, fullCustomer } = eventContext;
-	const { db } = ctx;
+	const { stripeSubscription } = eventContext;
 
 	if (!options) return;
 	const previousQuantity = options?.quantity ?? 0;
@@ -60,11 +59,11 @@ const processPrepaidPrice = async ({
 
 	const ent = customerEntitlement.entitlement;
 
-	const { end } = subToPeriodStartEnd({ sub: stripeSubscription });
+	const { start, end } = subToPeriodStartEnd({ sub: stripeSubscription });
 
 	const rolloverUpdate = getRolloverUpdates({
 		cusEnt: customerEntitlement,
-		nextResetAt: end * 1000,
+		nextResetAt: start * 1000,
 	});
 
 	if (notNullish(options?.upcoming_quantity) && customerProduct) {

--- a/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/apiBalanceV2Utils.ts
+++ b/server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/apiBalanceV2Utils.ts
@@ -37,12 +37,18 @@ export const mergeAggregatedBalanceIntoApiBalanceV2 = ({
 	const aggregatedRolloverBalance =
 		aggregatedFeatureBalance.rollover_balance ?? 0;
 	const aggregatedRolloverUsage = aggregatedFeatureBalance.rollover_usage ?? 0;
+	const aggregatedRolloverGrant = new Decimal(aggregatedRolloverBalance)
+		.add(aggregatedRolloverUsage)
+		.toNumber();
 
 	// Aggregate rows do not retain the full per-entity/per-product breakdown, so
 	// the top-level summary is merged from the coarse aggregate values only.
-	const granted = new Decimal(aggregatedAllowance)
+	const baseGranted = new Decimal(aggregatedAllowance)
 		.add(aggregatedPrepaidGrantFromOptions)
 		.add(aggregatedAdjustment)
+		.toNumber();
+	const granted = new Decimal(baseGranted)
+		.add(aggregatedRolloverGrant)
 		.toNumber();
 
 	// Main remaining is floored at 0 (matches legacy behaviour). Rollover
@@ -57,7 +63,7 @@ export const mergeAggregatedBalanceIntoApiBalanceV2 = ({
 		.toNumber();
 
 	// Usage mirrors the entity-view formula: (granted - main balance) + rollover usage.
-	const usage = new Decimal(granted)
+	const usage = new Decimal(baseGranted)
 		.sub(aggregatedBalance)
 		.add(aggregatedRolloverUsage);
 

--- a/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-rollover-expiry.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/invoice-created/invoice-created-rollover-expiry.test.ts
@@ -1,0 +1,125 @@
+// Red: usage-based rollovers expired from wall-clock time.
+// Green: prepaid and usage-based one-month rollovers expire at next_reset_at.
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type RolloverConfig,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	constructArrearItem,
+	constructPrepaidItem,
+} from "@/utils/scriptUtils/constructItem.js";
+import { expectBalanceCorrect } from "../../../utils/expectBalanceCorrect.js";
+
+const rolloverConfig: RolloverConfig = {
+	max: null,
+	length: 1,
+	duration: RolloverExpiryDurationType.Month,
+};
+
+const expectOneMonthRolloverExpiresAtNextReset = ({
+	customer,
+}: {
+	customer: ApiCustomerV5;
+}) => {
+	const balance = customer.balances[TestFeature.Messages];
+	expect(balance).toBeDefined();
+	expect(balance.next_reset_at).not.toBeNull();
+	expect(balance.rollovers?.length ?? 0).toBeGreaterThan(0);
+
+	const nextResetAt = balance.next_reset_at!;
+	expectBalanceCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		nextResetAt,
+		positiveRolloverCount: 1,
+	});
+
+	const positiveRollovers = balance.rollovers!.filter(
+		(item) => item.balance > 0,
+	);
+	const rollover = positiveRollovers[0];
+	const expectedExpiry = nextResetAt;
+	const actualExpiry = rollover.expires_at;
+	const diff = Math.abs(actualExpiry - expectedExpiry);
+
+	expect(
+		diff,
+		`Expected rollover to expire at ${new Date(expectedExpiry).toISOString()}, got ${new Date(actualExpiry).toISOString()}`,
+	).toBeLessThanOrEqual(10 * 60 * 1000);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("invoice.created rollover expiry: prepaid uses next reset boundary")}`,
+	async () => {
+		const prepaidItem = constructPrepaidItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 100,
+			billingUnits: 100,
+			price: 10,
+			rolloverConfig,
+		});
+		const pro = products.pro({
+			id: "pro-prepaid-rollover-expiry",
+			items: [prepaidItem],
+		});
+
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "invoice-created-prepaid-rollover-expiry",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 200 }],
+				}),
+				s.track({ featureId: TestFeature.Messages, value: 50, timeout: 2000 }),
+				s.advanceToNextInvoice({ withPause: true }),
+			],
+		});
+
+		const after = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectOneMonthRolloverExpiresAtNextReset({ customer: after });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("invoice.created rollover expiry: usage-based uses next reset boundary")}`,
+	async () => {
+		const consumableItem = constructArrearItem({
+			featureId: TestFeature.Messages,
+			includedUsage: 200,
+			price: 0.1,
+			billingUnits: 1,
+			rolloverConfig,
+		});
+		const pro = products.pro({
+			id: "pro-consumable-rollover-expiry",
+			items: [consumableItem],
+		});
+
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "invoice-created-consumable-rollover-expiry",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.track({ featureId: TestFeature.Messages, value: 50, timeout: 2000 }),
+				s.advanceToNextInvoice({ withPause: true }),
+			],
+		});
+
+		const after = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectOneMonthRolloverExpiresAtNextReset({ customer: after });
+	},
+);

--- a/server/tests/integration/crud/customers/get-customer-entity-rollover-granted.test.ts
+++ b/server/tests/integration/crud/customers/get-customer-entity-rollover-granted.test.ts
@@ -1,0 +1,77 @@
+// Red: customer aggregation omitted rollover grant from entity-scoped products.
+// Green: customer granted includes active entity rollover balance and usage.
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type LimitedItem,
+	ProductItemInterval,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expireAllCusEntsForReset } from "@tests/utils/cusProductUtils/resetTestUtils.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+
+test.concurrent(
+	`${chalk.yellowBright("get-customer: entity product rollovers contribute to granted")}`,
+	async () => {
+		const customerId = "get-customer-entity-rollover-granted";
+		const rolloverConfig = {
+			max: 500,
+			length: 1,
+			duration: RolloverExpiryDurationType.Month,
+		};
+		const creditsItem = constructFeatureItem({
+			featureId: TestFeature.Credits,
+			includedUsage: 100,
+			interval: ProductItemInterval.Month,
+			rolloverConfig,
+		}) as LimitedItem;
+		const base = products.base({
+			id: "entity-product-rollover-granted",
+			items: [creditsItem],
+		});
+
+		const { autumnV1, autumnV2_2, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.deleteCustomer({ customerId }),
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [base] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [s.billing.attach({ productId: base.id, entityIndex: 0 })],
+		});
+
+		await autumnV1.track({
+			customer_id: customerId,
+			entity_id: entities[0].id,
+			feature_id: TestFeature.Credits,
+			value: 40,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		await expireAllCusEntsForReset({
+			ctx,
+			customerId,
+			featureId: TestFeature.Credits,
+		});
+		await autumnV2_2.entities.get(customerId, entities[0].id);
+
+		const after = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+
+		expectBalanceCorrect({
+			customer: after,
+			featureId: TestFeature.Credits,
+			remaining: 160,
+			usage: 0,
+		});
+		expect(after.balances[TestFeature.Credits].granted).toBe(160);
+	},
+);

--- a/server/tests/integration/utils/expectBalanceCorrect.ts
+++ b/server/tests/integration/utils/expectBalanceCorrect.ts
@@ -8,10 +8,10 @@ import {
 	type ResetInterval,
 } from "@autumn/shared";
 
-const roundTo8Dp = (value: number) =>
-	Math.round(value * 1e8) / 1e8;
+const roundTo8Dp = (value: number) => Math.round(value * 1e8) / 1e8;
 
 type BucketExpectation = {
+	granted?: number;
 	included_grant?: number;
 	prepaid_grant?: number;
 	remaining?: number;
@@ -28,6 +28,7 @@ type BreakdownExpectation = Partial<Record<BreakdownKey, BucketExpectation>>;
 export const expectBalanceCorrect = ({
 	customer,
 	featureId,
+	granted,
 	remaining,
 	planId,
 	usage,
@@ -35,10 +36,12 @@ export const expectBalanceCorrect = ({
 	toleranceMs = TEN_MINUTES_MS,
 	breakdown,
 	rollovers,
+	positiveRolloverCount,
 }: {
 	customer: ApiCustomerV5 | ApiEntityV2;
 	featureId: string;
-	remaining: number;
+	granted?: number;
+	remaining?: number;
 	planId?: string | null;
 	usage?: number;
 	nextResetAt?: number | null;
@@ -46,10 +49,18 @@ export const expectBalanceCorrect = ({
 	breakdown?: BreakdownExpectation;
 	/** Expected rollovers in order (oldest first). Only specified fields are checked. */
 	rollovers?: Partial<ApiBalanceRollover>[];
+	positiveRolloverCount?: number;
 }) => {
 	const balance = customer.balances[featureId];
 	expect(balance).toBeDefined();
-	expect(roundTo8Dp(balance.remaining)).toBe(roundTo8Dp(remaining));
+
+	if (typeof granted !== "undefined") {
+		expect(roundTo8Dp(balance.granted)).toBe(roundTo8Dp(granted));
+	}
+
+	if (typeof remaining !== "undefined") {
+		expect(roundTo8Dp(balance.remaining)).toBe(roundTo8Dp(remaining));
+	}
 
 	if (typeof planId !== "undefined") {
 		expect(balance.breakdown?.[0]?.plan_id ?? null).toBe(planId);
@@ -106,5 +117,12 @@ export const expectBalanceCorrect = ({
 		for (let i = 0; i < rollovers.length; i++) {
 			expect(actual![i]).toMatchObject(rollovers[i]);
 		}
+	}
+
+	if (typeof positiveRolloverCount !== "undefined") {
+		const actual = balance.rollovers ?? [];
+		expect(actual.filter((item) => item.balance > 0).length).toBe(
+			positiveRolloverCount,
+		);
 	}
 };

--- a/server/tests/scenarios/attach/prepaid-consumable-rollover-scenario.test.ts
+++ b/server/tests/scenarios/attach/prepaid-consumable-rollover-scenario.test.ts
@@ -1,13 +1,14 @@
 import { test } from "bun:test";
-import { RolloverExpiryDurationType } from "@autumn/shared";
+import { type ApiCustomerV5, RolloverExpiryDurationType } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
 import {
 	constructArrearItem,
 	constructPrepaidItem,
 } from "@/utils/scriptUtils/constructItem";
-import { products } from "@tests/utils/fixtures/products";
-import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
-import chalk from "chalk";
-import { TestFeature } from "@tests/setup/v2Features";
 
 /**
  * Scenario: Prepaid + Consumable messages on the same plan, both with rollovers.
@@ -48,7 +49,7 @@ test(`${chalk.yellowBright("scenario: prepaid + consumable messages with rollove
 		items: [prepaidMessages, consumableMessages],
 	});
 
-	await initScenario({
+	const { autumnV2_2 } = await initScenario({
 		customerId: "combo-rollover",
 		setup: [
 			s.customer({ paymentMethod: "success" }),
@@ -62,5 +63,14 @@ test(`${chalk.yellowBright("scenario: prepaid + consumable messages with rollove
 			s.track({ featureId: TestFeature.Messages, value: 80, timeout: 2000 }),
 			s.advanceToNextInvoice(),
 		],
+	});
+
+	const customer =
+		await autumnV2_2.customers.get<ApiCustomerV5>("combo-rollover");
+
+	expectBalanceCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		positiveRolloverCount: 2,
 	});
 });

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -120,7 +120,7 @@ export class CusService {
 		axios: AxiosInstance;
 		customer_id: string;
 	}): Promise<{ success: boolean }> {
-		const { data } = await axios.post(`/customers/clear_cache`, {
+		const { data } = await axios.post(`/v1/customers/clear_cache`, {
 			customer_id,
 		});
 		return data;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes rollover expiry to align with the next reset boundary and includes rollovers in customer-level granted totals, preventing early expiry and incorrect balances. Also fixes the clear-cache endpoint path.

- **Bug Fixes**
  - Prepaid and usage-based rollovers created on `invoice.created` now use the subscription period start (`next_reset_at`).
  - Consumable price rollovers use `invoicePeriodEndMs` when processing on invoice creation.
  - Customer aggregate granted includes active rollover balance and rollover usage; usage derives from base granted.
  - Added tests: rollover expiry, customer granted for entity products, and a scenario validating two active rollovers.
  - Fix `CusService.clearCache` to call `/v1/customers/clear_cache`.

- **Dependencies**
  - Updated `ai` subproject pointer.

<sup>Written for commit 27f21809f8f07102e54744063caf237545e88460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes several bugs in the rollover entitlement system, correcting how rollover expiry timestamps are calculated and how the API-level `granted` balance is computed to include rollover amounts.

- **Bug fixes**: Rollover `nextResetAt` was previously computed from the *end* of the new subscription period (resulting in expiry one cycle too late) and is now correctly set to the *start* of the new period (`start * 1000` or `invoicePeriodEndMs`), so a 1-month rollover expires at the next `next_reset_at` boundary.
- **Bug fixes**: In the consumable-prices path, `Date.now()` (wall-clock, non-deterministic) was replaced by the deterministic `invoicePeriodEndMs` from Stripe's invoice object.
- **Bug fixes**: The aggregated `granted` field in `apiBalanceV2Utils` now correctly adds `rollover_balance + rollover_usage` (the original rollover grant), and `usage` is computed from `baseGranted` rather than the post-rollover `granted` to avoid double-counting.
- **Bug fixes**: Fixed an incorrect API URL (`/customers/clear_cache` → `/v1/customers/clear_cache`) in `CusService.tsx`.
</details>

<h3>Confidence Score: 4/5</h3>

The rollover date and balance fixes are logically sound and each has a corresponding integration test; the URL fix in CusService is trivial.

All four invoice-created handlers (two legacy, two v2) are consistently updated to use the start of the new billing period as the rollover base, producing expiry timestamps that align with next_reset_at. The apiBalanceV2Utils math is internally consistent. The consumable handler still uses forEach async for rollover inserts (fire-and-forget, pre-existing), meaning insert errors are silently dropped, but this was not introduced by this PR.

processConsumablePricesForInvoiceCreated.ts uses forEach async for RolloverService.insert, making rollover inserts fire-and-forget with no error surfacing; pre-existing but worth a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleInvoiceCreated/handlePrepaidPrices.ts | Corrects rollover nextResetAt from end (end of new period) to start (start of new period), so 1-month rollovers expire at the correct next_reset_at boundary. |
| server/src/external/stripe/webhookHandlers/handleInvoiceCreated/handleUsagePrices.ts | Same fix as handlePrepaidPrices: rollover nextResetAt switched from end*1000 to start*1000; also extracts start from subToPeriodStartEnd. |
| server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processConsumablePricesForInvoiceCreated.ts | Replaces non-deterministic Date.now() with invoicePeriodEndMs for rollover expiry; the forEach async pattern for RolloverService.insert remains fire-and-forget (pre-existing). |
| server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processPrepaidPricesForInvoiceCreated.ts | Applies the same nextResetAt fix (start instead of end) and removes now-unused fullCustomer and db variables. |
| server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/apiBalanceV2Utils.ts | Adds aggregatedRolloverGrant (rollover_balance + rollover_usage) to the granted total, and corrects usage to be based on baseGranted to avoid double-counting rollover amounts. |
| vite/src/services/customers/CusService.tsx | Fixes incorrect API URL from /customers/clear_cache to /v1/customers/clear_cache. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant InvoiceCreatedHandler
    participant RolloverUtils
    participant DB

    Stripe->>InvoiceCreatedHandler: invoice.created (subscription_cycle)
    InvoiceCreatedHandler->>InvoiceCreatedHandler: subToPeriodStartEnd(subscription)
    Note over InvoiceCreatedHandler: invoicePeriodEndMs = stripeInvoice.period_end * 1000

    InvoiceCreatedHandler->>RolloverUtils: "getRolloverUpdates(cusEnt, nextResetAt=start*1000)"
    Note over RolloverUtils: calculateNextExpiry(start, config) = addMonths(start,1) = end = next_reset_at

    RolloverUtils-->>InvoiceCreatedHandler: "toInsert rollover with expires_at=end"

    InvoiceCreatedHandler->>DB: RolloverService.insert(rollover)
    InvoiceCreatedHandler->>DB: "CusEntService.update(next_reset_at=end*1000)"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/rollovers"](https://github.com/useautumn/autumn/commit/27f21809f8f07102e54744063caf237545e88460) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35677471)</sub>

<!-- /greptile_comment -->