### PR TITLE
fix: usage alert threshold 2

### DIFF
--- a/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
+++ b/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
@@ -26,8 +26,8 @@ const wasThresholdCrossed = ({
 }) => {
 	if (alert.threshold_type === "usage") {
 		const shldAlert =
-			oldApiBalance.usage <= alert.threshold &&
-			newApiBalance.usage > alert.threshold;
+			oldApiBalance.usage < alert.threshold &&
+			newApiBalance.usage >= alert.threshold;
 
 		return shldAlert;
 	}
@@ -73,7 +73,7 @@ const wasThresholdCrossed = ({
 			.mul(100)
 			.toNumber();
 
-		return oldPercentage <= alert.threshold && newPercentage > alert.threshold;
+		return oldPercentage < alert.threshold && newPercentage >= alert.threshold;
 	}
 
 	return false;

--- a/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
+++ b/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
@@ -15,7 +15,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
 type AlertScope = "customer" | "entity" | "org";
 
-const wasThresholdCrossed = ({
+export const wasThresholdCrossed = ({
 	alert,
 	oldApiBalance,
 	newApiBalance,

--- a/server/src/internal/customers/actions/ensureStripeCustomerFromCustomerData.ts
+++ b/server/src/internal/customers/actions/ensureStripeCustomerFromCustomerData.ts
@@ -15,8 +15,6 @@ export const ensureStripeCustomerFromCustomerData = async ({
 }) => {
 	if (!customerData?.create_in_stripe || customer.processor?.id) return false;
 
-	if (customer.processor?.id) return true;
-
 	await getOrCreateStripeCustomer({
 		ctx,
 		customer,

--- a/server/src/internal/customers/actions/ensureStripeCustomerFromCustomerData.ts
+++ b/server/src/internal/customers/actions/ensureStripeCustomerFromCustomerData.ts
@@ -1,0 +1,42 @@
+import type { Customer, CustomerData } from "@autumn/shared";
+import { getOrCreateStripeCustomer } from "@/external/stripe/customers/index.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { updateCachedCustomerData as updateCachedFullSubjectCustomerData } from "@/internal/customers/cache/fullSubject/actions/updateCachedCustomerData.js";
+import { updateCachedCustomerData as updateCachedFullCustomerData } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/updateCachedCustomerData.js";
+
+export const ensureStripeCustomerFromCustomerData = async ({
+	ctx,
+	customer,
+	customerData,
+}: {
+	ctx: AutumnContext;
+	customer: Customer;
+	customerData?: CustomerData;
+}) => {
+	if (!customerData?.create_in_stripe || customer.processor?.id) return false;
+
+	if (customer.processor?.id) return true;
+
+	await getOrCreateStripeCustomer({
+		ctx,
+		customer,
+	});
+
+	if (!customer.processor?.id) return false;
+
+	const customerId = customer.id || customer.internal_id;
+	await Promise.all([
+		updateCachedFullCustomerData({
+			ctx,
+			customerId,
+			updates: { processor: customer.processor },
+		}),
+		updateCachedFullSubjectCustomerData({
+			ctx,
+			customerId,
+			updates: { processor: customer.processor },
+		}),
+	]);
+
+	return true;
+};

--- a/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts
@@ -5,6 +5,7 @@ import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjec
 import { getApiCustomer } from "../cusUtils/apiCusUtils/getApiCustomer.js";
 import { getOrCreateCachedFullCustomer } from "../cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.js";
 import { getApiCustomerV2 } from "../cusUtils/getApiCustomerV2/index.js";
+import { ensureStripeCustomerFromCustomerData } from "./ensureStripeCustomerFromCustomerData.js";
 
 export const getOrCreateApiCustomerByRollout = async ({
 	ctx,
@@ -19,29 +20,34 @@ export const getOrCreateApiCustomerByRollout = async ({
 	source?: string;
 	withAutumnId?: boolean;
 }) => {
+	let fullSubject:
+		| Awaited<ReturnType<typeof getOrCreateCachedFullSubject>>
+		| undefined;
+	let fullCustomer:
+		| Awaited<ReturnType<typeof getOrCreateCachedFullCustomer>>
+		| undefined;
+
 	if (isFullSubjectRolloutEnabled({ ctx })) {
-		const fullSubject = await getOrCreateCachedFullSubject({
+		fullSubject = await getOrCreateCachedFullSubject({
 			ctx,
 			params,
 			source,
 		});
-
-		return getApiCustomerV2({
+	} else {
+		fullCustomer = await getOrCreateCachedFullCustomer({
 			ctx,
-			fullSubject,
-			withAutumnId,
+			params,
+			source,
 		});
 	}
 
-	const fullCustomer = await getOrCreateCachedFullCustomer({
+	await ensureStripeCustomerFromCustomerData({
 		ctx,
-		params,
-		source,
+		customer: fullSubject?.customer ?? fullCustomer!,
+		customerData: params.customer_data,
 	});
 
-	return getApiCustomer({
-		ctx,
-		fullCustomer,
-		withAutumnId,
-	});
+	if (fullSubject) return getApiCustomerV2({ ctx, fullSubject, withAutumnId });
+
+	return getApiCustomer({ ctx, fullCustomer: fullCustomer!, withAutumnId });
 };

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-basic.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-basic.test.ts
@@ -114,6 +114,51 @@ test(`${chalk.yellowBright("usage-alert1: usage threshold crossing triggers webh
 	expect(data.usage_alert.threshold_type).toBe("usage");
 });
 
+test(`${chalk.yellowBright("usage-alert1b: usage threshold fires when usage lands exactly on threshold")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const freeProd = products.base({
+		id: "ua-threshold-exact-1",
+		items: [messagesItem],
+	});
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "usage-alert-threshold-exact-1",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	await setCustomerUsageAlerts({
+		autumn: autumnV2_1,
+		customerId,
+		usageAlerts: [
+			{
+				feature_id: TestFeature.Messages,
+				threshold: 500,
+				threshold_type: "usage",
+				enabled: true,
+			},
+		],
+	});
+
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 500,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.threshold === 500,
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result!.payload.data.usage_alert.threshold_type).toBe("usage");
+});
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // TEST 2: Usage percentage threshold crossing triggers webhook
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -168,6 +213,53 @@ test(`${chalk.yellowBright("usage-alert2: usage percentage threshold crossing tr
 	expect(data.feature_id).toBe(TestFeature.Messages);
 	expect(data.usage_alert.threshold).toBe(90);
 	expect(data.usage_alert.threshold_type).toBe("usage_percentage");
+});
+
+test(`${chalk.yellowBright("usage-alert2b: usage percentage threshold fires at exact percentage")}`, async () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 1000 });
+	const freeProd = products.base({
+		id: "ua-pct-exact-1",
+		items: [messagesItem],
+	});
+
+	const { customerId, autumnV2_1 } = await initScenario({
+		customerId: "usage-alert-pct-exact-1",
+		setup: [s.customer({ testClock: false }), s.products({ list: [freeProd] })],
+		actions: [s.attach({ productId: freeProd.id })],
+	});
+
+	await setCustomerUsageAlerts({
+		autumn: autumnV2_1,
+		customerId,
+		usageAlerts: [
+			{
+				feature_id: TestFeature.Messages,
+				threshold: 100,
+				threshold_type: "usage_percentage",
+				enabled: true,
+			},
+		],
+	});
+
+	await autumnV2_1.track({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+		value: 1000,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.usage_alert?.threshold === 100,
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result!.payload.data.usage_alert.threshold_type).toBe(
+		"usage_percentage",
+	);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/server/tests/integration/crud/customers/create-customer-existing-stripe.test.ts
+++ b/server/tests/integration/crud/customers/create-customer-existing-stripe.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService.js";
+
+const uniqueSuffix = () => Math.random().toString(36).slice(2, 10);
+
+// Contract: create_in_stripe on an existing Autumn customer ensures one Stripe processor.
+test.concurrent(
+	`${chalk.yellowBright("customers: existing customer create_in_stripe creates Stripe customer")}`,
+	async () => {
+		const suffix = uniqueSuffix();
+		const customerId = `existing-stripe-${suffix}`;
+		const email = `${customerId}@example.com`;
+
+		const { autumnV1, autumnV2_1, ctx } = await initScenario({
+			setup: [s.deleteCustomer({ customerId })],
+			actions: [],
+		});
+
+		const initial = await autumnV1.customers.create({
+			id: customerId,
+			name: "Existing Stripe",
+			email,
+			internalOptions: { disable_defaults: true },
+		});
+		expect(initial.stripe_id).toBeNull();
+
+		const createdInStripe = await autumnV1.customers.create({
+			id: customerId,
+			name: "Existing Stripe",
+			email,
+			create_in_stripe: true,
+			internalOptions: { disable_defaults: true },
+		});
+
+		expect(createdInStripe.stripe_id).toMatch(/^cus_/);
+
+		const apiCustomer =
+			await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+		expect(apiCustomer.processors?.stripe?.id).toBe(createdInStripe.stripe_id);
+
+		const fromDb = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		expect(fromDb.processor?.id).toBe(createdInStripe.stripe_id);
+
+		const second = await autumnV1.customers.create({
+			id: customerId,
+			name: "Existing Stripe",
+			email,
+			create_in_stripe: true,
+			internalOptions: { disable_defaults: true },
+		});
+		expect(second.stripe_id).toBe(createdInStripe.stripe_id);
+
+		const stripeCustomers = await ctx.stripeCli.customers.list({ email });
+		expect(stripeCustomers.data.map((customer) => customer.id)).toContain(
+			createdInStripe.stripe_id,
+		);
+		expect(
+			stripeCustomers.data.filter(
+				(customer) => customer.id === second.stripe_id,
+			),
+		).toHaveLength(1);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customers: concurrent existing create_in_stripe with paid default is idempotent")}`,
+	async () => {
+		const suffix = uniqueSuffix();
+		const customerId = `existing-stripe-race-${suffix}`;
+		const email = `${customerId}@example.com`;
+		const paidDefault = products.defaultTrial({
+			id: "existing-stripe-race-default",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+			trialDays: 14,
+			cardRequired: false,
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			setup: [
+				s.deleteCustomer({ customerId }),
+				s.products({ list: [paidDefault], prefix: customerId }),
+			],
+			actions: [],
+		});
+
+		await autumnV1.customers.create({
+			id: customerId,
+			name: "Existing Stripe Race",
+			email,
+			internalOptions: { disable_defaults: true },
+		});
+
+		const results = await Promise.all(
+			Array.from({ length: 5 }, () =>
+				autumnV1.customers.create({
+					id: customerId,
+					name: "Existing Stripe Race",
+					email,
+					create_in_stripe: true,
+					internalOptions: { default_group: customerId },
+				}),
+			),
+		);
+
+		const stripeIds = results.map((result) => result.stripe_id);
+		expect(new Set(stripeIds).size).toBe(1);
+		expect(stripeIds[0]).toMatch(/^cus_/);
+
+		const fromDb = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		expect(fromDb.processor?.id).toBe(stripeIds[0]);
+		expect(fromDb.customer_products).toHaveLength(0);
+
+		const subscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeIds[0],
+			status: "all",
+		});
+		expect(subscriptions.data).toHaveLength(0);
+	},
+);

--- a/server/tests/unit/balances/trackWebhooks/checkUsageAlerts.test.ts
+++ b/server/tests/unit/balances/trackWebhooks/checkUsageAlerts.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import type { ApiBalanceV1, DbUsageAlert } from "@autumn/shared";
+import { wasThresholdCrossed } from "@/internal/balances/trackWebhooks/checkUsageAlerts.js";
+
+const balance = ({
+	usage,
+	granted = 1000,
+	remaining = granted - usage,
+}: {
+	usage: number;
+	granted?: number;
+	remaining?: number;
+}): ApiBalanceV1 =>
+	({
+		object: "balance",
+		feature_id: "messages",
+		granted,
+		remaining,
+		usage,
+		unlimited: false,
+		overage_allowed: false,
+		max_purchase: null,
+		next_reset_at: null,
+	}) as ApiBalanceV1;
+
+const alert = ({
+	threshold,
+	threshold_type,
+}: Pick<DbUsageAlert, "threshold" | "threshold_type">): DbUsageAlert => ({
+	threshold,
+	threshold_type,
+	enabled: true,
+	feature_id: "messages",
+});
+
+describe("wasThresholdCrossed", () => {
+	test("usage alert fires when usage lands exactly on threshold", () => {
+		expect(
+			wasThresholdCrossed({
+				alert: alert({ threshold: 500, threshold_type: "usage" }),
+				oldApiBalance: balance({ usage: 490 }),
+				newApiBalance: balance({ usage: 500 }),
+			}),
+		).toBe(true);
+	});
+
+	test("usage alert does not refire when usage was already at threshold", () => {
+		expect(
+			wasThresholdCrossed({
+				alert: alert({ threshold: 500, threshold_type: "usage" }),
+				oldApiBalance: balance({ usage: 500 }),
+				newApiBalance: balance({ usage: 510 }),
+			}),
+		).toBe(false);
+	});
+
+	test("usage percentage alert fires when usage lands exactly on threshold", () => {
+		expect(
+			wasThresholdCrossed({
+				alert: alert({
+					threshold: 100,
+					threshold_type: "usage_percentage",
+				}),
+				oldApiBalance: balance({ usage: 990 }),
+				newApiBalance: balance({ usage: 1000 }),
+			}),
+		).toBe(true);
+	});
+
+	test("usage percentage alert does not refire when already at threshold", () => {
+		expect(
+			wasThresholdCrossed({
+				alert: alert({
+					threshold: 100,
+					threshold_type: "usage_percentage",
+				}),
+				oldApiBalance: balance({ usage: 1000 }),
+				newApiBalance: balance({ usage: 1010 }),
+			}),
+		).toBe(false);
+	});
+
+	test("remaining threshold behavior is already inclusive on the new value", () => {
+		expect(
+			wasThresholdCrossed({
+				alert: alert({ threshold: 200, threshold_type: "remaining" }),
+				oldApiBalance: balance({ usage: 790, remaining: 210 }),
+				newApiBalance: balance({ usage: 800, remaining: 200 }),
+			}),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes usage alert thresholds so alerts fire when usage reaches the boundary, and safely creates a Stripe customer for existing customers when `create_in_stripe` is set. Keeps caches in sync and prevents duplicate customers or unintended subscriptions.

- **Bug Fixes**
  - Usage and percentage alerts now fire when moving from below to at/above the threshold (old < threshold, new >= threshold). Added unit and integration tests for exact-threshold firing and no re-fires.
  - Added `ensureStripeCustomerFromCustomerData` and integrated it into `getOrCreateApiCustomerByRollout` to create a Stripe customer for existing customers when `create_in_stripe` is set. Updates both customer caches, is idempotent under concurrency, and avoids duplicate Stripe customers and subscriptions. Tests cover single-customer creation and race conditions.

<sup>Written for commit f3886c0a5c39637783b4f3ce07fd8b40c7020149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes usage alert threshold semantics and adds a new `ensureStripeCustomerFromCustomerData` helper that creates a Stripe customer on-demand during check/track calls when `create_in_stripe` is requested.

- **Bug fixes** — `checkUsageAlerts.ts`: corrects the threshold-crossing condition for `usage` and `usage_percentage` alert types so alerts fire when usage *reaches* the threshold (`>=`) rather than only when it strictly *exceeds* it (`>`).
- **Improvements** — `ensureStripeCustomerFromCustomerData.ts`: extracts Stripe-customer-creation logic into a dedicated helper and applies it across both the rollout and legacy customer paths in `getOrCreateApiCustomerByRollout`.
- **Improvements** — New integration tests covering idempotent and concurrent `create_in_stripe` scenarios for existing customers.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with one small fix recommended in the new helper function.

The threshold fix and the refactoring are clean. The new `ensureStripeCustomerFromCustomerData` helper has a logical inconsistency: its compound guard returns `false` when a Stripe processor already exists, when the correct return is `true`, and the second guard checking the same condition is unreachable dead code. The call site currently ignores the return value so there is no observable bug today, but the wrong semantic will cause silent misbehavior if the function is reused.

server/src/internal/customers/actions/ensureStripeCustomerFromCustomerData.ts — the early-return guard on line 16 should be split into two separate conditions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts | Fixes threshold-crossing semantics for `usage` and `usage_percentage` alert types: alerts now fire when usage reaches (>=) the threshold rather than only strictly exceeding it. `remaining` and `remaining_percentage` logic is untouched and correct. |
| server/src/internal/customers/actions/ensureStripeCustomerFromCustomerData.ts | New helper to create a Stripe customer when `create_in_stripe` is set. Has a logic bug: the compound early-return returns `false` when the processor already exists instead of `true`, and the second `if (customer.processor?.id)` guard is therefore unreachable dead code. |
| server/src/internal/customers/actions/getOrCreateApiCustomerByRollout.ts | Refactored to share the `ensureStripeCustomerFromCustomerData` call across both the rollout (fullSubject) and legacy (fullCustomer) paths. Logic is structurally correct. |
| server/tests/integration/crud/customers/create-customer-existing-stripe.test.ts | New integration tests covering idempotent Stripe customer creation and concurrent race-condition safety for `create_in_stripe` on existing customers. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getOrCreateApiCustomerByRollout] --> B{isFullSubjectRolloutEnabled?}
    B -- Yes --> C[getOrCreateCachedFullSubject\n→ fullSubject]
    B -- No --> D[getOrCreateCachedFullCustomer\n→ fullCustomer]
    C --> E[ensureStripeCustomerFromCustomerData\ncustomer = fullSubject.customer]
    D --> E
    E --> F{customerData.create_in_stripe?}
    F -- No --> G[return false\nskip Stripe creation]
    F -- Yes --> H{customer.processor.id exists?}
    H -- Yes --> I[return true\nalready in Stripe]
    H -- No --> J[getOrCreateStripeCustomer]
    J --> K{processor.id set\nafter call?}
    K -- No --> L[return false]
    K -- Yes --> M[updateCachedFullCustomerData\nupdateCachedFullSubjectCustomerData]
    M --> N[return true]
    G --> O{fullSubject set?}
    I --> O
    N --> O
    L --> O
    O -- Yes --> P[getApiCustomerV2]
    O -- No --> Q[getApiCustomer]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/customers/actions/ensureStripeCustomerFromCustomerData.ts:16-18
Dead code and incorrect early-return value — the compound guard on line 16 returns `false` when `customer.processor?.id` is truthy (customer already has a Stripe ID), but the correct semantic for that branch is `true` (Stripe customer already exists, nothing to do). The subsequent check on line 18 is therefore unreachable. While the return value is currently ignored at the only call site, this will silently misbehave if the function is reused.

```suggestion
	if (!customerData?.create_in_stripe) return false;

	if (customer.processor?.id) return true;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["added tests"](https://github.com/useautumn/autumn/commit/99d2525f2dd34b39f5a9692a0dba467e425d9e3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35914035)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->