### PR TITLE
fix: next cycle taxes

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/filterStripeDiscountsForNextCycle.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/filterStripeDiscountsForNextCycle.ts
@@ -9,11 +9,13 @@ export const filterStripeDiscountsForNextCycle = ({
 	currentEpochMs,
 	nextCycleStart,
 	discountStartMs,
+	hasImmediateInvoice = true,
 }: {
 	stripeDiscounts: StripeDiscountWithCoupon[];
 	currentEpochMs: number;
 	nextCycleStart: number;
 	discountStartMs?: number;
+	hasImmediateInvoice?: boolean;
 }) => {
 	return stripeDiscounts.filter((discount) =>
 		stripeDiscountAppliesToNextCycle({
@@ -21,6 +23,7 @@ export const filterStripeDiscountsForNextCycle = ({
 			currentEpochMs,
 			nextCycleStart,
 			discountStartMs,
+			hasImmediateInvoice,
 		}),
 	);
 };
@@ -33,11 +36,13 @@ const stripeDiscountAppliesToNextCycle = ({
 	currentEpochMs,
 	nextCycleStart,
 	discountStartMs,
+	hasImmediateInvoice,
 }: {
 	discount: StripeDiscountWithCoupon;
 	currentEpochMs: number;
 	nextCycleStart: number;
 	discountStartMs?: number;
+	hasImmediateInvoice: boolean;
 }) => {
 	if (discount.id) {
 		if (discount.end == null) return true;
@@ -51,7 +56,9 @@ const stripeDiscountAppliesToNextCycle = ({
 	}
 
 	if (coupon.duration === "once") {
-		return false;
+		// A fresh once coupon hits the first invoice after it's applied — when
+		// nothing is invoiced immediately, that first invoice is the next cycle's.
+		return !hasImmediateInvoice;
 	}
 
 	if (coupon.duration === "repeating") {

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
@@ -59,10 +59,6 @@ export const computeAttachTaxPreview = async ({
 	billingContext: BillingContext;
 	autumnBillingPlan: AutumnBillingPlan;
 }): Promise<PreviewTax | undefined> => {
-	if (!ctx.org.config.automatic_tax) return undefined;
-	if (billingContext.checkoutMode === "stripe_checkout") return undefined;
-	if (!billingContext.stripeCustomer?.id) return undefined;
-
 	const allLineItems = autumnBillingPlan.lineItems ?? [];
 	if (allLineItems.length === 0) return undefined;
 
@@ -77,6 +73,27 @@ export const computeAttachTaxPreview = async ({
 		(sum, line) => sum + (line.amountAfterDiscounts ?? line.amount),
 		0,
 	);
+
+	return computeStripeTaxPreviewForNetSubtotal({
+		ctx,
+		billingContext,
+		netSubtotal,
+	});
+};
+
+/** Core Stripe Tax lookup for a net post-discount subtotal. */
+export const computeStripeTaxPreviewForNetSubtotal = async ({
+	ctx,
+	billingContext,
+	netSubtotal,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+	netSubtotal: number;
+}): Promise<PreviewTax | undefined> => {
+	if (!ctx.org.config.automatic_tax) return undefined;
+	if (billingContext.checkoutMode === "stripe_checkout") return undefined;
+	if (!billingContext.stripeCustomer?.id) return undefined;
 
 	const currency = orgToCurrency({ org: ctx.org });
 	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
@@ -87,6 +87,27 @@ export const computeAttachTaxRateIdPreview = async ({
 	const taxableMinorUnits = immediateLines.map((lineItem) =>
 		lineItemToTaxableMinorUnits({ lineItem, currency }),
 	);
+
+	return computeTaxRateIdPreviewFromTaxableMinorUnits({
+		ctx,
+		billingContext,
+		taxableMinorUnits,
+	});
+};
+
+/** Core tax-rate-id math over pre-computed taxable amounts (minor units). */
+export const computeTaxRateIdPreviewFromTaxableMinorUnits = ({
+	ctx,
+	billingContext,
+	taxableMinorUnits,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+	taxableMinorUnits: number[];
+}): PreviewTax | undefined => {
+	if (!billingContext.taxRateId) return undefined;
+
+	const currency = orgToCurrency({ org: ctx.org });
 	const totalTaxableMinorUnits = taxableMinorUnits.reduce(
 		(sum, amount) => sum + amount,
 		0,

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeNextCycleTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeNextCycleTaxPreview.ts
@@ -1,0 +1,36 @@
+import type { BillingContext, PreviewTax } from "@autumn/shared";
+import { atmnToStripeAmount, orgToCurrency } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeStripeTaxPreviewForNetSubtotal } from "./computeAttachTaxPreview";
+import { computeTaxRateIdPreviewFromTaxableMinorUnits } from "./computeAttachTaxRateIdPreview";
+
+/**
+ * Tax preview for the next cycle, computed on its net post-discount total.
+ * Same precedence as the immediate preview: tax_rate_id overrides Stripe Tax.
+ */
+export const computeNextCycleTaxPreview = async ({
+	ctx,
+	billingContext,
+	netSubtotal,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+	netSubtotal: number;
+}): Promise<PreviewTax | undefined> => {
+	if (billingContext.taxRateId) {
+		const currency = orgToCurrency({ org: ctx.org });
+		return computeTaxRateIdPreviewFromTaxableMinorUnits({
+			ctx,
+			billingContext,
+			taxableMinorUnits: [
+				atmnToStripeAmount({ amount: netSubtotal, currency }),
+			],
+		});
+	}
+
+	return computeStripeTaxPreviewForNetSubtotal({
+		ctx,
+		billingContext,
+		netSubtotal,
+	});
+};

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCycleLineItems.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCycleLineItems.ts
@@ -129,11 +129,17 @@ export const billingPlanToNextCycleLineItems = ({
 	);
 
 	if (billingContext.stripeDiscounts?.length) {
+		// Mirrors buildStripeInvoiceAction's condition for creating an invoice now.
+		const hasImmediateInvoice = (autumnBillingPlan.lineItems ?? []).some(
+			(lineItem) => lineItem.chargeImmediately && lineItem.amount !== 0,
+		);
+
 		const nextCycleDiscounts = filterStripeDiscountsForNextCycle({
 			stripeDiscounts: billingContext.stripeDiscounts,
 			currentEpochMs: billingContext.currentEpochMs,
 			nextCycleStart,
 			discountStartMs: billingContext.subscriptionBackdateStartMs,
+			hasImmediateInvoice,
 		});
 
 		nextCycleAutumnLineItems = applyStripeDiscountsToLineItems({

--- a/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
+++ b/server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts
@@ -2,6 +2,7 @@ import type { BillingContext, BillingPlan } from "@autumn/shared";
 import { type BillingPreviewResponse, orgToCurrency } from "@autumn/shared";
 import { Decimal } from "decimal.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeNextCycleTaxPreview } from "./billingPlan/preview/tax/computeNextCycleTaxPreview";
 import { billingPlanToImmediatePreview } from "./billingPlan/toImmediatePreview/billingPlanToImmediatePreview";
 import { billingPlanToNextCyclePreview } from "./billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview";
 import { billingPlanToChanges } from "./billingPlan/toPreviewChanges/billingPlanToChanges";
@@ -16,13 +17,40 @@ import { logBillingPreview } from "./logs/logBillingPreview";
  *    never goes negative. Leftover credit rolls to the next invoice in
  *    Stripe; we don't surface that here beyond the row tooltip on the FE.
  *
- * `next_cycle.total` is intentionally NOT adjusted — we don't compute
- * next-cycle tax (would require a forward-dated Stripe Tax calculation),
- * and the `subtotal`/`total` doc strings on `next_cycle` reflect that.
+ * `next_cycle.total` is adjusted separately via `applyNextCycleTaxPreview`
+ * (tax only — credits are consumed by the immediate invoice first).
  *
  * If `billingPlan.preview` is undefined (non-attach flows that skip the
  * enrichment step) the math is a no-op and `total` is unchanged.
  */
+// Tax-only next-cycle adjustment; skipped for non-preview flows (no
+// billingPlan.preview bag) so checkout recomputes stay unchanged.
+const applyNextCycleTaxPreview = async ({
+	ctx,
+	billingContext,
+	billingPlan,
+	nextCycle,
+}: {
+	ctx: AutumnContext;
+	billingContext: BillingContext;
+	billingPlan: BillingPlan;
+	nextCycle: BillingPreviewResponse["next_cycle"];
+}): Promise<BillingPreviewResponse["next_cycle"]> => {
+	if (!nextCycle || !billingPlan.preview) return nextCycle;
+
+	const tax = await computeNextCycleTaxPreview({
+		ctx,
+		billingContext,
+		netSubtotal: nextCycle.total,
+	});
+	if (!tax) return nextCycle;
+
+	return {
+		...nextCycle,
+		total: new Decimal(nextCycle.total).add(tax.total).toDP(2).toNumber(),
+	};
+};
+
 const applyPreviewAdjustmentsToTotal = ({
 	subtotal,
 	total,
@@ -70,10 +98,18 @@ export const billingPlanToPreviewResponse = async ({
 	const currency = orgToCurrency({ org: ctx.org });
 
 	// Get next cycle object
-	const { nextCycle, debug: nextCycleDebug } = billingPlanToNextCyclePreview({
+	const { nextCycle: rawNextCycle, debug: nextCycleDebug } =
+		billingPlanToNextCyclePreview({
+			ctx,
+			billingContext,
+			billingPlan,
+		});
+
+	const nextCycle = await applyNextCycleTaxPreview({
 		ctx,
 		billingContext,
 		billingPlan,
+		nextCycle: rawNextCycle,
 	});
 
 	logBillingPreview({

--- a/server/tests/integration/billing/attach/scheduled-switch/discounts/scheduled-switch-discounts-preview.test.ts
+++ b/server/tests/integration/billing/attach/scheduled-switch/discounts/scheduled-switch-discounts-preview.test.ts
@@ -130,7 +130,9 @@ test.concurrent(`${chalk.yellowBright("scheduled-switch-discounts-preview 2: fre
 	).toBe(true);
 });
 
-test.concurrent(`${chalk.yellowBright("scheduled-switch-discounts-preview 3: fresh once coupon does not affect next_cycle")}`, async () => {
+// Nothing is billed today on a scheduled switch, so a fresh once coupon
+// survives to the first invoice after the switch — next_cycle is discounted.
+test.concurrent(`${chalk.yellowBright("scheduled-switch-discounts-preview 3: fresh once coupon with no immediate invoice applies to next_cycle")}`, async () => {
 	const customerId = "sched-switch-disc-preview-once";
 
 	const pro = products.pro({
@@ -172,12 +174,12 @@ test.concurrent(`${chalk.yellowBright("scheduled-switch-discounts-preview 3: fre
 
 	const nextCycle = expectPreviewNextCycleCorrect({
 		preview,
-		total: 20,
+		total: 16,
 	})!;
 
 	expect(
 		nextCycle.line_items.some((lineItem) => lineItem.discounts.length > 0),
-	).toBe(false);
+	).toBe(true);
 });
 
 test.concurrent(`${chalk.yellowBright("scheduled-switch-discounts-preview 4: fresh 1-month coupon does not affect annual next_cycle")}`, async () => {

--- a/server/tests/integration/billing/preview/preview-next-cycle-tax.test.ts
+++ b/server/tests/integration/billing/preview/preview-next-cycle-tax.test.ts
@@ -1,0 +1,127 @@
+/**
+ * TDD tests for next_cycle tax on billing previews (flim-ai report).
+ * next_cycle.total previously excluded tax even though its docstring says
+ * "after discounts and tax", so previews disagreed with the renewal invoice.
+ *
+ * Red-failure mode (pre-fix):
+ *  - next_cycle.total = post-discount subtotal only
+ *    (34.90 plan, 50% once coupon, 20% VAT -> 17.45 instead of 20.94).
+ *
+ * Green-success criteria (post-fix):
+ *  - next_cycle.total includes exclusive tax, mirroring the top-level
+ *    total contract.
+ */
+
+import { expect, test } from "bun:test";
+import type { PreviewUpdateSubscriptionResponse } from "@autumn/shared";
+import { createPercentCoupon } from "@tests/integration/billing/utils/discounts/discountTestUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// flim parity: 34.90 base, 50% once coupon, 20% exclusive VAT -> 20.94.
+test.concurrent(
+	`${chalk.yellowBright("preview-next-cycle-tax 1: tax_rate_id + once discount -> next_cycle.total includes VAT")}`,
+	async () => {
+		const customerId = "preview-next-cycle-tax-disc";
+
+		const pro = products.base({
+			id: "pro",
+			items: [items.monthlyPrice({ price: 34.9 })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "VAT",
+			percentage: 20,
+			inclusive: false,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: pro.id,
+			tax_rate_id: taxRate.id,
+		});
+
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			duration: "once",
+		});
+
+		const preview = (await autumnV1.subscriptions.previewUpdate({
+			customer_id: customerId,
+			product_id: pro.id,
+			discounts: [{ reward_id: coupon.id }],
+		})) as PreviewUpdateSubscriptionResponse;
+
+		expect(preview.total).toBe(0);
+		expect(preview.next_cycle, "next_cycle should be defined").toBeDefined();
+		const nextCycle = preview.next_cycle!;
+
+		// 34.90 - 50% = 17.45, + 20% VAT = 20.94.
+		expect(nextCycle.subtotal).toBe(34.9);
+		expect(nextCycle.total).toBe(20.94);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-next-cycle-tax 2: tax_rate_id without discount -> plain renewal taxed")}`,
+	async () => {
+		const customerId = "preview-next-cycle-tax-plain";
+
+		const pro = products.base({
+			id: "pro",
+			items: [items.monthlyPrice({ price: 20 })],
+		});
+
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "VAT",
+			percentage: 10,
+			inclusive: false,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: pro.id,
+			tax_rate_id: taxRate.id,
+		});
+
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			duration: "forever",
+		});
+
+		const preview = (await autumnV1.subscriptions.previewUpdate({
+			customer_id: customerId,
+			product_id: pro.id,
+			discounts: [{ reward_id: coupon.id }],
+		})) as PreviewUpdateSubscriptionResponse;
+
+		expect(preview.next_cycle, "next_cycle should be defined").toBeDefined();
+		const nextCycle = preview.next_cycle!;
+
+		// 20 - 50% = 10, + 10% VAT = 11.
+		expect(nextCycle.subtotal).toBe(20);
+		expect(nextCycle.total).toBe(11);
+	},
+);

--- a/server/tests/integration/billing/update-subscription/discounts/once-discount-next-cycle-preview.test.ts
+++ b/server/tests/integration/billing/update-subscription/discounts/once-discount-next-cycle-preview.test.ts
@@ -1,0 +1,122 @@
+/**
+ * TDD test for: previewUpdateSubscription with a fresh `once`-duration coupon
+ * via `discounts: [{ reward_id }]` not applying it to next_cycle (flim-ai).
+ * A discount-only update creates no immediate invoice, so Stripe applies the
+ * once coupon to the next renewal invoice — the preview should match.
+ *
+ * Red-failure mode (current behavior):
+ *  - next_cycle.total stays 34.90 with no discounts; the execution test shows
+ *    the actual renewal invoice IS discounted to 17.45.
+ *
+ * Green-success criteria (after fix):
+ *  - next_cycle.total = 17.45 with the discount on the base-price line item.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV3,
+	PreviewUpdateSubscriptionResponse,
+} from "@autumn/shared";
+import { createPercentCoupon } from "@tests/integration/billing/utils/discounts/discountTestUtils.js";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { advanceTestClock } from "@tests/utils/stripeUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test.concurrent(
+	`${chalk.yellowBright("preview-update-once-discount: fresh once coupon with no immediate invoice applies to next_cycle")}`,
+	async () => {
+		const customerId = "preview-update-once-disc";
+
+		const pro = products.base({
+			id: "pro",
+			items: [items.monthlyPrice({ price: 34.9 })],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			duration: "once",
+		});
+
+		const preview = (await autumnV1.subscriptions.previewUpdate({
+			customer_id: customerId,
+			product_id: pro.id,
+			discounts: [{ reward_id: coupon.id }],
+		})) as PreviewUpdateSubscriptionResponse;
+
+		// Discount-only update: nothing due today.
+		expect(preview.total).toBe(0);
+
+		expect(preview.next_cycle, "next_cycle should be defined").toBeDefined();
+		const nextCycle = preview.next_cycle!;
+
+		expect(
+			nextCycle.line_items.some((lineItem) => lineItem.discounts.length > 0),
+		).toBe(true);
+		expect(nextCycle.total).toBe(17.45);
+	},
+	300_000,
+);
+
+// Ground truth: executing the same update and advancing to renewal shows
+// Stripe applies the once coupon to the renewal invoice (17.45, not 34.90).
+test.concurrent(
+	`${chalk.yellowBright("preview-update-once-discount: execution ground truth — renewal invoice is discounted")}`,
+	async () => {
+		const customerId = "update-once-disc-ground-truth";
+
+		const pro = products.base({
+			id: "pro",
+			items: [items.monthlyPrice({ price: 34.9 })],
+		});
+
+		const { autumnV1, testClockId, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: true, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const coupon = await createPercentCoupon({
+			stripeCli: ctx.stripeCli,
+			percentOff: 50,
+			duration: "once",
+		});
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			discounts: [{ reward_id: coupon.id }],
+		});
+
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			numberOfMonths: 1,
+			numberOfHours: 2,
+			waitForSeconds: 30,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({
+			customer,
+			count: 2,
+			latestTotal: 17.45,
+		});
+	},
+	300_000,
+);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes next-cycle totals in billing previews. next_cycle.total now includes tax, and fresh once coupons apply to the next cycle when nothing is billed immediately.

- **Bug Fixes**
  - Added next-cycle tax preview: next_cycle.total now adds tax from tax_rate_id (overrides) or Stripe Tax on the net subtotal; limited to preview flows so checkout recomputes stay unchanged.
  - Updated once-coupon logic: when there’s no immediate invoice (mirrors invoice-creation condition), the coupon applies to next_cycle; added hasImmediateInvoice to filterStripeDiscountsForNextCycle.
  - Extracted shared tax helpers and wired them into billingPlanToPreviewResponse; added integration tests covering VAT inclusion and once-coupon behavior (scheduled switch, discount-only updates).

<sup>Written for commit 446826d797898f1097cd09a255541282c714a4d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs in billing preview: `next_cycle.total` was previously missing tax (despite the docstring promising post-tax totals), and fresh `once`-duration coupons were incorrectly excluded from next-cycle previews even when no immediate invoice is created (discount-only updates, scheduled switches).

- **Bug fixes**: `filterStripeDiscountsForNextCycle` now accepts a `hasImmediateInvoice` flag; `once` coupons return `!hasImmediateInvoice` instead of a hard `false`, so they correctly survive to the next renewal when nothing is billed today.
- **Bug fixes**: A new `applyNextCycleTaxPreview` step is wired into `billingPlanToPreviewResponse`, computing tax via `computeNextCycleTaxPreview` on the post-discount `nextCycle.total` using the same `taxRateId`-over-Stripe-Tax precedence as the immediate preview.
- **Improvements**: `computeAttachTaxPreview` and `computeAttachTaxRateIdPreview` are refactored to expose `computeStripeTaxPreviewForNetSubtotal` and `computeTaxRateIdPreviewFromTaxableMinorUnits` as reusable helpers, with comprehensive TDD tests (including a ground-truth clock-advance execution test) confirming both fixes.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrowly scoped to the preview path, guarded by billingPlan.preview, and backed by new integration tests including a clock-advance ground-truth execution test.

The once-coupon fix is logically sound: hasImmediateInvoice mirrors buildStripeInvoiceAction's own condition and defaults to true, preserving the old behavior for all callers that don't opt in. The tax fix applies only when billingPlan.preview is set, leaving checkout and non-preview flows untouched. Edge cases (netSubtotal ≤ 0, inclusive tax returning total: 0, prorated next-cycle amounts) are all handled correctly by the delegated helpers. The refactoring is clean with no behavioral change for existing callers of computeAttachTaxPreview or computeAttachTaxRateIdPreview.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/discounts/filterStripeDiscountsForNextCycle.ts | Adds hasImmediateInvoice parameter (default true) — once coupons now apply to next cycle when no immediate invoice is created, fixing preview discrepancy for discount-only updates and scheduled switches. |
| server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts | Refactored to extract computeStripeTaxPreviewForNetSubtotal (Stripe Tax guard checks moved there); guards now run after netSubtotal is computed but no behavioral change for existing callers. |
| server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts | Extracted computeTaxRateIdPreviewFromTaxableMinorUnits for reuse in next-cycle tax; duplicate taxRateId guard in the new function is a benign defensive check. |
| server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeNextCycleTaxPreview.ts | New file — computes next-cycle tax on the post-discount netSubtotal using the same taxRateId-over-Stripe-Tax precedence as the immediate preview; handles ≤0 edge cases via the delegated helpers. |
| server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCycleLineItems.ts | Computes hasImmediateInvoice from the current operation's line items and passes it to filterStripeDiscountsForNextCycle, correctly gating once-coupon next-cycle application. |
| server/src/internal/billing/v2/utils/billingPlanToPreviewResponse.ts | Adds applyNextCycleTaxPreview step after rawNextCycle is computed; correctly skips non-preview flows via the billingPlan.preview guard and uses post-discount total as netSubtotal. |
| server/tests/integration/billing/preview/preview-next-cycle-tax.test.ts | New TDD tests verifying next_cycle.total includes tax — one with a once-discount (34.90 - 50% = 17.45 + 20% VAT = 20.94) and one plain renewal with forever discount. |
| server/tests/integration/billing/update-subscription/discounts/once-discount-next-cycle-preview.test.ts | New TDD tests for once-coupon preview fix — a preview test (17.45 expected) plus a ground-truth execution test that advances the clock one month to confirm Stripe actually invoices at the discounted amount. |
| server/tests/integration/billing/attach/scheduled-switch/discounts/scheduled-switch-discounts-preview.test.ts | Updated test 3 to reflect the corrected behavior: a fresh once coupon with no immediate invoice now applies to next_cycle (total 16, discounts present vs old expectation of 20, no discounts). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller
    participant BPR as billingPlanToPreviewResponse
    participant BPNCP as billingPlanToNextCyclePreview
    participant BPNCLI as billingPlanToNextCycleLineItems
    participant FSDNC as filterStripeDiscountsForNextCycle
    participant ANTP as applyNextCycleTaxPreview
    participant CNCTP as computeNextCycleTaxPreview
    participant CTRP as computeTaxRateIdPreview
    participant CSTP as computeStripeTaxPreview

    C->>BPR: billingPlanToPreviewResponse(ctx, billingContext, billingPlan)
    BPR->>BPNCP: billingPlanToNextCyclePreview(...)
    BPNCP->>BPNCLI: billingPlanToNextCycleLineItems(...)
    BPNCLI->>BPNCLI: compute hasImmediateInvoice
    BPNCLI->>FSDNC: filterStripeDiscountsForNextCycle(..., hasImmediateInvoice)
    FSDNC->>FSDNC: once coupons return !hasImmediateInvoice
    FSDNC-->>BPNCLI: filtered discounts
    BPNCLI-->>BPNCP: subtotal, total (post-discount), line_items
    BPNCP-->>BPR: rawNextCycle
    BPR->>ANTP: applyNextCycleTaxPreview(ctx, billingContext, billingPlan, rawNextCycle)
    Note over ANTP: Guard: skip if !nextCycle or !billingPlan.preview
    ANTP->>CNCTP: "computeNextCycleTaxPreview(netSubtotal=nextCycle.total)"
    alt taxRateId set
        CNCTP->>CTRP: computeTaxRateIdPreviewFromTaxableMinorUnits(...)
        CTRP-->>CNCTP: PreviewTax
    else Stripe Tax
        CNCTP->>CSTP: computeStripeTaxPreviewForNetSubtotal(...)
        CSTP-->>CNCTP: PreviewTax
    end
    CNCTP-->>ANTP: tax
    ANTP-->>BPR: "nextCycle with total += tax.total"
    BPR-->>C: BillingPreviewResponse (next_cycle.total includes tax)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/useautumn/autumn/commit/446826d797898f1097cd09a255541282c714a4d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36693050)</sub>

<!-- /greptile_comment -->