### PR TITLE
chore: make trigger config dynamic

### DIFF
--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import {
 	additionalFiles,
 	additionalPackages,
@@ -7,27 +8,32 @@ import {
 import { defineConfig } from "@trigger.dev/sdk/v3";
 import { fetchInfisicalSecretsFromEnv } from "./server/src/external/infisical/fetchInfisicalSecrets.js";
 
-const workspacePackageJsonPaths = [
-	"server/package.json",
-	"shared/package.json",
-	"vite/package.json",
-	"scripts/package.json",
-	"apps/checkout/package.json",
-	"apps/docs/package.json",
-	"apps/website/package.json",
-	"apps/leaf/package.json",
-	"apps/sdk-test/package.json",
-	"packages/atmn/package.json",
-	"packages/atmn-tests/package.json",
-	"packages/auth/package.json",
-	"packages/logging/package.json",
-	"packages/mcp/package.json",
-	"packages/sdk/package.json",
-	"packages/autumn-js/package.json",
-	"packages/openapi/package.json",
-	"packages/ksuid/package.json",
-	"packages/stripe-sync/package.json",
-];
+// Derived from the root package.json workspaces so new workspace packages are
+// picked up automatically — the deploy image COPYs every workspace
+// package.json, and a missing one makes `bun install` fail against bun.lock.
+const rootPackageJson = JSON.parse(readFileSync("package.json", "utf-8")) as {
+	workspaces: string[] | { packages: string[] };
+};
+
+const workspacePatterns = Array.isArray(rootPackageJson.workspaces)
+	? rootPackageJson.workspaces
+	: rootPackageJson.workspaces.packages;
+
+const expandWorkspacePattern = (pattern: string): string[] => {
+	if (!pattern.includes("*")) {
+		return [pattern];
+	}
+	const baseDir = pattern.slice(0, pattern.indexOf("*")).replace(/\/$/, "");
+	return readdirSync(baseDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => `${baseDir}/${entry.name}`);
+};
+
+const workspacePackageJsonPaths = workspacePatterns
+	.flatMap(expandWorkspacePattern)
+	.map((dir) => `${dir}/package.json`)
+	.filter((path) => existsSync(path))
+	.sort();
 
 const workspacePackageDirs = workspacePackageJsonPaths.map((path) =>
 	path.replace(/\/package\.json$/, ""),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make Trigger config discover workspace packages dynamically from the root `package.json` workspaces. New packages are picked up automatically and the deploy image avoids `bun install` failures from missing workspace `package.json` files.

- **Refactors**
  - Replace hardcoded workspace list with dynamic discovery from root `package.json` `workspaces` (glob expansion).
  - Include only existing `package.json` files and sort the list for stable installs.

<sup>Written for commit df62e3ffa1016d11b70e723eb2873f6f094bf658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the manually-maintained list of workspace `package.json` paths in `trigger.config.ts` with dynamic discovery by reading and expanding the `workspaces` field from the root `package.json`, ensuring that newly-added workspace packages (e.g. `packages/ai-sdk`) are automatically included in the Trigger.dev deploy image without requiring a manual config update.

- **[Improvements]** Dynamic workspace discovery reads the root `package.json` at config-evaluation time, handles both the Bun `{ packages: [...] }` object format and the plain array format, and supports basic glob patterns (e.g. `packages/*`) via `readdirSync`, with a final `existsSync` guard so directories without a `package.json` are silently skipped.
- **[Bug fixes]** The old hardcoded list was missing the `packages/ai-sdk` workspace entry (present in `package.json` but absent from the list), which would have caused `bun install` to fail in the deploy image.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a straightforward automation of a previously manual list and fixes a real missing-entry bug.

The logic is correct for the current workspace configuration (all explicit paths, no globs). The one edge case worth noting is that the glob-expansion branch does not filter out node_modules or hidden directories, which could silently include unintended entries if glob patterns are ever added to the root package.json — but that path is not exercised today.

trigger.config.ts — specifically the expandWorkspacePattern glob branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| trigger.config.ts | Replaces hardcoded workspace package.json path list with dynamic discovery from the root package.json; correctly handles both array and object workspace formats, plus basic glob expansion via readdirSync. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["readFileSync('package.json')"] --> B["Parse workspaces field"]
    B --> C{Array or object?}
    C -- "Array" --> D["workspacePatterns = workspaces"]
    C -- "Object with .packages" --> E["workspacePatterns = workspaces.packages"]
    D --> F["flatMap(expandWorkspacePattern)"]
    E --> F
    F --> G{Pattern contains '*'?}
    G -- "No" --> H["Return [pattern] as-is"]
    G -- "Yes" --> I["readdirSync(baseDir)\n.filter(isDirectory)\n.map(entry => baseDir/entry.name)"]
    H --> J["map(dir => dir/package.json)"]
    I --> J
    J --> K["filter(existsSync)"]
    K --> L[".sort()"]
    L --> M["workspacePackageJsonPaths"]
    M --> N["additionalFiles({ files: ... })"]
    M --> O["COPY instructions in Docker layer"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
trigger.config.ts:27-29
When a workspace uses a glob pattern (e.g. `"packages/*"`), `expandWorkspacePattern` calls `readdirSync` and returns every subdirectory — including `node_modules` (if it exists under that base dir) and any hidden directories. Those directories then pass through `existsSync(path)` as long as they happen to contain a `package.json`, which could silently pull in unintended entries. Filtering to entries that aren't `node_modules` (or aren't hidden) is a small defensive guard that makes the behaviour unambiguous if glob patterns are ever added to the root `package.json`.

```suggestion
	return readdirSync(baseDir, { withFileTypes: true })
		.filter((entry) => entry.isDirectory() && entry.name !== "node_modules" && !entry.name.startsWith("."))
		.map((entry) => `${baseDir}/${entry.name}`);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: make trigger config dynamic"](https://github.com/useautumn/autumn/commit/df62e3ffa1016d11b70e723eb2873f6f094bf658) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37196436)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->