### PR TITLE
org rate limit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/org-rate-limit
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: ""
 
 jobs:
   checks:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: ""
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/org-rate-limit
 
 jobs:
   checks:

--- a/server/src/honoMiddlewares/rateLimitMiddleware.ts
+++ b/server/src/honoMiddlewares/rateLimitMiddleware.ts
@@ -6,6 +6,7 @@ import {
 	setRateLimitKeyInContext,
 } from "@/internal/misc/rateLimiter/rateLimitFactory";
 import {
+	getOrgAggregateType,
 	getRateLimitType,
 	RateLimitType,
 } from "../internal/misc/rateLimiter/rateLimitConfigs";
@@ -39,8 +40,31 @@ export const rateLimitMiddleware = async (c: Context<HonoEnv>, next: Next) => {
 		// 4. Get the appropriate limiter for this type
 		const limiter = getLimiterForType(rateLimitType);
 
-		// 5. Apply rate limiting
-		return await limiter(c as Context<Env>, next);
+		const aggregateType = getOrgAggregateType(rateLimitType);
+		if (!aggregateType) {
+			// 5. Apply rate limiting
+			return await limiter(c as Context<Env>, next);
+		}
+
+		// 5. Org-aggregate limiter wraps the per-customer one; the key slot is
+		// swapped between them since keyGenerator reads it at execution time.
+		setRateLimitKeyInContext(
+			c as Context,
+			getRateLimitKey({ c, rateLimitType: aggregateType }),
+		);
+		const aggregateLimiter = getLimiterForType(aggregateType);
+
+		let innerResponse: Response | undefined;
+		const aggregateResponse = await aggregateLimiter(
+			c as Context<Env>,
+			async () => {
+				setRateLimitKeyInContext(c as Context, rateLimitKey);
+				innerResponse = (await limiter(c as Context<Env>, next)) ?? undefined;
+			},
+		);
+
+		// hono-rate-limiter discards next()'s return, so re-surface an inner 429.
+		return aggregateResponse ?? innerResponse;
 	} catch (error) {
 		ctx.logger.error(
 			`Error checking rate limit, error: ${error}. Bypassing for now`,

--- a/server/src/honoUtils/HonoEnv.ts
+++ b/server/src/honoUtils/HonoEnv.ts
@@ -74,6 +74,10 @@ export type RequestContext = {
 	fullCustomer?: FullCustomer;
 	rolloutSnapshot?: RolloutSnapshot;
 
+	/** Org is over its aggregate rate cap — check/track flows skip the DB and
+	 *  serve their fail-open responses (allow / SQS queue) instead. */
+	orgRateLimitDegraded?: boolean;
+
 	testOptions?: {
 		skipCacheDeletion?: boolean;
 		skipWebhooks?: boolean;

--- a/server/src/internal/balances/check/runCheckWithRollout.ts
+++ b/server/src/internal/balances/check/runCheckWithRollout.ts
@@ -18,6 +18,18 @@ export const runCheckWithRollout = async ({
 	body: ParsedCheckParams;
 	requiredBalance: number;
 }): Promise<RunCheckResult<CheckData | CheckDataV2>> => {
+	if (ctx.orgRateLimitDegraded) {
+		return {
+			checkData: null,
+			response: getCheckFailOpenFallback({
+				ctx,
+				body,
+				requiredBalance,
+				error: new Error("org aggregate rate cap exceeded"),
+			}) as Record<string, unknown>,
+		};
+	}
+
 	if (!isFullSubjectRolloutEnabled({ ctx })) {
 		return runCheckLegacyFlow({ ctx, body, requiredBalance });
 	}

--- a/server/src/internal/balances/track/runTrackWithRollout.ts
+++ b/server/src/internal/balances/track/runTrackWithRollout.ts
@@ -24,6 +24,11 @@ export const runTrackWithRollout = async ({
 	apiVersion?: ApiVersion;
 }): Promise<TrackResponseV3> => {
 	if (shouldUseTrackV3({ ctx })) {
+		if (ctx.orgRateLimitDegraded) {
+			const queuedResponse = await queueTrack({ ctx, body });
+			if (queuedResponse) return queuedResponse;
+		}
+
 		return withRedisFailOpen<TrackResponseV3>({
 			source: "runTrackWithRollout",
 			run: () =>

--- a/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitConfigs.ts
@@ -13,7 +13,22 @@ export enum RateLimitType {
 	ListCustomers = "list_customers",
 	CustomerEntitiesGet = "customer_entities_get",
 	Logs = "logs",
+	TrackOrg = "track_org",
+	CheckOrg = "check_org",
+	EntitiesGetOrg = "entities_get_org",
 }
+
+// Org-wide aggregate caps summed across all of an org's customers — the
+// per-customer limits never bind for many-customer storms (2026-06-08 incident).
+const ORG_AGGREGATE_TYPES: Partial<Record<RateLimitType, RateLimitType>> = {
+	[RateLimitType.Track]: RateLimitType.TrackOrg,
+	[RateLimitType.Check]: RateLimitType.CheckOrg,
+	[RateLimitType.CustomerEntitiesGet]: RateLimitType.EntitiesGetOrg,
+};
+
+export const getOrgAggregateType = (
+	type: RateLimitType,
+): RateLimitType | undefined => ORG_AGGREGATE_TYPES[type];
 
 type RoutePattern = {
 	method: string;
@@ -120,6 +135,22 @@ const RATE_LIMIT_ROUTE_GROUPS: RateLimitRouteGroup[] = [
 	},
 ];
 
+// Check-group routes that can fail open (allowed: true) when an org is over
+// its aggregate cap; the establish routes in the group shed a 503 instead.
+const CHECK_FAIL_OPEN_PATTERNS: RoutePattern[] = [
+	route({ method: "POST", url: "/v1/check" }),
+	route({ method: "POST", url: "/v1/entitled" }),
+	route({ method: "POST", url: "/v1/balances.check" }),
+];
+
+export const isCheckFailOpenRoute = (c: Context<HonoEnv>): boolean => {
+	const method = c.req.method;
+	const path = c.req.path;
+	return CHECK_FAIL_OPEN_PATTERNS.some((pattern) =>
+		matchRoute({ url: path, method, pattern }),
+	);
+};
+
 export const getRateLimitType = (c: Context<HonoEnv>) => {
 	const method = c.req.method;
 	const path = c.req.path;
@@ -154,6 +185,9 @@ export type RateLimitConfig = {
 	windowMs: number;
 	notInRedis: boolean;
 	scope: RateLimitScope;
+	// "degrade" = over-limit requests fail open (check -> allow, track -> SQS
+	// queue) instead of 429, so the cap sheds DB load without losing events.
+	overLimit?: "reject" | "degrade";
 };
 
 export const resolveRateLimit = ({
@@ -252,6 +286,31 @@ export const RATE_LIMIT_CONFIGS: Record<RateLimitType, RateLimitConfig> = {
 		name: "logs",
 		limit: 10,
 		windowMs: 1000,
+		notInRedis: false,
+		scope: RateLimitScope.Org,
+	},
+	// 60s windows sized ~1.5-2x the highest legit per-org peak observed over 7d
+	// of prod traffic (check 157k/min, track 60k/min, entities.get 53k/min).
+	[RateLimitType.TrackOrg]: {
+		name: "track_org",
+		limit: 120_000,
+		windowMs: 60_000,
+		notInRedis: false,
+		scope: RateLimitScope.Org,
+		overLimit: "degrade",
+	},
+	[RateLimitType.CheckOrg]: {
+		name: "check_org",
+		limit: 240_000,
+		windowMs: 60_000,
+		notInRedis: false,
+		scope: RateLimitScope.Org,
+		overLimit: "degrade",
+	},
+	[RateLimitType.EntitiesGetOrg]: {
+		name: "entities_get_org",
+		limit: 90_000,
+		windowMs: 60_000,
 		notInRedis: false,
 		scope: RateLimitScope.Org,
 	},

--- a/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
@@ -1,14 +1,15 @@
 import type { ApiVersion } from "@autumn/shared";
-import type { Context } from "hono";
+import type { Context, Next } from "hono";
 import { rateLimiter } from "hono-rate-limiter";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { shouldUseRedis } from "@/external/redis/initRedis";
 import type { HonoEnv } from "@/honoUtils/HonoEnv";
 import {
+	isCheckFailOpenRoute,
 	RATE_LIMIT_CONFIGS,
 	type RateLimitConfig,
 	RateLimitScope,
-	type RateLimitType,
+	RateLimitType,
 	resolveRateLimit,
 } from "./rateLimitConfigs";
 import { getOrgRateLimitOverride } from "./rateLimitOverridesStore";
@@ -60,11 +61,38 @@ export const rateLimitFactory = ({
 		return resolveRateLimit({ config, apiVersion }).limit;
 	};
 
+	// Over-limit "degrade": fail open instead of 429 — check routes get the
+	// allow-fallback via the ctx flag; establish routes shed a retryable 503.
+	const degradeHandler = async (
+		c: Context,
+		next: Next,
+	): Promise<Response | undefined> => {
+		const honoContext = c as Context<HonoEnv>;
+		const ctx = honoContext.get("ctx");
+
+		if (type === RateLimitType.CheckOrg && !isCheckFailOpenRoute(honoContext)) {
+			return c.json(
+				{
+					message: "Service is temporarily unavailable, please retry shortly.",
+					code: "service_unavailable",
+					env: ctx?.env,
+				},
+				503,
+			);
+		}
+
+		if (ctx) ctx.orgRateLimitDegraded = true;
+		c.header("Retry-After", undefined);
+		await next();
+		return;
+	};
+
 	const options = {
 		windowMs,
 		limit: dynamicLimit,
 		standardHeaders: "draft-6" as const,
 		keyGenerator: getRateLimitKeyFromContext,
+		...(config.overLimit === "degrade" && { handler: degradeHandler }),
 	};
 
 	let inMemoryLimiter: ReturnType<typeof rateLimiter> | null = null;

--- a/server/tests/unit/rate-limits/org-aggregate-config.test.ts
+++ b/server/tests/unit/rate-limits/org-aggregate-config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getOrgAggregateType,
+	RATE_LIMIT_CONFIGS,
+	RateLimitScope,
+	RateLimitType,
+} from "@/internal/misc/rateLimiter/rateLimitConfigs.js";
+
+describe("org aggregate rate limits", () => {
+	test("high-volume per-customer types map to an org aggregate", () => {
+		expect(getOrgAggregateType(RateLimitType.Track)).toBe(
+			RateLimitType.TrackOrg,
+		);
+		expect(getOrgAggregateType(RateLimitType.Check)).toBe(
+			RateLimitType.CheckOrg,
+		);
+		expect(getOrgAggregateType(RateLimitType.CustomerEntitiesGet)).toBe(
+			RateLimitType.EntitiesGetOrg,
+		);
+	});
+
+	test("types without an aggregate return undefined", () => {
+		expect(getOrgAggregateType(RateLimitType.General)).toBeUndefined();
+		expect(getOrgAggregateType(RateLimitType.Attach)).toBeUndefined();
+		expect(getOrgAggregateType(RateLimitType.TrackOrg)).toBeUndefined();
+	});
+
+	test("aggregate configs are org-scoped, redis-backed, 60s windows", () => {
+		const aggregates = [
+			RateLimitType.TrackOrg,
+			RateLimitType.CheckOrg,
+			RateLimitType.EntitiesGetOrg,
+		];
+		for (const type of aggregates) {
+			const config = RATE_LIMIT_CONFIGS[type];
+			expect(config.scope).toBe(RateLimitScope.Org);
+			expect(config.notInRedis).toBe(false);
+			expect(config.windowMs).toBe(60_000);
+			expect(config.limit).toBeGreaterThan(0);
+		}
+	});
+
+	test("check/track aggregates degrade (fail open) instead of rejecting", () => {
+		expect(RATE_LIMIT_CONFIGS[RateLimitType.CheckOrg].overLimit).toBe(
+			"degrade",
+		);
+		expect(RATE_LIMIT_CONFIGS[RateLimitType.TrackOrg].overLimit).toBe(
+			"degrade",
+		);
+		expect(
+			RATE_LIMIT_CONFIGS[RateLimitType.EntitiesGetOrg].overLimit,
+		).toBeUndefined();
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds org-wide rate caps for high-volume routes to protect the DB during org-wide spikes. When an org exceeds its cap, `check` fails open (allow) and `track` queues; `entities.get` continues to reject normally.

- **New Features**
  - Introduced aggregate types `track_org`, `check_org`, `entities_get_org` (60s windows). `check_org` and `track_org` use fail-open degradation; `entities_get_org` keeps standard 429 behavior.
  - Middleware now nests the org limiter around the per-customer limiter and marks `ctx.orgRateLimitDegraded` when an org is over cap. Non fail-open check endpoints return 503.
  - Check flow skips DB and returns the allow fallback when degraded. Track flow queues to SQS when degraded.
  - Added route matching so fail-open applies only to `/v1/check`, `/v1/entitled`, and `/v1/balances.check`. Added unit tests for mappings and configs.

<sup>Written for commit 66819c4bbaca44cec42900c9daac70a6bb6206bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces org-aggregate rate limiting to guard against many-customer traffic storms (referencing the 2026-06-08 incident), where per-customer limits never fire individually but the sum across all customers overloads the DB. Three new org-scoped limit types (`TrackOrg`, `CheckOrg`, `EntitiesGetOrg`) wrap the existing per-customer limiters using a key-swap technique in the middleware.

- **[Improvements]** Added two-layer rate limiting in `rateLimitMiddleware`: the aggregate org limiter wraps the per-customer limiter, correctly re-surfacing inner 429s via `aggregateResponse ?? innerResponse`. `CheckOrg` and `TrackOrg` use a `"degrade"` mode that fails open (allow/SQS queue) rather than returning 429, so DB load is shed without dropping events.
- **[Improvements]** `runCheckWithRollout` and `runTrackWithRollout` respect the new `orgRateLimitDegraded` context flag: check routes return the existing fail-open fallback immediately; track routes attempt to queue the event to SQS before proceeding.
- **[Improvements]** Unit tests added for the config-layer invariants (mapping, scope, window, overLimit mode).
</details>

<h3>Confidence Score: 4/5</h3>

The core two-layer limiter design and the check fail-open path are sound. The track degradation path has a silent fallthrough when SQS queuing fails that could allow full DB writes to continue under the exact incident conditions this feature is designed to prevent.

The org aggregate limiting logic in the middleware is well-structured and the check flow's fail-open response is correct. The one gap is in runTrackWithRollout: when orgRateLimitDegraded is true and queueTrack returns null (unset TRACK_SQS_QUEUE_URL or SQS failure), the function quietly falls through to runTrackV3 and makes a synchronous DB write — the same behaviour the feature was introduced to avoid.

server/src/internal/balances/track/runTrackWithRollout.ts deserves another look on the queueTrack null-return path; server/src/internal/misc/rateLimiter/rateLimitFactory.ts has the minor Retry-After header coercion issue.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/rateLimitMiddleware.ts | Adds two-layer rate limiting: aggregate org limiter wraps the per-customer limiter via key-swapping; correctly re-surfaces inner 429 responses using the aggregateResponse ?? innerResponse pattern. |
| server/src/internal/misc/rateLimiter/rateLimitFactory.ts | Introduces degradeHandler for over-limit fail-open behaviour; c.header("Retry-After", undefined) coerces to string "undefined" via Fetch Headers API, adding a malformed header to all degraded responses. |
| server/src/internal/misc/rateLimiter/rateLimitConfigs.ts | Adds TrackOrg/CheckOrg/EntitiesGetOrg configs with 60s windows, org scope, and overLimit:"degrade" for check/track; adds helpers getOrgAggregateType and isCheckFailOpenRoute — all well-structured. |
| server/src/internal/balances/track/runTrackWithRollout.ts | Adds orgRateLimitDegraded fast-path that queues to SQS, but silently falls through to full runTrackV3 DB writes when queueTrack returns null, defeating load-shedding under queue pressure. |
| server/src/internal/balances/check/runCheckWithRollout.ts | Adds clean early-return guard when orgRateLimitDegraded is set; reuses existing getCheckFailOpenFallback — no issues. |
| server/src/honoUtils/HonoEnv.ts | Adds optional orgRateLimitDegraded boolean to RequestContext with clear JSDoc — straightforward and non-breaking. |
| server/tests/unit/rate-limits/org-aggregate-config.test.ts | New unit tests cover mapping, undefined return, scope/redis/window invariants, and overLimit mode — good coverage of the config layer. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant RateLimitMiddleware
    participant AggregateLimiter as Org Aggregate Limiter<br/>(TrackOrg/CheckOrg)
    participant CustomerLimiter as Per-Customer Limiter<br/>(Track/Check)
    participant DegradeHandler
    participant RouteHandler

    Client->>RateLimitMiddleware: HTTP Request

    alt No org aggregate type (e.g. Attach, General)
        RateLimitMiddleware->>CustomerLimiter: run directly
        CustomerLimiter->>RouteHandler: next()
        RouteHandler-->>Client: 200 response
    else Org aggregate type exists
        RateLimitMiddleware->>AggregateLimiter: run with org key
        alt Under org aggregate limit
            AggregateLimiter->>CustomerLimiter: next() (with customer key)
            alt Under per-customer limit
                CustomerLimiter->>RouteHandler: next()
                RouteHandler-->>Client: 200 response
            else Over per-customer limit
                CustomerLimiter-->>Client: 429 Too Many Requests
            end
        else Over org aggregate limit (degrade mode)
            AggregateLimiter->>DegradeHandler: over-limit handler
            alt Non-fail-open route (CheckOrg only)
                DegradeHandler-->>Client: 503 Service Unavailable
            else Fail-open route (check/track)
                DegradeHandler->>DegradeHandler: "set orgRateLimitDegraded=true"
                DegradeHandler->>CustomerLimiter: next() (inner callback)
                CustomerLimiter->>RouteHandler: next()
                RouteHandler->>RouteHandler: sees orgRateLimitDegraded flag
                note over RouteHandler: check -> fail-open allow<br/>track -> SQS queue
                RouteHandler-->>Client: 200 (degraded response)
            end
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/balances/track/runTrackWithRollout.ts:27-30
**Silent fallthrough defeats load-shedding when queue is unavailable**

When `orgRateLimitDegraded` is true and `queueTrack` returns `null` (either because `TRACK_SQS_QUEUE_URL` is unset, or because the SQS enqueue throws), the code falls through to `withRedisFailOpen({ run: runTrackV3 })` — a full synchronous DB write. During the exact traffic-storm scenario this feature targets, if SQS is also under pressure and `queueTrack` returns null, every degraded track request still hits the database, silently undermining the load-shedding goal. The `withRedisFailOpen` fallback already has a `throw` path when queuing fails; the same pattern should be applied here rather than a silent fallthrough.

### Issue 2 of 2
server/src/internal/misc/rateLimiter/rateLimitFactory.ts:84-87
**`c.header("Retry-After", undefined)` sets the header to the string `"undefined"`**

The Fetch `Headers` API coerces non-string values via `ByteString` conversion, so `undefined` becomes the literal string `"undefined"`. This adds a malformed `Retry-After: undefined` header on every degraded response. Since the custom `degradeHandler` runs instead of the default 429 handler — and `draft-6` standard headers don't include `Retry-After` — the header is likely not set at this point. Either delete it explicitly with `c.res.headers.delete(...)` or just remove the line.

```suggestion
		if (ctx) ctx.orgRateLimitDegraded = true;
		c.res.headers.delete("Retry-After");
		await next();
		return;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["clear staging deploy allowlist"](https://github.com/useautumn/autumn/commit/66819c4bbaca44cec42900c9daac70a6bb6206bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36780210)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->