### PR TITLE
fix: ends at propogation

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts
@@ -7,9 +7,9 @@ import { createStripeScheduleFromCheckout } from "@/external/stripe/webhookHandl
 import { modifyStripeSubscriptionFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/modifyStripeSubscriptionFromCheckout";
 import { syncSubscriptionItemMetadataFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/syncSubscriptionItemMetadataFromCheckout";
 import { updateBillingPlanFromCheckout } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/updateBillingPlanFromCheckout";
+import { withClaimedCheckoutSessionMetadata } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import { persistDeferredCreateSchedule } from "@/internal/billing/v2/actions/createSchedule/utils/persistDeferredCreateSchedule";
-import { checkoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock";
 import { addStripeSubscriptionScheduleIdToBillingPlan } from "@/internal/billing/v2/execute/addStripeSubscriptionScheduleIdToBillingPlan";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan";
@@ -34,6 +34,24 @@ export const handleCheckoutSessionMetadataV2 = async ({
 		`[checkout.completed] Handling checkout session metadata V2: ${metadata.id}`,
 	);
 
+	await withClaimedCheckoutSessionMetadata({
+		ctx,
+		checkoutContext,
+		metadata,
+		execute: () =>
+			executeCheckoutSessionMetadataV2({ ctx, checkoutContext, metadata }),
+	});
+};
+
+const executeCheckoutSessionMetadataV2 = async ({
+	ctx,
+	checkoutContext,
+	metadata,
+}: {
+	ctx: StripeWebhookContext;
+	checkoutContext: CheckoutSessionCompletedContext;
+	metadata: NonNullable<CheckoutSessionCompletedContext["metadata"]>;
+}): Promise<void> => {
 	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
 
 	// 1. Sync Autumn metadata onto subscription items created by checkout
@@ -95,14 +113,6 @@ export const handleCheckoutSessionMetadataV2 = async ({
 		billingContext: updatedDeferredData.billingContext,
 		billingPlan: updatedDeferredData.billingPlan,
 	});
-
-	// Clear checkout session lock now that customer_product rows exist
-	const lockCustomerId =
-		updatedDeferredData.billingContext.fullCustomer.id ??
-		updatedDeferredData.billingContext.fullCustomer.internal_id;
-	if (lockCustomerId) {
-		await checkoutSessionLock.clear({ ctx, customerId: lockCustomerId });
-	}
 
 	// Queue customer.products.updated webhook (mirrors executeBillingPlan)
 	await billingPlanToSendProductsUpdated({

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
@@ -1,0 +1,84 @@
+import {
+	type DeferredAutumnBillingPlanData,
+	MetadataType,
+} from "@autumn/shared";
+import { setStripeSubscriptionLock } from "@/external/stripe/subscriptions/utils/lockStripeSubscriptionUtils";
+import type { CheckoutSessionCompletedContext } from "@/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/setupCheckoutSessionCompletedContext";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
+import { checkoutSessionLock } from "@/internal/billing/v2/actions/locks/checkoutSessionLock/checkoutSessionLock";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+
+/**
+ * Runs `execute` exactly once across concurrent executors of the same deferred
+ * plan. The subscription lock marks the resulting subscription.updated events
+ * as Autumn-initiated; the checkout session lock is cleared even on failure
+ * since the Stripe session is already paid.
+ */
+export const withClaimedCheckoutSessionMetadata = async ({
+	ctx,
+	checkoutContext,
+	metadata,
+	execute,
+}: {
+	ctx: StripeWebhookContext;
+	checkoutContext: CheckoutSessionCompletedContext;
+	metadata: NonNullable<CheckoutSessionCompletedContext["metadata"]>;
+	execute: () => Promise<void>;
+}): Promise<void> => {
+	const claimed = await MetadataService.claim({
+		db: ctx.db,
+		id: metadata.id,
+		fromType: MetadataType.CheckoutSessionV2,
+		toType: MetadataType.CheckoutSessionV2Processing,
+	});
+
+	if (!claimed) {
+		ctx.logger.info(
+			`[checkout.completed] Metadata ${metadata.id} already claimed by another executor, skipping`,
+		);
+		return;
+	}
+
+	if (checkoutContext.stripeSubscription) {
+		await setStripeSubscriptionLock({
+			stripeSubscriptionId: checkoutContext.stripeSubscription.id,
+			lockedAtMs: Date.now(),
+		});
+	}
+
+	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
+	const lockCustomerId =
+		deferredData?.billingContext?.fullCustomer?.id ??
+		deferredData?.billingContext?.fullCustomer?.internal_id;
+
+	try {
+		await execute();
+	} catch (error) {
+		await revertMetadataClaim({ ctx, metadataId: metadata.id });
+		throw error;
+	} finally {
+		if (lockCustomerId) {
+			await checkoutSessionLock.clear({ ctx, customerId: lockCustomerId });
+		}
+	}
+};
+
+const revertMetadataClaim = async ({
+	ctx,
+	metadataId,
+}: {
+	ctx: StripeWebhookContext;
+	metadataId: string;
+}): Promise<void> => {
+	await MetadataService.claim({
+		db: ctx.db,
+		id: metadataId,
+		fromType: MetadataType.CheckoutSessionV2Processing,
+		toType: MetadataType.CheckoutSessionV2,
+	}).catch((revertError) => {
+		ctx.logger.error(
+			`[checkout.completed] Failed to revert metadata claim for ${metadataId}`,
+			{ revertError },
+		);
+	});
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
@@ -39,19 +39,19 @@ export const withClaimedCheckoutSessionMetadata = async ({
 		return;
 	}
 
-	if (checkoutContext.stripeSubscription) {
-		await setStripeSubscriptionLock({
-			stripeSubscriptionId: checkoutContext.stripeSubscription.id,
-			lockedAtMs: Date.now(),
-		});
-	}
-
 	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
 	const lockCustomerId =
 		deferredData?.billingContext?.fullCustomer?.id ??
 		deferredData?.billingContext?.fullCustomer?.internal_id;
 
 	try {
+		if (checkoutContext.stripeSubscription) {
+			await setStripeSubscriptionLock({
+				stripeSubscriptionId: checkoutContext.stripeSubscription.id,
+				lockedAtMs: Date.now(),
+			});
+		}
+
 		await execute();
 	} catch (error) {
 		await revertMetadataClaim({ ctx, metadataId: metadata.id });

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionCanceled/handleStripeSubscriptionCanceled.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionCanceled/handleStripeSubscriptionCanceled.ts
@@ -1,4 +1,10 @@
-import { AttachScenario, cp, type FullCusProduct } from "@autumn/shared";
+import {
+	AttachScenario,
+	cp,
+	type FullCusProduct,
+	notNullish,
+} from "@autumn/shared";
+import { msToSeconds } from "@shared/utils/common/unixUtils";
 import { getStripeSubscriptionLock } from "@/external/stripe/subscriptions/utils/lockStripeSubscriptionUtils";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
 import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
@@ -67,6 +73,13 @@ export const handleStripeSubscriptionCanceled = async ({
 			.onStripeSubscription({ stripeSubscriptionId: stripeSubscription.id });
 
 		if (!isActiveRecurringAndOnSub) continue;
+
+		// attach-set ends_at, not an external cancellation
+		const endedAtMatchesCancelAt =
+			notNullish(customerProduct.ended_at) &&
+			notNullish(cancelsAtMs) &&
+			msToSeconds(customerProduct.ended_at!) === msToSeconds(cancelsAtMs!);
+		if (endedAtMatchesCancelAt) continue;
 
 		const updates = {
 			canceled_at: canceledAtMs ?? Date.now(),

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionRenewed/handleStripeSubscriptionRenewed.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionRenewed/handleStripeSubscriptionRenewed.ts
@@ -77,6 +77,9 @@ export const handleStripeSubscriptionRenewed = async ({
 
 		if (!valid) continue;
 
+		// attach-set ends_at expiry, not a cancellation
+		if (!customerProduct.canceled && !customerProduct.canceled_at) continue;
+
 		// Clear cancellation fields
 		const updates = {
 			canceled_at: null,

--- a/server/src/internal/metadata/MetadataService.ts
+++ b/server/src/internal/metadata/MetadataService.ts
@@ -54,6 +54,31 @@ export class MetadataService {
 		return meta as Metadata;
 	}
 
+	/**
+	 * Atomically transitions a metadata row from one type to another.
+	 * Returns true only for the caller whose update matched the `fromType`
+	 * predicate — concurrent executors racing on the same row get false.
+	 */
+	static async claim({
+		db,
+		id,
+		fromType,
+		toType,
+	}: {
+		db: DrizzleCli;
+		id: string;
+		fromType: MetadataType;
+		toType: MetadataType;
+	}): Promise<boolean> {
+		const claimedRows = await db
+			.update(metadata)
+			.set({ type: toType })
+			.where(and(eq(metadata.id, id), eq(metadata.type, fromType)))
+			.returning({ id: metadata.id });
+
+		return claimedRows.length > 0;
+	}
+
 	static async delete({ db, id }: { db: DrizzleCli; id: string }) {
 		await db.delete(metadata).where(eq(metadata.id, id));
 	}

--- a/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-ends-at.test.ts
+++ b/server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-ends-at.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Stripe Checkout + ends_at Tests (Attach V2)
+ *
+ * Regression tests for ends_at surviving the Stripe Checkout deferred flow.
+ *
+ * Previously, after checkout completion:
+ * - A concurrent execution of the same deferred plan crashed the
+ *   checkout.session.completed handler on a duplicate customer_products insert
+ * - The handler took no Stripe subscription lock, so the subscription.updated
+ *   events it generated were misread as customer-initiated cancel/renew and
+ *   handleStripeSubscriptionRenewed wiped ended_at off the customer product
+ *
+ * Expected behavior:
+ * - cancel_at lands on the Stripe subscription and stays there
+ * - customer_product.ended_at persists with canceled=false (an Autumn-owned
+ *   expiry, not a cancellation)
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	type AttachParamsV1Input,
+	MetadataType,
+} from "@autumn/shared";
+import { getCustomerProduct } from "@tests/integration/billing/attach/params/start-date/utils";
+import { expectProductActive } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { completeStripeCheckoutFormV2 as completeStripeCheckoutForm } from "@tests/utils/browserPool/completeStripeCheckoutFormV2";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { timeout } from "@tests/utils/genUtils";
+import testContext from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { addDays } from "date-fns";
+import { MetadataService } from "@/internal/metadata/MetadataService";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Stripe Checkout attach with ends_at → cancel_at + ended_at persist
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("stripe-checkout: ends_at sets cancel_at and persists ended_at")}`,
+	async () => {
+		const customerId = "stripe-checkout-ends-at";
+
+		const pro = products.pro({
+			id: "pro-checkout-ends-at",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, ctx, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: true }), // No payment method → stripe_checkout
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		const endsAt = addDays(advancedTo, 7).getTime();
+
+		// 1. Attach with ends_at — should defer to Stripe Checkout
+		const result = await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			ends_at: endsAt,
+		});
+
+		expect(result.payment_url).toBeDefined();
+		expect(result.payment_url).toContain("checkout.stripe.com");
+
+		// 2. Complete checkout, then wait past the trailing subscription.updated
+		// events that previously wiped the cancellation fields
+		await completeStripeCheckoutForm({ url: result.payment_url });
+		await timeout(15000);
+
+		// 3. Product attached
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		await expectProductActive({ customer, productId: pro.id });
+
+		// 4. ended_at persisted as an Autumn-owned expiry — not a cancellation
+		const customerProduct = await getCustomerProduct({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+		expect(customerProduct.ended_at).toBe(endsAt);
+		expect(customerProduct.canceled).toBe(false);
+		expect(customerProduct.canceled_at ?? null).toBeNull();
+		expect(customerProduct.subscription_ids).toHaveLength(1);
+
+		// 5. cancel_at propagated onto the Stripe subscription and not cleared
+		const stripeSubscription = await ctx.stripeCli.subscriptions.retrieve(
+			customerProduct.subscription_ids![0]!,
+		);
+		expect(stripeSubscription.cancel_at).toBe(Math.floor(endsAt / 1000));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Metadata claim — exactly one concurrent executor wins
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("checkout metadata claim: only one concurrent executor wins")}`,
+	async () => {
+		const metadataId = `meta_claim_race_${Date.now()}`;
+
+		await MetadataService.insert({
+			db: testContext.db,
+			data: {
+				id: metadataId,
+				type: MetadataType.CheckoutSessionV2,
+				data: {},
+			},
+		});
+
+		try {
+			const claimResults = await Promise.all([
+				MetadataService.claim({
+					db: testContext.db,
+					id: metadataId,
+					fromType: MetadataType.CheckoutSessionV2,
+					toType: MetadataType.CheckoutSessionV2Processing,
+				}),
+				MetadataService.claim({
+					db: testContext.db,
+					id: metadataId,
+					fromType: MetadataType.CheckoutSessionV2,
+					toType: MetadataType.CheckoutSessionV2Processing,
+				}),
+			]);
+
+			expect(claimResults.filter(Boolean)).toHaveLength(1);
+
+			// Reverting the claim re-arms it for exactly one retry
+			const reverted = await MetadataService.claim({
+				db: testContext.db,
+				id: metadataId,
+				fromType: MetadataType.CheckoutSessionV2Processing,
+				toType: MetadataType.CheckoutSessionV2,
+			});
+			expect(reverted).toBe(true);
+
+			const reclaimed = await MetadataService.claim({
+				db: testContext.db,
+				id: metadataId,
+				fromType: MetadataType.CheckoutSessionV2,
+				toType: MetadataType.CheckoutSessionV2Processing,
+			});
+			expect(reclaimed).toBe(true);
+		} finally {
+			await MetadataService.delete({ db: testContext.db, id: metadataId });
+		}
+	},
+);

--- a/shared/models/otherModels/metadataTable.ts
+++ b/shared/models/otherModels/metadataTable.ts
@@ -9,6 +9,7 @@ export enum MetadataType {
 
 	DeferredInvoice = "deferred_invoice",
 	CheckoutSessionV2 = "checkout_session_v2",
+	CheckoutSessionV2Processing = "checkout_session_v2_processing",
 	CheckoutSessionEnabledImmediately = "checkout_session_enabled_immediately",
 	SetupPaymentV2 = "setup_payment_v2",
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ends_at propagation in the Stripe Checkout attach flow. `ended_at` now persists on the customer product and `cancel_at` stays on the Stripe subscription, even with concurrent handlers.

- **Bug Fixes**
  - Run checkout metadata handling exactly once using `MetadataService.claim` and a new `CheckoutSessionV2Processing` type; added `withClaimedCheckoutSessionMetadata` with a claim revert on subscription lock write failure.
  - Set a Stripe subscription lock during processing so resulting `subscription.updated` events are treated as internal.
  - Always clear the checkout session lock after execution (even on failure).
  - Ignore attach-set expiries: skip cancel handling when `ended_at` matches `cancel_at`, and skip renewal clearing when there was no real cancel.
  - Added regression tests for ends_at via Stripe Checkout and for the metadata claim race.

<sup>Written for commit 3c300bc8ae2bc7e2f258914df7d672d5e91c43ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `ends_at` propagation through the Stripe Checkout deferred billing flow by addressing two root causes: concurrent `checkout.session.completed` handlers racing on the same deferred plan, and `subscription.updated` events generated by the checkout being misread as user-initiated cancel/renew and wiping the `ended_at` field.

- **Bug fixes**: Introduces `withClaimedCheckoutSessionMetadata`, which atomically claims a deferred plan metadata row (compare-and-swap on `type`) so only one concurrent executor proceeds; moves `checkoutSessionLock.clear` into this wrapper and adds a Stripe subscription lock before execution to tag resulting webhook events as Autumn-initiated.
- **Bug fixes**: Adds a guard in `handleStripeSubscriptionCanceled` to skip products where `ended_at` already matches the Stripe `cancel_at` (Autumn-owned expiry, not an external cancellation), and a guard in `handleStripeSubscriptionRenewed` to skip products with no `canceled` / `canceled_at` fields (preventing renewal from wiping Autumn-set `ends_at`).
- **Improvements**: Adds `MetadataService.claim()` — a clean atomic conditional-update helper — and a `CheckoutSessionV2Processing` metadata type to represent in-flight state, accompanied by integration tests covering both the end-to-end flow and the concurrent-claim race.
</details>

<h3>Confidence Score: 4/5</h3>

The change is targeted and well-tested; the concurrent-claim mechanism is atomically correct, and the two new webhook guards address the described regression.

The core fix — atomic metadata claiming, subscription lock placement, and the two webhook guards — is mechanically sound and backed by integration tests. The main concerns are bounded edge cases: state drift when cancel_at is removed directly in Stripe (not via Autumn), and an uncleared subscription lock that could suppress later webhook processing until the TTL expires.

withClaimedCheckoutSessionMetadata.ts (subscription lock lifetime) and handleStripeSubscriptionRenewed.ts (guard behavior for direct Stripe-side renewals)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts | New file implementing an atomic "claim" wrapper that prevents duplicate execution of the checkout deferred plan and manages the checkout session lock lifecycle; subscription lock is set but never explicitly released. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/handleCheckoutSessionMetadataV2.ts | Refactored to delegate concurrency control to `withClaimedCheckoutSessionMetadata`; the `checkoutSessionLock.clear` was moved into the new wrapper and the main execution logic is unchanged. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionCanceled/handleStripeSubscriptionCanceled.ts | Adds a secondary guard to skip products where Autumn's `ended_at` already matches the Stripe `cancel_at`; logic is sound and relies on exact ms→s round-trip equality that holds because Autumn sets both values from the same timestamp. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionRenewed/handleStripeSubscriptionRenewed.ts | Adds a guard to skip products without `canceled` or `canceled_at` set, preventing renewal from wiping Autumn-owned `ends_at`; creates a state-drift edge case when users remove cancel_at directly in Stripe. |
| server/src/internal/metadata/MetadataService.ts | Adds `claim()`: an atomic conditional update (compare-and-swap on `type`) that returns true to the single winning concurrent caller; correct and clean implementation. |
| shared/models/otherModels/metadataTable.ts | Adds `CheckoutSessionV2Processing` enum value to track in-flight deferred checkout processing state. |
| server/tests/integration/billing/attach/checkout/stripe-checkout/stripe-checkout-ends-at.test.ts | New integration tests covering both the end-to-end `ends_at`-via-checkout flow and the concurrent metadata claim race; good coverage of the regression. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Customer
    participant A as Autumn API
    participant S as Stripe
    participant WH as Webhook Handler
    participant DB as Database (metadata)

    C->>A: "attach(ends_at=T+7d)"
    A->>S: "Create subscription (cancel_at=T+7d)"
    A->>DB: "Insert metadata (type=CheckoutSessionV2)"
    A-->>C: Return checkout URL

    C->>S: Complete checkout payment
    S->>WH: checkout.session.completed

    WH->>DB: claim(CheckoutSessionV2 to CheckoutSessionV2Processing)
    alt already claimed by concurrent executor
        DB-->>WH: false - skip
    else claim succeeds
        DB-->>WH: true
        WH->>S: setStripeSubscriptionLock(sub_id)
        WH->>DB: "executeCheckoutSessionMetadataV2() creates customer_product with ended_at=T+7d"
        WH->>DB: checkoutSessionLock.clear()
    end

    S->>WH: subscription.updated (cancel_at set)
    alt lock active
        WH-->>WH: skip (Autumn-initiated)
    else lock expired, ended_at matches cancel_at
        WH-->>WH: "endedAtMatchesCancelAt=true - skip"
    end

    S->>WH: subscription.updated (renewal-like event)
    WH-->>WH: "canceled=false AND canceled_at=null - skip, ends_at preserved"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleStripeSubscriptionRenewed/handleStripeSubscriptionRenewed.ts:80-81
**Stale `ended_at` after genuine Stripe-side renewal**

The guard skips clearing `ended_at` for any product where Autumn set expiry (`canceled=false, canceled_at=null`). This is correct for the primary bug scenario, but it also means if a user directly removes `cancel_at` from their Stripe subscription (a genuine renewal), the product's `ended_at` will not be cleared and the customer record will keep showing expiry at the old date, out of sync with Stripe. Products managed through Autumn's API will be fine, but products modified directly in Stripe will silently diverge.

### Issue 2 of 2
server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts:54-63
**Subscription lock not cleared after successful execution**

`setStripeSubscriptionLock` is set before `execute()` runs but is never explicitly cleared after a successful completion (only `checkoutSessionLock` is cleared in `finally`). If the lock TTL is long, any legitimate Stripe `subscription.updated` events arriving after checkout finishes — such as from a same-day plan change or usage update — will be silently ignored by `handleStripeSubscriptionCanceled` and `handleStripeSubscriptionRenewed` until the lock expires. The lock utility likely has a TTL that makes this acceptable, but it is worth confirming the TTL is short relative to expected downstream activity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ends at propogation"](https://github.com/useautumn/autumn/commit/0170ddf2735b6644e1394014da47fe0335f72808) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36929931)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->