### PR TITLE
fix: migration trial carryover

### DIFF
--- a/server/src/internal/migrations/v2/run/migrateCustomer/setup/setupMigrationOperationBillingContext.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/setup/setupMigrationOperationBillingContext.ts
@@ -10,6 +10,7 @@ import {
 import type Stripe from "stripe";
 import type { StripeSubscriptionWithDiscounts } from "@/external/stripe/subscriptions/index.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { setupUpdateSubscriptionTrialContext } from "@/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionTrialContext.js";
 import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor.js";
 import { setupResetCycleAnchor } from "@/internal/billing/v2/setup/setupResetCycleAnchor.js";
 import type { MigrateCustomerContext } from "@/internal/migrations/v2/operations/types/index.js";
@@ -71,12 +72,26 @@ export const setupMigrationOperationBillingContext = async ({
 		stripeCustomerContext.testClockFrozenTime ?? Date.now();
 	const resolvedFullProduct =
 		fullProduct ?? cusProductToProduct({ cusProduct: customerProduct });
-	const billingCycleAnchorMs = setupBillingCycleAnchor({
+	const trialContext = setupUpdateSubscriptionTrialContext({
+		stripeSubscription,
+		customerProduct,
+		currentEpochMs,
+		params: {},
+		fullProduct: resolvedFullProduct,
+	});
+
+	let billingCycleAnchorMs = setupBillingCycleAnchor({
 		stripeSubscription,
 		customerProduct,
 		newFullProduct: resolvedFullProduct,
+		trialContext,
 		currentEpochMs,
 	});
+
+	if (trialContext?.trialEndsAt) {
+		billingCycleAnchorMs = trialContext.trialEndsAt;
+	}
+
 	const resetCycleAnchorMs = setupResetCycleAnchor({
 		billingCycleAnchorMs,
 		customerProduct,
@@ -92,6 +107,7 @@ export const setupMigrationOperationBillingContext = async ({
 		currentEpochMs,
 		billingCycleAnchorMs,
 		resetCycleAnchorMs,
+		trialContext,
 		stripeCustomer: stripeCustomerContext.stripeCustomer,
 		stripeSubscription,
 		stripeSubscriptionSchedule,

--- a/server/tests/integration/billing/migrations-v2/trial/migration-paid-recurring-trial-carryover.test.ts
+++ b/server/tests/integration/billing/migrations-v2/trial/migration-paid-recurring-trial-carryover.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Regression coverage for paid recurring trials during update_plan migrations.
+ * Migrations must preserve active Stripe trial state in normal and entity-scoped setups.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3, ApiEntityV0, Migration } from "@autumn/shared";
+import type { MigrationFilter } from "@autumn/shared/api/migrations/filters/migrationFilter.js";
+import type { Operations } from "@autumn/shared/api/migrations/operations/operations.js";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectProductTrialing } from "@tests/integration/billing/utils/expectCustomerProductTrialing";
+import { expectStripeSubscriptionUnchanged } from "@tests/integration/billing/utils/stripe/expectStripeSubscriptionUnchanged";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { prepare } from "@/internal/migrations/v2/prepare/prepare.js";
+import { migrateCustomer } from "@/internal/migrations/v2/run/migrateCustomer/index.js";
+import { preProcessMigration } from "@/internal/migrations/v2/run/preProcess/index.js";
+
+type MigrationClient = {
+	migrationsV2: {
+		deleteAndCreate: (params: {
+			id: string;
+			filter?: MigrationFilter | null;
+			operations?: Operations | null;
+		}) => Promise<Migration>;
+	};
+};
+
+type TrialSubSnapshot = {
+	id: string;
+	trialEnd: number | null;
+	subscription: Stripe.Subscription;
+};
+
+const activeOrTrialing = (sub: Stripe.Subscription) =>
+	sub.status === "active" || sub.status === "trialing";
+
+const getTrialSubSnapshots = async ({
+	ctx,
+	stripeCustomerId,
+}: {
+	ctx: TestContext;
+	stripeCustomerId: string;
+}): Promise<TrialSubSnapshot[]> => {
+	const subscriptions = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCustomerId,
+		status: "all",
+	});
+	const activeSubs = subscriptions.data.filter(activeOrTrialing);
+	expect(activeSubs.length).toBeGreaterThan(0);
+
+	return activeSubs.map((subscription) => {
+		expect(subscription.status).toBe("trialing");
+		expect(subscription.trial_end).toBeDefined();
+		return {
+			id: subscription.id,
+			trialEnd: subscription.trial_end,
+			subscription,
+		};
+	});
+};
+
+const expectTrialSubsPreserved = async ({
+	ctx,
+	before,
+	expectUnchanged,
+}: {
+	ctx: TestContext;
+	before: TrialSubSnapshot[];
+	expectUnchanged: boolean;
+}) => {
+	for (const snapshot of before) {
+		const after = await ctx.stripeCli.subscriptions.retrieve(snapshot.id);
+		expect(after.status).toBe("trialing");
+		expect(after.trial_end).toBe(snapshot.trialEnd);
+
+		if (expectUnchanged) {
+			expectStripeSubscriptionUnchanged({
+				before: snapshot.subscription,
+				after,
+			});
+		}
+	}
+};
+
+const runVersionMigration = async ({
+	ctx,
+	migrationClient,
+	migrationId,
+	customerId,
+	filter,
+	operations,
+	noBillingChanges,
+}: {
+	ctx: AutumnContext;
+	migrationClient: MigrationClient;
+	migrationId: string;
+	customerId: string;
+	filter: MigrationFilter;
+	operations: Operations;
+	noBillingChanges: boolean;
+}) => {
+	const migration = await migrationClient.migrationsV2.deleteAndCreate({
+		id: migrationId,
+		filter,
+		operations,
+	});
+	const processedMigration = preProcessMigration({
+		...migration,
+		no_billing_changes: noBillingChanges,
+	});
+	const { preparedState } = await prepare({
+		ctx,
+		migration: processedMigration,
+		dryRun: false,
+	});
+
+	await migrateCustomer({
+		ctx,
+		customerId,
+		migration: {
+			...processedMigration,
+			prepared_state: preparedState,
+		},
+	});
+};
+
+const updateTrialProductsToV2 = async ({
+	autumnV1,
+	proId,
+	addonId,
+}: {
+	autumnV1: Awaited<ReturnType<typeof initScenario>>["autumnV1"];
+	proId: string;
+	addonId: string;
+}) => {
+	await autumnV1.products.update(proId, {
+		items: [
+			items.monthlyPrice({ price: 20 }),
+			items.monthlyMessages({ includedUsage: 600 }),
+		],
+	});
+	await autumnV1.products.update(addonId, {
+		items: [
+			items.monthlyPrice({ price: 20 }),
+			items.monthlyWords({ includedUsage: 300 }),
+		],
+	});
+};
+
+const migrationOps = ({
+	proId,
+	addonId,
+}: {
+	proId: string;
+	addonId: string;
+}): Operations => ({
+	customer: [
+		{
+			type: "update_plan",
+			plan_filter: { plan_id: proId },
+			version: 2,
+		},
+		{
+			type: "update_plan",
+			plan_filter: { plan_id: addonId },
+			version: 2,
+		},
+	],
+});
+
+for (const noBillingChanges of [false, true]) {
+	test.concurrent(
+		`${chalk.yellowBright(`migrations trial: paid pro + addon preserves trial (${noBillingChanges ? "no billing changes" : "billing changes"})`)}`,
+		async () => {
+			const suffix = noBillingChanges ? "db-only" : "billing";
+			const customerId = `mig-paid-trial-regular-${suffix}`;
+			const proTrial = products.proWithTrial({
+				id: "mig-paid-trial-pro",
+				items: [items.monthlyMessages({ includedUsage: 500 })],
+				trialDays: 14,
+				cardRequired: true,
+			});
+			const addon = products.recurringAddOn({
+				id: "mig-paid-trial-addon",
+				items: [items.monthlyWords({ includedUsage: 200 })],
+			});
+
+			const { autumnV1, autumnV2_2, ctx } = await initScenario({
+				customerId,
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [proTrial, addon] }),
+				],
+				actions: [
+					s.billing.attach({ productId: proTrial.id }),
+					s.billing.attach({ productId: addon.id }),
+				],
+			});
+
+			const customerBefore =
+				await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			const trialEndsAt = await expectProductTrialing({
+				customer: customerBefore,
+				productId: proTrial.id,
+			});
+			expect(trialEndsAt).toBeDefined();
+			await expectProductTrialing({
+				customer: customerBefore,
+				productId: addon.id,
+				trialEndsAt: trialEndsAt!,
+			});
+			expect(customerBefore.stripe_id).toBeDefined();
+			const subSnapshots = await getTrialSubSnapshots({
+				ctx,
+				stripeCustomerId: customerBefore.stripe_id as string,
+			});
+
+			await updateTrialProductsToV2({
+				autumnV1,
+				proId: proTrial.id,
+				addonId: addon.id,
+			});
+
+			await runVersionMigration({
+				ctx,
+				migrationClient: autumnV2_2,
+				migrationId: `${customerId}-mig`,
+				customerId,
+				filter: { customer: { plan: { plan_id: proTrial.id } } },
+				operations: migrationOps({ proId: proTrial.id, addonId: addon.id }),
+				noBillingChanges,
+			});
+
+			const customerAfter =
+				await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer: customerAfter,
+				active: [proTrial.id, addon.id],
+			});
+			await expectProductTrialing({
+				customer: customerAfter,
+				productId: proTrial.id,
+				trialEndsAt: trialEndsAt!,
+			});
+			await expectProductTrialing({
+				customer: customerAfter,
+				productId: addon.id,
+				trialEndsAt: trialEndsAt!,
+			});
+			await expectTrialSubsPreserved({
+				ctx,
+				before: subSnapshots,
+				expectUnchanged: noBillingChanges,
+			});
+		},
+	);
+
+	test.concurrent(
+		`${chalk.yellowBright(`migrations trial: multi-entity pro + addon preserves trial (${noBillingChanges ? "no billing changes" : "billing changes"})`)}`,
+		async () => {
+			const suffix = noBillingChanges ? "db-only" : "billing";
+			const customerId = `mig-paid-trial-entities-${suffix}`;
+			const proTrial = products.proWithTrial({
+				id: "mig-paid-trial-ent-pro",
+				items: [items.monthlyMessages({ includedUsage: 500 })],
+				trialDays: 14,
+				cardRequired: true,
+			});
+			const addon = products.recurringAddOn({
+				id: "mig-paid-trial-ent-addon",
+				items: [items.monthlyWords({ includedUsage: 200 })],
+			});
+
+			const { autumnV1, autumnV2_2, ctx, entities } = await initScenario({
+				customerId,
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [proTrial, addon] }),
+					s.entities({ count: 2, featureId: TestFeature.Users }),
+				],
+				actions: [
+					s.billing.attach({ productId: proTrial.id, entityIndex: 0 }),
+					s.billing.attach({ productId: addon.id, entityIndex: 0 }),
+					s.billing.attach({ productId: proTrial.id, entityIndex: 1 }),
+					s.billing.attach({ productId: addon.id, entityIndex: 1 }),
+				],
+			});
+
+			const entityBefore = await autumnV1.entities.get<ApiEntityV0>(
+				customerId,
+				entities[0].id,
+			);
+			const trialEndsAt = await expectProductTrialing({
+				customer: entityBefore,
+				productId: proTrial.id,
+			});
+			expect(trialEndsAt).toBeDefined();
+
+			for (const entity of entities) {
+				const entityCustomer = await autumnV1.entities.get<ApiEntityV0>(
+					customerId,
+					entity.id,
+				);
+				await expectProductTrialing({
+					customer: entityCustomer,
+					productId: proTrial.id,
+					trialEndsAt: trialEndsAt!,
+				});
+				await expectProductTrialing({
+					customer: entityCustomer,
+					productId: addon.id,
+					trialEndsAt: trialEndsAt!,
+				});
+			}
+
+			const customerBefore =
+				await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			expect(customerBefore.stripe_id).toBeDefined();
+			const subSnapshots = await getTrialSubSnapshots({
+				ctx,
+				stripeCustomerId: customerBefore.stripe_id as string,
+			});
+
+			await updateTrialProductsToV2({
+				autumnV1,
+				proId: proTrial.id,
+				addonId: addon.id,
+			});
+
+			await runVersionMigration({
+				ctx,
+				migrationClient: autumnV2_2,
+				migrationId: `${customerId}-mig`,
+				customerId,
+				filter: { customer: { plan: { plan_id: proTrial.id } } },
+				operations: migrationOps({ proId: proTrial.id, addonId: addon.id }),
+				noBillingChanges,
+			});
+
+			for (const entity of entities) {
+				const entityCustomer = await autumnV1.entities.get<ApiEntityV0>(
+					customerId,
+					entity.id,
+				);
+				await expectCustomerProducts({
+					customer: entityCustomer,
+					active: [proTrial.id, addon.id],
+				});
+				await expectProductTrialing({
+					customer: entityCustomer,
+					productId: proTrial.id,
+					trialEndsAt: trialEndsAt!,
+				});
+				await expectProductTrialing({
+					customer: entityCustomer,
+					productId: addon.id,
+					trialEndsAt: trialEndsAt!,
+				});
+			}
+			await expectTrialSubsPreserved({
+				ctx,
+				before: subSnapshots,
+				expectUnchanged: noBillingChanges,
+			});
+		},
+	);
+}

