### PR TITLE
fix: typecheck

### DIFF
--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -19,7 +19,7 @@
 		}
 	},
 	"scripts": {
-		"ts": "tsgo --noEmit --skipLibCheck",
+		"ts": "bunx tsgo --noEmit --skipLibCheck",
 		"test": "bun test tests/unit",
 		"build": "rm -rf dist && tsup",
 		"prepublishOnly": "bun run build"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use `bunx tsgo` in the `packages/ai-sdk` `ts` script so type checks run in Bun without a global install. Keeps `--noEmit` and `--skipLibCheck` unchanged.

<sup>Written for commit 6415274f0dbb66f62837cd00492b4174c1ebe629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the `ts` typecheck script in `packages/ai-sdk/package.json` by prepending `bunx` to the `tsgo` invocation, making it consistent with the rest of the bun-based toolchain in this package.

- **[Bug fixes]** Changed `tsgo --noEmit --skipLibCheck` to `bunx tsgo --noEmit --skipLibCheck` so the script no longer requires `tsgo` to be installed globally — it is now resolved on demand via `bunx`, matching how other bun-based scripts in the package are invoked.
</details>

<h3>Confidence Score: 5/5</h3>

Single-line script fix in a package.json; no logic, runtime code, or dependencies are affected.

The change is a one-word prefix addition (`bunx`) to a dev-only npm script. It has no impact on published build output, runtime behaviour, or other packages.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ai-sdk/package.json | Adds `bunx` prefix to the `ts` typecheck script so `tsgo` is resolved via bun's package executor rather than a globally-installed binary; no other changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Bun as bun
    participant Bunx as bunx
    participant tsgo as tsgo

    Note over Dev,tsgo: Before (broken without global install)
    Dev->>Bun: bun run ts
    Bun->>tsgo: tsgo --noEmit --skipLibCheck
    tsgo-->>Bun: command not found (if not globally installed)

    Note over Dev,tsgo: After (resolved via bunx)
    Dev->>Bun: bun run ts
    Bun->>Bunx: bunx tsgo --noEmit --skipLibCheck
    Bunx->>tsgo: resolve and run tsgo
    tsgo-->>Dev: type check output
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;fix/typecheck&#39; of https://..."](https://github.com/useautumn/autumn/commit/6415274f0dbb66f62837cd00492b4174c1ebe629) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36934646)</sub>

<!-- /greptile_comment -->