### PR TITLE
fix: leaf oauth scopes

### DIFF
--- a/apps/leaf/src/internal/installations/actions/replaceInstallationOAuthCredentials.ts
+++ b/apps/leaf/src/internal/installations/actions/replaceInstallationOAuthCredentials.ts
@@ -1,10 +1,10 @@
 import crypto from "node:crypto";
 import { prefixOAuthToken } from "@autumn/auth";
 import {
-	ALL_SCOPES,
 	AppEnv,
 	type ChatInstallation,
 	chatOAuthCredentials,
+	LEAF_OAUTH_SCOPES,
 	oauthAccessToken,
 	oauthClient,
 	oauthConsent,
@@ -109,7 +109,7 @@ const ensureSlackMcpOAuthClient = async ({
 			clientId,
 			name,
 			redirectUris: ["slack://autumn-chat"],
-			scopes: [...ALL_SCOPES],
+			scopes: [...LEAF_OAUTH_SCOPES],
 			tokenEndpointAuthMethod: "none",
 			grantTypes: ["authorization_code", "refresh_token"],
 			responseTypes: ["code"],
@@ -123,7 +123,7 @@ const ensureSlackMcpOAuthClient = async ({
 			target: oauthClient.clientId,
 			set: {
 				name,
-				scopes: [...ALL_SCOPES],
+				scopes: [...LEAF_OAUTH_SCOPES],
 				tokenEndpointAuthMethod: "none",
 				grantTypes: ["authorization_code", "refresh_token"],
 				responseTypes: ["code"],
@@ -171,7 +171,7 @@ const upsertOAuthConsent = async ({
 		await tx
 			.update(oauthConsent)
 			.set({
-				scopes: [...ALL_SCOPES],
+				scopes: [...LEAF_OAUTH_SCOPES],
 				metadata,
 				updatedAt: now,
 			})
@@ -185,7 +185,7 @@ const upsertOAuthConsent = async ({
 		clientId,
 		userId,
 		referenceId: orgId,
-		scopes: [...ALL_SCOPES],
+		scopes: [...LEAF_OAUTH_SCOPES],
 		env,
 		redirectUri: "slack://autumn-chat",
 		metadata,
@@ -235,7 +235,7 @@ const createCredentialForEnv = async ({
 		expiresAt: new Date(refreshTokenExpiresAt),
 		createdAt: nowDate,
 		authTime: nowDate,
-		scopes: [...ALL_SCOPES],
+		scopes: [...LEAF_OAUTH_SCOPES],
 	});
 	await tx.insert(oauthAccessToken).values({
 		id: accessTokenId,
@@ -246,7 +246,7 @@ const createCredentialForEnv = async ({
 		refreshId: refreshTokenId,
 		expiresAt: new Date(accessTokenExpiresAt),
 		createdAt: nowDate,
-		scopes: [...ALL_SCOPES],
+		scopes: [...LEAF_OAUTH_SCOPES],
 	});
 	const credential = {
 		id: `chat_oauth_${crypto.randomUUID().replace(/-/g, "")}`,
@@ -258,7 +258,7 @@ const createCredentialForEnv = async ({
 		access_token: encrypt(prefixOAuthToken({ token: rawAccessToken })),
 		refresh_token: encrypt(rawRefreshToken),
 		access_token_expires_at: accessTokenExpiresAt,
-		scopes: [...ALL_SCOPES],
+		scopes: [...LEAF_OAUTH_SCOPES],
 		created_at: now,
 		updated_at: now,
 	};

--- a/apps/leaf/src/mcp/auth/protectedResourceMetadata.ts
+++ b/apps/leaf/src/mcp/auth/protectedResourceMetadata.ts
@@ -1,10 +1,6 @@
-import {
-	getOAuthIssuerUrl,
-} from "@autumn/auth/oauth";
-import {
-	DEFAULT_AUTUMN_API_URL,
-	MCP_OAUTH_SCOPES,
-} from "@autumn/mcp";
+import { getOAuthIssuerUrl } from "@autumn/auth/oauth";
+import { DEFAULT_AUTUMN_API_URL } from "@autumn/mcp";
+import { LEAF_OAUTH_SCOPES } from "@autumn/shared";
 
 export class OAuthHttpError extends Error {
 	constructor(
@@ -28,7 +24,7 @@ export const getProtectedResourceMetadata = ({
 	authorization_servers: [
 		getOAuthIssuerUrl({ baseUrl: serverURL ?? DEFAULT_AUTUMN_API_URL }),
 	],
-	scopes_supported: [...MCP_OAUTH_SCOPES],
+	scopes_supported: [...LEAF_OAUTH_SCOPES],
 	bearer_methods_supported: ["header"],
 	resource_name: "Autumn MCP",
 });

--- a/apps/leaf/src/mcp/auth/resolveRequestAuth.ts
+++ b/apps/leaf/src/mcp/auth/resolveRequestAuth.ts
@@ -8,10 +8,10 @@ import {
 	type AutumnMcpAuth,
 	DEFAULT_API_VERSION,
 	environmentSchema,
-	MCP_OAUTH_SCOPES,
 	type MCPServerFlags,
 	type OAuthEnvironment,
 } from "@autumn/mcp";
+import { LEAF_OAUTH_SCOPES } from "@autumn/shared";
 import * as z from "zod/v4";
 import { OAuthHttpError } from "./protectedResourceMetadata.js";
 
@@ -135,7 +135,7 @@ export const buildAuthForRequest = async ({
 			env,
 			resource: resourceUrl,
 			principalId: principalFromSecret({ kind: "secret-key", value: apiKey }),
-			scopes: [...MCP_OAUTH_SCOPES],
+			scopes: [...LEAF_OAUTH_SCOPES],
 			serverURL: flags["server-url"],
 			xApiVersion,
 			failOpen,
@@ -150,7 +150,7 @@ export const buildAuthForRequest = async ({
 			env,
 			resource: resourceUrl,
 			principalId: "oauth:unverified",
-			scopes: [...MCP_OAUTH_SCOPES],
+			scopes: [...LEAF_OAUTH_SCOPES],
 			serverURL: flags["server-url"],
 			xApiVersion,
 			failOpen,

--- a/apps/leaf/src/providers/braintrust/config.ts
+++ b/apps/leaf/src/providers/braintrust/config.ts
@@ -1,8 +1,5 @@
 export const braintrustConfig = {
-	enabled:
-		process.env.LEAF_BRAINTRUST_ENABLED === "true" ||
-		(process.env.NODE_ENV !== "production" &&
-			process.env.LEAF_BRAINTRUST_ENABLED !== "false"),
+	enabled: true,
 	projectName: process.env.LEAF_BRAINTRUST_PROJECT ?? "leaf",
 	serviceName: process.env.LEAF_BRAINTRUST_SERVICE ?? "leaf",
 };

--- a/apps/leaf/tests/unit/mcp/oauth.test.ts
+++ b/apps/leaf/tests/unit/mcp/oauth.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { MCP_OAUTH_SCOPES } from "@autumn/mcp";
-import { Scopes } from "@autumn/shared/scopeDefinitions";
-import {
-	buildAuthForRequest,
-	type MCPOAuthFlags,
-} from "../../../src/mcp/auth/resolveRequestAuth.js";
+import { LEAF_OAUTH_SCOPES } from "@autumn/shared";
 import {
 	getProtectedResourceMetadata,
 	type OAuthHttpError,
 } from "../../../src/mcp/auth/protectedResourceMetadata.js";
+import {
+	buildAuthForRequest,
+	type MCPOAuthFlags,
+} from "../../../src/mcp/auth/resolveRequestAuth.js";
 
 const flags = {
 	"oauth-enabled": true,
@@ -24,15 +23,10 @@ const resourceUrl = "http://localhost:2718/mcp";
 const internalResourceUrl = "http://localhost:2718/internal/mcp";
 
 describe("MCP OAuth auth resolution", () => {
-	test("requests scopes required by public write tools", () => {
-		expect(MCP_OAUTH_SCOPES).toEqual(
-			expect.arrayContaining([
-				Scopes.Customers.Write,
-				Scopes.Plans.Write,
-				Scopes.Billing.Write,
-				Scopes.Balances.Write,
-			]),
-		);
+	test("advertises the Leaf OAuth scope allowlist", () => {
+		expect(
+			getProtectedResourceMetadata({ resourceUrl }).scopes_supported,
+		).toEqual([...LEAF_OAUTH_SCOPES]);
 	});
 
 	test("returns a WWW-Authenticate challenge without a bearer token", async () => {
@@ -79,7 +73,7 @@ describe("MCP OAuth auth resolution", () => {
 		try {
 			const auth = await buildAuthForRequest({
 				headers: new Headers({
-					authorization: "Bearer oauth_token",
+					authorization: "Bearer am_oauth_token",
 				}),
 				flags: flags as MCPOAuthFlags,
 				logger,
@@ -87,11 +81,12 @@ describe("MCP OAuth auth resolution", () => {
 			});
 
 			expect(auth).toMatchObject({
-				apiKey: "oauth_token",
+				apiKey: "am_oauth_token",
 				authMethod: "oauth",
 				env: "sandbox",
 				principalId: "oauth:unverified",
 				resource: "http://localhost:2718/mcp",
+				scopes: [...LEAF_OAUTH_SCOPES],
 				serverURL: "http://localhost:8080",
 			});
 			expect(fetchCalled).toBe(false);
@@ -113,6 +108,7 @@ describe("MCP OAuth auth resolution", () => {
 		expect(auth.apiKey).toBe("am_sk_test_chat");
 		expect(auth.principalId).toStartWith("secret-key:");
 		expect(auth.resource).toBe("http://localhost:2718/mcp");
+		expect(auth.scopes).toEqual([...LEAF_OAUTH_SCOPES]);
 	});
 
 	test("accepts an Autumn API key bearer token when OAuth is enabled", async () => {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -21,12 +21,17 @@
 			"default": "./src/oauth/index.ts"
 		}
 	},
-	"files": ["src"],
+	"files": [
+		"src"
+	],
 	"scripts": {
 		"build": "tsc",
 		"ts": "tsc --noEmit",
 		"prepack": "bun run build",
 		"prepublishOnly": "bun run build"
+	},
+	"dependencies": {
+		"@autumn/shared": "workspace:*"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.2.13",

--- a/packages/auth/src/oauth/index.ts
+++ b/packages/auth/src/oauth/index.ts
@@ -1,1 +1,2 @@
+export * from "./mcpOAuth.js";
 export * from "./oauthUrls.js";

--- a/packages/auth/src/oauth/index.ts
+++ b/packages/auth/src/oauth/index.ts
@@ -1,2 +1,3 @@
+export * from "./leafOAuth.js";
 export * from "./mcpOAuth.js";
 export * from "./oauthUrls.js";

--- a/packages/auth/src/oauth/leafOAuth.ts
+++ b/packages/auth/src/oauth/leafOAuth.ts
@@ -1,0 +1,15 @@
+import { LEAF_OAUTH_SCOPES } from "@autumn/shared/leafOAuthScopes";
+import type { ScopeString } from "@autumn/shared/scopeDefinitions";
+
+const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
+
+export const getDefaultOAuthScopes = (requestedScopes?: string[] | null) => {
+	const requested =
+		requestedScopes && requestedScopes.length > 0
+			? requestedScopes
+			: [...LEAF_OAUTH_SCOPES];
+
+	return [...new Set(requested)].filter((scope): scope is ScopeString =>
+		leafScopeSet.has(scope),
+	);
+};

--- a/packages/auth/src/oauth/mcpOAuth.ts
+++ b/packages/auth/src/oauth/mcpOAuth.ts
@@ -1,0 +1,108 @@
+import { LEAF_OAUTH_SCOPES } from "@autumn/shared/leafOAuthScopes";
+import type { ScopeString } from "@autumn/shared/scopeDefinitions";
+
+export const MCP_CLIENT_KIND = "mcp_client";
+export const SLACK_MCP_OAUTH_CLIENT_ID = "autumn_mcp_slack";
+export const AUTUMN_ADMIN_OAUTH_CLIENT_ID = "autumn_admin";
+
+export const MCP_OAUTH_CLIENTS = [
+	{ type: "claude", name: "Claude", clientId: "autumn_mcp_claude" },
+	{ type: "codex", name: "Codex", clientId: "autumn_mcp_codex" },
+	{ type: "cursor", name: "Cursor", clientId: "autumn_mcp_cursor" },
+	{ type: "opencode", name: "OpenCode", clientId: "autumn_mcp_opencode" },
+	{ type: "slack", name: "Slack", clientId: SLACK_MCP_OAUTH_CLIENT_ID },
+] as const;
+
+export type KnownMpcClientType = (typeof MCP_OAUTH_CLIENTS)[number]["type"];
+export type MpcClientType = KnownMpcClientType | "dynamic";
+export type MpcClientInfo = {
+	type: MpcClientType;
+	name: string;
+	clientId: string;
+};
+
+export const MCP_OAUTH_CLIENT_IDS = MCP_OAUTH_CLIENTS.map(
+	(client) => client.clientId,
+);
+
+export const isKnownMcpOAuthClientId = ({
+	clientId,
+}: {
+	clientId: string | null | undefined;
+}) =>
+	!!clientId && (MCP_OAUTH_CLIENT_IDS as readonly string[]).includes(clientId);
+
+const parseMetadata = (metadata: unknown) => {
+	if (!metadata) return {};
+	if (typeof metadata === "string") {
+		try {
+			const parsed = JSON.parse(metadata);
+			return parsed && typeof parsed === "object" ? parsed : {};
+		} catch {
+			return {};
+		}
+	}
+
+	return typeof metadata === "object" ? metadata : {};
+};
+
+export const isMcpOAuthClientRecord = ({
+	clientId,
+	metadata,
+}: {
+	clientId: string | null | undefined;
+	metadata?: unknown;
+}) => {
+	if (isKnownMcpOAuthClientId({ clientId })) return true;
+	const parsedMetadata = parseMetadata(metadata);
+	return parsedMetadata.kind === MCP_CLIENT_KIND;
+};
+
+export const returnsOAuthAccessTokenForClientId = ({
+	clientId,
+}: {
+	clientId: string;
+}) =>
+	isKnownMcpOAuthClientId({ clientId }) ||
+	clientId === AUTUMN_ADMIN_OAUTH_CLIENT_ID;
+
+export const isMcpOAuthResource = (resource: string | null | undefined) => {
+	if (!resource || !URL.canParse(resource)) return false;
+	return new URL(resource).pathname.replace(/\/+$/, "").endsWith("/mcp");
+};
+
+const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
+
+export const getLeafMcpOAuthScopes = (requestedScopes?: string[] | null) => {
+	const requested =
+		requestedScopes && requestedScopes.length > 0
+			? requestedScopes
+			: [...LEAF_OAUTH_SCOPES];
+
+	return [...new Set(requested)].filter((scope): scope is ScopeString =>
+		leafScopeSet.has(scope),
+	);
+};
+
+export const getResourceFromOAuthTokenRequest = async (request: Request) => {
+	const contentType = request.headers.get("content-type") ?? "";
+	const rawBody = await request.text();
+	if (!rawBody) return null;
+
+	if (contentType.includes("application/json")) {
+		try {
+			const body = JSON.parse(rawBody) as Record<string, unknown>;
+			const resource = body.resource;
+			if (Array.isArray(resource)) return getString(resource[0]);
+			return getString(resource);
+		} catch {
+			return null;
+		}
+	}
+
+	const params = new URLSearchParams(rawBody);
+	return params.getAll("resource")[0] ?? null;
+};
+
+const getString = (value: unknown) =>
+	typeof value === "string" && value.length > 0 ? value : null;

--- a/packages/auth/src/oauth/mcpOAuth.ts
+++ b/packages/auth/src/oauth/mcpOAuth.ts
@@ -1,6 +1,3 @@
-import { LEAF_OAUTH_SCOPES } from "@autumn/shared/leafOAuthScopes";
-import type { ScopeString } from "@autumn/shared/scopeDefinitions";
-
 export const MCP_CLIENT_KIND = "mcp_client";
 export const SLACK_MCP_OAUTH_CLIENT_ID = "autumn_mcp_slack";
 export const AUTUMN_ADMIN_OAUTH_CLIENT_ID = "autumn_admin";
@@ -69,19 +66,6 @@ export const returnsOAuthAccessTokenForClientId = ({
 export const isMcpOAuthResource = (resource: string | null | undefined) => {
 	if (!resource || !URL.canParse(resource)) return false;
 	return new URL(resource).pathname.replace(/\/+$/, "").endsWith("/mcp");
-};
-
-const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
-
-export const getLeafMcpOAuthScopes = (requestedScopes?: string[] | null) => {
-	const requested =
-		requestedScopes && requestedScopes.length > 0
-			? requestedScopes
-			: [...LEAF_OAUTH_SCOPES];
-
-	return [...new Set(requested)].filter((scope): scope is ScopeString =>
-		leafScopeSet.has(scope),
-	);
 };
 
 export const getResourceFromOAuthTokenRequest = async (request: Request) => {

--- a/server/src/honoMiddlewares/authMiddlewares/handleOAuthMiddleware.ts
+++ b/server/src/honoMiddlewares/authMiddlewares/handleOAuthMiddleware.ts
@@ -72,6 +72,7 @@ export const handleOAuthMiddleware = async ({
 	ctx.features = sortFeatures({ features: data.features }) ?? [];
 	ctx.env = env;
 	ctx.userId = tokenRecord.userId;
+	ctx.oauthResource = c.req.header("x-autumn-oauth-resource") ?? undefined;
 	ctx.authType = AuthType.SecretKey;
 	ctx.scopes = tokenRecord.scopes;
 

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -28,6 +28,7 @@ export type RequestContext = {
 	features: Feature[];
 	user?: User;
 	userId?: string;
+	oauthResource?: string;
 	customerId?: string;
 	entityId?: string;
 

--- a/server/src/internal/auth/actions/registerMcpOAuthClient.ts
+++ b/server/src/internal/auth/actions/registerMcpOAuthClient.ts
@@ -1,32 +1,20 @@
-import { ALL_SCOPES } from "@autumn/shared";
+import {
+	getLeafMcpOAuthScopes,
+	MCP_CLIENT_KIND,
+	MCP_OAUTH_CLIENTS,
+	type MpcClientInfo,
+	type MpcClientType,
+} from "@autumn/auth/oauth";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { generateId } from "@/utils/genUtils.js";
 import { type OAuthClientRecord, oauthClientRepo } from "../repos/index.js";
 
-const MCP_CLIENT_KIND = "mcp_client";
-export const SLACK_MCP_OAUTH_CLIENT_ID = "autumn_mcp_slack";
-export const AUTUMN_ADMIN_OAUTH_CLIENT_ID = "autumn_admin";
-export const returnsOAuthAccessTokenForClientId = ({
-	clientId,
-}: {
-	clientId: string;
-}) =>
-	clientId === SLACK_MCP_OAUTH_CLIENT_ID ||
-	clientId === AUTUMN_ADMIN_OAUTH_CLIENT_ID;
 const REGISTER_CACHE_TTL_MS = 5 * 60 * 1000;
 const DANGEROUS_REDIRECT_SCHEMES = new Set([
 	"javascript:",
 	"data:",
 	"vbscript:",
 ]);
-
-type MpcClientType = "claude" | "codex" | "cursor" | "opencode" | "slack";
-
-type MpcClientInfo = {
-	type: MpcClientType;
-	name: string;
-	clientId: string;
-};
 
 type McpMetadata = {
 	kind?: string;
@@ -81,6 +69,12 @@ export const isSafeOAuthRedirectUri = (redirectUri: string) => {
 
 const normalize = (value: string) => value.trim().toLowerCase();
 
+const getMcpClientName = (clientName: unknown) => {
+	if (typeof clientName !== "string") return "MCP client";
+	const trimmed = clientName.trim();
+	return trimmed || "MCP client";
+};
+
 const classifyMcpClient = ({
 	clientName,
 	redirectUris,
@@ -96,40 +90,45 @@ const classifyMcpClient = ({
 		.toLowerCase();
 
 	if (haystack.includes("cursor")) {
-		return { type: "cursor", name: "Cursor", clientId: "autumn_mcp_cursor" };
+		return MCP_OAUTH_CLIENTS.find((client) => client.type === "cursor") ?? null;
 	}
 	if (haystack.includes("claude")) {
-		return { type: "claude", name: "Claude", clientId: "autumn_mcp_claude" };
+		return MCP_OAUTH_CLIENTS.find((client) => client.type === "claude") ?? null;
 	}
 	if (
 		haystack.includes("opencode") ||
 		haystack.includes("open-code") ||
 		haystack.includes("open code")
 	) {
-		return {
-			type: "opencode",
-			name: "OpenCode",
-			clientId: "autumn_mcp_opencode",
-		};
+		return (
+			MCP_OAUTH_CLIENTS.find((client) => client.type === "opencode") ?? null
+		);
 	}
 	if (haystack.includes("codex")) {
-		return { type: "codex", name: "Codex", clientId: "autumn_mcp_codex" };
+		return MCP_OAUTH_CLIENTS.find((client) => client.type === "codex") ?? null;
 	}
 	if (haystack.includes("slack")) {
-		return {
-			type: "slack",
-			name: "Slack",
-			clientId: SLACK_MCP_OAUTH_CLIENT_ID,
-		};
+		return MCP_OAUTH_CLIENTS.find((client) => client.type === "slack") ?? null;
 	}
 
-	return null;
+	return {
+		type: "dynamic",
+		name: getMcpClientName(clientName),
+		clientId: generateId("oauth_client"),
+	};
 };
 
-const getRequestedScopes = (scope: unknown) => {
-	if (typeof scope !== "string" || !scope.trim()) return [...ALL_SCOPES];
-	const allowed = new Set(ALL_SCOPES);
-	return scope.split(" ").filter((scope) => allowed.has(scope as never));
+export const getRequestedScopesForMcpClient = ({
+	clientType: _clientType,
+	scope,
+}: {
+	clientType: MpcClientType;
+	scope: unknown;
+}) => {
+	if (typeof scope !== "string" || !scope.trim()) {
+		return getLeafMcpOAuthScopes();
+	}
+	return getLeafMcpOAuthScopes(scope.split(" "));
 };
 
 const mergeMetadata = ({
@@ -166,6 +165,7 @@ const clientMatches = ({
 }) => {
 	const metadata = parseMetadata(client.metadata);
 	if (
+		info.type !== "dynamic" &&
 		metadata.kind === MCP_CLIENT_KIND &&
 		metadata.mcpClientType === info.type
 	) {
@@ -249,7 +249,10 @@ export const registerMcpOAuthClient = async ({
 		return { error: "unsupported_mcp_client", status: 400 };
 	}
 
-	const requestedScopes = getRequestedScopes(scope);
+	const requestedScopes = getRequestedScopesForMcpClient({
+		clientType: info.type,
+		scope,
+	});
 	const scopeKey = [...requestedScopes].sort().join(" ");
 	const cacheKey = `${info.type}:${[...redirectUris].sort().join("|")}:${scopeKey}`;
 	const cached = getCachedRegistration(cacheKey);
@@ -266,9 +269,6 @@ export const registerMcpOAuthClient = async ({
 		const mergedRedirectUris = [
 			...new Set([...existingClient.redirectUris, ...redirectUris]),
 		];
-		const mergedScopes = [
-			...new Set([...(existingClient.scopes ?? []), ...requestedScopes]),
-		];
 
 		const updatedClient = await oauthClientRepo.updateById({
 			db,
@@ -276,7 +276,7 @@ export const registerMcpOAuthClient = async ({
 			updates: {
 				name: info.name,
 				redirectUris: mergedRedirectUris,
-				scopes: mergedScopes,
+				scopes: requestedScopes,
 				tokenEndpointAuthMethod: "none",
 				grantTypes: ["authorization_code", "refresh_token"],
 				responseTypes: ["code"],

--- a/server/src/internal/auth/actions/registerMcpOAuthClient.ts
+++ b/server/src/internal/auth/actions/registerMcpOAuthClient.ts
@@ -1,5 +1,5 @@
 import {
-	getLeafMcpOAuthScopes,
+	getDefaultOAuthScopes,
 	MCP_CLIENT_KIND,
 	MCP_OAUTH_CLIENTS,
 	type MpcClientInfo,
@@ -126,9 +126,9 @@ export const getRequestedScopesForMcpClient = ({
 	scope: unknown;
 }) => {
 	if (typeof scope !== "string" || !scope.trim()) {
-		return getLeafMcpOAuthScopes();
+		return getDefaultOAuthScopes();
 	}
-	return getLeafMcpOAuthScopes(scope.split(" "));
+	return getDefaultOAuthScopes(scope.split(" "));
 };
 
 const mergeMetadata = ({

--- a/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
+++ b/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
@@ -1,11 +1,10 @@
 import { AppEnv, RecaseError } from "@autumn/shared";
 import type { Context } from "hono";
 import { db } from "@/db/initDrizzle.js";
-import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { auth } from "@/utils/auth.js";
 import { oauthConsentRepo } from "../repos/index.js";
 import { isAtmnOAuthClientId } from "./atmnOAuthClients.js";
-import { assertMcpOAuthScopeGrant } from "./mcpOAuthScopes.js";
+import { getOAuthConsentScopeGrant } from "./oauthConsentScopes.js";
 
 type RequestFields = Record<string, unknown>;
 
@@ -67,10 +66,6 @@ const getRedirectUriFromFields = (fields: RequestFields) =>
 	getString(fields.redirect_uri) ??
 	getString(fields.redirectUri) ??
 	getNestedOAuthField(fields.oauth_query, "redirect_uri");
-
-const getResourceFromFields = (fields: RequestFields) =>
-	getString(fields.resource) ??
-	getNestedOAuthField(fields.oauth_query, "resource");
 
 const getScopesFromFields = (fields: RequestFields) => {
 	const rawScope =
@@ -159,25 +154,19 @@ export const handleOAuthConsentWithEnv = async (c: Context) => {
 		const orgId = session?.session?.activeOrganizationId;
 		if (userId && orgId) {
 			try {
-				const scopeGrant = await assertMcpOAuthScopeGrant({
-					clientId,
-					ctx: {
-						db,
-						oauthResource: getResourceFromFields(fields) ?? undefined,
-						org: { id: orgId },
-						userId,
-					} as AutumnContext,
+				const scopeGrant = await getOAuthConsentScopeGrant({
+					db,
+					organizationId: orgId,
 					requestedScopes: getScopesFromFields(fields),
+					userId,
 				});
-				if (scopeGrant) {
-					grantedScopes = scopeGrant;
-					request = withScope({
-						contentType,
-						request,
-						fields,
-						scope: scopeGrant.join(" "),
-					});
-				}
+				grantedScopes = scopeGrant;
+				request = withScope({
+					contentType,
+					request,
+					fields,
+					scope: scopeGrant.join(" "),
+				});
 			} catch (error) {
 				if (error instanceof RecaseError) {
 					return jsonOAuthError({ error });

--- a/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
+++ b/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
@@ -1,28 +1,34 @@
-import { AppEnv } from "@autumn/shared";
+import { AppEnv, RecaseError } from "@autumn/shared";
 import type { Context } from "hono";
 import { db } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { auth } from "@/utils/auth.js";
 import { oauthConsentRepo } from "../repos/index.js";
 import { isAtmnOAuthClientId } from "./atmnOAuthClients.js";
+import { assertMcpOAuthScopeGrant } from "./mcpOAuthScopes.js";
 
 type RequestFields = Record<string, unknown>;
 
 const parseRequestFields = async (request: Request) => {
 	const contentType = request.headers.get("content-type") ?? "";
 	const rawBody = await request.text();
-	if (!rawBody) return {};
+	if (!rawBody) return { contentType, fields: {}, rawBody };
 
 	if (contentType.includes("application/json")) {
 		try {
 			const body = JSON.parse(rawBody);
-			return body && typeof body === "object" ? (body as RequestFields) : {};
+			return {
+				contentType,
+				fields: body && typeof body === "object" ? (body as RequestFields) : {},
+				rawBody,
+			};
 		} catch {
-			return {};
+			return { contentType, fields: {}, rawBody };
 		}
 	}
 
 	const params = new URLSearchParams(rawBody);
-	return Object.fromEntries(params.entries());
+	return { contentType, fields: Object.fromEntries(params.entries()), rawBody };
 };
 
 const getString = (value: unknown) =>
@@ -62,25 +68,136 @@ const getRedirectUriFromFields = (fields: RequestFields) =>
 	getString(fields.redirectUri) ??
 	getNestedOAuthField(fields.oauth_query, "redirect_uri");
 
+const getResourceFromFields = (fields: RequestFields) =>
+	getString(fields.resource) ??
+	getNestedOAuthField(fields.oauth_query, "resource");
+
+const getScopesFromFields = (fields: RequestFields) => {
+	const rawScope =
+		getString(fields.scope) ?? getNestedOAuthField(fields.oauth_query, "scope");
+	return rawScope?.split(/\s+/).filter(Boolean) ?? null;
+};
+
+const getFieldsWithScope = ({
+	fields,
+	scope,
+}: {
+	fields: RequestFields;
+	scope: string;
+}) => {
+	const next: RequestFields = { ...fields, scope };
+	const oauthQuery = fields.oauth_query;
+	if (typeof oauthQuery === "string") {
+		try {
+			next.oauth_query = JSON.stringify({ ...JSON.parse(oauthQuery), scope });
+		} catch {
+			const params = new URLSearchParams(oauthQuery);
+			params.set("scope", scope);
+			next.oauth_query = params.toString();
+		}
+	} else if (typeof oauthQuery === "object" && oauthQuery !== null) {
+		next.oauth_query = {
+			...(oauthQuery as Record<string, unknown>),
+			scope,
+		};
+	}
+	return next;
+};
+
+const withScope = ({
+	contentType,
+	request,
+	fields,
+	scope,
+}: {
+	contentType: string;
+	request: Request;
+	fields: RequestFields;
+	scope: string;
+}) => {
+	const scopedFields = getFieldsWithScope({ fields, scope });
+	if (contentType.includes("application/json")) {
+		return new Request(request, {
+			body: JSON.stringify(scopedFields),
+		});
+	}
+
+	const params = new URLSearchParams();
+	for (const [key, value] of Object.entries(scopedFields)) {
+		if (typeof value === "string") params.set(key, value);
+	}
+
+	return new Request(request, { body: params });
+};
+
+const jsonOAuthError = ({ error }: { error: RecaseError }) =>
+	new Response(
+		JSON.stringify({
+			error: "invalid_scope",
+			error_description: error.message,
+		}),
+		{
+			status: error.statusCode,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
+
 export const handleOAuthConsentWithEnv = async (c: Context) => {
-	const fields = await parseRequestFields(c.req.raw.clone());
-	const response = await auth.handler(c.req.raw);
+	const { contentType, fields } = await parseRequestFields(c.req.raw.clone());
+	const clientId = getClientIdFromFields(fields);
+	const redirectUri = getRedirectUriFromFields(fields);
+	const env = parseEnv(fields.env);
+
+	let request = c.req.raw;
+	let grantedScopes: string[] | undefined;
+	if (acceptedConsent(fields.accept) && clientId) {
+		const session = await auth.api.getSession({
+			headers: c.req.raw.headers,
+		});
+
+		const userId = session?.user?.id;
+		const orgId = session?.session?.activeOrganizationId;
+		if (userId && orgId) {
+			try {
+				const scopeGrant = await assertMcpOAuthScopeGrant({
+					clientId,
+					ctx: {
+						db,
+						oauthResource: getResourceFromFields(fields) ?? undefined,
+						org: { id: orgId },
+						userId,
+					} as AutumnContext,
+					requestedScopes: getScopesFromFields(fields),
+				});
+				if (scopeGrant) {
+					grantedScopes = scopeGrant;
+					request = withScope({
+						contentType,
+						request,
+						fields,
+						scope: scopeGrant.join(" "),
+					});
+				}
+			} catch (error) {
+				if (error instanceof RecaseError) {
+					return jsonOAuthError({ error });
+				}
+				throw error;
+			}
+		}
+	}
+
+	const response = await auth.handler(request);
 
 	if (!response.ok || !acceptedConsent(fields.accept)) {
 		return response;
 	}
 
-	const clientId = getClientIdFromFields(fields);
-	const redirectUri = getRedirectUriFromFields(fields);
-	const env = parseEnv(fields.env);
 	if (!clientId || !env || (await isAtmnOAuthClientId({ db, clientId }))) {
 		return response;
 	}
 
-	const session = await auth.api.getSession({
-		headers: c.req.raw.headers,
-	});
-
+	const session = await auth.api.getSession({ headers: c.req.raw.headers });
 	const userId = session?.user?.id;
 	const orgId = session?.session?.activeOrganizationId;
 	if (!userId || !orgId) return response;
@@ -92,6 +209,7 @@ export const handleOAuthConsentWithEnv = async (c: Context) => {
 		referenceId: orgId,
 		env,
 		redirectUri,
+		scopes: grantedScopes,
 	});
 
 	return response;

--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -3,7 +3,7 @@ import {
 	getResourceFromOAuthTokenRequest,
 	returnsOAuthAccessTokenForClientId,
 } from "@autumn/auth/oauth";
-import { RecaseError } from "@autumn/shared";
+import { ErrCode, RecaseError } from "@autumn/shared";
 import type { Context } from "hono";
 import { db } from "@/db/initDrizzle.js";
 import { auth } from "@/utils/auth.js";
@@ -132,6 +132,13 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 			resource,
 			requestedScopes,
 		});
+		if (tokenRecord.scopes.length === 0) {
+			throw new RecaseError({
+				message: "OAuth token has no scopes",
+				code: ErrCode.InvalidRequest,
+				statusCode: 401,
+			});
+		}
 		const issuedScopes = await getOAuthConsentScopeGrant({
 			db,
 			organizationId: tokenRecord.referenceId,

--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -1,9 +1,14 @@
 import { prefixOAuthToken } from "@autumn/auth";
+import {
+	getResourceFromOAuthTokenRequest,
+	returnsOAuthAccessTokenForClientId,
+} from "@autumn/auth/oauth";
 import { RecaseError } from "@autumn/shared";
 import type { Context } from "hono";
 import { db } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { auth } from "@/utils/auth.js";
-import { returnsOAuthAccessTokenForClientId } from "../actions/registerMcpOAuthClient.js";
+import { assertMcpOAuthScopeGrant } from "./mcpOAuthScopes.js";
 import {
 	getExternalOAuthApiKeyForToken,
 	getOAuthAccessTokenRecord,
@@ -53,9 +58,11 @@ const rewriteTokenBody = ({
 const rewriteOAuthAccessTokenBody = ({
 	accessToken,
 	body,
+	scopes,
 }: {
 	accessToken: string;
 	body: Record<string, unknown>;
+	scopes: string[];
 }) => {
 	const response = body.response;
 	if (isRecord(response)) {
@@ -64,6 +71,7 @@ const rewriteOAuthAccessTokenBody = ({
 			response: {
 				...response,
 				access_token: accessToken,
+				scope: scopes.join(" "),
 			},
 		};
 	}
@@ -71,6 +79,7 @@ const rewriteOAuthAccessTokenBody = ({
 	return {
 		...body,
 		access_token: accessToken,
+		scope: scopes.join(" "),
 	};
 };
 
@@ -97,28 +106,8 @@ const jsonTokenResponse = ({
 		headers: tokenResponseHeaders(response),
 	});
 
-const getResourceFromTokenRequest = async (request: Request) => {
-	const contentType = request.headers.get("content-type") ?? "";
-	const rawBody = await request.text();
-	if (!rawBody) return null;
-
-	if (contentType.includes("application/json")) {
-		try {
-			const body = JSON.parse(rawBody) as Record<string, unknown>;
-			const resource = body.resource;
-			if (Array.isArray(resource)) return getString(resource[0]);
-			return getString(resource);
-		} catch {
-			return null;
-		}
-	}
-
-	const params = new URLSearchParams(rawBody);
-	return params.getAll("resource")[0] ?? null;
-};
-
 export const handleOAuthTokenWithApiKey = async (c: Context) => {
-	const resource = await getResourceFromTokenRequest(c.req.raw.clone());
+	const resource = await getResourceFromOAuthTokenRequest(c.req.raw.clone());
 	const response = await auth.handler(c.req.raw);
 	if (!response.ok) return response;
 
@@ -142,13 +131,25 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 			resource,
 			requestedScopes,
 		});
+		const mcpScopeGrant = await assertMcpOAuthScopeGrant({
+			clientId: tokenRecord.clientId,
+			ctx: {
+				db,
+				oauthResource: resource ?? undefined,
+				org: { id: tokenRecord.referenceId },
+				userId: tokenRecord.userId,
+			} as AutumnContext,
+			requestedScopes: tokenRecord.scopes,
+		});
 		if (
+			mcpScopeGrant ||
 			returnsOAuthAccessTokenForClientId({ clientId: tokenRecord.clientId })
 		) {
 			return jsonTokenResponse({
 				body: rewriteOAuthAccessTokenBody({
 					accessToken: prefixOAuthToken({ token: accessToken }),
 					body,
+					scopes: mcpScopeGrant ?? tokenRecord.scopes,
 				}),
 				response,
 				status: response.status,

--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -6,14 +6,15 @@ import {
 import { RecaseError } from "@autumn/shared";
 import type { Context } from "hono";
 import { db } from "@/db/initDrizzle.js";
-import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { auth } from "@/utils/auth.js";
-import { assertMcpOAuthScopeGrant } from "./mcpOAuthScopes.js";
+import { oauthAccessTokenRepo, oauthRefreshTokenRepo } from "../repos/index.js";
+import { isMcpOAuthClient } from "./mcpOAuthScopes.js";
 import {
 	getExternalOAuthApiKeyForToken,
 	getOAuthAccessTokenRecord,
 	scopesFromOAuthScopeString,
 } from "./oauthAccessTokenApiKey.js";
+import { getOAuthConsentScopeGrant } from "./oauthConsentScopes.js";
 
 const getString = (value: unknown) =>
 	typeof value === "string" && value.length > 0 ? value : null;
@@ -131,25 +132,41 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 			resource,
 			requestedScopes,
 		});
-		const mcpScopeGrant = await assertMcpOAuthScopeGrant({
-			clientId: tokenRecord.clientId,
-			ctx: {
-				db,
-				oauthResource: resource ?? undefined,
-				org: { id: tokenRecord.referenceId },
-				userId: tokenRecord.userId,
-			} as AutumnContext,
+		const issuedScopes = await getOAuthConsentScopeGrant({
+			db,
+			organizationId: tokenRecord.referenceId,
 			requestedScopes: tokenRecord.scopes,
+			userId: tokenRecord.userId,
+		});
+		tokenRecord.scopes = issuedScopes;
+		if (tokenRecord.id) {
+			await oauthAccessTokenRepo.updateScopes({
+				db,
+				id: tokenRecord.id,
+				scopes: issuedScopes,
+			});
+		}
+		if (tokenRecord.refreshId) {
+			await oauthRefreshTokenRepo.updateScopes({
+				db,
+				id: tokenRecord.refreshId,
+				scopes: issuedScopes,
+			});
+		}
+		const isMcpClient = await isMcpOAuthClient({
+			clientId: tokenRecord.clientId,
+			db,
+			resource: resource ?? undefined,
 		});
 		if (
-			mcpScopeGrant ||
+			isMcpClient ||
 			returnsOAuthAccessTokenForClientId({ clientId: tokenRecord.clientId })
 		) {
 			return jsonTokenResponse({
 				body: rewriteOAuthAccessTokenBody({
 					accessToken: prefixOAuthToken({ token: accessToken }),
 					body,
-					scopes: mcpScopeGrant ?? tokenRecord.scopes,
+					scopes: tokenRecord.scopes,
 				}),
 				response,
 				status: response.status,

--- a/server/src/internal/auth/oauth/internalMcpOAuthClients.ts
+++ b/server/src/internal/auth/oauth/internalMcpOAuthClients.ts
@@ -1,3 +1,4 @@
+import { MCP_CLIENT_KIND } from "@autumn/auth/oauth";
 import type { Context } from "hono";
 import { type DrizzleCli, db } from "@/db/initDrizzle.js";
 import { auth } from "@/utils/auth.js";
@@ -8,7 +9,6 @@ const INTERNAL_MCP_CLIENT_NAME = "Autumn internal-mcp";
 const INTERNAL_MCP_CLIENT_NAME_NORMALIZED =
 	INTERNAL_MCP_CLIENT_NAME.toLowerCase();
 const INTERNAL_MCP_KIND = "internal_mcp";
-const MCP_CLIENT_KIND = "mcp_client";
 
 type InternalMcpMetadata = {
 	kind?: string;

--- a/server/src/internal/auth/oauth/mcpOAuthScopes.ts
+++ b/server/src/internal/auth/oauth/mcpOAuthScopes.ts
@@ -1,0 +1,79 @@
+import {
+	getLeafMcpOAuthScopes,
+	isKnownMcpOAuthClientId,
+	isMcpOAuthClientRecord,
+	isMcpOAuthResource,
+} from "@autumn/auth/oauth";
+import { ErrCode, isScopeSubset, RecaseError } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getScopesForUserInOrg } from "@/utils/authUtils/customSessionScopes.js";
+import { oauthClientRepo } from "../repos/index.js";
+
+export const isMcpOAuthClientId = async ({
+	clientId,
+	ctx,
+}: {
+	clientId: string;
+	ctx: AutumnContext;
+}) => {
+	if (isMcpOAuthResource(ctx.oauthResource)) return true;
+	if (isKnownMcpOAuthClientId({ clientId })) return true;
+
+	const client = await oauthClientRepo.getByClientId({ db: ctx.db, clientId });
+	if (!client) return false;
+
+	return isMcpOAuthClientRecord(client);
+};
+
+export const getMcpOAuthScopeGrant = async ({
+	clientId,
+	ctx,
+	requestedScopes,
+}: {
+	clientId: string;
+	ctx: AutumnContext;
+	requestedScopes?: string[] | null;
+}) => {
+	if (!(await isMcpOAuthClientId({ ctx, clientId }))) return null;
+
+	const orgId = ctx.org?.id;
+	if (!ctx.userId || !orgId) {
+		throw new RecaseError({
+			message: "MCP OAuth scope grant is missing user or organization context",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+	const leafScopes = getLeafMcpOAuthScopes(requestedScopes);
+	const { scopes: userScopes } = await getScopesForUserInOrg({
+		db: ctx.db,
+		userId: ctx.userId,
+		organizationId: orgId,
+	});
+
+	return leafScopes.filter((scope) => isScopeSubset([scope], userScopes));
+};
+
+export const assertMcpOAuthScopeGrant = async ({
+	clientId,
+	ctx,
+	requestedScopes,
+}: {
+	clientId: string;
+	ctx: AutumnContext;
+	requestedScopes?: string[] | null;
+}) => {
+	const scopes = await getMcpOAuthScopeGrant({
+		clientId,
+		ctx,
+		requestedScopes,
+	});
+	if (!scopes) return null;
+	if (scopes.length > 0) return scopes;
+
+	throw new RecaseError({
+		message: "No requested scopes can be granted to this MCP client",
+		code: ErrCode.InsufficientScopes,
+		statusCode: 403,
+	});
+};

--- a/server/src/internal/auth/oauth/mcpOAuthScopes.ts
+++ b/server/src/internal/auth/oauth/mcpOAuthScopes.ts
@@ -1,13 +1,32 @@
 import {
-	getLeafMcpOAuthScopes,
+	getDefaultOAuthScopes,
 	isKnownMcpOAuthClientId,
 	isMcpOAuthClientRecord,
 	isMcpOAuthResource,
 } from "@autumn/auth/oauth";
 import { ErrCode, isScopeSubset, RecaseError } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getScopesForUserInOrg } from "@/utils/authUtils/customSessionScopes.js";
 import { oauthClientRepo } from "../repos/index.js";
+
+export const isMcpOAuthClient = async ({
+	clientId,
+	db,
+	resource,
+}: {
+	clientId: string;
+	db: DrizzleCli;
+	resource?: string;
+}) => {
+	if (isMcpOAuthResource(resource)) return true;
+	if (isKnownMcpOAuthClientId({ clientId })) return true;
+
+	const client = await oauthClientRepo.getByClientId({ db, clientId });
+	if (!client) return false;
+
+	return isMcpOAuthClientRecord(client);
+};
 
 export const isMcpOAuthClientId = async ({
 	clientId,
@@ -15,15 +34,12 @@ export const isMcpOAuthClientId = async ({
 }: {
 	clientId: string;
 	ctx: AutumnContext;
-}) => {
-	if (isMcpOAuthResource(ctx.oauthResource)) return true;
-	if (isKnownMcpOAuthClientId({ clientId })) return true;
-
-	const client = await oauthClientRepo.getByClientId({ db: ctx.db, clientId });
-	if (!client) return false;
-
-	return isMcpOAuthClientRecord(client);
-};
+}) =>
+	isMcpOAuthClient({
+		clientId,
+		db: ctx.db,
+		resource: ctx.oauthResource,
+	});
 
 export const getMcpOAuthScopeGrant = async ({
 	clientId,
@@ -44,7 +60,7 @@ export const getMcpOAuthScopeGrant = async ({
 			statusCode: 400,
 		});
 	}
-	const leafScopes = getLeafMcpOAuthScopes(requestedScopes);
+	const leafScopes = getDefaultOAuthScopes(requestedScopes);
 	const { scopes: userScopes } = await getScopesForUserInOrg({
 		db: ctx.db,
 		userId: ctx.userId,

--- a/server/src/internal/auth/oauth/oauthAccessTokenApiKey.ts
+++ b/server/src/internal/auth/oauth/oauthAccessTokenApiKey.ts
@@ -127,7 +127,7 @@ export const getExternalOAuthApiKeyForToken = async ({
 		userId: string;
 		referenceId: string;
 	};
-	requestedScopes: ScopeString[] | null;
+	requestedScopes: string[] | null;
 }) => {
 	const isAtmnClient = await isAtmnOAuthClientId({
 		db,
@@ -151,7 +151,7 @@ export const getExternalOAuthApiKeyForToken = async ({
 	}
 
 	const env = consent.env ?? AppEnv.Sandbox;
-	const scopes = requestedScopes ?? (tokenRecord.scopes as ScopeString[]);
+	const scopes = requestedScopes ?? tokenRecord.scopes;
 	const apiKey = await rotateOAuthConsentApiKey({
 		db,
 		consent,

--- a/server/src/internal/auth/oauth/oauthConsentApiKey.ts
+++ b/server/src/internal/auth/oauth/oauthConsentApiKey.ts
@@ -1,4 +1,4 @@
-import { AppEnv, type ScopeString } from "@autumn/shared";
+import { AppEnv } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import {
 	ApiKeyPrefix,
@@ -41,7 +41,7 @@ const createConsentApiKey = async ({
 	consent: OAuthConsentApiKeyRecord;
 	tokenRecord: OAuthApiKeyTokenRecord;
 	env: AppEnv;
-	scopes: ScopeString[];
+	scopes: string[];
 }) => {
 	const prefix = env === AppEnv.Live ? ApiKeyPrefix.Live : ApiKeyPrefix.Sandbox;
 	const keyName = await getOAuthClientApiKeyName({
@@ -93,7 +93,7 @@ export const rotateOAuthConsentApiKey = async ({
 	consent: OAuthConsentApiKeyRecord;
 	tokenRecord: OAuthApiKeyTokenRecord;
 	env: AppEnv;
-	scopes: ScopeString[];
+	scopes: string[];
 }) => {
 	const previousApiKeyId = consent.oauthApiKeyId;
 	const { apiKey, apiKeyId } = await createConsentApiKey({

--- a/server/src/internal/auth/oauth/oauthConsentScopes.ts
+++ b/server/src/internal/auth/oauth/oauthConsentScopes.ts
@@ -14,14 +14,14 @@ export const getOAuthConsentScopeGrant = async ({
 	requestedScopes?: string[] | null;
 	userId: string;
 }) => {
-	const requestedLeafScopes = getDefaultOAuthScopes(requestedScopes);
+	const finalRequestedScopes = getDefaultOAuthScopes(requestedScopes);
 	const { scopes: userScopes } = await getScopesForUserInOrg({
 		db,
 		userId,
 		organizationId,
 	});
 
-	const grant = requestedLeafScopes.filter((scope) =>
+	const grant = finalRequestedScopes.filter((scope) =>
 		isScopeSubset([scope], userScopes),
 	);
 	if (grant.length > 0) return grant;

--- a/server/src/internal/auth/oauth/oauthConsentScopes.ts
+++ b/server/src/internal/auth/oauth/oauthConsentScopes.ts
@@ -1,0 +1,34 @@
+import { getDefaultOAuthScopes } from "@autumn/auth/oauth";
+import { ErrCode, isScopeSubset, RecaseError } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { getScopesForUserInOrg } from "@/utils/authUtils/customSessionScopes.js";
+
+export const getOAuthConsentScopeGrant = async ({
+	db,
+	organizationId,
+	requestedScopes,
+	userId,
+}: {
+	db: DrizzleCli;
+	organizationId: string;
+	requestedScopes?: string[] | null;
+	userId: string;
+}) => {
+	const requestedLeafScopes = getDefaultOAuthScopes(requestedScopes);
+	const { scopes: userScopes } = await getScopesForUserInOrg({
+		db,
+		userId,
+		organizationId,
+	});
+
+	const grant = requestedLeafScopes.filter((scope) =>
+		isScopeSubset([scope], userScopes),
+	);
+	if (grant.length > 0) return grant;
+
+	throw new RecaseError({
+		message: "No requested scopes can be granted to this OAuth client",
+		code: ErrCode.InsufficientScopes,
+		statusCode: 403,
+	});
+};

--- a/server/src/internal/auth/repos/oauthAccessTokenRepo.ts
+++ b/server/src/internal/auth/repos/oauthAccessTokenRepo.ts
@@ -43,7 +43,22 @@ export const deleteOAuthAccessTokensByClientAndReference = async ({
 			),
 		);
 
+export const updateOAuthAccessTokenScopes = async ({
+	db,
+	id,
+	scopes,
+}: {
+	db: DrizzleCli;
+	id: string;
+	scopes: string[];
+}) =>
+	db
+		.update(oauthAccessToken)
+		.set({ scopes })
+		.where(eq(oauthAccessToken.id, id));
+
 export const oauthAccessTokenRepo = {
 	getValidByTokenValues: getValidOAuthAccessTokenByTokenValues,
 	deleteByClientAndReference: deleteOAuthAccessTokensByClientAndReference,
+	updateScopes: updateOAuthAccessTokenScopes,
 };

--- a/server/src/internal/auth/repos/oauthConsentRepo.ts
+++ b/server/src/internal/auth/repos/oauthConsentRepo.ts
@@ -65,6 +65,7 @@ export const updateOAuthConsentEnv = async ({
 	referenceId,
 	env,
 	redirectUri,
+	scopes,
 }: {
 	db: DrizzleCli;
 	clientId: string;
@@ -72,10 +73,16 @@ export const updateOAuthConsentEnv = async ({
 	referenceId: string;
 	env: AppEnv;
 	redirectUri: string | null;
+	scopes?: string[];
 }) =>
 	db
 		.update(oauthConsent)
-		.set({ env, redirectUri, updatedAt: new Date() })
+		.set({
+			env,
+			redirectUri,
+			...(scopes ? { scopes } : {}),
+			updatedAt: new Date(),
+		})
 		.where(
 			and(
 				eq(oauthConsent.clientId, clientId),
@@ -103,6 +110,7 @@ export const getOAuthConsentForClientUserOrg = async ({
 			env: oauthConsent.env,
 			oauthApiKeyId: oauthConsent.oauthApiKeyId,
 			redirectUri: oauthConsent.redirectUri,
+			scopes: oauthConsent.scopes,
 		})
 		.from(oauthConsent)
 		.where(

--- a/server/src/internal/auth/repos/oauthRefreshTokenRepo.ts
+++ b/server/src/internal/auth/repos/oauthRefreshTokenRepo.ts
@@ -22,6 +22,21 @@ export const deleteOAuthRefreshTokensByClientAndReference = async ({
 			),
 		);
 
+export const updateOAuthRefreshTokenScopes = async ({
+	db,
+	id,
+	scopes,
+}: {
+	db: DrizzleCli;
+	id: string;
+	scopes: string[];
+}) =>
+	db
+		.update(oauthRefreshToken)
+		.set({ scopes })
+		.where(eq(oauthRefreshToken.id, id));
+
 export const oauthRefreshTokenRepo = {
 	deleteByClientAndReference: deleteOAuthRefreshTokensByClientAndReference,
+	updateScopes: updateOAuthRefreshTokenScopes,
 };

--- a/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
+++ b/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
@@ -1,5 +1,6 @@
 import { AppEnv, ErrCode, RecaseError, Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { isMcpOAuthClientId } from "@/internal/auth/oauth/mcpOAuthScopes.js";
 import {
 	getExternalOAuthApiKeyForToken,
 	getOAuthAccessTokenRecord,
@@ -48,7 +49,8 @@ const parseBody = (rawBody: string): OAuthApiKeyRequestBody => {
 export const handleCreateOAuthApiKeys = createRoute({
 	scopes: [Scopes.Public],
 	handler: async (c) => {
-		const db = c.get("ctx").db;
+		const ctx = c.get("ctx");
+		const db = ctx.db;
 		const rawBody = await c.req.text();
 		const body = parseBody(rawBody);
 		const requestedScopes = parseRequestedScopes(body.scopes);
@@ -75,6 +77,13 @@ export const handleCreateOAuthApiKeys = createRoute({
 		const userId = tokenRecord.userId;
 		const orgId = tokenRecord.referenceId;
 		const clientId = tokenRecord.clientId;
+		if (await isMcpOAuthClientId({ clientId, ctx })) {
+			throw new RecaseError({
+				message: "MCP OAuth clients must use OAuth access tokens directly",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
 
 		const externalApiKey = await getExternalOAuthApiKeyForToken({
 			db,

--- a/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
+++ b/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
@@ -77,6 +77,13 @@ export const handleCreateOAuthApiKeys = createRoute({
 		const userId = tokenRecord.userId;
 		const orgId = tokenRecord.referenceId;
 		const clientId = tokenRecord.clientId;
+		if (tokenRecord.scopes.length === 0) {
+			throw new RecaseError({
+				message: "OAuth token has no scopes",
+				code: ErrCode.InvalidRequest,
+				statusCode: 401,
+			});
+		}
 		const apiKeyScopes = requestedScopes ?? tokenRecord.scopes;
 		if (await isMcpOAuthClientId({ clientId, ctx })) {
 			throw new RecaseError({

--- a/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
+++ b/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
@@ -77,6 +77,7 @@ export const handleCreateOAuthApiKeys = createRoute({
 		const userId = tokenRecord.userId;
 		const orgId = tokenRecord.referenceId;
 		const clientId = tokenRecord.clientId;
+		const apiKeyScopes = requestedScopes ?? tokenRecord.scopes;
 		if (await isMcpOAuthClientId({ clientId, ctx })) {
 			throw new RecaseError({
 				message: "MCP OAuth clients must use OAuth access tokens directly",
@@ -88,7 +89,7 @@ export const handleCreateOAuthApiKeys = createRoute({
 		const externalApiKey = await getExternalOAuthApiKeyForToken({
 			db,
 			tokenRecord,
-			requestedScopes,
+			requestedScopes: apiKeyScopes,
 		});
 		if (externalApiKey) {
 			return c.json({
@@ -132,7 +133,7 @@ export const handleCreateOAuthApiKeys = createRoute({
 				userId,
 				prefix: ApiKeyPrefix.Sandbox,
 				meta,
-				scopes: requestedScopes,
+				scopes: apiKeyScopes,
 			}),
 			createKey({
 				db,
@@ -142,7 +143,7 @@ export const handleCreateOAuthApiKeys = createRoute({
 				userId,
 				prefix: ApiKeyPrefix.Live,
 				meta,
-				scopes: requestedScopes,
+				scopes: apiKeyScopes,
 			}),
 		]);
 
@@ -152,7 +153,7 @@ export const handleCreateOAuthApiKeys = createRoute({
 			org_id: orgId,
 			user_id: userId,
 			client_id: clientId,
-			scopes: requestedScopes,
+			scopes: apiKeyScopes,
 		});
 	},
 });

--- a/server/src/internal/dev/cli/oauthApiKeyUtils.ts
+++ b/server/src/internal/dev/cli/oauthApiKeyUtils.ts
@@ -1,4 +1,9 @@
-import { ErrCode, RecaseError, type ScopeString } from "@autumn/shared";
+import {
+	ErrCode,
+	isValidScope,
+	RecaseError,
+	type ScopeString,
+} from "@autumn/shared";
 import { z } from "zod/v4";
 
 export type OAuthApiKeyRequestBody = {
@@ -13,7 +18,11 @@ export type ResourceAccessTokenRecord = {
 	scopes: string[];
 };
 
-const RequestedScopesSchema = z.array(z.string()).optional();
+const ScopeStringSchema = z.custom<ScopeString>(
+	(scope) => typeof scope === "string" && isValidScope(scope),
+	{ message: "Invalid scope" },
+);
+const RequestedScopesSchema = z.array(ScopeStringSchema).optional();
 export const OAuthApiKeyRequestBodySchema = z
 	.object({
 		resource: z.unknown().optional(),
@@ -23,7 +32,7 @@ export const OAuthApiKeyRequestBodySchema = z
 
 export const parseRequestedScopes = (scopes: unknown) => {
 	const parsed = RequestedScopesSchema.safeParse(scopes);
-	if (parsed.success) return (parsed.data ?? null) as ScopeString[] | null;
+	if (parsed.success) return parsed.data ?? null;
 
 	throw new RecaseError({
 		message: "Invalid scopes",

--- a/server/src/internal/dev/cli/oauthApiKeyUtils.ts
+++ b/server/src/internal/dev/cli/oauthApiKeyUtils.ts
@@ -12,6 +12,8 @@ export type OAuthApiKeyRequestBody = {
 };
 
 export type ResourceAccessTokenRecord = {
+	id?: string;
+	refreshId?: string | null;
 	userId: string | null;
 	referenceId: string | null;
 	clientId: string;

--- a/server/tests/unit/auth/registerMcpOAuthClient.test.ts
+++ b/server/tests/unit/auth/registerMcpOAuthClient.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { getLeafMcpOAuthScopes } from "@autumn/auth/oauth";
+import { LEAF_OAUTH_SCOPES } from "@autumn/shared";
+import { Scopes } from "@autumn/shared/scopeDefinitions";
+import { getRequestedScopesForMcpClient } from "@/internal/auth/actions/registerMcpOAuthClient.js";
+
+describe("getRequestedScopesForMcpClient", () => {
+	test("defaults Slack MCP clients to Leaf OAuth scopes", () => {
+		expect(
+			getRequestedScopesForMcpClient({ clientType: "slack", scope: undefined }),
+		).toEqual([...LEAF_OAUTH_SCOPES]);
+	});
+
+	test("defaults Codex MCP clients to Leaf OAuth scopes", () => {
+		expect(
+			getRequestedScopesForMcpClient({ clientType: "codex", scope: undefined }),
+		).toEqual([...LEAF_OAUTH_SCOPES]);
+	});
+
+	test("defaults dynamic MCP clients to Leaf OAuth scopes", () => {
+		expect(
+			getRequestedScopesForMcpClient({
+				clientType: "dynamic",
+				scope: undefined,
+			}),
+		).toEqual([...LEAF_OAUTH_SCOPES]);
+	});
+
+	test("caps explicit requested scopes to Leaf scopes", () => {
+		expect(
+			getRequestedScopesForMcpClient({
+				clientType: "slack",
+				scope: `${Scopes.Customers.Read} ${Scopes.Plans.Write} ${Scopes.ApiKeys.Write} invalid`,
+			}),
+		).toEqual([Scopes.Customers.Read, Scopes.Plans.Write]);
+	});
+
+	test("caps OAuth grants to Leaf scopes", () => {
+		expect(
+			getLeafMcpOAuthScopes([
+				Scopes.Customers.Read,
+				Scopes.ApiKeys.Write,
+				Scopes.Analytics.Read,
+			]),
+		).toEqual([Scopes.Customers.Read, Scopes.Analytics.Read]);
+	});
+});

--- a/server/tests/unit/auth/registerMcpOAuthClient.test.ts
+++ b/server/tests/unit/auth/registerMcpOAuthClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getLeafMcpOAuthScopes } from "@autumn/auth/oauth";
+import { getDefaultOAuthScopes } from "@autumn/auth/oauth";
 import { LEAF_OAUTH_SCOPES } from "@autumn/shared";
 import { Scopes } from "@autumn/shared/scopeDefinitions";
 import { getRequestedScopesForMcpClient } from "@/internal/auth/actions/registerMcpOAuthClient.js";
@@ -37,7 +37,7 @@ describe("getRequestedScopesForMcpClient", () => {
 
 	test("caps OAuth grants to Leaf scopes", () => {
 		expect(
-			getLeafMcpOAuthScopes([
+			getDefaultOAuthScopes([
 				Scopes.Customers.Read,
 				Scopes.ApiKeys.Write,
 				Scopes.Analytics.Read,

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -217,6 +217,7 @@ export * from "./utils/fullSubjectUtils";
 export * from "./utils/index";
 export * from "./utils/intervalUtils";
 export * from "./utils/invoices/index";
+export * from "./utils/leafOAuthScopes";
 export * from "./utils/planFeatureUtils/planToDbFreeTrial";
 export * from "./utils/productDisplayUtils";
 export * from "./utils/productDisplayUtils/sortProductItems";

--- a/shared/package.json
+++ b/shared/package.json
@@ -15,6 +15,11 @@
 			"import": "./utils/scopeDefinitions.ts",
 			"default": "./utils/scopeDefinitions.ts"
 		},
+		"./leafOAuthScopes": {
+			"types": "./utils/leafOAuthScopes.ts",
+			"import": "./utils/leafOAuthScopes.ts",
+			"default": "./utils/leafOAuthScopes.ts"
+		},
 		"./unixUtils": {
 			"types": "./utils/common/unixUtils.ts",
 			"import": "./utils/common/unixUtils.ts",

--- a/shared/utils/leafOAuthScopes.test.ts
+++ b/shared/utils/leafOAuthScopes.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { LEAF_OAUTH_SCOPES } from "./leafOAuthScopes";
+import { Scopes } from "./scopeDefinitions";
+
+describe("LEAF_OAUTH_SCOPES", () => {
+	test("contains the exact Leaf Slack and MCP OAuth allowlist", () => {
+		expect(LEAF_OAUTH_SCOPES).toEqual([
+			Scopes.Organisation.Read,
+			Scopes.Customers.Read,
+			Scopes.Customers.Write,
+			Scopes.Features.Read,
+			Scopes.Features.Write,
+			Scopes.Plans.Read,
+			Scopes.Plans.Write,
+			Scopes.Balances.Read,
+			Scopes.Balances.Write,
+			Scopes.Billing.Read,
+			Scopes.Billing.Write,
+			Scopes.Analytics.Read,
+		]);
+	});
+
+	test("does not include elevated or unrelated product scopes", () => {
+		expect(LEAF_OAUTH_SCOPES).not.toEqual(
+			expect.arrayContaining([
+				Scopes.Organisation.Write,
+				Scopes.ApiKeys.Read,
+				Scopes.ApiKeys.Write,
+				Scopes.Migrations.Read,
+				Scopes.Migrations.Write,
+				Scopes.Platform.Read,
+				Scopes.Platform.Write,
+				Scopes.Rewards.Read,
+				Scopes.Rewards.Write,
+				Scopes.Admin,
+				Scopes.Owner,
+				Scopes.Superuser,
+			]),
+		);
+	});
+});

--- a/shared/utils/leafOAuthScopes.ts
+++ b/shared/utils/leafOAuthScopes.ts
@@ -1,0 +1,16 @@
+import { type ScopeString, Scopes } from "./scopeDefinitions";
+
+export const LEAF_OAUTH_SCOPES = [
+	Scopes.Organisation.Read,
+	Scopes.Customers.Read,
+	Scopes.Customers.Write,
+	Scopes.Features.Read,
+	Scopes.Features.Write,
+	Scopes.Plans.Read,
+	Scopes.Plans.Write,
+	Scopes.Balances.Read,
+	Scopes.Balances.Write,
+	Scopes.Billing.Read,
+	Scopes.Billing.Write,
+	Scopes.Analytics.Read,
+] as const satisfies readonly ScopeString[];

--- a/vite/src/views/auth/Consent.tsx
+++ b/vite/src/views/auth/Consent.tsx
@@ -2,6 +2,8 @@ import {
 	AppEnv,
 	type GroupedPermission,
 	groupAndFormatScopes,
+	isScopeSubset,
+	LEAF_OAUTH_SCOPES,
 } from "@autumn/shared";
 import { Check, Clock, ExternalLink, Shield, X } from "lucide-react";
 import { useEffect, useId, useState } from "react";
@@ -30,7 +32,12 @@ interface ClientInfo {
 	logo_uri?: string;
 	policy_uri?: string;
 	tos_uri?: string;
+	is_internal_mcp?: boolean;
 }
+
+type SessionWithScopes = {
+	scopes?: string[];
+};
 
 // Joke scopes - one is randomly selected to show at the end
 const JOKE_SCOPES = [
@@ -136,6 +143,23 @@ const openConsentRedirect = ({
 	}
 };
 
+const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
+
+const getGrantableMcpScopes = ({
+	requestedScopes,
+	sessionScopes,
+}: {
+	requestedScopes: string[];
+	sessionScopes: string[];
+}) => {
+	const requested =
+		requestedScopes.length > 0 ? requestedScopes : [...LEAF_OAUTH_SCOPES];
+
+	return [...new Set(requested)]
+		.filter((scope) => leafScopeSet.has(scope))
+		.filter((scope) => isScopeSubset([scope], sessionScopes));
+};
+
 export const Consent = () => {
 	const [searchParams] = useSearchParams();
 	const { data: session } = useSession();
@@ -159,7 +183,10 @@ export const Consent = () => {
 
 	const clientId = searchParams.get("client_id");
 	const redirectUri = searchParams.get("redirect_uri");
-	const requestedScopes = searchParams.get("scope")?.split(" ") || [];
+	const requestedScopes =
+		searchParams.get("scope")?.split(/\s+/).filter(Boolean) || [];
+	const sessionScopes =
+		(session as SessionWithScopes | null | undefined)?.scopes ?? [];
 
 	// Get the current org (active or first available)
 	const currentOrg = activeOrganization || orgs?.[0];
@@ -185,6 +212,7 @@ export const Consent = () => {
 				return;
 			}
 
+			let isInternalMcp = false;
 			try {
 				// Fetch client name from our own endpoint
 				const clientInfoUrl = new URL(
@@ -198,10 +226,12 @@ export const Consent = () => {
 
 				if (response.ok) {
 					const data = await response.json();
+					isInternalMcp = data.is_internal_mcp === true;
 					setClientInfo({
 						client_id: clientId,
 						client_name: data.name || "Unknown Application",
 						is_atmn: data.is_atmn === true,
+						is_internal_mcp: isInternalMcp,
 					});
 				} else {
 					console.error("Error fetching client info:", response.status);
@@ -210,6 +240,7 @@ export const Consent = () => {
 						client_id: clientId,
 						client_name: "External Application",
 						is_atmn: false,
+						is_internal_mcp: false,
 					});
 				}
 			} catch (error) {
@@ -219,24 +250,41 @@ export const Consent = () => {
 					client_id: clientId,
 					client_name: "External Application",
 					is_atmn: false,
+					is_internal_mcp: false,
 				});
 			}
 
 			// Parse and group scopes by resource
-			const grouped = groupAndFormatScopes(requestedScopes);
+			const displayScopes =
+				isInternalMcp === true
+					? getGrantableMcpScopes({ requestedScopes, sessionScopes })
+					: requestedScopes;
+			const grouped = groupAndFormatScopes(displayScopes);
 			setGroupedPermissions(grouped);
 			setIsLoading(false);
 		}
 
 		fetchClientInfo();
-	}, [clientId, redirectUri, requestedScopes.join(",")]);
+	}, [
+		clientId,
+		redirectUri,
+		requestedScopes.join(","),
+		sessionScopes.join(","),
+	]);
 
 	const handleAuthorize = async () => {
+		if (!clientInfo) {
+			toast.error("Authorization failed");
+			return;
+		}
+
 		setIsSubmitting(true);
 		setPendingRedirectUrl(null);
 		try {
-			// Use the original requested scopes
-			const grantedScopes = requestedScopes.join(" ");
+			const grantedScopes =
+				clientInfo.is_internal_mcp === true
+					? getGrantableMcpScopes({ requestedScopes, sessionScopes }).join(" ")
+					: requestedScopes.join(" ");
 
 			const { data, error } = await authClient.oauth2.consent({
 				accept: true,


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Leaf/MCP OAuth to a strict `LEAF_OAUTH_SCOPES` allowlist with per-user, per-org enforcement. Tokens, refresh records, and consent now carry only granted scopes, and token responses include the final `scope`.

- **New Features**
  - Added `LEAF_OAUTH_SCOPES` in `@autumn/shared` and `@autumn/auth` helpers (`getDefaultOAuthScopes`, MCP client constants/detection, OAuth token request resource parsing).
  - Consent flow pre-validates scope grants, rewrites the request with the granted scope string, stores granted scopes on consent, and returns `invalid_scope` on mismatches.
  - Token endpoint intersects requested scopes with user/org grants, persists final scopes to access/refresh tokens, includes `scope` in responses, and uses resource-based MCP detection (`/mcp`) via `oauthResource`/`x-autumn-oauth-resource`.
  - Protected resource metadata now advertises the allowlist (`scopes_supported = LEAF_OAUTH_SCOPES`).
  - Consent UI filters MCP scopes by session and the allowlist, and submits the reduced scope string.
  - MCP client registration defaults and caps scopes via `getDefaultOAuthScopes`, and classifies unknown clients as `dynamic`.

- **Bug Fixes**
  - Replaced `ALL_SCOPES`/`MCP_OAUTH_SCOPES` with `LEAF_OAUTH_SCOPES` across installs, metadata, auth resolution, and tests.
  - Blocked OAuth API key creation for MCP clients; they must use OAuth access tokens. Non-MCP paths now use requested or token scopes consistently.
  - Reject token issuance when scopes are empty and make client registration scopes deterministic.

<sup>Written for commit c4b9669154c9cd8d0ea59c0012e33bcfdf0a0cbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the broad `ALL_SCOPES` grant used across Leaf/MCP OAuth flows with a curated `LEAF_OAUTH_SCOPES` allowlist, and adds server-side scope-intersection enforcement so tokens issued to MCP clients are capped to scopes the authenticated user actually holds.

- **Bug fixes / Improvements**: Introduces `LEAF_OAUTH_SCOPES` in `@autumn/shared` and `getLeafMcpOAuthScopes` in `@autumn/auth/oauth`, replacing scattered `ALL_SCOPES` references in Slack credential creation, the consent handler, the token endpoint, and leaf auth resolution.
- **Improvements**: Consent handler (`handleOAuthConsentWithEnv`) now validates and rewrites the requested scope before delegating to `auth.handler`, and the token handler (`handleOAuthTokenWithApiKey`) runs `assertMcpOAuthScopeGrant` and injects the granted scope string into the token response body.
- **Improvements**: `classifyMcpClient` in `registerMcpOAuthClient` now returns a `dynamic` type for unrecognized clients instead of rejecting them, and the consent UI filters displayable/grantable scopes by the user's session scopes for MCP clients.
</details>


<h3>Confidence Score: 3/5</h3>

The OAuth scope-narrowing logic is well-structured, but the Braintrust config change unconditionally enables tracing in all environments and should not ship as-is.

The core scope enforcement work — LEAF_OAUTH_SCOPES allowlist, server-side scope intersection, consent rewriting — is implemented correctly and is well-tested. However, braintrust/config.ts was changed to enabled: true, permanently enabling Braintrust tracing regardless of LEAF_BRAINTRUST_ENABLED or NODE_ENV. If this ships, every production request will be traced unconditionally with no way to opt out via environment variables.

apps/leaf/src/providers/braintrust/config.ts should be reverted before merge. server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts has a minor OAuth spec mismatch in its error mapping.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/providers/braintrust/config.ts | Braintrust enabled flag is now hardcoded to true, discarding the LEAF_BRAINTRUST_ENABLED / NODE_ENV guard that previously controlled it. |
| server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts | Token endpoint now validates MCP scope grants and injects the scope string into the token response; RecaseError catch block maps all errors — including insufficient-scope — to invalid_grant rather than the RFC 6749–correct invalid_scope. |
| server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts | Consent handler gains pre-flight scope validation and request rewriting before delegating to auth.handler; contains a minor redundant session fetch after the underlying handler returns. |
| server/src/internal/auth/oauth/mcpOAuthScopes.ts | New server module for scope-grant enforcement: isMcpOAuthClientId, getMcpOAuthScopeGrant, and assertMcpOAuthScopeGrant correctly intersect requested scopes with the user's session scopes and LEAF_OAUTH_SCOPES. |
| packages/auth/src/oauth/mcpOAuth.ts | New shared package module centralizing MCP OAuth client constants, type helpers, and getLeafMcpOAuthScopes filter — a clean extraction from server-local code. |
| shared/utils/leafOAuthScopes.ts | New file defining the LEAF_OAUTH_SCOPES allowlist — a curated read/write subset of ALL_SCOPES, excluding elevated scopes like ApiKeys, Migrations, and Admin. |
| server/src/internal/auth/actions/registerMcpOAuthClient.ts | Scope logic updated to use getLeafMcpOAuthScopes; classifyMcpClient now returns a dynamic client type for unknown clients instead of null, removing the unsupported_mcp_client rejection for truly unknown clients. |
| vite/src/views/auth/Consent.tsx | UI now computes grantable MCP scopes client-side based on is_internal_mcp flag and session scopes, ensuring the consent dialog only displays and submits scopes the user actually holds. |
| apps/leaf/src/internal/installations/actions/replaceInstallationOAuthCredentials.ts | Slack MCP OAuth credential creation updated from ALL_SCOPES to LEAF_OAUTH_SCOPES consistently across client registration, consent, and token records. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Consent as ConsentHandler
    participant Auth as auth.handler
    participant Token as TokenHandler
    participant DB as Database

    Client->>Consent: "POST /oauth/consent (accept=true, scope=...)"
    Consent->>Auth: getSession(headers)
    Auth-->>Consent: "session {userId, orgId}"
    Consent->>DB: assertMcpOAuthScopeGrant(clientId, requestedScopes)
    DB-->>Consent: grantedScopes (LEAF_OAUTH_SCOPES intersect userScopes)
    Consent->>Consent: withScope(request, grantedScopes)
    Consent->>Auth: auth.handler(rewritten request)
    Auth-->>Consent: 200 OK
    Consent->>DB: "updateOAuthConsentEnv(scopes=grantedScopes)"
    Consent-->>Client: 200 OK

    Client->>Token: "POST /oauth/token (code=...)"
    Token->>Auth: auth.handler(request)
    Auth-->>Token: "{access_token, scope}"
    Token->>DB: getOAuthAccessTokenRecord(accessToken)
    DB-->>Token: "tokenRecord {clientId, scopes}"
    Token->>DB: assertMcpOAuthScopeGrant(clientId, tokenRecord.scopes)
    DB-->>Token: grantedScopes
    Token-->>Client: "{access_token: am_oauth_..., scope: grantedScopes}"
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts`, line 163-174 ([link](https://github.com/useautumn/autumn/blob/223dfd79f8ee8ba6e852b1c1c1c62e3b89ac2caf/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts#L163-L174)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> When `assertMcpOAuthScopeGrant` throws its "No requested scopes can be granted" error (status 403, `ErrCode.InsufficientScopes`), the outer catch maps every `RecaseError` to `error: "invalid_grant"`. RFC 6749 §5.2 reserves `invalid_grant` for invalid or expired authorization codes/tokens; a scope mismatch should be `invalid_scope`. MCP clients that inspect the `error` field to guide retries may behave unexpectedly.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
   Line: 163-174

   Comment:
   When `assertMcpOAuthScopeGrant` throws its "No requested scopes can be granted" error (status 403, `ErrCode.InsufficientScopes`), the outer catch maps every `RecaseError` to `error: "invalid_grant"`. RFC 6749 §5.2 reserves `invalid_grant` for invalid or expired authorization codes/tokens; a scope mismatch should be `invalid_scope`. MCP clients that inspect the `error` field to guide retries may behave unexpectedly.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/leaf/src/providers/braintrust/config.ts:1-5
Braintrust tracing is now unconditionally enabled. The original logic respected `LEAF_BRAINTRUST_ENABLED` and `NODE_ENV`, so operators could gate tracing per environment. Hardcoding `true` means production traffic is always traced regardless of environment variables, which can quietly incur Braintrust costs or send sensitive data when the service was previously configured off.

```suggestion
export const braintrustConfig = {
	enabled:
		process.env.LEAF_BRAINTRUST_ENABLED === "true" ||
		(process.env.NODE_ENV !== "production" &&
			process.env.LEAF_BRAINTRUST_ENABLED !== "false"),
	projectName: process.env.LEAF_BRAINTRUST_PROJECT ?? "leaf",
	serviceName: process.env.LEAF_BRAINTRUST_SERVICE ?? "leaf",
};
```

### Issue 2 of 3
server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts:163-174
When `assertMcpOAuthScopeGrant` throws its "No requested scopes can be granted" error (status 403, `ErrCode.InsufficientScopes`), the outer catch maps every `RecaseError` to `error: "invalid_grant"`. RFC 6749 §5.2 reserves `invalid_grant` for invalid or expired authorization codes/tokens; a scope mismatch should be `invalid_scope`. MCP clients that inspect the `error` field to guide retries may behave unexpectedly.

```suggestion
	} catch (error) {
		if (error instanceof RecaseError) {
			const oauthError =
				error.code === ErrCode.InsufficientScopes
					? "invalid_scope"
					: "invalid_grant";
			return jsonTokenResponse({
				body: {
					error: oauthError,
					error_description: error.message,
				},
				status: error.statusCode,
			});
		}
		throw error;
	}
```

### Issue 3 of 3
server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts:200-203
Redundant session fetch after `auth.handler`. The session was already resolved on line 154 (for the scope-grant path) and will succeed again here under identical conditions — the same cookie/session headers are used both times. The first-fetch result could be threaded through to avoid the second round-trip.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: oauth scopes"](https://github.com/useautumn/autumn/commit/223dfd79f8ee8ba6e852b1c1c1c62e3b89ac2caf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36219136)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->