### PR TITLE
chore: attach free fix

### DIFF
--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -395,6 +395,7 @@ export function AttachFormProvider({
 		product: effectiveProduct,
 		prepaidOptions,
 		items,
+		grantFree,
 		version,
 		trialLength,
 		trialDuration,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -26,6 +26,7 @@ export interface BuildAttachRequestBodyParams {
 	product: ProductV2 | undefined;
 	prepaidOptions: Record<string, number | undefined>;
 	items: ProductItem[] | null;
+	grantFree: boolean;
 	version: number | undefined;
 	trialLength: number | null;
 	trialDuration: FreeTrialDuration;
@@ -57,6 +58,7 @@ export function buildAttachRequestBody({
 	product,
 	prepaidOptions,
 	items,
+	grantFree,
 	version,
 	trialLength,
 	trialDuration,
@@ -110,6 +112,13 @@ export function buildAttachRequestBody({
 				...item,
 				interval: (item.interval ?? null) as ProductItemInterval | null,
 			}));
+		} else if (grantFree) {
+			// When granting for free, stripping prices can leave no items at all
+			// (e.g. a purely priced product). The backend treats an explicit empty
+			// `items` array as "free / no priced items", but omitting `items`
+			// entirely falls back to the product's default (paid) items. Send the
+			// empty array so the free intent isn't lost. See useGrantFree.
+			body.items = [];
 		}
 	}
 
@@ -206,6 +215,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 		product,
 		prepaidOptions,
 		items,
+		grantFree,
 		version,
 		trialLength,
 		trialDuration,
@@ -238,6 +248,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 				product,
 				prepaidOptions,
 				items,
+				grantFree,
 				version,
 				trialLength,
 				trialDuration,
@@ -267,6 +278,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 			product,
 			prepaidOptions,
 			items,
+			grantFree,
 			version,
 			trialLength,
 			trialDuration,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -113,11 +113,8 @@ export function buildAttachRequestBody({
 				interval: (item.interval ?? null) as ProductItemInterval | null,
 			}));
 		} else if (grantFree) {
-			// When granting for free, stripping prices can leave no items at all
-			// (e.g. a purely priced product). The backend treats an explicit empty
-			// `items` array as "free / no priced items", but omitting `items`
-			// entirely falls back to the product's default (paid) items. Send the
-			// empty array so the free intent isn't lost. See useGrantFree.
+			// Send explicit `[]` so the backend overrides the product's default
+			// (paid) items; omitting `items` falls back to them. See useGrantFree.
 			body.items = [];
 		}
 	}

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -29,6 +29,7 @@ const baseParams: Omit<
 	customerId: "cus_123",
 	entityId: undefined,
 	items: null,
+	grantFree: false,
 	version: undefined,
 	trialLength: null,
 	trialDuration: "day" as const,
@@ -266,5 +267,38 @@ describe("buildAttachRequestBody — items serialization", () => {
 				interval: null,
 			},
 		]);
+	});
+});
+
+describe("buildAttachRequestBody — grant free", () => {
+	const product = makeProduct({
+		items: [{ price: 50, interval: ProductItemInterval.Month }],
+	});
+
+	test("sends explicit empty items when granting free strips all items", () => {
+		// Granting free on a purely priced product leaves an empty items array.
+		// It must be sent as `items: []` so the backend overrides the product's
+		// default (paid) items instead of falling back to them ($50 leak).
+		const result = buildAttachRequestBody({
+			...baseParams,
+			product,
+			prepaidOptions: {},
+			items: [],
+			grantFree: true,
+		});
+
+		expect(result?.items).toEqual([]);
+	});
+
+	test("omits items for an empty array when not granting free", () => {
+		const result = buildAttachRequestBody({
+			...baseParams,
+			product,
+			prepaidOptions: {},
+			items: [],
+			grantFree: false,
+		});
+
+		expect(result?.items).toBeUndefined();
 	});
 });


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes free attachments by sending `items: []` when granting free to override a product’s default paid items. Prevents accidental charges when no items are selected.

- **Bug Fixes**
  - Added `grantFree` to `AttachFormProvider` and `useAttachRequestBody`.
  - If `grantFree` is true and `items` is empty, send `items: []`; otherwise omit `items` to fall back to defaults.
  - Added tests for both grant-free and non-grant-free behaviors.

<sup>Written for commit 36eca99876304682c4107bfc7285ab0539b0b7c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a billing bug where attaching a product \"for free\" on a purely priced plan could accidentally charge the customer. When `grantFree` is enabled, `useGrantFree` strips all pricing items, leaving an empty array; the previous code omitted `items` in that case, causing the backend to fall back to the product's default (paid) items.

- **[Bug fixes]** `buildAttachRequestBody` now sends `body.items = []` when `grantFree` is true and the normalised items resolve to empty, overriding the backend's default items instead of silently falling back to them.
- **[Improvements]** Two new unit tests cover the critical split: `grantFree=true` emits an explicit empty array, `grantFree=false` omits the field entirely.
- **[Improvements]** `grantFree` is plumbed through `AttachFormProvider` into `useAttachRequestBody`, keeping the flag as the single source of truth from the form schema.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-tested fix to a single conditional in the request body builder.

The fix is small and surgical: one new branch in `buildAttachRequestBody` sends an explicit empty array when `grantFree` is true and no items survive normalisation. Both the positive and negative paths are covered by new unit tests. The plumbing change in `AttachFormProvider` is a straightforward pass-through. No pre-existing behaviour is altered when `grantFree` is false.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Adds `grantFree: boolean` param; when items normalise to empty but grantFree is true, sends explicit `body.items = []` so the backend does not fall back to the product's default paid items. |
| vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx | Threads `grantFree` from form context through to `useAttachRequestBody`; a one-line plumbing change with no logic of its own. |
| vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts | Adds two targeted tests that verify the explicit-empty-array path (grantFree=true) and the omit path (grantFree=false), covering both branches of the new logic. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildAttachRequestBody called] --> B{items !== null?}
    B -- No --> Z[items omitted from body]
    B -- Yes --> C[normalizeBillingRequestItems]
    C --> D{normalizedItems truthy?}
    D -- Yes --> E[body.items = normalizedItems]
    D -- No --> F{grantFree === true?}
    F -- Yes --> G["body.items = [] ← NEW FIX\n(backend override, no $$ leak)"]
    F -- No --> Z
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: comment cleanup"](https://github.com/useautumn/autumn/commit/36eca99876304682c4107bfc7285ab0539b0b7c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36182825)</sub>

<!-- /greptile_comment -->