### PR TITLE
chore: plan migrate diffs

### DIFF
--- a/vite/src/components/forms/shared/PlanItemsSection.tsx
+++ b/vite/src/components/forms/shared/PlanItemsSection.tsx
@@ -9,13 +9,18 @@ import { PencilSimpleIcon } from "@phosphor-icons/react";
 import { LayoutGroup, motion } from "motion/react";
 import { useMemo } from "react";
 import type { UseAttachForm } from "@/components/forms/attach-v2/hooks/useAttachForm";
+import type { AdminPlanIds } from "@/components/forms/shared/admin/AdminPlanIdsTooltip";
 import type { UseUpdateSubscriptionForm } from "@/components/forms/update-subscription-v2/hooks/useUpdateSubscriptionForm";
 import { Button } from "@/components/v2/buttons/Button";
 import { LAYOUT_TRANSITION } from "@/components/v2/sheets/SharedSheetComponents";
 import { CollapsedBooleanItems } from "./plan-items/CollapsedBooleanItems";
 import { DeletedItemRow } from "./plan-items/DeletedItemRow";
 import { PlanEditButton } from "./plan-items/PlanEditButton";
-import { getItemMatchKey, hasItemChanged, PlanItemRow } from "./plan-items/PlanItemRow";
+import {
+	getItemMatchKey,
+	hasItemChanged,
+	PlanItemRow,
+} from "./plan-items/PlanItemRow";
 import { PlanPriceHeader } from "./plan-items/PlanPriceHeader";
 import {
 	PlanTrialEditor,
@@ -60,30 +65,20 @@ export interface PlanItemsSectionProps {
 	changesOnly?: boolean;
 	readOnly?: boolean;
 
-	adminIds?: import(
-		"@/components/forms/shared/admin/AdminPlanIdsTooltip"
-	).AdminPlanIds;
+	adminIds?: AdminPlanIds;
 }
 
-export function PlanItemsSection({
+export function getPlanItemsDiff({
 	product,
 	originalItems,
-	features,
-	prepaidOptions,
-	initialPrepaidOptions,
-	existingOptions,
-	form,
 	showDiff,
-	currency,
-	onEditPlan,
-	priceChange,
-	versionChange,
-	trialConfig,
 	gateDeletedItemsByDiff = false,
-	changesOnly = false,
-	readOnly = false,
-	adminIds,
-}: PlanItemsSectionProps) {
+}: {
+	product: FrontendProduct | undefined;
+	originalItems: ProductItem[] | undefined;
+	showDiff: boolean;
+	gateDeletedItemsByDiff?: boolean;
+}) {
 	const originalItemsMap = new Map<string, ProductItem>(
 		originalItems
 			?.filter((i) => i.feature_id)
@@ -96,11 +91,6 @@ export function PlanItemsSection({
 			.map((i) => getItemMatchKey(i)) ?? [],
 	);
 
-	// When showing diffs, split changed items into red (deleted old) +
-	// green (created new) pairs instead of a single amber row. We remove
-	// the original from the map so PlanItemRow sees the new version as
-	// "created", and push the original into changedOriginals for the
-	// deleted-items list.
 	const changedOriginals: ProductItem[] = [];
 	if (showDiff) {
 		for (const item of product?.items ?? []) {
@@ -124,24 +114,68 @@ export function PlanItemsSection({
 		: (originalItems?.filter(isItemDeleted) ?? []);
 
 	const deletedItems = [...changedOriginals, ...purelyDeletedItems];
-
-	const sortedItems = useMemo(
-		() => sortPlanItems({ items: product?.items ?? [] }),
-		[product?.items],
-	);
-	const { visibleItems: allVisibleItems, collapsedBooleanItems: allCollapsedBooleanItems } = useMemo(
-		() => splitBooleanItems({ items: sortedItems }),
-		[sortedItems],
-	);
-
+	const sortedItems = sortPlanItems({ items: product?.items ?? [] });
+	const { visibleItems, collapsedBooleanItems } = splitBooleanItems({
+		items: sortedItems,
+	});
 	const isItemNew = (item: ProductItem) =>
 		!originalItemsMap.has(getItemMatchKey(item));
+	const diffVisibleItems = visibleItems.filter(isItemNew);
+	const diffCollapsedBooleanItems = collapsedBooleanItems.filter(isItemNew);
 
-	const visibleItems = changesOnly
-		? allVisibleItems.filter(isItemNew)
-		: allVisibleItems;
+	return {
+		originalItemsMap,
+		deletedItems,
+		visibleItems,
+		collapsedBooleanItems,
+		diffVisibleItems,
+		diffCollapsedBooleanItems,
+		hasDiffItems:
+			diffVisibleItems.length > 0 ||
+			diffCollapsedBooleanItems.length > 0 ||
+			deletedItems.length > 0,
+	};
+}
+
+export function PlanItemsSection({
+	product,
+	originalItems,
+	features,
+	prepaidOptions,
+	initialPrepaidOptions,
+	existingOptions,
+	form,
+	showDiff,
+	currency,
+	onEditPlan,
+	priceChange,
+	versionChange,
+	trialConfig,
+	gateDeletedItemsByDiff = false,
+	changesOnly = false,
+	readOnly = false,
+	adminIds,
+}: PlanItemsSectionProps) {
+	const {
+		originalItemsMap,
+		deletedItems,
+		visibleItems: allVisibleItems,
+		collapsedBooleanItems: allCollapsedBooleanItems,
+		diffVisibleItems,
+		diffCollapsedBooleanItems,
+	} = useMemo(
+		() =>
+			getPlanItemsDiff({
+				product,
+				originalItems,
+				showDiff,
+				gateDeletedItemsByDiff,
+			}),
+		[product, originalItems, showDiff, gateDeletedItemsByDiff],
+	);
+	const visibleItems = changesOnly ? diffVisibleItems : allVisibleItems;
 	const collapsedBooleanItems = changesOnly
-		? allCollapsedBooleanItems.filter(isItemNew)
+		? diffCollapsedBooleanItems
 		: allCollapsedBooleanItems;
 
 	const hasItems = (product?.items?.length ?? 0) > 0 || deletedItems.length > 0;

--- a/vite/src/views/products/plan/components/EditPlanHeader.tsx
+++ b/vite/src/views/products/plan/components/EditPlanHeader.tsx
@@ -1,4 +1,8 @@
-import { ArrowsClockwiseIcon, TriangleIcon, UserIcon } from "@phosphor-icons/react";
+import {
+	ArrowsClockwiseIcon,
+	TriangleIcon,
+	UserIcon,
+} from "@phosphor-icons/react";
 import { IconButton } from "@/components/v2/buttons/IconButton";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useMemo, useState } from "react";
@@ -38,7 +42,10 @@ import {
 	useProductQuery,
 	useProductQueryState,
 } from "../../product/hooks/useProductQuery";
-import { MigrateCustomersDialog } from "../versioning/MigrateCustomersDialog";
+import {
+	MigrateCustomersDialog,
+	useMigratableVersions,
+} from "../versioning/MigrateCustomersDialog";
 import { PlanToolbar } from "./PlanToolbar.tsx";
 
 export const EditPlanHeader = () => {
@@ -54,6 +61,7 @@ export const EditPlanHeader = () => {
 	const { mappings } = useRCMappings();
 	const { org } = useOrg();
 	const env = useEnv();
+	const currency = org?.default_currency ?? "USD";
 	const [migrateDialogOpen, setMigrateDialogOpen] = useState(false);
 
 	const pastVersionsWithCustomers = useMemo(() => {
@@ -67,6 +75,12 @@ export const EditPlanHeader = () => {
 			})
 			.map(([version]) => Number(version));
 	}, [numVersions, versionCounts]);
+	const migratableVersions = useMigratableVersions({
+		productId: product.id,
+		latestVersion: numVersions,
+		pastVersions: pastVersionsWithCustomers,
+		currency,
+	});
 
 	const hasRCMapping =
 		flags.revenuecat &&
@@ -139,7 +153,7 @@ export const EditPlanHeader = () => {
 				onOpenChange={setMigrateDialogOpen}
 				productId={product.id}
 				latestVersion={numVersions}
-				pastVersionsWithCustomers={pastVersionsWithCustomers}
+				migratableVersions={migratableVersions}
 				versionCounts={versionCounts}
 			/>
 			<div className="flex flex-col gap-2 p-4 pb-3  border-none shadow-none w-full max-w-5xl mx-auto pt-4 sm:pt-8 px-4 sm:px-12">
@@ -168,7 +182,9 @@ export const EditPlanHeader = () => {
 								{product.name}
 							</span>
 						</AdminHover>
-						<span className="text-sm text-tertiary-foreground">v{product.version}</span>
+						<span className="text-sm text-tertiary-foreground">
+							v{product.version}
+						</span>
 					</div>
 				</div>
 				<div className="flex flex-row justify-between items-center">
@@ -230,48 +246,56 @@ export const EditPlanHeader = () => {
 					</div>
 
 					<div className="flex flex-row gap-2 items-center">
-					{pastVersionsWithCustomers.length > 0 && !isCusPlanEditor && (
-						<IconButton
-							variant="secondary"
-							size="mini"
-							icon={<ArrowsClockwiseIcon />}
-							iconOrientation="left"
-							onClick={() => setMigrateDialogOpen(true)}
-						>
-							Migrate customers
-						</IconButton>
-					)}
-					{numVersions && numVersions > 1 && (
-					<Select
-						value={currentVersion.toString()}
-						onValueChange={handleVersionChange}
-						items={Object.fromEntries(versionOptions.map((version) => [version.toString(), `Version ${version}`]))}
-					>
-							<SelectTrigger className="w-fit min-w-28 !h-6" size="sm">
-								<SelectValue placeholder="Version" />
-							</SelectTrigger>
-							<SelectContent>
-								{versionOptions.map((version) => {
-									const count = versionCounts[version]?.active || 0;
-									const hasLoaded = Object.keys(versionCounts).length > 0;
-									return (
-										<SelectItem key={version} value={version.toString()}>
-											<div className="flex items-center justify-between w-full gap-3">
-												<span>Version {version}</span>
-												{hasLoaded ? (
-													<IconBadge variant="muted" icon={<UserIcon />}>
-														{count}
-													</IconBadge>
-												) : (
-													<SmallSpinner size={10} className="text-tertiary-foreground" />
-												)}
-											</div>
-										</SelectItem>
-									);
-								})}
-							</SelectContent>
-						</Select>
-					)}
+						{migratableVersions.length > 0 && !isCusPlanEditor && (
+							<IconButton
+								variant="secondary"
+								size="mini"
+								icon={<ArrowsClockwiseIcon />}
+								iconOrientation="left"
+								onClick={() => setMigrateDialogOpen(true)}
+							>
+								Migrate customers
+							</IconButton>
+						)}
+						{numVersions && numVersions > 1 && (
+							<Select
+								value={currentVersion.toString()}
+								onValueChange={handleVersionChange}
+								items={Object.fromEntries(
+									versionOptions.map((version) => [
+										version.toString(),
+										`Version ${version}`,
+									]),
+								)}
+							>
+								<SelectTrigger className="w-fit min-w-28 !h-6" size="sm">
+									<SelectValue placeholder="Version" />
+								</SelectTrigger>
+								<SelectContent>
+									{versionOptions.map((version) => {
+										const count = versionCounts[version]?.active || 0;
+										const hasLoaded = Object.keys(versionCounts).length > 0;
+										return (
+											<SelectItem key={version} value={version.toString()}>
+												<div className="flex items-center justify-between w-full gap-3">
+													<span>Version {version}</span>
+													{hasLoaded ? (
+														<IconBadge variant="muted" icon={<UserIcon />}>
+															{count}
+														</IconBadge>
+													) : (
+														<SmallSpinner
+															size={10}
+															className="text-tertiary-foreground"
+														/>
+													)}
+												</div>
+											</SelectItem>
+										);
+									})}
+								</SelectContent>
+							</Select>
+						)}
 						{!isCusPlanEditor && <PlanToolbar />}
 					</div>
 				</div>

--- a/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
+++ b/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
@@ -34,31 +34,70 @@ import {
 	buildVersionMigrationDraft,
 	type VersionMigrateScope,
 } from "./buildMigrationDraft";
+import { getPlanPriceChange, hasPlanMigrationDiff } from "./planMigrationDiff";
 
 interface MigrateCustomersDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	productId: string;
 	latestVersion: number;
-	pastVersionsWithCustomers: number[];
+	migratableVersions: number[];
 	versionCounts: Record<
 		number,
 		{ active: number; canceled: number; custom: number; trialing: number }
 	>;
 }
 
-function useVersionProducts(productId: string, pastVersions: number[]) {
+export function useMigratableVersions({
+	productId,
+	latestVersion,
+	pastVersions,
+	currency,
+}: {
+	productId: string;
+	latestVersion: number;
+	pastVersions: number[];
+	currency: string;
+}) {
+	const { products } = useProductsQuery({ allVersions: true });
+
+	return useMemo(() => {
+		const latest = products.find(
+			(p) => p.id === productId && p.version === latestVersion,
+		);
+		if (!latest) return [];
+
+		const latestProduct = productV2ToFrontendProduct({ product: latest });
+		const versions: number[] = [];
+		for (const p of products) {
+			if (p.id !== productId) continue;
+			if (!pastVersions.includes(p.version)) continue;
+			if (
+				hasPlanMigrationDiff({
+					baseProduct: productV2ToFrontendProduct({ product: p }),
+					product: latestProduct,
+					currency,
+				})
+			) {
+				versions.push(p.version);
+			}
+		}
+		return versions.sort((a, b) => b - a);
+	}, [products, productId, latestVersion, pastVersions, currency]);
+}
+
+function useVersionProducts(productId: string, versions: number[]) {
 	const { products } = useProductsQuery({ allVersions: true });
 
 	return useMemo(() => {
 		const map = new Map<number, FrontendProduct>();
 		for (const p of products) {
 			if (p.id !== productId) continue;
-			if (!pastVersions.includes(p.version)) continue;
+			if (!versions.includes(p.version)) continue;
 			map.set(p.version, productV2ToFrontendProduct({ product: p }));
 		}
 		return map;
-	}, [products, productId, pastVersions]);
+	}, [products, productId, versions]);
 }
 
 function useLatestProduct(productId: string, latestVersion: number) {
@@ -82,6 +121,11 @@ function VersionDiff({
 	currency: string;
 }) {
 	const { features = [] } = useFeaturesQuery();
+	const priceChange = getPlanPriceChange({
+		baseProduct: fromProduct,
+		product: toProduct,
+		currency,
+	});
 
 	return (
 		<PlanItemsSection
@@ -94,6 +138,7 @@ function VersionDiff({
 			changesOnly
 			currency={currency}
 			onEditPlan={() => {}}
+			priceChange={priceChange}
 			readOnly
 		/>
 	);
@@ -104,7 +149,7 @@ export function MigrateCustomersDialog({
 	onOpenChange,
 	productId,
 	latestVersion,
-	pastVersionsWithCustomers,
+	migratableVersions,
 	versionCounts,
 }: MigrateCustomersDialogProps) {
 	const navigate = useNavigate();
@@ -115,24 +160,31 @@ export function MigrateCustomersDialog({
 	const [scope, setScope] = useState<VersionMigrateScope>("all");
 	const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
 
-	const effectiveVersion = selectedVersion ?? pastVersionsWithCustomers[0] ?? null;
+	const effectiveVersion =
+		selectedVersion && migratableVersions.includes(selectedVersion)
+			? selectedVersion
+			: (migratableVersions[0] ?? null);
 
-	const versionProducts = useVersionProducts(productId, pastVersionsWithCustomers);
+	const versionProducts = useVersionProducts(productId, migratableVersions);
 	const latestProduct = useLatestProduct(productId, latestVersion);
 
 	const selectedFromProduct =
-		effectiveVersion !== null ? versionProducts.get(effectiveVersion) ?? null : null;
+		effectiveVersion !== null
+			? (versionProducts.get(effectiveVersion) ?? null)
+			: null;
 
 	const versionSelectItems = Object.fromEntries(
-		pastVersionsWithCustomers.map((v) => [String(v), `Version ${v}`]),
+		migratableVersions.map((v) => [String(v), `Version ${v}`]),
 	);
 
 	const handleCreate = async () => {
+		if (migratableVersions.length === 0) return;
+
 		const draft = buildVersionMigrationDraft({
 			productId,
 			latestVersion,
 			scope,
-			pastVersions: pastVersionsWithCustomers,
+			pastVersions: migratableVersions,
 		});
 
 		try {
@@ -140,14 +192,13 @@ export function MigrateCustomersDialog({
 
 			toast.success("Migration created");
 			onOpenChange(false);
-			navigateTo(
-				`/migrations/${migration.id}?step=live&run=true`,
-				navigate,
-			);
+			navigateTo(`/migrations/${migration.id}?step=live&run=true`, navigate);
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to create migration"));
 		}
 	};
+
+	if (migratableVersions.length === 0) return null;
 
 	return (
 		<Dialog
@@ -162,7 +213,7 @@ export function MigrateCustomersDialog({
 				<div className="overflow-y-auto min-h-0 flex-1">
 					<DialogDescription asChild>
 						<div className="text-sm flex flex-col gap-4">
-							{pastVersionsWithCustomers.length > 1 && (
+							{migratableVersions.length > 1 && (
 								<RadioGroup
 									value={scope === "all" ? "all" : "specific"}
 									onValueChange={(val) => {
@@ -176,7 +227,7 @@ export function MigrateCustomersDialog({
 									<AreaRadioGroupItem
 										value="all"
 										label={`Migrate all past versions to v${latestVersion}`}
-										description={`Move all non-custom customers across ${pastVersionsWithCustomers.length} versions.`}
+										description={`Move all non-custom customers across ${migratableVersions.length} versions.`}
 									/>
 									<AreaRadioGroupItem
 										value="specific"
@@ -191,7 +242,11 @@ export function MigrateCustomersDialog({
 									Version
 								</span>
 								<Select
-									value={effectiveVersion !== null ? String(effectiveVersion) : undefined}
+									value={
+										effectiveVersion !== null
+											? String(effectiveVersion)
+											: undefined
+									}
 									onValueChange={(v) => {
 										const num = Number(v);
 										setSelectedVersion(num);
@@ -203,7 +258,7 @@ export function MigrateCustomersDialog({
 										<SelectValue placeholder="Select version" />
 									</SelectTrigger>
 									<SelectContent>
-										{pastVersionsWithCustomers.map((version) => {
+										{migratableVersions.map((version) => {
 											const count =
 												(versionCounts[version]?.active ?? 0) -
 												(versionCounts[version]?.custom ?? 0);

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -1,10 +1,9 @@
 import type { FrontendProduct } from "@autumn/shared";
-import { isPriceItem, productsAreSame } from "@autumn/shared";
+import { productsAreSame } from "@autumn/shared";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { PlanItemsSection } from "@/components/forms/shared";
-import { getProductPriceDisplay } from "@/components/forms/update-subscription-v2/components/PriceDisplay";
 import { Switch } from "@/components/ui/switch";
 import { ShortcutButton } from "@/components/v2/buttons/ShortcutButton";
 import { MiniCopyButton } from "@/components/v2/buttons/CopyButton";
@@ -37,6 +36,7 @@ import {
 	buildMigrationDraft,
 	type MigrationScope,
 } from "./buildMigrationDraft";
+import { getPlanPriceChange, hasPlanMigrationDiff } from "./planMigrationDiff";
 
 type VersionChoice = "new" | "update";
 
@@ -69,45 +69,6 @@ function ConfirmInput({
 			/>
 		</div>
 	);
-}
-
-function usePriceChange(
-	baseProduct: FrontendProduct | null,
-	product: FrontendProduct,
-	currency: string,
-) {
-	return useMemo(() => {
-		if (!baseProduct) return null;
-
-		const oldDisplay = getProductPriceDisplay({
-			product: baseProduct,
-			currency,
-		});
-		const newDisplay = getProductPriceDisplay({ product, currency });
-
-		const oldPrice =
-			oldDisplay.type === "price" ? oldDisplay.formattedPrice : "Free";
-		const newPrice =
-			newDisplay.type === "price" ? newDisplay.formattedPrice : "Free";
-		const oldInterval =
-			oldDisplay.type === "price" ? oldDisplay.intervalText : null;
-		const newInterval =
-			newDisplay.type === "price" ? newDisplay.intervalText : null;
-
-		if (oldPrice === newPrice && oldInterval === newInterval) return null;
-
-		const originalPriceItem = baseProduct.items?.find((i) => isPriceItem(i));
-		const currentPriceItem = product.items?.find((i) => isPriceItem(i));
-
-		return {
-			oldPrice,
-			newPrice,
-			oldIntervalText: oldInterval !== newInterval ? oldInterval : null,
-			newIntervalText: newInterval,
-			isUpgrade:
-				(currentPriceItem?.price ?? 0) > (originalPriceItem?.price ?? 0),
-		};
-	}, [baseProduct, product.items, currency]);
 }
 
 export default function PlanChangeDialog({
@@ -143,7 +104,10 @@ export default function PlanChangeDialog({
 	const confirmed = confirmText === product.id;
 
 	const currency = org?.default_currency ?? "USD";
-	const priceChange = usePriceChange(baseProduct, product, currency);
+	const priceChange = useMemo(
+		() => getPlanPriceChange({ baseProduct, product, currency }),
+		[baseProduct, product, currency],
+	);
 	const hasMultipleVersions = (numVersions ?? 1) > 1;
 
 	const customCount = useMemo(() => {
@@ -162,6 +126,9 @@ export default function PlanChangeDialog({
 		});
 		return !same;
 	}, [baseProduct, product, features]);
+	const hasMigrationDiff = useMemo(() => {
+		return hasPlanMigrationDiff({ baseProduct, product, currency });
+	}, [baseProduct, product, currency]);
 
 	const resetState = () => {
 		setStep(1);
@@ -207,10 +174,16 @@ export default function PlanChangeDialog({
 						features,
 					}),
 				);
-				setMigrationBaseProduct(baseProduct);
 				markSaved();
 				toast.success("Plan updated");
-				setStep(2);
+				if (hasMigrationDiff) {
+					setMigrationBaseProduct(baseProduct);
+					setStep(2);
+				} else {
+					setOpen(false);
+					resetState();
+					void refetch();
+				}
 				void invalidateProducts();
 			} catch (error) {
 				toast.error(getBackendErr(error, "Failed to update plan"));
@@ -248,12 +221,23 @@ export default function PlanChangeDialog({
 	const handleStep2Action = async () => {
 		const draftBaseProduct = migrationBaseProduct ?? baseProduct;
 		if (!draftBaseProduct) return;
+		if (
+			!hasPlanMigrationDiff({
+				baseProduct: draftBaseProduct,
+				product,
+				currency,
+			})
+		) {
+			setOpen(false);
+			resetState();
+			void refetch();
+			void invalidateProducts();
+			return;
+		}
 
 		setIsLoading(true);
 		try {
-			const scope = hasMultipleVersions
-				? migrationScope
-				: "this_version";
+			const scope = hasMultipleVersions ? migrationScope : "this_version";
 
 			const draft = buildMigrationDraft({
 				baseProduct: draftBaseProduct,
@@ -303,9 +287,7 @@ export default function PlanChangeDialog({
 			<DialogContent className="max-w-md max-h-[85vh] flex flex-col">
 				<DialogHeader>
 					<DialogTitle>
-						{step === 1
-							? "Save plan changes"
-							: "Create migration"}
+						{step === 1 ? "Save plan changes" : "Create migration"}
 					</DialogTitle>
 				</DialogHeader>
 
@@ -317,9 +299,7 @@ export default function PlanChangeDialog({
 									{hasChanges && (
 										<PlanItemsSection
 											product={product}
-											originalItems={
-												baseProduct?.items
-											}
+											originalItems={baseProduct?.items}
 											features={features}
 											prepaidOptions={{}}
 											initialPrepaidOptions={{}}
@@ -336,9 +316,7 @@ export default function PlanChangeDialog({
 										className="pt-1 pb-3"
 										value={versionChoice}
 										onValueChange={(val) =>
-											setVersionChoice(
-												val as VersionChoice,
-											)
+											setVersionChoice(val as VersionChoice)
 										}
 									>
 										<AreaRadioGroupItem
@@ -364,12 +342,10 @@ export default function PlanChangeDialog({
 							{step === 2 && (
 								<>
 									<p className="text-sm text-muted-foreground">
-										Autumn updated the current version of
-										this plan directly. New customers will
-										get these changes immediately. Now
-										create a migration so you can review
-										and apply the same changes to current
-										users.
+										Autumn updated the current version of this plan directly.
+										New customers will get these changes immediately. Now create
+										a migration so you can review and apply the same changes to
+										current users.
 									</p>
 
 									{hasMultipleVersions && (
@@ -377,9 +353,7 @@ export default function PlanChangeDialog({
 											className="pt-1 pb-3"
 											value={migrationScope}
 											onValueChange={(val) =>
-												setMigrationScope(
-													val as MigrationScope,
-												)
+												setMigrationScope(val as MigrationScope)
 											}
 										>
 											<AreaRadioGroupItem
@@ -402,34 +376,24 @@ export default function PlanChangeDialog({
 													Apply to custom plans
 												</span>
 												<span className="text-xs text-muted-foreground">
-													There{" "}
-													{customCount === 1
-														? "is"
-														: "are"}{" "}
-													{customCount} user
-													{customCount !== 1
-														? "s"
-														: ""}{" "}
-													on custom versions of
+													There {customCount === 1 ? "is" : "are"} {customCount}{" "}
+													user
+													{customCount !== 1 ? "s" : ""} on custom versions of
 													this plan
 												</span>
 											</div>
 											<Switch
 												checked={includeCustom}
-												onCheckedChange={
-													setIncludeCustom
-												}
+												onCheckedChange={setIncludeCustom}
 											/>
 										</div>
 									)}
 
-									{!hasMultipleVersions &&
-										customCount === 0 && (
-											<p className="text-sm text-muted-foreground">
-												Preview a migration for
-												current users on this plan.
-											</p>
-										)}
+									{!hasMultipleVersions && customCount === 0 && (
+										<p className="text-sm text-muted-foreground">
+											Preview a migration for current users on this plan.
+										</p>
+									)}
 								</>
 							)}
 						</div>
@@ -440,16 +404,9 @@ export default function PlanChangeDialog({
 					<ShortcutButton
 						variant="primary"
 						metaShortcut="enter"
-						onClick={
-							step === 1
-								? handleStep1Action
-								: handleStep2Action
-						}
+						onClick={step === 1 ? handleStep1Action : handleStep2Action}
 						isLoading={isLoading}
-						disabled={
-							isLoading ||
-							(step === 1 && !confirmed)
-						}
+						disabled={isLoading || (step === 1 && !confirmed)}
 						className="w-full"
 					>
 						{buttonText}

--- a/vite/src/views/products/plan/versioning/planMigrationDiff.ts
+++ b/vite/src/views/products/plan/versioning/planMigrationDiff.ts
@@ -1,0 +1,60 @@
+import type { FrontendProduct } from "@autumn/shared";
+import { isPriceItem } from "@autumn/shared";
+import { getPlanItemsDiff } from "@/components/forms/shared";
+import { getProductPriceDisplay } from "@/components/forms/update-subscription-v2/components/PriceDisplay";
+
+export function getPlanPriceChange({
+	baseProduct,
+	product,
+	currency,
+}: {
+	baseProduct: FrontendProduct | null | undefined;
+	product: FrontendProduct;
+	currency: string;
+}) {
+	if (!baseProduct) return null;
+
+	const oldDisplay = getProductPriceDisplay({ product: baseProduct, currency });
+	const newDisplay = getProductPriceDisplay({ product, currency });
+	const oldPrice =
+		oldDisplay.type === "price" ? oldDisplay.formattedPrice : "Free";
+	const newPrice =
+		newDisplay.type === "price" ? newDisplay.formattedPrice : "Free";
+	const oldInterval =
+		oldDisplay.type === "price" ? oldDisplay.intervalText : null;
+	const newInterval =
+		newDisplay.type === "price" ? newDisplay.intervalText : null;
+
+	if (oldPrice === newPrice && oldInterval === newInterval) return null;
+
+	const originalPriceItem = baseProduct.items?.find((i) => isPriceItem(i));
+	const currentPriceItem = product.items?.find((i) => isPriceItem(i));
+
+	return {
+		oldPrice,
+		newPrice,
+		oldIntervalText: oldInterval !== newInterval ? oldInterval : null,
+		newIntervalText: newInterval,
+		isUpgrade: (currentPriceItem?.price ?? 0) > (originalPriceItem?.price ?? 0),
+	};
+}
+
+export function hasPlanMigrationDiff({
+	baseProduct,
+	product,
+	currency,
+}: {
+	baseProduct: FrontendProduct | null | undefined;
+	product: FrontendProduct;
+	currency: string;
+}) {
+	if (!baseProduct) return false;
+	return (
+		!!getPlanPriceChange({ baseProduct, product, currency }) ||
+		getPlanItemsDiff({
+			product,
+			originalItems: baseProduct.items,
+			showDiff: true,
+		}).hasDiffItems
+	);
+}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show the migrate flow only when there are real plan diffs, and surface clear price/item changes. Shared diff utilities now power both migration and plan change flows for consistent behavior.

- **New Features**
  - Show “Migrate customers” only when past versions actually differ from the latest.
  - Filter the version list to migratable versions; hide the dialog if none exist.
  - Display concise item diffs and price changes during previews.
  - After saving a plan, skip the migration step when there’s nothing to migrate.

- **Refactors**
  - Added `planMigrationDiff.ts` with `getPlanPriceChange` and `hasPlanMigrationDiff`.
  - Extracted `getPlanItemsDiff` from `PlanItemsSection` and simplified diff handling.
  - Updated dialogs to use shared diff utilities for consistent logic.
  - Minor typing/prop cleanups (e.g., `AdminPlanIds` import).

<sup>Written for commit c48d2e98f37749291ecc04b88480ce8a44650da6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts plan-version migration diff detection into a dedicated `planMigrationDiff.ts` utility, and uses that logic to filter which past versions actually require a migration (price or item changes). The \"Migrate customers\" button and step 2 of `PlanChangeDialog` are now only shown when a real customer-facing diff exists.

- **Improvements** — `getPlanItemsDiff` is extracted from `PlanItemsSection` as a pure function; `getPlanPriceChange` and `hasPlanMigrationDiff` are moved from inline `PlanChangeDialog` hooks into the shared utility, removing duplication.
- **Improvements** — `useMigratableVersions` filters past versions to those with at least one billing or item difference versus the latest version, so the migration flow is only offered when it's meaningful.
- **Improvements** — `PlanChangeDialog` now closes immediately after a \"Update existing version\" save when there is no migration diff, skipping the migration step entirely and improving the save UX.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are additive refactoring with a clear UX improvement for the migration flow.

The extraction and reuse of diff logic is clean throughout. The one thing worth a second look is in MigrateCustomersDialog: when the user switches the radio to "Migrate a specific version" before ever touching the version select, selectedVersion is still null and setScope(null) is called, which may fall outside the expected VersionMigrateScope type. The rest of the code — the useMigratableVersions filtering loop, the hasMigrationDiff guard in PlanChangeDialog, and the getPlanItemsDiff extraction — all look correct.

MigrateCustomersDialog.tsx — the setScope(selectedVersion) call in the radio group handler when selectedVersion is null.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/planMigrationDiff.ts | New utility file extracting getPlanPriceChange and hasPlanMigrationDiff from PlanChangeDialog; logic is a clean lift-and-shift with correct null guards and short-circuit evaluation. |
| vite/src/components/forms/shared/PlanItemsSection.tsx | Extracts getPlanItemsDiff as a pure function for reuse in planMigrationDiff.ts; PlanItemsSection wraps the call in useMemo with the correct dependency array. |
| vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx | Adds useMigratableVersions hook that filters past versions to only those with actual plan diffs; replaces pastVersionsWithCustomers throughout. Early return null guard is correctly placed after all hook calls. |
| vite/src/views/products/plan/components/EditPlanHeader.tsx | Uses useMigratableVersions to gate the Migrate customers button; clean refactoring with stable memoized pastVersionsWithCustomers dependency. |
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Removes inline usePriceChange hook in favour of getPlanPriceChange; adds hasMigrationDiff to skip step 2 when no billing/item changes exist; handleStep2Action adds a defensive re-check before creating migration. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Edit Plan] --> B{Save plan changes\nPlanChangeDialog step 1}
    B --> C{versionChoice}
    C -->|new| D[Create new version\nupdateProduct]
    C -->|update| E[Update existing version\nProductService.updatePlan]
    D --> F[Close dialog + sync to latest]
    E --> G{hasMigrationDiff?\nhasPlanMigrationDiff}
    G -->|No diff| H[Close dialog]
    G -->|Has diff| I[Step 2: Create migration]
    I --> J{handleStep2Action\nguard: hasPlanMigrationDiff}
    J -->|No diff| H
    J -->|Has diff| K[buildMigrationDraft + createMigration]
    K --> L[Navigate to /migrations/:id]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx`, line 219-225 ([link](https://github.com/useautumn/autumn/blob/c48d2e98f37749291ecc04b88480ce8a44650da6/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx#L219-L225)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Scope set to `null` before version is selected**

   When the dialog opens, `selectedVersion` is `null`. If the user switches the radio to "Migrate a specific version" before touching the version select, `setScope(null)` is called. `buildVersionMigrationDraft` then receives a `null` scope, which likely falls outside the `VersionMigrateScope` type and may produce an unintended draft. Consider defaulting to `migratableVersions[0]` when `selectedVersion` is null: `setScope(selectedVersion ?? migratableVersions[0] ?? null)`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
   Line: 219-225

   Comment:
   **Scope set to `null` before version is selected**

   When the dialog opens, `selectedVersion` is `null`. If the user switches the radio to "Migrate a specific version" before touching the version select, `setScope(null)` is called. `buildVersionMigrationDraft` then receives a `null` scope, which likely falls outside the `VersionMigrateScope` type and may produce an unintended draft. Consider defaulting to `migratableVersions[0]` when `selectedVersion` is null: `setScope(selectedVersion ?? migratableVersions[0] ?? null)`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx:219-225
**Scope set to `null` before version is selected**

When the dialog opens, `selectedVersion` is `null`. If the user switches the radio to "Migrate a specific version" before touching the version select, `setScope(null)` is called. `buildVersionMigrationDraft` then receives a `null` scope, which likely falls outside the `VersionMigrateScope` type and may produce an unintended draft. Consider defaulting to `migratableVersions[0]` when `selectedVersion` is null: `setScope(selectedVersion ?? migratableVersions[0] ?? null)`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: plan migrate diffs"](https://github.com/useautumn/autumn/commit/c48d2e98f37749291ecc04b88480ce8a44650da6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36451792)</sub>

<!-- /greptile_comment -->