### PR TITLE
fix(track): release idempotency key when deduction fails (#1138)

### DIFF
--- a/server/src/internal/balances/track/runTrackV2.ts
+++ b/server/src/internal/balances/track/runTrackV2.ts
@@ -12,6 +12,7 @@ import { getOrSetCachedFullCustomer } from "@/internal/customers/cusUtils/fullCu
 import type { AutumnContext } from "../../../honoUtils/HonoEnv.js";
 import { getOrCreateCachedFullCustomer } from "../../customers/cusUtils/fullCustomerCacheUtils/getOrCreateCachedFullCustomer.js";
 import type { FeatureDeduction } from "../utils/types/featureDeduction.js";
+import { releaseIdempotencyKey } from "@/internal/misc/idempotency/checkIdempotencyKey.js";
 import { handleEventIdempotencyKey } from "./utils/handleEventIdempotencyKey.js";
 import { runRedisTrack } from "./utils/runRedisTrack.js";
 
@@ -51,7 +52,12 @@ export const runTrackV2 = async ({
 				source: "runTrackV2",
 			});
 
-	// If idempotency key is provided, insert event first and skip insertion later
+	// If idempotency key is provided, CLAIM it BEFORE the deduction so concurrent
+	// retries get a deterministic 409 instead of double-deducting. If the deduction
+	// then fails (insufficient balance, transient Redis fault, etc.), the catch
+	// block below RELEASES the claim so the caller can safely retry once the
+	// failure cause is resolved. Fixes #1138 — previously the claim was permanent
+	// on first failure and 409'd retries for the full 24h TTL.
 	if (body.idempotency_key) {
 		await handleEventIdempotencyKey({
 			ctx,
@@ -59,14 +65,27 @@ export const runTrackV2 = async ({
 		});
 	}
 
-	// Try Redis deduction - returns TrackResponseV3 (with ApiBalanceV1)
-	const response: TrackResponseV3 = await runRedisTrack({
-		ctx,
-		fullCustomer,
-		featureDeductions,
-		overageBehavior: body.overage_behavior || "cap",
-		body,
-	});
+	let response: TrackResponseV3;
+	try {
+		// Try Redis deduction - returns TrackResponseV3 (with ApiBalanceV1)
+		response = await runRedisTrack({
+			ctx,
+			fullCustomer,
+			featureDeductions,
+			overageBehavior: body.overage_behavior || "cap",
+			body,
+		});
+	} catch (error) {
+		if (body.idempotency_key) {
+			await releaseIdempotencyKey({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				idempotencyKey: `track:${body.idempotency_key}`,
+				logger: ctx.logger,
+			});
+		}
+		throw error;
+	}
 
 	// Version changes will transform V3 -> V2 -> V1 -> V0 based on target API version
 	const transformedResponse = applyResponseVersionChanges<TrackResponseV3>({

--- a/server/src/internal/balances/track/v3/runTrackV3.ts
+++ b/server/src/internal/balances/track/v3/runTrackV3.ts
@@ -13,6 +13,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getOrCreateCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.js";
 import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
 import type { FeatureDeduction } from "../../utils/types/featureDeduction.js";
+import { releaseIdempotencyKey } from "@/internal/misc/idempotency/checkIdempotencyKey.js";
 import { handleEventIdempotencyKey } from "../utils/handleEventIdempotencyKey.js";
 import { runRedisTrackV3 } from "./runRedisTrackV3.js";
 import { getTrackIdempotencyKey } from "./trackIdempotencyKey.js";
@@ -65,6 +66,10 @@ export const runTrackV3 = async ({
 		body,
 	});
 
+	// Claim the user-supplied idempotency key BEFORE the deduction so concurrent
+	// retries get a deterministic 409 instead of double-deducting. On failure,
+	// the catch below RELEASES the claim so retries can succeed once the cause
+	// (insufficient balance, transient Redis fault) is resolved. Fixes #1138.
 	if (body.idempotency_key) {
 		await handleEventIdempotencyKey({
 			ctx,
@@ -74,14 +79,27 @@ export const runTrackV3 = async ({
 
 	const redisIdempotencyKey = getTrackIdempotencyKey({ ctx });
 
-	const response: TrackResponseV3 = await runRedisTrackV3({
-		ctx,
-		fullSubject,
-		featureDeductions,
-		overageBehavior: body.overage_behavior || "cap",
-		body,
-		idempotencyKey: redisIdempotencyKey,
-	});
+	let response: TrackResponseV3;
+	try {
+		response = await runRedisTrackV3({
+			ctx,
+			fullSubject,
+			featureDeductions,
+			overageBehavior: body.overage_behavior || "cap",
+			body,
+			idempotencyKey: redisIdempotencyKey,
+		});
+	} catch (error) {
+		if (body.idempotency_key) {
+			await releaseIdempotencyKey({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				idempotencyKey: `track:${body.idempotency_key}`,
+				logger: ctx.logger,
+			});
+		}
+		throw error;
+	}
 
 	return applyResponseVersionChanges<TrackResponseV3>({
 		input: response,

--- a/server/src/internal/misc/idempotency/checkIdempotencyKey.ts
+++ b/server/src/internal/misc/idempotency/checkIdempotencyKey.ts
@@ -10,6 +10,58 @@ const hashIdempotencyKey = (key: string): string => {
 	return hasher.digest("base64url");
 };
 
+const buildIdempotencyRedisKey = ({
+	orgId,
+	env,
+	idempotencyKey,
+}: {
+	orgId: string;
+	env: string;
+	idempotencyKey: string;
+}): string => {
+	const hashedKey = hashIdempotencyKey(idempotencyKey);
+	return `${orgId}:${env}:idempotency:${hashedKey}`;
+};
+
+/**
+ * Releases (deletes) a previously-claimed idempotency key.
+ *
+ * Use this when the side-effecting operation guarded by the key FAILS, so the
+ * caller can safely retry without hitting a 24-hour 409 wall on a deduction
+ * that never actually committed. See bug #1138.
+ *
+ * Mirrors `checkIdempotencyKey`'s fail-open Redis-not-ready behavior — if the
+ * delete itself fails or Redis is down, we don't surface that to the caller
+ * (the original deduction error is what they care about).
+ */
+export const releaseIdempotencyKey = async ({
+	orgId,
+	env,
+	idempotencyKey,
+	logger,
+}: {
+	orgId: string;
+	env: string;
+	idempotencyKey: string;
+	logger: Logger;
+}): Promise<void> => {
+	if (redis.status !== "ready") return;
+	const redisKey = buildIdempotencyRedisKey({ orgId, env, idempotencyKey });
+	try {
+		await redis.del(redisKey);
+		logger.info(
+			`[releaseIdempotencyKey] released idempotency key ${idempotencyKey}`,
+		);
+	} catch (error) {
+		// Best-effort release. The caller already has a real error to report;
+		// the worst case of a release failure is a 24h TTL on a key that's
+		// safe to leave (won't double-charge anyone).
+		logger.warn(
+			`[releaseIdempotencyKey] failed to release ${idempotencyKey}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+};
+
 /**
  * Checks and sets an idempotency key in Redis using atomic SET NX operation.
  * If Redis is not ready, allows the request to proceed (fail-open).
@@ -31,13 +83,12 @@ export const checkIdempotencyKey = async ({
 		return;
 	}
 
-	const hashedKey = hashIdempotencyKey(idempotencyKey);
-	const redisKey = `${orgId}:${env}:idempotency:${hashedKey}`;
+	const redisKey = buildIdempotencyRedisKey({ orgId, env, idempotencyKey });
 
 	try {
 		// Use SET NX (set if not exists) for atomic check-and-set to prevent race conditions
 		logger.info(
-			`[checkIdempotencyKey] setting idempotency key ${idempotencyKey}, hash: ${hashedKey}`,
+			`[checkIdempotencyKey] setting idempotency key ${idempotencyKey}`,
 		);
 
 		const wasSet = await redis.set(

--- a/server/tests/unit/misc/idempotency/checkIdempotencyKey.test.ts
+++ b/server/tests/unit/misc/idempotency/checkIdempotencyKey.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for the idempotency-key check + release pair.
+ *
+ * Covers the regression for #1138: when a side-effecting operation guarded
+ * by an idempotency key FAILS, `releaseIdempotencyKey` must delete the
+ * Redis-stored key so that a subsequent retry can succeed once the failure
+ * cause (insufficient balance, transient Redis fault, etc.) is resolved.
+ *
+ * Without release, the key sat in Redis for 24h and every retry hit a
+ * 409 "duplicate_idempotency_key" wall.
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import { AppEnv, RecaseError } from "@autumn/shared";
+import type { Logger } from "@/external/logtail/logtailUtils";
+
+type RedisCall = { method: string; args: unknown[] };
+const redisState = {
+	status: "ready" as "ready" | "wait" | "end",
+	store: new Map<string, string>(),
+	calls: [] as RedisCall[],
+	throwOn: null as null | { method: string; error: Error },
+};
+
+mock.module("@/external/redis/initRedis.js", () => ({
+	redis: {
+		get status() {
+			return redisState.status;
+		},
+		set: async (key: string, value: string, ...args: unknown[]) => {
+			redisState.calls.push({ method: "set", args: [key, value, ...args] });
+			if (
+				redisState.throwOn?.method === "set"
+			) throw redisState.throwOn.error;
+			// Mimic SET NX semantics: return null if key already exists, "OK" otherwise.
+			const nxIndex = args.findIndex(
+				(a) => typeof a === "string" && a.toUpperCase() === "NX",
+			);
+			if (nxIndex >= 0 && redisState.store.has(key)) return null;
+			redisState.store.set(key, value);
+			return "OK";
+		},
+		del: async (key: string) => {
+			redisState.calls.push({ method: "del", args: [key] });
+			if (redisState.throwOn?.method === "del") throw redisState.throwOn.error;
+			const existed = redisState.store.has(key);
+			redisState.store.delete(key);
+			return existed ? 1 : 0;
+		},
+	},
+	currentRegion: "test",
+}));
+
+import {
+	checkIdempotencyKey,
+	releaseIdempotencyKey,
+} from "@/internal/misc/idempotency/checkIdempotencyKey.js";
+
+const noopLogger: Logger = {
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+	debug: () => {},
+	// biome-ignore lint/suspicious/noExplicitAny: minimal logger shape for tests
+} as any;
+
+const baseArgs = {
+	orgId: "org_test",
+	env: AppEnv.Sandbox,
+	idempotencyKey: "track:req_abc123",
+	logger: noopLogger,
+};
+
+beforeEach(() => {
+	redisState.status = "ready";
+	redisState.store.clear();
+	redisState.calls.length = 0;
+	redisState.throwOn = null;
+});
+
+afterEach(() => {
+	redisState.throwOn = null;
+});
+
+afterAll(() => {
+	mock.restore();
+});
+
+describe("checkIdempotencyKey + releaseIdempotencyKey", () => {
+	test("first call sets the key; second call throws 409 (atomic SET NX)", async () => {
+		await checkIdempotencyKey(baseArgs);
+		await expect(checkIdempotencyKey(baseArgs)).rejects.toBeInstanceOf(
+			RecaseError,
+		);
+		const setCalls = redisState.calls.filter((c) => c.method === "set");
+		expect(setCalls).toHaveLength(2);
+		// Both calls used NX
+		for (const c of setCalls) {
+			expect(c.args.some((a) => String(a).toUpperCase() === "NX")).toBe(true);
+		}
+	});
+
+	test("releaseIdempotencyKey deletes the key so a retry can succeed (#1138)", async () => {
+		await checkIdempotencyKey(baseArgs);
+		// Simulate the side-effecting operation FAILED; release the claim.
+		await releaseIdempotencyKey(baseArgs);
+		// A retry must now succeed (no 409).
+		await expect(checkIdempotencyKey(baseArgs)).resolves.toBeUndefined();
+		const delCalls = redisState.calls.filter((c) => c.method === "del");
+		expect(delCalls).toHaveLength(1);
+	});
+
+	test("release is a no-op when Redis is not ready (fail-open, matches check)", async () => {
+		redisState.status = "wait";
+		await releaseIdempotencyKey(baseArgs);
+		expect(redisState.calls).toHaveLength(0);
+	});
+
+	test("release swallows Redis errors and does not throw", async () => {
+		// Pre-populate to make sure del actually attempts.
+		await checkIdempotencyKey(baseArgs);
+		redisState.throwOn = { method: "del", error: new Error("redis down") };
+		await expect(releaseIdempotencyKey(baseArgs)).resolves.toBeUndefined();
+	});
+
+	test("releasing a never-claimed key is harmless", async () => {
+		await expect(releaseIdempotencyKey(baseArgs)).resolves.toBeUndefined();
+	});
+
+	test("different idempotency keys map to different Redis keys (no cross-talk)", async () => {
+		await checkIdempotencyKey({ ...baseArgs, idempotencyKey: "track:A" });
+		await expect(
+			checkIdempotencyKey({ ...baseArgs, idempotencyKey: "track:B" }),
+		).resolves.toBeUndefined();
+		// And releasing A does not affect B.
+		await releaseIdempotencyKey({ ...baseArgs, idempotencyKey: "track:A" });
+		await expect(
+			checkIdempotencyKey({ ...baseArgs, idempotencyKey: "track:B" }),
+		).rejects.toBeInstanceOf(RecaseError);
+	});
+
+	test("check fails-open when Redis is not ready (no key stored)", async () => {
+		redisState.status = "wait";
+		await expect(checkIdempotencyKey(baseArgs)).resolves.toBeUndefined();
+		expect(redisState.calls).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Fixes #1138.

### The bug

`/track` calls with an `idempotency_key` permanently 409 on retry after a single failure. The key is `SET NX` into Redis with a 24-hour TTL *before* `runRedisTrack`/`runRedisTrackV3` runs, so if the deduction throws (insufficient balance, transient Redis fault, etc.) the key sits there blocking every retry for the next 24 hours — even though no deduction ever committed.

### The fix

Add `releaseIdempotencyKey()` next to `checkIdempotencyKey()` — same Redis key layout, just `DEL`. Then wrap the `runRedisTrack` / `runRedisTrackV3` call in `runTrackV2` and `runTrackV3` in `try/catch`. On any throw:

1. Release the idempotency claim (so a retry can succeed once the cause is resolved).
2. Re-throw the original error (the caller still sees the real failure — 402, 500, whatever).

This preserves the existing concurrent-request safety — two simultaneous retries still race on `SET NX` and only one proceeds — while fixing the retry-after-failure path.

I kept this strictly to the `body.idempotency_key` path. The internal `getTrackIdempotencyKey({ctx})` Redis lock used inside `executeRedisDeductionV2` is unchanged; that's a per-deduction internal mechanism with its own lifecycle.

### Tests

New unit file `server/tests/unit/misc/idempotency/checkIdempotencyKey.test.ts` — 7/7 green:

- first call sets, second call throws 409 (atomic SET NX)
- release-then-retry succeeds (the #1138 path)
- release is a no-op when Redis isn't ready (matches check's fail-open)
- release swallows Redis errors (best-effort)
- releasing a never-claimed key is harmless
- distinct keys don't cross-talk
- check fails-open when Redis isn't ready

Existing `handle-track-queue-fallback.test.ts` (3/3) and `trackIdempotencyKey.test.ts` (1/1) still pass.

### Notes for the author of #1138

Your proposed "move storage to after success" change works for the retry path you described, but it opens a window where two concurrent retries both pass the (not-yet-set) check and both perform the deduction. The rollback pattern here keeps concurrent-safety intact. I also left `body.skip_event` and `handleEventIdempotencyKey`'s commented-out event-insert block alone — those are a separate concern (sync-vs-queue event logging) and didn't seem worth bundling into a focused fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `/track` requests with an `idempotency_key` returned 409 on every retry after a failed deduction. We now release the key on errors so retries can proceed, while keeping concurrent safety intact.

- **Bug Fixes**
  - Added `releaseIdempotencyKey()` to delete `track:<idempotency_key>` in Redis when a deduction fails.
  - Wrapped `runRedisTrack`/`runRedisTrackV3` in try/catch inside `runTrackV2`/`runTrackV3`; on error, release the key and re-throw.
  - Preserves existing `SET NX` concurrency guarantees; retries after failure no longer 409.
  - Added unit tests covering release-then-retry, Redis fail-open, and distinct key isolation.

<sup>Written for commit 55752522e2a2d258e1d393cf865d4cae01ac99ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

