### PR TITLE
customer-leading events_customer_hourly_mv for per-customer aggregates

### DIFF
--- a/server/src/internal/analytics/actions/getCountAndSum.ts
+++ b/server/src/internal/analytics/actions/getCountAndSum.ts
@@ -129,7 +129,7 @@ export const getCountAndSum = async ({
 		`
 		: `
 			SELECT event_name, sum(event_count) as count, sum(total_value) as sum
-			FROM ${useOrgRollup ? "events_org_hourly_mv" : "events_hourly_no_properties_two_mv"}
+			FROM ${useOrgRollup ? "events_org_hourly_mv" : "events_customer_hourly_mv"}
 			WHERE org_id = {org_id:String} AND env = {env:String}
 				${!useOrgRollup && !params.aggregateAll ? "AND customer_id = {customer_id:String}" : ""}
 				${!useOrgRollup && params.entity_id ? "AND entity_id = {entity_id:String}" : ""}

--- a/server/tinybird/copies/events_customer_hourly_mv_backfill.pipe
+++ b/server/tinybird/copies/events_customer_hourly_mv_backfill.pipe
@@ -1,0 +1,34 @@
+DESCRIPTION >
+    History backfill for events_customer_hourly_mv (deployed with BACKFILL skip). Fills the window before
+    the MV's forward-materialization seam, in bounded half-open [start_date, end_date) chunks on on-demand
+    compute
+    (tb copy run events_customer_hourly_mv_backfill --on-demand-compute --param start_date=... --param end_date=...).
+    SQL mirrors events_customer_hourly_mv_pipe EXACTLY (same projection + GROUP BY, no ARRAY JOIN) so
+    backfilled rows are identical to forward-materialized ones. No fan-out, so chunks can be wide.
+
+    Seam safety: MergeTree does NOT dedup — keep every end_date <= the MV's actual promote time
+    (capture it empirically: min(hour) once forward events land), else overlapping hours double-count.
+    Only ~100 days of history is needed to cover the max servable window (the 92-day custom_range clamp
+    plus billing-cycle headroom); backfilling further back is wasted storage.
+
+NODE migrate
+SQL >
+    %
+    SELECT
+        org_id,
+        env,
+        customer_id,
+        event_name,
+        coalesce(entity_id, '') as entity_id,
+        internal_product_id,
+        toStartOfHour(timestamp) as hour,
+        sum(toFloat64(coalesce(value, 1))) as total_value,
+        count() as event_count
+    FROM events
+    WHERE timestamp >= {{DateTime(start_date, '2026-06-01 00:00:00')}}
+        AND timestamp < {{DateTime(end_date, '2026-06-02 00:00:00')}}
+    GROUP BY org_id, env, customer_id, event_name, entity_id, internal_product_id, hour
+
+TYPE COPY
+TARGET_DATASOURCE events_customer_hourly_mv
+COPY_MODE append

--- a/server/tinybird/materializations/events_customer_hourly_mv.datasource
+++ b/server/tinybird/materializations/events_customer_hourly_mv.datasource
@@ -1,0 +1,31 @@
+DESCRIPTION >
+    Customer-leading hourly rollup of `events`, keyed (org_id, env, customer_id, entity_id, event_name, hour).
+    Same grain and projection as events_hourly_no_properties_two_mv, but with customer_id LEADING the sort key
+    so a per-customer (or per-customer+entity) query prunes straight to that customer's slice instead of
+    scanning the whole org's hourly partitions — events_hourly_no_properties_two_mv leads with `hour`, so a
+    per-customer query there cannot prune by customer and scans the entire org/env date window.
+
+    Serves the per-customer ungrouped timeseries + count/sum and the group-by customer_id/entity_id/plan_id
+    paths once the read pipes (aggregate_simple, aggregate_groupable, getCountAndSum) are repointed at it.
+    Totals reconcile exactly with events_hourly_no_properties_two_mv because both pre-aggregate one row per
+    event at insert and the read pipe re-sums by (period, event_name, group_value).
+
+    BACKFILL skip: deploy empty + forward-materialization trigger only (no deploy-time repopulate of the
+    existing events history); fill history in bounded chunks via events_customer_hourly_mv_backfill.
+
+SCHEMA >
+    `org_id` String,
+    `env` String,
+    `customer_id` String,
+    `event_name` String,
+    `entity_id` String DEFAULT '',
+    `internal_product_id` Nullable(String),
+    `hour` DateTime,
+    `total_value` Float64,
+    `event_count` UInt64
+
+ENGINE "MergeTree"
+ENGINE_PARTITION_KEY "toYYYYMM(hour)"
+ENGINE_SORTING_KEY "org_id, env, customer_id, entity_id, event_name, hour"
+
+BACKFILL skip

--- a/server/tinybird/materializations/events_customer_hourly_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_customer_hourly_mv_pipe.pipe
@@ -1,0 +1,22 @@
+DESCRIPTION >
+    Materializes events into customer-leading hourly aggregates without properties.
+    Projection + GROUP BY are identical to events_hourly_no_properties_two_mv_pipe, so the two rollups
+    are row-for-row equivalent; only the destination sort key differs (customer-leading here).
+
+NODE materialize
+SQL >
+    SELECT
+        org_id,
+        env,
+        customer_id,
+        event_name,
+        coalesce(entity_id, '') as entity_id,
+        internal_product_id,
+        toStartOfHour(timestamp) as hour,
+        sum(toFloat64(coalesce(value, 1))) as total_value,
+        count() as event_count
+    FROM events
+    GROUP BY org_id, env, customer_id, event_name, entity_id, internal_product_id, hour
+
+TYPE materialized
+DATASOURCE events_customer_hourly_mv

--- a/server/tinybird/pipes/aggregate_groupable.pipe
+++ b/server/tinybird/pipes/aggregate_groupable.pipe
@@ -41,7 +41,7 @@ SQL >
         sum(total_value) as total_value
     FROM
         {% if use_no_props %}
-        events_hourly_no_properties_two_mv
+        events_customer_hourly_mv
         {% elif use_property_rollup %}
         events_property_mv
         {% else %}

--- a/server/tinybird/pipes/aggregate_simple.pipe
+++ b/server/tinybird/pipes/aggregate_simple.pipe
@@ -20,7 +20,7 @@ SQL >
         {% end %}
         event_name,
         sum(total_value) as total_value
-    FROM {% if not no_property_filters %}events_hourly_mv{% elif use_org_rollup %}events_org_hourly_mv{% else %}events_hourly_no_properties_two_mv{% end %}
+    FROM {% if not no_property_filters %}events_hourly_mv{% elif use_org_rollup %}events_org_hourly_mv{% else %}events_customer_hourly_mv{% end %}
     WHERE
         org_id = {{ String(org_id, '') }}
         AND env = {{ String(env, 'test') }}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a customer-leading hourly materialized view for events and switch per-customer reads to it. This prunes by customer and speeds up per-customer aggregates with identical totals.

- New Features
  - Added `events_customer_hourly_mv` (sorted by org_id, env, customer_id, entity_id, event_name, hour).
  - Added `events_customer_hourly_mv_pipe` with the same projection as the prior no-properties rollup.
  - Updated `aggregate_simple`, `aggregate_groupable`, and `getCountAndSum` to read from `events_customer_hourly_mv` when org rollup is off.
  - Added `events_customer_hourly_mv_backfill` for historical backfill.

- Migration
  - Deploy with BACKFILL skip and start forward materialization.
  - If history is needed, backfill in bounded windows before the MV’s promote hour to avoid double counts:
    `tb copy run events_customer_hourly_mv_backfill --on-demand-compute --param start_date=... --param end_date=...`
  - Backfill up to ~100 days to cover the served window.

<sup>Written for commit 6ff593703be506535fde3c3d01222f90a181ad7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `events_customer_hourly_mv`, a new Tinybird MV that mirrors `events_hourly_no_properties_two_mv` with a customer-leading sort key (`org_id, env, customer_id, entity_id, event_name, hour`), allowing per-customer queries to prune directly to a single customer's data instead of scanning the full org/hour partition. All three read paths (`aggregate_simple`, `aggregate_groupable`, `getCountAndSum`) are updated in the same changeset to route non-org-rollup, no-property queries to the new MV, and a backfill copy pipe is provided for history population.

- **[Improvements]** New `events_customer_hourly_mv` datasource with customer-leading sort key replaces `events_hourly_no_properties_two_mv` as the routing target for per-customer and per-entity analytics queries, improving index pruning efficiency for those query shapes.
- **[Improvements]** `aggregate_simple.pipe`, `aggregate_groupable.pipe`, and `getCountAndSum.ts` all repointed to the new customer-leading MV; routing conditions are otherwise unchanged.
- **[Improvements]** `events_customer_hourly_mv_backfill.pipe` copy pipe added for bounded, on-demand history population with clear seam-safety documentation.
</details>


<h3>Confidence Score: 3/5</h3>

Deploying the read-pipe changes before the backfill has run will cause all historical analytics queries to return zero counts for any period predating the MV's promote time.

All three read paths switch to an empty MV the moment this lands. Any customer-facing analytics query for historical data will silently return zeros until the backfill copy job is manually executed. The code itself is correct and well-structured, but the deployment sequencing means live data will be wrong for an indeterminate window after merge.

The deployment ordering of `events_customer_hourly_mv.datasource` (BACKFILL skip) relative to the pipe changes in `aggregate_simple.pipe`, `aggregate_groupable.pipe`, and `getCountAndSum.ts` needs explicit coordination before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/getCountAndSum.ts | Switches non-org-rollup path from `events_hourly_no_properties_two_mv` to `events_customer_hourly_mv`; logic and query structure are correct, but the new MV is empty at deploy time. |
| server/tinybird/materializations/events_customer_hourly_mv.datasource | New customer-leading MV with `BACKFILL skip`; schema and sort key are well-designed for per-customer pruning, but the `BACKFILL skip` flag means the table is empty at deploy time while read pipes are already switched over. |
| server/tinybird/materializations/events_customer_hourly_mv_pipe.pipe | Forward-materialization pipe; SQL mirrors `events_hourly_no_properties_two_mv_pipe` exactly as documented — no issues. |
| server/tinybird/copies/events_customer_hourly_mv_backfill.pipe | Backfill copy pipe; SQL matches the materialization exactly; seam-safety warning in description is accurate and helpful. |
| server/tinybird/pipes/aggregate_groupable.pipe | SQL correctly routes `customer_id`/`entity_id`/`plan_id` grouping to the new MV; DESCRIPTION block has a stale reference to `events_hourly_no_properties_two_mv`. |
| server/tinybird/pipes/aggregate_simple.pipe | Routing logic is unchanged in structure; correctly uses `events_customer_hourly_mv` for customer/entity-scoped no-property queries. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q[Incoming analytics query] --> A{Property filters?}
    A -- Yes --> HMV[events_hourly_mv]
    A -- No --> B{customer_id / entity_id present?}
    B -- No --> OMV[events_org_hourly_mv]
    B -- Yes --> CMV[events_customer_hourly_mv\norg_id, env, customer_id,\nentity_id, event_name, hour]

    subgraph Materialization
        E[events raw table] -->|forward MV pipe| CMV
        E -->|backfill copy pipe| CMV
    end

    CMV --> RS[aggregate_simple.pipe]
    CMV --> RG[aggregate_groupable.pipe\ncustomer_id / entity_id / plan_id]
    CMV --> GCS[getCountAndSum.ts]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/tinybird/pipes/aggregate_groupable.pipe`, line 3-5 ([link](https://github.com/useautumn/autumn/blob/6ff593703be506535fde3c3d01222f90a181ad7f/server/tinybird/pipes/aggregate_groupable.pipe#L3-L5)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The DESCRIPTION block still names `events_hourly_no_properties_two_mv` as the routing target, but the SQL now routes to `events_customer_hourly_mv`. Update it to match the actual table.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/tinybird/pipes/aggregate_groupable.pipe
   Line: 3-5

   Comment:
   The DESCRIPTION block still names `events_hourly_no_properties_two_mv` as the routing target, but the SQL now routes to `events_customer_hourly_mv`. Update it to match the actual table.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tinybird/materializations/events_customer_hourly_mv.datasource:31
**Data gap during backfill window**

The datasource deploys with `BACKFILL skip` (starts empty), but `aggregate_simple.pipe`, `aggregate_groupable.pipe`, and `getCountAndSum.ts` are all repointed to `events_customer_hourly_mv` in the same PR. From the moment this lands until `events_customer_hourly_mv_backfill` is manually run for all needed historical windows, every analytics query served by those three paths will return zero counts for any period that predates the MV's promote time. The fix is either to run the backfill before switching the read pipes, or to decouple the pipe changes into a separate PR deployed after the backfill has caught up.

### Issue 2 of 2
server/tinybird/pipes/aggregate_groupable.pipe:3-5
The DESCRIPTION block still names `events_hourly_no_properties_two_mv` as the routing target, but the SQL now routes to `events_customer_hourly_mv`. Update it to match the actual table.

```suggestion
    Routes to the smallest viable MV for the query shape:
      - events_customer_hourly_mv: customer_id/entity_id/plan_id grouping with no property filters
      - events_hourly_mv:          arbitrary properties or filtered queries
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["customer-leading events\_customer\_hourly\_..."](https://github.com/useautumn/autumn/commit/6ff593703be506535fde3c3d01222f90a181ad7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36798415)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->