### PR TITLE
fix: idempotency errors

### DIFF
--- a/server/src/honoMiddlewares/idempotencyMiddleware.ts
+++ b/server/src/honoMiddlewares/idempotencyMiddleware.ts
@@ -1,10 +1,31 @@
+import { ErrCode } from "@autumn/shared";
 import type { Context, Next } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
-import { checkIdempotencyKey } from "@/internal/misc/idempotency/checkIdempotencyKey.js";
+import {
+	checkIdempotencyKey,
+	releaseIdempotencyKey,
+} from "@/internal/misc/idempotency/checkIdempotencyKey.js";
 
-/**
- * Middleware that checks for idempotence in a request
- */
+const shouldReleaseStatus = (status: number) =>
+	status >= 400 && status < 500 && status !== 409;
+
+const shouldReleaseError = (error: unknown) => {
+	const statusCode =
+		typeof error === "object" && error !== null && "statusCode" in error
+			? Number(error.statusCode)
+			: null;
+	const code =
+		typeof error === "object" && error !== null && "code" in error
+			? String(error.code)
+			: null;
+
+	return (
+		statusCode !== null &&
+		shouldReleaseStatus(statusCode) &&
+		code !== ErrCode.DuplicateIdempotencyKey
+	);
+};
+
 export const idempotencyMiddleware = async (
 	c: Context<HonoEnv>,
 	next: Next,
@@ -23,5 +44,25 @@ export const idempotencyMiddleware = async (
 		});
 	}
 
-	await next();
+	try {
+		await next();
+	} catch (error) {
+		if (idempotencyKey && shouldReleaseError(error)) {
+			await releaseIdempotencyKey({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				idempotencyKey,
+			});
+		}
+
+		throw error;
+	}
+
+	if (idempotencyKey && shouldReleaseStatus(c.res.status)) {
+		await releaseIdempotencyKey({
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idempotencyKey,
+		});
+	}
 };

--- a/server/src/internal/misc/idempotency/checkIdempotencyKey.ts
+++ b/server/src/internal/misc/idempotency/checkIdempotencyKey.ts
@@ -10,11 +10,22 @@ const hashIdempotencyKey = (key: string): string => {
 	return hasher.digest("base64url");
 };
 
