### PR TITLE
fixed bug

### DIFF
--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -235,11 +235,11 @@ export function buildMigrationDraft({
 	const planFilter = includeCustom
 		? basePlanFilter
 		: { ...basePlanFilter, custom: false };
-	const updatePlanOp = (custom: boolean): UpdatePlanOp => ({
+	const updatePlanOp: UpdatePlanOp = {
 		type: "update_plan",
-		plan_filter: { ...basePlanFilter, custom },
+		plan_filter: planFilter,
 		...(customize ? { customize } : {}),
-	});
+	};
 
 	const filter: MigrationFilter = {
 		customer: { plan: planFilter },
@@ -252,9 +252,7 @@ export function buildMigrationDraft({
 		id: `${baseProduct.id}-${suffix}-${migrationUid()}`,
 		filter,
 		operations: {
-			customer: includeCustom
-				? [updatePlanOp(false), updatePlanOp(true)]
-				: [updatePlanOp(false)],
+			customer: [updatePlanOp],
 		},
 		no_billing_changes: diffHasBillingChanges(migrationDiff) === false,
 	};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate plan updates in migration drafts when custom plans are included. We now create a single "update_plan" operation using a consolidated plan filter, preventing double application and ensuring correct behavior.

- **Bug Fixes**
  - Replaced per-custom operation builder with a single `UpdatePlanOp` that uses `planFilter`; `operations.customer` now includes one operation and respects `includeCustom`/`customize`.

<sup>Written for commit ed456f8fc9614be43472a63f91e09daac859f106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in `buildMigrationDraft` where `includeCustom = true` incorrectly produced two separate `UpdatePlanOp` operations (one filtering `custom: false`, one filtering `custom: true`) instead of a single operation using the broader `planFilter` that already captures both groups. It also bumps the `ai` submodule pointer.

- **Bug fixes**: `buildMigrationDraft` now builds a single `updatePlanOp` with the pre-computed `planFilter`, eliminating the split-operation pattern that was inconsistent with the migration `filter` when `includeCustom = true`.
- **Improvements**: The refactoring removes the factory-function form of `updatePlanOp`, making the operation's shape directly visible at the call site.
</details>


<h3>Confidence Score: 3/5</h3>

The fix to `buildMigrationDraft` looks correct, but the adjacent `buildVersionMigrationDraft` function retains the same two-operation pattern the fix was meant to eliminate, which could mean version-migration paths are still broken when `includeCustom = true`.

The `buildMigrationDraft` change is a clear improvement and its new logic is consistent with how the migration `filter` is constructed. The concern is that `buildVersionMigrationDraft`, just above it in the same file, still uses the old split-operation approach — if the underlying bug was the mismatch between the filter and the operations, that same mismatch remains there.

`vite/src/views/products/plan/versioning/buildMigrationDraft.ts` — specifically the `buildVersionMigrationDraft` function which was not updated.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/buildMigrationDraft.ts | Fixes the `buildMigrationDraft` function by collapsing two separate operations (one per `custom` value) into a single operation using the already-computed `planFilter`. However, the sibling function `buildVersionMigrationDraft` retains the same two-operation pattern, leaving a potential inconsistency. |
| ai | Submodule pointer bump — cannot review internal diff without submodule contents. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildMigrationDraft called] --> B{includeCustom?}
    B -- false --> C["planFilter = { ...basePlanFilter, custom: false }"]
    B -- true --> D["planFilter = basePlanFilter (no custom restriction)"]

    C --> E["updatePlanOp: plan_filter = planFilter (custom: false)"]
    D --> F["updatePlanOp: plan_filter = planFilter (all customers)"]

    E --> G["operations.customer = [updatePlanOp]"]
    F --> G

    subgraph OLD ["OLD (before fix)"]
        OA["updatePlanOp(false): plan_filter = {...basePlanFilter, custom: false}"]
        OB["updatePlanOp(true): plan_filter = {...basePlanFilter, custom: true}"]
        OC["operations.customer = [op(false), op(true)]"]
        OA --> OC
        OB --> OC
    end

    subgraph NEW ["NEW (after fix)"]
        NA["updatePlanOp: plan_filter = basePlanFilter"]
        NB["operations.customer = [updatePlanOp]"]
        NA --> NB
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/products/plan/versioning/buildMigrationDraft.ts`, line 182-196 ([link](https://github.com/useautumn/autumn/blob/ed456f8fc9614be43472a63f91e09daac859f106/vite/src/views/products/plan/versioning/buildMigrationDraft.ts#L182-L196)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`buildVersionMigrationDraft` not updated alongside fix**

   `buildMigrationDraft` was refactored to use a single operation with `planFilter` (matching all customers when `includeCustom = true`), but `buildVersionMigrationDraft` (lines 182–196) still uses the old two-operation pattern — explicitly splitting on `custom: false` / `custom: true`. If the original two-operation approach was the root cause of the bug, the same pattern here may reproduce it for version migrations when `includeCustom = true`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/products/plan/versioning/buildMigrationDraft.ts
   Line: 182-196

   Comment:
   **`buildVersionMigrationDraft` not updated alongside fix**

   `buildMigrationDraft` was refactored to use a single operation with `planFilter` (matching all customers when `includeCustom = true`), but `buildVersionMigrationDraft` (lines 182–196) still uses the old two-operation pattern — explicitly splitting on `custom: false` / `custom: true`. If the original two-operation approach was the root cause of the bug, the same pattern here may reproduce it for version migrations when `includeCustom = true`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/products/plan/versioning/buildMigrationDraft.ts:182-196
**`buildVersionMigrationDraft` not updated alongside fix**

`buildMigrationDraft` was refactored to use a single operation with `planFilter` (matching all customers when `includeCustom = true`), but `buildVersionMigrationDraft` (lines 182–196) still uses the old two-operation pattern — explicitly splitting on `custom: false` / `custom: true`. If the original two-operation approach was the root cause of the bug, the same pattern here may reproduce it for version migrations when `includeCustom = true`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fixed bug"](https://github.com/useautumn/autumn/commit/ed456f8fc9614be43472a63f91e09daac859f106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36534030)</sub>

<!-- /greptile_comment -->