### PR TITLE
Fix usage limit ai credit dimension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: fix-health-check-redis-disabled-detection feat/track-rate-limit-redis feat/events-hourly-rollup fix/analytics-tz-bucket-offset uw-1-storage
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: fix-health-check-redis-disabled-detection feat/track-rate-limit-redis feat/events-hourly-rollup fix/analytics-tz-bucket-offset uw-1-storage fix/usage-limit-ai-credit-dimension
 
 jobs:
   checks:

--- a/server/tests/integration/balances/track/basic/track-tokens-limits.test.ts
+++ b/server/tests/integration/balances/track/basic/track-tokens-limits.test.ts
@@ -1,17 +1,22 @@
 import { expect, test } from "bun:test";
 
 import type { ApiCustomerV5, TrackResponseV3 } from "@autumn/shared";
-import { ErrCode } from "@autumn/shared";
+import { ApiVersion, ErrCode, ResetInterval } from "@autumn/shared";
+import { setCustomerUsageLimit } from "@tests/integration/balances/utils/usage-limit-utils/customerUsageLimitUtils.js";
 import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { expectUsageLimitCorrect } from "@tests/integration/utils/expectUsageLimitCorrect.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
 
 // custom/internal-model: input_cost=5 $/M, output_cost=15 $/M, markup=0%
 // in=5000/out=2500 -> 0.0625; in=10000/out=5000 -> 0.125
+
+const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
 
 // ═══════════════════════════════════════════════════════════════════
 // TRACK-TOKENS-LIM-1: default behavior caps deduction at zero balance
