### PR TITLE
fix: rollovers

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts
@@ -90,7 +90,7 @@ export const computeCustomPlanNewCustomerProduct = ({
 				? { subscriptionId: params.processor_subscription_id }
 				: {}),
 
-			...(params.status ? { status: params.status } : {}),
+			status: params.status ?? currentCustomerProduct.status,
 
 			onTrialEnd:
 				trialContext?.onEnd ??

--- a/server/tests/integration/billing/migrations-v2/update-plan-operation/update-plan-op-states.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-operation/update-plan-op-states.test.ts
@@ -9,19 +9,23 @@
  */
 
 import { expect, test } from "bun:test";
-import type { ApiCustomerV3, ApiEntityV0 } from "@autumn/shared";
 import {
 	CusProductStatus,
+	findActiveCustomerProductById,
 	customerPrices,
 	customerProducts,
 	customers,
 	prices,
+	type ApiCustomerV3,
+	type ApiEntityV0,
 } from "@autumn/shared";
 import {
+	expectCustomerProducts,
 	expectProductCanceling,
 	expectProductNotPresent,
 	expectProductScheduled,
 } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectCustomerProductStatuses } from "@tests/integration/billing/utils/expectCustomerProductStatuses";
 import { expectNoExpiredCustomerProducts } from "@tests/integration/billing/utils/expectNoExpiredCustomerProducts";
 import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
