### PR TITLE
feat: agent2

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,17 +15,17 @@
 		"chalk": "^5.3.0",
 		"dotenv": "^16.5.0",
 		"drizzle-orm": "catalog:",
-		"ink": "^5.1.0",
+		"ink": "^6.6.0",
 		"ioredis": "^5.10.0",
 		"inquirer": "^12.6.3",
 		"p-limit": "^7.2.0",
 		"pg": "8.20.0",
-		"react": "^18.3.1"
+		"react": "^19.2.1"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.11",
 		"@types/pg": "8.20.0",
-		"@types/react": "^18.3.1",
+		"@types/react": "^19.2.1",
 		"tsx": "^4.19.2",
 		"typescript": "^5.7.3"
 	}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `ink` and `react` in `scripts` to fix CLI compatibility and align with React 19.

- **Dependencies**
  - `ink` → ^6.6.0 (was ^5.1.0)
  - `react` → ^19.2.1 (was ^18.3.1)
  - `@types/react` → ^19.2.1 (was ^18.3.1)

<sup>Written for commit 2c6522f49040ed31a15b21fd0998dd0fb074bc2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Bumps three dependencies in `scripts/package.json` to align the scripts workspace package with the rest of the monorepo: `ink` moves from v5 to v6, and both `react` and `@types/react` move from v18 to v19.

- **[Improvements]** Upgrades `ink` from `^5.1.0` to `^6.6.0`, a major-version bump that adds React 19 compatibility and new terminal input features.
- **[Improvements]** Upgrades `react` and `@types/react` from `^18.3.1` to `^19.2.1`, matching the versions already used in `apps/checkout` and `apps/website`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a straightforward dependency upgrade with no code changes required.

The only consumer of ink in the scripts workspace (runTestsV2.tsx) uses stable, long-lived APIs (Box, Text, Static, render, useApp, and standard React hooks) that have not changed across these version ranges. React 19 is already deployed across apps/checkout and apps/website, so the ecosystem alignment is consistent. No functional logic was modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/package.json | Bumps ink (^5.1.0 → ^6.6.0), react (^18.3.1 → ^19.2.1), and @types/react (^18.3.1 → ^19.2.1) — aligns the scripts package with the rest of the monorepo which is already on React 19 |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scripts/package.json] --> B[ink v6]
    A --> C[react v19]
    A --> D[types-react v19]
    B --> E[runTestsV2.tsx]
    C --> E
    D --> E
    E --> F[CLI Test Runner UI]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ink/react in autumn/scripts"](https://github.com/useautumn/autumn/commit/2c6522f49040ed31a15b21fd0998dd0fb074bc2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36924997)</sub>

<!-- /greptile_comment -->