### PR TITLE
chore: add first time condition to rewards

### DIFF
--- a/server/src/external/stripe/coupons/resolvePromotionCode.ts
+++ b/server/src/external/stripe/coupons/resolvePromotionCode.ts
@@ -46,6 +46,7 @@ export const resolvePromotionCode = async ({
 		return {
 			source: { coupon: couponRaw },
 			promotionCodeId: promo.id,
+			promotionCode: promo.code,
 			firstTimeTransaction: promo.restrictions?.first_time_transaction,
 		};
 	} catch (error) {

--- a/server/src/external/stripe/coupons/resolvePromotionCode.ts
+++ b/server/src/external/stripe/coupons/resolvePromotionCode.ts
@@ -46,6 +46,7 @@ export const resolvePromotionCode = async ({
 		return {
 			source: { coupon: couponRaw },
 			promotionCodeId: promo.id,
+			firstTimeTransaction: promo.restrictions?.first_time_transaction,
 		};
 	} catch (error) {
 		if (error instanceof RecaseError) throw error;

--- a/server/src/external/stripe/coupons/resolvePromotionCode.ts
+++ b/server/src/external/stripe/coupons/resolvePromotionCode.ts
@@ -46,7 +46,6 @@ export const resolvePromotionCode = async ({
 		return {
 			source: { coupon: couponRaw },
 			promotionCodeId: promo.id,
-			promotionCode: promo.code,
 			firstTimeTransaction: promo.restrictions?.first_time_transaction,
 		};
 	} catch (error) {

--- a/server/src/external/stripe/customers/index.ts
+++ b/server/src/external/stripe/customers/index.ts
@@ -1,4 +1,5 @@
 export * from "./operations/createStripeCustomer.js";
 export * from "./operations/getExpandedStripeCustomer.js";
 export * from "./operations/getOrCreateStripeCustomer.js";
+export * from "./operations/isFirstTimeStripeCustomer.js";
 export * from "./utils/convertStripeCustomer.js";

--- a/server/src/external/stripe/customers/operations/isFirstTimeStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/isFirstTimeStripeCustomer.ts
@@ -1,9 +1,11 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import type Stripe from "stripe";
 
-/** Per Stripe's first_time_transaction rule, any non-void invoice counts */
+/**
+ * Drafts (and null statuses) don't count — never finalized or collected, and a
+ * false block is a hard denial while a false pass falls back to Stripe's check.
+ */
 const BLOCKING_INVOICE_STATUSES: Stripe.Invoice.Status[] = [
-	"draft",
 	"open",
 	"paid",
 	"uncollectible",

--- a/server/src/external/stripe/customers/operations/isFirstTimeStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/isFirstTimeStripeCustomer.ts
@@ -1,0 +1,78 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+import type Stripe from "stripe";
+
+/** Per Stripe's first_time_transaction rule, any non-void invoice counts */
+const BLOCKING_INVOICE_STATUSES: Stripe.Invoice.Status[] = [
+	"draft",
+	"open",
+	"paid",
+	"uncollectible",
+];
+
+/**
+ * Whether the customer has no prior successful payments or non-void invoices —
+ * Stripe's `restrictions.first_time_transaction` definition.
+ */
+export const isFirstTimeStripeCustomer = async ({
+	stripeCli,
+	stripeCustomerId,
+}: {
+	stripeCli: Stripe;
+	stripeCustomerId?: string | null;
+}): Promise<boolean> => {
+	if (!stripeCustomerId) return true;
+
+	const hasSuccessfulPayment = async () => {
+		for await (const charge of stripeCli.charges.list({
+			customer: stripeCustomerId,
+			limit: 100,
+		})) {
+			if (charge.status === "succeeded") return true;
+		}
+		return false;
+	};
+
+	const hasBlockingInvoice = async () => {
+		for await (const invoice of stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			limit: 100,
+		})) {
+			if (invoice.status && BLOCKING_INVOICE_STATUSES.includes(invoice.status))
+				return true;
+		}
+		return false;
+	};
+
+	const [paymentFound, invoiceFound] = await Promise.all([
+		hasSuccessfulPayment(),
+		hasBlockingInvoice(),
+	]);
+
+	return !(paymentFound || invoiceFound);
+};
+
+/** Throws PromoCodeFirstTimeOnly when the customer has prior transactions */
+export const assertFirstTimeStripeCustomer = async ({
+	stripeCli,
+	stripeCustomerId,
+	promoCode,
+}: {
+	stripeCli: Stripe;
+	stripeCustomerId?: string | null;
+	promoCode?: string;
+}) => {
+	const isFirstTime = await isFirstTimeStripeCustomer({
+		stripeCli,
+		stripeCustomerId,
+	});
+
+	if (isFirstTime) return;
+
+	throw new RecaseError({
+		message: promoCode
+			? `Promo code "${promoCode}" is only valid for first-time purchases`
+			: "This promo code is only valid for first-time purchases",
+		code: ErrCode.PromoCodeFirstTimeOnly,
+		statusCode: 400,
+	});
+};

--- a/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
+++ b/server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts
@@ -225,6 +225,9 @@ export const createStripeCoupon = async ({
 				coupon: stripeCoupon.id,
 			},
 			code: promoCode.code,
+			...(promoCode.first_time_transaction
+				? { restrictions: { first_time_transaction: true } }
+				: {}),
 		});
 	}
 };

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeDiscountsForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeDiscountsForBilling.ts
@@ -9,6 +9,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { resolveParamDiscounts } from "../utils/discounts/resolveParamDiscounts";
 import { stripeCustomerToDiscounts } from "../utils/discounts/stripeCustomerToDiscounts";
 import { subToDiscounts } from "../utils/discounts/subToDiscounts";
+import { validateFirstTimeDiscounts } from "../utils/discounts/validateFirstTimeDiscounts";
 
 /**
  * Extracts discounts from already-fetched Stripe subscription or customer.
@@ -109,6 +110,20 @@ export const fetchStripeDiscountsForBilling = async ({
 	const resolvedParamDiscounts = await resolveParamDiscounts({
 		stripeCli,
 		discounts: paramDiscounts,
+	});
+
+	// Re-sent codes already on the subscription are deduped below, not re-redeemed
+	const existingCouponIds = new Set(
+		existingDiscounts.map((discount) => discount.source.coupon.id),
+	);
+	const newParamDiscounts = resolvedParamDiscounts.filter(
+		(discount) => !existingCouponIds.has(discount.source.coupon.id),
+	);
+
+	await validateFirstTimeDiscounts({
+		stripeCli,
+		discounts: newParamDiscounts,
+		stripeCustomerId: stripeCustomer?.id,
 	});
 
 	// Merge existing + param discounts, deduplicating by coupon ID.

--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/validateFirstTimeDiscounts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/validateFirstTimeDiscounts.ts
@@ -25,6 +25,5 @@ export const validateFirstTimeDiscounts = async ({
 	await assertFirstTimeStripeCustomer({
 		stripeCli,
 		stripeCustomerId,
-		promoCode: firstTimeDiscount.promotionCode,
 	});
 };

--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/validateFirstTimeDiscounts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/validateFirstTimeDiscounts.ts
@@ -1,0 +1,26 @@
+import type { StripeDiscountWithCoupon } from "@autumn/shared";
+import type Stripe from "stripe";
+import { assertFirstTimeStripeCustomer } from "@/external/stripe/customers";
+
+/**
+ * Rejects first-time-restricted promo codes for customers with prior payments.
+ * No Stripe customer yet → necessarily first-time → skip.
+ */
+export const validateFirstTimeDiscounts = async ({
+	stripeCli,
+	discounts,
+	stripeCustomerId,
+}: {
+	stripeCli: Stripe;
+	discounts: StripeDiscountWithCoupon[];
+	stripeCustomerId?: string;
+}) => {
+	const hasFirstTimeRestriction = discounts.some(
+		(discount) => discount.firstTimeTransaction,
+	);
+
+	if (!hasFirstTimeRestriction) return;
+	if (!stripeCustomerId) return;
+
+	await assertFirstTimeStripeCustomer({ stripeCli, stripeCustomerId });
+};

--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/validateFirstTimeDiscounts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/validateFirstTimeDiscounts.ts
@@ -15,12 +15,16 @@ export const validateFirstTimeDiscounts = async ({
 	discounts: StripeDiscountWithCoupon[];
 	stripeCustomerId?: string;
 }) => {
-	const hasFirstTimeRestriction = discounts.some(
+	const firstTimeDiscount = discounts.find(
 		(discount) => discount.firstTimeTransaction,
 	);
 
-	if (!hasFirstTimeRestriction) return;
+	if (!firstTimeDiscount) return;
 	if (!stripeCustomerId) return;
 
-	await assertFirstTimeStripeCustomer({ stripeCli, stripeCustomerId });
+	await assertFirstTimeStripeCustomer({
+		stripeCli,
+		stripeCustomerId,
+		promoCode: firstTimeDiscount.promotionCode,
+	});
 };

--- a/server/src/internal/rewards/actions/redeemPromoCode.ts
+++ b/server/src/internal/rewards/actions/redeemPromoCode.ts
@@ -7,6 +7,8 @@ import {
 	RecaseError,
 	RewardType,
 } from "@autumn/shared";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { assertFirstTimeStripeCustomer } from "@/external/stripe/customers/index.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { prepareNewBalanceForInsertion } from "@/internal/balances/createBalance/prepareNewBalanceForInsertion.js";
 import { CusService } from "@/internal/customers/CusService.js";
@@ -112,6 +114,16 @@ export const redeemPromoCode = async ({
 			message: `Customer "${customerId}" has already redeemed this reward`,
 			code: ErrCode.CustomerAlreadyRedeemedReferralCode,
 			statusCode: 400,
+		});
+	}
+
+	// 4.5. First-time restriction (no Stripe customer → necessarily first-time)
+	if (promoCode.first_time_transaction && fullCustomer.processor?.id) {
+		const stripeCli = createStripeCli({ org, env });
+		await assertFirstTimeStripeCustomer({
+			stripeCli,
+			stripeCustomerId: fullCustomer.processor.id,
+			promoCode: code,
 		});
 	}
 

--- a/server/tests/integration/billing/attach/discounts/attach-discounts-first-time.test.ts
+++ b/server/tests/integration/billing/attach/discounts/attach-discounts-first-time.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration tests for promotion codes restricted to first-time transactions.
+ *
+ * Tests:
+ * - First-time customer can redeem a restricted promo code
+ * - Customer with a prior paid purchase is blocked with PromoCodeFirstTimeOnly
+ */
+
+import { test } from "bun:test";
+import { type ApiCustomerV3, ErrCode } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect.js";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import {
+	createPercentCoupon,
+	createPromotionCode,
+} from "../../utils/discounts/discountTestUtils.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: First-time customer can redeem a first-time-only promo code
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer on free product (no prior payments)
+ * - Create 25% coupon + promotion code with first_time_transaction restriction
+ * - Attach pro ($20/mo) with the promo code
+ *
+ * Expected:
+ * - Pro active, invoice = $20 * 0.75 = $15
+ */
+test.concurrent(
+	`${chalk.yellowBright("attach-discount-first-time 1: first-time customer can redeem")}`,
+	async () => {
+		const customerId = "att-disc-ft-fresh";
+
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+			],
+			actions: [s.billing.attach({ productId: free.id })],
+		});
+
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		const coupon = await createPercentCoupon({ stripeCli, percentOff: 25 });
+		const promoCode = await createPromotionCode({
+			stripeCli,
+			coupon,
+			code: `FTFRESH-${customerId}`,
+			firstTimeTransaction: true,
+		});
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+			discounts: [{ promotion_code: promoCode.code }],
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		await expectCustomerProducts({
+			customer,
+			active: [pro.id],
+			notPresent: [free.id],
+		});
+
+		expectCustomerInvoiceCorrect({
+			customer,
+			count: 1,
+			latestTotal: 15,
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Customer with prior purchase is blocked
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - Customer attaches pro ($20/mo) — now has a paid invoice
+ * - Create 25% coupon + promotion code with first_time_transaction restriction
+ * - Attach premium ($50/mo) with the promo code
+ *
+ * Expected:
+ * - PromoCodeFirstTimeOnly error, premium not attached
+ */
+test.concurrent(
+	`${chalk.yellowBright("attach-discount-first-time 2: prior purchase blocked")}`,
+	async () => {
+		const customerId = "att-disc-ft-blocked";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		const coupon = await createPercentCoupon({ stripeCli, percentOff: 25 });
+		const promoCode = await createPromotionCode({
+			stripeCli,
+			coupon,
+			code: `FTBLOCK-${customerId}`,
+			firstTimeTransaction: true,
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.PromoCodeFirstTimeOnly,
+			func: async () => {
+				await autumnV1.billing.attach({
+					customer_id: customerId,
+					product_id: premium.id,
+					discounts: [{ promotion_code: promoCode.code }],
+				});
+			},
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer,
+			active: [pro.id],
+			notPresent: [premium.id],
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: Re-sending a code already on the subscription is deduped, not blocked
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Scenario:
+ * - First-time customer attaches pro with a first-time-only promo code (forever
+ *   duration) — succeeds, customer now has a paid invoice
+ * - Upgrade to premium re-sending the same promotion code
+ *
+ * Expected:
+ * - No PromoCodeFirstTimeOnly error — the code's coupon is already applied to
+ *   the subscription, so it is deduplicated instead of re-validated
+ */
+test.concurrent(
+	`${chalk.yellowBright("attach-discount-first-time 3: re-sent applied code is deduped")}`,
+	async () => {
+		const customerId = "att-disc-ft-resend";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const premium = products.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 1000 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
+		});
+
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		const coupon = await createPercentCoupon({ stripeCli, percentOff: 25 });
+		const promoCode = await createPromotionCode({
+			stripeCli,
+			coupon,
+			code: `FTRESEND-${customerId}`,
+			firstTimeTransaction: true,
+		});
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+			discounts: [{ promotion_code: promoCode.code }],
+		});
+
+		await timeout(5000);
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: premium.id,
+			discounts: [{ promotion_code: promoCode.code }],
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer,
+			active: [premium.id],
+			notPresent: [pro.id],
+		});
+	},
+);