--- a/server/tests/integration/billing/migrations-v2/update-plan-version/migration-free-trial-carryover.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-version/migration-free-trial-carryover.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression: update_plan version migrations must carry active free-product trial_ends_at.
+ * Pre-fix replacements became active without a trial; post-fix they keep the trial isolated from paid subscriptions.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import {
+	expectProductNotTrialing,
+	expectProductTrialing,
+} from "@tests/integration/billing/utils/expectCustomerProductTrialing";
+import { expectStripeSubscriptionUnchanged } from "@tests/integration/billing/utils/stripe/expectStripeSubscriptionUnchanged";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { runUpdatePlanMigration } from "../utils/runUpdatePlanMigration";
+
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: free trial v1->v2 carries trial without trialing paid subscription")}`,
+	async () => {
+		const customerId = "mig-free-trial-carryover-paid-guard";
+		const freeTrial = products.baseWithTrial({
+			id: "mig-free-trial-carryover",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+			trialDays: 14,
+			cardRequired: false,
+		});
+		const paidAddon = products.recurringAddOn({
+			id: "mig-free-trial-paid-addon",
+			items: [items.monthlyCredits({ includedUsage: 50 })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [freeTrial, paidAddon] }),
+			],
+			actions: [
+				s.billing.attach({ productId: freeTrial.id }),
+				s.billing.attach({ productId: paidAddon.id }),
+			],
+		});
+
+		const customerBefore =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		const trialEndsAt = await expectProductTrialing({
+			customer: customerBefore,
+			productId: freeTrial.id,
+		});
+		expect(trialEndsAt).toBeDefined();
+		await expectProductNotTrialing({
+			customer: customerBefore,
+			productId: paidAddon.id,
+		});
+
+		const stripeCustomerId = customerBefore.stripe_id;
+		expect(stripeCustomerId).toBeDefined();
+		const subsBefore = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId as string,
+			status: "all",
+		});
+		const paidSubBefore = subsBefore.data.find(
+			(sub) => sub.status === "active" || sub.status === "trialing",
+		);
+		expect(paidSubBefore).toBeDefined();
+		expect(paidSubBefore!.status).not.toBe("trialing");
+
+		await autumnV1.products.update(freeTrial.id, {
+			items: [
+				items.monthlyMessages({ includedUsage: 200 }),
+				items.monthlyUsers({ includedUsage: 10 }),
+			],
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_2,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: freeTrial.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: freeTrial.id },
+						version: 2,
+					},
+				],
+			},
+			runOnServer: false,
+		});
+
+		const customerAfter =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer: customerAfter,
+			active: [freeTrial.id, paidAddon.id],
+		});
+		await expectProductTrialing({
+			customer: customerAfter,
+			productId: freeTrial.id,
+			trialEndsAt: trialEndsAt!,
+		});
+		await expectProductNotTrialing({
+			customer: customerAfter,
+			productId: paidAddon.id,
+		});
+		expectCustomerFeatureCorrect({
+			customer: customerAfter,
+			featureId: TestFeature.Messages,
+			includedUsage: 200,
+			balance: 200,
+			usage: 0,
+		});
+		expectCustomerFeatureCorrect({
+			customer: customerAfter,
+			featureId: TestFeature.Users,
+			includedUsage: 10,
+			balance: 10,
+			usage: 0,
+		});
+
+		const paidSubAfter = await ctx.stripeCli.subscriptions.retrieve(
+			paidSubBefore!.id,
+		);
+		expect(paidSubAfter.status).not.toBe("trialing");
+		expectStripeSubscriptionUnchanged({
+			before: paidSubBefore!,
+			after: paidSubAfter,
+		});
+	},
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes v2 `update_plan` migrations to preserve active Stripe trials by aligning the billing cycle anchor with the subscription’s trial end. Prevents trial loss and avoids putting paid subscriptions into trialing, including for entity-scoped customers and no-billing-changes runs.