@@ -31,6 +35,8 @@ import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { and, eq, isNull } from "drizzle-orm";
+import { CusService } from "@/internal/customers/CusService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { runUpdatePlanMigration } from "../utils/runUpdatePlanMigration";
 
 const getScheduledIds = async ({
@@ -110,6 +116,90 @@ const getCustomerProductPriceAmounts = async ({
 		)
 		.filter((amount): amount is number => typeof amount === "number")
 		.sort((a, b) => a - b);
+
+// Red: version update_plan replacement reset a past_due cusProduct to active.
+// Green: the replacement inherits past_due while the old row expires.
+test.concurrent(`${chalk.yellowBright("migrations update_plan states: past_due survives version update")}`, async () => {
+	const customerId = "migration-update-state-past-due";
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+	});
+
+	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.billing.attach({ productId: pro.id })],
+	});
+
+	const fullCustomerBefore = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const cusProductBefore = findActiveCustomerProductById({
+		fullCus: fullCustomerBefore,
+		productId: pro.id,
+	});
+	expect(cusProductBefore).toBeDefined();
+
+	await CusProductService.update({
+		ctx,
+		cusProductId: cusProductBefore!.id,
+		updates: { status: CusProductStatus.PastDue },
+	});
+
+	const invoiceCountBefore =
+		(await autumnV1.customers.get<ApiCustomerV3>(customerId)).invoices
+			?.length ?? 0;
+
+	await autumnV1.products.update(pro.id, {
+		items: [
+			items.monthlyPrice({ price: 20 }),
+			items.monthlyMessages({ includedUsage: 600 }),
+		],
+	});
+
+	await runUpdatePlanMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: `${customerId}-mig`,
+		customerId,
+		runOnServer: false,
+		filter: { customer: { plan: { plan_id: pro.id } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: pro.id },
+					version: 2,
+				},
+			],
+		},
+	});
+
+	const customerAfter = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+	await expectCustomerProducts({
+		customer: customerAfter,
+		pastDue: [pro.id],
+	});
+
+	const { byStatus } = await expectCustomerProductStatuses({
+		ctx,
+		customerId,
+		productId: pro.id,
+		expected: {
+			[CusProductStatus.PastDue]: 1,
+			[CusProductStatus.Expired]: 1,
+		},
+	});
+
+	expect(byStatus[CusProductStatus.PastDue]?.[0]?.product.version).toBe(2);
+	expect(customerAfter.invoices?.length ?? 0).toBe(invoiceCountBefore);
+	await expectStripeSubscriptionCorrect({ ctx, customerId });
+});
 
 test.concurrent(`${chalk.yellowBright("migrations update_plan states: scheduled downgrade survives active plan price update")}`, async () => {
 	const customerId = "migration-update-state-downgrade";

--- a/server/tests/integration/billing/update-subscription/params/update-processor-no-billing-changes.test.ts
+++ b/server/tests/integration/billing/update-subscription/params/update-processor-no-billing-changes.test.ts
@@ -1,14 +1,18 @@
 import { expect, test } from "bun:test";
 import {
+	findActiveCustomerProductById,
 	CusProductStatus,
 	type UpdateSubscriptionV1ParamsInput,
 } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectCustomerProductStatuses } from "@tests/integration/billing/utils/expectCustomerProductStatuses";
 import { items } from "@tests/utils/fixtures/items";
 import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
 import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { CusService } from "@/internal/customers/CusService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 
 test(`${chalk.yellowBright("processor_subscription_id: attach with existing stripe subscription anchors reset cycle")}`, async () => {});
 
@@ -35,10 +39,10 @@ test(`${chalk.yellowBright("update no_billing_changes: customize preserves subsc
 		ctx,
 		idOrInternalId: customerId,
 	});
-	const cusProductBefore = fullCustomerBefore.customer_products.find(
-		(cp) =>
-			cp.product_id === pro.id && cp.status === CusProductStatus.Active,
-	);
+	const cusProductBefore = findActiveCustomerProductById({
+		fullCus: fullCustomerBefore,
+		productId: pro.id,
+	});
 	expect(cusProductBefore).toBeDefined();
 	const originalSubIds = cusProductBefore?.subscription_ids ?? [];
 	expect(originalSubIds.length).toBeGreaterThan(0);
@@ -54,16 +58,85 @@ test(`${chalk.yellowBright("update no_billing_changes: customize preserves subsc
 		},
 	});
 
-	const fullCustomerAfter = await CusService.getFull({
+	await expectCustomerProducts({
+		customer: await autumnV2.customers.get(customerId),
+		active: [pro.id],
+	});
+
+	const { byStatus } = await expectCustomerProductStatuses({
+		ctx,
+		customerId,
+		productId: pro.id,
+		expected: {
+			[CusProductStatus.Active]: 1,
+		},
+	});
+	expect(byStatus[CusProductStatus.Active]?.[0]?.subscription_ids).toEqual(
+		originalSubIds,
+	);
+});
+
+// Red: replacement-style updates reset a past_due cusProduct to active.
+// Green: the replacement inherits status and keeps the subscription link.
+test(`${chalk.yellowBright("update no_billing_changes: replacement customize preserves past_due status")}`, async () => {
+	const customerId = "update-no-billing-preserves-past-due";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const priceItem = items.monthlyPrice({ price: 20 });
+	const pro = products.base({ id: "pro", items: [messagesItem, priceItem] });
+
+	const { autumnV1, autumnV2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const fullCustomerBefore = await CusService.getFull({
 		ctx,
 		idOrInternalId: customerId,
 	});
-	const activeProRows = fullCustomerAfter.customer_products.filter(
-		(cp) =>
-			cp.product_id === pro.id && cp.status === CusProductStatus.Active,
-	);
-	expect(activeProRows.length).toBe(1);
-	const cusProductAfter = activeProRows[0];
+	const cusProductBefore = findActiveCustomerProductById({
+		fullCus: fullCustomerBefore,
+		productId: pro.id,
+	});
+	expect(cusProductBefore).toBeDefined();
+	const originalSubIds = cusProductBefore?.subscription_ids ?? [];
+	expect(originalSubIds.length).toBeGreaterThan(0);
 
-	expect(cusProductAfter.subscription_ids).toEqual(originalSubIds);
+	await CusProductService.update({
+		ctx,
+		cusProductId: cusProductBefore!.id,
+		updates: { status: CusProductStatus.PastDue },
+	});
+
+	await autumnV2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+		customer_id: customerId,
+		plan_id: pro.id,
+		no_billing_changes: true,
+		customize: {
+			price: itemsV2.monthlyPrice({ amount: 20 }),
+			items: [itemsV2.monthlyMessages({ included: 250 })],
+		},
+	});
+
+	await expectCustomerProducts({
+		customer: await autumnV1.customers.get(customerId),
+		pastDue: [pro.id],
+	});
+
+	const { byStatus } = await expectCustomerProductStatuses({
+		ctx,
+		customerId,
+		productId: pro.id,
+		expected: {
+			[CusProductStatus.PastDue]: 1,
+			[CusProductStatus.Expired]: 1,
+		},
+	});
+	expect(byStatus[CusProductStatus.PastDue]?.[0]?.subscription_ids).toEqual(
+		originalSubIds,
+	);
 });

--- a/server/tests/integration/billing/utils/expectCustomerProductStatuses.ts
+++ b/server/tests/integration/billing/utils/expectCustomerProductStatuses.ts
@@ -1,0 +1,73 @@
+import { expect } from "bun:test";
+import {
+	CusProductStatus,
+	type FullCusProduct,
+	type CusProductStatus as CusProductStatusType,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusService } from "@/internal/customers/CusService";
+
+type CustomerProductStatusesResult = {
+	customerProducts: FullCusProduct[];
+	byStatus: Partial<Record<CusProductStatusType, FullCusProduct[]>>;
+};
+
+export const expectCustomerProductStatuses = async ({
+	ctx,
+	customerId,
+	productId,
+	entityId,
+	expected,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	productId: string;
+	entityId?: string;
+	expected: Partial<Record<CusProductStatusType, number>>;
+}): Promise<CustomerProductStatusesResult> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		inStatuses: [
+			CusProductStatus.Active,
+			CusProductStatus.PastDue,
+			CusProductStatus.Scheduled,
+			CusProductStatus.Expired,
+		],
+		withEntities: true,
+	});
+
+	const customerProducts = fullCustomer.customer_products.filter(
+		(customerProduct) =>
+			customerProduct.product_id === productId &&
+			(entityId ? customerProduct.entity_id === entityId : true),
+	);
+
+	const byStatus = customerProducts.reduce<
+		Partial<Record<CusProductStatusType, FullCusProduct[]>>
+	>((acc, customerProduct) => {
+		acc[customerProduct.status] = [
+			...(acc[customerProduct.status] ?? []),
+			customerProduct,
+		];
+		return acc;
+	}, {});
+
+	for (const [status, count] of Object.entries(expected)) {
+		const matchingCustomerProducts =
+			byStatus[status as CusProductStatusType] ?? [];
+
+		expect(
+			matchingCustomerProducts.length,
+			`Expected ${count} ${status} rows for ${productId}; got ${JSON.stringify(
+				customerProducts.map((customerProduct) => ({
+					id: customerProduct.id,
+					status: customerProduct.status,
+					version: customerProduct.product.version,
+				})),
+			)}`,
+		).toBe(count);
+	}
+
+	return { customerProducts, byStatus };
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix rollover logic to carry over customer product status when creating replacement rows, so states like past_due survive plan version updates and no-billing customize updates. Adds tests to lock this behavior and avoid billing side effects.

