### PR TITLE
chore: fix url overflow

### DIFF
--- a/vite/src/components/forms/shared/UrlSuccessView.tsx
+++ b/vite/src/components/forms/shared/UrlSuccessView.tsx
@@ -47,7 +47,8 @@ export function UrlSuccessView({
 				</Button>
 				<CopyButton
 					text={url}
-					innerClassName="text-xs text-tertiary-foreground font-mono w-96"
+					className="w-full"
+					innerClassName="text-xs text-tertiary-foreground font-mono min-w-0 flex-1"
 				/>
 			</SheetFooter>
 		</>


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long URL overflow in the URL success view by making the copy field full-width and letting the inner text flex instead of using a fixed width.

Updates `CopyButton` to use `className="w-full"` and `innerClassName="... min-w-0 flex-1"`, preventing clipping on long URLs and small screens.

<sup>Written for commit b726877f457f7517b078c8fb58870b30323ec58e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a URL overflow issue in the `UrlSuccessView` sheet footer by replacing a fixed `w-96` width on the copy button's inner span with fluid `min-w-0 flex-1`, and adding `w-full` to the outer `CopyButton` wrapper.

- **[Bug fixes]** Removes the fixed `w-96` width on the inner URL text span and replaces it with `min-w-0 flex-1`, allowing the flex child to shrink correctly and the existing `truncate` class to take effect when the URL is longer than the available space.
- **[Improvements]** Adds `className="w-full"` to the `CopyButton` so the button stretches to fill the `SheetFooter`'s flex-column layout, matching the `Button` above it.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely cosmetic, touching only Tailwind class names on a single component.

The diff replaces a fixed `w-96` width with `min-w-0 flex-1` on the inner text span and adds `w-full` to the outer button. Both values work correctly with the existing `truncate` class on the span and the `flex flex-col` layout of `SheetFooter`. No logic, data flow, or API surface is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/shared/UrlSuccessView.tsx | Adds `className="w-full"` to CopyButton and replaces the fixed `w-96` inner width with `min-w-0 flex-1` to allow proper text truncation and prevent URL overflow in the sheet footer. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SheetFooter - flex flex-col] --> B[Button w-full]
    A --> C[CopyButton - className: w-full]
    C --> D[IconButton - spreads className]
    D --> E[span - truncate + innerClassName]
    E -->|before| F[w-96 fixed width - overflows on long URLs]
    E -->|after| G[min-w-0 flex-1 - shrinks and truncates properly]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix url overflow"](https://github.com/useautumn/autumn/commit/b726877f457f7517b078c8fb58870b30323ec58e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36193840)</sub>

<!-- /greptile_comment -->