- **Bug Fixes**
  - Use `setupUpdateSubscriptionTrialContext` to compute `trialContext` and override `billingCycleAnchorMs` with `trialEndsAt` when present; pass `trialContext` through the migration setup.
  - Add regression tests for paid recurring trials and free-plan trials with paid add-ons, covering single/multi-entity customers and the no-billing-changes path.

<sup>Written for commit 765ecae854fbdbff8166733db344bf5487f49b32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where active trials were not carried over during `update_plan` version migrations. The migration billing context setup now computes `trialContext` via `setupUpdateSubscriptionTrialContext` (matching the update-subscription flow), passes it into `setupBillingCycleAnchor`, and additionally overrides `billingCycleAnchorMs` with `trialContext.trialEndsAt` to handle the free→free product case that `setupBillingCycleAnchor` previously returned early before reaching the trial check.

- **Bug fixes** — `setupMigrationOperationBillingContext` now computes and propagates `trialContext`, fixing lost trial state for both free and paid recurring products during migrations.
- **Improvements** — Two new integration tests cover the repaired paths: free product trial carryover and paid recurring (including multi-entity) trial carryover.
</details>

<h3>Confidence Score: 4/5</h3>

The change is a focused, well-tested bug fix that adds trial context propagation to the migration billing setup path.

