### PR TITLE
fix: patch schedules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "autumn",

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachProductContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachProductContext.ts
@@ -1,11 +1,99 @@
 import type {
 	AttachParamsV1,
 	BillingContextOverride,
+	Entitlement,
+	FullCustomer,
+	FullProduct,
 	MultiAttachParamsV0,
+	UpdateSubscriptionV1Params,
+} from "@autumn/shared";
+import {
+	BillingVersion,
+	cusProductToProduct,
+	isCustomizePlanPatchStyle,
+	type PatchContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { setupPatchContext } from "@/internal/billing/v2/setup/patch";
+import { initFullCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct";
+import { getEntsWithFeature } from "@/internal/products/entitlements/entitlementUtils";
 import { ProductService } from "@/internal/products/ProductService";
 import { setupCustomFullProduct } from "../../../setup/setupCustomFullProduct";
+
+const patchContextToFullProduct = ({
+	ctx,
+	patchContext,
+}: {
+	ctx: AutumnContext;
+	patchContext: PatchContext;
+}): FullProduct => {
+	const fullProduct = cusProductToProduct({
+		cusProduct: patchContext.finalCustomerProduct,
+	});
+
+	return {
+		...fullProduct,
+		prices: [...fullProduct.prices, ...patchContext.customPrices],
+		entitlements: getEntsWithFeature({
+			ents: [
+				...fullProduct.entitlements,
+				...(patchContext.customEntitlements as Entitlement[]),
+			],
+			features: ctx.features,
+		}),
+	};
+};
+
+const setupAttachPatchProductContext = ({
+	ctx,
+	params,
+	fullCustomer,
+	fullProduct,
+	currentEpochMs,
+}: {
+	ctx: AutumnContext;
+	params: AttachParamsV1 | MultiAttachParamsV0["plans"][number];
+	fullCustomer: FullCustomer;
+	fullProduct: FullProduct;
+	currentEpochMs?: number;
+}) => {
+	if (!isCustomizePlanPatchStyle(params.customize)) return undefined;
+
+	const baseCustomerProduct = initFullCustomerProduct({
+		ctx,
+		initContext: {
+			fullCustomer,
+			fullProduct,
+			featureQuantities: [],
+			resetCycleAnchor: currentEpochMs ?? Date.now(),
+			freeTrial: null,
+			now: currentEpochMs ?? Date.now(),
+			billingVersion: BillingVersion.V2,
+		},
+	});
+
+	const patchParams: UpdateSubscriptionV1Params = {
+		customer_id: fullCustomer.id ?? fullCustomer.internal_id,
+		plan_id: params.plan_id,
+		customize: params.customize,
+		version: params.version,
+	};
+
+	const patchContext = setupPatchContext({
+		ctx,
+		params: patchParams,
+		customerProduct: baseCustomerProduct,
+		fullProduct,
+	});
+
+	if (!patchContext) return undefined;
+
+	return {
+		fullProduct: patchContextToFullProduct({ ctx, patchContext }),
+		customPrices: patchContext.customPrices,
+		customEnts: patchContext.customEntitlements,
+	};
+};
 
 /**
  * Loads the product being attached, handling version and custom items params.
@@ -14,10 +102,14 @@ export const setupAttachProductContext = async ({
 	ctx,
 	params,
 	contextOverride = {},
+	fullCustomer,
+	currentEpochMs,
 }: {
 	ctx: AutumnContext;
 	params: AttachParamsV1 | MultiAttachParamsV0["plans"][number];
 	contextOverride?: BillingContextOverride;
+	fullCustomer?: FullCustomer;
+	currentEpochMs?: number;
 }) => {
 	const { productContext } = contextOverride;
 	if (productContext) return productContext;
@@ -34,6 +126,20 @@ export const setupAttachProductContext = async ({
 		logResult: true,
 		logger: ctx.logger,
 	});
+
+	if (fullCustomer) {
+		const patchProductContext = setupAttachPatchProductContext({
+			ctx,
+			params,
+			fullCustomer,
+			fullProduct,
+			currentEpochMs,
+		});
+
+		if (patchProductContext) {
+			return patchProductContext;
+		}
+	}
 
 	// 2. Handle custom items if provided
 	const {

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -14,8 +14,8 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupAttachProductContext } from "@/internal/billing/v2/actions/attach/setup/setupAttachProductContext";
 import { setupAttachTransitionContext } from "@/internal/billing/v2/actions/attach/setup/setupAttachTransitionContext";
 import { setupStripeBillingContext } from "@/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext";
-import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
 import { fetchStoredLineItemsForSubscriptionBilling } from "@/internal/billing/v2/setup/fetchStoredLineItemsForSubscriptionBilling";
+import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
 import { setupFeatureQuantitiesContext } from "@/internal/billing/v2/setup/setupFeatureQuantitiesContext";
 import { setupFullCustomerContext } from "@/internal/billing/v2/setup/setupFullCustomerContext";
 import { setupInvoiceModeContext } from "@/internal/billing/v2/setup/setupInvoiceModeContext";
@@ -131,6 +131,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 						customize: plan.customize,
 						version: plan.version,
 					},
+					fullCustomer,
 				});
 
 			const { currentCustomerProduct, scheduledCustomerProduct } =

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -114,6 +114,8 @@ export const setupCreateScheduleBillingContext = async ({
 	const scheduledPhaseContexts = await setupScheduledProductsContext({
 		ctx,
 		phases: futurePhases,
+		fullCustomer: billingContext.fullCustomer,
+		currentEpochMs: billingContext.currentEpochMs,
 	});
 
 	const scheduledCustomPrices = scheduledPhaseContexts.flatMap((phase) =>

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupScheduledProductsContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupScheduledProductsContext.ts
@@ -1,5 +1,6 @@
 import type {
 	CreateScheduleParamsV0,
+	FullCustomer,
 	ScheduledPhaseContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -11,9 +12,13 @@ import { validateCreateSchedulePhasePlans } from "../errors/validateCreateSchedu
 export const setupScheduledProductsContext = async ({
 	ctx,
 	phases,
+	fullCustomer,
+	currentEpochMs,
 }: {
 	ctx: AutumnContext;
 	phases: CreateScheduleParamsV0["phases"][number][];
+	fullCustomer: FullCustomer;
+	currentEpochMs: number;
 }): Promise<ScheduledPhaseContext[]> =>
 	Promise.all(
 		phases.map(async (phase, index) => {
@@ -28,6 +33,8 @@ export const setupScheduledProductsContext = async ({
 					} = await setupAttachProductContext({
 						ctx,
 						params: plan,
+						fullCustomer,
+						currentEpochMs,
 					});
 
 					const featureQuantities = setupFeatureQuantitiesContext({

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-customize.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-customize.test.ts
@@ -1,11 +1,13 @@
 import { expect, test } from "bun:test";
 import {
+	BillingMethod,
 	CusProductStatus,
 	customerEntitlements,
 	customerProducts,
 	ms,
 	schedulePhases,
 } from "@autumn/shared";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
 import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
@@ -16,9 +18,13 @@ import chalk from "chalk";
 import { eq } from "drizzle-orm";
 import {
 	getCustomerProductEntitlementBalances,
+	getCustomerProductFeaturePriceAmounts,
 	getCustomerProductPriceAmounts,
 	getRequiredScheduleId,
 } from "../utils/createScheduleTestHelpers";
+
+// Contract: V2.2 schedule customize accepts PATCH-style add_items/remove_items.
+// Contract: patched items/prices apply to immediate and future cusProducts, including Stripe.
 
 test.concurrent(
 	`${chalk.yellowBright("create-schedule: preserves feature quantity options on created customer products")}`,
@@ -73,6 +79,180 @@ test.concurrent(
 				quantity: 4,
 			}),
 		]);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule: patch customize applies to immediate customer products and Stripe")}`,
+	async () => {
+		const base = products.base({
+			id: "create-schedule-patch-immediate",
+			items: [
+				items.monthlyPrice(),
+				items.monthlyMessages({ includedUsage: 100 }),
+				items.monthlyWords({ includedUsage: 50 }),
+			],
+		});
+
+		const { customerId, autumnV2_2, ctx } = await initScenario({
+			customerId: "create-schedule-patch-immediate",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [base] }),
+			],
+			actions: [],
+		});
+
+		const response = await autumnV2_2.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{
+					starts_at: Date.now(),
+					plans: [
+						{
+							plan_id: base.id,
+							customize: {
+								price: itemsV2.monthlyPrice({ amount: 42 }),
+								remove_items: [{ feature_id: TestFeature.Messages }],
+								add_items: [itemsV2.dashboard()],
+							},
+						},
+					],
+				},
+			],
+		});
+
+		const customerProductId = response.phases[0]!.customer_product_ids[0]!;
+		const customerProduct = await ctx.db.query.customerProducts.findFirst({
+			where: eq(customerProducts.id, customerProductId),
+		});
+
+		expect(customerProduct?.is_custom).toBe(true);
+		expect(
+			await getCustomerProductPriceAmounts({ ctx, customerProductId }),
+		).toEqual([42]);
+		expect(
+			await getCustomerProductEntitlementBalances({
+				ctx,
+				customerProductId,
+			}),
+		).toEqual(
+			expect.arrayContaining([
+				{ feature_id: TestFeature.Words, balance: 50 },
+				{ feature_id: TestFeature.Dashboard, balance: 0 },
+			]),
+		);
+		expect(
+			await getCustomerProductEntitlementBalances({
+				ctx,
+				customerProductId,
+			}),
+		).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ feature_id: TestFeature.Messages }),
+			]),
+		);
+
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule: patch customize applies to future customer products and Stripe schedule")}`,
+	async () => {
+		const base = products.base({
+			id: "create-schedule-patch-future",
+			items: [
+				items.monthlyPrice(),
+				items.monthlyMessages({ includedUsage: 100 }),
+				items.prepaid({
+					featureId: TestFeature.Words,
+					price: 10,
+					billingUnits: 100,
+				}),
+			],
+		});
+
+		const { customerId, autumnV2_2, ctx } = await initScenario({
+			customerId: "create-schedule-patch-future",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [base] }),
+			],
+			actions: [],
+		});
+
+		const now = Date.now();
+		const response = await autumnV2_2.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{
+					starts_at: now,
+					plans: [{ plan_id: base.id }],
+				},
+				{
+					starts_at: now + ms.days(30),
+					plans: [
+						{
+							plan_id: base.id,
+							customize: {
+								remove_items: [
+									{
+										feature_id: TestFeature.Words,
+										billing_method: BillingMethod.Prepaid,
+									},
+								],
+								add_items: [
+									itemsV2.prepaidWords({ amount: 7, billingUnits: 100 }),
+								],
+							},
+							feature_quantities: [
+								{
+									feature_id: TestFeature.Words,
+									quantity: 300,
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+		const futureCustomerProductId =
+			response.phases[1]!.customer_product_ids[0]!;
+		const futureCustomerProduct = await ctx.db.query.customerProducts.findFirst(
+			{
+				where: eq(customerProducts.id, futureCustomerProductId),
+			},
+		);
+
+		expect(futureCustomerProduct?.is_custom).toBe(true);
+		expect(
+			await getCustomerProductPriceAmounts({
+				ctx,
+				customerProductId: futureCustomerProductId,
+			}),
+		).toEqual([20]);
+		expect(
+			await getCustomerProductFeaturePriceAmounts({
+				ctx,
+				customerProductId: futureCustomerProductId,
+				featureId: TestFeature.Words,
+			}),
+		).toEqual([7]);
+		expect(
+			await getCustomerProductEntitlementBalances({
+				ctx,
+				customerProductId: futureCustomerProductId,
+			}),
+		).toEqual(
+			expect.arrayContaining([
+				{ feature_id: TestFeature.Messages, balance: 100 },
+				{ feature_id: TestFeature.Words, balance: 300 },
+			]),
+		);
+
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
 	},
 );
 

--- a/server/tests/integration/billing/create-schedule/utils/createScheduleTestHelpers.ts
+++ b/server/tests/integration/billing/create-schedule/utils/createScheduleTestHelpers.ts
@@ -51,6 +51,40 @@ export const getCustomerProductPriceAmounts = async ({
 		.filter((amount): amount is number => typeof amount === "number")
 		.sort((a, b) => a - b);
 
+export const getCustomerProductFeaturePriceAmounts = async ({
+	ctx,
+	customerProductId,
+	featureId,
+}: {
+	ctx: Ctx;
+	customerProductId: string;
+	featureId: string;
+}) =>
+	(
+		await ctx.db
+			.select({ config: prices.config })
+			.from(customerPrices)
+			.innerJoin(prices, eq(customerPrices.price_id, prices.id))
+			.where(eq(customerPrices.customer_product_id, customerProductId))
+	)
+		.flatMap((row) => {
+			const config = row.config;
+			if (
+				!config ||
+				!("feature_id" in config) ||
+				config.feature_id !== featureId ||
+				!("usage_tiers" in config) ||
+				!Array.isArray(config.usage_tiers)
+			) {
+				return [];
+			}
+
+			return config.usage_tiers
+				.map((tier) => tier.amount)
+				.filter((amount): amount is number => typeof amount === "number");
+		})
+		.sort((a, b) => a - b);
+
 export const getCustomerProductEntitlementBalances = async ({
 	ctx,
 	customerProductId,

--- a/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-paid-features.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-paid-features.test.ts
@@ -26,222 +26,248 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { runUpdatePlanMigration } from "../../utils/runUpdatePlanMigration";
 
-test.concurrent(`${chalk.yellowBright("migrations update_plan: consumable paid feature carries usage without charging")}`, async () => {
-	const customerId = "migration-update-paid-consumable";
-	const messagesUsage = 60;
-	const included = 50;
-	const pro = products.pro({
-		items: [items.monthlyMessages({ includedUsage: 100 })],
-	});
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: consumable paid feature carries usage without charging")}`,
+	async () => {
+		const customerId = "migration-update-paid-consumable";
+		const messagesUsage = 60;
+		const included = 50;
+		const pro = products.pro({
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
 
-	const { autumnV1, autumnV2_2, ctx } = await initScenario({
-		customerId,
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [s.billing.attach({ productId: pro.id })],
-	});
-
-	await autumnV1.track(
-		{
-			customer_id: customerId,
-			feature_id: TestFeature.Messages,
-			value: messagesUsage,
-		},
-		{ timeout: 2000 },
-	);
-
-	await runUpdatePlanMigration({
-		ctx,
-		migrationClient: autumnV2_2,
-		migrationId: `${customerId}-mig`,
-		customerId,
-		filter: { customer: { plan: { plan_id: pro.id } } },
-		operations: {
-			customer: [
-				{
-					type: "update_plan",
-					plan_filter: { plan_id: pro.id },
-					customize: {
-						remove_items: [{ feature_id: TestFeature.Messages }],
-						add_items: [
-							itemsV2.dashboard(),
-							{
-								...itemsV2.consumableMessages({ amount: 0.1 }),
-								included,
-							},
-						],
-					},
-				},
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
 			],
-		},
-	});
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
 
-	const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
-	await expectCustomerProducts({ customer, active: [pro.id] });
-	expectFlagCorrect({
-		customer,
-		featureId: TestFeature.Dashboard,
-		planId: pro.id,
-	});
-	expectBalanceCorrect({
-		customer,
-		featureId: TestFeature.Messages,
-		remaining: 0,
-		usage: messagesUsage,
-		planId: pro.id,
-		breakdown: {
-			[BillingMethod.UsageBased]: {
-				included_grant: included,
-				remaining: 0,
-				usage: messagesUsage,
+		await autumnV1.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: messagesUsage,
 			},
-		},
-	});
-	await expectCustomerInvoiceCorrect({
-		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
-		count: 1,
-		latestTotal: 20,
-	});
-	await expectNoExpiredCustomerProducts({ ctx, customerId, productId: pro.id });
-	await expectStripeSubscriptionCorrect({ ctx, customerId });
-});
+			{ timeout: 2000 },
+		);
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_2,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: pro.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: pro.id },
+						customize: {
+							remove_items: [{ feature_id: TestFeature.Messages }],
+							add_items: [
+								itemsV2.dashboard(),
+								{
+									...itemsV2.consumableMessages({ amount: 0.1 }),
+									included,
+								},
+							],
+						},
+					},
+				],
+			},
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [pro.id] });
+		expectFlagCorrect({
+			customer,
+			featureId: TestFeature.Dashboard,
+			planId: pro.id,
+		});
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			remaining: 0,
+			usage: messagesUsage,
+			planId: pro.id,
+			breakdown: {
+				[BillingMethod.UsageBased]: {
+					included_grant: included,
+					remaining: 0,
+					usage: messagesUsage,
+				},
+			},
+		});
+		await expectCustomerInvoiceCorrect({
+			customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+			count: 1,
+			latestTotal: 20,
+		});
+		await expectNoExpiredCustomerProducts({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
 
 // Red: migration update_plan creates the new prepaid users item with zero paid packs.
-// Green: carried usage synthesizes the same inclusive quantity an attach call would receive.
-test.concurrent(`${chalk.yellowBright("migrations update_plan: prepaid users replacement keeps carried usage quantity")}`, async () => {
-	const customerId = "migration-update-paid-prepaid-users";
-	const usersUsage = 9;
-	const pro = products.pro({
-		id: "migration-update-paid-prepaid-users-plan",
-		items: [items.monthlyUsers({ includedUsage: 10 })],
-	});
+// Green: same-feature usage below the old allowance still synthesizes paid packs.
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: prepaid users replacement keeps carried usage quantity")}`,
+	async () => {
+		const customerId = "migration-update-paid-prepaid-users";
+		const usersUsage = 8;
+		const pro = products.pro({
+			id: "migration-update-paid-prepaid-users-plan",
+			items: [items.monthlyUsers({ includedUsage: 10 })],
+		});
 
-	const { autumnV1, autumnV2_2, ctx } = await initScenario({
-		customerId,
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [
-			s.billing.attach({ productId: pro.id }),
-			s.track({ featureId: TestFeature.Users, value: usersUsage, timeout: 2000 }),
-		],
-	});
-
-	const invoiceCountBefore =
-		(await autumnV1.customers.get<ApiCustomerV3>(customerId)).invoices
-			?.length ?? 0;
-
-	await runUpdatePlanMigration({
-		ctx,
-		migrationClient: autumnV2_2,
-		migrationId: `${customerId}-mig`,
-		customerId,
-		filter: { customer: { plan: { plan_id: pro.id } } },
-		operations: {
-			customer: [
-				{
-					type: "update_plan",
-					plan_filter: { plan_id: pro.id },
-					customize: {
-						remove_items: [{ feature_id: TestFeature.Users }],
-						add_items: [
-							itemsV2.prepaidUsers({
-								amount: 20,
-								included: 1,
-							}),
-						],
-					},
-				},
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
 			],
-		},
-		runOnServer: false,
-	});
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.track({
+					featureId: TestFeature.Users,
+					value: usersUsage,
+					timeout: 2000,
+				}),
+			],
+		});
 
-	const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
-	await expectCustomerProducts({ customer, active: [pro.id] });
-	expectBalanceCorrect({
-		customer,
-		featureId: TestFeature.Users,
-		remaining: 0,
-		usage: usersUsage,
-		planId: pro.id,
-		breakdown: {
-			[BillingMethod.Prepaid]: {
-				included_grant: 1,
-				prepaid_grant: 8,
-				remaining: 0,
-				usage: usersUsage,
+		const invoiceCountBefore =
+			(await autumnV1.customers.get<ApiCustomerV3>(customerId)).invoices
+				?.length ?? 0;
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_2,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: pro.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: pro.id },
+						customize: {
+							remove_items: [{ feature_id: TestFeature.Users }],
+							add_items: [
+								itemsV2.prepaidUsers({
+									amount: 10,
+									included: 1,
+								}),
+							],
+						},
+					},
+				],
 			},
-		},
-	});
-	await expectCustomerInvoiceCorrect({
-		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
-		count: invoiceCountBefore,
-	});
-	await expectNoExpiredCustomerProducts({ ctx, customerId, productId: pro.id });
-	await expectStripeSubscriptionCorrect({ ctx, customerId });
-});
+			runOnServer: false,
+		});
 
-test.concurrent(`${chalk.yellowBright("migrations update_plan: no_billing_changes remove paid feature stays DB-only")}`, async () => {
-	const customerId = "migration-update-paid-remove-no-billing";
-	const pro = products.pro({
-		id: "migration-update-paid-remove-no-billing-plan",
-		items: [items.consumableMessages({ includedUsage: 100, price: 0.1 })],
-	});
-
-	const { autumnV1, autumnV2_2, ctx } = await initScenario({
-		customerId,
-		setup: [
-			s.customer({ paymentMethod: "success" }),
-			s.products({ list: [pro] }),
-		],
-		actions: [s.billing.attach({ productId: pro.id })],
-	});
-
-	const customerBefore = await autumnV1.customers.get<ApiCustomerV3>(customerId);
-	const invoiceCountBefore = customerBefore.invoices?.length ?? 0;
-	const subsBefore = await ctx.stripeCli.subscriptions.list({
-		customer: customerBefore.stripe_id as string,
-		status: "all",
-	});
-	const subBefore = subsBefore.data.find(
-		(sub) => sub.status === "active" || sub.status === "trialing",
-	);
-	expect(subBefore).toBeDefined();
-
-	await runUpdatePlanMigration({
-		ctx,
-		migrationClient: autumnV2_2,
-		migrationId: `${customerId}-mig`,
-		customerId,
-		filter: { customer: { plan: { plan_id: pro.id } } },
-		operations: {
-			customer: [
-				{
-					type: "update_plan",
-					plan_filter: { plan_id: pro.id },
-					customize: {
-						remove_items: [{ feature_id: TestFeature.Messages }],
-					},
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [pro.id] });
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Users,
+			remaining: 0,
+			usage: usersUsage,
+			planId: pro.id,
+			breakdown: {
+				[BillingMethod.Prepaid]: {
+					included_grant: 1,
+					prepaid_grant: 7,
+					remaining: 0,
+					usage: usersUsage,
 				},
+			},
+		});
+		await expectCustomerInvoiceCorrect({
+			customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+			count: invoiceCountBefore,
+		});
+		await expectNoExpiredCustomerProducts({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: no_billing_changes remove paid feature stays DB-only")}`,
+	async () => {
+		const customerId = "migration-update-paid-remove-no-billing";
+		const pro = products.pro({
+			id: "migration-update-paid-remove-no-billing-plan",
+			items: [items.consumableMessages({ includedUsage: 100, price: 0.1 })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
 			],
-		},
-		noBillingChanges: true,
-		runOnServer: false,
-	});
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
 
-	const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
-	await expectCustomerProducts({ customer, active: [pro.id] });
-	expect(customer.balances[TestFeature.Messages]).toBeUndefined();
-	await expectNoExpiredCustomerProducts({ ctx, customerId, productId: pro.id });
+		const customerBefore =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		const invoiceCountBefore = customerBefore.invoices?.length ?? 0;
+		const subsBefore = await ctx.stripeCli.subscriptions.list({
+			customer: customerBefore.stripe_id as string,
+			status: "all",
+		});
+		const subBefore = subsBefore.data.find(
+			(sub) => sub.status === "active" || sub.status === "trialing",
+		);
+		expect(subBefore).toBeDefined();
 
-	const subAfter = await ctx.stripeCli.subscriptions.retrieve(subBefore!.id);
-	expectStripeSubscriptionUnchanged({ before: subBefore!, after: subAfter });
-	await expectCustomerInvoiceCorrect({
-		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
-		count: invoiceCountBefore,
-	});
-});
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_2,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: pro.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: pro.id },
+						customize: {
+							remove_items: [{ feature_id: TestFeature.Messages }],
+						},
+					},
+				],
+			},
+			noBillingChanges: true,
+			runOnServer: false,
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		await expectCustomerProducts({ customer, active: [pro.id] });
+		expect(customer.balances[TestFeature.Messages]).toBeUndefined();
+		await expectNoExpiredCustomerProducts({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+
+		const subAfter = await ctx.stripeCli.subscriptions.retrieve(subBefore!.id);
+		expectStripeSubscriptionUnchanged({ before: subBefore!, after: subAfter });
+		await expectCustomerInvoiceCorrect({
+			customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+			count: invoiceCountBefore,
+		});
+	},
+);

--- a/server/tests/unit/billing/create-schedule/create-schedule-params.spec.ts
+++ b/server/tests/unit/billing/create-schedule/create-schedule-params.spec.ts
@@ -54,6 +54,47 @@ describe(chalk.yellowBright("CreateScheduleParamsV0Schema"), () => {
 		).toThrow();
 	});
 
+	test("rejects empty customize inputs", () => {
+		expect(() =>
+			CreateScheduleParamsV0Schema.parse({
+				customer_id: "cus_123",
+				phases: [
+					{
+						starts_at: 1_000,
+						plans: [
+							{
+								plan_id: "pro",
+								customize: {},
+							},
+						],
+					},
+				],
+			}),
+		).toThrow("When using customize, at least one of price");
+	});
+
+	test("rejects mixed customize items and patch items", () => {
+		expect(() =>
+			CreateScheduleParamsV0Schema.parse({
+				customer_id: "cus_123",
+				phases: [
+					{
+						starts_at: 1_000,
+						plans: [
+							{
+								plan_id: "pro",
+								customize: {
+									items: [{ feature_id: "messages" }],
+									add_items: [{ feature_id: "words" }],
+								},
+							},
+						],
+					},
+				],
+			}),
+		).toThrow("customize.items (PUT-style) cannot be combined");
+	});
+
 	test("preserves subscription_id on parsed plan items", () => {
 		const parsed = CreateScheduleParamsV0Schema.parse({
 			customer_id: "cus_123",

--- a/shared/api/billing/common/customizePlan/customizePlanV1.ts
+++ b/shared/api/billing/common/customizePlan/customizePlanV1.ts
@@ -5,6 +5,7 @@ import { PlanItemFilterSchema } from "@api/products/items/filter/planItemFilter"
 import { ResetInterval } from "@models/productModels/intervals/resetInterval";
 import { z } from "zod/v4";
 
+/** Deprecated: use remove_items and add_items to replace plan items. */
 export const UpdatePlanItemParamsV1Schema = z
 	.object({
 		filter: PlanItemFilterSchema.meta({
@@ -19,15 +20,17 @@ export const UpdatePlanItemParamsV1Schema = z
 			description:
 				"Override the matched item's reset interval. Use 'one_off' for non-resetting balances.",
 		}),
-		})
-		.meta({
-			title: "UpdatePlanItem",
-			description:
-				"Deprecated. Use remove_items and add_items to replace plan items.",
-			deprecated: true,
-		});
+	})
+	.meta({
+		title: "UpdatePlanItem",
+		description:
+			"Deprecated. Use remove_items and add_items to replace plan items.",
+		deprecated: true,
+	});
 
