### PR TITLE
fix: admin oauth

### DIFF
--- a/server/src/internal/admin/handleSlackAdminChat.ts
+++ b/server/src/internal/admin/handleSlackAdminChat.ts
@@ -1,24 +1,32 @@
-import { randomUUID } from "node:crypto";
+import crypto, { randomUUID } from "node:crypto";
+import { stripOAuthTokenPrefix } from "@autumn/auth";
 import {
 	AppEnv,
+	apiKeys,
+	type ChatOAuthCredential,
 	chatInstallations,
 	chatOAuthCredentials,
 	createChatInstallState,
 	ErrCode,
+	oauthAccessToken,
+	oauthConsent,
+	oauthRefreshToken,
 	organizations,
 	RecaseError,
 	Scopes,
 } from "@autumn/shared";
 import { addMinutes } from "date-fns";
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { hashOAuthToken } from "@/utils/oauthUtils.js";
 import {
 	createSlackInstallUrl,
 	getChatStateSecret,
 	getSlackAdminProvider,
 } from "../chat/chatUtils.js";
+import { clearSecretKeyCache } from "../dev/api-keys/cacheApiKeyUtils.js";
 
 const targetBody = z.strictObject({
 	org_id: z.string().min(1),
@@ -55,6 +63,123 @@ const getSlackAdminOAuthCredentials = async ({
 		where: eq(chatOAuthCredentials.chat_installation_id, installationId),
 	});
 
+const getOrgSummary = async ({
+	db,
+	orgId,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+}) =>
+	db.query.organizations.findFirst({
+		where: eq(organizations.id, orgId),
+		columns: {
+			id: true,
+			name: true,
+			slug: true,
+		},
+	});
+
+const decryptChatCredentialToken = ({ token }: { token: string }) => {
+	const key = crypto
+		.createHash("sha256")
+		.update(process.env.ENCRYPTION_PASSWORD ?? "")
+		.digest();
+	const buffer = Buffer.from(token, "base64");
+	if (buffer[0] !== 1) throw new Error("Unsupported encrypted payload");
+	const decipher = crypto.createDecipheriv(
+		"aes-256-gcm",
+		key,
+		buffer.subarray(1, 13),
+	);
+	decipher.setAuthTag(buffer.subarray(13, 29));
+	return Buffer.concat([
+		decipher.update(buffer.subarray(29)),
+		decipher.final(),
+	]).toString("utf8");
+};
+
+const getStoredOAuthTokenValues = async ({
+	token,
+	stripPrefix = false,
+}: {
+	token: string;
+	stripPrefix?: boolean;
+}) => {
+	const rawToken = stripPrefix ? stripOAuthTokenPrefix({ token }) : token;
+	return [rawToken, await hashOAuthToken(rawToken)];
+};
+
+const revokeSlackAdminOAuthArtifacts = async ({
+	db,
+	credentials,
+}: {
+	db: Pick<DrizzleCli, "delete" | "select">;
+	credentials: ChatOAuthCredential[];
+}) => {
+	const consentIds = [
+		...new Set(
+			credentials
+				.map((credential) => credential.oauth_consent_id)
+				.filter((id): id is string => Boolean(id)),
+		),
+	];
+
+	if (consentIds.length > 0) {
+		const accessTokenValues: string[] = [];
+		const refreshTokenValues: string[] = [];
+		for (const credential of credentials) {
+			accessTokenValues.push(
+				...(await getStoredOAuthTokenValues({
+					token: decryptChatCredentialToken({ token: credential.access_token }),
+					stripPrefix: true,
+				})),
+			);
+			refreshTokenValues.push(
+				...(await getStoredOAuthTokenValues({
+					token: decryptChatCredentialToken({
+						token: credential.refresh_token,
+					}),
+				})),
+			);
+		}
+
+		const uniqueAccessTokenValues = [...new Set(accessTokenValues)];
+		const uniqueRefreshTokenValues = [...new Set(refreshTokenValues)];
+		if (uniqueAccessTokenValues.length > 0) {
+			await db
+				.delete(oauthAccessToken)
+				.where(inArray(oauthAccessToken.token, uniqueAccessTokenValues));
+		}
+		if (uniqueRefreshTokenValues.length > 0) {
+			await db
+				.delete(oauthRefreshToken)
+				.where(inArray(oauthRefreshToken.token, uniqueRefreshTokenValues));
+		}
+
+		for (const consentId of consentIds) {
+			const linkedKeys = await db
+				.select({ id: apiKeys.id, hashedKey: apiKeys.hashed_key })
+				.from(apiKeys)
+				.where(sql`${apiKeys.meta}->>'oauth_consent_id' = ${consentId}`);
+
+			for (const key of linkedKeys) {
+				await db.delete(apiKeys).where(eq(apiKeys.id, key.id));
+				if (key.hashedKey)
+					await clearSecretKeyCache({ hashedKey: key.hashedKey });
+			}
+		}
+
+		await db.delete(oauthConsent).where(inArray(oauthConsent.id, consentIds));
+	}
+
+	const credentialIds = credentials.map((credential) => credential.id);
+	if (credentialIds.length > 0) {
+		await db
+			.delete(chatOAuthCredentials)
+			.where(inArray(chatOAuthCredentials.id, credentialIds));
+	}
+};
+
 export const handleCreateSlackAdminInstall = createRoute({
 	scopes: [Scopes.Superuser],
 	handler: async (c) => {
@@ -78,6 +203,9 @@ export const handleGetSlackAdminInstall = createRoute({
 	handler: async (c) => {
 		const { db } = c.get("ctx");
 		const installation = await getSlackAdminInstallation({ db });
+		const targetOrg = installation
+			? await getOrgSummary({ db, orgId: installation.org_id })
+			: null;
 		const oauthCredentials = installation
 			? await getSlackAdminOAuthCredentials({
 					db,
@@ -93,6 +221,8 @@ export const handleGetSlackAdminInstall = createRoute({
 						workspace_name: installation.workspace_name,
 						bot_user_id: installation.bot_user_id,
 						target_org_id: installation.org_id,
+						target_org_name: targetOrg?.name ?? null,
+						target_org_slug: targetOrg?.slug ?? null,
 						target_env: installation.default_env,
 						updated_at: installation.updated_at,
 						installed_by_user_id: installation.installed_by_user_id,
@@ -135,6 +265,10 @@ export const handleUpdateSlackAdminTarget = createRoute({
 			});
 		}
 
+		const oauthCredentials = await getSlackAdminOAuthCredentials({
+			db,
+			installationId: installation.id,
+		});
 		const updated = await db.transaction(async (tx) => {
 			const now = Date.now();
 			const [updatedInstallation] = await tx
@@ -148,9 +282,10 @@ export const handleUpdateSlackAdminTarget = createRoute({
 				.where(eq(chatInstallations.id, installation.id))
 				.returning();
 
-			await tx
-				.delete(chatOAuthCredentials)
-				.where(eq(chatOAuthCredentials.chat_installation_id, installation.id));
+			await revokeSlackAdminOAuthArtifacts({
+				db: tx,
+				credentials: oauthCredentials,
+			});
 
 			return updatedInstallation;
 		});
@@ -161,6 +296,8 @@ export const handleUpdateSlackAdminTarget = createRoute({
 				workspace_id: updated.workspace_id,
 				workspace_name: updated.workspace_name,
 				target_org_id: updated.org_id,
+				target_org_name: targetOrg.name,
+				target_org_slug: targetOrg.slug,
 				target_env: updated.default_env,
 				updated_at: updated.updated_at,
 				installed_by_user_id: updated.installed_by_user_id,
@@ -175,11 +312,16 @@ export const handleDeleteSlackAdminInstall = createRoute({
 		const { db } = c.get("ctx");
 		const installation = await getSlackAdminInstallation({ db });
 		if (!installation) return c.json({ success: true });
+		const oauthCredentials = await getSlackAdminOAuthCredentials({
+			db,
+			installationId: installation.id,
+		});
 
 		await db.transaction(async (tx) => {
-			await tx
-				.delete(chatOAuthCredentials)
-				.where(eq(chatOAuthCredentials.chat_installation_id, installation.id));
+			await revokeSlackAdminOAuthArtifacts({
+				db: tx,
+				credentials: oauthCredentials,
+			});
 			await tx
 				.delete(chatInstallations)
 				.where(

--- a/server/src/internal/auth/repos/oauthConsentRepo.ts
+++ b/server/src/internal/auth/repos/oauthConsentRepo.ts
@@ -1,5 +1,6 @@
+import { AUTUMN_ADMIN_OAUTH_CLIENT_ID } from "@autumn/auth/oauth";
 import { type AppEnv, oauthConsent } from "@autumn/shared";
-import { and, eq, isNull, or } from "drizzle-orm";
+import { and, eq, isNull, ne, or, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 export type OAuthConsentApiKeyRecord = {
@@ -13,10 +14,12 @@ export const listOAuthConsentsByReferenceId = async ({
 	db,
 	referenceId,
 	env,
+	includeInternal = false,
 }: {
 	db: DrizzleCli;
 	referenceId: string;
 	env?: AppEnv;
+	includeInternal?: boolean;
 }) =>
 	db
 		.select({
@@ -35,6 +38,12 @@ export const listOAuthConsentsByReferenceId = async ({
 				env
 					? or(isNull(oauthConsent.env), eq(oauthConsent.env, env))
 					: undefined,
+				includeInternal
+					? undefined
+					: and(
+							ne(oauthConsent.clientId, AUTUMN_ADMIN_OAUTH_CLIENT_ID),
+							sql`COALESCE(${oauthConsent.metadata}->>'kind', '') != 'slack_admin'`,
+						),
 			),
 		);
 

--- a/vite/src/views/admin/components/SlackAdminBotTab.tsx
+++ b/vite/src/views/admin/components/SlackAdminBotTab.tsx
@@ -23,6 +23,8 @@ type SlackAdminInstallation = {
 	workspace_name?: string | null;
 	bot_user_id?: string | null;
 	target_org_id: string;
+	target_org_name?: string | null;
+	target_org_slug?: string | null;
 	target_env: AppEnv;
 	updated_at?: number | null;
 	installed_by_user_id?: string | null;
@@ -75,6 +77,10 @@ export const SlackAdminBotTab = () => {
 
 	const installation = data?.installation ?? null;
 	const credentials = installation?.oauth_credentials ?? [];
+	const targetOrgName =
+		installation?.target_org_name ||
+		installation?.target_org_slug ||
+		installation?.target_org_id;
 
 	const { data: orgSearchData, isLoading: isSearchingOrgs } =
 		useQuery<OrgSearchResponse>({
@@ -215,6 +221,19 @@ export const SlackAdminBotTab = () => {
 				<div className="grid grid-cols-1 md:grid-cols-[1fr_160px_auto] gap-2 items-start">
 					<div className="space-y-1">
 						<span className="text-xs text-muted-foreground">Target org</span>
+						{installation ? (
+							<div className="rounded-md border border-border bg-background px-3 py-2">
+								<p className="truncate text-xs font-medium text-foreground">
+									{targetOrgName}
+								</p>
+								<p className="truncate font-mono text-[11px] text-tertiary-foreground">
+									{installation.target_org_id}
+									{installation.target_org_slug
+										? ` - ${installation.target_org_slug}`
+										: ""}
+								</p>
+							</div>
+						) : null}
 						<Input
 							value={targetOrgIdOrSlug}
 							onChange={(event) => setTargetOrgIdOrSlug(event.target.value)}


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack Admin OAuth by fully revoking tokens, consents, and linked API keys when changing the target org or uninstalling. Also shows the target org name/slug in the Slack Admin tab and hides internal admin consents from normal lists.

- **Bug Fixes**
  - Revoke all OAuth artifacts on target change/uninstall: delete `oauth_access_token`, `oauth_refresh_token`, `oauth_consent`, and related `api_keys`, and clear cached keys.
  - Correctly derive hashed token values from encrypted credentials, handling prefix stripping from `@autumn/auth`.
  - Exclude internal admin consents in `listOAuthConsentsByReferenceId` by default (filters `AUTUMN_ADMIN_OAUTH_CLIENT_ID` and `metadata.kind=slack_admin`), with an `includeInternal` opt-in.

- **UI Improvements**
  - Display target org name/slug/id in the Slack Admin tab for clarity.

<sup>Written for commit 4384c26758d281275cfc8c1e0c6e6d63575d1ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes admin OAuth cleanup so that revoking or retargeting the Slack admin bot properly tears down all linked OAuth artifacts — access tokens, refresh tokens, API keys, and consents — instead of only deleting the `chatOAuthCredentials` row. It also enriches the install response with the target org's name and slug, and filters internal OAuth consents from the user-facing consent list by default.

- **Bug fixes**: Replace bare `chatOAuthCredentials` deletion with `revokeSlackAdminOAuthArtifacts`, which decrypts stored tokens, deletes linked `oauthAccessToken`/`oauthRefreshToken` rows, removes associated API keys (with cache invalidation), and deletes the parent `oauthConsent` record.
- **Improvements**: `handleGetSlackAdminInstall` and `handleUpdateSlackAdminTarget` now return `target_org_name` and `target_org_slug`; the admin UI renders a summary card showing the currently targeted org.
- **Improvements**: `listOAuthConsentsByReferenceId` gains an `includeInternal` flag (default `false`) that excludes consents linked to the admin OAuth client ID or tagged with `kind: slack_admin` from non-admin callers.
</details>

<h3>Confidence Score: 3/5</h3>

The core revocation logic works correctly in the happy path, but a gap in the token-cleanup guard means credentials without an `oauth_consent_id` can leave orphaned token rows even after the bot is fully revoked.

The token/refresh-token deletion block is entirely wrapped in `if (consentIds.length > 0)`, so credentials stored without a consent linkage never have their backing `oauthAccessToken`/`oauthRefreshToken` records removed. This is a real cleanup gap since the column is nullable and legacy rows can exist. The rest of the implementation — transaction handling, cache invalidation, consent filter, UI — looks solid.

The revocation function in `handleSlackAdminChat.ts` (lines 112–181) needs the most attention; `oauthConsentRepo.ts` and the frontend component are low risk.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/admin/handleSlackAdminChat.ts | Adds `revokeSlackAdminOAuthArtifacts` to properly clean up OAuth tokens, API keys, and consents; adds org name/slug enrichment to install responses. Token decryption occurs inside the transaction with no fallback, and credentials are fetched outside the transaction boundary. |
| server/src/internal/auth/repos/oauthConsentRepo.ts | Adds `includeInternal` flag to `listOAuthConsentsByReferenceId` to exclude admin-bot-linked consents from user-facing consent lists by default. Filter logic and De Morgan's application are correct. |
| vite/src/views/admin/components/SlackAdminBotTab.tsx | Adds display of target org name/slug from the enriched API response. Fallback chain (name to slug to id) is correct, and new fields are consistently optional in the type definition. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Admin as Admin UI
    participant Server as Server
    participant DB as Database (tx)
    participant Cache as Key Cache

    Admin->>Server: PATCH /admin/chat/slack-admin/target
    Server->>DB: getSlackAdminInstallation()
    Server->>DB: findTargetOrg()
    Server->>DB: getSlackAdminOAuthCredentials() [outside tx]
    Server->>DB: BEGIN TRANSACTION
    Server->>DB: UPDATE chatInstallations SET org_id, env
    Server->>Server: decryptChatCredentialToken(access_token x N)
    Server->>Server: decryptChatCredentialToken(refresh_token x N)
    Server->>DB: DELETE oauthAccessToken WHERE token IN [...]
    Server->>DB: DELETE oauthRefreshToken WHERE token IN [...]
    loop per consentId
        Server->>DB: "SELECT apiKeys WHERE meta->oauth_consent_id = consentId"
        Server->>DB: "DELETE apiKeys WHERE id = key.id"
        Server->>Cache: clearSecretKeyCache(hashedKey)
    end
    Server->>DB: DELETE oauthConsent WHERE id IN consentIds
    Server->>DB: DELETE chatOAuthCredentials WHERE id IN credentialIds
    Server->>DB: COMMIT
    Server-->>Admin: installation with target_org_name, target_org_slug
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/admin/handleSlackAdminChat.ts:127-157
**Token cleanup silently skipped when no credential carries an `oauth_consent_id`**

The entire access-token, refresh-token, API-key, and consent deletion block is gated on `consentIds.length > 0`. A credential row is valid with a `null` `oauth_consent_id` (the column has no `notNull` constraint). If all stored credentials happen to have `null` there — for example, credentials created before the consent linkage was introduced — `oauthAccessToken` and `oauthRefreshToken` records whose values match those credentials are never deleted, even though the decrypted token values are computed for all credentials unconditionally. The `chatOAuthCredentials` rows are still removed (the outer block runs), but the backing token-table records leak.

```suggestion
	const accessTokenValues: string[] = [];
	const refreshTokenValues: string[] = [];
	for (const credential of credentials) {
		accessTokenValues.push(
			...(await getStoredOAuthTokenValues({
				token: decryptChatCredentialToken({ token: credential.access_token }),
				stripPrefix: true,
			})),
		);
		refreshTokenValues.push(
			...(await getStoredOAuthTokenValues({
				token: decryptChatCredentialToken({
					token: credential.refresh_token,
				}),
			})),
		);
	}

	const uniqueAccessTokenValues = [...new Set(accessTokenValues)];
	const uniqueRefreshTokenValues = [...new Set(refreshTokenValues)];
	if (uniqueAccessTokenValues.length > 0) {
		await db
			.delete(oauthAccessToken)
			.where(inArray(oauthAccessToken.token, uniqueAccessTokenValues));
	}
	if (uniqueRefreshTokenValues.length > 0) {
		await db
			.delete(oauthRefreshToken)
			.where(inArray(oauthRefreshToken.token, uniqueRefreshTokenValues));
	}

	if (consentIds.length > 0) {
		for (const consentId of consentIds) {
```

### Issue 2 of 2
server/src/internal/admin/handleSlackAdminChat.ts:268-291
**Credentials fetched outside the transaction boundary**

`oauthCredentials` is read before `db.transaction(...)` starts. If a concurrent OAuth callback inserts a new `chatOAuthCredentials` row between the fetch and the transaction commit, that credential will not be included in `revokeSlackAdminOAuthArtifacts`; its associated `oauthAccessToken`, `oauthRefreshToken`, `apiKeys`, and `oauthConsent` records will be left behind. The same pattern appears in `handleDeleteSlackAdminInstall` (line ~315). The `chatOAuthCredentials` cascade-delete on `chatInstallations` will still remove the raw row, but the sibling OAuth artifact tables won't be cleaned up.

Consider re-fetching `oauthCredentials` using `tx.select()` inside the transaction so the read and the deletes share the same snapshot.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: admin oauth"](https://github.com/useautumn/autumn/commit/4384c26758d281275cfc8c1e0c6e6d63575d1ff4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36225889)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->