### PR TITLE
fix: 🐛 cli auth broken

### DIFF
--- a/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
+++ b/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
@@ -68,8 +68,7 @@ const getRedirectUriFromFields = (fields: RequestFields) =>
 	getNestedOAuthField(fields.oauth_query, "redirect_uri");
 
 const getScopesFromFields = (fields: RequestFields) => {
-	const rawScope =
-		getString(fields.scope) ?? getNestedOAuthField(fields.oauth_query, "scope");
+	const rawScope = getNestedOAuthField(fields.oauth_query, "scope");
 	return rawScope?.split(/\s+/).filter(Boolean) ?? null;
 };
 
@@ -80,23 +79,7 @@ const getFieldsWithScope = ({
 	fields: RequestFields;
 	scope: string;
 }) => {
-	const next: RequestFields = { ...fields, scope };
-	const oauthQuery = fields.oauth_query;
-	if (typeof oauthQuery === "string") {
-		try {
-			next.oauth_query = JSON.stringify({ ...JSON.parse(oauthQuery), scope });
-		} catch {
-			const params = new URLSearchParams(oauthQuery);
-			params.set("scope", scope);
-			next.oauth_query = params.toString();
-		}
-	} else if (typeof oauthQuery === "object" && oauthQuery !== null) {
-		next.oauth_query = {
-			...(oauthQuery as Record<string, unknown>),
-			scope,
-		};
-	}
-	return next;
+	return { ...fields, scope };
 };
 
 const withScope = ({


### PR DESCRIPTION
<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/5719e055-84af-11f0-a94e-3eef481a796b/pull/1856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CLI OAuth consent flow by simplifying scope handling. We now read scope only from `oauth_query` and stop rewriting it, preventing malformed params that broke CLI login.

- **Bug Fixes**
  - `getScopesFromFields` reads `scope` exclusively from `oauth_query`.
  - `getFieldsWithScope` no longer mutates `oauth_query`; it only sets `fields.scope`.

<sup>Written for commit d9e13bcd943b6b51b33811e7980cd9ea08e9e6f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR simplifies the OAuth consent scope handling in the CLI auth flow by removing a complex `oauth_query` mutation block and dropping the top-level `scope` field fallback in `getScopesFromFields`. The intent is to fix broken CLI authentication caused by the old logic incorrectly rewriting `oauth_query`.

- **Bug fixes** — Removes the `oauth_query` JSON/URLSearchParams mutation from `getFieldsWithScope` that was likely corrupting the request body for CLI auth flows.
- **Bug fixes** — `getScopesFromFields` now reads scope exclusively from `oauth_query`, matching where the CLI places it, instead of also checking a top-level `scope` field first.
</details>

<h3>Confidence Score: 3/5</h3>

The change unblocks CLI auth but introduces an inconsistency: the granted scope is injected only at the top level while `oauth_query` still carries the original, potentially broader, scope string.

The simplified `getFieldsWithScope` no longer updates `oauth_query` with the narrowed scope, yet `getScopesFromFields` reads exclusively from `oauth_query`. If `auth.handler` (better-auth) also resolves the final token scopes from `oauth_query`, the scope restriction applied by `getOAuthConsentScopeGrant` would be silently ignored on every CLI consent approval. Additionally, dropping the top-level `scope` fallback in `getScopesFromFields` could cause clients that send scope as a plain field to receive a default scope set instead of what they requested.

All changes are in `server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts` — specifically the `getScopesFromFields` and `getFieldsWithScope` functions warrant a closer look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts | Simplifies scope reading (drops top-level `scope` fallback) and scope injection (no longer updates `oauth_query`). While this likely unblocks the CLI flow, the granted scope is not written back into `oauth_query`, so `auth.handler` may still see the original unrestricted scope if it reads from there. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as CLI Client
    participant Handler as handleOAuthConsentWithEnv
    participant ScopeGrant as getOAuthConsentScopeGrant
    participant AuthHandler as auth.handler (better-auth)

    CLI->>Handler: "POST /oauth/consent (oauth_query: {scope: "read write"})"
    Handler->>Handler: "getScopesFromFields()<br/>reads oauth_query.scope → ["read","write"]"
    Handler->>ScopeGrant: "requestedScopes=["read","write"]"
    ScopeGrant-->>Handler: "grantedScopes=["read"]"
    Handler->>Handler: "getFieldsWithScope()<br/>sets top-level scope="read"<br/>⚠️ oauth_query.scope still="read write""
    Handler->>AuthHandler: "request body with scope="read"<br/>BUT oauth_query.scope="read write" unchanged"
    AuthHandler-->>Handler: response (may use oauth_query.scope)
    Handler-->>CLI: OAuth token (scope may be broader than granted)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts:82
**Scope grant not propagated into `oauth_query`**

`getScopesFromFields` now reads the scope exclusively from `oauth_query`, which means that's where the scope lives for this flow. But after `getOAuthConsentScopeGrant` narrows the granted scopes, `getFieldsWithScope` only sets the top-level `scope` property and leaves `oauth_query` unchanged. When `withScope` reconstructs the request body — either as JSON (`JSON.stringify(scopedFields)`) or as URL params — the original (potentially broader) scope inside `oauth_query` is forwarded untouched to `auth.handler`. If `auth.handler` (better-auth) resolves the final token scope from `oauth_query` rather than from the top-level `scope` field, the restriction applied by `getOAuthConsentScopeGrant` is silently bypassed.

### Issue 2 of 2
server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts:70-73
**Top-level `scope` field dropped from fallback**

The old `getScopesFromFields` tried `getString(fields.scope)` first, then fell back to `oauth_query.scope`. The new version only reads from `oauth_query`. This is fine for the CLI flow where the scope lives in `oauth_query`, but it silently breaks any client that sends `scope` as a plain top-level form/JSON field (without wrapping it in `oauth_query`). Those requests will now see `requestedScopes: null`, which is passed to `getDefaultOAuthScopes` — potentially granting a default set of scopes rather than the explicitly requested ones.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 cli auth broken"](https://github.com/useautumn/autumn/commit/d9e13bcd943b6b51b33811e7980cd9ea08e9e6f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36420588)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->