--- a/server/tests/integration/billing/utils/discounts/discountTestUtils.ts
+++ b/server/tests/integration/billing/utils/discounts/discountTestUtils.ts
@@ -198,10 +198,12 @@ export const createPromotionCode = async ({
 	stripeCli,
 	coupon,
 	code,
+	firstTimeTransaction,
 }: {
 	stripeCli: Stripe;
 	coupon: Stripe.Coupon;
 	code: string;
+	firstTimeTransaction?: boolean;
 }) => {
 	return stripeCli.promotionCodes.create({
 		promotion: {
@@ -209,6 +211,9 @@ export const createPromotionCode = async ({
 			coupon: coupon.id,
 		},
 		code: `${code}${Date.now()}`,
+		...(firstTimeTransaction
+			? { restrictions: { first_time_transaction: true } }
+			: {}),
 	});
 };
 

--- a/server/tests/integration/rewards/rewards-redeem-first-time.test.ts
+++ b/server/tests/integration/rewards/rewards-redeem-first-time.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Integration tests for feature-grant promo codes restricted to
+ * first-time transactions (promo_codes[].first_time_transaction).
+ *
+ * Tests:
+ * - Customer with a prior paid purchase is blocked with PromoCodeFirstTimeOnly
+ * - Fresh customer (no payments) can still redeem the same code
+ */
+
+import { expect, test } from "bun:test";
+import { ErrCode } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+test(`${chalk.yellowBright("feature-grant-first-time: blocked after purchase, fresh customer redeems")}`, async () => {
+	const customerId = "fg-first-time-paid";
+	const freshCustomerId = "fg-first-time-fresh";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyWords({ includedUsage: 100 })],
+	});
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+			s.otherCustomers([{ id: freshCustomerId }]),
+			s.featureGrant({
+				entitlements: [{ feature_id: TestFeature.Messages, allowance: 10 }],
+				promoCodes: [{ code: "FIRSTTIMEMSG", first_time_transaction: true }],
+			}),
+		],
+		actions: [s.billing.attach({ productId: pro.id })],
+	});
+
+	// Customer with a paid invoice is blocked
+	await expectAutumnError({
+		errCode: ErrCode.PromoCodeFirstTimeOnly,
+		func: async () => {
+			await autumnV1.rewards.redeem({
+				code: "FIRSTTIMEMSG",
+				customerId,
+			});
+		},
+	});
+
+	const blockedCheck = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(blockedCheck.balance ?? 0).toBe(0);
+
+	// Fresh customer with no payments redeems successfully
+	await autumnV1.rewards.redeem({
+		code: "FIRSTTIMEMSG",
+		customerId: freshCustomerId,
+	});
+
+	const freshCheck = await autumnV1.check({
+		customer_id: freshCustomerId,
+		feature_id: TestFeature.Messages,
+	});
+	expect(freshCheck.allowed).toBe(true);
+	expect(freshCheck.balance).toBe(10);
+});

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -82,7 +82,11 @@ type FeatureGrantConfig = {
 	id?: string;
 	name?: string;
 	entitlements: FeatureGrantEntitlement[];
-	promoCodes: { code: string; max_redemptions?: number }[];
+	promoCodes: {
+		code: string;
+		max_redemptions?: number;
+		first_time_transaction?: boolean;
+	}[];
 };
 
 // Discriminated union for all action types
