### PR TITLE
fix: compute pool budget guard from env-resolved maxes

### DIFF
--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -120,9 +120,22 @@ const PROD_POOL_MAX = {
 	replica: 6,
 };
 
+const criticalPoolMax = poolMaxFromEnv({
+	envVar: "CRITICAL_DB_POOL_MAX",
+	fallback: isProd ? PROD_POOL_MAX.critical : 10,
+});
+const generalPoolMax = poolMaxFromEnv({
+	envVar: "GENERAL_DB_POOL_MAX",
+	fallback: isProd ? PROD_POOL_MAX.general : 10,
+});
+const replicaPoolMax = poolMaxFromEnv({
+	envVar: "REPLICA_DB_POOL_MAX",
+	fallback: PROD_POOL_MAX.replica,
+});
+
 const budgetedFleetConnections =
 	BUDGETED_FLEET_PROCESSES *
-		(PROD_POOL_MAX.critical + PROD_POOL_MAX.general + PROD_POOL_MAX.replica) +
+		(criticalPoolMax + generalPoolMax + replicaPoolMax) +
 	BUDGETED_NON_SERVER_CONNECTIONS;
 
 if (
@@ -130,14 +143,9 @@ if (
 	PGBOUNCER_MAX_CLIENT_CONN * POOL_BUDGET_HEADROOM
 ) {
 	logger.warn(
-		`[initDrizzle] pool budget (${budgetedFleetConnections}) exceeds ${POOL_BUDGET_HEADROOM} of max_client_conn (${PGBOUNCER_MAX_CLIENT_CONN}) — resize PROD_POOL_MAX`,
+		`[initDrizzle] pool budget (${budgetedFleetConnections}) exceeds ${POOL_BUDGET_HEADROOM} of max_client_conn (${PGBOUNCER_MAX_CLIENT_CONN}) — lower the pool maxes or raise the ceiling`,
 	);
 }
-
-const criticalPoolMax = poolMaxFromEnv({
-	envVar: "CRITICAL_DB_POOL_MAX",
-	fallback: isProd ? PROD_POOL_MAX.critical : 10,
-});
 
 export const { db: dbCritical, client: clientCritical } = initDrizzle({
 	name: "critical",
@@ -155,10 +163,7 @@ export const { db: dbCritical, client: clientCritical } = initDrizzle({
 // -- General pool: used by all other endpoints --
 export const { db: dbGeneral, client: clientGeneral } = initDrizzle({
 	name: "general",
-	maxConnections: poolMaxFromEnv({
-		envVar: "GENERAL_DB_POOL_MAX",
-		fallback: isProd ? PROD_POOL_MAX.general : 10,
-	}),
+	maxConnections: generalPoolMax,
 	connectTimeout: isProd ? 5 : 30,
 });
 
@@ -168,10 +173,7 @@ const replicaResult = process.env.DATABASE_REPLICA_URL
 	? initDrizzle({
 			name: "replica",
 			replica: true,
-			maxConnections: poolMaxFromEnv({
-				envVar: "REPLICA_DB_POOL_MAX",
-				fallback: PROD_POOL_MAX.replica,
-			}),
+			maxConnections: replicaPoolMax,
 			connectTimeout: null,
 		})
 	: null;


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Compute the pool budget guard using env-resolved max connections instead of static prod defaults, so warnings reflect actual configuration. Also deduplicate and reuse the resolved max values for the critical, general, and replica pools during initialization.

<sup>Written for commit 67a8272dfcafb8a83b0f91a37c36cc8f61160f9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the pool budget guard in `initDrizzle.ts` to compute `budgetedFleetConnections` from the actual env-resolved pool maximums rather than the hardcoded `PROD_POOL_MAX` constants. Previously, raising any pool size via env vars (e.g. `CRITICAL_DB_POOL_MAX=50`) would silently bypass the budget check because the guard still measured against the hard-coded defaults.

- **Bug fixes**: All three pool-max variables (`criticalPoolMax`, `generalPoolMax`, `replicaPoolMax`) are now resolved from `poolMaxFromEnv` before the budget calculation, so the guard reflects actual runtime values.
- **Improvements**: The warning message is updated from the prescriptive `resize PROD_POOL_MAX` to the more accurate `lower the pool maxes or raise the ceiling`, matching the new env-var-driven configuration model.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted correctness fix with no behavioural impact when env vars are not set.

When no override env vars are present, all three resolved pool maxes fall back to exactly the same values that were hardcoded before, so the budget number and pool sizes are identical to the previous behaviour. The only observable difference is when an operator explicitly raises a pool size via env var — in that case the guard now correctly fires instead of staying silent. The refactored variable hoisting is straightforward and the updated warning message is accurate.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/initDrizzle.ts | Pool budget guard now correctly uses env-resolved max values; all three pool-max consts hoisted above the budget calculation and reused for pool initialization. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Module load] --> B[Resolve criticalPoolMax\nenv CRITICAL_DB_POOL_MAX\nor PROD_POOL_MAX.critical / 10]
    A --> C[Resolve generalPoolMax\nenv GENERAL_DB_POOL_MAX\nor PROD_POOL_MAX.general / 10]
    A --> D[Resolve replicaPoolMax\nenv REPLICA_DB_POOL_MAX\nor PROD_POOL_MAX.replica]
    B --> E[Compute budgetedFleetConnections\n= FLEET_PROCESSES x sum + NON_SERVER]
    C --> E
    D --> E
    E --> F{budget > PGBOUNCER_MAX x HEADROOM?}
    F -- Yes --> G[logger.warn budget exceeded]
    F -- No --> H[Silent - budget OK]
    G --> I[initDrizzle - critical pool\nmaxConnections = criticalPoolMax]
    H --> I
    I --> J[initDrizzle - general pool\nmaxConnections = generalPoolMax]
    J --> K{DATABASE_REPLICA_URL set?}
    K -- Yes --> L[initDrizzle - replica pool\nmaxConnections = replicaPoolMax]
    K -- No --> M[dbReplica = null]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: compute pool budget guard from env-..."](https://github.com/useautumn/autumn/commit/67a8272dfcafb8a83b0f91a37c36cc8f61160f9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36788745)</sub>

<!-- /greptile_comment -->