### PR TITLE
chore: un feature flag

### DIFF
--- a/shared/utils/scopeDefinitions.test.ts
+++ b/shared/utils/scopeDefinitions.test.ts
@@ -599,15 +599,16 @@ describe("ROLE_SCOPES", () => {
 		expect(ROLE_SCOPES.sales.length).toBe(7);
 	});
 
-	test("member contains all :read scopes, no :write", () => {
-		expect(ROLE_SCOPES.member.length).toBe(RESOURCES.length);
+	test("member contains expected :read scopes, no :write", () => {
+		expect(ROLE_SCOPES.member.length).toBe(RESOURCES.length - 1);
 		for (const s of ROLE_SCOPES.member) {
 			expect(s.endsWith(":read")).toBe(true);
 			expect(s.endsWith(":write")).toBe(false);
 		}
-		for (const r of RESOURCES) {
+		for (const r of RESOURCES.filter((r) => r !== "migrations")) {
 			expect(ROLE_SCOPES.member).toContain(`${r}:read` as ScopeString);
 		}
+		expect(ROLE_SCOPES.member).not.toContain(Scopes.Migrations.Read);
 	});
 });
 

--- a/shared/utils/scopeDefinitions.ts
+++ b/shared/utils/scopeDefinitions.ts
@@ -402,7 +402,6 @@ export const ROLE_SCOPES: Record<Role, ScopeString[]> = {
 		Scopes.Rewards.Read,
 		Scopes.Balances.Read,
 		Scopes.Billing.Read,
-		Scopes.Migrations.Read,
 		Scopes.Analytics.Read,
 		Scopes.ApiKeys.Read,
 		Scopes.Platform.Read,

--- a/vite/src/components/v2/selects/RoleSelect.tsx
+++ b/vite/src/components/v2/selects/RoleSelect.tsx
@@ -23,17 +23,17 @@ const ROLE_META: Record<Role, { label: string; description: string }> = {
 	owner: {
 		label: "Owner",
 		description:
-			"Write on everything (organisation, customers, features, plans, rewards, balances, billing, API keys, platform) + read analytics. Can delete the org and manage ownership.",
+			"Write on everything (organisation, customers, features, plans, rewards, balances, billing, migrations, API keys, platform) + read analytics. Can delete the org and manage ownership.",
 	},
 	admin: {
 		label: "Admin",
 		description:
-			"Write on everything (organisation, customers, features, plans, rewards, balances, billing, API keys, platform) + read analytics. Cannot delete the org or transfer ownership.",
+			"Write on everything (organisation, customers, features, plans, rewards, balances, billing, migrations, API keys, platform) + read analytics. Cannot delete the org or transfer ownership.",
 	},
 	developer: {
 		label: "Developer",
 		description:
-			"Write on customers, features, plans, rewards, balances, billing, API keys, and platform. Read organisation and analytics.",
+			"Write on customers, features, plans, rewards, balances, billing, migrations, API keys, and platform. Read organisation and analytics.",
 	},
 	sales: {
 		label: "Sales",
@@ -43,7 +43,7 @@ const ROLE_META: Record<Role, { label: string; description: string }> = {
 	member: {
 		label: "Member",
 		description:
-			"Read-only on everything: organisation, customers, features, plans, rewards, balances, billing, analytics, API keys, platform. No write access.",
+			"Read-only on organisation, customers, features, plans, rewards, balances, billing, analytics, API keys, and platform. No migrations access.",
 	},
 };
 

--- a/vite/src/views/main-sidebar/MainSidebar.tsx
+++ b/vite/src/views/main-sidebar/MainSidebar.tsx
@@ -13,6 +13,7 @@ import {
 	UsersIcon,
 	WebhooksLogoIcon,
 } from "@phosphor-icons/react";
+import { Scopes } from "@autumn/shared";
 import { PanelLeft } from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { BetaBadge } from "@/components/v2/badges/BetaBadge";
@@ -23,7 +24,6 @@ import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 import { useScopes } from "@/hooks/useScopes";
 import { cn } from "@/lib/utils";
 import { useEnv } from "@/utils/envUtils";
-import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { CollapsibleNavGroup } from "./CollapsibleNavGroup";
 import { OrgDropdown } from "./components/OrgDropdown";
 import { EnvDropdown } from "./EnvDropdown";
@@ -92,8 +92,8 @@ export const MainSidebar = ({
 
 	const flags = useAutumnFlags();
 	const { has } = useScopes();
-	const { isAdmin } = useAdmin();
-	const canSeeDev = has("apiKeys:read");
+	const canSeeDev = has(Scopes.ApiKeys.Read);
+	const canSeeMigrations = has(Scopes.Migrations.Read);
 
 	const [storedExpanded, setExpanded] = useLocalStorage<boolean>(
 		"sidebar.expanded",
@@ -183,7 +183,7 @@ export const MainSidebar = ({
 								},
 							]}
 						/>
-						{isAdmin ? (
+						{canSeeMigrations ? (
 							<CollapsibleNavGroup
 								value="customers"
 								icon={<UserCircleIcon size={16} weight="fill" />}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make migrations access scope-based rather than admin-only. Member role no longer has migrations read access; sidebar and role copy reflect this.

- **Refactors**
  - Gate Migrations nav by `Scopes.Migrations.Read` instead of `isAdmin`.
  - Use `Scopes.ApiKeys.Read` for dev tools visibility (replaces string check).
  - Remove `Scopes.Migrations.Read` from `member` in `ROLE_SCOPES`; update tests and role descriptions.

<sup>Written for commit f3e7adca503e53259979b03a7f4822ef50a3f245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the feature flag gating the Migrations sidebar entry, replacing the `isAdmin` hook check with a scope-based `has(Scopes.Migrations.Read)` check. Members no longer have `migrations:read` in their scope grant, while owner/admin (via `MODERN_SCOPES`) and developer (via `migrations:write` → write-implies-read) retain access.

- **[Improvements]** Migrations sidebar visibility is now driven by the `migrations:read` scope rather than the `isAdmin` hook, consistent with how every other sidebar entry is gated.
- **[Improvements]** `member` role is stripped of `migrations:read`, and the role description UI is updated to reflect \"no migrations access\" for members while adding \"migrations\" to the write list for owner/admin/developer.
- **[Improvements]** Test updated to assert the member scope set is `RESOURCES.length - 1` and explicitly does not contain `Scopes.Migrations.Read`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward, well-coordinated removal of an admin-only feature flag in favour of scope-based access control, with tests updated to match.

All four changed files are internally consistent: the scope grant, the test assertions, the sidebar gate, and the role-description copy all agree on the new access model. The write-implies-read expansion in expandScopes ensures owner/admin/developer retain sidebar access. No edge cases or regressions are apparent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/scopeDefinitions.ts | Removes Scopes.Migrations.Read from the member role grant; owner/admin/developer keep access via MODERN_SCOPES or write-implies-read. |
| shared/utils/scopeDefinitions.test.ts | Test updated to expect RESOURCES.length - 1 scopes for member and to assert Migrations.Read is absent; accurate to the new grant. |
| vite/src/views/main-sidebar/MainSidebar.tsx | Replaces isAdmin hook with has(Scopes.Migrations.Read) scope check for gating the Migrations nav group; useAdmin import removed. |
| vite/src/components/v2/selects/RoleSelect.tsx | Role descriptions updated to list migrations in write scope for owner/admin/developer and to state No migrations access for member. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User loads MainSidebar] --> B{has Scopes.Migrations.Read?}
    B -->|true| C[Show Customers group with Migrations sub-tab]
    B -->|false| D[Show plain Customers NavButton only]

    subgraph Scope resolution
        E[owner / admin role] -->|MODERN_SCOPES includes migrations:read| F[migrations:read ✓]
        G[developer role] -->|has migrations:write - write implies read| F
        H[sales role] -->|no migrations scope| I[migrations:read ✗]
        J[member role] -->|Migrations.Read removed in this PR| I
    end

    F --> B
    I --> B
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: un feature flag"](https://github.com/useautumn/autumn/commit/f3e7adca503e53259979b03a7f4822ef50a3f245) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36475547)</sub>

<!-- /greptile_comment -->