@@ -1235,6 +1239,7 @@ export async function initScenario({
 				promo_codes: fg.promoCodes.map((pc) => ({
 					code: pc.code,
 					max_redemptions: pc.max_redemptions,
+					first_time_transaction: pc.first_time_transaction,
 				})),
 				created_at: Date.now(),
 			},

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -127,6 +127,7 @@ export const ErrCode = {
 	// Rewards
 	InvalidReward: "invalid_reward",
 	PromoCodeAlreadyExistsInStripe: "promo_code_already_exists_in_stripe",
+	PromoCodeFirstTimeOnly: "promo_code_first_time_only",
 
 	// Entity
 	EntityNotFound: "entity_not_found",

--- a/shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts
+++ b/shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts
@@ -16,6 +16,8 @@ export type StripeDiscountWithCoupon = {
 	end?: number | null;
 	source: { coupon: Stripe.Coupon };
 	promotionCodeId?: string;
+	/** Human-readable promotion code, for error messages */
+	promotionCode?: string;
 	/** Promo code restricted to first-time transactions */
 	firstTimeTransaction?: boolean;
 };

--- a/shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts
+++ b/shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts
@@ -16,8 +16,6 @@ export type StripeDiscountWithCoupon = {
 	end?: number | null;
 	source: { coupon: Stripe.Coupon };
 	promotionCodeId?: string;
-	/** Human-readable promotion code, for error messages */
-	promotionCode?: string;
 	/** Promo code restricted to first-time transactions */
 	firstTimeTransaction?: boolean;
 };

--- a/shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts
+++ b/shared/models/billingModels/stripe/stripeDiscountWithCoupon.ts
@@ -16,4 +16,6 @@ export type StripeDiscountWithCoupon = {
 	end?: number | null;
 	source: { coupon: Stripe.Coupon };
 	promotionCodeId?: string;
+	/** Promo code restricted to first-time transactions */
+	firstTimeTransaction?: boolean;
 };

--- a/shared/models/rewardModels/rewardModels/rewardModels.ts
+++ b/shared/models/rewardModels/rewardModels/rewardModels.ts
@@ -8,6 +8,8 @@ import { CouponDurationType, RewardType } from "./rewardEnums";
 const PromoCodeSchema = z.object({
 	code: z.string(),
 	global_max_redemption: z.number().positive().optional(),
+	/** Only redeemable by customers with no prior successful payments or invoices */
+	first_time_transaction: z.boolean().optional(),
 	/** @deprecated Use global_max_redemption. */
 	max_redemptions: z.number().positive().optional(),
 });

--- a/vite/src/views/products/rewards/reward-config/components/DiscountRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/DiscountRewardConfig.tsx
@@ -1,4 +1,5 @@
 import { CouponDurationType } from "@autumn/shared";
+import { TextCheckbox } from "@/components/v2/checkboxes/TextCheckbox";
 import { FormLabel } from "@/components/v2/form/FormLabel";
 import { Input } from "@/components/v2/inputs/Input";
 import {
@@ -16,6 +17,7 @@ import {
 import { SheetSection } from "@/components/v2/sheets/SharedSheetComponents";
 import { useOrg } from "@/hooks/common/useOrg";
 import type { FrontendReward } from "../../types/frontendReward";
+import { FirstTimeTransactionTooltip } from "./FirstTimeTransactionTooltip";
 import { ProductPriceSelector } from "./ProductPriceSelector";
 
 interface DiscountRewardConfigProps {
@@ -29,6 +31,7 @@ export function DiscountRewardConfig({
 }: DiscountRewardConfigProps) {
 	const { org } = useOrg();
 	const config = reward.discount_config!;
+	const promoCode = reward.promo_codes[0];
 
 	const setConfig = (key: string, value: any) => {
 		setReward({
@@ -54,7 +57,9 @@ export function DiscountRewardConfig({
 							items={{
 								percentage: "Percentage",
 								fixed: "Fixed",
-								...(reward.discountType === "invoice_credits" && { invoice_credits: "Invoice Credits" }),
+								...(reward.discountType === "invoice_credits" && {
+									invoice_credits: "Invoice Credits",
+								}),
 							}}
 						>
 							<SelectTrigger className="w-full">
@@ -76,19 +81,40 @@ export function DiscountRewardConfig({
 						<FormLabel>Promotional Code (Optional)</FormLabel>
 						<Input
 							placeholder="SAVE20"
-							value={reward.promo_codes[0]?.code || ""}
+							value={promoCode?.code || ""}
 							maxLength={500}
 							onChange={(e) => {
 								// Stripe only allows alphanumeric characters (a-z, A-Z, 0-9)
 								const sanitized = e.target.value.replace(/[^a-zA-Z0-9]/g, "");
 								setReward({
 									...reward,
-									promo_codes: sanitized ? [{ code: sanitized }] : [],
+									promo_codes: sanitized
+										? [{ ...promoCode, code: sanitized }]
+										: [],
 								});
 							}}
 						/>
 					</div>
 				</div>
+
+				{promoCode && (
+					<div className="flex items-center gap-1.5">
+						<TextCheckbox
+							checked={promoCode.first_time_transaction ?? false}
+							onCheckedChange={(checked) =>
+								setReward({
+									...reward,
+									promo_codes: [
+										{ ...promoCode, first_time_transaction: checked === true },
+									],
+								})
+							}
+						>
+							Limit to first-time customers
+						</TextCheckbox>
+						<FirstTimeTransactionTooltip />
+					</div>
+				)}
 
 				{/* Row 2: Amount and Duration */}
 				<div className="grid grid-cols-2 gap-2">

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -120,9 +120,11 @@ export function FeatureGrantRewardConfig({
 	}) => {
 		const updated = [...(reward.promo_codes || [])];
 		const promoCode = updated[index] ?? { code: "" };
+		const globalMaxRedemption = getGlobalMaxRedemption(promoCode);
 		const { max_redemptions: _maxRedemptions, ...rest } = promoCode;
 		updated[index] = {
 			...rest,
+			global_max_redemption: globalMaxRedemption,
 			first_time_transaction: value,
 		};
 		setReward({ ...reward, promo_codes: updated });

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -4,6 +4,7 @@ import { CheckIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { cloneElement, isValidElement } from "react";
 import { Button } from "@/components/v2/buttons/Button";
+import { TextCheckbox } from "@/components/v2/checkboxes/TextCheckbox";
 import { FormLabel } from "@/components/v2/form/FormLabel";
 import { Input } from "@/components/v2/inputs/Input";
 import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
@@ -23,6 +24,7 @@ import type {
 	FrontendReward,
 	FrontendRewardEntitlement,
 } from "../../types/frontendReward";
+import { FirstTimeTransactionTooltip } from "./FirstTimeTransactionTooltip";
 
 interface FeatureGrantRewardConfigProps {
 	reward: FrontendReward;
@@ -101,9 +103,27 @@ export function FeatureGrantRewardConfig({
 	}) => {
 		const updated = [...(reward.promo_codes || [])];
 		const promoCode = updated[index] ?? { code: "" };
+		const { max_redemptions: _maxRedemptions, ...rest } = promoCode;
 		updated[index] = {
-			code: promoCode.code,
+			...rest,
 			global_max_redemption: value,
+		};
+		setReward({ ...reward, promo_codes: updated });
+	};
+
+	const updateFirstTimeTransaction = ({
+		index,
+		value,
+	}: {
+		index: number;
+		value: boolean;
+	}) => {
+		const updated = [...(reward.promo_codes || [])];
+		const promoCode = updated[index] ?? { code: "" };
+		const { max_redemptions: _maxRedemptions, ...rest } = promoCode;
+		updated[index] = {
+			...rest,
+			first_time_transaction: value,
 		};
 		setReward({ ...reward, promo_codes: updated });
 	};
@@ -156,47 +176,63 @@ export function FeatureGrantRewardConfig({
 			<SheetSection title="Promo Codes" withSeparator={false}>
 				<div className="space-y-3">
 					{(reward.promo_codes || []).map((promoCode, index) => (
-						<div key={index} className="flex items-end gap-2">
-							<div className="flex-1">
-								{index === 0 && <FormLabel>Code</FormLabel>}
-								<Input
-									value={promoCode.code}
-									onChange={(e) =>
-										updatePromoCode({
+						<div key={index} className="space-y-2">
+							<div className="flex items-end gap-2">
+								<div className="flex-1">
+									{index === 0 && <FormLabel>Code</FormLabel>}
+									<Input
+										value={promoCode.code}
+										onChange={(e) =>
+											updatePromoCode({
+												index,
+												code: e.target.value
+													.toUpperCase()
+													.replace(/[^A-Z0-9]/g, ""),
+											})
+										}
+										placeholder="PROMO2024"
+									/>
+								</div>
+								<div className="w-32">
+									{index === 0 && <FormLabel>Max Uses</FormLabel>}
+									<Input
+										type="number"
+										value={getGlobalMaxRedemption(promoCode) ?? ""}
+										onChange={(e) =>
+											updateMaxRedemptions({
+												index,
+												value: e.target.value
+													? Number(e.target.value)
+													: undefined,
+											})
+										}
+										placeholder="Unlimited"
+									/>
+								</div>
+								{(reward.promo_codes || []).length > 1 && (
+									<button
+										type="button"
+										onClick={() => removePromoCode({ index })}
+										className="p-2 text-subtle hover:text-foreground transition-colors"
+									>
+										<TrashIcon size={14} />
+									</button>
+								)}
+							</div>
+							<div className="flex items-center gap-1.5">
+								<TextCheckbox
+									checked={promoCode.first_time_transaction ?? false}
+									onCheckedChange={(checked) =>
+										updateFirstTimeTransaction({
 											index,
-											code: e.target.value
-												.toUpperCase()
-												.replace(/[^A-Z0-9]/g, ""),
+											value: checked === true,
 										})
 									}
-									placeholder="PROMO2024"
-								/>
-							</div>
-							<div className="w-32">
-								{index === 0 && <FormLabel>Max Uses</FormLabel>}
-								<Input
-									type="number"
-									value={getGlobalMaxRedemption(promoCode) ?? ""}
-									onChange={(e) =>
-										updateMaxRedemptions({
-											index,
-											value: e.target.value
-												? Number(e.target.value)
-												: undefined,
-										})
-									}
-									placeholder="Unlimited"
-								/>
-							</div>
-							{(reward.promo_codes || []).length > 1 && (
-								<button
-									type="button"
-									onClick={() => removePromoCode({ index })}
-									className="p-2 text-subtle hover:text-foreground transition-colors"
 								>
-									<TrashIcon size={14} />
-								</button>
-							)}
+									Limit to first-time customers
+								</TextCheckbox>
+								<FirstTimeTransactionTooltip />
+							</div>
 						</div>
 					))}
 					<Button variant="secondary" size="sm" onClick={addPromoCode}>
@@ -323,21 +359,26 @@ export function FeatureGrantRewardConfig({
 													placeholder="30"
 													className="w-20"
 												/>
-											<Select
-												value={ent.expiry.duration}
-												onValueChange={(value) =>
-													updateEntitlement({
-														index,
-														updates: {
-															expiry: {
-																duration: value as EntitlementDuration,
-																length: ent.expiry?.length ?? 1,
+												<Select
+													value={ent.expiry.duration}
+													onValueChange={(value) =>
+														updateEntitlement({
+															index,
+															updates: {
+																expiry: {
+																	duration: value as EntitlementDuration,
+																	length: ent.expiry?.length ?? 1,
+																},
 															},
-														},
-													})
-												}
-												items={{ [EntitlementDuration.Day]: "Day(s)", [EntitlementDuration.Week]: "Week(s)", [EntitlementDuration.Month]: "Month(s)", [EntitlementDuration.Year]: "Year(s)" }}
-											>
+														})
+													}
+													items={{
+														[EntitlementDuration.Day]: "Day(s)",
+														[EntitlementDuration.Week]: "Week(s)",
+														[EntitlementDuration.Month]: "Month(s)",
+														[EntitlementDuration.Year]: "Year(s)",
+													}}
+												>
 													<SelectTrigger className="flex-1">
 														<SelectValue />
 													</SelectTrigger>

--- a/vite/src/views/products/rewards/reward-config/components/FirstTimeTransactionTooltip.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FirstTimeTransactionTooltip.tsx
@@ -12,8 +12,8 @@ export function FirstTimeTransactionTooltip() {
 				<InfoIcon className="size-3.5 cursor-help text-tertiary-foreground" />
 			</TooltipTrigger>
 			<TooltipContent>
-				Applies when this promo code is redeemed. First-time means the customer
-				has no prior successful payments or invoices in Stripe.
+				Applies when the customer has no prior successful payments or invoices
+				in Stripe.
 			</TooltipContent>
 		</Tooltip>
 	);

--- a/vite/src/views/products/rewards/reward-config/components/FirstTimeTransactionTooltip.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FirstTimeTransactionTooltip.tsx
@@ -1,0 +1,20 @@
+import { InfoIcon } from "@phosphor-icons/react";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/v2/tooltips/Tooltip";
+
+export function FirstTimeTransactionTooltip() {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<InfoIcon className="size-3.5 cursor-help text-tertiary-foreground" />
+			</TooltipTrigger>
+			<TooltipContent>
+				Applies when this promo code is redeemed. First-time means the customer
+				has no prior successful payments or invoices in Stripe.
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/vite/src/views/products/rewards/utils/rewardMappers.ts
+++ b/vite/src/views/products/rewards/utils/rewardMappers.ts
@@ -21,6 +21,7 @@ const normalizePromoCode = ({
 	code,
 	global_max_redemption,
 	max_redemptions,
+	first_time_transaction,
 }: ApiPromoCode): ApiPromoCode => {
 	const globalMaxRedemption = global_max_redemption ?? max_redemptions;
 
@@ -29,6 +30,7 @@ const normalizePromoCode = ({
 		...(globalMaxRedemption !== undefined
 			? { global_max_redemption: globalMaxRedemption }
 			: {}),
+		...(first_time_transaction ? { first_time_transaction: true } : {}),
 	};
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-time customer restrictions to promo codes across billing and rewards. Blocks customers with prior Stripe succeeded charges or open/paid/uncollectible invoices; draft invoices don’t block. The UI lets you mark codes as first-time only.

- New Features
  - Stripe promo codes: set/read `first_time_transaction` on create/resolve; map to discounts.
  - Validation: `isFirstTimeStripeCustomer` + `assertFirstTimeStripeCustomer` with `ErrCode.PromoCodeFirstTimeOnly`; error messages include the promo code when available.
  - Billing attach: `validateFirstTimeDiscounts` checks only new discounts; re-sent, already-applied codes are deduped, not revalidated.
  - Rewards redeem: enforce first-time restriction for feature-grant codes.
  - Models: add `first_time_transaction` and `firstTimeTransaction` fields.
  - UI: add “Limit to first-time customers” checkbox and tooltip in discount and feature-grant configs; mapper normalization.
  - Tests: integration coverage for fresh, blocked-after-purchase, and re-send-deduped flows.

<sup>Written for commit 0a68ec8e1e4efa48e0f6aedd51061ffeb50e1209. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `first_time_transaction` restriction to reward promo codes (both discount and feature-grant types), gating redemption on whether the customer has any prior Stripe charges or non-void invoices. The feature is surfaced in the UI as a per-promo-code checkbox and enforced server-side via a new `isFirstTimeStripeCustomer` helper that runs in both the billing-attach and reward-redeem flows.

- **[Improvements]** New `isFirstTimeStripeCustomer` / `assertFirstTimeStripeCustomer` helpers run concurrent paginated Stripe API calls (`charges.list` + `invoices.list`) and are integrated into `fetchStripeDiscountsForBilling` (with deduplication to avoid re-blocking already-applied codes) and `redeemPromoCode`.
- **[Improvements]** `createStripeCoupon` now propagates `restrictions.first_time_transaction: true` to Stripe so the native Stripe restriction is set alongside the application-level guard.
- **[API changes]** New `PromoCodeFirstTimeOnly` error code added to `ErrCode`; `first_time_transaction` field added to `PromoCodeSchema` and `StripeDiscountWithCoupon`; `resolvePromotionCode` reads the flag from the Stripe promo object.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with low risk; the new enforcement paths are well-integrated and have integration test coverage for the key scenarios

The core logic is correct and the deduplication guard prevents re-blocking customers who already have the code applied. The one area worth a closer look is the BLOCKING_INVOICE_STATUSES list — including 'draft' invoices may over-block customers who have unfinalized invoices but have never actually paid, which would silently reject legitimate first-time users. Everything else — the concurrent Stripe API calls, the two-layer guard (Stripe native + application-level), the UI state management, and the test coverage — looks solid.

server/src/external/stripe/customers/operations/isFirstTimeStripeCustomer.ts — specifically the BLOCKING_INVOICE_STATUSES constant and whether 'draft' matches Stripe's own definition of a prior transaction

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/customers/operations/isFirstTimeStripeCustomer.ts | New helper that checks charges + invoices via auto-paginating Stripe list calls; including 'draft' invoices in the blocking list may diverge from Stripe's own first_time_transaction semantics |
| server/src/internal/billing/v2/providers/stripe/utils/discounts/validateFirstTimeDiscounts.ts | New utility that gates billing-path first-time-only discounts; correctly skips validation when no Stripe customer exists; missing promoCode param yields generic error messages |
| server/src/internal/billing/v2/providers/stripe/setup/fetchStripeDiscountsForBilling.ts | Adds deduplication of re-sent coupon IDs before running first-time validation, correctly scoping the check to genuinely new param discounts only |
| server/src/internal/rewards/actions/redeemPromoCode.ts | Correctly inserts first-time check after the existing-redemption guard and before entitlement creation; skips when no Stripe customer ID exists |
| server/src/external/stripe/stripeCouponUtils/stripeCouponUtils.ts | Propagates first_time_transaction restriction to Stripe promotion code creation so Stripe's native check also applies on checkout |
| server/tests/integration/billing/attach/discounts/attach-discounts-first-time.test.ts | Three comprehensive integration tests covering fresh-customer success, blocked-customer rejection, and re-sent-code deduplication |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant R as redeemPromoCode
    participant B as fetchStripeDiscountsForBilling
    participant V as validateFirstTimeDiscounts
    participant S as isFirstTimeStripeCustomer
    participant St as Stripe API

    C->>R: rewards.redeem(code, customerId)
    R->>R: find reward + promoCode
    R->>R: check global redemption limit
    R->>R: fetch fullCustomer
    R->>R: check existingRedemption
    alt "promoCode.first_time_transaction && processor.id"
        R->>S: assertFirstTimeStripeCustomer(stripeCustomerId)
        S->>St: charges.list(customer) [autopaginate]
        S->>St: invoices.list(customer) [autopaginate]
        St-->>S: results
        S-->>R: throws PromoCodeFirstTimeOnly or continues
    end
    R-->>C: entitlements granted

    C->>B: billing.attach(productId, discounts)
    B->>B: extractStripeDiscounts (existing)
    B->>B: resolveParamDiscounts
    B->>B: filter out already-applied coupon IDs
    B->>V: validateFirstTimeDiscounts(newParamDiscounts, stripeCustomerId)
    V->>S: assertFirstTimeStripeCustomer(stripeCustomerId)
    S->>St: charges.list + invoices.list [parallel]
    St-->>S: results
    S-->>V: throws or continues
    V-->>B: ok
    B-->>C: merged discounts
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/stripe/customers/operations/isFirstTimeStripeCustomer.ts:5-10
**`"draft"` invoice status may over-block first-time customers**

The comment asserts "Per Stripe's `first_time_transaction` rule, any non-void invoice counts," but Stripe's own docs describe the restriction as applying to customers who have "never had a successful invoice or payment." A `draft` invoice has never been finalized or collected — it is pre-payment. A customer whose only invoice is an unfinalized draft (e.g., created by metered usage items or a manually created invoice that was never sent) would be incorrectly rejected as non-first-time. This custom check runs both for the billing-attach path and the feature-grant redeem path, so the mismatch could silently block legitimate first-time users. It is worth verifying Stripe's exact semantics and removing `"draft"` from the blocking list if Stripe itself does not count draft invoices.

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/utils/discounts/validateFirstTimeDiscounts.ts:18-25
The `assertFirstTimeStripeCustomer` call here doesn't receive a promo-code identifier, so the resulting `RecaseError` message will always be the generic "This promo code is only valid for first-time purchases" rather than naming the specific code. When a batch of discounts includes multiple codes and only one carries the restriction, callers won't know which code caused the error. Passing the restriction's promotion-code ID improves the error surface.

```suggestion
	const firstTimeDiscount = discounts.find(
		(discount) => discount.firstTimeTransaction,
	);

	if (!firstTimeDiscount) return;
	if (!stripeCustomerId) return;

	await assertFirstTimeStripeCustomer({
		stripeCli,
		stripeCustomerId,
		promoCode: firstTimeDiscount.promotionCodeId,
	});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add first time condition to rewar..."](https://github.com/useautumn/autumn/commit/b810d60f56534dbd743e3af1a9b3878cf1f3136d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37205631)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->