### PR TITLE
fix: validate application owner

### DIFF
--- a/server/src/external/stripe/subscriptions/utils/convertStripeSubscription.ts
+++ b/server/src/external/stripe/subscriptions/utils/convertStripeSubscription.ts
@@ -156,3 +156,15 @@ export const stripeSubscriptionToScheduleId = ({
 		? stripeSubscription.schedule
 		: (stripeSubscription.schedule?.id ?? undefined);
 };
+
+export const stripeSubscriptionToApplication = ({
+	stripeSubscription,
+}: {
+	stripeSubscription?: Stripe.Subscription;
+}): string | null => {
+	if (!stripeSubscription?.application) return null;
+
+	return typeof stripeSubscription.application === "string"
+		? stripeSubscription.application
+		: stripeSubscription.application.id;
+};

--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts
@@ -12,6 +12,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildCustomerProductsForStripe } from "@/internal/billing/v2/providers/stripe/actionBuilders/buildCustomerProductsForStripe";
 import { buildStripeRefundAction } from "@/internal/billing/v2/providers/stripe/actionBuilders/buildStripeRefundAction.js";
 import { buildStripeSubscriptionScheduleAction } from "@/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionScheduleAction";
+import { validateStripeSubscriptionActionOwnership } from "@/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership";
 import { shouldCreateManualStripeInvoice } from "@/internal/billing/v2/providers/stripe/utils/invoices/shouldCreateManualStripeInvoice";
 import { autumnBillingPlanToFinalFullCustomer } from "@/internal/billing/v2/utils/autumnBillingPlanToFinalFullCustomer";
 import { buildStripeCheckoutSessionAction } from "../../../providers/stripe/actionBuilders/buildStripeCheckoutSessionAction";
