### PR TITLE
fix(billing): charge zero-decimal currencies in major units

### DIFF
--- a/server/src/external/stripe/priceToStripeItem/priceToUsageInAdvance.ts
+++ b/server/src/external/stripe/priceToStripeItem/priceToUsageInAdvance.ts
@@ -1,4 +1,5 @@
 import {
+	atmnToStripeAmount,
 	type EntitlementWithFeature,
 	type FeatureOptions,
 	featureOptionUtils,
@@ -58,7 +59,10 @@ export const priceToOneOffAndTiered = ({
 			product: config.stripe_product_id
 				? config.stripe_product_id
 				: stripeProductId,
-			unit_amount: Number(amount.toFixed(2)) * 100,
+			unit_amount: atmnToStripeAmount({
+				amount,
+				currency: orgToCurrency({ org }),
+			}),
 			currency: orgToCurrency({ org }),
 		},
 

--- a/server/src/external/stripe/stripePriceUtils.ts
+++ b/server/src/external/stripe/stripePriceUtils.ts
@@ -1,4 +1,5 @@
 import {
+	atmnToStripeAmount,
 	BillingInterval,
 	type Customer,
 	type Feature,
@@ -95,7 +96,7 @@ export const getInvoiceItemForUsage = ({
 
 		price_data: {
 			product: config.stripe_product_id!,
-			unit_amount: Math.max(Math.round(amount * 100), 0),
+			unit_amount: Math.max(atmnToStripeAmount({ amount, currency }), 0),
 			currency,
 		},
 		period: {

--- a/server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/updateOneOffTieredItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/updateOneOffTieredItems.ts
@@ -1,4 +1,5 @@
 import {
+	atmnToStripeAmount,
 	InternalError,
 	type LineItemContext,
 	type Organization,
@@ -76,7 +77,7 @@ export const updateOneOffTieredItems = ({
 				product_data: {
 					name: lineItem.description,
 				},
-				unit_amount: Math.round(lineItem.amount * 100),
+				unit_amount: atmnToStripeAmount({ amount: lineItem.amount, currency }),
 				currency,
 			},
 			quantity: 1,

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams.ts
@@ -35,11 +35,11 @@ const toStripeCreateInvoiceItemParams = ({
 
 		amount: shouldUsePriceData
 			? undefined
-			: atmnToStripeAmount({ amount: lineAmount }),
+			: atmnToStripeAmount({ amount: lineAmount, currency }),
 
 		price_data: shouldUsePriceData
 			? {
-					unit_amount: atmnToStripeAmount({ amount: lineAmount }),
+					unit_amount: atmnToStripeAmount({ amount: lineAmount, currency }),
 					currency,
 					product: stripeProductId,
 				}

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToInvoiceAddLinesParams.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToInvoiceAddLinesParams.ts
@@ -28,10 +28,10 @@ const toStripeAddLineParams = ({
 		description,
 		amount: shouldUsePriceData
 			? undefined
-			: atmnToStripeAmount({ amount: lineAmount }),
+			: atmnToStripeAmount({ amount: lineAmount, currency }),
 		price_data: shouldUsePriceData
 			? {
-					unit_amount: atmnToStripeAmount({ amount: lineAmount }),
+					unit_amount: atmnToStripeAmount({ amount: lineAmount, currency }),
 					currency,
 					product: stripeProductId,
 				}

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToSubscriptionAddInvoiceItemsParams.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToSubscriptionAddInvoiceItemsParams.ts
@@ -19,7 +19,10 @@ const toStripeSubscriptionAddInvoiceItem = ({
 		price_data: {
 			currency: context.currency,
 			product: stripeProductId,
-			unit_amount: atmnToStripeAmount({ amount: amountAfterDiscounts }),
+			unit_amount: atmnToStripeAmount({
+				amount: amountAfterDiscounts,
+				currency: context.currency,
+			}),
 		},
 		period: context.effectivePeriod
 			? {

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -1,7 +1,8 @@
-import type {
-	BillingContext,
-	StripeDiscountWithCoupon,
-	StripeInvoiceAction,
+import {
+	type BillingContext,
+	orgToCurrency,
+	type StripeDiscountWithCoupon,
+	type StripeInvoiceAction,
 } from "@autumn/shared";
 import {
 	type PayInvoiceResult,
@@ -92,12 +93,17 @@ export const createInvoiceForBilling = async ({
 	});
 
 	const wantsAutoTax = shouldEnableStripeAutomaticTax({ ctx, billingContext });
+	const stripeSubId = options.skipSubscriptionLink
+		? undefined
+		: billingContext.stripeSubscription?.id;
+
 	const draftInvoice = await createStripeInvoice({
 		stripeCli,
 		stripeCusId: billingContext.stripeCustomer?.id ?? "none",
-		stripeSubId: options.skipSubscriptionLink
-			? undefined
-			: billingContext.stripeSubscription?.id,
+		stripeSubId,
+		// Subscription-linked invoices inherit currency from the subscription;
+		// standalone invoices default to the account currency, not the org's.
+		currency: stripeSubId ? undefined : orgToCurrency({ org: ctx.org }),
 		collectionMethod,
 		daysUntilDue: invoiceMode?.daysUntilDue,
 		footer: invoiceMode?.footer,

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
@@ -2,6 +2,7 @@ import {
 	type AttachConfig,
 	type AttachFunctionResponse,
 	AttachFunctionResponseSchema,
+	atmnToStripeAmount,
 	isFixedPrice,
 	MetadataType,
 	priceToInvoiceAmount,
@@ -99,7 +100,10 @@ export const handleOneOffFunction = async ({
 			invoiceItemData = {
 				description,
 				price_data: {
-					unit_amount: new Decimal(amount).mul(100).round().toNumber(),
+					unit_amount: atmnToStripeAmount({
+						amount,
+						currency: orgToCurrency({ org }),
+					}),
 					currency: orgToCurrency({ org }),
 					product: price.config?.stripe_product_id || product?.processor?.id,
 				},
@@ -136,7 +140,7 @@ export const handleOneOffFunction = async ({
 
 	// Skip auto_tax in invoice mode: send_invoice has no
 	// address-collection UI so Stripe Tax rejects.
-const wantsAutoTax =
+	const wantsAutoTax =
 		!!org.config.automatic_tax &&
 		!attachParams.invoiceOnly &&
 		customerHasUsableTaxLocationForStripeTax(attachParams.stripeCus);
@@ -145,12 +149,8 @@ const wantsAutoTax =
 		customer: customer.processor.id!,
 		auto_advance: false,
 		currency: orgToCurrency({ org }),
-		discounts: rewards
-			? rewards.map((r) => ({ coupon: r.id }))
-			: undefined,
-		collection_method: attachParams.invoiceOnly
-			? "send_invoice"
-			: undefined,
+		discounts: rewards ? rewards.map((r) => ({ coupon: r.id })) : undefined,
+		collection_method: attachParams.invoiceOnly ? "send_invoice" : undefined,
 		days_until_due: attachParams.invoiceOnly ? 30 : undefined,
 		...(shouldMemo ? { description: invoiceMemo } : {}),
 		...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),

--- a/server/src/internal/customers/attach/attachFunctions/upgradeDiffIntFlow/createUsageInvoiceItems.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeDiffIntFlow/createUsageInvoiceItems.ts
@@ -1,4 +1,5 @@
 import {
+	atmnToStripeAmount,
 	type BillingInterval,
 	BillingType,
 	cusProductsToCusPrices,
@@ -91,7 +92,10 @@ const getUsageInvoiceItems = async ({
 			description,
 			price_data: {
 				product: config.stripe_product_id!,
-				unit_amount: Math.round(amount * 100),
+				unit_amount: atmnToStripeAmount({
+					amount,
+					currency: org.default_currency || "usd",
+				}),
 				currency: org.default_currency || "usd",
 			},
 			period: {

--- a/server/src/internal/customers/attach/attachUtils/getContUseItems/createContUseInvoiceItems.ts
+++ b/server/src/internal/customers/attach/attachUtils/getContUseItems/createContUseInvoiceItems.ts
@@ -1,4 +1,5 @@
 import {
+	atmnToStripeAmount,
 	type BillingInterval,
 	BillingType,
 	cusProductToPrices,
@@ -138,7 +139,10 @@ export const createAndFilterContUseItems = async ({
 		const { start, end } = subToPeriodStartEnd({ sub });
 		await stripeCli.invoiceItems.create({
 			customer: customer.processor?.id ?? undefined,
-			amount: Math.round(item.amount * 100),
+			amount: atmnToStripeAmount({
+				amount: item.amount,
+				currency: org.default_currency || "usd",
+			}),
 			description: item.description,
 			currency: org.default_currency || "usd",
 			subscription: sub.id,

--- a/server/src/internal/invoices/invoiceItemUtils/invoiceItemUtils.ts
+++ b/server/src/internal/invoices/invoiceItemUtils/invoiceItemUtils.ts
@@ -1,5 +1,9 @@
-import type { Price, Product, UsagePriceConfig } from "@autumn/shared";
-import { Decimal } from "decimal.js";
+import {
+	atmnToStripeAmount,
+	type Price,
+	type Product,
+	type UsagePriceConfig,
+} from "@autumn/shared";
 import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
@@ -27,9 +31,10 @@ export const constructStripeInvoiceItem = ({
 	const { org } = ctx;
 	const config = price.config as UsagePriceConfig;
 
-	const amountInCents = Math.floor(
-		new Decimal(amount).mul(100).round().toNumber(),
-	);
+	const amountInCents = atmnToStripeAmount({
+		amount,
+		currency: org.default_currency || "usd",
+	});
 
 	const priceData =
 		amountInCents > 0

--- a/server/tests/_groups/core/coreAttach.ts
+++ b/server/tests/_groups/core/coreAttach.ts
@@ -6,6 +6,7 @@ export const coreAttach: TestGroup = {
 	tier: "core",
 	paths: [
 		"billing/attach/new-plan/attach-paid.test.ts",
+		"billing/attach/new-plan/attach-one-off-zero-decimal.test.ts",
 		"billing/attach/new-plan/attach-free.test.ts",
 		"billing/attach/new-plan/attach-addon.test.ts",
 		"billing/attach/new-plan/attach-entities.test.ts",

--- a/server/tests/_groups/core/coreLegacy.ts
+++ b/server/tests/_groups/core/coreLegacy.ts
@@ -16,6 +16,7 @@ export const coreLegacy: TestGroup = {
 		"legacy/attach/invoice/payment-failure/legacy-attach-payment-failed.test.ts",
 		"legacy/attach/new/legacy-new-merged.test.ts",
 		"legacy/attach/new/legacy-new-oneoff.test.ts",
+		"legacy/attach/new/legacy-new-oneoff-zero-decimal.test.ts",
 		"legacy/attach/trial/legacy-trial.test.ts",
 		"legacy/attach/update-quantity/legacy-update-quantity.test.ts",
 		"legacy/attach/upgrade/legacy-upgrade.test.ts",

--- a/server/tests/integration/billing/attach/new-plan/attach-one-off-zero-decimal.test.ts
+++ b/server/tests/integration/billing/attach/new-plan/attach-one-off-zero-decimal.test.ts
@@ -18,36 +18,8 @@ import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { setOrgCurrency } from "@tests/utils/testInitUtils/setOrgCurrency.js";
 import chalk from "chalk";
-import { db } from "@/db/initDrizzle.js";
-import {
-	getConfiguredRegions,
-	getRegionalRedis,
-	waitForRedisReady,
-} from "@/external/redis/initRedis.js";
-import { OrgService } from "@/internal/orgs/OrgService.js";
-import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
-
-const setOrgCurrency = async ({
-	orgId,
-	currency,
-}: {
-	orgId: string;
-	currency: string;
-}) => {
-	await OrgService.update({
-		db,
-		orgId,
-		updates: { default_currency: currency },
-	});
-	// clearOrgCache silently skips Redis deletes until each regional client is ready
-	await Promise.all(
-		getConfiguredRegions().map((region) =>
-			waitForRedisReady(getRegionalRedis(region), region),
-		),
-	);
-	await clearOrgCache({ db, orgId });
-};
 
 test(`${chalk.yellowBright("v2 one-off rwf: billing.attach invoices in the org currency")}`, async () => {
 	const customerId = "v2-oneoff-rwf-zero-decimal";

--- a/server/tests/integration/billing/attach/new-plan/attach-one-off-zero-decimal.test.ts
+++ b/server/tests/integration/billing/attach/new-plan/attach-one-off-zero-decimal.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for v2 billing.attach one-off purchases in a non-USD org:
+ * createInvoiceForBilling did not pass `currency` to stripeCli.invoices.create,
+ * so Stripe defaulted the invoice to the account currency (usd) and rejected
+ * the org-currency (rwf) price with "price only supports rwf, expected usd".
+ *
+ * Pre-fix: attach fails with a Stripe currency-mismatch error.
+ * Post-fix: invoice created in RWF with total 23,198 (23,188 prepaid + 10 base).
+ *
+ * Uses a dedicated sub-org because default_currency is org-wide state and
+ * group runs execute test files in parallel against the shared master org.
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { db } from "@/db/initDrizzle.js";
+import {
+	getConfiguredRegions,
+	getRegionalRedis,
+	waitForRedisReady,
+} from "@/external/redis/initRedis.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
+
+const setOrgCurrency = async ({
+	orgId,
+	currency,
+}: {
+	orgId: string;
+	currency: string;
+}) => {
+	await OrgService.update({
+		db,
+		orgId,
+		updates: { default_currency: currency },
+	});
+	// clearOrgCache silently skips Redis deletes until each regional client is ready
+	await Promise.all(
+		getConfiguredRegions().map((region) =>
+			waitForRedisReady(getRegionalRedis(region), region),
+		),
+	);
+	await clearOrgCache({ db, orgId });
+};
+
+test(`${chalk.yellowBright("v2 one-off rwf: billing.attach invoices in the org currency")}`, async () => {
+	const customerId = "v2-oneoff-rwf-zero-decimal";
+
+	// Sub-org first so the currency is RWF before any Stripe prices exist.
+	const { ctx } = await initScenario({
+		setup: [s.platform.create({ setupDefaultFeatures: true })],
+		actions: [],
+	});
+
+	await setOrgCurrency({ orgId: ctx.org.id, currency: "rwf" });
+	ctx.org.default_currency = "rwf";
+
+	const oneOff = products.oneOff({
+		id: "v2-one-off-rwf",
+		items: [
+			items.oneOffMessages({
+				includedUsage: 0,
+				billingUnits: 1,
+				price: 23_188,
+			}),
+		],
+	});
+
+	const { autumnV1 } = await initScenario({
+		ctx,
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [oneOff] }),
+		],
+		actions: [],
+	});
+
+	await autumnV1.billing.attach({
+		customer_id: customerId,
+		product_id: oneOff.id,
+		options: [{ feature_id: TestFeature.Messages, quantity: 1 }],
+	});
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	// 23,188 RWF prepaid item + 10 RWF product base price
+	await expectCustomerInvoiceCorrect({
+		customer,
+		count: 1,
+		latestTotal: 23_198,
+		latestStatus: "paid",
+	});
+}, 120_000);

--- a/server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-zero-decimal.test.ts
+++ b/server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-zero-decimal.test.ts
@@ -17,45 +17,15 @@ import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { setOrgCurrency } from "@tests/utils/testInitUtils/setOrgCurrency.js";
 import chalk from "chalk";
-import { db } from "@/db/initDrizzle.js";
-import {
-	getConfiguredRegions,
-	getRegionalRedis,
-	waitForRedisReady,
-} from "@/external/redis/initRedis.js";
-import { OrgService } from "@/internal/orgs/OrgService.js";
-import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
-
-const setOrgCurrency = async ({
-	orgId,
-	currency,
-}: {
-	orgId: string;
-	currency: string;
-}) => {
-	await OrgService.update({
-		db,
-		orgId,
-		updates: { default_currency: currency },
-	});
-	// clearOrgCache silently skips Redis deletes until each regional client is ready
-	await Promise.all(
-		getConfiguredRegions().map((region) =>
-			waitForRedisReady(getRegionalRedis(region), region),
-		),
-	);
-	await clearOrgCache({ db, orgId });
-};
 
 test(`${chalk.yellowBright("legacy one-off rwf: prepaid one-off charges major units, not x100")}`, async () => {
 	const customerId = "legacy-oneoff-rwf-zero-decimal";
 
 	// Sub-org first so the currency is RWF before any Stripe prices exist.
 	const { ctx } = await initScenario({
-		setup: [
-			s.platform.create({ setupDefaultFeatures: true }),
-		],
+		setup: [s.platform.create({ setupDefaultFeatures: true })],
 		actions: [],
 	});
 

--- a/server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-zero-decimal.test.ts
+++ b/server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-zero-decimal.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression test for zero-decimal currency (RWF) one-off purchases charging
+ * 100x: handleOneOffFunction built inline price_data with a raw `* 100`
+ * instead of atmnToStripeAmount, so RWF 23,188 was charged as RWF 2,318,800.
+ *
+ * Pre-fix: invoice total 2,318,810 RWF (prepaid item 100x'd; fixed base OK).
+ * Post-fix: invoice total 23,198 RWF (23,188 prepaid + 10 base).
+ *
+ * Uses a dedicated sub-org because default_currency is org-wide state and
+ * group runs execute test files in parallel against the shared master org.
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { db } from "@/db/initDrizzle.js";
+import {
+	getConfiguredRegions,
+	getRegionalRedis,
+	waitForRedisReady,
+} from "@/external/redis/initRedis.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
+
+const setOrgCurrency = async ({
+	orgId,
+	currency,
+}: {
+	orgId: string;
+	currency: string;
+}) => {
+	await OrgService.update({
+		db,
+		orgId,
+		updates: { default_currency: currency },
+	});
+	// clearOrgCache silently skips Redis deletes until each regional client is ready
+	await Promise.all(
+		getConfiguredRegions().map((region) =>
+			waitForRedisReady(getRegionalRedis(region), region),
+		),
+	);
+	await clearOrgCache({ db, orgId });
+};
+
+test(`${chalk.yellowBright("legacy one-off rwf: prepaid one-off charges major units, not x100")}`, async () => {
+	const customerId = "legacy-oneoff-rwf-zero-decimal";
+
+	// Sub-org first so the currency is RWF before any Stripe prices exist.
+	const { ctx } = await initScenario({
+		setup: [
+			s.platform.create({ setupDefaultFeatures: true }),
+		],
+		actions: [],
+	});
+
+	await setOrgCurrency({ orgId: ctx.org.id, currency: "rwf" });
+	ctx.org.default_currency = "rwf";
+
+	const oneOff = products.oneOff({
+		id: "one-off-rwf",
+		items: [
+			items.oneOffMessages({
+				includedUsage: 0,
+				billingUnits: 1,
+				price: 23_188,
+			}),
+		],
+	});
+
+	const { autumnV1 } = await initScenario({
+		ctx,
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [oneOff] }),
+		],
+		actions: [],
+	});
+
+	await autumnV1.attach({
+		customer_id: customerId,
+		product_id: oneOff.id,
+		options: [{ feature_id: TestFeature.Messages, quantity: 1 }],
+	});
+
+	const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+	// 23,188 RWF prepaid item + 10 RWF product base price
+	await expectCustomerInvoiceCorrect({
+		customer,
+		count: 1,
+		latestTotal: 23_198,
+		latestStatus: "paid",
+	});
+}, 120_000);

--- a/server/tests/utils/testInitUtils/setOrgCurrency.ts
+++ b/server/tests/utils/testInitUtils/setOrgCurrency.ts
@@ -1,0 +1,33 @@
+import { db } from "@/db/initDrizzle.js";
+import {
+	getConfiguredRegions,
+	getRegionalRedis,
+	waitForRedisReady,
+} from "@/external/redis/initRedis.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache.js";
+
+/**
+ * Sets an org's default_currency and clears its cached secret-key verification.
+ * Use a dedicated sub-org: currency is org-wide state and test files run in parallel.
+ */
+export const setOrgCurrency = async ({
+	orgId,
+	currency,
+}: {
+	orgId: string;
+	currency: string;
+}) => {
+	await OrgService.update({
+		db,
+		orgId,
+		updates: { default_currency: currency },
+	});
+	// clearOrgCache silently skips Redis deletes until each regional client is ready
+	await Promise.all(
+		getConfiguredRegions().map((region) =>
+			waitForRedisReady(getRegionalRedis(region), region),
+		),
+	);
+	await clearOrgCache({ db, orgId });
+};


### PR DESCRIPTION
## Problem

A customer billing in RWF reported one-off purchases charging **100×** the configured price — RWF 23,188 invoiced as RWF 2,318,800 ([Discord report](https://discord.com)). RWF is one of Stripe's 16 zero-decimal currencies: its minor unit *is* the major unit, so multiplying by 100 overcharges by 100×.

The shared util `atmnToStripeAmount` already handles zero-decimal currencies correctly — these paths just bypassed it.

## Fixes

**Raw `× 100` → `atmnToStripeAmount` (7 sites):**
- `handleOneOffFunction` — legacy one-off attach (the customer's exact path)
- `priceToOneOffAndTiered` — tiered one-off, legacy checkout
- `updateOneOffTieredItems` — tiered one-off, v2 checkout
- `constructStripeInvoiceItem` — usage invoice items on subscriptions
- `createUsageInvoiceItems` — cross-interval upgrade usage charges
- `createContUseInvoiceItems` — continuous-use prorations
- `getInvoiceItemForUsage` (stripePriceUtils) — legacy usage invoices

**v2 billing currency plumbing (discovered while writing the v2 test):**
- `createInvoiceForBilling` never passed `currency` to `stripeCli.invoices.create`, so standalone invoices defaulted to the **account** currency — for an RWF org, `billing.attach` one-offs hard-failed with `price only supports rwf, expected usd`. Now passes the org currency for standalone invoices only (subscription-linked invoices inherit theirs).
- The three v2 line-item converters (`lineItemsToInvoiceAddLinesParams`, `lineItemsToCreateInvoiceItemsParams`, `lineItemsToSubscriptionAddInvoiceItemsParams`) destructured `currency` from context but called `atmnToStripeAmount({ amount })` without it — silently defaulting to USD and always ×100.

No behavior change for USD/EUR/etc: explicit currency produces the same result as the old default.

## Tests (TDD, red→green)

Both registered in the **core-billing** group, both use an isolated sub-org (currency is org-wide state and group files run in parallel):

- `legacy/attach/new/legacy-new-oneoff-zero-decimal.test.ts` — red: total 2,318,810 RWF; green: 23,198 RWF, paid
- `billing/attach/new-plan/attach-one-off-zero-decimal.test.ts` — red: Stripe currency-mismatch error; green: 23,198 RWF, paid

## Notes

- The affected customer was genuinely overcharged 100× on two invoices and will need partial refunds (the refund path converts correctly).
- Stripe's three-decimal currencies (BHD, JOD, KWD, OMR, TND) remain unhandled (`atmnToStripeAmount` doesn't round their minor amounts to the nearest 10) — separate issue if we ever support them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix zero-decimal currency overcharges by using `atmnToStripeAmount` and correctly passing currency through v2 invoice and line-item flows. Prevents 100× charges (e.g., RWF) and ensures standalone invoices use the org currency.

- **Bug Fixes**
  - Replaced raw “* 100” with `atmnToStripeAmount` across one-off and usage invoice paths (legacy + v2).
  - Passed org `currency` to `stripeCli.invoices.create` for standalone v2 invoices; subscription-linked invoices still inherit currency.
  - Ensured v2 line-item converters pass `currency` to `atmnToStripeAmount` to avoid implicit USD.
  - Added RWF regression tests (legacy + v2); one-off totals now 23,198 RWF and paid.

- **Refactors**
  - Extracted shared `setOrgCurrency` test helper to remove duplication in zero-decimal tests.

<sup>Written for commit af173861e21a7d972ab344c4927572f536f7f4a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a critical billing bug where zero-decimal currencies (e.g., RWF) were being charged 100× the configured price because seven code paths used raw `× 100` multiplication instead of the existing `atmnToStripeAmount` utility that already handles zero-decimal currencies. A secondary fix passes the org's currency to `createInvoiceForBilling` for standalone invoices, which were defaulting to the Stripe account currency and causing a currency-mismatch error for non-USD orgs.

- **Bug fixes** — Seven `× 100` / `mul(100)` charge calculations replaced with `atmnToStripeAmount({ amount, currency })` across one-off, tiered, usage, and proration invoice paths.
- **Bug fixes** — `createInvoiceForBilling` now passes `currency` for subscription-free invoices; three v2 line-item converters now thread `currency` through to `atmnToStripeAmount` instead of silently defaulting to USD.
- **Improvements** — Two integration regression tests added with proper sub-org isolation to avoid parallel-test interference.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for USD/EUR and all previously-working currencies; RWF one-off, tiered, usage, and proration paths are now correctly handled.

All seven targeted charge-calculation sites are fixed correctly, currency is now threaded through consistently, and the new tests are properly isolated with sub-orgs. The only uncertainty is a related code path in createStripeArrearProrated.ts that was not part of this PR scope and may still overcharge for zero-decimal currencies if arrear-prorated tiers are in use.

server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts — unchanged by this PR but contains the same raw x100 multiplication for Stripe Price tier amounts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts | Core fix: replaces Decimal.mul(100) with atmnToStripeAmount for one-off invoice price_data; also fixes missing indentation on wantsAutoTax declaration and reformats ternaries. |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts | Correctly passes org currency to standalone Stripe invoices only; subscription-linked invoices keep currency=undefined to inherit from the subscription. |
| server/src/internal/invoices/invoiceItemUtils/invoiceItemUtils.ts | Replaces Math.floor(new Decimal(amount).mul(100).round()) with atmnToStripeAmount, correctly passing org currency for zero-decimal support. |
| server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams.ts | Passes currency to atmnToStripeAmount in both the amount and price_data.unit_amount branches, fixing silent USD default. |
| server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToInvoiceAddLinesParams.ts | Same currency-threading fix as lineItemsToCreateInvoiceItemsParams — both branches now correctly pass currency. |
| server/src/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToSubscriptionAddInvoiceItemsParams.ts | Passes context.currency to atmnToStripeAmount for subscription invoice items, fixing silent USD default. |
| server/src/internal/customers/attach/attachFunctions/upgradeDiffIntFlow/createUsageInvoiceItems.ts | Replaces Math.round(amount * 100) with atmnToStripeAmount using org.default_currency for cross-interval upgrade usage charges. |
| server/src/internal/customers/attach/attachUtils/getContUseItems/createContUseInvoiceItems.ts | Replaces Math.round(item.amount * 100) with atmnToStripeAmount using org.default_currency for continuous-use prorations. |
| server/src/external/stripe/stripePriceUtils.ts | Replaces Math.round(amount * 100) with atmnToStripeAmount in getInvoiceItemForUsage; currency was already available in scope. |
| server/src/external/stripe/priceToStripeItem/priceToUsageInAdvance.ts | Replaces Number(amount.toFixed(2)) * 100 with atmnToStripeAmount for tiered one-off price_data in legacy checkout. |
| server/src/internal/billing/v2/providers/stripe/utils/checkoutSessions/updateOneOffTieredItems.ts | Replaces Math.round(lineItem.amount * 100) with atmnToStripeAmount; currency is already derived from orgToCurrency at top of function. |
| server/tests/integration/billing/attach/new-plan/attach-one-off-zero-decimal.test.ts | New regression test for v2 one-off RWF billing; correctly uses a sub-org for currency isolation and verifies invoice total at 23,198 RWF. |
| server/tests/integration/billing/legacy/attach/new/legacy-new-oneoff-zero-decimal.test.ts | New regression test for legacy one-off RWF billing; uses identical structure and sub-org isolation as the v2 test. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AttachHandler
    participant InvoiceBuilder
    participant atmnToStripeAmount
    participant StripeAPI

    Client->>AttachHandler: billing.attach(customer, product, options)
    AttachHandler->>InvoiceBuilder: build invoice items (amount, org.default_currency)
    Note over InvoiceBuilder,atmnToStripeAmount: Before fix: raw amount x 100. After fix: atmnToStripeAmount({amount, currency})
    InvoiceBuilder->>atmnToStripeAmount: "{amount: 23188, currency: rwf}"
    atmnToStripeAmount-->>InvoiceBuilder: 23188 (zero-decimal: no x100)
    InvoiceBuilder->>StripeAPI: "invoices.create({currency: rwf})"
    Note over InvoiceBuilder,StripeAPI: Standalone invoice now passes org currency
    InvoiceBuilder->>StripeAPI: "invoiceItems.create({amount: 23188, currency: rwf})"
    StripeAPI-->>Client: Invoice RWF 23198 correct
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/tests/integration/billing/attach/new-plan/attach-one-off-zero-decimal.test.ts:35-52
**Duplicated `setOrgCurrency` helper across both test files**

`setOrgCurrency` is defined identically in both `attach-one-off-zero-decimal.test.ts` and `legacy-new-oneoff-zero-decimal.test.ts`. Extracting it to a shared test utility (e.g., `server/tests/utils/testInitUtils/setOrgCurrency.ts`) would avoid drift if the cache-clearing logic ever needs updating.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): 🐛 charge zero-decimal cur..."](https://github.com/useautumn/autumn/commit/60e7e24a7b06c4632e8d2deeff2e004acc858ba5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36960854)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->