@@ -249,6 +254,66 @@ test.concurrent(
 			featureId: TestFeature.AiCredits,
 			remaining: 999.875,
 			usage: 0.125,
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// TRACK-TOKENS-LIM-6: a usage limit counts AI credits consumed, not calls
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("track-tokens-lim-6: usage limit counts AI credits consumed, not call count")}`,
+	async () => {
+		const aiCreditsItem = items.free({
+			featureId: TestFeature.AiCredits,
+			includedUsage: 1000,
+		});
+		const freeProd = products.base({ id: "free", items: [aiCreditsItem] });
+
+		const { customerId } = await initScenario({
+			customerId: "track-tokens-lim-6",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		// Cap AI-credit spend at 100 credits/day — well above one call's cost.
+		await setCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.AiCredits,
+			limit: 100,
+			interval: ResetInterval.Day,
+		});
+
+		// One token track costs 0.125 credits.
+		await autumnV2_3.post("/track_tokens", {
+			customer_id: customerId,
+			feature_id: TestFeature.AiCredits,
+			model_id: "custom/internal-model",
+			input_tokens: 10000,
+			output_tokens: 5000,
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		// The balance is deducted by the dollar cost...
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.AiCredits,
+			remaining: 999.875,
+			usage: 0.125,
+		});
+		// ...and the cap counter must reflect that SAME spend. Regression: before
+		// the usage-window dimension fix this counted 1 (the call), not 0.125.
+		expectUsageLimitCorrect({
+			customer,
+			featureId: TestFeature.AiCredits,
+			usage: 0.125,
+			limit: 100,
+			interval: ResetInterval.Day,
 		});
 	},
 );

--- a/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
+++ b/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
@@ -25,6 +25,11 @@ const creditsFeature = {
 	internal_id: "icredits",
 	type: FeatureType.CreditSystem,
 } as Feature;
+const aiCreditsFeature = {
+	id: "ai_credits",
+	internal_id: "iai_credits",
+	type: FeatureType.AiCreditSystem,
+} as Feature;
 // Credit system whose schema contains action1, for the membership-anchor path.
 const creditsContainingAction1 = {
 	id: "credits",
@@ -200,6 +205,25 @@ describe("fullSubjectToUsageWindowLimits", () => {
 			}),
 			featureIds: ["credits"],
 			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			dimension_type: "balance",
+			dimension_feature_id: null,
+		});
+	});
+
+	test("an ai-credit-system feature resolves to the balance dimension", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				usageLimits: [
+					{ feature_id: "ai_credits", limit: 100, interval: ResetInterval.Day },
+				],
+			}),
+			featureIds: ["ai_credits"],
+			features: [aiCreditsFeature],
 			now: NOW,
 		});
 

--- a/shared/utils/usageWindowUtils/convertUsageWindow/getUsageWindowDimension.ts
+++ b/shared/utils/usageWindowUtils/convertUsageWindow/getUsageWindowDimension.ts
@@ -1,11 +1,11 @@
 import type { UsageWindowDimension } from "../../../models/cusProductModels/cusEntModels/usageWindowModels.js";
-import { FeatureType } from "../../../models/featureModels/featureEnums.js";
 import type { Feature } from "../../../models/featureModels/featureModels.js";
+import { isAnyCreditSystem } from "../../featureUtils/classifyFeature/isAnyCreditSystem.js";
 
 /**
  * Which dimension a usage limit on `feature` counts against:
- * - a credit-system feature caps the credit POOL (`balance` dimension,
- *   counted in credits drained);
+ * - any credit-system feature (classic or AI token-based) caps the credit
+ *   POOL (`balance` dimension, counted in credits drained);
  * - any other feature caps that feature's own usage (`metered_feature`
  *   dimension, counted in tracked units).
  */
@@ -17,7 +17,7 @@ export const getUsageWindowDimension = ({
 	dimensionType: UsageWindowDimension;
 	dimensionFeatureId: string | null;
 } => {
-	const isCreditSystem = feature.type === FeatureType.CreditSystem;
+	const isCreditSystem = isAnyCreditSystem(feature.type);
 
 	return {
 		dimensionType: isCreditSystem ? "balance" : "metered_feature",


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes usage limits for AI-credit features to count credits consumed, not calls, so caps now match actual spend via the balance dimension.

- **Bug Fixes**
  - Treat all credit systems (classic and AI) as `balance` usage-window dimension using isAnyCreditSystem.
  - Added unit and integration tests to verify AI-credit limits track fractional spend (e.g., 0.125 credits) on token usage.
  - Added `fix/usage-limit-ai-credit-dimension` to `STAGING_DEPLOY_BRANCH_ALLOWLIST` for staging deploys.

<sup>Written for commit abec351f5186f4e8f6a6dd0cb0bf868b332a2bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where usage limits on AI-credit features (`AiCreditSystem`) were being tracked against the `metered_feature` dimension (counting API calls) instead of the `balance` dimension (counting credits drained). The one-line core fix replaces a hardcoded `FeatureType.CreditSystem` equality check with the `isAnyCreditSystem()` helper that covers both credit types.

- **[Bug fixes]** `getUsageWindowDimension.ts`: replaces `feature.type === FeatureType.CreditSystem` with `isAnyCreditSystem(feature.type)` so `AiCreditSystem` features also resolve to the `balance` dimension, tracking consumed credits rather than call count.
- **[Improvements]** Adds a unit test verifying the dimension resolution for `AiCreditSystem` features, and an integration test (`track-tokens-lim-6`) confirming the usage counter reflects credit spend (0.125) rather than call count (1).
- **[Improvements]** `build.yml`: adds the `fix/usage-limit-ai-credit-dimension` branch to the staging deploy allowlist.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line targeted fix with both a unit test and an integration test covering the regression.

The fix is minimal and surgical: one equality check replaced by an existing well-tested helper. The new unit test directly asserts the corrected dimension resolution for AiCreditSystem, and the integration test confirms fractional credit spend is recorded correctly end-to-end. No other call sites or data paths appear affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/usageWindowUtils/convertUsageWindow/getUsageWindowDimension.ts | Core bug fix: swaps hardcoded CreditSystem equality check for isAnyCreditSystem() to include AiCreditSystem in the balance dimension path. |
| server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts | New unit test verifies AiCreditSystem features resolve to the balance dimension with null dimensionFeatureId; covers the regression directly. |
| server/tests/integration/balances/track/basic/track-tokens-limits.test.ts | New integration test (track-tokens-lim-6) validates that usage limit usage reflects fractional credit spend, not integer call count. |
| .github/workflows/build.yml | Adds the PR's branch to the staging deploy allowlist; routine and safe. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getUsageWindowDimension called] --> B{isAnyCreditSystem\nfeature.type}
    B -- "CreditSystem\nOR AiCreditSystem" --> C["dimensionType: 'balance'\ndimensionFeatureId: null\n(counts credits drained)"]
    B -- "Metered / Boolean / other" --> D["dimensionType: 'metered_feature'\ndimensionFeatureId: feature.id\n(counts tracked units)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["deploy from pr"](https://github.com/useautumn/autumn/commit/abec351f5186f4e8f6a6dd0cb0bf868b332a2bdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37199502)</sub>

<!-- /greptile_comment -->