### PR TITLE
Release 12/06/2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: fix-health-check-redis-disabled-detection feat/track-rate-limit-redis feat/events-hourly-rollup fix/analytics-tz-bucket-offset uw-1-storage
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: fix-health-check-redis-disabled-detection feat/track-rate-limit-redis feat/events-hourly-rollup fix/analytics-tz-bucket-offset uw-1-storage fix/usage-limit-ai-credit-dimension
 
 jobs:
   checks:

--- a/server/tests/integration/balances/track/basic/track-tokens-limits.test.ts
+++ b/server/tests/integration/balances/track/basic/track-tokens-limits.test.ts
@@ -1,17 +1,22 @@
 import { expect, test } from "bun:test";
 
 import type { ApiCustomerV5, TrackResponseV3 } from "@autumn/shared";
-import { ErrCode } from "@autumn/shared";
+import { ApiVersion, ErrCode, ResetInterval } from "@autumn/shared";
+import { setCustomerUsageLimit } from "@tests/integration/balances/utils/usage-limit-utils/customerUsageLimitUtils.js";
 import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { expectUsageLimitCorrect } from "@tests/integration/utils/expectUsageLimitCorrect.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
 
 // custom/internal-model: input_cost=5 $/M, output_cost=15 $/M, markup=0%
 // in=5000/out=2500 -> 0.0625; in=10000/out=5000 -> 0.125
+
+const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
 
 // ═══════════════════════════════════════════════════════════════════
 // TRACK-TOKENS-LIM-1: default behavior caps deduction at zero balance