@@ -72,6 +73,12 @@ export const evaluateStripeBillingPlan = async ({
 		stripeSubscriptionScheduleAction,
 		subscriptionCancelAt,
 		subscriptionStartsAt,
+	});
+
+	validateStripeSubscriptionActionOwnership({
+		ctx,
+		billingContext,
+		stripeSubscriptionAction,
 	});
 
 	const stripeRefundAction = await buildStripeRefundAction({

--- a/server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts
@@ -49,6 +49,7 @@ export const validateStripeSubscriptionActionOwnership = ({
 	if (!applicationId) return;
 
 	const expectedApplicationId = expectedStripeApplicationId({ ctx });
+	if (!expectedApplicationId) return;
 
 	if (applicationId === expectedApplicationId) {
 		return;

--- a/server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts
@@ -1,0 +1,67 @@
+import type { BillingContext, StripeSubscriptionAction } from "@autumn/shared";
+import { AppEnv, ErrCode, InternalError } from "@autumn/shared";
+import { stripeSubscriptionToApplication } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { isStripeConnected } from "@/internal/orgs/orgUtils";
+
+const expectedStripeApplicationId = ({ ctx }: { ctx: AutumnContext }) =>
+	ctx.env === AppEnv.Live
+		? process.env.STRIPE_LIVE_CLIENT_ID
+		: process.env.STRIPE_SANDBOX_CLIENT_ID;
+
+const shouldValidateStripeApplicationOwnership = ({
+	ctx,
+}: {
+	ctx: AutumnContext;
+}) =>
+	isStripeConnected({
+		org: ctx.org,
+		env: ctx.env,
+		throughAccountId: true,
+	}) &&
+	!isStripeConnected({
+		org: ctx.org,
+		env: ctx.env,
+		throughSecretKey: true,
+	});
+
+export const validateStripeSubscriptionActionOwnership = ({
+	ctx,
+	billingContext,
+	stripeSubscriptionAction,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+	stripeSubscriptionAction?: StripeSubscriptionAction;
+}) => {
+	if (!shouldValidateStripeApplicationOwnership({ ctx })) return;
+
+	if (
+		stripeSubscriptionAction?.type !== "update" &&
+		stripeSubscriptionAction?.type !== "cancel"
+	) {
+		return;
+	}
+
+	const applicationId = stripeSubscriptionToApplication({
+		stripeSubscription: billingContext.stripeSubscription,
+	});
+	if (!applicationId) return;
+
+	const expectedApplicationId = expectedStripeApplicationId({ ctx });
+
+	if (applicationId === expectedApplicationId) {
+		return;
+	}
+
+	throw new InternalError({
+		message:
+			"Cannot update subscription because it was not created by Autumn. Import or relink the subscription with no_billing_changes before changing billing.",
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+		data: {
+			stripe_subscription_id: billingContext.stripeSubscription?.id,
+			stripe_application_id: applicationId,
+		},
+	});
+};

--- a/server/tests/integration/billing/update-subscription/errors/update-foreign-stripe-subscription.test.ts
+++ b/server/tests/integration/billing/update-subscription/errors/update-foreign-stripe-subscription.test.ts
@@ -1,0 +1,245 @@
+/**
+ * TDD test for Connect subscriptions created by another application.
+ *
+ * Red-failure mode (current behavior):
+ *  - Autumn can create and pay a manual update invoice before Stripe rejects the subscription update.
+ *
+ * Green-success criteria (after fix):
+ *  - The update throws before creating another invoice.
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV3, BillingInterval, ErrCode } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { CusService } from "@/internal/customers/CusService";
+
+test.concurrent(
+	`${chalk.yellowBright("error: mismatched Connect application rejects before invoice")}`,
+	async () => {
+		const customerId = "foreign-connect-sub-update";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [messagesItem, priceItem],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomer = (await ctx.stripeCli.customers.retrieve(
+			fullCustomer.processor.id!,
+		)) as Stripe.Customer;
+		const stripeSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomer.id,
+			status: "all",
+			limit: 1,
+		});
+		const stripeSubscription = stripeSubscriptions.data[0];
+		expect(stripeSubscription).toBeDefined();
+
+		const paymentMethods = await ctx.stripeCli.paymentMethods.list({
+			customer: stripeCustomer.id,
+			type: "card",
+			limit: 1,
+		});
+
+		let thrown: unknown;
+		try {
+			await billingActions.updateSubscription({
+				ctx,
+				params: {
+					customer_id: customerId,
+					plan_id: pro.id,
+					customize: {
+						price: {
+							amount: 30,
+							interval: BillingInterval.Month,
+						},
+					},
+				},
+				contextOverride: {
+					stripeBillingContext: {
+						stripeCustomer,
+						stripeSubscription: {
+							...stripeSubscription,
+							application: "ca_foreign_app",
+						},
+						stripeDiscounts: [],
+						paymentMethod: paymentMethods.data[0],
+					},
+				},
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeDefined();
+		expect((thrown as { code?: string }).code).toBe(ErrCode.InvalidRequest);
+		expect((thrown as Error).message).toContain(
+			"Cannot update subscription because it was not created by Autumn",
+		);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: 20,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("Connect subscription ownership: null application is allowed")}`,
+	async () => {
+		const customerId = "connect-null-application-sub";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [messagesItem, priceItem],
+		});
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomer = (await ctx.stripeCli.customers.retrieve(
+			fullCustomer.processor.id!,
+		)) as Stripe.Customer;
+		const stripeSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomer.id,
+			status: "all",
+			limit: 1,
+		});
+		const stripeSubscription = stripeSubscriptions.data[0];
+		expect(stripeSubscription).toBeDefined();
+
+		await expect(
+			billingActions.updateSubscription({
+				ctx,
+				preview: true,
+				params: {
+					customer_id: customerId,
+					plan_id: pro.id,
+					customize: {
+						price: {
+							amount: 30,
+							interval: BillingInterval.Month,
+						},
+					},
+				},
+				contextOverride: {
+					stripeBillingContext: {
+						stripeCustomer,
+						stripeSubscription: {
+							...stripeSubscription,
+							application: null,
+						},
+						stripeDiscounts: [],
+					},
+				},
+			}),
+		).resolves.toBeDefined();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("secret-key subscription ownership: null application is allowed")}`,
+	async () => {
+		const customerId = "secret-key-sub-ownership";
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const priceItem = items.monthlyPrice({ price: 20 });
+		const pro = products.base({
+			id: "pro",
+			items: [messagesItem, priceItem],
+		});
+
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const stripeCustomer = (await ctx.stripeCli.customers.retrieve(
+			fullCustomer.processor.id!,
+		)) as Stripe.Customer;
+		const stripeSubscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomer.id,
+			status: "all",
+			limit: 1,
+		});
+		const stripeSubscription = stripeSubscriptions.data[0];
+		expect(stripeSubscription).toBeDefined();
+
+		const secretKeyCtx = {
+			...ctx,
+			org: {
+				...ctx.org,
+				stripe_config: {
+					...ctx.org.stripe_config,
+					test_api_key: "present-for-ownership-check",
+				},
+			},
+		};
+
+		await expect(
+			billingActions.updateSubscription({
+				ctx: secretKeyCtx,
+				preview: true,
+				params: {
+					customer_id: customerId,
+					plan_id: pro.id,
+					customize: {
+						price: {
+							amount: 30,
+							interval: BillingInterval.Month,
+						},
+					},
+				},
+				contextOverride: {
+					stripeBillingContext: {
+						stripeCustomer,
+						stripeSubscription: {
+							...stripeSubscription,
+							application: null,
+						},
+						stripeDiscounts: [],
+					},
+				},
+			}),
+		).resolves.toBeDefined();
+	},
+);

--- a/server/tests/integration/billing/update-subscription/errors/update-foreign-stripe-subscription.test.ts
+++ b/server/tests/integration/billing/update-subscription/errors/update-foreign-stripe-subscription.test.ts
@@ -60,6 +60,9 @@ test.concurrent(
 			limit: 1,
 		});
 
+		const originalClientId = process.env.STRIPE_SANDBOX_CLIENT_ID;
+		process.env.STRIPE_SANDBOX_CLIENT_ID = "ca_autumn_app";
+
 		let thrown: unknown;
 		try {
 			await billingActions.updateSubscription({
@@ -88,6 +91,8 @@ test.concurrent(
 			});
 		} catch (error) {
 			thrown = error;
+		} finally {
+			process.env.STRIPE_SANDBOX_CLIENT_ID = originalClientId;
 		}
 
 		expect(thrown).toBeDefined();


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate Stripe Connect subscription ownership before update/cancel to block billing changes on subscriptions created by other applications and prevent unwanted invoices. Adds a safe no-op when the expected client ID env var is missing to avoid false rejects.

- **Bug Fixes**
  - Enforce ownership check in `evaluateStripeBillingPlan` for update/cancel actions.
  - Resolve `subscription.application` via `stripeSubscriptionToApplication` (string or expanded object).
  - Skip validation when using a secret key, when the application is null, or when the expected client ID is missing.
  - Throw `InvalidRequest` (400) early with subscription/application IDs on mismatch; no invoices or refunds are created.
  - Added integration tests covering foreign-app rejection and allowed paths.

<sup>Written for commit 5434d14b9758b1c9795c904651cd62d41c426a58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an ownership guard that prevents Autumn from attempting to update or cancel Stripe subscriptions that were created by a different Connect application, fixing a race condition where a manual invoice could be created before Stripe ultimately rejected the subscription mutation.

- **Bug fixes**: New `validateStripeSubscriptionActionOwnership` validator is inserted in `evaluateStripeBillingPlan` immediately after the subscription action is built and before any invoice or refund actions are constructed, correctly short-circuiting the flow for foreign-owned subscriptions.
- **Bug fixes / Improvements**: `stripeSubscriptionToApplication` utility handles both the unexpanded string form and the expanded object form of `Stripe.Subscription.application`, mirroring the existing `stripeSubscriptionToScheduleId` pattern.
- **Improvements**: Validation is intentionally skipped for orgs using a direct secret key (not Connect), for actions other than `update`/`cancel`, and for subscriptions with a `null` application field; three integration tests confirm each bypass path.
</details>

<h3>Confidence Score: 3/5</h3>

The fix addresses the foreign-subscription billing race correctly, but the validator itself has a gap: if the Stripe OAuth client-ID env var is absent, the function will reject updates to Autumn's own Connect subscriptions.

The ownership check works as intended in a fully configured environment, and the test coverage is solid. However, when STRIPE_LIVE_CLIENT_ID or STRIPE_SANDBOX_CLIENT_ID is not set, expectedApplicationId is undefined, and any Connect subscription that carries a non-null application ID will always fail the equality check and throw — including ones Autumn legitimately created. This would silently break all Connect-mode update and cancel flows in that deployment until the missing variable is noticed.

server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts needs a guard around the missing-env-var case before the application-ID comparison.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts | New validator that blocks update/cancel actions on subscriptions not owned by Autumn in Connect-only setups; has a logic gap when the expected application-ID env var is absent. |
| server/src/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan.ts | Adds the ownership validation call right after buildStripeSubscriptionAction, correctly positioned before invoice creation to prevent premature charges on foreign subscriptions. |
| server/src/external/stripe/subscriptions/utils/convertStripeSubscription.ts | Adds stripeSubscriptionToApplication utility that safely resolves the application field from both its string and expanded-object forms. |
| server/tests/integration/billing/update-subscription/errors/update-foreign-stripe-subscription.test.ts | Integration tests covering the foreign-application rejection, null-application pass-through, and secret-key bypass; hardcoded ca_foreign_app value works correctly only if the sandbox client-ID env var differs from it (the normal case). |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[evaluateStripeBillingPlan] --> B[buildStripeSubscriptionAction]
    B --> C[validateStripeSubscriptionActionOwnership]
    C --> D{shouldValidate?\nConnect via accountId\nAND NOT via secretKey}
    D -- No --> G[Continue]
    D -- Yes --> E{action type\nupdate or cancel?}
    E -- No --> G
    E -- Yes --> F{applicationId\nnon-null?}
    F -- No: null app --> G
    F -- Yes --> H{applicationId ==\nexpectedStripeApplicationId?}
    H -- Yes: Autumn owns sub --> G
    H -- No: foreign app --> I[throw InternalError 400]
    G --> J[buildStripeRefundAction]
    J --> K[shouldCreateManualStripeInvoice]
    K --> L[Build invoice actions]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts:51-55
If `STRIPE_LIVE_CLIENT_ID` or `STRIPE_SANDBOX_CLIENT_ID` is not set, `expectedApplicationId` is `undefined`. A non-empty `applicationId` string will never equal `undefined`, so the function always throws — blocking Autumn from updating or canceling its own Connect subscriptions. Adding an early return when `expectedApplicationId` is falsy makes the missing env var a no-op instead of a hard failure.

```suggestion
	const expectedApplicationId = expectedStripeApplicationId({ ctx });

	if (!expectedApplicationId) return;

	if (applicationId === expectedApplicationId) {
		return;
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["validate stripe application owner"](https://github.com/useautumn/autumn/commit/b089e544599f60d89b62192c9f4f3db2cd49f95d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36023256)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->