### PR TITLE
fix: tax rate id preview

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyPercentOffDiscountToLineItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyPercentOffDiscountToLineItems.ts
@@ -56,7 +56,6 @@ export const applyPercentOffDiscountToLineItems = ({
 		const itemDiscount = new Decimal(discountableAmount)
 			.times(percentOff)
 			.dividedBy(100)
-			.round()
 			.toNumber();
 
 		if (itemDiscount === 0) return item;
@@ -77,9 +76,10 @@ export const applyPercentOffDiscountToLineItems = ({
 			0,
 		);
 
-		const description = item.context.discountable
-			? item.description // if discountable, stripe applies discount, don't need our own tag
-			: addDiscountTagToDescription({ description: item.description });
+		const description =
+			item.context.discountable || options.skipDescriptionTag
+				? item.description
+				: addDiscountTagToDescription({ description: item.description });
 
 		return {
 			...item,

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
@@ -1,6 +1,7 @@
 import type {
 	AutumnBillingPlan,
 	BillingContext,
+	LineItem,
 	PreviewTax,
 } from "@autumn/shared";
 import {
@@ -8,31 +9,63 @@ import {
 	orgToCurrency,
 	stripeToAtmnAmount,
 } from "@autumn/shared";
+import { Decimal } from "decimal.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
-/**
- * Build-stage helper that computes a tax preview for an attach when the
- * caller passed an explicit Stripe `tax_rate_id`. Sibling to
- * `computeAttachTaxPreview` (which handles automatic_tax).
- *
- * Pure math: the Stripe TaxRate was fetched once at setup and lives on
- * `billingContext.stripeTaxRate`. Tax is applied to the same net
- * `chargeImmediately` subtotal the automatic-tax helper uses, so both
- * branches feed the formatter and total-assembly identically.
- *
- * Skip-conditions (return undefined):
- *  - no `taxRateId` on context
- *  - flow is `stripe_checkout` (Stripe Checkout computes tax itself, same
- *    reasoning as the automatic-tax helper)
- *  - no `chargeImmediately` line items
- *
- * On `netSubtotal <= 0` we short-circuit with `{ status: "complete", ...zeros }` —
- * tax does not apply to a credit invoice.
- *
- * On a missing/expanded `stripeTaxRate` (fetch failed at setup) we return
- * `{ status: "incomplete", ...zeros }` so the merchant sees an explicit
- * "tax not computed" signal rather than a silently missing field.
- */
+const lineItemToTaxableMinorUnits = ({
+	lineItem,
+	currency,
+}: {
+	lineItem: LineItem;
+	currency: string;
+}) => {
+	const amount = lineItem.context.discountable
+		? lineItem.amount
+		: (lineItem.amountAfterDiscounts ?? lineItem.amount);
+
+	let taxableMinorUnits = atmnToStripeAmount({ amount, currency });
+
+	if (!lineItem.context.discountable || taxableMinorUnits <= 0) {
+		return taxableMinorUnits;
+	}
+
+	for (const discount of lineItem.discounts ?? []) {
+		const discountMinorUnits = discount.percentOff
+			? new Decimal(taxableMinorUnits)
+					.times(discount.percentOff)
+					.div(100)
+					.round()
+					.toNumber()
+			: atmnToStripeAmount({ amount: discount.amountOff, currency });
+
+		taxableMinorUnits = Math.max(taxableMinorUnits - discountMinorUnits, 0);
+	}
+
+	return taxableMinorUnits;
+};
+
+const taxableMinorUnitsToTaxMinorUnits = ({
+	taxableMinorUnits,
+	percentage,
+	inclusive,
+}: {
+	taxableMinorUnits: number;
+	percentage: number;
+	inclusive: boolean;
+}) => {
+	return inclusive
+		? new Decimal(taxableMinorUnits)
+				.times(percentage)
+				.div(100 + percentage)
+				.round()
+				.toNumber()
+		: new Decimal(taxableMinorUnits)
+				.times(percentage)
+				.div(100)
+				.round()
+				.toNumber();
+};
+
 export const computeAttachTaxRateIdPreview = async ({
 	ctx,
 	billingContext,
@@ -43,7 +76,6 @@ export const computeAttachTaxRateIdPreview = async ({
 	autumnBillingPlan: AutumnBillingPlan;
 }): Promise<PreviewTax | undefined> => {
 	if (!billingContext.taxRateId) return undefined;
-	if (billingContext.checkoutMode === "stripe_checkout") return undefined;
 
 	const allLineItems = autumnBillingPlan.lineItems ?? [];
 	if (allLineItems.length === 0) return undefined;
@@ -51,14 +83,16 @@ export const computeAttachTaxRateIdPreview = async ({
 	const immediateLines = allLineItems.filter((line) => line.chargeImmediately);
 	if (immediateLines.length === 0) return undefined;
 
-	const netSubtotal = immediateLines.reduce(
-		(sum, line) => sum + (line.amountAfterDiscounts ?? line.amount),
+	const currency = orgToCurrency({ org: ctx.org });
+	const taxableMinorUnits = immediateLines.map((lineItem) =>
+		lineItemToTaxableMinorUnits({ lineItem, currency }),
+	);
+	const totalTaxableMinorUnits = taxableMinorUnits.reduce(
+		(sum, amount) => sum + amount,
 		0,
 	);
 
-	const currency = orgToCurrency({ org: ctx.org });
-
-	if (netSubtotal <= 0) {
+	if (totalTaxableMinorUnits <= 0) {
 		return {
 			total: 0,
 			amount_inclusive: 0,
@@ -82,25 +116,22 @@ export const computeAttachTaxRateIdPreview = async ({
 		};
 	}
 
-	// Round through Stripe minor-units to match how Stripe rounds tax on
-	// the real invoice (per-line rounding to the nearest cent).
-	const subtotalMinorUnits = atmnToStripeAmount({
-		amount: netSubtotal,
+	const taxMinorUnits = taxableMinorUnits.reduce(
+		(sum, amount) =>
+			sum +
+			taxableMinorUnitsToTaxMinorUnits({
+				taxableMinorUnits: amount,
+				percentage: taxRate.percentage,
+				inclusive: taxRate.inclusive,
+			}),
+		0,
+	);
+
+	const taxAmount = stripeToAtmnAmount({
+		amount: Math.max(taxMinorUnits, 0),
 		currency,
 	});
 
-	const taxMinorUnits = taxRate.inclusive
-		? Math.round(
-				(subtotalMinorUnits * taxRate.percentage) / (100 + taxRate.percentage),
-			)
-		: Math.round((subtotalMinorUnits * taxRate.percentage) / 100);
-
-	const taxAmount = stripeToAtmnAmount({ amount: taxMinorUnits, currency });
-
-	// For an inclusive rate the line amount already contains the tax, so
-	// Stripe charges only the line amount. `total` drives
-	// applyPreviewAdjustmentsToTotal and must stay 0 here to avoid inflating
-	// preview.total. `amount_inclusive` still reports the notional split.
 	return {
 		total: taxRate.inclusive ? 0 : taxAmount,
 		amount_inclusive: taxRate.inclusive ? taxAmount : 0,

--- a/server/tests/integration/billing/attach/attach-metadata.test.ts
+++ b/server/tests/integration/billing/attach/attach-metadata.test.ts
@@ -215,13 +215,23 @@ test.concurrent(`${chalk.yellowBright("metadata: passthrough via Stripe checkout
 		customer_id: customerId,
 		plan_id: pro.id,
 		metadata: {
-			source: "web",
-			campaign_id: "camp-789",
+			datafast_visitor_id: "visitor-789",
+			datafast_session_id: "session-789",
 		},
 	});
 
 	expect(result.payment_url).toBeDefined();
 	expect(result.payment_url).toContain("checkout.stripe.com");
+
+	const checkoutPathParts = new URL(result.payment_url).pathname.split("/");
+	const checkoutSessionId = checkoutPathParts[checkoutPathParts.length - 1];
+	expect(checkoutSessionId).toBeDefined();
+
+	const checkoutSession = await ctx.stripeCli.checkout.sessions.retrieve(
+		checkoutSessionId!,
+	);
+	expect(checkoutSession.metadata?.datafast_visitor_id).toBe("visitor-789");
+	expect(checkoutSession.metadata?.datafast_session_id).toBe("session-789");
 
 	await completeStripeCheckoutForm({ url: result.payment_url });
 	await timeout(12000);
@@ -251,6 +261,6 @@ test.concurrent(`${chalk.yellowBright("metadata: passthrough via Stripe checkout
 		(sub) => sub.status === "active" || sub.status === "trialing",
 	);
 	expect(subscription).toBeDefined();
-	expect(subscription!.metadata.source).toBe("web");
-	expect(subscription!.metadata.campaign_id).toBe("camp-789");
+	expect(subscription!.metadata.datafast_visitor_id).toBe("visitor-789");
+	expect(subscription!.metadata.datafast_session_id).toBe("session-789");
 });

--- a/server/tests/integration/billing/tax/attach-tax-rates/preview-attach-tax-rate-id.test.ts
+++ b/server/tests/integration/billing/tax/attach-tax-rates/preview-attach-tax-rate-id.test.ts
@@ -15,9 +15,12 @@
 
 import { expect, test } from "bun:test";
 import type { AttachPreviewResponse } from "@autumn/shared";
+import { getStripeSubscription } from "@tests/integration/billing/utils/stripeSubscriptionUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { createPercentCoupon } from "../../utils/discounts/discountTestUtils.js";
 
 test.concurrent(
 	`${chalk.yellowBright("preview-attach-tax-rate-id (exclusive 10%): preview returns tax.status=complete and inflates total")}`,
@@ -106,6 +109,118 @@ test.concurrent(
 );
 
 test.concurrent(
+	`${chalk.yellowBright("preview-attach-tax-rate-id (stripe checkout): explicit tax_rate_id still returns tax")}`,
+	async () => {
+		const customerId = "preview-tax-rate-stripe-checkout";
+		const proProd = products.pro({ id: "pro", items: [] });
+
+		const { ctx, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [proProd] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "Test Tax Checkout",
+			percentage: 10,
+			inclusive: false,
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach({
+			customer_id: customerId,
+			plan_id: proProd.id,
+			tax_rate_id: taxRate.id,
+		})) as AttachPreviewResponse;
+
+		expect(preview.checkout_type).toBe("stripe_checkout");
+		expect(preview.tax).toBeDefined();
+		expect(preview.tax?.status).toBe("complete");
+		expect(preview.tax?.amount_exclusive).toBe(2);
+		expect(preview.total).toBe(22);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-attach-tax-rate-id (discounted switch): preview tax matches Stripe invoice tax")}`,
+	async () => {
+		const customerId = "preview-tax-rate-discount-switch";
+		const group = "preview-tax-rate-discount-switch";
+		const basicProd = products.base({
+			id: "basic-tax-preview",
+			group,
+			items: [items.monthlyPrice({ price: 14.9 })],
+		});
+		const proProd = products.base({
+			id: "pro-tax-preview",
+			group,
+			items: [items.monthlyPrice({ price: 34.9 })],
+		});
+
+		const { ctx, autumnV2_2 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [basicProd, proProd] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "Test Tax Discount Switch",
+			percentage: 20,
+			inclusive: false,
+		});
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: basicProd.id,
+			tax_rate_id: taxRate.id,
+			discounts: [{ reward_id: coupon.id }],
+		});
+
+		const switchParams = {
+			customer_id: customerId,
+			plan_id: proProd.id,
+			tax_rate_id: taxRate.id,
+			discounts: [{ reward_id: coupon.id }],
+			plan_schedule: "immediate" as const,
+			proration_behavior: "prorate_immediately" as const,
+			billing_cycle_anchor: "now" as const,
+		};
+
+		const preview = (await autumnV2_2.billing.previewAttach(
+			switchParams,
+		)) as AttachPreviewResponse;
+
+		await autumnV2_2.billing.attach(switchParams);
+
+		const { stripeCli, subscription } = await getStripeSubscription({
+			customerId,
+		});
+		const latestInvoiceId =
+			typeof subscription.latest_invoice === "string"
+				? subscription.latest_invoice
+				: subscription.latest_invoice?.id;
+
+		expect(latestInvoiceId).toBeDefined();
+
+		const invoice = await stripeCli.invoices.retrieve(latestInvoiceId!);
+		expect(invoice.total_excluding_tax).not.toBeNull();
+		const invoiceTax = invoice.total - invoice.total_excluding_tax!;
+
+		expect(preview.tax?.total).toBe(invoiceTax / 100);
+		expect(preview.total).toBe(invoice.total / 100);
+	},
+);
+
+test.concurrent(
 	`${chalk.yellowBright("preview-attach-tax-rate-id (no tax_rate_id, auto_tax off): preview omits tax field")}`,
 	async () => {
 		const customerId = "preview-tax-rate-omitted";
@@ -127,5 +242,4 @@ test.concurrent(
 
 		expect(preview.tax).toBeUndefined();
 	},
-	300_000,
 );

--- a/server/tests/unit/billing/stripe/discounts/apply-percent-off-discount-to-line-items.spec.ts
+++ b/server/tests/unit/billing/stripe/discounts/apply-percent-off-discount-to-line-items.spec.ts
@@ -212,7 +212,6 @@ describe(chalk.yellowBright("applyPercentOffDiscountToLineItems"), () => {
 		});
 
 		test("handles decimal rounding correctly", () => {
-			// 33 * 10% = 3.3, should round to 3
 			const lineItems = [lineItemFixtures.charge({ amount: 33 })];
 			const discount = discounts.tenPercentOff();
 
@@ -221,8 +220,8 @@ describe(chalk.yellowBright("applyPercentOffDiscountToLineItems"), () => {
 				discount,
 			});
 
-			expect(result[0].discounts[0].amountOff).toBe(3);
-			expect(result[0].amountAfterDiscounts).toBe(30);
+			expect(result[0].discounts[0].amountOff).toBe(3.3);
+			expect(result[0].amountAfterDiscounts).toBe(29.7);
 		});
 
 		test("zero amount line item is skipped", () => {

--- a/server/tests/unit/utils/convert-amount-utils.test.ts
+++ b/server/tests/unit/utils/convert-amount-utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { atmnToStripeAmount } from "@autumn/shared";
+
+describe("convertAmountUtils", () => {
+	test("converts decimal currencies to integer minor units", () => {
+		expect(atmnToStripeAmount({ amount: 10.235, currency: "USD" })).toBe(1024);
+	});
+
+	test("rounds zero-decimal currencies to integer Stripe units", () => {
+		expect(atmnToStripeAmount({ amount: 1000.5, currency: "JPY" })).toBe(1001);
+	});
+});

--- a/shared/utils/productUtils/priceUtils/convertAmountUtils.ts
+++ b/shared/utils/productUtils/priceUtils/convertAmountUtils.ts
@@ -26,7 +26,7 @@ const ZERO_DECIMAL_CURRENCIES = [
 /**
  * Converts an Autumn amount to a Stripe amount.
  * For most currencies, multiplies by 100 (e.g., $1.00 -> 100 cents).
- * For zero-decimal currencies like JPY, returns the amount as-is.
+ * For zero-decimal currencies like JPY, rounds to the nearest integer.
  */
 export const atmnToStripeAmount = ({
 	amount,
@@ -36,7 +36,7 @@ export const atmnToStripeAmount = ({
 	currency?: string;
 }): number => {
 	if (ZERO_DECIMAL_CURRENCIES.includes(currency.toUpperCase())) {
-		return amount;
+		return new Decimal(amount).round().toNumber();
 	}
 	return new Decimal(amount).mul(100).round().toNumber();
 };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes attach tax preview with explicit `tax_rate_id` by computing tax per line in Stripe minor units and returning tax for `stripe_checkout`, so preview totals match Stripe invoices.

- **Bug Fixes**
  - Compute tax per line with discounts applied and correct inclusive/exclusive math; totals now align with Stripe.
  - Preserve decimal discount amounts in `applyPercentOffDiscountToLineItems`; add `skipDescriptionTag` to avoid description tagging.
  - Always include tax in preview when `tax_rate_id` is set, even for `stripe_checkout`.
  - Fix zero-decimal currency rounding in `atmnToStripeAmount` (e.g., `JPY`).

<sup>Written for commit c9a4b941490e02e7a991865107706b08108c612c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `tax_rate_id` preview calculation so it accurately reflects what Stripe will actually charge — it now works for `stripe_checkout` flows and correctly handles discounts on Stripe-managed (`discountable`) line items by applying them in minor-unit space with per-line rounding, matching Stripe's own invoice computation.

- **Bug fixes**: Removes the `stripe_checkout` early-return guard so `tax_rate_id` previews are now computed for all checkout modes; computes taxable amounts per line item in Stripe minor units (with per-discount rounding) rather than on a pre-aggregated Autumn-amount subtotal, matching Stripe's actual per-line tax logic.
- **Bug fixes**: `atmnToStripeAmount` for zero-decimal currencies (e.g. JPY) now rounds to the nearest integer instead of returning a raw potentially-fractional value, preventing fractional minor-unit amounts reaching Stripe.
- **Improvements**: Removes premature `.round()` from discount `amountOff` computation in `applyPercentOffDiscountToLineItems` so full-precision decimals are preserved until the Stripe conversion step; adds `skipDescriptionTag` option for future callers; expands integration and unit test coverage for the corrected paths.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge. The rewritten tax-preview path correctly replicates Stripe's per-line minor-unit rounding and no longer skips stripe_checkout flows; the zero-decimal currency rounding fix is straightforward. The only concern is a minor NaN propagation risk on a rarely-exercised fallback branch, not triggered in normal operation.

The core logic change is well-reasoned and backed by new integration tests that compare preview output directly against real Stripe invoice totals. The `amountOff` fallback in `lineItemToTaxableMinorUnits` could silently propagate `NaN` if a line-item record is malformed, but this requires corrupted data and does not affect the happy path. The checkout-metadata test uses URL-path parsing that is tied to Stripe's current URL format — fragile but not a correctness issue for production code.

`computeAttachTaxRateIdPreview.ts` — the new `lineItemToTaxableMinorUnits` helper is the most complex change and worth a second read; the `discount.amountOff` fallback branch has no NaN guard. `attach-metadata.test.ts` — session-ID extraction from the Stripe checkout URL is format-dependent.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts | Core tax-preview rewrite: removes stripe_checkout early-return, moves discount application to Stripe minor-unit space (per-line rounding), and adds per-line tax computation matching Stripe's actual invoice logic. Logic is sound; minor NaN propagation risk on `amountOff` fallback path. |
| server/src/internal/billing/v2/providers/stripe/utils/discounts/applyPercentOffDiscountToLineItems.ts | Removes premature `.round()` from discount amount so `amountOff`/`amountAfterDiscounts` are stored as full-precision decimals; rounding now deferred to the Stripe minor-unit conversion. Adds `skipDescriptionTag` option (no callers yet, pure extension point). Change is correct. |
| shared/utils/productUtils/priceUtils/convertAmountUtils.ts | Bugfix: zero-decimal currency path now rounds to nearest integer instead of returning raw (potentially fractional) amount, preventing fractional minor-unit values being sent to Stripe. |
| server/tests/integration/billing/tax/attach-tax-rates/preview-attach-tax-rate-id.test.ts | Adds integration tests for stripe_checkout tax preview (previously returned undefined) and discounted-switch scenario that compares preview tax against actual Stripe invoice tax. Good coverage of the fixed paths. |
| server/tests/integration/billing/attach/attach-metadata.test.ts | Updates metadata keys to datafast_* and adds checkout session metadata verification by extracting the session ID from the payment URL. URL-path-based extraction is fragile if Stripe changes URL structure. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[computeAttachTaxRateIdPreview] --> B{taxRateId present?}
    B -- No --> Z[return undefined]
    B -- Yes --> C{immediateLines empty?}
    C -- Yes --> Z
    C -- No --> D[Map each line item to taxableMinorUnits]

    D --> E{lineItem.context.discountable?}
    E -- false/undefined --> F[atmnToStripeAmount of amountAfterDiscounts]
    E -- true --> G[atmnToStripeAmount of lineItem.amount]
    G --> H{taxableMinorUnits <= 0?}
    H -- Yes --> F
    H -- No --> I[For each discount in lineItem.discounts]
    I --> J{discount.percentOff?}
    J -- Yes --> K[round taxableMinorUnits x percentOff / 100]
    J -- No --> L[atmnToStripeAmount of amountOff]
    K --> M[taxableMinorUnits = max 0, prev - discountMinorUnits]
    L --> M
    F --> N[Collect all taxableMinorUnits]
    M --> N
    N --> O{totalTaxableMinorUnits <= 0?}
    O -- Yes --> P[return status=complete, zeros]
    O -- No --> Q{stripeTaxRate present?}
    Q -- No --> R[return status=incomplete, zeros]
    Q -- Yes --> S[Per-line: taxableMinorUnitsToTaxMinorUnits with round]
    S --> T{inclusive?}
    T -- Yes --> U[amount x pct / 100+pct, rounded]
    T -- No --> V[amount x pct / 100, rounded]
    U --> W[Sum all taxMinorUnits -> stripeToAtmnAmount]
    V --> W
    W --> X[return status=complete with total/amount_inclusive/amount_exclusive]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts:32-44
**`amountOff` fallback silently deducts zero when `percentOff` is absent but `amountOff` could be `NaN`**

`discount.amountOff` is required by the schema (`z.number()`), but `atmnToStripeAmount({ amount: discount.amountOff, currency })` is reached whenever `discount.percentOff` is falsy — including when it equals `0`. If somehow `amountOff` ends up as `NaN` (e.g., from a corrupted line-item record), `taxableMinorUnits - NaN` propagates `NaN` through `Math.max`, which returns `NaN`, and the subsequent tax computation produces `NaN` silently passed to `stripeToAtmnAmount`. A guard here, or at least a non-null assertion, would make the failure explicit.

### Issue 2 of 2
server/tests/integration/billing/attach/attach-metadata.test.ts:222-230
**Checkout session ID parsed from URL path structure**

`checkoutPathParts[checkoutPathParts.length - 1]` relies on Stripe always putting the session ID as the last path segment (e.g., `/c/pay/cs_test_xxx`). Stripe has changed checkout URL formats before, and if a trailing slash or query parameter is ever present, this extraction silently produces the wrong value and the subsequent `sessions.retrieve` call would throw rather than the test failing with a clear assertion error. Consider asserting the format with a regex (`/^cs_test_/` or similar) before use.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: tax rate id preview"](https://github.com/useautumn/autumn/commit/c9a4b941490e02e7a991865107706b08108c612c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36443866)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->