@@ -249,6 +254,66 @@ test.concurrent(
 			featureId: TestFeature.AiCredits,
 			remaining: 999.875,
 			usage: 0.125,
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// TRACK-TOKENS-LIM-6: a usage limit counts AI credits consumed, not calls
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("track-tokens-lim-6: usage limit counts AI credits consumed, not call count")}`,
+	async () => {
+		const aiCreditsItem = items.free({
+			featureId: TestFeature.AiCredits,
+			includedUsage: 1000,
+		});
+		const freeProd = products.base({ id: "free", items: [aiCreditsItem] });
+
+		const { customerId } = await initScenario({
+			customerId: "track-tokens-lim-6",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd] }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		// Cap AI-credit spend at 100 credits/day — well above one call's cost.
+		await setCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.AiCredits,
+			limit: 100,
+			interval: ResetInterval.Day,
+		});
+
+		// One token track costs 0.125 credits.
+		await autumnV2_3.post("/track_tokens", {
+			customer_id: customerId,
+			feature_id: TestFeature.AiCredits,
+			model_id: "custom/internal-model",
+			input_tokens: 10000,
+			output_tokens: 5000,
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		// The balance is deducted by the dollar cost...
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.AiCredits,
+			remaining: 999.875,
+			usage: 0.125,
+		});
+		// ...and the cap counter must reflect that SAME spend. Regression: before
+		// the usage-window dimension fix this counted 1 (the call), not 0.125.
+		expectUsageLimitCorrect({
+			customer,
+			featureId: TestFeature.AiCredits,
+			usage: 0.125,
+			limit: 100,
+			interval: ResetInterval.Day,
 		});
 	},
 );

--- a/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
+++ b/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
@@ -25,6 +25,11 @@ const creditsFeature = {
 	internal_id: "icredits",
 	type: FeatureType.CreditSystem,
 } as Feature;
+const aiCreditsFeature = {
+	id: "ai_credits",
+	internal_id: "iai_credits",
+	type: FeatureType.AiCreditSystem,
+} as Feature;
 // Credit system whose schema contains action1, for the membership-anchor path.
 const creditsContainingAction1 = {
 	id: "credits",
@@ -200,6 +205,25 @@ describe("fullSubjectToUsageWindowLimits", () => {
 			}),
 			featureIds: ["credits"],
 			features: [creditsFeature],
+			now: NOW,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			dimension_type: "balance",
+			dimension_feature_id: null,
+		});
+	});
+
+	test("an ai-credit-system feature resolves to the balance dimension", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				usageLimits: [
+					{ feature_id: "ai_credits", limit: 100, interval: ResetInterval.Day },
+				],
+			}),
+			featureIds: ["ai_credits"],
+			features: [aiCreditsFeature],
 			now: NOW,
 		});
 

--- a/shared/utils/usageWindowUtils/convertUsageWindow/getUsageWindowDimension.ts
+++ b/shared/utils/usageWindowUtils/convertUsageWindow/getUsageWindowDimension.ts
@@ -1,11 +1,11 @@
 import type { UsageWindowDimension } from "../../../models/cusProductModels/cusEntModels/usageWindowModels.js";
-import { FeatureType } from "../../../models/featureModels/featureEnums.js";
 import type { Feature } from "../../../models/featureModels/featureModels.js";
+import { isAnyCreditSystem } from "../../featureUtils/classifyFeature/isAnyCreditSystem.js";
 
 /**
  * Which dimension a usage limit on `feature` counts against:
- * - a credit-system feature caps the credit POOL (`balance` dimension,
- *   counted in credits drained);
+ * - any credit-system feature (classic or AI token-based) caps the credit
+ *   POOL (`balance` dimension, counted in credits drained);
  * - any other feature caps that feature's own usage (`metered_feature`
  *   dimension, counted in tracked units).
  */
@@ -17,7 +17,7 @@ export const getUsageWindowDimension = ({
 	dimensionType: UsageWindowDimension;
 	dimensionFeatureId: string | null;
 } => {
-	const isCreditSystem = feature.type === FeatureType.CreditSystem;
+	const isCreditSystem = isAnyCreditSystem(feature.type);
 
 	return {
 		dimensionType: isCreditSystem ? "balance" : "metered_feature",

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import {
 	additionalFiles,
 	additionalPackages,
@@ -7,27 +8,32 @@ import {
 import { defineConfig } from "@trigger.dev/sdk/v3";
 import { fetchInfisicalSecretsFromEnv } from "./server/src/external/infisical/fetchInfisicalSecrets.js";
 
-const workspacePackageJsonPaths = [
-	"server/package.json",
-	"shared/package.json",
-	"vite/package.json",
-	"scripts/package.json",
-	"apps/checkout/package.json",
-	"apps/docs/package.json",
-	"apps/website/package.json",
-	"apps/leaf/package.json",
-	"apps/sdk-test/package.json",
-	"packages/atmn/package.json",
-	"packages/atmn-tests/package.json",
-	"packages/auth/package.json",
-	"packages/logging/package.json",
-	"packages/mcp/package.json",
-	"packages/sdk/package.json",
-	"packages/autumn-js/package.json",
-	"packages/openapi/package.json",
-	"packages/ksuid/package.json",
-	"packages/stripe-sync/package.json",
-];
+// Derived from the root package.json workspaces so new workspace packages are
+// picked up automatically — the deploy image COPYs every workspace
+// package.json, and a missing one makes `bun install` fail against bun.lock.
+const rootPackageJson = JSON.parse(readFileSync("package.json", "utf-8")) as {
+	workspaces: string[] | { packages: string[] };
+};
+
+const workspacePatterns = Array.isArray(rootPackageJson.workspaces)
+	? rootPackageJson.workspaces
+	: rootPackageJson.workspaces.packages;
+
+const expandWorkspacePattern = (pattern: string): string[] => {
+	if (!pattern.includes("*")) {
+		return [pattern];
+	}
+	const baseDir = pattern.slice(0, pattern.indexOf("*")).replace(/\/$/, "");
+	return readdirSync(baseDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => `${baseDir}/${entry.name}`);
+};
+
+const workspacePackageJsonPaths = workspacePatterns
+	.flatMap(expandWorkspacePattern)
+	.map((dir) => `${dir}/package.json`)
+	.filter((path) => existsSync(path))
+	.sort();
 
 const workspacePackageDirs = workspacePackageJsonPaths.map((path) =>
 	path.replace(/\/package\.json$/, ""),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes AI-credit usage limits to count credits consumed (balance) instead of calls, and makes the Trigger deploy config auto-discover workspace packages to prevent deploy install failures.

- **Bug Fixes**
  - Any credit-system feature (classic or AI) now resolves to the balance dimension via `getUsageWindowDimension` using `isAnyCreditSystem`.
  - Tests added: an integration case validating AI credits count 0.125 credits per call, and a unit test confirming ai-credit-system maps to balance.

- **Refactors**
  - `trigger.config.ts` derives workspace package paths from root `workspaces`, expands globs, filters existing, and sorts, so new packages are included and `bun install` doesn’t fail in the image.
  - CI: updated `STAGING_DEPLOY_BRANCH_ALLOWLIST` to include `fix/usage-limit-ai-credit-dimension`.

<sup>Written for commit ebc5014b6251f5a57f7de747cd5b58daf9b033da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where usage limits on `AiCreditSystem` features were incorrectly counting API calls (1 per track) instead of the fractional credits consumed, by widening the `getUsageWindowDimension` guard from `FeatureType.CreditSystem` only to `isAnyCreditSystem()`. It also refactors `trigger.config.ts` to auto-discover workspace `package.json` paths from the root `package.json` rather than maintaining a hardcoded list.

- **Bug fixes** — `getUsageWindowDimension` now routes `AiCreditSystem` features to the `balance` dimension (credits drained), matching the existing `CreditSystem` behaviour and fixing the regression where the cap counter reflected call count instead of spend.
- **Improvements** — Unit and integration tests (`fullSubjectToUsageWindowLimits`, `track-tokens-lim-6`) are added to cover the corrected dimension resolution end-to-end.
- **Improvements** — `trigger.config.ts` workspace path discovery is now derived from `package.json` workspaces globs at build time, removing the need for manual list maintenance when new packages are added.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core fix is minimal, correctly targeted, and backed by both unit and integration tests. The trigger.config.ts change introduces a minor unguarded directory read that is worth addressing.

The dimension-fix and its tests are clean. The trigger.config.ts refactor is a useful DRY improvement, but `readdirSync` on a potentially non-existent base directory could crash config loading if a workspace pattern ever references a directory that doesn't exist on disk yet.

trigger.config.ts — the `expandWorkspacePattern` function calls `readdirSync` without checking whether the base directory exists first.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/usageWindowUtils/convertUsageWindow/getUsageWindowDimension.ts | Core bug fix: replaces a direct FeatureType.CreditSystem equality check with isAnyCreditSystem(), ensuring AiCreditSystem features also resolve to the balance dimension instead of the metered_feature dimension. |
| server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts | Adds a unit test covering the AiCreditSystem → balance dimension path; well-structured alongside the existing CreditSystem test case. |
| server/tests/integration/balances/track/basic/track-tokens-limits.test.ts | Adds integration test track-tokens-lim-6 that verifies the usage-limit counter records fractional credit cost (0.125) rather than call count (1), directly exercising the regression path. |
| trigger.config.ts | Replaces a hardcoded list of workspace package.json paths with filesystem-derived auto-discovery from root package.json workspaces; minor edge cases around non-standard glob patterns and missing directory guards. |
| .github/workflows/build.yml | Adds fix/usage-limit-ai-credit-dimension to the staging deploy branch allowlist; routine housekeeping. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[usage limit check on feature] --> B{isAnyCreditSystem?}
    B -- "CreditSystem OR AiCreditSystem" --> C[dimensionType = 'balance'\ndimensionFeatureId = null\ncounts credits drained]
    B -- "Metered / other" --> D[dimensionType = 'metered_feature'\ndimensionFeatureId = feature.id\ncounts tracked units]
    C --> E[usage window key built on balance pool]
    D --> F[usage window key built on feature usage]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
trigger.config.ts:26-29
`readdirSync` throws synchronously if `baseDir` doesn't exist on disk. If a workspace pattern in `package.json` references a directory that hasn't been created yet (e.g., a scaffolded but empty package), the entire `trigger.config.ts` module will fail to load at build time. A simple existence guard keeps the same filtering semantics without the crash risk.

```suggestion
	const baseDir = pattern.slice(0, pattern.indexOf("*")).replace(/\/$/, "");
	if (!existsSync(baseDir)) {
		return [];
	}
	return readdirSync(baseDir, { withFileTypes: true })
		.filter((entry) => entry.isDirectory())
		.map((entry) => `${baseDir}/${entry.name}`);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1912 from useautumn/..."](https://github.com/useautumn/autumn/commit/ebc5014b6251f5a57f7de747cd5b58daf9b033da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37201296)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->