### PR TITLE
feat: redirect /docs to docs.

### DIFF
--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -20,6 +20,15 @@ const nextConfig = {
     // falling back to WebP. Next.js negotiates via Accept header automatically.
     formats: ["image/avif", "image/webp"],
   },
+  async redirects() {
+    return [
+      {
+        source: "/docs",
+        destination: "https://docs.useautumn.com",
+        permanent: false,
+      },
+    ];
+  },
   async headers() {
     if (!isProd) return [];
 


### PR DESCRIPTION
## Summary
- Redirect `/docs` on the marketing site to `https://docs.useautumn.com`
- Not permanent redirect so `/docs` can be reclaimed later if docs move to the main domain

## Testing
- Manually verified

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a temporary (302) redirect from /docs on the marketing site to https://docs.useautumn.com. This points visitors to the new docs while keeping /docs available for future use on the main domain.

- **New Features**
  - Non-permanent redirect for `/docs` to `https://docs.useautumn.com` (can reclaim `/docs` later).

<sup>Written for commit 8fe3d049c49a0a655826547e8ab15eac3db5be2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

