### PR TITLE
fix: 🐛 hot fix cli bugs

### DIFF
--- a/shared/utils/scopeDefinitions.ts
+++ b/shared/utils/scopeDefinitions.ts
@@ -676,6 +676,17 @@ function requirementMentions(
 }
 
 /**
+ * Rewrite a legacy CRUDL requirement scope to its modern R/W equivalent so it
+ * can be matched against an expanded grant (which only ever holds modern + meta
+ * scopes). Modern and meta scopes pass through unchanged. Deliberately applies
+ * only LEGACY_SCOPE_ALIASES, not expandScopes, so a required `admin`/`owner`
+ * is never blown up into "every modern scope".
+ */
+function normaliseRequiredScope(scope: ScopeString): ScopeString {
+	return (LEGACY_SCOPE_ALIASES[scope] ?? scope) as ScopeString;
+}
+
+/**
  * Check whether a set of granted scopes satisfies a route's requirement.
  *
  * `granted` may contain legacy scopes; normalisation (and write→read
@@ -705,7 +716,9 @@ export function checkScopes(
 
 	// Shorthand: a plain array means ALL required.
 	if (Array.isArray(required)) {
-		const missing = required.filter((s) => !expanded.has(s));
+		const missing = required
+			.map(normaliseRequiredScope)
+			.filter((s) => !expanded.has(s));
 		return { allowed: missing.length === 0, missing };
 	}
 
@@ -714,8 +727,8 @@ export function checkScopes(
 		ANY?: readonly ScopeString[];
 	};
 
-	const allList = req.ALL ?? [];
-	const anyList = req.ANY ?? [];
+	const allList = (req.ALL ?? []).map(normaliseRequiredScope);
+	const anyList = (req.ANY ?? []).map(normaliseRequiredScope);
 
 	const missingAll = allList.filter((s) => !expanded.has(s));
 	const anySatisfied =


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes scope matching in the CLI so legacy CRUDL requirement scopes are correctly recognized against modern read/write grants. Prevents false “missing scope” errors and command failures when users have modern grants.

- **Bug Fixes**
  - Added normalization for required scopes to map legacy CRUDL to modern R/W; modern/meta scopes pass through, and `admin`/`owner` are not expanded.
  - Applied normalization to array shorthand and `ALL`/`ANY` lists in `checkScopes`.

<sup>Written for commit e8befdb3834ea7772f01900b03574350bc5edda0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a scope-matching asymmetry in `checkScopes`: the grant side was already normalised (legacy CRUDL → modern R/W) by `expandScopes`, but the required side was not, so routes declaring legacy scopes like `customers:list` could never match `customers:read` in the expanded set. The new `normaliseRequiredScope` helper closes that gap by applying `LEGACY_SCOPE_ALIASES` to each required scope before the membership check.

- **Bug fixes** — Adds `normaliseRequiredScope` and applies it to all three `checkScopes` code paths (plain array, `ALL`, `ANY`), ensuring legacy required scopes are rewritten to their modern R/W equivalents before comparison.
- **Improvements** — The `missing` array returned on failure now contains modern scope names (e.g., `customers:read`) rather than legacy ones (e.g., `customers:list`), giving callers cleaner error output.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-scoped fix with no risky side effects.

The fix correctly symmetrises both sides of the scope membership check. `normaliseRequiredScope` intentionally uses only `LEGACY_SCOPE_ALIASES` (not `expandScopes`), so meta-scopes like `admin` and `owner` are preserved as-is in requirements rather than being blown up into every modern scope. All three code paths in `checkScopes` (plain array, ALL, ANY) are updated consistently.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/scopeDefinitions.ts | Adds `normaliseRequiredScope` helper and applies it to the required-side of all three scope-check paths (plain array, ALL, ANY), so legacy CRUDL required scopes are rewritten to their modern R/W equivalents before being matched against the already-expanded grant set. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant checkScopes
    participant expandScopes
    participant normaliseRequiredScope
    participant LEGACY_SCOPE_ALIASES

    Caller->>checkScopes: required (may contain legacy scopes), granted
    checkScopes->>expandScopes: granted
    expandScopes->>LEGACY_SCOPE_ALIASES: map each granted scope
    expandScopes-->>checkScopes: "expanded Set<ScopeString> (modern + meta only)"

    Note over checkScopes: NEW: normalise required side too
    checkScopes->>normaliseRequiredScope: each required scope
    normaliseRequiredScope->>LEGACY_SCOPE_ALIASES: lookup legacy alias
    normaliseRequiredScope-->>checkScopes: modern scope (or unchanged)

    checkScopes->>checkScopes: "filter(s => !expanded.has(s))"
    checkScopes-->>Caller: "{ allowed, missing }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 hot fix cli bugs"](https://github.com/useautumn/autumn/commit/e8befdb3834ea7772f01900b03574350bc5edda0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35718080)</sub>

<!-- /greptile_comment -->