-export type UpdatePlanItemParamsV1 = z.infer<typeof UpdatePlanItemParamsV1Schema>;
+export type UpdatePlanItemParamsV1 = z.infer<
+	typeof UpdatePlanItemParamsV1Schema
+>;
 
 export const CustomizePlanV1Schema = z
 	.object({
@@ -35,22 +38,22 @@ export const CustomizePlanV1Schema = z
 			description:
 				"Override the base price of the plan. Pass null to remove the base price.",
 		}),
-			items: z.array(CreatePlanItemParamsV1Schema).optional().meta({
-				description:
-					"Override the items in the plan (PUT-style — replaces all existing items). Mutually exclusive with add_items / remove_items / deprecated update_items.",
-			}),
+		items: z.array(CreatePlanItemParamsV1Schema).optional().meta({
+			description:
+				"Override the items in the plan (PUT-style — replaces all existing items). Mutually exclusive with add_items / remove_items / deprecated update_items.",
+		}),
 		add_items: z.array(CreatePlanItemParamsV1Schema).optional().meta({
 			description: "Items to add to the plan.",
 		}),
 		remove_items: z.array(PlanItemFilterSchema).optional().meta({
 			description: "Filters selecting items to remove from the plan.",
 		}),
-			update_items: z.array(UpdatePlanItemParamsV1Schema).optional().meta({
-				description:
-					"Deprecated. Use remove_items and add_items to replace matched plan items.",
-				internal: true,
-				deprecated: true,
-			}),
+		update_items: z.array(UpdatePlanItemParamsV1Schema).optional().meta({
+			description:
+				"Deprecated. Use remove_items and add_items to replace matched plan items.",
+			internal: true,
+			deprecated: true,
+		}),
 		free_trial: FreeTrialParamsV1Schema.nullable().optional().meta({
 			description:
 				"Override the plan's default free trial. Pass an object to set a custom trial, or null to remove the trial entirely.",
@@ -64,10 +67,10 @@ export const CustomizePlanV1Schema = z
 			data.add_items !== undefined ||
 			data.remove_items !== undefined ||
 			data.update_items !== undefined,
-			{
-				message:
-					"When using customize, at least one of price, items, add_items, remove_items, deprecated update_items, or free_trial must be provided",
-			},
+		{
+			message:
+				"When using customize, at least one of price, items, add_items, remove_items, deprecated update_items, or free_trial must be provided",
+		},
 	)
 	.refine(
 		(data) =>
@@ -77,10 +80,10 @@ export const CustomizePlanV1Schema = z
 					data.remove_items !== undefined ||
 					data.update_items !== undefined)
 			),