-/**
- * Checks and sets an idempotency key in Redis using atomic SET NX operation.
- * If Redis is not ready, allows the request to proceed (fail-open).
- * Throws if the key already exists (duplicate request).
- */
+const buildRedisIdempotencyKey = ({
+	orgId,
+	env,
+	idempotencyKey,
+}: {
+	orgId: string;
+	env: string;
+	idempotencyKey: string;
+}) => {
+	const hashedKey = hashIdempotencyKey(idempotencyKey);
+	return {
+		hashedKey,
+		redisKey: `${orgId}:${env}:idempotency:${hashedKey}`,
+	};
+};
+
 export const checkIdempotencyKey = async ({
 	orgId,
 	env,
@@ -31,8 +42,11 @@ export const checkIdempotencyKey = async ({
 		return;
 	}
 
-	const hashedKey = hashIdempotencyKey(idempotencyKey);
-	const redisKey = `${orgId}:${env}:idempotency:${hashedKey}`;
+	const { hashedKey, redisKey } = buildRedisIdempotencyKey({
+		orgId,
+		env,
+		idempotencyKey,
+	});
 
 	try {
 		// Use SET NX (set if not exists) for atomic check-and-set to prevent race conditions
@@ -61,6 +75,32 @@ export const checkIdempotencyKey = async ({
 			throw error;
 		}
 		// For other Redis errors, fail-open (allow request)
+		return;
+	}
+};
+
+export const releaseIdempotencyKey = async ({
+	orgId,
+	env,
+	idempotencyKey,
+}: {
+	orgId: string;
+	env: string;
+	idempotencyKey: string;
+}): Promise<void> => {
+	if (redis.status !== "ready") {
+		return;
+	}
+
+	const { redisKey } = buildRedisIdempotencyKey({
+		orgId,
+		env,
+		idempotencyKey,
+	});
+
+	try {
+		await redis.del(redisKey);
+	} catch {
 		return;
 	}
 };

--- a/server/tests/integration/balances/track/track-global-idempotency-4xx.test.ts
+++ b/server/tests/integration/balances/track/track-global-idempotency-4xx.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression: pre-side-effect 4xx track failures must not burn the global Idempotency-Key.
+ * Before this, retrying returned duplicate_idempotency_key instead of the original 4xx.
+ */
+
+import { expect, test } from "bun:test";
+
+import { ErrCode } from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("track-global-idempotency-4xx: retries return original 4xx")}`,
+	async () => {
+		const { autumnV1, customerId } = await initScenario({
+			customerId: "track-global-idempotency-4xx",
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		const idempotencyKey = `track-global-idempotency-4xx-${Date.now().toString(36)}`;
+		const trackMissingEntity = async () =>
+			autumnV1.post(
+				"/track",
+				{
+					customer_id: customerId,
+					entity_id: `${customerId}-missing-entity`,
+					event_name: "messages",
+					value: 1,
+				},
+				{ "Idempotency-Key": idempotencyKey },
+			);
+
+		const getErrorCode = async () => {
+			try {
+				await trackMissingEntity();
+			} catch (error) {
+				if (error && typeof error === "object" && "code" in error) {
+					return String(error.code);
+				}
+
+				throw error;
+			}
+
+			throw new Error("Expected track to fail");
+		};
+
+		const firstCode = await getErrorCode();
+		expect(firstCode).not.toBe(ErrCode.DuplicateIdempotencyKey);
+		expect(await getErrorCode()).toBe(firstCode);
+	},
+);


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes idempotency handling so pre-side-effect 4xx errors don’t consume the global Idempotency-Key. Retries now return the original 4xx instead of `DuplicateIdempotencyKey`.

- **Bug Fixes**
  - Middleware releases idempotency keys on eligible 4xx responses and thrown errors (400–499 except 409); skips when error code is `ErrCode.DuplicateIdempotencyKey` from `@autumn/shared`.
  - Added `releaseIdempotencyKey` and a shared Redis key builder; continues fail-open behavior if Redis isn’t ready.
  - Added integration test `track-global-idempotency-4xx` to ensure retries return the original 4xx.

<sup>Written for commit e570a6d5bf3b91322ec495fb87a723451c2ffe25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where 4xx responses from track requests would permanently consume the idempotency key, causing retries to receive a `duplicate_idempotency_key` (409) error instead of the original 4xx. The fix introduces a `releaseIdempotencyKey` function that deletes the Redis key when a non-409 4xx response is produced, either as a thrown error or a returned response.

- **Bug fixes**: Adds `releaseIdempotencyKey` to delete the Redis idempotency key on 4xx responses (excluding 409), restoring the key for client retries. Handles both thrown errors (`statusCode` on the error object) and returned responses (`c.res.status`).
- **Improvements**: Extracts `buildRedisIdempotencyKey` helper to avoid duplicating the key construction logic between `checkIdempotencyKey` and the new `releaseIdempotencyKey`.
- **Bug fixes**: Adds an integration test that exercises the specific regression: submitting a failing track twice with the same idempotency key and asserting both calls return the original 4xx rather than `duplicate_idempotency_key`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix correctly releases the idempotency key on 4xx outcomes and is covered by a new integration test.

The two-path release strategy (catch block for thrown errors, post-`next()` check for returned responses) covers both ways a 4xx can surface in Hono. The new integration test directly exercises the regression. The only note is a redundant `DuplicateIdempotencyKey` guard that can never be triggered by an error flowing through `next()`.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/idempotencyMiddleware.ts | Core fix: wraps `next()` in try/catch and adds post-response status check to release the idempotency key on non-409 4xx outcomes. Logic is correct; one internal check is redundant. |
| server/src/internal/misc/idempotency/checkIdempotencyKey.ts | Adds `releaseIdempotencyKey` export and extracts `buildRedisIdempotencyKey` helper; both are straightforward and well-guarded with a Redis-ready check and a silent catch. |
| server/tests/integration/balances/track/track-global-idempotency-4xx.test.ts | New integration test that directly verifies the regression: two identical failing track calls return the same original error code, not `duplicate_idempotency_key`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as idempotencyMiddleware
    participant Redis
    participant Handler as Route Handler

    Client->>Middleware: Request + Idempotency-Key
    Middleware->>Redis: SET NX (key, 1, PX 24h)
    alt Key already exists
        Redis-->>Middleware: null (not set)
        Middleware-->>Client: 409 DuplicateIdempotencyKey
    else Key set successfully
        Redis-->>Middleware: "OK"
        Middleware->>Handler: next()
        alt Handler throws 4xx error (not 409)
            Handler-->>Middleware: throw RecaseError(statusCode: 4xx)
            Middleware->>Redis: DEL key (releaseIdempotencyKey)
            Middleware-->>Client: re-throw → 4xx response
            Note over Client,Redis: Key released — retry will succeed
        else Handler returns 4xx response
            Handler-->>Middleware: response (status 4xx, not 409)
            Middleware->>Redis: DEL key (releaseIdempotencyKey)
            Middleware-->>Client: 4xx response
            Note over Client,Redis: Key released — retry will succeed
        else Handler succeeds or returns 5xx
            Handler-->>Middleware: response (2xx or 5xx)
            Middleware-->>Client: response
            Note over Client,Redis: Key retained for full TTL
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/honoMiddlewares/idempotencyMiddleware.ts:22-26
The `code !== ErrCode.DuplicateIdempotencyKey` guard inside `shouldReleaseError` can never be reached by a `DuplicateIdempotencyKey` error. That error is thrown by `checkIdempotencyKey` *before* the `try { await next() }` block, so it bypasses the catch entirely and never enters `shouldReleaseError`. The check is harmless but misleading — it implies there's a path from a duplicate-key throw through `next()` that doesn't exist. Consider removing it to keep the intent clear.

```suggestion
	return statusCode !== null && shouldReleaseStatus(statusCode);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: idempotency errors"](https://github.com/useautumn/autumn/commit/e570a6d5bf3b91322ec495fb87a723451c2ffe25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36280075)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->