### PR TITLE
fix: usage alerts 3

### DIFF
--- a/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
+++ b/server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts
@@ -207,7 +207,7 @@ export const checkUsageAlerts = async ({
 		scope: "customer",
 	});
 
-	// 2. Org-level alerts (apply to all customers; evaluated against customer-level balance).
+	// 2. Org-level alerts apply to all customers and use the tracked subject.
 	// Env-scoped: sandbox reads sandbox_usage_alerts, live reads usage_alerts.
 	const orgAlerts =
 		ctx.env === AppEnv.Sandbox
@@ -219,6 +219,7 @@ export const checkUsageAlerts = async ({
 			oldFullCus,
 			newFullCus,
 			feature,
+			entityId,
 			alerts: orgAlerts,
 			scope: "org",
 		});

--- a/server/tests/integration/balances/track/usage-alerts/usage-alert-org.test.ts
+++ b/server/tests/integration/balances/track/usage-alerts/usage-alert-org.test.ts
@@ -9,8 +9,8 @@
  *       customer-level and entity-level alerts.
  *     - Org alerts fire INDEPENDENTLY of customer alerts (idempotency key
  *       takes a scope segment so Svix does not dedup them).
- *     - Org alerts evaluate against the customer-level balance only — they do
- *       not iterate per entity.
+ *     - Org alerts evaluate against the tracked subject balance, including
+ *       the entity balance when the track call is entity-scoped.
  *     - Disabled org alerts (enabled: false) do not fire.
  *     - Org alert with no feature_id fires on usage of any feature (global).
  *   Side effects:
@@ -156,6 +156,62 @@ test(`${chalk.yellowBright("org-alert1: org-level alert fires when customer cros
 	expect(data.usage_alert.threshold).toBe(750);
 	expect(data.usage_alert.threshold_type).toBe("usage");
 	expect(data.usage_alert.name).toBe("org-threshold-750");
+});
+
+// Red: org/global alerts used the customer balance and missed entity usage.
+// Green: a 100% org alert fires when an entity-scoped balance lands exactly at 100%.
+test(`${chalk.yellowBright("org-alert1b: org usage_percentage alert fires for entity balance at 100%")}`, async () => {
+	const perEntityMessages = items.monthlyMessages({
+		includedUsage: 100,
+		entityFeatureId: TestFeature.Users,
+	});
+	const prod = products.base({
+		id: "org-ua-entity-100pct",
+		items: [perEntityMessages],
+	});
+
+	await setOrgUsageAlerts([
+		{
+			feature_id: TestFeature.Messages,
+			threshold: 100,
+			threshold_type: "usage_percentage",
+			enabled: true,
+			name: "org-entity-100pct",
+		},
+	]);
+
+	const { customerId, autumnV2_1, entities } = await initScenario({
+		customerId: "org-usage-alert-entity-100pct",
+		setup: [
+			s.customer({ testClock: false }),
+			s.products({ list: [prod] }),
+			s.entities({ count: 1, featureId: TestFeature.Users }),
+		],
+		actions: [s.attach({ productId: prod.id })],
+	});
+
+	await autumnV2_1.track({
+		customer_id: customerId,
+		entity_id: entities[0].id,
+		feature_id: TestFeature.Messages,
+		value: 100,
+	});
+
+	const result = await waitForWebhook<BalancesUsageAlertTriggeredPayload>({
+		token: playToken,
+		predicate: (payload) =>
+			payload.type === "balances.usage_alert_triggered" &&
+			payload.data?.customer_id === customerId &&
+			payload.data?.entity_id === entities[0].id &&
+			payload.data?.usage_alert?.name === "org-entity-100pct",
+		timeoutMs: 15000,
+	});
+
+	expect(result).not.toBeNull();
+	expect(result!.payload.data.usage_alert.threshold).toBe(100);
+	expect(result!.payload.data.usage_alert.threshold_type).toBe(
+		"usage_percentage",
+	);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes org-level usage alerts to evaluate the tracked subject (customer or entity) instead of always using the customer balance. Org alerts now trigger for entity-scoped usage when thresholds are reached.

- **Bug Fixes**
  - Pass `entityId` into org-scope alert evaluation so thresholds consider entity balances.
  - Add integration test for a 100% `usage_percentage` org alert firing on an entity-scoped track; update docs to reflect tracked-subject behavior.

<sup>Written for commit 886e996cf8fced76403dc16b038a1361d3c59077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes org-level usage alerts so they evaluate against the "tracked subject" balance — the entity balance when the track call includes an `entity_id`, or the customer aggregate balance when it does not. Previously, org alerts always evaluated the customer-level balance regardless of entity scoping, causing them to miss entity-specific usage thresholds.

- **Bug fixes** — `checkUsageAlerts` now passes `entityId` to `processAlerts` for the org-level alert path, aligning org-alert balance resolution with how entity-level and customer-level alerts already work.
- **Bug fixes / Improvements** — New integration test `org-alert1b` asserts that a `usage_percentage` org alert fires when an entity-scoped balance reaches 100%, providing a regression anchor for the fixed behaviour.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line addition that threads an already-validated value through an existing call path, with a new integration test confirming the corrected behaviour end-to-end.

The fix is minimal and surgical: one extra argument passed to `processAlerts` for the org-alert path, mirroring exactly how the entity-alert path already works. The rest of `processAlerts` already handles an optional `entityId` correctly (entity lookup, balance resolution, idempotency key, webhook payload). The new test directly exercises the previously broken scenario and will catch regressions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/trackWebhooks/checkUsageAlerts.ts | Passes entityId to processAlerts for org-level alerts, fixing org alerts to evaluate the entity balance for entity-scoped tracks instead of always using the customer aggregate balance. |
| server/tests/integration/balances/track/usage-alerts/usage-alert-org.test.ts | Adds test org-alert1b: verifies a 100% usage_percentage org alert fires when an entity-scoped track hits the entity's full allocation; also updates the contract docstring to reflect the new tracked subject semantics. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant checkUsageAlerts
    participant processAlerts

    Caller->>checkUsageAlerts: "{ customerId, entityId?, feature }"

    checkUsageAlerts->>processAlerts: customer alerts (no entityId)
    processAlerts-->>checkUsageAlerts: evaluate customer balance

    alt entityId present
        checkUsageAlerts->>processAlerts: org alerts (with entityId) [FIXED]
        processAlerts-->>checkUsageAlerts: evaluate entity balance
    else no entityId
        checkUsageAlerts->>processAlerts: org alerts (no entityId)
        processAlerts-->>checkUsageAlerts: evaluate customer balance
    end

    alt entityId present
        checkUsageAlerts->>processAlerts: entity alerts (with entityId)
        processAlerts-->>checkUsageAlerts: evaluate entity balance
    end

    processAlerts-->>Caller: fire Svix webhook if threshold crossed
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: usage alerts 3"](https://github.com/useautumn/autumn/commit/886e996cf8fced76403dc16b038a1361d3c59077) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36102565)</sub>

<!-- /greptile_comment -->