### PR TITLE
budget db pool maxes under the pgbouncer ceiling

### DIFF
--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -97,9 +97,25 @@ export const initDrizzle = ({
 // Strict latency limits in prod; relaxed locally so dev pool warm-up doesn't kill tests.
 const isProd = process.env.NODE_ENV === "production";
 
+const poolMaxFromEnv = ({
+	envVar,
+	fallback,
+}: {
+	envVar: string;
+	fallback: number;
+}): number => {
+	const parsed = Number(process.env[envVar]);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+// Per-process maxes are budgeted so the fleet total stays under PgBouncer's
+// max_client_conn (2026-06-08 incident): procs × Σ(max) ≤ 0.8 × ceiling.
 export const { db: dbCritical, client: clientCritical } = initDrizzle({
 	name: "critical",
-	maxConnections: isProd ? 100 : 10,
+	maxConnections: poolMaxFromEnv({
+		envVar: "CRITICAL_DB_POOL_MAX",
+		fallback: isProd ? 22 : 10,
+	}),
 	connectTimeout: isProd ? 2 : 30,
 	databaseUrl: process.env.DATABASE_CRITICAL_URL,
 	poolConfig: {
@@ -113,6 +129,10 @@ export const { db: dbCritical, client: clientCritical } = initDrizzle({
 // -- General pool: used by all other endpoints --
 export const { db: dbGeneral, client: clientGeneral } = initDrizzle({
 	name: "general",
+	maxConnections: poolMaxFromEnv({
+		envVar: "GENERAL_DB_POOL_MAX",
+		fallback: isProd ? 14 : 10,
+	}),
 	connectTimeout: isProd ? 5 : 30,
 });
 
@@ -122,7 +142,10 @@ const replicaResult = process.env.DATABASE_REPLICA_URL
 	? initDrizzle({
 			name: "replica",
 			replica: true,
-			maxConnections: 15,
+			maxConnections: poolMaxFromEnv({
+				envVar: "REPLICA_DB_POOL_MAX",
+				fallback: 6,
+			}),
 			connectTimeout: null,
 		})
 	: null;

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -134,19 +134,21 @@ if (
 	);
 }
 
+const criticalPoolMax = poolMaxFromEnv({
+	envVar: "CRITICAL_DB_POOL_MAX",
+	fallback: isProd ? PROD_POOL_MAX.critical : 10,
+});
+
 export const { db: dbCritical, client: clientCritical } = initDrizzle({
 	name: "critical",
-	maxConnections: poolMaxFromEnv({
-		envVar: "CRITICAL_DB_POOL_MAX",
-		fallback: isProd ? PROD_POOL_MAX.critical : 10,
-	}),
+	maxConnections: criticalPoolMax,
 	connectTimeout: isProd ? 2 : 30,
 	databaseUrl: process.env.DATABASE_CRITICAL_URL,
 	poolConfig: {
 		application_name: "autumn-critical",
 		query_timeout: isProd ? 2_000 : 30_000,
-		// Keep 10 warm conns to avoid TLS-handshake stampedes on bursty traffic.
-		min: 10,
+		// Keep warm conns to avoid TLS-handshake stampedes on bursty traffic.
+		min: Math.min(10, criticalPoolMax),
 	},
 });
 

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -8,6 +8,7 @@ import { instrumentDrizzleClient } from "@kubiks/otel-drizzle";
 import type { SQLWrapper } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg, { type PoolConfig } from "pg";
+import { logger } from "../external/logtail/logtailUtils.js";
 import { otelConfig } from "../utils/otel/otelConfig.js";
 import { attachPoolErrorHandlers, registerPool } from "./pgPoolMonitor.js";
 
@@ -108,13 +109,36 @@ const poolMaxFromEnv = ({
 	return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 };
 
-// Per-process maxes are budgeted so the fleet total stays under PgBouncer's
-// max_client_conn (2026-06-08 incident): procs × Σ(max) ≤ 0.8 × ceiling.
+const PGBOUNCER_MAX_CLIENT_CONN = 7_600;
+const BUDGETED_FLEET_PROCESSES = 150;
+const BUDGETED_NON_SERVER_CONNECTIONS = 80;
+const POOL_BUDGET_HEADROOM = 0.85;
+
+const PROD_POOL_MAX = {
+	critical: 22,
+	general: 14,
+	replica: 6,
+};
+
+const budgetedFleetConnections =
+	BUDGETED_FLEET_PROCESSES *
+		(PROD_POOL_MAX.critical + PROD_POOL_MAX.general + PROD_POOL_MAX.replica) +
+	BUDGETED_NON_SERVER_CONNECTIONS;
+
+if (
+	budgetedFleetConnections >
+	PGBOUNCER_MAX_CLIENT_CONN * POOL_BUDGET_HEADROOM
+) {
+	logger.warn(
+		`[initDrizzle] pool budget (${budgetedFleetConnections}) exceeds ${POOL_BUDGET_HEADROOM} of max_client_conn (${PGBOUNCER_MAX_CLIENT_CONN}) — resize PROD_POOL_MAX`,
+	);
+}
+
 export const { db: dbCritical, client: clientCritical } = initDrizzle({
 	name: "critical",
 	maxConnections: poolMaxFromEnv({
 		envVar: "CRITICAL_DB_POOL_MAX",
-		fallback: isProd ? 22 : 10,
+		fallback: isProd ? PROD_POOL_MAX.critical : 10,
 	}),
 	connectTimeout: isProd ? 2 : 30,
 	databaseUrl: process.env.DATABASE_CRITICAL_URL,
@@ -131,7 +155,7 @@ export const { db: dbGeneral, client: clientGeneral } = initDrizzle({
 	name: "general",
 	maxConnections: poolMaxFromEnv({
 		envVar: "GENERAL_DB_POOL_MAX",
-		fallback: isProd ? 14 : 10,
+		fallback: isProd ? PROD_POOL_MAX.general : 10,
 	}),
 	connectTimeout: isProd ? 5 : 30,
 });
@@ -144,7 +168,7 @@ const replicaResult = process.env.DATABASE_REPLICA_URL
 			replica: true,
 			maxConnections: poolMaxFromEnv({
 				envVar: "REPLICA_DB_POOL_MAX",
-				fallback: 6,
+				fallback: PROD_POOL_MAX.replica,
 			}),
 			connectTimeout: null,
 		})


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Right-sized per-process Postgres pool limits to keep the fleet under PgBouncer’s ceiling and prevent connection exhaustion. Added env-configurable max settings, a boot-time budget guard, and a safety clamp on the critical pool.

- Bug Fixes
  - Set conservative prod maxConnections: critical 22, general 14, replica 6 (down from 100/∅/15).
  - Allow overrides via env vars: `CRITICAL_DB_POOL_MAX`, `GENERAL_DB_POOL_MAX`, `REPLICA_DB_POOL_MAX`.
  - Clamp the critical pool’s min to its max to avoid invalid min>max when `CRITICAL_DB_POOL_MAX` < 10.

<sup>Written for commit 358d49508dfe194f94cfac44b45a9f251bc7e206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR right-sizes per-process Postgres pool limits and adds a boot-time budget guard to keep the fleet under PgBouncer's `max_client_conn` ceiling, along with env-var overrides for all three pools.

- **Bug fixes / Improvements**: Drops `maxConnections` from 100/∅/15 to 22/14/6 for critical/general/replica pools in prod, and adds `CRITICAL_DB_POOL_MAX`, `GENERAL_DB_POOL_MAX`, `REPLICA_DB_POOL_MAX` env-var overrides with a boot-time warning when the budgeted fleet total exceeds 85% of PgBouncer's ceiling.
- **Bug fixes**: Clamps the critical pool's `min` to `Math.min(10, criticalPoolMax)` to prevent an invalid `min > max` configuration when the env-var override is set below 10.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for the immediate goal of reducing default pool sizes, but the env-var override path has a logical gap that leaves the safety net ineffective.

The hardcoded defaults are correct and will immediately reduce connection pressure in prod. However, the boot-time budget guard always evaluates against the compile-time PROD_POOL_MAX constants rather than the values actually resolved from env vars — meaning any operator who raises a pool ceiling via env var gets no warning even when the fleet would breach the PgBouncer limit.

server/src/db/initDrizzle.ts — specifically the ordering of budgetedFleetConnections vs. the poolMaxFromEnv resolutions

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/initDrizzle.ts | Right-sizes pool maxes and adds env-var overrides; boot-time budget guard always evaluates against hardcoded PROD_POOL_MAX constants rather than the resolved env values, so it will silently miss overbudget configurations. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/db/initDrizzle.ts:123-140
**Budget guard never checks env-overridden values**

`budgetedFleetConnections` is computed from the hardcoded `PROD_POOL_MAX` constants (lines 117–121) and runs *before* `criticalPoolMax` is resolved — and the general/replica maxes are never named at all. If an operator sets `CRITICAL_DB_POOL_MAX=50`, `GENERAL_DB_POOL_MAX=30`, or `REPLICA_DB_POOL_MAX=20`, the arithmetic still uses 22/14/6 and the warning never fires, defeating the entire purpose of the boot-time guard.

The fix is to resolve all three pool maxes into named constants first, use those in the budget calculation, and then pass them into the pool initialisations — replacing the three inline `poolMaxFromEnv(...)` calls further down.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: clamp critical pool min to its max"](https://github.com/useautumn/autumn/commit/358d49508dfe194f94cfac44b45a9f251bc7e206) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36780198)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->