The post-setupBillingCycleAnchor override correctly handles the free→free early-return blind spot and is safe for all other product transitions. The test helper getTrialSubSnapshots uses an activeOrTrialing filter that is broader than its inner assertion requires, which could surface as a confusing failure if a non-trialing active subscription appears in the Stripe customer record.

server/tests/integration/billing/migrations-v2/trial/migration-paid-recurring-trial-carryover.test.ts — the getTrialSubSnapshots filter/assertion mismatch is worth tidying.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/migrations/v2/run/migrateCustomer/setup/setupMigrationOperationBillingContext.ts | Core fix: adds trialContext computation and propagation; the post-setupBillingCycleAnchor override correctly handles the free→free early-return path but is redundant for all other product type transitions. |
| server/tests/integration/billing/migrations-v2/trial/migration-paid-recurring-trial-carryover.test.ts | New integration test for paid recurring trial preservation (regular + multi-entity, billing and no-billing-changes paths). The activeOrTrialing filter in getTrialSubSnapshots is wider than the inner assertion requires. |
| server/tests/integration/billing/migrations-v2/update-plan-version/migration-free-trial-carryover.test.ts | New integration test for free product trial carryover; verifies the paid add-on subscription is not erroneously trialed and the stripe subscription is unchanged after migration. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[setupMigrationOperationBillingContext] --> B[setupUpdateSubscriptionTrialContext]
    B --> C{Product type}
    C -->|Paid recurring and trialing sub| D[inheritTrialFromSubscription]
    C -->|Free product| E[inheritTrialFromCustomerProduct]
    C -->|Paid recurring not trialing| F[undefined trialContext]
    D --> G[trialContext with trialEndsAt]
    E --> G
    G --> I[setupBillingCycleAnchor with trialContext]
    F --> I
    I --> J{Product transition path}
    J -->|Free to Free| K[returns starts_at - skips trial check]
    J -->|Paid trialing| L[returns trialContext.trialEndsAt]
    J -->|Other| M[returns billing_cycle_anchor]
    K --> N[Post-call override applies trialEndsAt - THE FIX]
    L --> O[Post-call override is redundant but correct]
    M --> P[Override skipped - trialContext is undefined]
    N --> Q[Return with trialContext propagated]
    O --> Q
    P --> Q
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/billing/migrations-v2/trial/migration-paid-recurring-trial-carryover.test.ts:55-59
The `activeOrTrialing` filter includes `status === "active"` subscriptions, but the inner `.map()` immediately asserts `expect(subscription.status).toBe("trialing")`. Any non-trialing active subscription (e.g. a future add-on not sharing the trial subscription) would fail the assertion with a confusing message rather than a clear test signal. Filtering to only `"trialing"` subscriptions up front makes the intent explicit and avoids the redundant/contradictory filter.

```suggestion
	const activeSubs = subscriptions.data.filter(
		(sub) => sub.status === "trialing",
	);
	expect(activeSubs.length).toBeGreaterThan(0);

	return activeSubs.map((subscription) => {
		expect(subscription.status).toBe("trialing");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: migration trial carryover"](https://github.com/useautumn/autumn/commit/765ecae854fbdbff8166733db344bf5487f49b32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35835436)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->