### PR TITLE
patch: 🩹 attach has metadata stripped out

### DIFF
--- a/packages/autumn-js/src/backend/core/handlers/executeRoute.ts
+++ b/packages/autumn-js/src/backend/core/handlers/executeRoute.ts
@@ -13,11 +13,13 @@ import { resolveIdentity } from "./resolveIdentity";
 const buildSdkArgs = ({
 	body,
 	identity,
+	route,
 }: {
 	body: unknown;
 	identity: ResolvedIdentity;
+	route: RouteDefinition;
 }): Record<string, unknown> => {
-	const args = sanitizeBody(body);
+	const args = sanitizeBody(body, route.protectedBodyFields);
 
 	if (identity.customerId) {
 		args.customerId = identity.customerId;
@@ -71,7 +73,7 @@ export const executeRoute = async ({
 	}
 
 	// 3. Build args and call SDK
-	const sdkArgs = buildSdkArgs({ body, identity });
+	const sdkArgs = buildSdkArgs({ body, identity, route });
 
 	try {
 		const result = await route.sdkMethod(autumn, sdkArgs);

--- a/packages/autumn-js/src/backend/core/routes/routeConfigs.ts
+++ b/packages/autumn-js/src/backend/core/routes/routeConfigs.ts
@@ -16,7 +16,12 @@ import {
 	updateSubscriptionParamsSchema,
 } from "../../../generated";
 import type { RouteDefinition, RouteName } from "../types";
-import { backendError, backendSuccess, sanitizeBody } from "../utils";
+import {
+	backendError,
+	backendSuccess,
+	CUSTOMER_PROTECTED_BODY_FIELDS,
+	sanitizeBody,
+} from "../utils";
 
 const getEntityBodySchema = z.object({
 	entityId: z.string(),
@@ -33,8 +38,9 @@ export const routeConfigs: RouteDefinition<RouteName>[] = [
 			// expand: z.array(z.enum(CustomerExpand)).optional(),
 			expand: z.array(z.string()).optional(),
 		}),
+		protectedBodyFields: CUSTOMER_PROTECTED_BODY_FIELDS,
 		customHandler: async ({ autumn, identity, body }) => {
-			const sanitizedBody = sanitizeBody(body);
+			const sanitizedBody = sanitizeBody(body, CUSTOMER_PROTECTED_BODY_FIELDS);
 
 			// Special case: if no customer and errorOnNotFound is false, return 204
 			if (!identity?.customerId && sanitizedBody.errorOnNotFound === false) {

--- a/packages/autumn-js/src/backend/core/types/routeTypes.ts
+++ b/packages/autumn-js/src/backend/core/types/routeTypes.ts
@@ -1,5 +1,6 @@
 import type { Autumn } from "@useautumn/sdk";
 import type { z } from "zod/v4";
+import type { ProtectedBodyField } from "../utils/sanitizeBody";
 import type { ResolvedIdentity } from "./authTypes";
 import type { BackendResult } from "./responseTypes";
 
@@ -48,6 +49,8 @@ export type RouteDefinition<T extends RouteName = RouteName> = {
 	customHandler?: CustomHandlerFn;
 	/** Whether customer ID is required (default: true) */
 	requireCustomer?: boolean;
+	/** Body fields that must come from identity, not frontend */
+	protectedBodyFields?: readonly ProtectedBodyField[];
 	/** Zod schema for request body validation (used by better-auth plugin) */
 	bodySchema?: z.ZodTypeAny;
 };

--- a/packages/autumn-js/src/backend/core/utils/index.ts
+++ b/packages/autumn-js/src/backend/core/utils/index.ts
@@ -1,3 +1,8 @@
 export { secretKeyCheck } from "./secretKeyCheck";
 export { backendSuccess, backendError, isBackendResult } from "./backendRes";
-export { sanitizeBody } from "./sanitizeBody";
+export {
+	CUSTOMER_PROTECTED_BODY_FIELDS,
+	DEFAULT_PROTECTED_BODY_FIELDS,
+	sanitizeBody,
+} from "./sanitizeBody";
+export type { ProtectedBodyField } from "./sanitizeBody";

--- a/packages/autumn-js/src/backend/core/utils/sanitizeBody.ts
+++ b/packages/autumn-js/src/backend/core/utils/sanitizeBody.ts
@@ -1,19 +1,31 @@
 /** Fields that must come from identity, not frontend */
-const PROTECTED_FIELDS = [
+export const DEFAULT_PROTECTED_BODY_FIELDS = [
 	"customerId",
+	"customerData",
 	"name",
 	"email",
-	"metadata",
 	"stripeId",
-];
+] as const;
+
+export const CUSTOMER_PROTECTED_BODY_FIELDS = [
+	...DEFAULT_PROTECTED_BODY_FIELDS,
+	"metadata",
+] as const;
+
+export type ProtectedBodyField =
+	| (typeof DEFAULT_PROTECTED_BODY_FIELDS)[number]
+	| (typeof CUSTOMER_PROTECTED_BODY_FIELDS)[number];
 
 /** Strip protected fields from body to prevent spoofing */
-export const sanitizeBody = (body: unknown): Record<string, unknown> => {
+export const sanitizeBody = (
+	body: unknown,
+	protectedFields: readonly ProtectedBodyField[] = DEFAULT_PROTECTED_BODY_FIELDS,
+): Record<string, unknown> => {
 	const rawBody = (body as Record<string, unknown>) || {};
 	const sanitized: Record<string, unknown> = {};
 
 	for (const [key, value] of Object.entries(rawBody)) {
-		if (!PROTECTED_FIELDS.includes(key)) {
+		if (!protectedFields.includes(key as ProtectedBodyField)) {
 			sanitized[key] = value;
 		}
 	}


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes metadata being stripped from attach requests by making protected body fields configurable per route. `metadata` now passes through for attach requests while remaining protected on customer endpoints.

- **Bug Fixes**
  - Added route-level `protectedBodyFields`; `executeRoute` now passes it to `sanitizeBody`.
  - Introduced `DEFAULT_PROTECTED_BODY_FIELDS` (excludes `metadata`) and `CUSTOMER_PROTECTED_BODY_FIELDS` (includes `metadata`); applied to customer routes.
  - Updated route types and utils exports to support the new config.

<sup>Written for commit 6a32c660c6f6ef3349f40f6ba0ebee872a2c750b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This patch fixes a bug where `metadata` was being stripped from the `attach` request body (and all other non-customer routes) because it was previously listed as a globally protected field. The fix separates protected-field logic into two named sets and makes the sanitization per-route configurable.

- **Bug fixes**: Splits `PROTECTED_FIELDS` into `DEFAULT_PROTECTED_BODY_FIELDS` (without `metadata`) and `CUSTOMER_PROTECTED_BODY_FIELDS` (with `metadata`), so `attach` and other billing routes now correctly forward caller-supplied `metadata` to the SDK.
- **Improvements**: Adds `customerData` to the default protected set (it was unprotected before) and wires `protectedBodyFields` into `RouteDefinition` so each route can declare its own sanitization policy.
- **API changes**: `sanitizeBody` now accepts an optional second argument; callers that previously relied on the implicit `metadata` stripping for non-customer routes will need to opt in to `CUSTOMER_PROTECTED_BODY_FIELDS`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core fix is correct and the changes are well-scoped.

The bug fix is sound — metadata now correctly passes through for billing routes like attach while remaining protected for the customer identity route. The two minor findings are non-blocking: a redundant type union and a protectedBodyFields config entry on getOrCreateCustomer that has no runtime effect because that route uses a customHandler.

routeConfigs.ts — the protectedBodyFields entry on getOrCreateCustomer is misleading since sanitization for that route is handled entirely inside its customHandler.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/autumn-js/src/backend/core/utils/sanitizeBody.ts | Core fix: splits PROTECTED_FIELDS into DEFAULT_PROTECTED_BODY_FIELDS (without metadata) and CUSTOMER_PROTECTED_BODY_FIELDS (with metadata), allowing attach and other billing routes to pass metadata through. ProtectedBodyField type is slightly redundant. |
| packages/autumn-js/src/backend/core/routes/routeConfigs.ts | Sets protectedBodyFields: CUSTOMER_PROTECTED_BODY_FIELDS on getOrCreateCustomer route, but this field is never read at runtime since the route uses customHandler and bypasses buildSdkArgs. |
| packages/autumn-js/src/backend/core/handlers/executeRoute.ts | Passes route into buildSdkArgs so protectedBodyFields is respected per-route; clean change. |
| packages/autumn-js/src/backend/core/types/routeTypes.ts | Adds optional protectedBodyFields to RouteDefinition; straightforward type addition. |
| packages/autumn-js/src/backend/core/utils/index.ts | Exports new constants and type from sanitizeBody; clean barrel-file update. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming request body] --> B{route.customHandler?}
    B -- Yes --> C[customHandler called directly\nwith raw body]
    C --> D[sanitizeBody called inside\ncustomHandler with explicit\nCUSTOMER_PROTECTED_BODY_FIELDS]
    B -- No --> E[buildSdkArgs called]
    E --> F{route.protectedBodyFields\nset?}
    F -- Yes --> G[sanitizeBody with\nroute.protectedBodyFields]
    F -- No --> H[sanitizeBody with\nDEFAULT_PROTECTED_BODY_FIELDS\nmetadata allowed through]
    G --> I[Inject identity.customerId]
    H --> I
    I --> J[route.sdkMethod called]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/autumn-js/src/backend/core/routes/routeConfigs.ts:41
**`protectedBodyFields` is dead config for this route**

Because `getOrCreateCustomer` defines a `customHandler`, the `executeRoute` handler takes the early-return path at line 58–73 and never calls `buildSdkArgs` — which is the only place `route.protectedBodyFields` is consumed. The field has no runtime effect here; sanitization is performed directly inside the `customHandler` via an explicit `sanitizeBody(body, CUSTOMER_PROTECTED_BODY_FIELDS)` call. A future contributor who changes `CUSTOMER_PROTECTED_BODY_FIELDS` expecting this config entry to enforce protection for the route will be silently wrong.

### Issue 2 of 2
packages/autumn-js/src/backend/core/utils/sanitizeBody.ts:15-17
**`ProtectedBodyField` type is a redundant union**

`CUSTOMER_PROTECTED_BODY_FIELDS` already spreads every element of `DEFAULT_PROTECTED_BODY_FIELDS`, so `(typeof DEFAULT_PROTECTED_BODY_FIELDS)[number]` is a strict subset of `(typeof CUSTOMER_PROTECTED_BODY_FIELDS)[number]`. The union collapses to just the wider type, meaning the left branch adds nothing.

```suggestion
export type ProtectedBodyField = (typeof CUSTOMER_PROTECTED_BODY_FIELDS)[number];
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["patch: 🩹 attach has metadata stripped o..."](https://github.com/useautumn/autumn/commit/6a32c660c6f6ef3349f40f6ba0ebee872a2c750b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36289245)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->