### PR TITLE
chore: treat AI credit systems as generic credit systems in plan editor

### DIFF
--- a/shared/utils/featureUtils/classifyFeature/isAnyCreditSystem.ts
+++ b/shared/utils/featureUtils/classifyFeature/isAnyCreditSystem.ts
@@ -1,6 +1,5 @@
 import { FeatureType } from "@models/featureModels/featureEnums";
 import { isAiCreditSystem } from "@utils/featureUtils/classifyFeature/isAiCreditSystem";
 
-export const isAnyCreditSystem = (
-	type: FeatureType | undefined | null,
-): boolean => type === FeatureType.CreditSystem || isAiCreditSystem(type);
+export const isAnyCreditSystem = (type: FeatureType): boolean =>
+	type === FeatureType.CreditSystem || isAiCreditSystem(type);

--- a/shared/utils/featureUtils/classifyFeature/isAnyCreditSystem.ts
+++ b/shared/utils/featureUtils/classifyFeature/isAnyCreditSystem.ts
@@ -1,5 +1,6 @@
 import { FeatureType } from "@models/featureModels/featureEnums";
 import { isAiCreditSystem } from "@utils/featureUtils/classifyFeature/isAiCreditSystem";
 
-export const isAnyCreditSystem = (type: FeatureType): boolean =>
-	type === FeatureType.CreditSystem || isAiCreditSystem(type);
+export const isAnyCreditSystem = (
+	type: FeatureType | undefined | null,
+): boolean => type === FeatureType.CreditSystem || isAiCreditSystem(type);

--- a/shared/utils/productDisplayUtils.ts
+++ b/shared/utils/productDisplayUtils.ts
@@ -14,7 +14,6 @@ import {
 	isFeaturePriceItem,
 	isPriceItem,
 } from "./productV2Utils/productItemUtils/getItemType.js";
-import { isAiCreditSystem } from "@utils/featureUtils/classifyFeature/isAiCreditSystem";
 import { notNullish, nullish } from "./utils.js";
 
 // ============================================================================
