### PR TITLE
chore: actually fix plan diffs

### DIFF
--- a/vite/src/views/products/plan/components/EditPlanHeader.tsx
+++ b/vite/src/views/products/plan/components/EditPlanHeader.tsx
@@ -61,7 +61,6 @@ export const EditPlanHeader = () => {
 	const { mappings } = useRCMappings();
 	const { org } = useOrg();
 	const env = useEnv();
-	const currency = org?.default_currency ?? "USD";
 	const [migrateDialogOpen, setMigrateDialogOpen] = useState(false);
 
 	const pastVersionsWithCustomers = useMemo(() => {
@@ -79,7 +78,6 @@ export const EditPlanHeader = () => {
 		productId: product.id,
 		latestVersion: numVersions,
 		pastVersions: pastVersionsWithCustomers,
-		currency,
 	});
 
 	const hasRCMapping =

--- a/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
+++ b/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
@@ -52,14 +52,13 @@ export function useMigratableVersions({
 	productId,
 	latestVersion,
 	pastVersions,
-	currency,
 }: {
 	productId: string;
 	latestVersion: number;
 	pastVersions: number[];
-	currency: string;
 }) {
 	const { products } = useProductsQuery({ allVersions: true });
+	const { features = [] } = useFeaturesQuery();
 
 	return useMemo(() => {
 		const latest = products.find(
@@ -76,14 +75,14 @@ export function useMigratableVersions({
 				hasPlanMigrationDiff({
 					baseProduct: productV2ToFrontendProduct({ product: p }),
 					product: latestProduct,
-					currency,
+					features,
 				})
 			) {
 				versions.push(p.version);
 			}
 		}
 		return versions.sort((a, b) => b - a);
-	}, [products, productId, latestVersion, pastVersions, currency]);
+	}, [products, productId, latestVersion, pastVersions, features]);
 }
 
 function useVersionProducts(productId: string, versions: number[]) {

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -127,8 +127,8 @@ export default function PlanChangeDialog({
 		return !same;
 	}, [baseProduct, product, features]);
 	const hasMigrationDiff = useMemo(() => {
-		return hasPlanMigrationDiff({ baseProduct, product, currency });
-	}, [baseProduct, product, currency]);
+		return hasPlanMigrationDiff({ baseProduct, product, features });
+	}, [baseProduct, product, features]);
 
 	const resetState = () => {
 		setStep(1);
@@ -225,7 +225,7 @@ export default function PlanChangeDialog({
 			!hasPlanMigrationDiff({
 				baseProduct: draftBaseProduct,
 				product,
-				currency,
+				features,
 			})
 		) {
 			setOpen(false);

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -137,6 +137,21 @@ function diffHasBillingChanges(diff: DiffedCustomizePlanV1): boolean {
 	return false;
 }
 
+export function getMigratablePlanDiff(
+	diff: DiffedCustomizePlanV1,
+): DiffedCustomizePlanV1 {
+	return {
+		...(diff.price !== undefined ? { price: diff.price } : {}),
+		...(diff.add_items !== undefined ? { add_items: diff.add_items } : {}),
+		...(diff.remove_items !== undefined
+			? { remove_items: diff.remove_items }
+			: {}),
+		...(diff.update_items !== undefined
+			? { update_items: diff.update_items }
+			: {}),
+	};
+}
+
 export type MigrationScope = "this_version" | "all_customers";
 
 export type VersionMigrateScope = "all" | number;
@@ -206,9 +221,10 @@ export function buildMigrationDraft({
 	const from = frontendProductToApiPlanV1(baseProduct, features);
 	const to = frontendProductToApiPlanV1(editedProduct, features);
 	const diff = diffPlanV1({ from, to });
+	const migrationDiff = getMigratablePlanDiff(diff);
 
-	const hasCustomize = Object.keys(diff).length > 0;
-	const customize = hasCustomize ? diff : undefined;
+	const hasCustomize = Object.keys(migrationDiff).length > 0;
+	const customize = hasCustomize ? migrationDiff : undefined;
 
 	const basePlanFilter = {
 		plan_id: baseProduct.id,
@@ -240,6 +256,6 @@ export function buildMigrationDraft({
 				? [updatePlanOp(false), updatePlanOp(true)]
 				: [updatePlanOp(false)],
 		},
-		no_billing_changes: diffHasBillingChanges(diff) === false,
+		no_billing_changes: diffHasBillingChanges(migrationDiff) === false,
 	};
 }

--- a/vite/src/views/products/plan/versioning/planMigrationDiff.ts
+++ b/vite/src/views/products/plan/versioning/planMigrationDiff.ts
@@ -1,7 +1,10 @@
-import type { FrontendProduct } from "@autumn/shared";
-import { isPriceItem } from "@autumn/shared";
-import { getPlanItemsDiff } from "@/components/forms/shared";
+import type { Feature, FrontendProduct } from "@autumn/shared";
+import { diffPlanV1, isPriceItem } from "@autumn/shared";
 import { getProductPriceDisplay } from "@/components/forms/update-subscription-v2/components/PriceDisplay";
+import {
+	frontendProductToApiPlanV1,
+	getMigratablePlanDiff,
+} from "./buildMigrationDraft";
 
 export function getPlanPriceChange({
 	baseProduct,
@@ -42,19 +45,18 @@ export function getPlanPriceChange({
 export function hasPlanMigrationDiff({
 	baseProduct,
 	product,
-	currency,
+	features,
 }: {
 	baseProduct: FrontendProduct | null | undefined;
 	product: FrontendProduct;
-	currency: string;
+	features: Feature[];
 }) {
 	if (!baseProduct) return false;
-	return (
-		!!getPlanPriceChange({ baseProduct, product, currency }) ||
-		getPlanItemsDiff({
-			product,
-			originalItems: baseProduct.items,
-			showDiff: true,
-		}).hasDiffItems
-	);
+
+	const diff = diffPlanV1({
+		from: frontendProductToApiPlanV1(baseProduct, features),
+		to: frontendProductToApiPlanV1(product, features),
+	});
+
+	return Object.keys(getMigratablePlanDiff(diff)).length > 0;
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes plan migration diffs by comparing API-shaped plans built with features and ignoring non-migratable fields. This makes migratable version detection and migration drafts accurate and consistent.

- **Bug Fixes**
  - Use `diffPlanV1` on `frontendProductToApiPlanV1(...)` and remove `currency` from diff checks.
  - Add `getMigratablePlanDiff` to restrict diffs to price and item add/remove/update; use it for UI gating and the `customize` payload.
  - Compute `no_billing_changes` from the migratable diff, not the full diff.
  - Update migrate/change dialogs to use feature-aware diffs and fix migratable versions list and dialog close logic.

<sup>Written for commit cc443cf4a70f3f83dc2af9e4b932ef4ccb2b1459. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes plan migration diff detection by unifying the logic between `hasPlanMigrationDiff` and `buildMigrationDraft` — both now use `diffPlanV1` + a new `getMigratablePlanDiff` filter, replacing the previous currency-based heuristic that could diverge from the actual migration payload.

- **Bug fixes** — `hasPlanMigrationDiff` now produces the same diff as `buildMigrationDraft`, eliminating false-positives (e.g., name/description/free_trial-only changes triggering the migration dialog) and false-negatives.
- **Bug fixes** — `getMigratablePlanDiff` filters the full plan diff to only the migration-actionable fields (`price`, `add_items`, `remove_items`, `update_items`), ensuring `no_billing_changes` and `customize` are computed from the same scoped diff.
- **Improvements** — `currency` is removed from the migration diff API surface; `features` (used by `productItemsToPlanItemsV1`) is now the correct dependency for accurate item comparison.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes tighten the consistency between the migration-trigger check and the migration payload builder with no new risk surfaces.

The diff is a targeted correctness fix: the gate check (hasPlanMigrationDiff) and the payload builder (buildMigrationDraft) now share the same diff pipeline, removing the prior mismatch. The getMigratablePlanDiff helper is straightforward and its output is used consistently. No new async paths, no new API calls, no schema changes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/planMigrationDiff.ts | hasPlanMigrationDiff rewritten to use diffPlanV1 + getMigratablePlanDiff instead of the old currency-based price/items check, making it consistent with buildMigrationDraft |
| vite/src/views/products/plan/versioning/buildMigrationDraft.ts | New getMigratablePlanDiff helper extracts only the migration-relevant diff fields (price, add/remove/update_items), and buildMigrationDraft now uses it to both set customize and no_billing_changes |
| vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx | useMigratableVersions drops the currency param, adds its own useFeaturesQuery call, and passes features to hasPlanMigrationDiff |
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Both hasPlanMigrationDiff call sites updated to pass features instead of currency |
| vite/src/views/products/plan/components/EditPlanHeader.tsx | Removes unused currency variable and its forwarding to useMigratableVersions |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Plan edited by user] --> B{hasPlanMigrationDiff}
    B --> C[frontendProductToApiPlanV1\nbaseProduct, features]
    B --> D[frontendProductToApiPlanV1\nproduct, features]
    C --> E[diffPlanV1\nfrom, to]
    D --> E
    E --> F[getMigratablePlanDiff\nfilter to price/add/remove/update_items]
    F --> G{Object.keys length > 0?}
    G -- No --> H[No migration needed\nclose dialog]
    G -- Yes --> I[Show migration dialog]
    I --> J[buildMigrationDraft]
    J --> K[frontendProductToApiPlanV1 x2 with features]
    K --> L[diffPlanV1]
    L --> M[getMigratablePlanDiff]
    M --> N{hasCustomize?}
    N -- Yes --> O[customize = migrationDiff]
    N -- No --> P[customize = undefined]
    O --> Q[MigrationDraft]
    P --> Q
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: actually fix plan diffs"](https://github.com/useautumn/autumn/commit/cc443cf4a70f3f83dc2af9e4b932ef4ccb2b1459) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36460798)</sub>

<!-- /greptile_comment -->