### PR TITLE
release

### DIFF
--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -395,6 +395,7 @@ export function AttachFormProvider({
 		product: effectiveProduct,
 		prepaidOptions,
 		items,
+		grantFree,
 		version,
 		trialLength,
 		trialDuration,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -26,6 +26,7 @@ export interface BuildAttachRequestBodyParams {
 	product: ProductV2 | undefined;
 	prepaidOptions: Record<string, number | undefined>;
 	items: ProductItem[] | null;
+	grantFree: boolean;
 	version: number | undefined;
 	trialLength: number | null;
 	trialDuration: FreeTrialDuration;
@@ -57,6 +58,7 @@ export function buildAttachRequestBody({
 	product,
 	prepaidOptions,
 	items,
+	grantFree,
 	version,
 	trialLength,
 	trialDuration,
@@ -110,6 +112,13 @@ export function buildAttachRequestBody({
 				...item,
 				interval: (item.interval ?? null) as ProductItemInterval | null,
 			}));
+		} else if (grantFree) {
+			// When granting for free, stripping prices can leave no items at all
+			// (e.g. a purely priced product). The backend treats an explicit empty
+			// `items` array as "free / no priced items", but omitting `items`
+			// entirely falls back to the product's default (paid) items. Send the
+			// empty array so the free intent isn't lost. See useGrantFree.
+			body.items = [];
 		}
 	}
 
@@ -206,6 +215,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 		product,
 		prepaidOptions,
 		items,
+		grantFree,
 		version,
 		trialLength,
 		trialDuration,
@@ -238,6 +248,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 				product,
 				prepaidOptions,
 				items,
+				grantFree,
 				version,
 				trialLength,
 				trialDuration,
@@ -267,6 +278,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 			product,
 			prepaidOptions,
 			items,
+			grantFree,
 			version,
 			trialLength,
 			trialDuration,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -113,11 +113,8 @@ export function buildAttachRequestBody({
 				interval: (item.interval ?? null) as ProductItemInterval | null,
 			}));
 		} else if (grantFree) {
-			// When granting for free, stripping prices can leave no items at all
-			// (e.g. a purely priced product). The backend treats an explicit empty
-			// `items` array as "free / no priced items", but omitting `items`
-			// entirely falls back to the product's default (paid) items. Send the
-			// empty array so the free intent isn't lost. See useGrantFree.
+			// Send explicit `[]` so the backend overrides the product's default
+			// (paid) items; omitting `items` falls back to them. See useGrantFree.
 			body.items = [];
 		}
 	}

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -29,6 +29,7 @@ const baseParams: Omit<
 	customerId: "cus_123",
 	entityId: undefined,
 	items: null,
+	grantFree: false,
 	version: undefined,
 	trialLength: null,
 	trialDuration: "day" as const,
@@ -266,5 +267,38 @@ describe("buildAttachRequestBody — items serialization", () => {
 				interval: null,
 			},
 		]);
+	});
+});
+
+describe("buildAttachRequestBody — grant free", () => {
+	const product = makeProduct({
+		items: [{ price: 50, interval: ProductItemInterval.Month }],
+	});
+
+	test("sends explicit empty items when granting free strips all items", () => {
+		// Granting free on a purely priced product leaves an empty items array.
+		// It must be sent as `items: []` so the backend overrides the product's
+		// default (paid) items instead of falling back to them ($50 leak).
+		const result = buildAttachRequestBody({
+			...baseParams,
+			product,
+			prepaidOptions: {},
+			items: [],
+			grantFree: true,
+		});
+
+		expect(result?.items).toEqual([]);
+	});
+
+	test("omits items for an empty array when not granting free", () => {
+		const result = buildAttachRequestBody({
+			...baseParams,
+			product,
+			prepaidOptions: {},
+			items: [],
+			grantFree: false,
+		});
+
+		expect(result?.items).toBeUndefined();
 	});
 });


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the grant-free attach flow by sending `items: []` when granting free so the backend overrides default paid items. Passes `grantFree` through the form context and request body builder and adds tests for both grant/non-grant cases.

- **Bug Fixes**
  - Add `grantFree` to `AttachFormProvider` and `buildAttachRequestBody` params.
  - When `grantFree` and selected items are empty, send `items: []`; if not granting free, omit `items`.
  - Add tests covering both behaviors to prevent fallback to paid defaults.

<sup>Written for commit 163a892e5a144c38e4d8ad183a9faee95acc769b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a billing bug where granting free access to a purely-priced product would silently fall through to the backend's default paid items, charging the customer. The fix threads the existing `grantFree` form flag into `buildAttachRequestBody` so that an explicit `items: []` is sent when the user enables the "grant free" toggle.

- **Bug fixes** — `buildAttachRequestBody` now sends `body.items = []` when `grantFree` is `true` and `normalizeBillingRequestItems` returns `undefined` (e.g., all items were price-only and stripped away), preventing the backend from falling back to the product's default paid items.
- **Improvements** — `grantFree` is plumbed through `AttachFormProvider` → `useAttachRequestBody` → `buildAttachRequestBody` with matching updates to the `BuildAttachRequestBodyParams` interface and both `useMemo` dependency arrays.
- **Bug fixes** — Two targeted tests cover the critical branching: `items: []` with `grantFree: true` produces `result.items === []`, while `grantFree: false` leaves `result.items` undefined.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped, well-tested billing bug fix with no observable regressions on the non-grant-free path.

The fix correctly targets the one gap where an empty `items` array caused `normalizeBillingRequestItems` to return `undefined`, leaving `body.items` unset and allowing the backend to fall back to paid defaults. Both sides of the new branch are exercised by the new tests, and the existing `baseParams` default (`grantFree: false`) ensures all prior tests still exercise the unchanged path.

No files require special attention. The only subtlety worth knowing is that the `grantFree` guard is skipped entirely when `items === null`, but `useGrantFree` always sets `items` to the stripped array before setting `grantFree: true`, so that path is never reachable in practice.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Adds `grantFree` param to `buildAttachRequestBody`; when `items` normalizes to `undefined` (empty array) and `grantFree` is true, explicitly sets `body.items = []` to prevent the backend falling back to the product's default paid items. |
| vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx | Threads the existing `grantFree` form value through to `useAttachRequestBody`; one-line addition with no logic changes. |
| vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts | Adds `grantFree: false` to `baseParams` and a new describe block with two test cases: explicit `[]` when `grantFree=true` and `undefined` when `grantFree=false` — correctly pinning both sides of the new branch. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as AttachFormProvider
    participant Hook as useAttachRequestBody
    participant Pure as buildAttachRequestBody
    participant Norm as normalizeBillingRequestItems
    participant BE as Backend API

    UI->>Hook: "{ items: [], grantFree: true, ... }"
    Hook->>Pure: buildAttachRequestBody(params)
    Pure->>Norm: "normalizeBillingRequestItems({ items: [] })"
    Norm-->>Pure: undefined (empty array → no items)
    alt "grantFree === true"
        Pure->>Pure: "body.items = []"
        Note over Pure: Explicit empty array sent
    else "grantFree === false"
        Pure->>Pure: body.items unset
        Note over BE: Backend falls back to product default (paid items!)
    end
    Pure-->>Hook: "AttachParamsV0 { items: [] }"
    Hook-->>UI: requestBody
    UI->>BE: "POST /attach { items: [] }"
    BE-->>UI: Free access granted ✓
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1844 from useautumn/..."](https://github.com/useautumn/autumn/commit/163a892e5a144c38e4d8ad183a9faee95acc769b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36187079)</sub>

<!-- /greptile_comment -->