### PR TITLE
fail open check/track on hydration-gate rejections

### DIFF
--- a/server/src/db/shed503OnTransientError.ts
+++ b/server/src/db/shed503OnTransientError.ts
@@ -18,7 +18,7 @@ export const shed503OnTransientError = async <T>({
 		if (!(isTransientDbError({ error }) || isTransientRedisError({ error }))) {
 			throw error;
 		}
-		ctx.logger.warn(`[${source}] DB unavailable, shedding with 503`, {
+		ctx.logger.warn(`[${source}] transient DB error, shedding with 503`, {
 			type: `${source}_fail_open`,
 			error,
 		});

--- a/server/src/external/redis/utils/withRedisFailOpen.ts
+++ b/server/src/external/redis/utils/withRedisFailOpen.ts
@@ -3,16 +3,18 @@ import { shouldUseRedisV2 } from "@/external/redis/initUtils/redisV2Availability
 import { RedisUnavailableError } from "./errors.js";
 import { isTransientRedisError } from "./isTransientRedisError.js";
 
-/** Runs `run`. If Redis is unavailable or a transient DB error occurs,
- *  calls `fallback`. Any other error propagates. */
+/** Runs `run`. If Redis is unavailable, a transient DB error occurs, or
+ *  `alsoFailOpen` matches, calls `fallback`. Any other error propagates. */
 export const withRedisFailOpen = async <T>({
 	source,
 	run,
 	fallback,
+	alsoFailOpen,
 }: {
 	source: string;
 	run: () => T | Promise<T>;
 	fallback: (error: unknown) => T | Promise<T>;
+	alsoFailOpen?: (error: unknown) => boolean;
 }): Promise<T> => {
 	try {
 		if (!shouldUseRedisV2()) {
@@ -21,7 +23,11 @@ export const withRedisFailOpen = async <T>({
 
 		return await run();
 	} catch (error) {
-		if (isTransientRedisError({ error }) || isTransientDbError({ error })) {
+		if (
+			isTransientRedisError({ error }) ||
+			isTransientDbError({ error }) ||
+			alsoFailOpen?.(error)
+		) {
 			return await fallback(error);
 		}
 

--- a/server/src/internal/balances/check/runCheckWithRollout.ts
+++ b/server/src/internal/balances/check/runCheckWithRollout.ts
@@ -3,6 +3,7 @@ import { withRedisFailOpen } from "@/external/redis/utils/withRedisFailOpen.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { CheckData } from "@/internal/api/check/checkTypes/CheckData.js";
 import { getCheckFailOpenFallback } from "@/internal/api/check/checkUtils/getCheckFailOpenFallback.js";
+import { isFullSubjectGateRejection } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
 import { runCheckLegacyFlow } from "./runCheckLegacyFlow.js";
@@ -37,6 +38,7 @@ export const runCheckWithRollout = async ({
 	return withRedisFailOpen<RunCheckResult<CheckData | CheckDataV2>>({
 		source: "runCheckWithRollout",
 		run: () => runCheckV2({ ctx, body, requiredBalance }),
+		alsoFailOpen: isFullSubjectGateRejection,
 		fallback: (error) => ({
 			checkData: null,
 			response: getCheckFailOpenFallback({

--- a/server/src/internal/balances/track/runTrackWithRollout.ts
+++ b/server/src/internal/balances/track/runTrackWithRollout.ts
@@ -1,6 +1,7 @@
 import type { ApiVersion, TrackParams, TrackResponseV3 } from "@autumn/shared";
 import { withRedisFailOpen } from "@/external/redis/utils/withRedisFailOpen.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { isFullSubjectGateRejection } from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import type { FeatureDeduction } from "../utils/types/featureDeduction.js";
 import { runTrackV2 } from "./runTrackV2.js";
@@ -38,6 +39,7 @@ export const runTrackWithRollout = async ({
 					featureDeductions,
 					apiVersion,
 				}),
+			alsoFailOpen: isFullSubjectGateRejection,
 			fallback: async (error) => {
 				const queuedResponse = await queueTrack({ ctx, body });
 				if (queuedResponse) return queuedResponse;

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -99,11 +99,21 @@ const attrs = ({ orgId, env }: { orgId: string; env: AppEnv }) => ({
 	env,
 });
 
+const GATE_REJECTION_REASONS = [
+	"per_customer_queue_full",
+	"per_org_queue_full",
+	"wait_timeout",
+] as const;
+type GateRejectionReason = (typeof GATE_REJECTION_REASONS)[number];
+const gateRejectionReasonSet: ReadonlySet<string> = new Set(
+	GATE_REJECTION_REASONS,
+);
+
 const rejectOverloaded = ({
 	reason,
 	labels,
 }: {
-	reason: string;
+	reason: GateRejectionReason;
 	labels: Record<string, string>;
 }): never => {
 	rejectedCounter.add(1, { ...labels, reason });
@@ -116,10 +126,19 @@ const rejectOverloaded = ({
 	});
 };
 
-export const isFullSubjectGateRejection = (error: unknown): boolean =>
-	error instanceof RecaseError &&
-	error.code === "rate_limit_exceeded" &&
-	error.statusCode === 429;
+export const isFullSubjectGateRejection = (error: unknown): boolean => {
+	if (!(error instanceof RecaseError)) return false;
+	if (error.code !== "rate_limit_exceeded" || error.statusCode !== 429)
+		return false;
+	const data = error.data;
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		"reason" in data &&
+		typeof data.reason === "string" &&
+		gateRejectionReasonSet.has(data.reason)
+	);
+};
 
 export const runWithFullSubjectGate = async <T>({
 	customerId,

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts
@@ -116,6 +116,11 @@ const rejectOverloaded = ({
 	});
 };
 
+export const isFullSubjectGateRejection = (error: unknown): boolean =>
+	error instanceof RecaseError &&
+	error.code === "rate_limit_exceeded" &&
+	error.statusCode === 429;
+
 export const runWithFullSubjectGate = async <T>({
 	customerId,
 	orgId,

--- a/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
@@ -40,6 +40,26 @@ const warnRateLimitBypass = () => {
 	);
 };
 
+const CAP_EXCEEDED_WARNING_INTERVAL_MS = 10_000;
+let lastCapExceededWarningAt = 0;
+
+const warnOrgCapExceeded = ({
+	limitType,
+	orgSlug,
+}: {
+	limitType: string;
+	orgSlug?: string;
+}) => {
+	const now = Date.now();
+	if (now - lastCapExceededWarningAt < CAP_EXCEEDED_WARNING_INTERVAL_MS) return;
+
+	lastCapExceededWarningAt = now;
+	logger.warn(
+		`[rate-limit] org aggregate cap exceeded: ${orgSlug ?? "unknown"} (${limitType})`,
+		{ type: "org_rate_cap_exceeded", limitType, org: orgSlug },
+	);
+};
+
 export const rateLimitFactory = ({
 	type,
 	config,
@@ -69,6 +89,7 @@ export const rateLimitFactory = ({
 	): Promise<Response | undefined> => {
 		const honoContext = c as Context<HonoEnv>;
 		const ctx = honoContext.get("ctx");
+		warnOrgCapExceeded({ limitType: type, orgSlug: ctx?.org?.slug });
 
 		if (type === RateLimitType.CheckOrg && !isCheckFailOpenRoute(honoContext)) {
 			return c.json(

--- a/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
+++ b/server/src/internal/misc/rateLimiter/rateLimitFactory.ts
@@ -41,7 +41,7 @@ const warnRateLimitBypass = () => {
 };
 
 const CAP_EXCEEDED_WARNING_INTERVAL_MS = 10_000;
-let lastCapExceededWarningAt = 0;
+const lastCapWarnAtByType = new Map<string, number>();
 
 const warnOrgCapExceeded = ({
 	limitType,
@@ -51,9 +51,10 @@ const warnOrgCapExceeded = ({
 	orgSlug?: string;
 }) => {
 	const now = Date.now();
-	if (now - lastCapExceededWarningAt < CAP_EXCEEDED_WARNING_INTERVAL_MS) return;
+	const lastWarnAt = lastCapWarnAtByType.get(limitType) ?? 0;
+	if (now - lastWarnAt < CAP_EXCEEDED_WARNING_INTERVAL_MS) return;
 
-	lastCapExceededWarningAt = now;
+	lastCapWarnAtByType.set(limitType, now);
 	logger.warn(
 		`[rate-limit] org aggregate cap exceeded: ${orgSlug ?? "unknown"} (${limitType})`,
 		{ type: "org_rate_cap_exceeded", limitType, org: orgSlug },

--- a/server/tests/integration/balances/gate-failopen/gate-reject-failopen.test.ts
+++ b/server/tests/integration/balances/gate-failopen/gate-reject-failopen.test.ts
@@ -38,6 +38,12 @@ const { invalidateCachedFullSubject } = await import(
 const { _setFullSubjectGateConfigForTesting } = await import(
 	"@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js"
 );
+const { primeRedisV2Monitor } = await import(
+	"@/external/redis/initUtils/redisV2Availability.js"
+);
+
+// In-process runs skip server boot, which is what normally primes availability.
+await primeRedisV2Monitor();
 
 const CONCURRENCY = 8;
 
@@ -144,7 +150,12 @@ test.concurrent(
 			actions: [s.attach({ productId: freeProd.id })],
 		});
 
-		const ctx = await buildContext({ customerId });
+		// One ctx per call: concurrent prod tracks carry distinct request IDs,
+		// and the Redis dedup treats a reused ID as a duplicate request.
+		const contexts = await Promise.all(
+			Array.from({ length: CONCURRENCY }, () => buildContext({ customerId })),
+		);
+		const [ctx] = contexts;
 		const feature = ctx.features.find(
 			(candidate: { id: string }) => candidate.id === TestFeature.Messages,
 		);
@@ -154,9 +165,9 @@ test.concurrent(
 		queueCalls.length = 0;
 
 		const results = await Promise.allSettled(
-			Array.from({ length: CONCURRENCY }, () =>
+			contexts.map((trackContext) =>
 				runTrackWithRollout({
-					ctx,
+					ctx: trackContext,
 					body: { customer_id: customerId, feature_id: TestFeature.Messages },
 					featureDeductions: [{ feature, deduction: 1 }],
 				}),

--- a/server/tests/integration/balances/gate-failopen/gate-reject-failopen.test.ts
+++ b/server/tests/integration/balances/gate-failopen/gate-reject-failopen.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Trips the real FullSubject gate (tiny limits + cold cache + concurrent
+ * calls) and verifies check/track fail open instead of surfacing 429s.
+ */
+
+import { afterAll, expect, mock, test } from "bun:test";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const queueCalls: Record<string, unknown>[] = [];
+mock.module("@/queue/queueUtils.js", () => ({
+	addTaskToQueue: async (args: Record<string, unknown>) => {
+		queueCalls.push(args);
+	},
+}));
+
+process.env.TRACK_SQS_QUEUE_URL ??= "https://sqs.test/gate-failopen";
+
+const { ParsedCheckParamsSchema } = await import("@autumn/shared");
+const { TestFeature } = await import("@tests/setup/v2Features.js");
+const { items } = await import("@tests/utils/fixtures/items.js");
+const { products } = await import("@tests/utils/fixtures/products.js");
+const { initScenario, s } = await import(
+	"@tests/utils/testInitUtils/initScenario.js"
+);
+const { createTestContext } = await import(
+	"@tests/utils/testInitUtils/createTestContext.js"
+);
+const { runCheckWithRollout } = await import(
+	"@/internal/balances/check/runCheckWithRollout.js"
+);
+const { runTrackWithRollout } = await import(
+	"@/internal/balances/track/runTrackWithRollout.js"
+);
+const { invalidateCachedFullSubject } = await import(
+	"@/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject.js"
+);
+const { _setFullSubjectGateConfigForTesting } = await import(
+	"@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js"
+);
+
+const CONCURRENCY = 8;
+
+// Held for the whole file so test.concurrent tests can't reset it mid-flight.
+_setFullSubjectGateConfigForTesting({
+	config: {
+		per_customer_limit: 1,
+		per_org_limit: 1,
+		max_wait_ms: 100,
+		per_customer_pending_max: 1,
+		per_org_pending_max: 1,
+	},
+});
+
+afterAll(() => {
+	_setFullSubjectGateConfigForTesting({ config: {} });
+});
+
+const buildContext = async ({ customerId }: { customerId: string }) => {
+	const ctx = (await createTestContext()) as unknown as AutumnContext;
+	ctx.rolloutSnapshot = {
+		rolloutId: "v2-cache",
+		enabled: true,
+		percent: 100,
+		previousPercent: 100,
+		changedAt: 0,
+		customerBucket: 0,
+	};
+	ctx.customerId = customerId;
+	return ctx;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("gate-failopen: concurrent checks on cold cache never 429")}`,
+	async () => {
+		const customerId = "gate-failopen-check";
+		const freeProd = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		const ctx = await buildContext({ customerId });
+		const body = ParsedCheckParamsSchema.parse({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+
+		await invalidateCachedFullSubject({ ctx, customerId, source: "test" });
+
+		const results = await Promise.allSettled(
+			Array.from({ length: CONCURRENCY }, () =>
+				runCheckWithRollout({ ctx, body, requiredBalance: 1 }),
+			),
+		);
+
+		const rejected = results.filter((result) => result.status === "rejected");
+		expect(rejected).toEqual([]);
+
+		const fulfilled = results.filter(
+			(result) => result.status === "fulfilled",
+		) as PromiseFulfilledResult<
+			Awaited<ReturnType<typeof runCheckWithRollout>>
+		>[];
+
+		const failOpen = fulfilled.filter(
+			(result) => result.value.checkData === null,
+		);
+		const served = fulfilled.filter(
+			(result) => result.value.checkData !== null,
+		);
+
+		expect(failOpen.length).toBeGreaterThan(0);
+		expect(served.length).toBeGreaterThan(0);
+		for (const result of failOpen) {
+			expect(result.value.response).toMatchObject({ allowed: true });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("gate-failopen: concurrent tracks on cold cache queue instead of 429")}`,
+	async () => {
+		const customerId = "gate-failopen-track";
+		const freeProd = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		const ctx = await buildContext({ customerId });
+		const feature = ctx.features.find(
+			(candidate: { id: string }) => candidate.id === TestFeature.Messages,
+		);
+		if (!feature) throw new Error("Messages feature missing from test org");
+
+		await invalidateCachedFullSubject({ ctx, customerId, source: "test" });
+		queueCalls.length = 0;
+
+		const results = await Promise.allSettled(
+			Array.from({ length: CONCURRENCY }, () =>
+				runTrackWithRollout({
+					ctx,
+					body: { customer_id: customerId, feature_id: TestFeature.Messages },
+					featureDeductions: [{ feature, deduction: 1 }],
+				}),
+			),
+		);
+
+		const rejected = results.filter((result) => result.status === "rejected");
+		expect(rejected).toEqual([]);
+		expect(queueCalls.length).toBeGreaterThan(0);
+	},
+);

--- a/server/tests/unit/full-subject-gate/gate-rejection-failopen.test.ts
+++ b/server/tests/unit/full-subject-gate/gate-rejection-failopen.test.ts
@@ -66,6 +66,23 @@ describe("isFullSubjectGateRejection", () => {
 		expect(isFullSubjectGateRejection(wrongStatus)).toBe(false);
 	});
 
+	test("does not match rate-limit 429s that are not from the gate", () => {
+		const unknownReason = new RecaseError({
+			message: "rate limited",
+			code: "rate_limit_exceeded",
+			statusCode: 429,
+			data: { reason: "some_other_limiter" },
+		});
+		expect(isFullSubjectGateRejection(unknownReason)).toBe(false);
+
+		const noData = new RecaseError({
+			message: "rate limited",
+			code: "rate_limit_exceeded",
+			statusCode: 429,
+		});
+		expect(isFullSubjectGateRejection(noData)).toBe(false);
+	});
+
 	test("does not match plain errors or non-errors", () => {
 		expect(isFullSubjectGateRejection(new Error("rate_limit_exceeded"))).toBe(
 			false,

--- a/server/tests/unit/full-subject-gate/gate-rejection-failopen.test.ts
+++ b/server/tests/unit/full-subject-gate/gate-rejection-failopen.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { AppEnv, RecaseError } from "@autumn/shared";
+import {
+	isFullSubjectGateRejection,
+	runWithFullSubjectGate,
+} from "@/internal/customers/repos/getFullSubject/getFullSubjectGate.js";
+import { _setFullSubjectGateConfigForTesting } from "@/internal/misc/fullSubjectGateEdgeConfig/fullSubjectGateEdgeConfigStore.js";
+
+describe("isFullSubjectGateRejection", () => {
+	test("matches a rejection thrown by the real gate", async () => {
+		_setFullSubjectGateConfigForTesting({
+			config: {
+				per_customer_limit: 1,
+				per_org_limit: 1,
+				max_wait_ms: 100,
+				per_customer_pending_max: 1,
+				per_org_pending_max: 1,
+			},
+		});
+
+		const slow = () => new Promise((resolve) => setTimeout(resolve, 80));
+		const results = await Promise.allSettled(
+			Array.from({ length: 6 }, () =>
+				runWithFullSubjectGate({
+					customerId: "cus-predicate-real-gate",
+					orgId: "org-predicate-real-gate",
+					env: AppEnv.Live,
+					queryFn: slow,
+				}),
+			),
+		);
+
+		const rejections = results.filter(
+			(result) => result.status === "rejected",
+		) as PromiseRejectedResult[];
+		expect(rejections.length).toBeGreaterThan(0);
+		for (const rejection of rejections) {
+			expect(isFullSubjectGateRejection(rejection.reason)).toBe(true);
+		}
+
+		_setFullSubjectGateConfigForTesting({ config: {} });
+	});
+	test("matches the gate's rejection error", () => {
+		const rejection = new RecaseError({
+			message: "Too many concurrent requests for this customer.",
+			code: "rate_limit_exceeded",
+			statusCode: 429,
+			data: { reason: "per_org_queue_full" },
+		});
+		expect(isFullSubjectGateRejection(rejection)).toBe(true);
+	});
+
+	test("does not match other RecaseErrors", () => {
+		const serviceUnavailable = new RecaseError({
+			message: "Service is temporarily unavailable, please retry shortly.",
+			code: "service_unavailable",
+			statusCode: 503,
+		});
+		expect(isFullSubjectGateRejection(serviceUnavailable)).toBe(false);
+
+		const wrongStatus = new RecaseError({
+			message: "rate limited",
+			code: "rate_limit_exceeded",
+			statusCode: 400,
+		});
+		expect(isFullSubjectGateRejection(wrongStatus)).toBe(false);
+	});
+
+	test("does not match plain errors or non-errors", () => {
+		expect(isFullSubjectGateRejection(new Error("rate_limit_exceeded"))).toBe(
+			false,
+		);
+		expect(isFullSubjectGateRejection(null)).toBe(false);
+		expect(isFullSubjectGateRejection("rate_limit_exceeded")).toBe(false);
+	});
+});

--- a/server/tests/unit/redis/with-redis-fail-open-gate-rejection.test.ts
+++ b/server/tests/unit/redis/with-redis-fail-open-gate-rejection.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersionClass, LATEST_VERSION, RecaseError } from "@autumn/shared";
+
+mock.module("@/external/redis/initUtils/redisV2Availability.js", () => ({
+	shouldUseRedisV2: () => true,
+}));
+
+const gateRejection = () =>
+	new RecaseError({
+		message: "Too many concurrent requests for this customer.",
+		code: "rate_limit_exceeded",
+		statusCode: 429,
+		data: { reason: "per_customer_queue_full" },
+	});
+
+mock.module("@/internal/balances/check/runCheckV2.js", () => ({
+	runCheckV2: async () => {
+		throw checkError;
+	},
+}));
+
+mock.module("@/internal/balances/track/v3/runTrackV3.js", () => ({
+	runTrackV3: async () => {
+		throw trackError;
+	},
+}));
+
+const queueCalls: Record<string, unknown>[] = [];
+mock.module("@/queue/queueUtils.js", () => ({
+	addTaskToQueue: async (args: Record<string, unknown>) => {
+		queueCalls.push(args);
+	},
+}));
+
+let checkError: unknown = gateRejection();
+let trackError: unknown = gateRejection();
+
+const { withRedisFailOpen } = await import(
+	"@/external/redis/utils/withRedisFailOpen.js"
+);
+const { isFullSubjectGateRejection } = await import(
+	"@/internal/customers/repos/getFullSubject/getFullSubjectGate.js"
+);
+const { runCheckWithRollout } = await import(
+	"@/internal/balances/check/runCheckWithRollout.js"
+);
+const { runTrackWithRollout } = await import(
+	"@/internal/balances/track/runTrackWithRollout.js"
+);
+const { ParsedCheckParamsSchema } = await import("@autumn/shared");
+
+process.env.TRACK_SQS_QUEUE_URL = "https://sqs.test/queue";
+
+const noopLogger = {
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+	debug: () => {},
+};
+
+const makeContext = () =>
+	({
+		id: "req_test_gate_failopen",
+		org: { id: "org_test", slug: "test-org" },
+		env: "live",
+		apiVersion: new ApiVersionClass(LATEST_VERSION),
+		logger: noopLogger,
+		extraLogs: {},
+		features: [],
+		rolloutSnapshot: {
+			rolloutId: "v2-cache",
+			enabled: true,
+			percent: 100,
+			previousPercent: 100,
+			changedAt: 0,
+			customerBucket: 0,
+		},
+		// biome-ignore lint/suspicious/noExplicitAny: minimal test context
+	}) as any;
+
+const checkBody = ParsedCheckParamsSchema.parse({
+	customer_id: "cus_gate_failopen",
+	feature_id: "messages",
+});
+
+describe("withRedisFailOpen alsoFailOpen", () => {
+	test("gate rejection falls open when alsoFailOpen matches", async () => {
+		const rejection = gateRejection();
+		let receivedError: unknown;
+		const result = await withRedisFailOpen<string>({
+			source: "test",
+			run: () => {
+				throw rejection;
+			},
+			alsoFailOpen: isFullSubjectGateRejection,
+			fallback: (error) => {
+				receivedError = error;
+				return "fallback";
+			},
+		});
+		expect(result).toBe("fallback");
+		expect(receivedError).toBe(rejection);
+	});
+
+	test("gate rejection still propagates without alsoFailOpen", async () => {
+		await expect(
+			withRedisFailOpen<string>({
+				source: "test",
+				run: () => {
+					throw gateRejection();
+				},
+				fallback: () => "fallback",
+			}),
+		).rejects.toMatchObject({ code: "rate_limit_exceeded", statusCode: 429 });
+	});
+
+	test("non-matching errors propagate even with alsoFailOpen", async () => {
+		await expect(
+			withRedisFailOpen<string>({
+				source: "test",
+				run: () => {
+					throw new Error("boom");
+				},
+				alsoFailOpen: isFullSubjectGateRejection,
+				fallback: () => "fallback",
+			}),
+		).rejects.toThrow("boom");
+	});
+
+	test("transient db errors still fall open without alsoFailOpen", async () => {
+		const result = await withRedisFailOpen<string>({
+			source: "test",
+			run: () => {
+				const error = new Error("too many connections") as Error & {
+					code: string;
+				};
+				error.code = "53300";
+				throw error;
+			},
+			fallback: () => "fallback",
+		});
+		expect(result).toBe("fallback");
+	});
+});
+
+describe("check flow on gate rejection", () => {
+	beforeEach(() => {
+		checkError = gateRejection();
+	});
+
+	test("returns the fail-open allow response instead of throwing", async () => {
+		const result = await runCheckWithRollout({
+			ctx: makeContext(),
+			body: checkBody,
+			requiredBalance: 1,
+		});
+		expect(result.checkData).toBeNull();
+		expect(result.response).toMatchObject({ allowed: true });
+	});
+
+	test("non-gate errors still propagate", async () => {
+		checkError = new Error("genuine bug");
+		await expect(
+			runCheckWithRollout({
+				ctx: makeContext(),
+				body: checkBody,
+				requiredBalance: 1,
+			}),
+		).rejects.toThrow("genuine bug");
+	});
+});
+
+describe("track flow on gate rejection", () => {
+	beforeEach(() => {
+		trackError = gateRejection();
+		queueCalls.length = 0;
+	});
+
+	test("queues the event and returns the queued response", async () => {
+		const ctx = makeContext();
+		const result = await runTrackWithRollout({
+			ctx,
+			body: { customer_id: "cus_gate_failopen", feature_id: "messages" },
+			featureDeductions: [],
+		});
+		expect(result).toMatchObject({
+			customer_id: "cus_gate_failopen",
+			balance: null,
+		});
+		expect(queueCalls.length).toBe(1);
+		expect(queueCalls[0]?.messageDeduplicationId).toBe(ctx.id);
+	});
+
+	test("non-gate errors still propagate", async () => {
+		trackError = new Error("genuine bug");
+		await expect(
+			runTrackWithRollout({
+				ctx: makeContext(),
+				body: { customer_id: "cus_gate_failopen", feature_id: "messages" },
+				featureDeductions: [],
+			}),
+		).rejects.toThrow("genuine bug");
+		expect(queueCalls.length).toBe(0);
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checks and tracks now fail open on FullSubject gate rejections (429) so callers don’t see rate limits during hydration spikes. Predicate is pinned to gate-only reasons, and org cap warnings are throttled per limit type.

- New Features
  - `withRedisFailOpen` accepts `alsoFailOpen` to treat custom errors as fail-open.
  - `isFullSubjectGateRejection` validates `reason` against gate reasons (`per_customer_queue_full`, `per_org_queue_full`, `wait_timeout`); used in `runCheckWithRollout` and `runTrackWithRollout` to fail open on gate 429s.
  - Rate limiter logs org aggregate cap exceeded and throttles warnings per `limitType` (10s).
  - Tweaked transient DB shed warning message; added unit and integration tests that trip the real gate to verify fail-open behavior.

<sup>Written for commit 1f855bdbc54939a57cacb99a2f1a73305539db9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes check and track endpoints fail open when the `FullSubject` hydration gate rejects requests due to concurrency overload, preventing internal 429s from surfacing to callers. Previously, gate rejections propagated as uncaught errors; now they are caught and routed to the existing fail-open fallbacks (allow-response for check, SQS queue for track).

- **[Improvements]** Extends `withRedisFailOpen` with an optional `alsoFailOpen` predicate and exports `isFullSubjectGateRejection` from the gate module to wire this up in both `runCheckWithRollout` and `runTrackWithRollout`.
- **[Improvements]** Adds a throttled `warnOrgCapExceeded` warning log to the `degradeHandler` in `rateLimitFactory` so org-level aggregate cap events are observable in logs.
- **[Bug fixes]** Gate rejection errors (hydration overload 429s) no longer bubble through as unhandled exceptions during concurrent cold-cache traffic spikes.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge. The fail-open path for gate rejections is narrowly scoped and backed by both unit and integration tests; non-gate errors still propagate as before.

The core change is well-structured and the new `alsoFailOpen` hook correctly delegates to the existing fallback paths without altering transient-error handling. Two minor observability concerns exist: the `isFullSubjectGateRejection` predicate relies only on error code and status code rather than also checking the gate-specific `reason` field, and the cap-exceeded warning throttle in `rateLimitFactory` is shared across all rate-limit types, meaning a `TrackOrg` warning can suppress a simultaneous `CheckOrg` warning within the same 10-second window.

The `isFullSubjectGateRejection` predicate in `getFullSubjectGate.ts` and the shared `lastCapExceededWarningAt` counter in `rateLimitFactory.ts` are the two spots worth a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/utils/withRedisFailOpen.ts | Adds optional `alsoFailOpen` predicate to widen fail-open conditions; the new branch correctly short-circuits to `fallback` without altering existing transient-error handling. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts | Exports `isFullSubjectGateRejection`; predicate is currently accurate but doesn't check `data.reason`, leaving it slightly broad for future callers. |
| server/src/internal/balances/check/runCheckWithRollout.ts | Wires `alsoFailOpen: isFullSubjectGateRejection` into the existing fail-open fallback path; no behaviour change for non-gate errors. |
| server/src/internal/balances/track/runTrackWithRollout.ts | Wires `alsoFailOpen: isFullSubjectGateRejection` into track's SQS-queue fallback path; re-throws on queue failure preserving original error. |
| server/src/internal/misc/rateLimiter/rateLimitFactory.ts | Adds `warnOrgCapExceeded` to the degrade handler; the throttle counter is module-level and shared across all rate limit types, so a TrackOrg warning can suppress a CheckOrg warning within the same 10-second window. |
| server/src/db/shed503OnTransientError.ts | Minor log message improvement: "DB unavailable" to "transient DB error" for clarity. |
| server/tests/unit/full-subject-gate/gate-rejection-failopen.test.ts | Unit tests for `isFullSubjectGateRejection` cover real-gate trips, exact error construction, negative cases, and non-error values. |
| server/tests/unit/redis/with-redis-fail-open-gate-rejection.test.ts | Unit tests for both check and track gate-rejection flows, verifying fail-open and error propagation; also validates that non-gate errors still propagate. |
| server/tests/integration/balances/gate-failopen/gate-reject-failopen.test.ts | Integration tests that trip the real gate with tiny limits and cold-cache concurrency; verifies neither check nor track surfaces 429s under concurrent load. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant runCheckWithRollout
    participant withRedisFailOpen
    participant runCheckV2
    participant FullSubjectGate
    participant getCheckFailOpenFallback

    Caller->>runCheckWithRollout: check(ctx, body)
    runCheckWithRollout->>withRedisFailOpen: "run=runCheckV2, alsoFailOpen=isFullSubjectGateRejection"
    withRedisFailOpen->>runCheckV2: run()
    runCheckV2->>FullSubjectGate: runWithFullSubjectGate(queryFn)
    alt gate capacity available
        FullSubjectGate-->>runCheckV2: result
        runCheckV2-->>withRedisFailOpen: CheckDataV2
        withRedisFailOpen-->>Caller: checkData and response
    else gate overloaded 429
        FullSubjectGate-->>runCheckV2: throw RecaseError rate_limit_exceeded 429
        runCheckV2-->>withRedisFailOpen: throw
        withRedisFailOpen->>withRedisFailOpen: isFullSubjectGateRejection returns true
        withRedisFailOpen->>getCheckFailOpenFallback: fallback(error)
        getCheckFailOpenFallback-->>withRedisFailOpen: allowed true
        withRedisFailOpen-->>Caller: checkData null response allow
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/customers/repos/getFullSubject/getFullSubjectGate.ts:119-122
The predicate matches any `RecaseError` with `code === "rate_limit_exceeded"` and `statusCode === 429` — currently unique to the gate, but not pinned to it. If another call inside `runCheckV2` or `runTrackV3` ever throws a `RecaseError` with those same properties, it would be silently swallowed as a gate rejection instead of propagating. Narrowing the check to the known `reason` values from `rejectOverloaded` makes the predicate self-documenting and future-proof.

```suggestion
const GATE_REJECTION_REASONS = new Set([
	"per_customer_queue_full",
	"per_org_queue_full",
	"wait_timeout",
]);

export const isFullSubjectGateRejection = (error: unknown): boolean =>
	error instanceof RecaseError &&
	error.code === "rate_limit_exceeded" &&
	error.statusCode === 429 &&
	GATE_REJECTION_REASONS.has(
		(error.data as { reason?: string } | undefined)?.reason ?? "",
	);
```

### Issue 2 of 2
server/src/internal/misc/rateLimiter/rateLimitFactory.ts:44-56
**Cross-type throttle suppresses distinct warnings**

`lastCapExceededWarningAt` is a single module-level variable shared by every `rateLimitFactory` instance. Both `TrackOrg` and `CheckOrg` use `overLimit: "degrade"` and each produces a warning with a different `limitType`. If `TrackOrg` fires first, any `CheckOrg` cap-exceeded event within the next 10 seconds is silently dropped — even though the log payload carries the type. Under a mixed spike where both caps are hit simultaneously, only one of the two warnings reaches the log. Consider keying the throttle per `limitType` (e.g. `const lastWarnAt = new Map<string, number>()`) so each type gets its own 10-second window.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fail open check/track on hydration-gate ..."](https://github.com/useautumn/autumn/commit/0ed9bddde7e6a57e9ad71809d14d78d2fe99b1f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36950488)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->