@@ -54,9 +53,6 @@ const getIncludedUsageText = (item: ProductItem, feature: Feature): string => {
 
 	if (item.included_usage === Infinite) {
 		return `Unlimited ${featureName}`;
-	}
-	if (isAiCreditSystem(feature.type)) {
-		return `$${numberWithCommas(item.included_usage ?? 0)} of ${featureName}`;
 	}
 	if (nullish(item.included_usage) || item.included_usage === 0) {
 		return `0 ${featureName}`;
@@ -229,11 +225,7 @@ export const getFeaturePriceItemDisplay = ({
 	});
 	let includedUsageStr = "";
 	if (hasIncludedUsage) {
-		if (isAiCreditSystem(feature.type)) {
-			includedUsageStr = `$${numberWithCommas(includedUsage)} of ${includedFeatureName}`;
-		} else {
-			includedUsageStr = `${numberWithCommas(includedUsage)} ${includedFeatureName}`;
-		}
+		includedUsageStr = `${numberWithCommas(includedUsage)} ${includedFeatureName}`;
 	}
 
 	const volumeFlatAmount = isVolumeFlatAmountItem(item);
@@ -242,7 +234,13 @@ export const getFeaturePriceItemDisplay = ({
 	// lives in tier.flat_amount, so we must pass useFlatAmount: true.
 	let priceStr: string;
 	if (volumeFlatAmount) {
-		priceStr = formatTiers({ item, currency, amountFormatOptions, useFlatAmount: true }) ?? "";
+		priceStr =
+			formatTiers({
+				item,
+				currency,
+				amountFormatOptions,
+				useFlatAmount: true,
+			}) ?? "";
 	} else if (item.tiers) {
 		priceStr = formatTiers({ item, currency, amountFormatOptions }) ?? "";
 	} else {
@@ -257,18 +255,10 @@ export const getFeaturePriceItemDisplay = ({
 		feature,
 		units: billingUnits,
 	});
-	let perUnitStr: string;
-	if (isAiCreditSystem(feature.type)) {
-		perUnitStr =
-			billingUnits > 1
-				? `$${numberWithCommas(billingUnits)} of ${billingFeatureName}`
-				: `$1 of ${billingFeatureName}`;
-	} else {
-		perUnitStr =
-			billingUnits > 1
-				? `${numberWithCommas(billingUnits)} ${billingFeatureName}`
-				: billingFeatureName;
-	}
+	const perUnitStr =
+		billingUnits > 1
+			? `${numberWithCommas(billingUnits)} ${billingFeatureName}`
+			: billingFeatureName;
 
 	// Build interval string
 	const showInterval = isMainPrice || fullDisplay;
@@ -283,13 +273,6 @@ export const getFeaturePriceItemDisplay = ({
 	}
 
 	// Format output based on what we have
-	if (isAiCreditSystem(feature.type)) {
-		return {
-			primary_text: includedUsageStr || "$0 included",
-			secondary_text: "then charged based on model usage",
-		};
-	}
-
 	if (hasIncludedUsage) {
 		if (volumeFlatAmount) {
 			const featureName = getFeatureName({ feature, units: 2 });

--- a/vite/src/utils/product/product-item/formatProductItem.ts
+++ b/vite/src/utils/product/product-item/formatProductItem.ts
@@ -1,17 +1,12 @@
 import {
 	type Feature,
-	FeatureType,
 	type FrontendOrg,
 	formatAmount,
 	formatInterval,
-	Infinite,
-	isAiCreditSystem,
 	type ProductItem,
 	ProductItemType,
 	TierBehavior,
 } from "@autumn/shared";
-import { notNullish } from "@/utils/genUtils";
-import { getFeature } from "../entitlementUtils";
 import { getItemType, intervalIsNone } from "../productItemUtils";
 
 const isVolumeFlatAmountItem = (item: ProductItem): boolean => {
@@ -132,38 +127,6 @@ const getFixedPriceString = ({
 	}
 
 	return `${formattedAmount}`;
-};
-
-const getFeatureString = ({
-	item,
-	features,
-}: {
-	item: ProductItem;
-	features: Feature[];
-}) => {
-	const feature = features.find((f: Feature) => f.id === item.feature_id);
-
-	if (feature?.type === FeatureType.Boolean) {
-		return `${feature.name}`;
-	}
-
-	if (item.included_usage === Infinite) {
-		return `Unlimited ${feature?.name}`;
-	}
-
-	const intervalStr = formatInterval({
-		interval: item.interval ?? undefined,
-		intervalCount: item.interval_count ?? undefined,
-	});
-
-	if (isAiCreditSystem(feature?.type)) {
-		const amount = item.included_usage ?? 0;
-		const formattedAmount =
-			amount === 0 ? "$0.00" : `$${Number(amount).toFixed(2)}`;
-		return `${formattedAmount} of ${feature?.name}${notNullish(item.interval) ? ` ${intervalStr}` : ""}`;
-	}
-
-	return `${item.included_usage ?? 0} ${feature?.name}${item.entity_feature_id ? ` per ${getFeature(item.entity_feature_id, features)?.name}` : ""}${notNullish(item.interval) ? ` ${intervalStr}` : ""}`;
 };
 
 export const formatProductItemText = ({

--- a/vite/src/views/products/plan/components/edit-plan-feature/BillingType.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/BillingType.tsx
@@ -3,7 +3,6 @@ import {
 	FeatureUsageType,
 	getFeatureName,
 	Infinite,
-	isAiCreditSystem,
 	isContUseItem,
 	isFeaturePriceItem,
 	ProductItemInterval,
@@ -105,9 +104,7 @@ export function BillingType() {
 				<div className="flex-1">
 					<div className="text-body-highlight mb-1">Included</div>
 					<div className="text-body-secondary leading-tight">
-						{isAiCreditSystem(feature?.type)
-							? "Set an included USD budget (eg, $10 per month)."
-							: isConsumable
+						{isConsumable
 							? `Set an included usage limit (eg, 100 ${featureName} per month).`
 							: isAllocated
 								? `Set a usage limit (eg, 5 ${featureName}).`
@@ -127,9 +124,7 @@ export function BillingType() {
 				<div className="flex-1">
 					<div className="text-body-highlight mb-1">Priced</div>
 					<div className="text-body-secondary leading-tight">
-						{isAiCreditSystem(feature?.type)
-							? "Bill model usage at the markup you set in USD after the included budget is used."
-							: isConsumable
+						{isConsumable
 							? `Charge a price for usage (eg, $0.05 per ${singleFeatureName}).`
 							: isAllocated
 								? `Charge a price based on usage (eg, $10 per ${singleFeatureName}).`

--- a/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/EditPlanFeatureSheet.tsx
@@ -1,4 +1,4 @@
-import { FeatureType, isAiCreditSystem, TierBehavior } from "@autumn/shared";
+import { FeatureType, isAnyCreditSystem, TierBehavior } from "@autumn/shared";
 import { PencilSimpleIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { IconButton } from "@/components/v2/buttons/IconButton";
@@ -170,7 +170,7 @@ export function EditPlanFeatureSheet({
 							<IncludedUsage />
 						</SheetSection>
 
-						{isFeaturePrice && !isAiCreditSystem(feature?.type) && (
+						{isFeaturePrice && (
 							<SheetSection
 								title={
 									item.tiers && item.tiers.length > 1 ? (
@@ -223,7 +223,7 @@ export function EditPlanFeatureSheet({
 			/>
 
 			{/* Edit Feature Sheet */}
-			{feature?.type === FeatureType.CreditSystem ? (
+			{isAnyCreditSystem(feature?.type) ? (
 				<UpdateCreditSystemSheet
 					open={editFeatureOpen}
 					setOpen={setEditFeatureOpen}

--- a/vite/src/views/products/plan/components/edit-plan-feature/IncludedUsage.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/IncludedUsage.tsx
@@ -5,17 +5,11 @@ import {
 	entToItemInterval,
 	getFeatureName,
 	Infinite,
-	isAiCreditSystem,
 	isContUseItem,
 } from "@autumn/shared";
 import { InfinityIcon } from "@phosphor-icons/react";
 import { IconCheckbox } from "@/components/v2/checkboxes/IconCheckbox";
 import { Input } from "@/components/v2/inputs/Input";
-import {
-	InputGroup,
-	InputGroupInput,
-	InputGroupText,
-} from "@/components/v2/inputs/InputGroup";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { isFeaturePriceItem } from "@/utils/product/getItemType";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
@@ -48,67 +42,32 @@ export function IncludedUsage() {
 			<div className="w-full h-auto flex items-end gap-2">
 				<div className="flex-1">
 					<div className="text-tertiary-foreground text-sm block mb-2">
-						{isAiCreditSystem(feature?.type) ? (
-							`USD budget ${isFeaturePrice ? "granted before billing" : "allocated to this plan"}`
-						) : (
-							<>
-								Quantity of&nbsp;
-								<span className="font-medium text-foreground">
-									{getFeatureName({ feature, plural: true })}
-								</span>
-								{isFeaturePrice
-									? " granted before billing"
-									: " that can be used"}
-							</>
-						)}
+						Quantity of&nbsp;
+						<span className="font-medium text-foreground">
+							{getFeatureName({ feature, plural: true })}
+						</span>
+						{isFeaturePrice ? " granted before billing" : " that can be used"}
 					</div>
 					<div className="flex items-center gap-2">
-						{isAiCreditSystem(feature?.type) ? (
-							<InputGroup data-disabled={includedUsage === Infinite}>
-								<InputGroupText>$</InputGroupText>
-								<InputGroupInput
-									key={`included-usage-${item.feature_id || item.price_id || "default"}`}
-									placeholder={
-										includedUsage === Infinite ? "Unlimited" : "eg. 10.00"
-									}
-									value={getInputValue()}
-									onChange={(e) => {
-										const value = e.target.value.trim();
+						<Input
+							key={`included-usage-${item.feature_id || item.price_id || "default"}`}
+							placeholder="eg, 100"
+							value={getInputValue()}
+							onChange={(e) => {
+								const value = e.target.value.trim();
 
-										if (value === "") {
-											setItem({ ...item, included_usage: null });
-										} else {
-											const numValue = Number(value);
-											if (!Number.isNaN(numValue)) {
-												setItem({ ...item, included_usage: numValue });
-											}
-										}
-									}}
-									disabled={includedUsage === Infinite}
-									type="number"
-								/>
-							</InputGroup>
-						) : (
-							<Input
-								key={`included-usage-${item.feature_id || item.price_id || "default"}`}
-								placeholder="eg, 100"
-								value={getInputValue()}
-								onChange={(e) => {
-									const value = e.target.value.trim();
-
-									if (value === "") {
-										setItem({ ...item, included_usage: null });
-									} else {
-										const numValue = Number(value);
-										if (!Number.isNaN(numValue)) {
-											setItem({ ...item, included_usage: numValue });
-										}
+								if (value === "") {
+									setItem({ ...item, included_usage: null });
+								} else {
+									const numValue = Number(value);
+									if (!Number.isNaN(numValue)) {
+										setItem({ ...item, included_usage: numValue });
 									}
-								}}
-								disabled={includedUsage === Infinite}
-								type="number"
-							/>
-						)}
+								}
+							}}
+							disabled={includedUsage === Infinite}
+							type="number"
+						/>
 						<IconCheckbox
 							hide={isFeaturePrice}
 							icon={<InfinityIcon />}

--- a/vite/src/views/products/plan/components/plan-card/DummyPlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/DummyPlanFeatureRow.tsx
@@ -1,4 +1,8 @@
-import { FeatureType, FeatureUsageType, isAiCreditSystem } from "@autumn/shared";
+import {
+	FeatureType,
+	FeatureUsageType,
+	isAnyCreditSystem,
+} from "@autumn/shared";
 import { BoxArrowDownIcon } from "@phosphor-icons/react";
 import { useFeatureStore } from "@/hooks/stores/useFeatureStore";
 import { cn } from "@/lib/utils";
@@ -38,7 +42,7 @@ export const DummyPlanFeatureRow = () => {
 
 	// Get placeholder name based on feature type
 	const getPlaceholderName = () => {
-		if (featureType === FeatureType.CreditSystem) return "Credits";
+		if (isAnyCreditSystem(featureType)) return "Credits";
 		if (isBoolean) return "Premium Analytics";
 		if (isNonConsumable) return "Seats";
 		return "Chat Messages";
@@ -48,11 +52,7 @@ export const DummyPlanFeatureRow = () => {
 	const getDisplayText = () => {
 		const name = hasName ? featureName : getPlaceholderName();
 
-		if (isAiCreditSystem(feature.type)) {
-			return { primary: `$10.00 of ${name}`, secondary: "" };
-		}
-
-		if (featureType === FeatureType.CreditSystem) {
+		if (isAnyCreditSystem(featureType)) {
 			return { primary: `100 ${name}`, secondary: "" };
 		}
 

--- a/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanFeatureRow.tsx
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/a11y/noStaticElementInteractions: needed */
 /** biome-ignore-all lint/a11y/useSemanticElements: needed */
-import { type ProductItem, isAiCreditSystem } from "@autumn/shared";
+import type { ProductItem } from "@autumn/shared";
 import { getProductItemDisplay } from "@autumn/shared";
 import { TrashIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
@@ -56,7 +56,7 @@ export const PlanFeatureRow = ({
 		(queryStates.step !== OnboardingStep.Playground ||
 			playgroundMode !== "edit");
 
-	const item = readOnly ? itemProp : (product.items?.[index] || itemProp);
+	const item = readOnly ? itemProp : product.items?.[index] || itemProp;
 
 	const display = getProductItemDisplay({
 		item,
@@ -207,8 +207,11 @@ export const PlanFeatureRow = ({
 						{displayText}
 					</span>
 
-					{!isAiCreditSystem(feature?.type) && display.secondary_text && (
-						<span className="text-body-secondary"> {display.secondary_text}</span>
+					{display.secondary_text && (
+						<span className="text-body-secondary">
+							{" "}
+							{display.secondary_text}
+						</span>
 					)}
 				</p>
 


### PR DESCRIPTION
## Summary

Removes the AI-credit-specific UI from the plan editor so AI credit systems are configured and displayed exactly like classic credit systems. The AI credit system itself (feature editor with model markups, schema, and backend billing) is unchanged.

## Changes

- **IncludedUsage**: removed the "USD budget" label and `$`-prefixed input; AI credit items now use the standard "Quantity of {feature}" input.
- **BillingType**: removed the AI-specific Included/Priced descriptions ("Set an included USD budget...", "Bill model usage at the markup..."); generic copy is used instead.
- **EditPlanFeatureSheet**: the Price/tiers section is no longer hidden for AI credit items, and the "Edit Feature" button now opens the credit system sheet for AI credit systems (previously fell through to the generic feature sheet).
- **PlanFeatureRow**: secondary display text is no longer suppressed for AI credit items.
- **DummyPlanFeatureRow**: new-feature preview shows "100 Credits" instead of "$10.00 of ..." for any credit system type.
- **shared/productDisplayUtils**: removed the AI display branches ("$X of {feature}", "then charged based on model usage") so display strings are generated identically for all credit systems. Note this helper also feeds plan/product API display fields and invoice memos, which now render AI credits generically as well.
- **isAnyCreditSystem**: widened signature to accept `undefined | null`, matching `isAiCreditSystem`.
- Deleted the unused `getFeatureString` helper in `vite/.../formatProductItem.ts` (dead code carrying an AI branch).

## Testing

- `bun ts` passes in `server/` and `vite/`
- `bun test:unit` in `vite/`: 277 pass, 0 fail
- `npx ultracite check` clean on changed files (remaining warnings are pre-existing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the plan editor so AI credit systems are configured and displayed like any credit system. Removes USD‑budget UI/copy and standardizes plan/product/invoice text.

- **Refactors**
  - Plan editor: AI credits use the standard “Quantity of {feature}” input and generic Included/Priced copy.
  - Pricing: Show price/tiers for AI credit items; “Edit Feature” opens the credit system sheet for all credit systems.
  - Plan cards: Secondary text now shows for AI credit items; preview shows “100 Credits” for any credit system.
  - Display utils: Removed AI-specific branches; identical strings are generated for all credit systems across product/plan displays and invoice memos.
  - Utils: Replaced `isAiCreditSystem` checks with `isAnyCreditSystem`; `isAnyCreditSystem` accepts `undefined | null`. Removed dead `getFeatureString`.
  - No changes to the credit feature editor or billing logic.

<sup>Written for commit 9eba433769e8114d65c05b7ce55755bd0936a23f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