-			{
-				message:
-					"customize.items (PUT-style) cannot be combined with add_items / remove_items / deprecated update_items (PATCH-style); pick one approach",
-			},
+		{
+			message:
+				"customize.items (PUT-style) cannot be combined with add_items / remove_items / deprecated update_items (PATCH-style); pick one approach",
+		},
 	)
 	.meta({
 		title: "CustomizePlan",

--- a/shared/api/billing/common/customizePlan/customizePlanV1.ts
+++ b/shared/api/billing/common/customizePlan/customizePlanV1.ts
@@ -32,8 +32,52 @@ export type UpdatePlanItemParamsV1 = z.infer<
 	typeof UpdatePlanItemParamsV1Schema
 >;
 
-export const CustomizePlanV1Schema = z
-	.object({
+type CustomizePlanRefinementData = {
+	price?: unknown;
+	items?: unknown;
+	add_items?: unknown;
+	remove_items?: unknown;
+	update_items?: unknown;
+	free_trial?: unknown;
+};
+
+export const refineCustomizePlanV1Schema = <
+	TSchema extends z.ZodType<CustomizePlanRefinementData>,
+>(
+	schema: TSchema,
+	{ includeFreeTrial = true }: { includeFreeTrial?: boolean } = {},
+) =>
+	schema
+		.refine(
+			(data) =>
+				data.items !== undefined ||
+				data.price !== undefined ||
+				(includeFreeTrial && data.free_trial !== undefined) ||
+				data.add_items !== undefined ||
+				data.remove_items !== undefined ||
+				data.update_items !== undefined,
+			{
+				message: includeFreeTrial
+					? "When using customize, at least one of price, items, add_items, remove_items, deprecated update_items, or free_trial must be provided"
+					: "When using customize, at least one of price, items, add_items, remove_items, or deprecated update_items must be provided",
+			},
+		)
+		.refine(
+			(data) =>
+				!(
+					data.items !== undefined &&
+					(data.add_items !== undefined ||
+						data.remove_items !== undefined ||
+						data.update_items !== undefined)
+				),
+			{
+				message:
+					"customize.items (PUT-style) cannot be combined with add_items / remove_items / deprecated update_items (PATCH-style); pick one approach",
+			},
+		);
+
+export const CustomizePlanV1Schema = refineCustomizePlanV1Schema(
+	z.object({
 		price: BasePriceParamsSchema.nullable().optional().meta({
 			description:
 				"Override the base price of the plan. Pass null to remove the base price.",
@@ -58,38 +102,12 @@ export const CustomizePlanV1Schema = z
 			description:
 				"Override the plan's default free trial. Pass an object to set a custom trial, or null to remove the trial entirely.",
 		}),
-	})
-	.refine(
-		(data) =>
-			data.items !== undefined ||
-			data.price !== undefined ||
-			data.free_trial !== undefined ||
-			data.add_items !== undefined ||
-			data.remove_items !== undefined ||
-			data.update_items !== undefined,
-		{
-			message:
-				"When using customize, at least one of price, items, add_items, remove_items, deprecated update_items, or free_trial must be provided",
-		},
-	)
-	.refine(
-		(data) =>
-			!(
-				data.items !== undefined &&
-				(data.add_items !== undefined ||
-					data.remove_items !== undefined ||
-					data.update_items !== undefined)
-			),
-		{
-			message:
-				"customize.items (PUT-style) cannot be combined with add_items / remove_items / deprecated update_items (PATCH-style); pick one approach",
-		},
-	)
-	.meta({
-		title: "CustomizePlan",
-		description:
-			"Customize a plan by overriding its price, items, free trial, or a combination.",
-	});
+	}),
+).meta({
+	title: "CustomizePlan",
+	description:
+		"Customize a plan by overriding its price, items, free trial, or a combination.",
+});
 
 export type CustomizePlanV1 = z.infer<typeof CustomizePlanV1Schema>;
 

--- a/shared/api/billing/createSchedule/createScheduleParamsV0.ts
+++ b/shared/api/billing/createSchedule/createScheduleParamsV0.ts
@@ -1,31 +1,15 @@
 import { FeatureQuantityParamsV0Schema } from "@api/billing/common/featureQuantity/featureQuantityParamsV0";
 import { InvoiceModeParamsSchema } from "@api/billing/common/invoiceModeParams";
 import { RedirectModeSchema } from "@api/billing/common/redirectMode";
-import { BasePriceParamsSchema } from "@api/products/components/basePrice/basePrice";
-import { CreatePlanItemParamsV1Schema } from "@api/products/items/crud/createPlanItemParamsV1";
 import { z } from "zod/v4";
 import { AttachDiscountSchema } from "../attachV2/attachDiscount";
 import { BillingBehaviorSchema } from "../common/billingBehavior";
 import { BillingCycleAnchorSchema } from "../common/billingCycleAnchor";
+import { CustomizePlanV1Schema } from "../common/customizePlan/customizePlanV1";
 
-const CreateScheduleCustomizePlanSchema = z
-	.object({
-		price: BasePriceParamsSchema.nullable().optional().meta({
-			description:
-				"Override the base price of the plan. Pass null to remove the base price.",
-		}),
-		items: z.array(CreatePlanItemParamsV1Schema).optional().meta({
-			description: "Override the items in the plan.",
-		}),
-	})
-	.strict()
-	.refine(
-		(customize) =>
-			customize.items !== undefined || customize.price !== undefined,
-		{
-			message: "When using customize, either items or price must be provided",
-		},
-	);
+const CreateScheduleCustomizePlanSchema = CustomizePlanV1Schema.omit({
+	free_trial: true,
+});
 
 export const CreateSchedulePlanSchema = z.object({
 	plan_id: z.string().meta({
@@ -39,7 +23,7 @@ export const CreateSchedulePlanSchema = z.object({
 	}),
 	customize: CreateScheduleCustomizePlanSchema.optional().meta({
 		description:
-			"Customize the plan to schedule. Can override the price, items, or both.",
+			"Customize the plan to schedule. Can override price, replace items, or patch items with add_items, remove_items, and update_items.",
 	}),
 	subscription_id: z.string().optional().meta({
 		description:

--- a/shared/api/billing/createSchedule/createScheduleParamsV0.ts
+++ b/shared/api/billing/createSchedule/createScheduleParamsV0.ts
@@ -5,11 +5,17 @@ import { z } from "zod/v4";
 import { AttachDiscountSchema } from "../attachV2/attachDiscount";
 import { BillingBehaviorSchema } from "../common/billingBehavior";
 import { BillingCycleAnchorSchema } from "../common/billingCycleAnchor";
-import { CustomizePlanV1Schema } from "../common/customizePlan/customizePlanV1";
+import {
+	CustomizePlanV1Schema,
+	refineCustomizePlanV1Schema,
+} from "../common/customizePlan/customizePlanV1";
 
-const CreateScheduleCustomizePlanSchema = CustomizePlanV1Schema.omit({
-	free_trial: true,
-});
+const CreateScheduleCustomizePlanSchema = refineCustomizePlanV1Schema(
+	CustomizePlanV1Schema.omit({
+		free_trial: true,
+	}),
+	{ includeFreeTrial: false },
+);
 
 export const CreateSchedulePlanSchema = z.object({
 	plan_id: z.string().meta({

--- a/shared/utils/cusProductUtils/convertCusProduct/cusProductToConvertedFeatureOptions.ts
+++ b/shared/utils/cusProductUtils/convertCusProduct/cusProductToConvertedFeatureOptions.ts
@@ -1,3 +1,4 @@
+import type { FullCusEntWithFullCusProduct } from "@models/cusProductModels/cusEntModels/cusEntWithProduct";
 import type {
 	FeatureOptions,
 	FullCusProduct,
@@ -5,11 +6,54 @@ import type {
 import type { EntitlementWithFeature } from "@models/productModels/entModels/entModels";
 import type { Price } from "@models/productModels/priceModels/priceModels";
 import { roundUsageToNearestBillingUnit } from "@utils/billingUtils/usageUtils/roundUsageToNearestBillingUnit";
+import { cusEntsToUsage } from "@utils/cusEntUtils";
+import { findCustomerEntitlementByFeature } from "@utils/cusEntUtils/findCustomerEntitlement/findCustomerEntitlementByFeature";
 import { cusPriceToCusEnt } from "@utils/cusPriceUtils";
 import { findPrepaidCusPriceByFeature } from "@utils/cusPriceUtils/findCusPriceUtils/findPrepaidCusPriceByFeature";
 import { nullish } from "@utils/utils";
 import { Decimal } from "decimal.js";
 import { cusProductToFeatureOptions } from "./cusProductToFeatureOptions";
+
+const usageToConvertedFeatureOptions = ({
+	cusProduct,
+	entitlement,
+	newPrice,
+}: {
+	cusProduct: FullCusProduct;
+	entitlement: EntitlementWithFeature;
+	newPrice: Price;
+}): FeatureOptions | undefined => {
+	const customerEntitlement = findCustomerEntitlementByFeature({
+		cusEnts: cusProduct.customer_entitlements,
+		feature: entitlement.feature,
+	});
+	if (!customerEntitlement) return undefined;
+
+	const usage = cusEntsToUsage({
+		cusEnts: [
+			{
+				...customerEntitlement,
+				customer_product: cusProduct,
+			} satisfies FullCusEntWithFullCusProduct,
+		],
+	});
+	const newAllowance = entitlement.allowance ?? 0;
+	const newBillingUnits = newPrice.config.billing_units ?? 1;
+	const paidUsage = Math.max(
+		0,
+		new Decimal(usage).sub(newAllowance).toNumber(),
+	);
+	const roundedPaidUsage = roundUsageToNearestBillingUnit({
+		usage: paidUsage,
+		billingUnits: newBillingUnits,
+	});
+
+	return {
+		internal_feature_id: entitlement.feature.internal_id,
+		feature_id: entitlement.feature.id,
+		quantity: new Decimal(roundedPaidUsage).div(newBillingUnits).toNumber(),
+	};
+};
 
 /**
  * Converts purchased packs from an old customer product to packs in new billing units.
@@ -27,16 +71,22 @@ export const cusProductToConvertedFeatureOptions = ({
 	const feature = entitlement.feature;
 	const currentOption = cusProductToFeatureOptions({ cusProduct, feature });
 
-	if (nullish(currentOption?.quantity)) return undefined;
+	// if (nullish(currentOption?.quantity)) return undefined;
 
 	const oldCusPrice = findPrepaidCusPriceByFeature({
 		customerPrices: cusProduct.customer_prices,
 		feature,
 	});
 
-	if (!oldCusPrice)
-		// If no old price found, we can't interpret the stored quantity
-		return undefined;
+	// if (!oldCusPrice) return undefined;
+
+	if (nullish(currentOption?.quantity) || !oldCusPrice) {
+		return usageToConvertedFeatureOptions({
+			cusProduct,
+			entitlement,
+			newPrice,
+		});
+	}
 
 	const oldCustomerEntitlement = cusPriceToCusEnt({
 		cusPrice: oldCusPrice,

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -235,11 +235,11 @@ export function buildMigrationDraft({
 	const planFilter = includeCustom
 		? basePlanFilter
 		: { ...basePlanFilter, custom: false };
-	const updatePlanOp: UpdatePlanOp = {
+	const updatePlanOp = (custom: boolean): UpdatePlanOp => ({
 		type: "update_plan",
-		plan_filter: planFilter,
+		plan_filter: { ...basePlanFilter, custom },
 		...(customize ? { customize } : {}),
-	};
+	});
 
 	const filter: MigrationFilter = {
 		customer: { plan: planFilter },
@@ -252,7 +252,9 @@ export function buildMigrationDraft({
 		id: `${baseProduct.id}-${suffix}-${migrationUid()}`,
 		filter,
 		operations: {
-			customer: [updatePlanOp],
+			customer: includeCustom
+				? [updatePlanOp(false), updatePlanOp(true)]
+				: [updatePlanOp(false)],
 		},
 		no_billing_changes: diffHasBillingChanges(migrationDiff) === false,
 	};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PATCH-style schedule customization (add_items/remove_items/update_items) for immediate and future phases with strict validation, and fixes carried-usage conversion to prepaid when old quantities or prices are missing. Custom items and prices now apply to Stripe subscriptions and schedules.

- **Bug Fixes**
  - Reapply `CustomizePlanV1` refinements via `refineCustomizePlanV1Schema` (reject empty `customize`; block mixing `items` with `add_items/remove_items/update_items`; support `.omit({ free_trial: true })` for schedules).
  - Enable patch-style customize in attach and schedule flows by threading `fullCustomer` and `currentEpochMs`, producing correct custom prices and entitlements for immediate and future phases.
  - Convert usage to feature options when old prepaid quantity or price is absent, respecting billing units.
  - Apply migration update_plan ops to both non-custom and custom plans when custom plans are included in the draft builder.

<sup>Written for commit f3e438894c030d4d53f19c1519f80232899fb148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the `createSchedule` billing API to accept PATCH-style plan customization (`add_items` / `remove_items` / `update_items`) for both immediate and future phases, and fixes a conversion bug where migrating from an included/consumable feature to a prepaid feature produced zero packs instead of carrying over the customer's actual usage.

- **Bug fixes / API changes**: `createScheduleParamsV0` now reuses `CustomizePlanV1Schema.omit({ free_trial: true })` so schedule plans accept the same PATCH-style `add_items` / `remove_items` fields already supported by `attachV2`.
- **Bug fixes**: `cusProductToConvertedFeatureOptions` adds a `usageToConvertedFeatureOptions` fallback for customers without an existing prepaid price, computing paid-pack quantity from real usage rather than returning zero.
- **Improvements**: `setupAttachProductContext` gains a new PATCH-path that initialises a fresh baseline customer product and runs `setupPatchContext` when `fullCustomer` is supplied; `setupScheduledProductsContext` and `setupImmediateMultiProductBillingContext` are updated to thread `fullCustomer` / `currentEpochMs` through to this path.
</details>

<h3>Confidence Score: 3/5</h3>

The core billing logic is sound, but the schema change for createSchedule may silently skip mutual-exclusivity validation in the Zod v4 version in use.

The new PATCH-style schedule customization path is well-structured and the usage-conversion fix in cusProductToConvertedFeatureOptions is correct. The main concern is that CustomizePlanV1Schema.omit({ free_trial: true }) — relying on a Zod v4 behaviour where .omit() on a refined schema preserves refinements — may in practice bypass the check that prevents mixing PUT-style items with PATCH-style add_items/remove_items. A caller who inadvertently sends both would get silent partial application (only items takes effect), with no validation error.

shared/api/billing/createSchedule/createScheduleParamsV0.ts — verify that the CustomizePlanV1Schema.omit() schema enforces its refinements at runtime against the pinned Zod version.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/billing/createSchedule/createScheduleParamsV0.ts | Expands the schedule customize schema to accept full PATCH-style operations (add_items, remove_items, update_items) by reusing CustomizePlanV1Schema.omit({ free_trial: true }); the old strict two-field schema is replaced but the .omit() call may silently bypass mutual-exclusivity refinements in Zod v4. |
| server/src/internal/billing/v2/actions/attach/setup/setupAttachProductContext.ts | Adds a new PATCH-style code path: when fullCustomer is provided and customize is patch-style, a fresh baseline customer product is created, the patch context is applied, and the resulting FullProduct is returned; falls back to the existing PUT-style path otherwise. |
| shared/utils/cusProductUtils/convertCusProduct/cusProductToConvertedFeatureOptions.ts | Adds usageToConvertedFeatureOptions fallback: when a customer product has no prepaid price or no stored quantity, actual usage is used to compute the equivalent number of prepaid packs needed; two old early-return lines are commented out but not removed. |
| server/src/internal/billing/v2/actions/createSchedule/setup/setupScheduledProductsContext.ts | Now accepts and threads fullCustomer and currentEpochMs down to setupAttachProductContext so that PATCH-style customization works for scheduled (future-phase) products. |
| server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts | Passes billingContext.fullCustomer and billingContext.currentEpochMs into setupScheduledProductsContext — a minimal two-line change that enables the downstream patch context. |
| server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts | One-line change: passes fullCustomer to setupAttachProductContext so that immediate-phase plans also benefit from the new PATCH-style product context setup. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant createSchedule
    participant setupCreateScheduleBillingContext
    participant setupScheduledProductsContext
    participant setupAttachProductContext
    participant setupPatchContext
    participant setupCustomFullProduct

    Client->>createSchedule: POST /billing/createSchedule (phases with customize)
    createSchedule->>setupCreateScheduleBillingContext: "{ctx, params}"
    setupCreateScheduleBillingContext->>setupScheduledProductsContext: "{phases, fullCustomer, currentEpochMs}"

    loop each phase plan
        setupScheduledProductsContext->>setupAttachProductContext: "{params, fullCustomer, currentEpochMs}"

        alt PATCH-style customize (add_items / remove_items / price)
            setupAttachProductContext->>setupAttachProductContext: initFullCustomerProduct (baseline)
            setupAttachProductContext->>setupPatchContext: "{patchParams, baseCustomerProduct, fullProduct}"
            setupPatchContext-->>setupAttachProductContext: PatchContext
            setupAttachProductContext->>setupAttachProductContext: patchContextToFullProduct
            setupAttachProductContext-->>setupScheduledProductsContext: "{fullProduct, customPrices, customEnts}"
        else PUT-style (items) or no customize
            setupAttachProductContext->>setupCustomFullProduct: "{fullProduct, customizePlan}"
            setupCustomFullProduct-->>setupAttachProductContext: "{fullProduct, customPrices, customEnts}"
            setupAttachProductContext-->>setupScheduledProductsContext: "{fullProduct, customPrices, customEnts}"
        end
    end

    setupScheduledProductsContext-->>setupCreateScheduleBillingContext: ScheduledPhaseContext[]
    setupCreateScheduleBillingContext-->>createSchedule: BillingContext
    createSchedule-->>Client: schedule response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
shared/api/billing/createSchedule/createScheduleParamsV0.ts:10-12
**Zod v4 `.omit()` silently drops refinements**

In Zod v4, calling `.omit()` on a refined schema bypasses the `.refine()` checks (reported in [colinhacks/zod#5425](https://github.com/colinhacks/zod/issues/5425)). `CustomizePlanV1Schema` has two refinements: one that requires at least one field, and — critically — one that rejects the PUT+PATCH mix (`items` alongside `add_items`/`remove_items`). After `.omit()`, both checks are silently skipped.

If a caller sends `customize: { items: [...], add_items: [...] }` to `createSchedule`, validation passes, but downstream `isCustomizePlanPatchStyle` returns `false` (because `items` is set), so the PATCH path is skipped entirely and `add_items` is silently ignored by `setupCustomFullProduct`. The `DiffedCustomizePlanV1Schema` already uses this pattern, but it's worth double-checking whether the Zod version in use has the fix, or whether the refinements should be re-applied manually after `.omit()`.

### Issue 2 of 2
shared/utils/cusProductUtils/convertCusProduct/cusProductToConvertedFeatureOptions.ts:74-83
Remove the two commented-out lines — they're now dead code replaced by the new combined condition below them, and leaving them creates a misleading "these were previously separate early-returns" hint without explaining why they changed.

```suggestion
	const oldCusPrice = findPrepaidCusPriceByFeature({
		customerPrices: cusProduct.customer_prices,
		feature,
	});

	if (nullish(currentOption?.quantity) || !oldCusPrice) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: usage converted to feature options"](https://github.com/useautumn/autumn/commit/edd18791e69a31202e58d69e704189109db83d95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36520306)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->