### PR TITLE
feat: customer header quick-action buttons + subscription sheet polish

### DIFF
--- a/apps/website/content/blog/active-active-redis-cache.mdx
+++ b/apps/website/content/blog/active-active-redis-cache.mdx
@@ -3,7 +3,7 @@ title: "Active-active fixed our counters and broke everything else"
 description: "Why we moved Autumn to a multi-region architecture, the tradeoffs we hit with active-active Redis, and why we eventually returned to a simpler single-region setup."
 date: "2026-06-08"
 author: "John, Autumn Co-Founder"
-slug: "how-we-built-a-multi-region-architecture-and-why-we-went-back"
+slug: "active-active-redis-cache"
 image: "/images/blog/multi-region-initial-architecture.png"
 ---
 

--- a/apps/website/content/blog/how-we-built-a-multi-region-architecture-and-why-we-went-back.mdx
+++ b/apps/website/content/blog/how-we-built-a-multi-region-architecture-and-why-we-went-back.mdx
@@ -1,5 +1,5 @@
 ---
-title: "We went multi-region then undid it"
+title: "Active-active fixed our counters and broke everything else"
 description: "Why we moved Autumn to a multi-region architecture, the tradeoffs we hit with active-active Redis, and why we eventually returned to a simpler single-region setup."
 date: "2026-06-08"
 author: "John, Autumn Co-Founder"

--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -27,6 +27,11 @@ const nextConfig = {
         destination: "https://docs.useautumn.com",
         permanent: false,
       },
