### PR TITLE
fix: idempotency errors

### DIFF
--- a/server/src/honoMiddlewares/idempotencyMiddleware.ts
+++ b/server/src/honoMiddlewares/idempotencyMiddleware.ts
@@ -6,8 +6,7 @@ import {
 	releaseIdempotencyKey,
 } from "@/internal/misc/idempotency/checkIdempotencyKey.js";
 
-const shouldReleaseStatus = (status: number) =>
-	status >= 400 && status < 500 && status !== 409;
+const shouldReleaseStatus = (status: number) => status >= 400 && status !== 409;
 
 const shouldReleaseError = (error: unknown) => {
 	const statusCode =

--- a/server/tests/integration/others/idempotency/idempotency-middleware.test.ts
+++ b/server/tests/integration/others/idempotency/idempotency-middleware.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { ErrCode } from "@autumn/shared";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { Hono } from "hono";
+import { errorMiddleware } from "@/honoMiddlewares/errorMiddleware.js";
+import { idempotencyMiddleware } from "@/honoMiddlewares/idempotencyMiddleware.js";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+
+const buildApp = () => {
+	const app = new Hono<HonoEnv>();
+
+	app.use("*", async (c, next) => {
+		c.set("ctx", ctx);
+		await next();
+	});
+	app.use("*", idempotencyMiddleware);
+
+	app.post("/success", (c) => c.json({ success: true }));
+	app.post("/failure", (c) => c.json({ success: false }, 500));
+
+	app.onError(errorMiddleware);
+
+	return app;
+};
+
+test.concurrent(
+	"idempotency middleware keeps keys for 200 responses",
+	async () => {
+		const app = buildApp();
+		const idempotencyKey = `idem-success-${Date.now().toString(36)}`;
+
+		const first = await app.request("http://localhost/success", {
+			method: "POST",
+			headers: { "Idempotency-Key": idempotencyKey },
+		});
+		const second = await app.request("http://localhost/success", {
+			method: "POST",
+			headers: { "Idempotency-Key": idempotencyKey },
+		});
+		const secondBody = await second.json();
+
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(409);
+		expect(secondBody.code).toBe(ErrCode.DuplicateIdempotencyKey);
+	},
+);
+
+test.concurrent(
+	"idempotency middleware releases keys for 500 responses",
+	async () => {
+		const app = buildApp();
+		const idempotencyKey = `idem-failure-${Date.now().toString(36)}`;
+
+		const first = await app.request("http://localhost/failure", {
+			method: "POST",
+			headers: { "Idempotency-Key": idempotencyKey },
+		});
+		const second = await app.request("http://localhost/failure", {
+			method: "POST",
+			headers: { "Idempotency-Key": idempotencyKey },
+		});
+
+		expect(first.status).toBe(500);
+		expect(second.status).toBe(500);
+	},
+);


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes idempotency so keys are released on all non-409 errors (including 5xx), preventing stuck keys and false 409s on retries. Adds integration tests confirming 200 responses keep the key and 500 responses release it.

- **Bug Fixes**
  - Updated `shouldReleaseStatus` to return true for `status >= 400 && status !== 409`.

<sup>Written for commit cc79c1ae2f18f4c5b56947fbc74037291d3c4bbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in the idempotency middleware where server errors (5xx) would leave idempotency keys permanently locked, blocking legitimate client retries. The single-line logic change now releases keys for all error statuses ≥ 400 except 409 (duplicate-key), aligning with industry-standard idempotency semantics (e.g. Stripe).

- **[Bug fixes]** Removed the `status < 500` upper bound in `shouldReleaseStatus`, so keys are now released after 5xx responses as well as 4xx; without this fix, any server error would permanently block retries using the same idempotency key.
- **[Improvements]** Added a new integration test suite covering both the "keep key on 200" and "release key on 500" paths, exercising the middleware end-to-end through a minimal Hono app.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix to key-release logic with direct test coverage.

The middleware previously held idempotency keys open after any server error, making retries impossible for clients who received a 5xx. The fix is a one-line removal of the `status < 500` upper bound, well-understood in scope, and covered by a new integration test that exercises both the retention (200 → 409 on retry) and release (500 → 500 on retry) paths. No edge cases appear to be left unhandled.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/idempotencyMiddleware.ts | Single-line fix: removes the `status < 500` guard so 5xx responses now release the idempotency key, allowing clients to retry after server errors. |
| server/tests/integration/others/idempotency/idempotency-middleware.test.ts | New integration tests validating that keys are retained after 200 responses (producing 409 on retry) and released after 500 responses (allowing retry to proceed normally). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as idempotencyMiddleware
    participant Handler as Route Handler
    participant Store as Idempotency Store

    Client->>Middleware: POST /endpoint (Idempotency-Key: K)
    Middleware->>Store: checkIdempotencyKey(K)
    Store-->>Middleware: OK (key registered)
    Middleware->>Handler: next()
    Handler-->>Middleware: response (200/4xx/5xx)

    alt status 200 (success)
        note over Middleware,Store: shouldReleaseStatus(200) → false
        Middleware-->>Client: 200 OK
        Client->>Middleware: POST /endpoint (Idempotency-Key: K) [retry]
        Middleware->>Store: checkIdempotencyKey(K)
        Store-->>Middleware: 409 DuplicateIdempotencyKey
        Middleware-->>Client: 409
    else status 5xx (server error) — FIXED
        note over Middleware,Store: shouldReleaseStatus(5xx) → true (was false before fix)
        Middleware->>Store: releaseIdempotencyKey(K)
        Middleware-->>Client: 5xx
        Client->>Middleware: POST /endpoint (Idempotency-Key: K) [retry]
        Middleware->>Store: checkIdempotencyKey(K)
        Store-->>Middleware: OK (key was released)
        Middleware->>Handler: next()
        Handler-->>Client: response
    else status 4xx except 409
        note over Middleware,Store: shouldReleaseStatus(4xx≠409) → true
        Middleware->>Store: releaseIdempotencyKey(K)
        Middleware-->>Client: 4xx
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/idempotency..."](https://github.com/useautumn/autumn/commit/cc79c1ae2f18f4c5b56947fbc74037291d3c4bbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36284335)</sub>

<!-- /greptile_comment -->