### PR TITLE
fix: usage alerts 3

### DIFF
--- a/vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx
@@ -1,4 +1,10 @@
-import type { DbUsageAlert, Feature, FrontendOrg, OrgConfig } from "@autumn/shared";
+import {
+	AppEnv,
+	type DbUsageAlert,
+	type Feature,
+	type FrontendOrg,
+	type OrgConfig,
+} from "@autumn/shared";
 import { PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
@@ -28,6 +34,11 @@ const formatThreshold = (alert: DbUsageAlert) => {
 	return isPct ? `${alert.threshold}%` : alert.threshold.toLocaleString();
 };
 
+type OrgUsageAlertsConfigKey = "usage_alerts" | "sandbox_usage_alerts";
+
+const getUsageAlertsConfigKey = (env: AppEnv): OrgUsageAlertsConfigKey =>
+	env === AppEnv.Sandbox ? "sandbox_usage_alerts" : "usage_alerts";
+
 interface DialogState {
 	open: boolean;
 	editingIndex: number | null;
@@ -40,6 +51,7 @@ export const OrgUsageAlertsSubsection = () => {
 	const queryClient = useQueryClient();
 	const env = useEnv();
 	const orgQueryKey = ["org", env];
+	const usageAlertsConfigKey = getUsageAlertsConfigKey(env);
 
 	const [dialog, setDialog] = useState<DialogState>({
 		open: false,
@@ -47,8 +59,8 @@ export const OrgUsageAlertsSubsection = () => {
 	});
 
 	const orgAlerts: DbUsageAlert[] = useMemo(
-		() => org?.config?.usage_alerts ?? [],
-		[org?.config?.usage_alerts],
+		() => org?.config?.[usageAlertsConfigKey] ?? [],
+		[org?.config, usageAlertsConfigKey],
 	);
 
 	const featureNameById = useMemo(
@@ -59,7 +71,7 @@ export const OrgUsageAlertsSubsection = () => {
 	const { mutateAsync, isPending } = useMutation({
 		mutationFn: async (updatedAlerts: DbUsageAlert[]) => {
 			const { data } = await axiosInstance.patch("/organization/config", {
-				usage_alerts: updatedAlerts,
+				[usageAlertsConfigKey]: updatedAlerts,
 			});
 			return data as { config: OrgConfig };
 		},
@@ -74,8 +86,7 @@ export const OrgUsageAlertsSubsection = () => {
 		},
 	});
 
-	const handleAddClick = () =>
-		setDialog({ open: true, editingIndex: null });
+	const handleAddClick = () => setDialog({ open: true, editingIndex: null });
 
 	const handleEditClick = (index: number) =>
 		setDialog({ open: true, editingIndex: index });
@@ -96,7 +107,9 @@ export const OrgUsageAlertsSubsection = () => {
 			await mutateAsync(next);
 			setDialog({ open: false, editingIndex: null });
 			toast.success(
-				dialog.editingIndex !== null ? "Usage alert updated" : "Usage alert added",
+				dialog.editingIndex !== null
+					? "Usage alert updated"
+					: "Usage alert added",
 			);
 		} catch {
 			// onError handles toast + invalidate
@@ -160,7 +173,8 @@ export const OrgUsageAlertsSubsection = () => {
 								</span>
 								<span className="truncate text-sm font-medium">
 									{alert.feature_id
-										? (featureNameById.get(alert.feature_id) ?? alert.feature_id)
+										? (featureNameById.get(alert.feature_id) ??
+											alert.feature_id)
 										: "All features"}
 								</span>
 								{alert.name && (


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the usage alerts UI to read and write the correct org config key based on environment. In Sandbox it uses `sandbox_usage_alerts`; otherwise `usage_alerts`.

- **Bug Fixes**
  - Added `AppEnv`-based selector to choose `usage_alerts` vs `sandbox_usage_alerts` and patched axios payload to use the dynamic key.
  - Read alerts from `org.config[usageAlertsConfigKey]` so the list reflects and edits the correct config.

<sup>Written for commit c20f33d73cd9845ea954a4f303f38ce5a97a4130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes org-level usage alerts so they respect the current environment — sandbox routes now read and persist to `sandbox_usage_alerts` in the org config, while live routes continue using `usage_alerts`. The change aligns the frontend with the server-side behaviour already documented in `OrgConfigSchema`.

- **Bug fixes** — introduces `getUsageAlertsConfigKey(env)` and threads the derived key through both the `useMemo` selector and the PATCH mutation payload, so alerts are no longer silently written to the wrong config field when the user is in the sandbox environment.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a small, targeted fix with no side-effects outside the component.

The change is minimal and well-scoped: it adds a two-line helper, threads the derived key through the existing useMemo and useMutation, and correctly matches the server-side schema contract already in place. The OrgConfigSchema already defines both usage_alerts and sandbox_usage_alerts, so no backend changes are needed. React Query cache keys are already environment-scoped via ["org", env], keeping live and sandbox state isolated.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/settings/sections/components/OrgUsageAlertsSubsection.tsx | Adds environment-aware config key selection so sandbox usage alerts read/write from `sandbox_usage_alerts` and live alerts continue to use `usage_alerts` — matching the server-side `checkUsageAlerts` contract defined in `OrgConfigSchema`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OrgUsageAlertsSubsection renders] --> B[useEnv reads pathname]
    B --> C{path includes /sandbox?}
    C -- yes --> D[configKey = sandbox_usage_alerts]
    C -- no --> E[configKey = usage_alerts]
    D --> F[orgAlerts = org.config.sandbox_usage_alerts]
    E --> G[orgAlerts = org.config.usage_alerts]
    F --> H[Render alert list]
    G --> H
    H --> I[User adds / edits / deletes alert]
    I --> J["PATCH /organization/config\n{ [configKey]: updatedAlerts }"]
    J --> K[onSuccess: update React Query cache\nkey = orgQueryKey = org + env]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/usage-alert..."](https://github.com/useautumn/autumn/commit/23ebb8052945d8e48888a54a3d601d83e86fec48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36103224)</sub>

<!-- /greptile_comment -->