### PR TITLE
chore: update attach items ui

### DIFF
--- a/vite/src/components/forms/shared/PlanItemsSection.tsx
+++ b/vite/src/components/forms/shared/PlanItemsSection.tsx
@@ -147,7 +147,7 @@ export function PlanItemsSection({
 			/>
 			<LayoutGroup>
 				<motion.div
-					className="flex flex-col gap-1.5"
+					className="flex flex-col gap-0"
 					layout="position"
 					transition={{ layout: LAYOUT_TRANSITION }}
 				>

--- a/vite/src/components/forms/shared/plan-items/PlanEditButton.tsx
+++ b/vite/src/components/forms/shared/plan-items/PlanEditButton.tsx
@@ -5,7 +5,11 @@ import { LAYOUT_TRANSITION } from "@/components/v2/sheets/SharedSheetComponents"
 
 export function PlanEditButton({ onEditPlan }: { onEditPlan: () => void }) {
 	return (
-		<motion.div layout="position" transition={{ layout: LAYOUT_TRANSITION }}>
+		<motion.div
+			layout="position"
+			transition={{ layout: LAYOUT_TRANSITION }}
+			className="mt-2"
+		>
 			<Button variant="secondary" onClick={onEditPlan} className="w-full">
 				<PencilSimpleIcon size={14} className="mr-1" />
 				Create Custom Plan

--- a/vite/src/components/forms/shared/plan-items/PlanPriceHeader.tsx
+++ b/vite/src/components/forms/shared/plan-items/PlanPriceHeader.tsx
@@ -47,7 +47,7 @@ export function PlanPriceHeader({
 	);
 
 	return (
-		<div className="flex gap-2 justify-between items-center mb-3">
+		<div className="flex gap-2 justify-between items-center mb-1">
 			{wrapped}
 		</div>
 	);

--- a/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
+++ b/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
@@ -109,7 +109,7 @@ function PrepaidQuantityControl({
 
 	if (readOnly) {
 		return (
-			<div className="flex items-center h-10 px-3 rounded-xl input-base w-fit shrink-0">
+			<div className="flex items-center py-1 w-fit shrink-0">
 				<span className="text-sm tabular-nums text-tertiary-foreground">{displayText}</span>
 			</div>
 		);
@@ -120,7 +120,7 @@ function PrepaidQuantityControl({
 			layout
 			transition={FAST_TRANSITION}
 			className={cn(
-				"flex items-center h-10 px-3 rounded-xl input-base w-fit shrink-0 gap-2 overflow-hidden",
+				"flex items-center py-1 w-fit shrink-0 gap-2 overflow-hidden",
 				showRing && "ring-1 ring-inset ring-amber-500/50",
 			)}
 		>
@@ -170,9 +170,9 @@ function PrepaidQuantityControl({
 						)}
 						<IconButton
 							icon={<PencilSimpleIcon size={14} />}
-							variant="skeleton"
+							variant="secondary"
 							size="sm"
-							className="text-subtle hover:text-muted-foreground hover:bg-muted"
+							iconOrientation="center"
 							onClick={() => onEditingChange(true)}
 						/>
 					</motion.div>
@@ -259,7 +259,7 @@ export function SubscriptionItemRow({
 		<div className="flex items-center gap-2">
 			<div
 				className={cn(
-					"flex items-center flex-1 min-w-0 h-10 px-3 rounded-xl input-base gap-2",
+					"flex items-center flex-1 min-w-0 gap-2 py-1",
 					!readOnly && isDeleted && "opacity-50",
 				)}
 			>

--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -94,7 +94,7 @@ function SubscriptionDetailItems({
 
 	return (
 		<SheetSection>
-			<div className="flex gap-2 justify-between items-center h-6 mb-3">
+			<div className="flex gap-2 justify-between items-center h-6 mb-1">
 				<BasePriceDisplay
 					product={product}
 					readOnly={true}
@@ -102,7 +102,7 @@ function SubscriptionDetailItems({
 				/>
 			</div>
 
-			<div className="space-y-2">
+			<div className="flex flex-col gap-0">
 				{visibleItems.map((item, index) => renderRow(item, index))}
 				{collapsedBooleanItems.length > 0 && (
 					<CollapsedBooleanItems

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -159,8 +159,9 @@ export const PlanFeatureRow = ({
 			{...(isDisabled && { "data-disabled": true })}
 			data-pressed={isPressed}
 			className={cn(
-				"flex items-center w-full group h-10! group/row select-none rounded-xl hover:relative hover:z-95",
-				"input-base input-state-open-tiny",
+				"flex items-center w-full group group/row select-none rounded-xl hover:relative hover:z-95",
+				!readOnly && "h-10! input-base input-state-open-tiny",
+				readOnly && "py-1",
 				isDisabled && "pointer-events-none cursor-default",
 				isSelected &&
 					"border-transparent z-95 relative bg-interative-secondary outline-4! outline-outer-background!",
@@ -237,7 +238,7 @@ export const PlanFeatureRow = ({
 					/>
 				</div>
 				{prepaidQuantity && (
-					<span className="bg-muted px-1 py-0.5 rounded-md">
+					<span className="bg-muted px-1.5 py-0.5 rounded-md text-xs">
 						x{parseFloat(Number(prepaidQuantity).toFixed(2))}
 					</span>
 				)}


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the attach-items UI for plans and subscriptions with compact spacing and consistent read-only styles. Updates edit controls and chips for clearer, consistent styling.

- **Refactors**
  - Reduced vertical spacing: `PlanItemsSection` gap-0; headers in `PlanPriceHeader` and `SubscriptionDetailSheet` use mb-1; items list uses gap-0.
  - Simplified rows/controls: replaced h-10/input-base shells with py-1 in read-only rows; `PlanFeatureRow` uses `py-1` when read-only and keeps height only when editable.
  - Control tweaks: `PlanEditButton` adds `mt-2`; prepaid quantity chip is smaller (`px-1.5`, `text-xs`); quantity edit `IconButton` switches to `secondary` with centered icon.

<sup>Written for commit e762b5accdf9e9cc38654464e90f2730c3ff2e00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens the spacing and visual style of the attach/subscription items UI, moving from a fixed-height "input box" look to a lighter, padding-only row style for read-only contexts.

- **[Improvements]** Read-only item rows across `PlanFeatureRow`, `SubscriptionItemRow`, and `SubscriptionDetailSheet` now use `py-1` padding instead of `h-10 input-base rounded-xl`, removing the bordered input appearance in display-only views.
- **[Improvements]** List gaps consolidated: `gap-1.5` / `space-y-2` between rows replaced with `gap-0`, and `mb-3` header margins reduced to `mb-1`; the \"Create Custom Plan\" button gains `mt-2` to compensate.
- **[Improvements]** The prepaid quantity pencil button moves from `skeleton` to `secondary` variant with centered icon orientation, and the prepaid quantity badge gains `text-xs` sizing and slightly wider padding (`px-1.5`).
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are cosmetic Tailwind class adjustments with no logic, data, or API surface touched.

The editable PrepaidQuantityControl loses rounded-xl alongside the other input-box classes, so the amber off-unit warning ring now renders with sharp corners while the rest of the UI uses rounded-xl. It only appears on a specific edge case (prepaid items with a billing-unit mismatch during editing), but it is a visible inconsistency worth addressing before merge.

vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx — the editable PrepaidQuantityControl container's rounded corners were removed alongside other styling, which affects the amber ring indicator.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/shared/PlanItemsSection.tsx | Reduces row gap from `gap-1.5` to `gap-0`; spacing now handled per-row via `py-1` padding. |
| vite/src/components/forms/shared/plan-items/PlanEditButton.tsx | Adds `mt-2` top margin to the "Create Custom Plan" button wrapper to compensate for removed list gap. |
| vite/src/components/forms/shared/plan-items/PlanPriceHeader.tsx | Reduces price header bottom margin from `mb-3` to `mb-1` for tighter layout. |
| vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx | Strips `input-base` / `rounded-xl` / fixed-height styling from both read-only and editable containers; changes pencil button to `secondary` variant; editable container now missing rounded corners when the amber off-unit ring is displayed. |
| vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx | Header margin reduced from `mb-3` to `mb-1`; item list changed from `space-y-2` to `flex flex-col gap-0`, deferring spacing to per-row padding. |
| vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx | Read-only rows now use `py-1` instead of `h-10! input-base input-state-open-tiny`; prepaid badge gains `text-xs` and wider horizontal padding (`px-1.5`). |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PlanItemsSection\ngap-1.5 → gap-0] --> B[PlanPriceHeader\nmb-3 → mb-1]
    A --> C[PlanFeatureRow]
    C --> D{readOnly?}
    D -- Yes --> E[py-1\nno input-base/h-10]
    D -- No --> F[h-10! input-base\ninput-state-open-tiny]
    A --> G[PlanEditButton\n+ mt-2]
    H[SubscriptionDetailSheet\nspace-y-2 → gap-0\nmb-3 → mb-1] --> I[SubscriptionItemRow]
    I --> J{readOnly?}
    J -- Yes --> K[py-1\nno input-base/h-10]
    J -- No --> L[py-1 + gap-2\nno input-base/h-10\npencil: skeleton → secondary]
    L --> M{showRing?}
    M -- Yes --> N[ring-1 amber\nno rounded-xl ⚠️]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx`, line 119-125 ([link](https://github.com/useautumn/autumn/blob/e762b5accdf9e9cc38654464e90f2730c3ff2e00/vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx#L119-L125)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Amber ring loses rounded corners**

   The editable `PrepaidQuantityControl` previously had `rounded-xl` alongside the `ring-1 ring-inset ring-amber-500/50` indicator that warns about off-unit prepaid quantities. After removing `h-10 px-3 rounded-xl input-base`, the container no longer has a border-radius, so the amber warning ring now renders with sharp corners while every other interactive element in this UI uses `rounded-xl`. The ring will still appear functionally but the appearance is inconsistent — add `rounded-xl` back to the editable variant's className to keep it visually consistent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx
   Line: 119-125

   Comment:
   **Amber ring loses rounded corners**

   The editable `PrepaidQuantityControl` previously had `rounded-xl` alongside the `ring-1 ring-inset ring-amber-500/50` indicator that warns about off-unit prepaid quantities. After removing `h-10 px-3 rounded-xl input-base`, the container no longer has a border-radius, so the amber warning ring now renders with sharp corners while every other interactive element in this UI uses `rounded-xl`. The ring will still appear functionally but the appearance is inconsistent — add `rounded-xl` back to the editable variant's className to keep it visually consistent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/components/forms/update-subscription-v2/components/SubscriptionItemRow.tsx:119-125
**Amber ring loses rounded corners**

The editable `PrepaidQuantityControl` previously had `rounded-xl` alongside the `ring-1 ring-inset ring-amber-500/50` indicator that warns about off-unit prepaid quantities. After removing `h-10 px-3 rounded-xl input-base`, the container no longer has a border-radius, so the amber warning ring now renders with sharp corners while every other interactive element in this UI uses `rounded-xl`. The ring will still appear functionally but the appearance is inconsistent — add `rounded-xl` back to the editable variant's className to keep it visually consistent.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update attach items ui"](https://github.com/useautumn/autumn/commit/e762b5accdf9e9cc38654464e90f2730c3ff2e00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36292664)</sub>

<!-- /greptile_comment -->