- **Bug Fixes**
  - New replacement rows now set `status` to `params.status ?? currentCustomerProduct.status` to prevent unintended resets.
  - Added integration tests for update_plan migrations and `no_billing_changes` customize flows, plus `expectCustomerProductStatuses` helper, ensuring past_due is preserved, previous rows expire, and subscription links remain intact.

<sup>Written for commit 62e8b9b6ca5cd2a053e8639c5c46f1feafea4015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where replacement-style customer product updates (via `update_plan` migration and `no_billing_changes` subscriptions) were silently resetting a `past_due` customer product back to `active`. The root cause was a conditional spread that omitted the `status` field entirely when `params.status` was absent, causing `initFullCustomerProduct` to fall back to its default `active` state instead of preserving the existing status.

- **[Bug fixes]** `computeCustomPlanNewCustomerProduct`: replaces `...(params.status ? { status: params.status } : {})` with `status: params.status ?? currentCustomerProduct.status`, ensuring the replacement product always inherits the current product's status when no explicit override is supplied.
- **[Improvements]** New `expectCustomerProductStatuses` test utility queries all status rows (active, past_due, scheduled, expired) for a product and asserts exact per-status counts, enabling precise rollover/replacement assertions.
- **[Improvements]** Two new integration tests cover the `past_due` survival scenario for both the migration `update_plan` path and the `no_billing_changes` customize path.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line targeted fix with two new integration tests that directly exercise the repaired path.

The production change is minimal and correct: replacing a conditional spread that silently dropped the status field with an explicit nullish-coalescing assignment. The fallback to currentCustomerProduct.status is the right default for all realistic states (active, past_due, scheduled). Both the migration and the no_billing_changes paths are covered by new end-to-end tests that verify old rows expire and new rows inherit status.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/compute/customPlan/computeCustomPlanNewCustomerProduct.ts | One-line fix: always propagate status to the new customer product, defaulting to the current product's status when params.status is absent. Correctly preserves past_due (and other non-active) statuses across plan replacements. |
| server/tests/integration/billing/utils/expectCustomerProductStatuses.ts | New test helper that fetches all status rows for a product and asserts per-status counts. Clean implementation; correctly fetches expired rows by passing all statuses to CusService.getFull. |
| server/tests/integration/billing/migrations-v2/update-plan-operation/update-plan-op-states.test.ts | New integration test validates that past_due status survives an update_plan migration: old row becomes expired, new v2 row retains past_due. Existing tests refactored to use the new utility. |
| server/tests/integration/billing/update-subscription/params/update-processor-no-billing-changes.test.ts | New integration test validates that past_due status and subscription_ids are preserved through a no_billing_changes customize operation. Existing subscription-ID preservation test refactored to use the new helper. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant computeCustomPlanNewCustomerProduct
    participant initFullCustomerProduct

    Caller->>computeCustomPlanNewCustomerProduct: "params (status=undefined), currentCustomerProduct (status=past_due)"

    note over computeCustomPlanNewCustomerProduct: OLD: ...(params.status ? { status } : {})<br/>→ status field omitted entirely

    note over computeCustomPlanNewCustomerProduct: NEW: status = params.status ?? currentCustomerProduct.status<br/>→ status = past_due

    computeCustomPlanNewCustomerProduct->>initFullCustomerProduct: "initOptions { status: past_due, ... }"
    initFullCustomerProduct-->>computeCustomPlanNewCustomerProduct: "newFullCustomerProduct (status=past_due)"
    computeCustomPlanNewCustomerProduct-->>Caller: newFullCustomerProduct

    note over Caller: Old row → Expired, New row → PastDue ✓
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/rollovers"](https://github.com/useautumn/autumn/commit/5bc264826ebcffc42d848629d046d988272e79c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35717337)</sub>

<!-- /greptile_comment -->