### PR TITLE
chore: invoice line items fix

### DIFF
--- a/server/src/internal/invoices/lineItems/repos/getByCustomerProductIds.ts
+++ b/server/src/internal/invoices/lineItems/repos/getByCustomerProductIds.ts
@@ -25,7 +25,10 @@ export const getByCustomerProductIds = async ({
 		.where(
 			and(
 				inArray(invoiceLineItems.direction, [...directions]),
-				sql`${invoiceLineItems.customer_product_ids}::jsonb ?| ${customerProductIds}::text[]`,
+				sql`${invoiceLineItems.customer_product_ids} ?| ARRAY[${sql.join(
+					customerProductIds.map((id) => sql`${id}`),
+					sql`, `,
+				)}]::text[]`,
 			),
 		);
 };

--- a/server/tests/integration/db/invoice-line-items/get-by-customer-product-ids.test.ts
+++ b/server/tests/integration/db/invoice-line-items/get-by-customer-product-ids.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { invoiceLineItems } from "@autumn/shared";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { eq } from "drizzle-orm";
+import { invoiceLineItemRepo } from "@/internal/invoices/lineItems/repos/index.js";
+
+test.concurrent("invoice line items: get by single customer product id", async () => {
+	const lineItemId = "invoice_li_get_by_cus_prod_ids";
+	const customerProductId = "cus_prod_3EfbA8teNA8ColQSwRemt4BevN9";
+
+	await ctx.db.delete(invoiceLineItems).where(eq(invoiceLineItems.id, lineItemId));
+	await ctx.db.insert(invoiceLineItems).values({
+		id: lineItemId,
+		amount: 100,
+		amount_after_discounts: 100,
+		description: "Test line item",
+		direction: "charge",
+		customer_product_ids: [customerProductId],
+	});
+
+	try {
+		const rows = await invoiceLineItemRepo.getByCustomerProductIds({
+			db: ctx.db,
+			customerProductIds: [customerProductId],
+		});
+
+		expect(rows.map((row) => row.id)).toContain(lineItemId);
+	} finally {
+		await ctx.db.delete(invoiceLineItems).where(eq(invoiceLineItems.id, lineItemId));
+	}
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed invoice line item lookup by customer product IDs so queries return the expected rows.

- **Bug Fixes**
  - Updated `getByCustomerProductIds` to build `ARRAY[...]::text[]` for the `?|` operator, ensuring correct matching.
  - Added an integration test using `bun:test`, `@autumn/shared`, and `invoiceLineItemRepo.getByCustomerProductIds` for a single ID case.

<sup>Written for commit 70f43877a793ea972bb38799961d192bf6e5817d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes an incorrect JSONB `?|` query in `getByCustomerProductIds` where passing a raw JS array as a single SQL parameter produced invalid SQL. The fix constructs a proper parameterized `ARRAY[$1, $2, ...]::text[]` literal using `sql.join`, and an integration test is added to validate the query.

- **Bug fixes** — Rewrites the `?|` array-overlap predicate to use individually parameterized values via `sql.join`, replacing the broken `${customerProductIds}::text[]` binding that Drizzle could not serialize correctly.
- **Improvements** — Removes the redundant `::jsonb` cast on the `customer_product_ids` column reference, since the column is already JSONB.
- **Improvements** — Adds an integration test with setup/teardown to confirm the single-ID lookup path works end-to-end.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the query fix is correct and each value is properly parameterized; the only gap is that the test exercises only the single-ID path.

The rewritten SQL correctly parameterizes every customer product ID individually, fixing what was a broken raw-array binding. The logic is straightforward and the new integration test validates the happy path. The multi-ID sql.join branch — the most structurally novel part of the change — is not covered by a test, so a regression there would go undetected without manual inspection or a future test addition.

The test file would benefit from a multi-ID scenario to cover the sql.join path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/invoices/lineItems/repos/getByCustomerProductIds.ts | Fixes broken SQL by replacing a raw JS-array parameter binding with individually parameterized ARRAY[...] literals; removes the now-redundant ::jsonb cast on the column reference. |
| server/tests/integration/db/invoice-line-items/get-by-customer-product-ids.test.ts | New integration test covering single-ID lookup; does not exercise the multi-ID sql.join path or the refund direction filter. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant getByCustomerProductIds
    participant Drizzle SQL
    participant PostgreSQL

    Caller->>getByCustomerProductIds: "{ db, customerProductIds, directions }"
    alt customerProductIds is empty
        getByCustomerProductIds-->>Caller: []
    else
        getByCustomerProductIds->>Drizzle SQL: build query with sql.join(ids.map(id => sql`${id}`))
        Note over Drizzle SQL: ARRAY[$1, $2, ...]::text[]<br/>(each id parameterized)
        Drizzle SQL->>PostgreSQL: SELECT * FROM invoice_line_items WHERE direction IN (...) AND customer_product_ids ?| ARRAY[$1,...]::text[]
        PostgreSQL-->>Drizzle SQL: matching rows
        Drizzle SQL-->>getByCustomerProductIds: DbInvoiceLineItem[]
        getByCustomerProductIds-->>Caller: DbInvoiceLineItem[]
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/db/invoice-line-items/get-by-customer-product-ids.test.ts:7-31
**Multi-ID path not covered by test**

The test only exercises the single-ID path. The core of the fix is the `sql.join(customerProductIds.map(...))` branch, which only activates with two or more IDs. A test with multiple `customerProductIds` where only one overlaps the stored row (and a row whose IDs don't overlap, to confirm it's excluded) would directly validate the rewritten `ARRAY[...]::text[]` construction and the `?|` operator semantics across the realistic use-case.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: invoice line items fix"](https://github.com/useautumn/autumn/commit/70f43877a793ea972bb38799961d192bf6e5817d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35887140)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->