### PR TITLE
Charlie/trigger fix

### DIFF
--- a/shared/utils/scopeDefinitions.test.ts
+++ b/shared/utils/scopeDefinitions.test.ts
@@ -599,15 +599,16 @@ describe("ROLE_SCOPES", () => {
 		expect(ROLE_SCOPES.sales.length).toBe(7);
 	});
 
-	test("member contains all :read scopes, no :write", () => {
-		expect(ROLE_SCOPES.member.length).toBe(RESOURCES.length);
+	test("member contains expected :read scopes, no :write", () => {
+		expect(ROLE_SCOPES.member.length).toBe(RESOURCES.length - 1);
 		for (const s of ROLE_SCOPES.member) {
 			expect(s.endsWith(":read")).toBe(true);
 			expect(s.endsWith(":write")).toBe(false);
 		}
-		for (const r of RESOURCES) {
+		for (const r of RESOURCES.filter((r) => r !== "migrations")) {
 			expect(ROLE_SCOPES.member).toContain(`${r}:read` as ScopeString);
 		}
+		expect(ROLE_SCOPES.member).not.toContain(Scopes.Migrations.Read);
 	});
 });
 

--- a/shared/utils/scopeDefinitions.ts
+++ b/shared/utils/scopeDefinitions.ts
@@ -402,7 +402,6 @@ export const ROLE_SCOPES: Record<Role, ScopeString[]> = {
 		Scopes.Rewards.Read,
 		Scopes.Balances.Read,
 		Scopes.Billing.Read,
-		Scopes.Migrations.Read,
 		Scopes.Analytics.Read,
 		Scopes.ApiKeys.Read,
 		Scopes.Platform.Read,

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -19,6 +19,7 @@ const workspacePackageJsonPaths = [
 	"apps/sdk-test/package.json",
 	"packages/atmn/package.json",
 	"packages/atmn-tests/package.json",
+	"packages/auth/package.json",
 	"packages/logging/package.json",
 	"packages/mcp/package.json",
 	"packages/sdk/package.json",

--- a/vite/src/components/v2/selects/RoleSelect.tsx
+++ b/vite/src/components/v2/selects/RoleSelect.tsx
@@ -23,17 +23,17 @@ const ROLE_META: Record<Role, { label: string; description: string }> = {
 	owner: {
 		label: "Owner",
 		description:
-			"Write on everything (organisation, customers, features, plans, rewards, balances, billing, API keys, platform) + read analytics. Can delete the org and manage ownership.",
+			"Write on everything (organisation, customers, features, plans, rewards, balances, billing, migrations, API keys, platform) + read analytics. Can delete the org and manage ownership.",
 	},
 	admin: {
 		label: "Admin",
 		description:
-			"Write on everything (organisation, customers, features, plans, rewards, balances, billing, API keys, platform) + read analytics. Cannot delete the org or transfer ownership.",
+			"Write on everything (organisation, customers, features, plans, rewards, balances, billing, migrations, API keys, platform) + read analytics. Cannot delete the org or transfer ownership.",
 	},
 	developer: {
 		label: "Developer",
 		description:
-			"Write on customers, features, plans, rewards, balances, billing, API keys, and platform. Read organisation and analytics.",
+			"Write on customers, features, plans, rewards, balances, billing, migrations, API keys, and platform. Read organisation and analytics.",
 	},
 	sales: {
 		label: "Sales",
@@ -43,7 +43,7 @@ const ROLE_META: Record<Role, { label: string; description: string }> = {
 	member: {
 		label: "Member",
 		description:
-			"Read-only on everything: organisation, customers, features, plans, rewards, balances, billing, analytics, API keys, platform. No write access.",
+			"Read-only on organisation, customers, features, plans, rewards, balances, billing, analytics, API keys, and platform. No migrations access.",
 	},
 };
 

--- a/vite/src/views/main-sidebar/MainSidebar.tsx
+++ b/vite/src/views/main-sidebar/MainSidebar.tsx
@@ -13,6 +13,7 @@ import {
 	UsersIcon,
 	WebhooksLogoIcon,
 } from "@phosphor-icons/react";
+import { Scopes } from "@autumn/shared";
 import { PanelLeft } from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { BetaBadge } from "@/components/v2/badges/BetaBadge";
@@ -23,7 +24,6 @@ import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 import { useScopes } from "@/hooks/useScopes";
 import { cn } from "@/lib/utils";
 import { useEnv } from "@/utils/envUtils";
-import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { CollapsibleNavGroup } from "./CollapsibleNavGroup";
 import { OrgDropdown } from "./components/OrgDropdown";
 import { EnvDropdown } from "./EnvDropdown";
@@ -92,8 +92,8 @@ export const MainSidebar = ({
 
 	const flags = useAutumnFlags();
 	const { has } = useScopes();
-	const { isAdmin } = useAdmin();
-	const canSeeDev = has("apiKeys:read");
+	const canSeeDev = has(Scopes.ApiKeys.Read);
+	const canSeeMigrations = has(Scopes.Migrations.Read);
 
 	const [storedExpanded, setExpanded] = useLocalStorage<boolean>(
 		"sidebar.expanded",
@@ -183,7 +183,7 @@ export const MainSidebar = ({
 								},
 							]}
 						/>
-						{isAdmin ? (
+						{canSeeMigrations ? (
 							<CollapsibleNavGroup
 								value="customers"
 								icon={<UserCircleIcon size={16} weight="fill" />}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch Migrations access to scope-based checks and remove Member read access. Updated sidebar gating, role copy, tests, and added `packages/auth` to `trigger.config.ts`.

- **Bug Fixes**
  - Sidebar: use Scopes from `@autumn/shared` for Dev (API Keys) and Migrations; removed admin-only check.
  - Roles: removed Migrations read from Member; updated role descriptions to reflect migrations access.
  - Tests: adjusted Member expectations to exclude Migrations.
  - Trigger: included `packages/auth` in workspace package paths.

<sup>Written for commit eac7cf1cf7332d2fbd4476e394cf6404504a9ce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refines the migrations feature access model: the `member` role loses `migrations:read`, the sidebar switches from a global Autumn-staff check (`isAdmin`) to a scope-based check (`canSeeMigrations`), and the trigger config gains a missing `packages/auth/package.json` entry.

- **[Bug fixes | Improvements]** `trigger.config.ts`: adds the missing `packages/auth/package.json` to the Trigger.dev workspace package paths, fixing the omission that would cause the auth package to be excluded from trigger task bundling.
- **[API changes]** `scopeDefinitions.ts`: removes `Scopes.Migrations.Read` from the `member` role, restricting migrations access to developer+ roles; tests are updated to match (`RESOURCES.length - 1`, explicit `not.toContain` assertion).
- **[Improvements]** `MainSidebar.tsx`: replaces the global-admin `useAdmin` / `isAdmin` guard with `has(Scopes.Migrations.Read)`, so org owners, admins, and developers now see the Migrations sidebar tab (previously only Autumn staff could). Role descriptions in `RoleSelect.tsx` are updated to match the new access model.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are coherent and well-coordinated across scopes, tests, UI, and config.

The scope removal from `member`, the sidebar guard swap, and the role description updates all point in the same direction and are consistent with each other. The `write implies read` expansion in `expandScopes` means the `developer` role correctly gains sidebar visibility via `migrations:write`. Tests are updated to reflect the new cardinality. The trigger config fix is a straightforward additive change. No regressions or inconsistencies found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/scopeDefinitions.ts | Removes Scopes.Migrations.Read from the member role's scope list, restricting migrations access to developer+ roles only. |
| shared/utils/scopeDefinitions.test.ts | Test correctly updated to expect RESOURCES.length - 1 scopes for member, filters out migrations from the coverage loop, and adds an explicit not.toContain assertion for Scopes.Migrations.Read. |
| vite/src/views/main-sidebar/MainSidebar.tsx | Replaces the global-admin isAdmin check (Autumn staff only) with canSeeMigrations = has(Scopes.Migrations.Read), exposing the Migrations sidebar tab to org owners, admins, and developers. Uses typed Scopes.* constants throughout. |
| vite/src/components/v2/selects/RoleSelect.tsx | Role descriptions updated to reflect migrations access for owner/admin/developer and explicit no-migrations statement for member. |
| trigger.config.ts | Adds the missing packages/auth/package.json to the workspace package JSON paths used by the Trigger.dev configuration. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits MainSidebar] --> B{has Scopes.Migrations.Read?}
    B -- Yes owner/Admin/Developer --> C[CollapsibleNavGroup: Customers
  - All Customers
  - Migrations tab]
    B -- No sales/member --> D[Plain NavButton: Customers
  no Migrations tab]

    subgraph Role to migrations:read
        E[owner] -- admin meta-scope expands all MODERN_SCOPES --> F[migrations:read]
        G[admin] -- admin meta-scope expands all MODERN_SCOPES --> F
        H[developer] -- migrations:write write implies read --> F
        I[sales] --> J[no migrations:read]
        K[member after this PR] --> J
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix trigger config"](https://github.com/useautumn/autumn/commit/eac7cf1cf7332d2fbd4476e394cf6404504a9ce4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36477330)</sub>

<!-- /greptile_comment -->