### PR TITLE
fix: bunlock

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,9 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 	bun install --ignore-scripts --no-save \
 		--minimum-release-age 0 \
 		--filter @autumn/server \
-		--filter @autumn/leaf
+		--filter @autumn/leaf \
+		--filter autumn-js \
+		--filter @useautumn/sdk
 
 FROM oven/bun:1.3.10
 WORKDIR /app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,15 +41,11 @@ COPY packages/stripe-sync/package.json packages/stripe-sync/
 # install step doesn't fail before the real source is copied.
 RUN mkdir -p scripts && touch scripts/preload-env.ts
 
-# Install only runtime workspaces; --no-save keeps this layer from mutating bun.lock.
-# Frozen filtered installs fail even immediately after Bun regenerates the lockfile.
+# Install the full workspace because runtime source imports cross package boundaries.
+# --no-save keeps this image layer from mutating bun.lock.
 RUN --mount=type=cache,target=/root/.bun/install/cache \
 	bun install --ignore-scripts --no-save \
-		--minimum-release-age 0 \
-		--filter @autumn/server \
-		--filter @autumn/leaf \
-		--filter autumn-js \
-		--filter @useautumn/sdk
+		--minimum-release-age 0
 
 FROM oven/bun:1.3.10
 WORKDIR /app


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker build and `bun.lock` stability by switching the deps stage to a full workspace install (no `--filter`) so cross-package runtime imports resolve correctly. Keeps `--no-save` to prevent lockfile changes during the image build.

<sup>Written for commit 86ec65f3c77dc2669773c4490335e99de9b120e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Docker build issue by adding two missing workspace packages (`autumn-js` and `@useautumn/sdk`) to the `bun install --filter` list in the `deps` build stage.

- **Bug fixes**: The `@autumn/server` workspace depends on `autumn-js`, which in turn depends on `@useautumn/sdk` (via `workspace:*`). Without these filters, the filtered bun install was unable to resolve those workspace dependencies, breaking the lockfile-driven Docker build. Adding the two packages ensures their transitive workspace deps are included in the install layer.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal and targeted, adding two workspace package filters that were already needed by the installed workspaces.

The two new filter names (autumn-js and @useautumn/sdk) match their workspace package.json names exactly, their manifests were already being copied in the deps stage, and the dependency chain from @autumn/server → autumn-js → @useautumn/sdk explains why they need to be listed explicitly for the filtered install to succeed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Adds --filter autumn-js and --filter @useautumn/sdk to the bun install step; both names match their workspace package.json exactly and their manifests were already COPY'd in the deps stage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FROM oven/bun:1.3.10 AS deps] --> B[COPY package.json manifests for all workspaces]
    B --> C[bun install --filter]
    C --> D["@autumn/server"]
    C --> E["@autumn/leaf"]
    C --> F["autumn-js new"]
    C --> G["@useautumn/sdk new"]
    D -.->|depends on workspace| F
    F -.->|devDep workspace:*| G
    C --> H[node_modules layer cached]
    H --> I[FROM oven/bun:1.3.10 final]
    I --> J[COPY --from=deps /app ./]
    I --> K[COPY . .]
    K --> L[EXPOSE 8080 / CMD bun start]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/bunlock"](https://github.com/useautumn/autumn/commit/f3fd7dbdfb475336f200fcef4a40055ea5eae0f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36958923)</sub>

<!-- /greptile_comment -->