+      {
+        source: "/blog/how-we-built-a-multi-region-architecture-and-why-we-went-back",
+        destination: "/blog/active-active-redis-cache",
+        permanent: true,
+      },
     ];
   },
   async headers() {

--- a/vite/src/components/v2/buttons/IconTooltipButton.tsx
+++ b/vite/src/components/v2/buttons/IconTooltipButton.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { IconButton } from "@/components/v2/buttons/IconButton";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/v2/tooltips/Tooltip";
+import { cn } from "@/lib/utils";
+
+export function IconTooltipButton({
+	tooltip,
+	icon,
+	onClick,
+	disabled,
+	className,
+}: {
+	tooltip: string;
+	icon: ReactNode;
+	onClick?: () => void;
+	disabled?: boolean;
+	className?: string;
+}) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<IconButton
+					variant="secondary"
+					size="icon"
+					iconOrientation="center"
+					onClick={onClick}
+					disabled={disabled}
+					aria-label={tooltip}
+					icon={icon}
+					className={cn("shrink-0 text-tertiary-foreground", className)}
+				/>
+			</TooltipTrigger>
+			<TooltipContent>{tooltip}</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/vite/src/components/v2/buttons/OpenInStripeButton.tsx
+++ b/vite/src/components/v2/buttons/OpenInStripeButton.tsx
@@ -1,0 +1,36 @@
+import { IconTooltipButton } from "@/components/v2/buttons/IconTooltipButton";
+import { StripeIcon } from "@/components/v2/icons/AutumnIcons";
+import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
+import { useEnv } from "@/utils/envUtils";
+import { getStripeSubLink } from "@/utils/linkUtils";
+
+export function OpenInStripeButton({
+	subscriptionId,
+	className,
+}: {
+	subscriptionId: string;
+	className?: string;
+}) {
+	const { stripeAccount } = useOrgStripeQuery();
+	const env = useEnv();
+
+	const handleOpen = () => {
+		window.open(
+			getStripeSubLink({
+				subscriptionId,
+				env,
+				accountId: stripeAccount?.id,
+			}),
+			"_blank",
+		);
+	};
+
+	return (
+		<IconTooltipButton
+			tooltip="Open in Stripe"
+			icon={<StripeIcon size={14} />}
+			onClick={handleOpen}
+			className={className}
+		/>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -11,7 +11,6 @@ import {
 	UsageModel,
 } from "@autumn/shared";
 import {
-	ArrowSquareOutIcon,
 	CalendarBlankIcon,
 	CreditCardIcon,
 	CubeIcon,
@@ -29,24 +28,23 @@ import { format } from "date-fns";
 import { useMemo } from "react";
 import { CollapsedBooleanItems } from "@/components/forms/shared/plan-items/CollapsedBooleanItems";
 import { Button } from "@/components/v2/buttons/Button";
-import { MiniCopyButton } from "@/components/v2/buttons/CopyButton";
-import { IconButton } from "@/components/v2/buttons/IconButton";
+import { CopyButton } from "@/components/v2/buttons/CopyButton";
+import { OpenInStripeButton } from "@/components/v2/buttons/OpenInStripeButton";
 import { InfoRow } from "@/components/v2/InfoRow";
 import { SheetHeader, SheetSection } from "@/components/v2/sheets/InlineSheet";
 import { useCusRewardsQuery } from "@/hooks/queries/useCusRewardsQuery";
-import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
 import { useProductVersionQuery } from "@/hooks/queries/useProductVersionQuery";
 import { usePrepaidItems } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useSubscriptionById } from "@/hooks/stores/useSubscriptionStore";
 
 import { backendToDisplayQuantity } from "@/utils/billing/prepaidQuantityUtils";
-import { useEnv } from "@/utils/envUtils";
-import { getStripeSubLink } from "@/utils/linkUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { BasePriceDisplay } from "@/views/products/plan/components/plan-card/BasePriceDisplay";
 import { PlanFeatureRow } from "@/views/products/plan/components/plan-card/PlanFeatureRow";
 import { CustomerProductsStatus } from "../table/customer-products/CustomerProductsStatus";
+
+const ID_CHIP_INNER_CLASS = "max-w-40 text-tiny-id truncate !font-normal";
 
 function formatDiscountLabel({ discount }: { discount: ApiDiscount }): string {
 	const value =
@@ -120,8 +118,6 @@ function SubscriptionDetailItems({
 
 export function SubscriptionDetailSheet() {
 	const { customer, testClockFrozenTimeMs } = useCusQuery();
-	const { stripeAccount } = useOrgStripeQuery();
-	const env = useEnv();
 	const itemId = useSheetStore((s) => s.itemId);
 	const setSheet = useSheetStore((s) => s.setSheet);
 	// Get customer product and productV2 by itemId
@@ -178,6 +174,14 @@ export function SubscriptionDetailSheet() {
 		internal_product_id: cusProduct.product?.internal_id ?? null,
 	};
 
+	const planEndsInFuture =
+		!!cusProduct.ended_at && cusProduct.ended_at > nowMs && !isExpired;
+	const endLabel = isOneOff
+		? "Access Ends"
+		: planEndsInFuture
+			? "Plan Ends"
+			: "Ended";
+
 	const formatDate = (timestamp: number | null | undefined) => {
 		if (!timestamp) return "—";
 		return format(new Date(timestamp), "MMM d, yyyy, HH:mm");
@@ -185,30 +189,6 @@ export function SubscriptionDetailSheet() {
 
 	const handleUpdateSubscription = () => {
 		setSheet({ type: "subscription-update", itemId });
-	};
-
-	const handleViewStripe = () => {
-		if (!cusProduct?.subscription_ids?.[0]) return;
-
-		const subscriptionId = cusProduct.subscription_ids[0];
-		if (stripeAccount) {
-			window.open(
-				getStripeSubLink({
-					subscriptionId,
-					env,
-					accountId: stripeAccount.id,
-				}),
-				"_blank",
-			);
-		} else {
-			window.open(
-				getStripeSubLink({
-					subscriptionId,
-					env,
-				}),
-				"_blank",
-			);
-		}
 	};
 
 	return (
@@ -238,8 +218,14 @@ export function SubscriptionDetailSheet() {
 						<InfoRow
 							icon={<HashIcon size={16} />}
 							label="ID"
-							value={cusProduct.product_id}
-							mono
+							value={
+								<CopyButton
+									text={cusProduct.product_id}
+									size="mini"
+									className="text-tertiary-foreground"
+									innerClassName={ID_CHIP_INNER_CLASS}
+								/>
+							}
 						/>
 						<InfoRow
 							icon={<GitBranchIcon size={16} />}
@@ -257,35 +243,35 @@ export function SubscriptionDetailSheet() {
 							<InfoRow
 								icon={<TagIcon size={16} weight="duotone" />}
 								label="Sub ID"
-								value={cusProduct.external_id}
-								mono
+								value={
+									<CopyButton
+										text={cusProduct.external_id}
+										size="mini"
+										className="text-tertiary-foreground"
+										innerClassName={ID_CHIP_INNER_CLASS}
+									/>
+								}
 							/>
 						)}
 						{cusProduct.subscription_ids?.length > 0 && (
-							<div className="flex items-center gap-2 min-w-0 overflow-hidden">
-								<div className="text-subtle/60 shrink-0">
-									<CreditCardIcon size={16} />
-								</div>
-								<div className="flex min-w-0 items-center overflow-hidden">
-									<div className="text-tertiary-foreground text-sm font-medium w-20 shrink-0 whitespace-nowrap">
-										Stripe ID
-									</div>
-									<div className="min-w-0 overflow-hidden">
-										<MiniCopyButton
+							<InfoRow
+								icon={<CreditCardIcon size={16} />}
+								label="Stripe ID"
+								className="flex-1 min-w-0"
+								value={
+									<div className="flex items-center gap-2 min-w-0 w-full">
+										<CopyButton
 											text={cusProduct.subscription_ids[0]}
-											innerClassName="text-sm text-foreground font-mono truncate"
+											size="mini"
+											className="text-tertiary-foreground min-w-0 shrink"
+											innerClassName="text-tiny-id truncate !font-normal min-w-0"
+										/>
+										<OpenInStripeButton
+											subscriptionId={cusProduct.subscription_ids[0]}
 										/>
 									</div>
-								</div>
-								<IconButton
-									variant="secondary"
-									onClick={handleViewStripe}
-									icon={<ArrowSquareOutIcon size={16} weight="duotone" />}
-									className="shrink-0"
-								>
-									View Stripe
-								</IconButton>
-							</div>
+								}
+							/>
 						)}
 					</div>
 				</div>
@@ -363,8 +349,14 @@ export function SubscriptionDetailSheet() {
 
 					{cusProduct.ended_at && (
 						<InfoRow
-							icon={<XCircle size={16} weight="duotone" />}
-							label={isOneOff ? "Access Ends" : "Ended"}
+							icon={
+								planEndsInFuture ? (
+									<CalendarBlankIcon size={16} weight="duotone" />
+								) : (
+									<XCircle size={16} weight="duotone" />
+								)
+							}
+							label={endLabel}
 							value={formatDate(cusProduct.ended_at)}
 						/>
 					)}

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -35,6 +35,7 @@ import { CustomerBreadcrumbs } from "./CustomerBreadcrumbs2";
 import { CustomerContext } from "./CustomerContext";
 import { CustomerPageDetails } from "./CustomerPageDetails";
 import { CustomerSheets } from "./CustomerSheets";
+import { CustomerHeaderActions } from "./components/CustomerHeaderActions";
 import { SelectedEntityDetails } from "./components/SelectedEntityDetails";
 import { SHEET_ANIMATION } from "./customerAnimations";
 import { Workbench } from "./workbench/Workbench";
@@ -114,6 +115,7 @@ export default function CustomerView2() {
 								<div className="flex flex-col w-full">
 									<div className="flex items-center justify-between w-full gap-4">
 										<CustomerBreadcrumbs />
+										<CustomerHeaderActions />
 									</div>
 									<div className="flex items-center justify-between w-full pt-2 gap-2">
 										<div className="flex items-center gap-2 min-w-0">

--- a/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
+++ b/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
@@ -1,0 +1,84 @@
+import { ProcessorType } from "@autumn/shared";
+import { BracketsSquareIcon, UserCircleGearIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { IconTooltipButton } from "@/components/v2/buttons/IconTooltipButton";
+import { StripeIcon } from "@/components/v2/icons/AutumnIcons";
+import { useOrgStripeQuery } from "@/hooks/queries/useOrgStripeQuery";
+import { CusService } from "@/services/customers/CusService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { useEnv } from "@/utils/envUtils";
+import { getBackendErr } from "@/utils/genUtils";
+import { getStripeCusLink } from "@/utils/linkUtils";
+import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { ShowCustomerObjectSheet } from "./ShowCustomerObjectSheet";
+
+export function CustomerHeaderActions() {
+	const { customer } = useCusQuery();
+	const { stripeAccount } = useOrgStripeQuery();
+	const env = useEnv();
+	const axiosInstance = useAxiosInstance();
+
+	const [portalLoading, setPortalLoading] = useState(false);
+	const [showObjectOpen, setShowObjectOpen] = useState(false);
+
+	const stripeCustomerId = customer?.processor?.id;
+	const showStripe =
+		Boolean(stripeCustomerId) &&
+		customer?.processor?.type === ProcessorType.Stripe;
+
+	const handleOpenStripe = () => {
+		if (!stripeCustomerId) return;
+		window.open(
+			getStripeCusLink({
+				customerId: stripeCustomerId,
+				env,
+				accountId: stripeAccount?.id,
+			}),
+			"_blank",
+		);
+	};
+
+	const handleOpenBillingPortal = async () => {
+		if (!customer) return;
+		setPortalLoading(true);
+		try {
+			const { url } = await CusService.createBillingPortalSession({
+				axios: axiosInstance,
+				customer_id: customer.id || customer.internal_id,
+			});
+			window.open(url, "_blank");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to open billing portal"));
+		} finally {
+			setPortalLoading(false);
+		}
+	};
+
+	return (
+		<div className="flex items-center gap-1">
+			<ShowCustomerObjectSheet
+				open={showObjectOpen}
+				setOpen={setShowObjectOpen}
+			/>
+			<IconTooltipButton
+				tooltip="Show customer object"
+				icon={<BracketsSquareIcon size={14} />}
+				onClick={() => setShowObjectOpen(true)}
+			/>
+			<IconTooltipButton
+				tooltip="Open customer portal"
+				icon={<UserCircleGearIcon size={14} />}
+				onClick={handleOpenBillingPortal}
+				disabled={portalLoading}
+			/>
+			{showStripe && (
+				<IconTooltipButton
+					tooltip="Open in Stripe"
+					icon={<StripeIcon size={14} />}
+					onClick={handleOpenStripe}
+				/>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## What

### Customer page header
Adds three small icon buttons with hover tooltips to the top-right of the customer header, directly above the **Actions** menu:
- **Show customer object** — opens the existing customer-object sheet
- **Open customer portal** — creates a Stripe billing portal session
- **Open in Stripe** — opens the customer in Stripe (only for Stripe customers)

These mirror existing Actions-menu items; the menu items are intentionally **left in place** as well.

### Subscription detail sheet
- **Plan end date**: shows **"Plan Ends"** for a future `ended_at` (e.g. cancel-at-period-end) instead of the past-tense **"Ended"**, with a calendar icon. Past/expired still reads "Ended"; one-off still reads "Access Ends".
- **ID formatting**: product ID, sub ID, and Stripe ID now render as the standard muted ID chip (`CopyButton`), matching how IDs are displayed elsewhere in the app.
- **View Stripe button**: replaced the "View Stripe" text button with a compact Stripe icon button. Also fixes it being clipped off the right edge of the 28rem sheet (the long subscription id no longer pushes it out of view).

### Shared components
- `IconTooltipButton` — icon-only secondary button + tooltip; the common base so all of the above buttons stay visually consistent.
- `OpenInStripeButton` — self-contained subscription "open in Stripe" button (resolves the Stripe URL internally), built on `IconTooltipButton`.

### Website
- Renames the multi-region blog post title.

## Why
Make Stripe / customer actions reachable in one click from the header, and clean up the subscription sheet so end dates read correctly and IDs/actions match the rest of the app.

## Notes for reviewers
- The header "Open in Stripe" opens the **customer** in Stripe (`getStripeCusLink`), while `OpenInStripeButton` is **subscription**-specific (`getStripeSubLink`) — both share the same `IconTooltipButton` look rather than overloading one component.
- `tsc` and `ultracite` are clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds three quick-action icon buttons (show customer object, open billing portal, open in Stripe) to the customer page header, and polishes the subscription detail sheet with corrected end-date labels/icons, standardised ID chips, and a compact Stripe icon button. It also renames a blog post file and adds a permanent redirect.

- **Improvements**: New `IconTooltipButton` and `OpenInStripeButton` shared components, header quick-action buttons with loading/error states, and subscription sheet end-date label/icon logic that distinguishes future vs past `ended_at`.
- **Improvements**: Subscription sheet IDs now use the standard `CopyButton` chip, matching the rest of the app; the Stripe button is replaced with a compact icon that no longer overflows the 28rem sheet.
- **Improvements**: Blog post file renamed to `active-active-redis-cache` with a `permanent: true` redirect from the old slug.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are additive UI components with no shared state or data mutations.

All three new interaction paths (show object, billing portal, open Stripe) are independently scoped: the portal call has a loading guard and error toast, the Stripe button is conditionally rendered only for Stripe processor customers, and the subscription sheet's end-date logic correctly handles future vs past vs expired vs one-off cases. The blog rename is paired with a permanent redirect. No regressions are visible in the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/v2/buttons/IconTooltipButton.tsx | New shared component: icon-only secondary button with tooltip; clean and well-typed with aria-label forwarded from tooltip text. |
| vite/src/components/v2/buttons/OpenInStripeButton.tsx | New self-contained subscription Stripe-link button; resolves URL internally using optional accountId chaining, consistent with pre-existing pattern. |
| vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx | New component adding header quick-actions; billing-portal button has proper loading state, error toast, and the Stripe button is correctly guarded by ProcessorType.Stripe check. |
| vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx | End-date label logic correctly differentiates future vs past ended_at; ID rows refactored to CopyButton chips; inline Stripe logic extracted to OpenInStripeButton. |
| apps/website/next.config.mjs | Adds permanent redirect from old blog slug to new slug; redirect type is correctly permanent:true. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CH[CustomerView2 Header] --> CHB[CustomerBreadcrumbs]
    CH --> CHA[CustomerHeaderActions]

    CHA --> SOB[Show Customer Object Button]
    CHA --> CPB[Open Billing Portal Button]
    CHA --> SIB{showStripe?}
    SIB -- yes --> OSB[Open in Stripe Button]
    SIB -- no --> NONE[hidden]

    SOB --> SOCS[ShowCustomerObjectSheet]
    CPB --> API[CusService.createBillingPortalSession]
    API --> WIN1[window.open url]
    OSB --> WIN2[window.open getStripeCusLink]

    SDS[SubscriptionDetailSheet] --> PFCHK{planEndsInFuture?}
    PFCHK -- yes --> PL[label: Plan Ends icon: Calendar]
    PFCHK -- no --> EL[label: Ended icon: XCircle]
    PFCHK -- isOneOff --> AE[label: Access Ends]

    SDS --> SUBID{subscription_ids present?}
    SUBID -- yes --> CB[CopyButton chip]
    SUBID -- yes --> OISB[OpenInStripeButton]
    OISB --> WIN3[window.open getStripeSubLink]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: rename multi-region blog url + re..."](https://github.com/useautumn/autumn/commit/8bb1ff7489d77807f616d8407f300a1db3aedf72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36718838)</sub>

<!-- /greptile_comment -->