### PR TITLE
Plan version migrations: filter compiler, migrate dialog, and billing-change visibility

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -43,7 +43,7 @@
 			"includeEntryExports": false
 		},
 		"vite": {
-			"entry": ["tests/**/*.{ts,tsx}"],
+			"entry": ["tests/**/*.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
 			"project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
 			"ignore": ["src/components/ai-elements/**", "src/hooks/useControllableState.ts", "src/types/**/*.d.ts"],
 			"ignoreDependencies": [

--- a/server/src/internal/customers/cusUtils/cusResponseUtils/getCusUsageLimitsWithUsage.ts
+++ b/server/src/internal/customers/cusUtils/cusResponseUtils/getCusUsageLimitsWithUsage.ts
@@ -1,0 +1,83 @@
+import {
+	type ApiUsageLimit,
+	type FullCustomer,
+	fullSubjectToApiUsageLimits,
+	orgToInStatuses,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/index.js";
+
+export type UsageLimitsWithUsage = {
+	customer?: ApiUsageLimit[];
+	byInternalEntityId: Record<string, ApiUsageLimit[]>;
+};
+
+const SOURCE = "dashboard_usage_limits";
+
+/**
+ * Decorate usage limits with `usage` (consumed in the active window) the same
+ * way getApiCustomerBaseV2 does. The live counter lives in the Redis balance
+ * hash, so we read each scope via getOrSetCachedFullSubject (which rehydrates
+ * it) — a DB-only read returns a stale/zero counter.
+ *
+ * Done for the customer AND every entity with caps, because the dashboard
+ * payload carries both and the client may fetch either scope, so usage must
+ * not hinge on the request's entity_id. Returns undefined when no caps exist.
+ */
+export const getCusUsageLimitsWithUsage = async ({
+	ctx,
+	fullCus,
+}: {
+	ctx: AutumnContext;
+	fullCus: FullCustomer;
+}): Promise<UsageLimitsWithUsage | undefined> => {
+	const entitiesWithCaps = (fullCus.entities ?? []).filter(
+		(entity) => (entity.usage_limits?.length ?? 0) > 0,
+	);
+	const customerHasCaps = (fullCus.usage_limits?.length ?? 0) > 0;
+	if (!customerHasCaps && entitiesWithCaps.length === 0) {
+		return undefined;
+	}
+
+	const features = ctx.features;
+	const inStatuses = orgToInStatuses({ org: ctx.org });
+	const customerId = fullCus.internal_id;
+
+	const [customer, entityEntries] = await Promise.all([
+		customerHasCaps
+			? getOrSetCachedFullSubject({ ctx, customerId, source: SOURCE }).then(
+					(fullSubject) =>
+						fullSubjectToApiUsageLimits({
+							fullSubject,
+							features,
+							inStatuses,
+							source: "customer",
+						}),
+				)
+			: Promise.resolve(undefined),
+		Promise.all(
+			entitiesWithCaps.map(async (entity) => {
+				const fullSubject = await getOrSetCachedFullSubject({
+					ctx,
+					customerId,
+					entityId: entity.id ?? entity.internal_id,
+					source: SOURCE,
+				});
+				const decorated = fullSubjectToApiUsageLimits({
+					fullSubject,
+					features,
+					inStatuses,
+					source: "entity",
+				});
+				return [entity.internal_id, decorated] as const;
+			}),
+		),
+	]);
+
+	const byInternalEntityId: Record<string, ApiUsageLimit[]> = {};
+	for (const [internalEntityId, decorated] of entityEntries) {
+		if (decorated) byInternalEntityId[internalEntityId] = decorated;
+	}
+
+	return { customer, byInternalEntityId };
+};

--- a/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetCustomer.ts
@@ -9,6 +9,7 @@ import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { CusService } from "@/internal/customers/CusService";
 import { getCusAutoTopupPurchaseLimits } from "@/internal/customers/cusUtils/cusResponseUtils/getCusAutoTopupPurchaseLimits";
 import { getCusRewards } from "@/internal/customers/cusUtils/cusResponseUtils/getCusRewards";
+import { getCusUsageLimitsWithUsage } from "@/internal/customers/cusUtils/cusResponseUtils/getCusUsageLimitsWithUsage";
 
 /**
  * Internal route for get full customer object.
@@ -42,34 +43,51 @@ export const handleGetCustomer = createRoute({
 			entityId: entityId || undefined,
 		});
 
-		const [testClockFrozenTimeMs, autoTopupsWithLimits, rewards] =
-			await Promise.all([
-				getTestClockFrozenTimeMs({
-					ctx,
-					stripeCustomerId: fullCus.processor?.id,
-				}),
-				getCusAutoTopupPurchaseLimits({
-					ctx,
-					internalCustomerId: fullCus.internal_id,
-					autoTopupsConfig: fullCus.auto_topups,
-					expand: [CustomerExpand.AutoTopupsPurchaseLimit],
-				}),
-				getCusRewards({
-					org: ctx.org,
-					env: ctx.env,
-					fullCus,
-					subIds: fullCus.customer_products.flatMap(
-						(cp: FullCusProduct) => cp.subscription_ids || [],
-					),
-					expand,
-				}),
-			]);
+		const [
+			testClockFrozenTimeMs,
+			autoTopupsWithLimits,
+			rewards,
+			usageLimitsWithUsage,
+		] = await Promise.all([
+			getTestClockFrozenTimeMs({
+				ctx,
+				stripeCustomerId: fullCus.processor?.id,
+			}),
+			getCusAutoTopupPurchaseLimits({
+				ctx,
+				internalCustomerId: fullCus.internal_id,
+				autoTopupsConfig: fullCus.auto_topups,
+				expand: [CustomerExpand.AutoTopupsPurchaseLimit],
+			}),
+			getCusRewards({
+				org: ctx.org,
+				env: ctx.env,
+				fullCus,
+				subIds: fullCus.customer_products.flatMap(
+					(cp: FullCusProduct) => cp.subscription_ids || [],
+				),
+				expand,
+			}),
+			getCusUsageLimitsWithUsage({ ctx, fullCus }),
+		]);
+
+		// Overlay usage onto the customer and every entity that has caps, so the
+		// pill shows usage regardless of which scope the client fetched.
+		const entities = usageLimitsWithUsage
+			? fullCus.entities?.map((entity) => {
+					const decorated =
+						usageLimitsWithUsage.byInternalEntityId[entity.internal_id];
+					return decorated ? { ...entity, usage_limits: decorated } : entity;
+				})
+			: fullCus.entities;
 
 		return c.json({
 			customer: {
 				...fullCus,
 				auto_topups: autoTopupsWithLimits ?? fullCus.auto_topups,
 				rewards: rewards ?? undefined,
+				entities: entities ?? fullCus.entities,
+				usage_limits: usageLimitsWithUsage?.customer ?? fullCus.usage_limits,
 			},
 			test_clock_frozen_time_ms: testClockFrozenTimeMs,
 		});

--- a/server/tests/integration/migrations/filters/composition-filter.test.ts
+++ b/server/tests/integration/migrations/filters/composition-filter.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration test for the migration `$and` / `$or` customer-level quantifiers,
+ * end-to-end against real data.
+ *
+ * Contract under test (raw filter is parsed through CustomerFilterSchema first —
+ * that parse layer is where unknown keys get stripped):
+ *   - parse({ $and: [{ plan: A }, { plan: B }] }) -> only customers on BOTH A and B
+ *   - parse({ $or:  [{ plan: A }, { plan: B }] }) -> customers on A OR B
+ *
+ * Regression: `$and`/`$or` are independent existence checks. Two plan conditions
+ * in one group used to collapse into a single `$some` plan (which a single plan
+ * can't satisfy), and before the schema gained `$and`/`$or`, CustomerFilterSchema
+ * stripped them to `{}` — the preview then returned 0. Both failures make the
+ * `$and` assertion below count the wrong set.
+ *
+ * Free base products in distinct groups let one customer hold two active plans
+ * without any payment setup.
+ */
+
+import { expect, test } from "bun:test";
+import { CustomerFilterSchema } from "@autumn/shared/api/migrations/filters/customerFilter.js";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	type CustomerRow,
+	countCustomers,
+	filterCustomers,
+} from "@/internal/migrations/v2/filters/customers/filterCustomers.js";
+
+async function collectIds(
+	gen: AsyncGenerator<CustomerRow[]>,
+): Promise<Set<string>> {
+	const ids = new Set<string>();
+	for await (const batch of gen) {
+		for (const row of batch) if (row.id) ids.add(row.id);
+	}
+	return ids;
+}
+
+test.concurrent(
+	`${chalk.yellowBright("migration filter $and/$or: composes independent plan checks")}`,
+	async () => {
+		const pfx = `comp-flt-${Math.random().toString(36).slice(2, 8)}`;
+		const both = `${pfx}-both`;
+		const freeOnly = `${pfx}-free`;
+		const proOnly = `${pfx}-pro`;
+		const other = `${pfx}-other`;
+
+		// Distinct groups so a customer can hold two active base plans at once.
+		const planFree = products.base({
+			id: `${pfx}-pfree`,
+			group: `${pfx}-g1`,
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const planPro = products.base({
+			id: `${pfx}-ppro`,
+			group: `${pfx}-g2`,
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const planOther = products.base({
+			id: `${pfx}-pother`,
+			group: `${pfx}-g3`,
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { ctx } = await initScenario({
+			customerId: both,
+			setup: [
+				s.customer({ testClock: false }),
+				s.otherCustomers([{ id: freeOnly }, { id: proOnly }, { id: other }]),
+				s.products({ list: [planFree, planPro, planOther] }),
+			],
+			actions: [
+				s.billing.attach({ productId: planFree.id }),
+				s.billing.attach({ productId: planPro.id }),
+				s.billing.attach({ productId: planFree.id, customerId: freeOnly }),
+				s.billing.attach({ productId: planPro.id, customerId: proOnly }),
+				s.billing.attach({ productId: planOther.id, customerId: other }),
+			],
+		});
+
+		const andFilter = CustomerFilterSchema.parse({
+			$and: [
+				{ plan: { plan_id: planFree.id } },
+				{ plan: { plan_id: planPro.id } },
+			],
+		});
+		const orFilter = CustomerFilterSchema.parse({
+			$or: [
+				{ plan: { plan_id: planFree.id } },
+				{ plan: { plan_id: planPro.id } },
+			],
+		});
+
+		// ── $and -> only the customer holding BOTH plans ───────────────────────
+		expect(await countCustomers({ ctx, filter: andFilter, search: pfx })).toBe(
+			1,
+		);
+		const andIds = await collectIds(
+			filterCustomers({ ctx, filter: andFilter, search: pfx }),
+		);
+		expect(andIds.has(both)).toBe(true);
+		expect(andIds.has(freeOnly)).toBe(false);
+		expect(andIds.has(proOnly)).toBe(false);
+		expect(andIds.has(other)).toBe(false);
+
+		// ── $or -> customers on either plan, excluding the unrelated plan ──────
+		expect(await countCustomers({ ctx, filter: orFilter, search: pfx })).toBe(
+			3,
+		);
+		const orIds = await collectIds(
+			filterCustomers({ ctx, filter: orFilter, search: pfx }),
+		);
+		expect(orIds.has(both)).toBe(true);
+		expect(orIds.has(freeOnly)).toBe(true);
+		expect(orIds.has(proOnly)).toBe(true);
+		expect(orIds.has(other)).toBe(false);
+	},
+);

--- a/server/tests/unit/compiler/customer/composition.test.ts
+++ b/server/tests/unit/compiler/customer/composition.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import type { Feature } from "@autumn/shared";
+import { compileFilter } from "@autumn/shared/api/migrations/compiler/compileFilter.js";
+import { contexts } from "@tests/utils/fixtures/db/contexts";
+
+const features: Feature[] = [
+	{ id: "credits", internal_id: "fea_credits_internal" } as Feature,
+];
+
+const ctx = contexts.create({ features });
+const ambient = { orgId: "org_test", env: "live" };
+
+const ROOT_AMBIENT = "c.org_id = ? AND c.env = ?";
+const PLAN_AMBIENT = "cp.status IN (?, ?, ?)";
+const PLAN_AMBIENT_PARAMS = ["active", "past_due", "scheduled"];
+
+const normalize = (sql: string) =>
+	sql.replace(/\s+/g, " ").replace(/\(\s+/g, "(").replace(/\s+\)/g, ")").trim();
+
+const planExists = (predicate: string) =>
+	`EXISTS (
+		SELECT 1
+		FROM customer_products cp JOIN products p ON p.internal_id = cp.internal_product_id
+		WHERE cp.internal_customer_id = c.internal_id
+			AND ${PLAN_AMBIENT}
+			AND ${predicate}
+	)`;
+
+// Customer-level `$and` / `$or` compose INDEPENDENT plan quantifiers. "has free
+// AND has pro" must be two separate EXISTS — a single plan can't be both, so
+// merging them into one quantifier would drop a condition.
+describe("compileFilter — customer / composition ($and, $or)", () => {
+	test("$and → two independent EXISTS, AND'd", () => {
+		const result = compileFilter({
+			filter: {
+				$and: [
+					{ plan: { plan_id: "free" } },
+					{ plan: { plan_id: { $in: ["pro_6mo", "pro_3mo"] } } },
+				],
+			},
+			ctx: { features: ctx.features },
+			ambient,
+		});
+
+		expect(normalize(result.sql)).toBe(
+			normalize(`
+				${ROOT_AMBIENT} AND (
+					${planExists("p.id = ?")}
+					AND
+					${planExists("p.id IN (?, ?)")}
+				)
+			`),
+		);
+		expect(result.params).toEqual([
+			"org_test",
+			"live",
+			...PLAN_AMBIENT_PARAMS,
+			"free",
+			...PLAN_AMBIENT_PARAMS,
+			"pro_6mo",
+			"pro_3mo",
+		]);
+	});
+
+	test("$or → two independent EXISTS, OR'd", () => {
+		const result = compileFilter({
+			filter: {
+				$or: [{ plan: { plan_id: "free" } }, { plan: { plan_id: "pro" } }],
+			},
+			ctx: { features: ctx.features },
+			ambient,
+		});
+
+		expect(normalize(result.sql)).toBe(
+			normalize(`
+				${ROOT_AMBIENT} AND (
+					${planExists("p.id = ?")}
+					OR
+					${planExists("p.id = ?")}
+				)
+			`),
+		);
+		expect(result.params).toEqual([
+			"org_test",
+			"live",
+			...PLAN_AMBIENT_PARAMS,
+			"free",
+			...PLAN_AMBIENT_PARAMS,
+			"pro",
+		]);
+	});
+
+	test("plan_id + version stay bound inside one EXISTS", () => {
+		const result = compileFilter({
+			filter: { plan: { plan_id: "pro", version: 2 } },
+			ctx: { features: ctx.features },
+			ambient,
+		});
+
+		expect(normalize(result.sql)).toBe(
+			normalize(
+				`${ROOT_AMBIENT} AND ${planExists("(p.id = ? AND p.version = ?)")}`,
+			),
+		);
+		expect(result.params).toEqual([
+			"org_test",
+			"live",
+			...PLAN_AMBIENT_PARAMS,
+			"pro",
+			2,
+		]);
+	});
+});

--- a/server/tests/unit/compiler/customer/negation.test.ts
+++ b/server/tests/unit/compiler/customer/negation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import type { Feature } from "@autumn/shared";
+import { compileFilter } from "@autumn/shared/api/migrations/compiler/compileFilter.js";
+import { contexts } from "@tests/utils/fixtures/db/contexts";
+
+const features: Feature[] = [
+	{ id: "credits", internal_id: "fea_credits_internal" } as Feature,
+];
+
+const ctx = contexts.create({ features });
+const ambient = { orgId: "org_test", env: "live" };
+
+const ROOT_AMBIENT = "c.org_id = ? AND c.env = ?";
+const PLAN_AMBIENT = "cp.status IN (?, ?, ?)";
+const PLAN_AMBIENT_PARAMS = ["active", "past_due", "scheduled"];
+
+const ITEM_FROM = [
+	"customer_entitlements ce",
+	"JOIN entitlements e ON e.id = ce.entitlement_id",
+	"LEFT JOIN prices pr ON pr.entitlement_id = e.id",
+	"LEFT JOIN customer_prices cpr ON cpr.price_id = pr.id AND cpr.customer_product_id = ce.customer_product_id",
+].join(" ");
+
+const normalize = (sql: string) =>
+	sql.replace(/\s+/g, " ").replace(/\(\s+/g, "(").replace(/\s+\)/g, ")").trim();
+
+// `$none` is how the dashboard's "is not" / "not in" operators compile. It must
+// emit NOT EXISTS so a Free+Pro customer is excluded from "plan is not free" —
+// the per-plan `p.id <> free` (EXISTS) form would leak them in via Pro.
+describe("compileFilter — customer / negation ($none)", () => {
+	test("plan_id $none → NOT EXISTS over plans", () => {
+		const result = compileFilter({
+			filter: { plan: { $none: { plan_id: "free" } } },
+			ctx: { features: ctx.features },
+			ambient,
+		});
+
+		expect(normalize(result.sql)).toBe(
+			normalize(`
+				${ROOT_AMBIENT} AND NOT EXISTS (
+					SELECT 1
+					FROM customer_products cp JOIN products p ON p.internal_id = cp.internal_product_id
+					WHERE cp.internal_customer_id = c.internal_id
+						AND ${PLAN_AMBIENT}
+						AND p.id = ?
+				)
+			`),
+		);
+		expect(result.params).toEqual([
+			"org_test",
+			"live",
+			...PLAN_AMBIENT_PARAMS,
+			"free",
+		]);
+	});
+
+	test("plan_id $none with $in → NOT EXISTS with IN list", () => {
+		const result = compileFilter({
+			filter: { plan: { $none: { plan_id: { $in: ["free", "trial"] } } } },
+			ctx: { features: ctx.features },
+			ambient,
+		});
+
+		expect(normalize(result.sql)).toBe(
+			normalize(`
+				${ROOT_AMBIENT} AND NOT EXISTS (
+					SELECT 1
+					FROM customer_products cp JOIN products p ON p.internal_id = cp.internal_product_id
+					WHERE cp.internal_customer_id = c.internal_id
+						AND ${PLAN_AMBIENT}
+						AND p.id IN (?, ?)
+				)
+			`),
+		);
+		expect(result.params).toEqual([
+			"org_test",
+			"live",
+			...PLAN_AMBIENT_PARAMS,
+			"free",
+			"trial",
+		]);
+	});
+
+	test("feature $none → NOT EXISTS over plans with nested item EXISTS", () => {
+		const result = compileFilter({
+			filter: { plan: { $none: { item: { feature_id: "credits" } } } },
+			ctx: { features: ctx.features },
+			ambient,
+		});
+
+		expect(normalize(result.sql)).toBe(
+			normalize(`
+				${ROOT_AMBIENT} AND NOT EXISTS (
+					SELECT 1
+					FROM customer_products cp JOIN products p ON p.internal_id = cp.internal_product_id
+					WHERE cp.internal_customer_id = c.internal_id
+						AND ${PLAN_AMBIENT}
+						AND EXISTS (
+							SELECT 1
+							FROM ${ITEM_FROM}
+							WHERE ce.customer_product_id = cp.id
+								AND e.internal_feature_id = ?
+						)
+				)
+			`),
+		);
+		expect(result.params).toEqual([
+			"org_test",
+			"live",
+			...PLAN_AMBIENT_PARAMS,
+			"fea_credits_internal",
+		]);
+	});
+});

--- a/shared/api/migrations/compiler/filterToIr/scopes/parseCustomerFilter.ts
+++ b/shared/api/migrations/compiler/filterToIr/scopes/parseCustomerFilter.ts
@@ -31,5 +31,21 @@ export function parseCustomerFilter({
 			child: parseItemNav({ raw: filter.item, ctx }),
 		});
 
+	if (filter.$and !== undefined) {
+		for (const branch of filter.$and)
+			children.push(parseCustomerFilter({ filter: branch, ctx }));
+	}
+
+	if (filter.$or !== undefined) {
+		if (filter.$or.length === 0)
+			throw new Error("$or requires at least one branch");
+		children.push({
+			kind: "or",
+			children: filter.$or.map((branch) =>
+				parseCustomerFilter({ filter: branch, ctx }),
+			),
+		});
+	}
+
 	return wrapAnd(children);
 }

--- a/shared/api/migrations/filters/customerFilter.ts
+++ b/shared/api/migrations/filters/customerFilter.ts
@@ -48,8 +48,8 @@ export const CustomerFilterSchema: z.ZodType<CustomerFilter> = z.lazy(() =>
 		customer_id: StringMatcherSchema.optional(),
 		plan: arrayFilter(PlanFilterSchema).optional(),
 		item: arrayFilter(PlanItemFilterSchema).optional(),
-		$and: z.array(CustomerFilterSchema).optional(),
-		$or: z.array(CustomerFilterSchema).optional(),
+		$and: z.array(CustomerFilterSchema).min(1).optional(),
+		$or: z.array(CustomerFilterSchema).min(1).optional(),
 	}),
 );
 

--- a/shared/api/migrations/filters/customerFilter.ts
+++ b/shared/api/migrations/filters/customerFilter.ts
@@ -14,13 +14,43 @@ import { PlanItemFilterSchema } from "./planItemFilter.js";
  * `item` is sugar for `plan: { item: ... }` — matches customers with at
  * least one active plan that has at least one matching item. Sibling with
  * `plan` it AND's (each must independently have a match).
+ *
+ * `$and` / `$or` compose independent customer-level predicates: each branch
+ * is its own `CustomerFilter` (typically a single `plan` quantifier), so
+ * `$and: [{ plan: free }, { plan: pro }]` means "has free AND also has pro"
+ * — two separate existence checks, not one plan that is both.
  */
-export const CustomerFilterSchema = z.object({
-	customer_id: StringMatcherSchema.optional(),
-	plan: arrayFilter(PlanFilterSchema).optional(),
-	item: arrayFilter(PlanItemFilterSchema).optional(),
-});
+type PlanFilterValue = z.infer<typeof PlanFilterSchema>;
+type PlanItemFilterValue = z.infer<typeof PlanItemFilterSchema>;
 
-export type CustomerFilter = z.infer<typeof CustomerFilterSchema>;
+export type CustomerFilter = {
+	customer_id?: z.infer<typeof StringMatcherSchema>;
+	plan?:
+		| PlanFilterValue
+		| {
+				$some?: PlanFilterValue;
+				$every?: PlanFilterValue;
+				$none?: PlanFilterValue;
+		  };
+	item?:
+		| PlanItemFilterValue
+		| {
+				$some?: PlanItemFilterValue;
+				$every?: PlanItemFilterValue;
+				$none?: PlanItemFilterValue;
+		  };
+	$and?: CustomerFilter[];
+	$or?: CustomerFilter[];
+};
+
+export const CustomerFilterSchema: z.ZodType<CustomerFilter> = z.lazy(() =>
+	z.object({
+		customer_id: StringMatcherSchema.optional(),
+		plan: arrayFilter(PlanFilterSchema).optional(),
+		item: arrayFilter(PlanItemFilterSchema).optional(),
+		$and: z.array(CustomerFilterSchema).optional(),
+		$or: z.array(CustomerFilterSchema).optional(),
+	}),
+);
 
 export const DEFAULT_CUSTOMER_FILTER: CustomerFilter = {};

--- a/vite/src/hooks/stores/useProductSync.ts
+++ b/vite/src/hooks/stores/useProductSync.ts
@@ -1,6 +1,11 @@
 import type { FrontendProduct, ProductV2 } from "@autumn/shared";
-import { productV2ToFrontendProduct, sortPlanItems } from "@autumn/shared";
+import {
+	productsAreSame,
+	productV2ToFrontendProduct,
+	sortPlanItems,
+} from "@autumn/shared";
 import { useEffect, useRef } from "react";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductStore } from "./useProductStore";
 
 /**
@@ -14,6 +19,7 @@ export const useProductSync = ({
 	const setBaseProduct = useProductStore((s) => s.setBaseProduct);
 	const setProduct = useProductStore((s) => s.setProduct);
 	const currentProduct = useProductStore((s) => s.product);
+	const { features = [] } = useFeaturesQuery();
 	const hasInitialized = useRef(false);
 	const lastProductRef = useRef<ProductV2 | null>(null);
 
@@ -35,11 +41,30 @@ export const useProductSync = ({
 				items: sortPlanItems({ items: converted.items }),
 			};
 
+			// "Clean" = working copy has no unsaved edits vs the base it was synced
+			// from. Captured before setBaseProduct overwrites it below.
+			const baseBeforeSync = useProductStore.getState().baseProduct;
+			const editorIsClean =
+				!!baseBeforeSync &&
+				productsAreSame({
+					newProductV2: currentProduct,
+					curProductV2: baseBeforeSync,
+					features,
+				}).same;
+
 			// Always update baseProduct to reflect backend state
 			setBaseProduct(frontendProduct);
 
-			// Update product on initial load, when switching products, or when version changes
-			if (!hasInitialized.current || isNewProduct || isVersionChanged) {
+			// Reset the working copy on initial load, when switching products, on a
+			// version change, or whenever the editor is clean — the last case keeps
+			// the working copy in lockstep after an in-place save (same version),
+			// without clobbering genuine unsaved edits.
+			if (
+				!hasInitialized.current ||
+				isNewProduct ||
+				isVersionChanged ||
+				editorIsClean
+			) {
 				// Preserve frontend-only fields during creation flow, so Free vs Variable shows correctly
 				const shouldPreserveFrontendFields =
 					!currentProduct?.internal_id &&
@@ -59,5 +84,5 @@ export const useProductSync = ({
 				hasInitialized.current = true;
 			}
 		}
-	}, [product, setBaseProduct, setProduct, currentProduct]);
+	}, [product, setBaseProduct, setProduct, currentProduct, features]);
 };

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -2,6 +2,7 @@ import type {
 	DbOverageAllowed,
 	DbSpendLimit,
 	DbUsageAlert,
+	DbUsageLimit,
 } from "@autumn/shared";
 import type { AxiosInstance } from "axios";
 
@@ -43,6 +44,7 @@ export class CusService {
 		entityId: string;
 		billingControls: {
 			spend_limits?: DbSpendLimit[];
+			usage_limits?: DbUsageLimit[];
 			usage_alerts?: DbUsageAlert[];
 			overage_allowed?: DbOverageAllowed[];
 		};

--- a/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
+++ b/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
@@ -1,4 +1,5 @@
 import type {
+	ApiUsageLimit,
 	AutoTopupResponse,
 	DbOverageAllowed,
 	DbSpendLimit,
@@ -160,27 +161,34 @@ const UsageLimitRow = ({
 	featureNameById,
 	onClick,
 }: {
-	usageLimit: DbUsageLimit;
+	usageLimit: ApiUsageLimit;
 	featureNameById: Map<string, string>;
 	onClick: () => void;
-}) => (
-	<button type="button" className={rowClassName} onClick={onClick}>
-		{/* A usage_limits entry's presence arms the cap. */}
-		<StatusPill enabled />
-		<span className="truncate text-sm text-foreground font-medium">
-			{getFeatureLabel({
-				featureId: usageLimit.feature_id,
-				featureNameById,
-			})}
-		</span>
-		<div className="ml-auto flex items-center gap-1.5 shrink-0">
-			<Pill>
-				Usage limit:{" "}
-				{`${usageLimit.limit.toLocaleString()} / ${usageLimit.interval}`}
-			</Pill>
-		</div>
-	</button>
-);
+}) => {
+	const { usage, limit, interval } = usageLimit;
+	return (
+		<button type="button" className={rowClassName} onClick={onClick}>
+			{/* A usage_limits entry's presence arms the cap. */}
+			<StatusPill enabled />
+			<span className="truncate text-sm text-foreground font-medium">
+				{getFeatureLabel({
+					featureId: usageLimit.feature_id,
+					featureNameById,
+				})}
+			</span>
+			<div className="ml-auto flex items-center gap-1.5 shrink-0">
+				{usage != null && (
+					<Pill>
+						{`${usage.toLocaleString()} / ${limit.toLocaleString()} this ${interval}`}
+					</Pill>
+				)}
+				<Pill>
+					Usage limit: {`${limit.toLocaleString()} / ${interval}`}
+				</Pill>
+			</div>
+		</button>
+	);
+};
 
 const UsageAlertRow = ({
 	usageAlert,
@@ -282,10 +290,10 @@ export function CustomerBillingControlsSection() {
 		item,
 		index,
 	}));
-	// Usage limits are their own customer-scoped billing control (no entity
-	// variant in v1).
 	const usageLimits = (
-		selectedEntity ? [] : (fullCustomer?.usage_limits ?? [])
+		selectedEntity
+			? (selectedEntity.usage_limits ?? [])
+			: (fullCustomer?.usage_limits ?? [])
 	).map((item: DbUsageLimit, index: number) => ({ item, index }));
 	const usageAlerts = selectedEntity
 		? (selectedEntity.usage_alerts ?? [])
@@ -305,6 +313,7 @@ export function CustomerBillingControlsSection() {
 		fullCustomer?.entities?.filter(
 			(entity: Entity) =>
 				(entity.spend_limits?.length ?? 0) > 0 ||
+				(entity.usage_limits?.length ?? 0) > 0 ||
 				(entity.usage_alerts?.length ?? 0) > 0 ||
 				(entity.overage_allowed?.length ?? 0) > 0,
 		).length ?? 0;

--- a/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
@@ -30,6 +30,7 @@ import { CusService } from "@/services/customers/CusService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
+import { useCustomerContext } from "../../customer/CustomerContext";
 
 // Interval is required (no inherit) and one_off intervals are not supported.
 const INTERVAL_OPTIONS: Record<string, string> = {
@@ -59,6 +60,7 @@ export function BillingUsageLimitSheet() {
 	const sheetData = useSheetStore((s) => s.data);
 	const sheetType = useSheetStore((s) => s.type);
 	const { customer, refetch } = useCusQuery();
+	const { entityId } = useCustomerContext();
 	const { features } = useFeaturesQuery();
 	const axiosInstance = useAxiosInstance();
 
@@ -66,8 +68,12 @@ export function BillingUsageLimitSheet() {
 	const existingItem = sheetData?.item as DbUsageLimit | undefined;
 	const existingIndex = sheetData?.index as number | undefined;
 
-	// v1: usage limits are customer-scoped only (no entity variant).
 	const fullCustomer = customer as FullCustomer | undefined;
+	const selectedEntity = entityId
+		? fullCustomer?.entities?.find(
+				(e) => e.id === entityId || e.internal_id === entityId,
+			)
+		: null;
 
 	const [isSaving, setIsSaving] = useState(false);
 	const [featureId, setFeatureId] = useState(existingItem?.feature_id ?? "");
@@ -82,19 +88,29 @@ export function BillingUsageLimitSheet() {
 		(f: Feature) => !f.archived && f.type !== FeatureType.Boolean,
 	);
 
-	const getCurrentUsageLimits = (): DbUsageLimit[] => [
-		...(fullCustomer?.usage_limits ?? []),
-	];
+	const getCurrentUsageLimits = (): DbUsageLimit[] => {
+		if (selectedEntity) return [...(selectedEntity.usage_limits ?? [])];
+		return [...(fullCustomer?.usage_limits ?? [])];
+	};
 
 	const saveBillingControls = async (usageLimits: DbUsageLimit[]) => {
 		const customerId = fullCustomer?.id || fullCustomer?.internal_id;
 		if (!customerId) return;
 
-		await CusService.updateCustomer({
-			axios: axiosInstance,
-			customer_id: customerId,
-			data: { billing_controls: { usage_limits: usageLimits } },
-		});
+		if (selectedEntity) {
+			await CusService.updateEntity({
+				axios: axiosInstance,
+				customerId,
+				entityId: selectedEntity.id || selectedEntity.internal_id,
+				billingControls: { usage_limits: usageLimits },
+			});
+		} else {
+			await CusService.updateCustomer({
+				axios: axiosInstance,
+				customer_id: customerId,
+				data: { billing_controls: { usage_limits: usageLimits } },
+			});
+		}
 	};
 
 	const handleSave = async () => {

--- a/vite/src/views/migrations/migration/FilterStep.tsx
+++ b/vite/src/views/migrations/migration/FilterStep.tsx
@@ -8,8 +8,10 @@ import type { useMigrationEditorForm } from "./useMigrationEditorForm";
 
 type FormInstance = ReturnType<typeof useMigrationEditorForm>["form"];
 
-function hasActiveFilter(filter: CustomerFilter): boolean {
+export function hasActiveFilter(filter: CustomerFilter): boolean {
 	if (filter.customer_id) return true;
+	// Multi-condition filters compose quantifiers at the customer level.
+	if (filter.$and?.length || filter.$or?.length) return true;
 	if (!filter.plan) return false;
 	const plan = filter.plan;
 	if (typeof plan !== "object") return false;

--- a/vite/src/views/migrations/migration/filters/FilterForm.tsx
+++ b/vite/src/views/migrations/migration/filters/FilterForm.tsx
@@ -1,4 +1,5 @@
 import type {
+	CustomerFilter,
 	MigrationFilter,
 	PlanFilter,
 	StringMatcher,
@@ -11,15 +12,20 @@ import { AddButton } from "../shared/AddButton";
 import { FilterGroup } from "./FilterGroup";
 import {
 	customerIdToStrings,
+	type FilterField,
 	type FilterGroupData,
 	type FilterOperator,
 	type FilterRule,
-	groupsToPlanFilter,
 	planFilterToGroups,
+	planKeysToFilter,
+	ruleToStringMatcher,
 	stringsToCustomerId,
 } from "./filterRowTypes";
 
 const DEFAULT_PLAN_FILTER: PlanFilter = { plan_id: "" };
+
+const hasStringValue = (rule: FilterRule) =>
+	rule.values.some((value) => value.trim().length > 0);
 
 function inferCustomerIdOperator(
 	matcher: StringMatcher | undefined,
@@ -53,15 +59,112 @@ function planNoneInner(plan: unknown): PlanFilter | null {
 	return null;
 }
 
-/** Flip a `plan_id` rule between the `in` (positive) and `not_in` forms. */
-function flipPlanIdInToNotIn(groups: FilterGroupData[]): FilterGroupData[] {
-	return groups.map((g) => ({
-		rules: g.rules.map((r) =>
-			r.field === "plan_id" && r.operator === "in"
-				? { ...r, operator: "not_in" as FilterOperator }
-				: r,
-		),
-	}));
+// Fields whose negation is a customer-level `$none` quantifier ("no plan that
+// is X" / "no plan with feature X"), not a per-plan matcher. Both fan out
+// one-to-many, so `$some ... <> X` would match customers who also hold X.
+const NEGATABLE_FIELDS = new Set<FilterField>(["plan_id", "item_feature_id"]);
+
+function isNegatedRule(rule: FilterRule): boolean {
+	return (
+		NEGATABLE_FIELDS.has(rule.field) &&
+		(rule.operator === "is_not" || rule.operator === "not_in") &&
+		rule.values.length > 0
+	);
+}
+
+/** `is_not`/`not_in` → `is`/`in`, so the rule builds a positive `$none` inner. */
+function flipNegatedToPositive(rule: FilterRule): FilterRule {
+	if (!NEGATABLE_FIELDS.has(rule.field)) return rule;
+	if (rule.operator === "not_in")
+		return { ...rule, operator: "in" as FilterOperator };
+	if (rule.operator === "is_not")
+		return { ...rule, operator: "is" as FilterOperator };
+	return rule;
+}
+
+/** Inverse of the above: decode a `$none` inner back to the negated operator. */
+function negateRules(rules: FilterRule[]): FilterRule[] {
+	return rules.map((r) => {
+		if (!NEGATABLE_FIELDS.has(r.field)) return r;
+		if (r.operator === "in")
+			return { ...r, operator: "not_in" as FilterOperator };
+		if (r.operator === "is")
+			return { ...r, operator: "is_not" as FilterOperator };
+		return r;
+	});
+}
+
+function negateGroups(groups: FilterGroupData[]): FilterGroupData[] {
+	return groups.map((g) => ({ rules: negateRules(g.rules) }));
+}
+
+// SAVE — one row becomes one customer-level quantifier (a CustomerFilter with
+// a single `plan` nav). Independent rows AND together at the customer level, so
+// "has free AND has pro" is two quantifiers, not one plan that is both.
+function planIdQuantifier(rule: FilterRule): CustomerFilter | null {
+	if (rule.operator === "none") return { plan: { $none: {} } };
+	if (!hasStringValue(rule)) return null;
+	const positive = isNegatedRule(rule) ? flipNegatedToPositive(rule) : rule;
+	const planFilter = planKeysToFilter(positive.values);
+	return isNegatedRule(rule)
+		? { plan: { $none: planFilter } }
+		: { plan: planFilter };
+}
+
+function featureQuantifier(rule: FilterRule): CustomerFilter | null {
+	if (!hasStringValue(rule)) return null;
+	if (isNegatedRule(rule))
+		return {
+			plan: {
+				$none: {
+					item: {
+						feature_id: ruleToStringMatcher(flipNegatedToPositive(rule)),
+					},
+				},
+			},
+		};
+	return { plan: { item: { feature_id: ruleToStringMatcher(rule) } } };
+}
+
+function ruleToQuantifier(rule: FilterRule): CustomerFilter | null {
+	switch (rule.field) {
+		case "plan_id":
+			return planIdQuantifier(rule);
+		case "item_feature_id":
+			return featureQuantifier(rule);
+		case "custom":
+			return { plan: { custom: rule.values[0] === "true" } };
+		case "paid":
+			return { plan: { paid: rule.values[0] === "true" } };
+		case "recurring":
+			return { plan: { recurring: rule.values[0] === "true" } };
+		case "price":
+			return {
+				plan: { price: rule.operator === "exists" ? { $ne: null } : null },
+			};
+		case "item_unlimited":
+			return { plan: { item: { unlimited: rule.values[0] === "true" } } };
+		default:
+			return null;
+	}
+}
+
+// DECODE — reverse a single `plan` quantifier back into its UI row(s).
+function planQuantifierToRules(plan: unknown): FilterRule[] {
+	if (planRawIsNone(plan))
+		return [{ field: "plan_id", operator: "none", values: [] }];
+	const noneInner = planNoneInner(plan);
+	if (noneInner)
+		return negateRules(planFilterToGroups(noneInner).flatMap((g) => g.rules));
+	return planFilterToGroups(plan as PlanFilter).flatMap((g) => g.rules);
+}
+
+function branchToRules(branch: CustomerFilter): FilterRule[] {
+	const rules: FilterRule[] = [];
+	if (branch.$and)
+		for (const sub of branch.$and) rules.push(...branchToRules(sub));
+	if (branch.plan) rules.push(...planQuantifierToRules(branch.plan));
+	return rules;
 }
 
 function customerIdRuleFromValue(value: MigrationFilter): FilterRule | null {
@@ -84,9 +187,26 @@ function prependCustomerId(
 	return [{ rules: [customerIdRule, ...(first?.rules ?? [])] }, ...rest];
 }
 
-function buildGroups(value: MigrationFilter): FilterGroupData[] {
+export function buildGroups(value: MigrationFilter): FilterGroupData[] {
 	const customerIdRule = customerIdRuleFromValue(value);
-	const plan = value.customer?.plan;
+	const customer = value.customer;
+
+	// Customer-level `$or` → one OR-group per branch.
+	if (customer?.$or) {
+		const groups = customer.$or.map((branch) => ({
+			rules: branchToRules(branch),
+		}));
+		return prependCustomerId(groups, customerIdRule);
+	}
+	// Customer-level `$and` → one group, a row per branch.
+	if (customer?.$and)
+		return prependCustomerId(
+			[{ rules: branchToRules(customer) }],
+			customerIdRule,
+		);
+
+	// Single quantifier / legacy merged plan filter — decode `customer.plan`.
+	const plan = customer?.plan;
 
 	// "has no plans at all" → single `none` rule.
 	if (planRawIsNone(plan)) {
@@ -99,11 +219,11 @@ function buildGroups(value: MigrationFilter): FilterGroupData[] {
 		return [{ rules }];
 	}
 
-	// `{ $none: <inner> }` is the empty-inclusive "not on plan X" — decode the
-	// inner filter and flip its `plan_id` rule back to `not_in`.
+	// `{ $none: <inner> }` is the empty-inclusive "not on plan X" / "no feature
+	// X" — decode the inner filter and flip its negatable rules back.
 	const noneInner = planNoneInner(plan);
 	if (noneInner) {
-		const groups = flipPlanIdInToNotIn(planFilterToGroups(noneInner));
+		const groups = negateGroups(planFilterToGroups(noneInner));
 		return prependCustomerId(groups, customerIdRule);
 	}
 
@@ -128,72 +248,49 @@ function ruleToCustomerIdMatcher(rule: FilterRule): StringMatcher | undefined {
 }
 
 /**
- * Inner filter for a customer-level `$none` quantifier, or null when the groups
- * carry no plan negation. "has none" → `{}`; a `plan_id` "not in [X]" rule →
- * the group's plan filter with `plan_id` flipped to `$in` (negated by `$none`).
+ * One group → its customer-level node: the lone quantifier when a single row
+ * carries a condition, otherwise `{ $and: [...] }` over each row's quantifier.
+ * `customer_id` rows are hoisted out (they constrain the customer, not a plan).
  */
-function groupsToPlanNone(groups: FilterGroupData[]): PlanFilter | null {
-	if (groups.some((g) => g.rules.some((r) => r.operator === "none"))) return {};
-
-	const hasPlanNotIn = groups.some((g) =>
-		g.rules.some(
-			(r) =>
-				r.field === "plan_id" &&
-				r.operator === "not_in" &&
-				r.values.length > 0,
-		),
-	);
-	if (!hasPlanNotIn) return null;
-
-	const flipped = groups.map((g) => ({
-		rules: g.rules.map((r) =>
-			r.field === "plan_id" && r.operator === "not_in"
-				? { ...r, operator: "in" as FilterOperator }
-				: r,
-		),
-	}));
-	return groupsToPlanFilter(flipped);
+function groupToNode(group: FilterGroupData): {
+	customerId: StringMatcher | undefined;
+	node: CustomerFilter | null;
+} {
+	let customerId: StringMatcher | undefined;
+	const quantifiers: CustomerFilter[] = [];
+	for (const rule of group.rules) {
+		if (rule.field === "customer_id") {
+			const matcher = ruleToCustomerIdMatcher(rule);
+			if (matcher !== undefined) customerId = matcher;
+			continue;
+		}
+		const quantifier = ruleToQuantifier(rule);
+		if (quantifier) quantifiers.push(quantifier);
+	}
+	if (quantifiers.length === 0) return { customerId, node: null };
+	if (quantifiers.length === 1) return { customerId, node: quantifiers[0] };
+	return { customerId, node: { $and: quantifiers } };
 }
 
-function groupsToMigrationFilter(
+export function groupsToMigrationFilter(
 	groups: FilterGroupData[],
 	base: MigrationFilter,
 ): MigrationFilter {
-	let customerIdMatcher: StringMatcher | undefined;
-	const cleaned = groups.map((g) => ({
-		rules: g.rules.filter((r) => {
-			if (r.field === "customer_id") {
-				customerIdMatcher = ruleToCustomerIdMatcher(r);
-				return false;
-			}
-			return true;
-		}),
-	}));
-	// Plan negation is a customer-level quantifier ($none), not a per-plan
-	// matcher: "has none" → $none: {}, and "plan_id not in [X]" →
-	// $none: { plan_id: { $in: [X] } } so zero-plan customers are included.
-	const noneInner = groupsToPlanNone(cleaned);
-	if (noneInner) {
-		return {
-			...base,
-			customer: {
-				...base.customer,
-				customer_id: customerIdMatcher,
-				plan: { $none: noneInner },
-			},
-		};
+	let customerId: StringMatcher | undefined;
+	const nodes: CustomerFilter[] = [];
+	for (const group of groups) {
+		const { customerId: groupCustomerId, node } = groupToNode(group);
+		if (groupCustomerId !== undefined) customerId = groupCustomerId;
+		if (node) nodes.push(node);
 	}
 
-	const planFilter = groupsToPlanFilter(cleaned);
-	const hasPlanFilter = Object.keys(planFilter).length > 0;
-	return {
-		...base,
-		customer: {
-			...base.customer,
-			customer_id: customerIdMatcher,
-			plan: hasPlanFilter ? planFilter : undefined,
-		},
-	};
+	const customer: CustomerFilter = {};
+	if (customerId !== undefined) customer.customer_id = customerId;
+	// One node spreads its `plan` / `$and` onto the customer; many nodes OR.
+	if (nodes.length === 1) Object.assign(customer, nodes[0]);
+	else if (nodes.length > 1) customer.$or = nodes;
+
+	return { ...base, customer };
 }
 
 const EMPTY_GROUP: FilterGroupData = {
@@ -297,7 +394,11 @@ export function FilterForm({
 			))}
 			{hasConditions && (
 				<div className="flex items-center gap-2 mt-3">
-					<AddButton label="OR condition" onClick={addGroup} className="flex-1" />
+					<AddButton
+						label="OR condition"
+						onClick={addGroup}
+						className="flex-1"
+					/>
 					<Button
 						variant="skeleton"
 						size="sm"

--- a/vite/src/views/migrations/migration/filters/FilterGroup.tsx
+++ b/vite/src/views/migrations/migration/filters/FilterGroup.tsx
@@ -1,10 +1,8 @@
 import { UserIcon } from "@phosphor-icons/react";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
-import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { useCusSearchQueryV2 } from "@/views/customers/hooks/useCusSearchQuery";
 import { AddButton } from "../shared/AddButton";
 import { buildFeatureSuggestions } from "../shared/featureSuggestions";
-import { buildPlanSuggestions } from "../shared/planSuggestions";
 import { RemoveButton } from "../shared/RemoveButton";
 import type { ValuePickerOption } from "../shared/ValuePicker";
 import { FilterRow } from "./FilterRow";
@@ -19,7 +17,6 @@ import {
 function useSuggestionsForField(
 	field: string,
 ): ValuePickerOption[] | undefined {
-	const { products } = useProductsQuery();
 	const { features } = useFeaturesQuery();
 	const { customers } = useCusSearchQueryV2({
 		search: "",
@@ -40,7 +37,6 @@ function useSuggestionsForField(
 				};
 			});
 	}
-	if (field === "plan_id") return buildPlanSuggestions(products);
 	if (field === "item_feature_id") {
 		return buildFeatureSuggestions(features);
 	}

--- a/vite/src/views/migrations/migration/filters/FilterRow.tsx
+++ b/vite/src/views/migrations/migration/filters/FilterRow.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import {
 	Select,
 	SelectContent,
@@ -8,6 +7,7 @@ import {
 } from "@/components/v2/selects/Select";
 import { cn } from "@/lib/utils";
 import { BooleanPill } from "../shared/BooleanPill";
+import { PlanVersionPicker } from "../shared/PlanVersionPicker";
 import { RemoveButton } from "../shared/RemoveButton";
 import { ValuePicker } from "../shared/ValuePicker";
 import {
@@ -67,6 +67,13 @@ export function FilterRow({
 			values: next,
 		});
 	};
+
+	const handleValuesChange = (next: string[]) =>
+		onChange({
+			...rule,
+			operator: inferOperator(rule.operator, next.length),
+			values: next,
+		});
 
 	return (
 		<div className="flex items-center gap-2.5 group/row">
@@ -141,6 +148,7 @@ export function FilterRow({
 				onChange={onChange}
 				onToggle={handleToggle}
 				onChipRemove={handleChipRemove}
+				onValuesChange={handleValuesChange}
 			/>
 
 			<RemoveButton onClick={onRemove} />
@@ -156,6 +164,7 @@ function FilterValueInput({
 	onChange,
 	onToggle,
 	onChipRemove,
+	onValuesChange,
 }: {
 	config: FieldConfig;
 	rule: FilterRule;
@@ -164,10 +173,20 @@ function FilterValueInput({
 	onChange: (rule: FilterRule) => void;
 	onToggle: (value: string) => void;
 	onChipRemove: (value: string) => void;
+	onValuesChange: (values: string[]) => void;
 }) {
 	if (config.valueType === "none") return null;
 	// `none` (has no plans) takes no value.
 	if (rule.operator === "none") return null;
+
+	if (config.valueType === "plan")
+		return (
+			<PlanVersionPicker
+				className="flex-1"
+				onChange={onValuesChange}
+				values={rule.values}
+			/>
+		);
 
 	if (config.valueType === "boolean")
 		return (
@@ -178,25 +197,6 @@ function FilterValueInput({
 				/>
 			</div>
 		);
-
-	if (config.valueType === "number") {
-		const isMulti = rule.operator === "in" || rule.operator === "not_in";
-		if (isMulti) return <CommaSeparatedInput rule={rule} onChange={onChange} />;
-		return (
-			<input
-				type="number"
-				className="h-8 text-sm rounded-xl px-3 input-base flex-1 min-w-0 text-foreground placeholder:text-tertiary-foreground"
-				placeholder="Number"
-				value={rule.values[0] ?? ""}
-				onChange={(e) =>
-					onChange({
-						...rule,
-						values: e.target.value === "" ? [] : [e.target.value],
-					})
-				}
-			/>
-		);
-	}
 
 	if (suggestions && suggestions.length > 0)
 		return (
@@ -216,41 +216,6 @@ function FilterValueInput({
 			placeholder="Value"
 			value={rule.values[0] ?? ""}
 			onChange={(e) => onChange({ ...rule, values: [e.target.value] })}
-		/>
-	);
-}
-
-function CommaSeparatedInput({
-	rule,
-	onChange,
-}: {
-	rule: FilterRule;
-	onChange: (rule: FilterRule) => void;
-}) {
-	const [text, setText] = useState(() => rule.values.join(", "));
-
-	useEffect(() => {
-		setText(rule.values.join(", "));
-	}, [rule.values.join(",")]);
-
-	const commit = (raw: string) => {
-		const values = raw
-			.split(",")
-			.map((s) => s.trim())
-			.filter(Boolean);
-		onChange({ ...rule, values });
-	};
-
-	return (
-		<input
-			className="h-8 text-sm rounded-xl px-3 input-base flex-1 min-w-0 text-foreground placeholder:text-tertiary-foreground"
-			placeholder="1, 2, 3"
-			value={text}
-			onChange={(e) => setText(e.target.value)}
-			onBlur={(e) => commit(e.target.value)}
-			onKeyDown={(e) => {
-				if (e.key === "Enter") commit(e.currentTarget.value);
-			}}
 		/>
 	);
 }

--- a/vite/src/views/migrations/migration/filters/filterNegation.test.ts
+++ b/vite/src/views/migrations/migration/filters/filterNegation.test.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "bun:test";
+import type { MigrationFilter } from "@autumn/shared";
+import { buildGroups, groupsToMigrationFilter } from "./FilterForm";
+import type { FilterGroupData, FilterRule } from "./filterRowTypes";
+
+const group = (...rules: FilterRule[]): FilterGroupData[] => [{ rules }];
+const planOf = (filter: MigrationFilter) => filter.customer?.plan;
+
+// "Plan is not free" must mean "customer has no free plan" ($none), not
+// "customer has some non-free plan" ($some ... <> free) — otherwise a
+// Free+Pro customer leaks through via the Pro plan.
+test("plan_id is_not compiles to a $none quantifier", () => {
+	const filter = groupsToMigrationFilter(
+		group({ field: "plan_id", operator: "is_not", values: ["free"] }),
+		{},
+	);
+	expect(planOf(filter)).toEqual({ $none: { plan_id: "free" } });
+});
+
+test("plan_id not_in compiles to a $none quantifier", () => {
+	const filter = groupsToMigrationFilter(
+		group({ field: "plan_id", operator: "not_in", values: ["free", "trial"] }),
+		{},
+	);
+	expect(planOf(filter)).toEqual({
+		$none: { plan_id: { $in: ["free", "trial"] } },
+	});
+});
+
+test("feature is_not compiles to a $none quantifier over items", () => {
+	const filter = groupsToMigrationFilter(
+		group({
+			field: "item_feature_id",
+			operator: "is_not",
+			values: ["credits"],
+		}),
+		{},
+	);
+	expect(planOf(filter)).toEqual({
+		$none: { item: { feature_id: "credits" } },
+	});
+});
+
+test("positive plan_id stays a $some matcher", () => {
+	const filter = groupsToMigrationFilter(
+		group({ field: "plan_id", operator: "is", values: ["pro"] }),
+		{},
+	);
+	expect(planOf(filter)).toEqual({ plan_id: "pro" });
+});
+
+test("plan_id is_not round-trips back to the is_not operator", () => {
+	const filter: MigrationFilter = {
+		customer: { plan: { $none: { plan_id: "free" } } },
+	};
+	const rules = buildGroups(filter).flatMap((g) => g.rules);
+	expect(rules).toContainEqual({
+		field: "plan_id",
+		operator: "is_not",
+		values: ["free"],
+	});
+});
+
+test("feature is_not round-trips back to the is_not operator", () => {
+	const filter: MigrationFilter = {
+		customer: { plan: { $none: { item: { feature_id: "credits" } } } },
+	};
+	const rules = buildGroups(filter).flatMap((g) => g.rules);
+	expect(rules).toContainEqual({
+		field: "item_feature_id",
+		operator: "is_not",
+		values: ["credits"],
+	});
+});
+
+// Two plan rows in one group = "has BOTH" — independent $and quantifiers, not
+// a single plan that is both (which silently dropped the first condition).
+test("two plan rows in a group compile to customer-level $and", () => {
+	const filter = groupsToMigrationFilter(
+		group(
+			{ field: "plan_id", operator: "is", values: ["free"] },
+			{ field: "plan_id", operator: "in", values: ["pro_6mo", "pro_3mo"] },
+		),
+		{},
+	);
+	expect(filter.customer).toEqual({
+		$and: [
+			{ plan: { plan_id: "free" } },
+			{ plan: { plan_id: { $in: ["pro_6mo", "pro_3mo"] } } },
+		],
+	});
+});
+
+test("a plan row and a feature row in a group compile to $and", () => {
+	const filter = groupsToMigrationFilter(
+		group(
+			{ field: "plan_id", operator: "is", values: ["pro"] },
+			{ field: "item_feature_id", operator: "is", values: ["credits"] },
+		),
+		{},
+	);
+	expect(filter.customer).toEqual({
+		$and: [
+			{ plan: { plan_id: "pro" } },
+			{ plan: { item: { feature_id: "credits" } } },
+		],
+	});
+});
+
+test("separate groups compile to customer-level $or", () => {
+	const filter = groupsToMigrationFilter(
+		[
+			{ rules: [{ field: "plan_id", operator: "is", values: ["free"] }] },
+			{ rules: [{ field: "plan_id", operator: "is", values: ["pro"] }] },
+		],
+		{},
+	);
+	expect(filter.customer).toEqual({
+		$or: [{ plan: { plan_id: "free" } }, { plan: { plan_id: "pro" } }],
+	});
+});
+
+test("customer_id is hoisted above an $and group", () => {
+	const filter = groupsToMigrationFilter(
+		group(
+			{ field: "customer_id", operator: "is", values: ["cus_1"] },
+			{ field: "plan_id", operator: "is", values: ["free"] },
+			{ field: "plan_id", operator: "is", values: ["pro"] },
+		),
+		{},
+	);
+	expect(filter.customer).toEqual({
+		customer_id: "cus_1",
+		$and: [{ plan: { plan_id: "free" } }, { plan: { plan_id: "pro" } }],
+	});
+});
+
+test("$and round-trips back to two plan rows in one group", () => {
+	const filter: MigrationFilter = {
+		customer: {
+			$and: [
+				{ plan: { plan_id: "free" } },
+				{ plan: { plan_id: { $in: ["pro_6mo", "pro_3mo"] } } },
+			],
+		},
+	};
+	const groups = buildGroups(filter);
+	expect(groups).toHaveLength(1);
+	expect(groups[0].rules).toEqual([
+		{ field: "plan_id", operator: "is", values: ["free"] },
+		{ field: "plan_id", operator: "in", values: ["pro_6mo", "pro_3mo"] },
+	]);
+});
+
+test("$or round-trips back to two OR-groups", () => {
+	const filter: MigrationFilter = {
+		customer: {
+			$or: [{ plan: { plan_id: "free" } }, { plan: { plan_id: "pro" } }],
+		},
+	};
+	const groups = buildGroups(filter);
+	expect(groups).toHaveLength(2);
+	expect(groups[0].rules).toEqual([
+		{ field: "plan_id", operator: "is", values: ["free"] },
+	]);
+	expect(groups[1].rules).toEqual([
+		{ field: "plan_id", operator: "is", values: ["pro"] },
+	]);
+});

--- a/vite/src/views/migrations/migration/filters/filterRowTypes.ts
+++ b/vite/src/views/migrations/migration/filters/filterRowTypes.ts
@@ -1,4 +1,4 @@
-import type { PlanFilter, StringMatcher } from "@autumn/shared";
+import type { NumberMatcher, PlanFilter, StringMatcher } from "@autumn/shared";
 
 export type FilterField =
 	| "customer_id"
@@ -215,16 +215,34 @@ function planIdsFromMatcher(
 	return null;
 }
 
-/** A PlanFilter that is purely a plan selection (`plan_id` and an optional bare
- *  `version`) → its value keys, else null. */
+// A version pin folds into a plan key only as a single concrete number — bare
+// `N` or `{ $eq: N }`. Returns `undefined` when absent, or `"unfoldable"` for
+// matcher forms ($in, ranges, $ne, null) a key can't carry.
+function pinnedVersion(
+	matcher: NumberMatcher | undefined,
+): number | undefined | "unfoldable" {
+	if (matcher === undefined) return undefined;
+	if (typeof matcher === "number") return matcher;
+	if (
+		typeof matcher === "object" &&
+		matcher !== null &&
+		typeof matcher.$eq === "number" &&
+		Object.keys(matcher).length === 1
+	)
+		return matcher.$eq;
+	return "unfoldable";
+}
+
+/** A PlanFilter that is purely a plan selection (`plan_id` and an optional
+ *  single-version pin) → its value keys, else null. */
 function pureSelectionKeys(filter: PlanFilter): string[] | null {
 	if (filter.plan_id === undefined) return null;
 	if (Object.keys(filter).some((key) => !PLAN_SELECTION_KEYS.has(key)))
 		return null;
 	const ids = planIdsFromMatcher(filter.plan_id);
 	if (ids === null) return null;
-	const version =
-		typeof filter.version === "number" ? filter.version : undefined;
+	const version = pinnedVersion(filter.version);
+	if (version === "unfoldable") return null;
 	return ids.map((planId) => makePlanKey({ planId, version }));
 }
 

--- a/vite/src/views/migrations/migration/filters/filterRowTypes.ts
+++ b/vite/src/views/migrations/migration/filters/filterRowTypes.ts
@@ -1,9 +1,8 @@
-import type { NumberMatcher, PlanFilter, StringMatcher } from "@autumn/shared";
+import type { PlanFilter, StringMatcher } from "@autumn/shared";
 
 export type FilterField =
 	| "customer_id"
 	| "plan_id"
-	| "version"
 	| "custom"
 	| "paid"
 	| "recurring"
@@ -20,11 +19,7 @@ export type FilterOperator =
 	| "starts_with"
 	| "exists"
 	| "not_exists"
-	| "none"
-	| "gt"
-	| "gte"
-	| "lt"
-	| "lte";
+	| "none";
 
 export type FilterRule = {
 	field: FilterField;
@@ -42,7 +37,6 @@ export const FILTER_FIELD_OPTIONS: {
 }[] = [
 	{ value: "customer_id", label: "Customer" },
 	{ value: "plan_id", label: "Plan" },
-	{ value: "version", label: "Version" },
 	{ value: "custom", label: "Custom" },
 	{ value: "paid", label: "Paid" },
 	{ value: "recurring", label: "Recurring" },
@@ -54,24 +48,8 @@ export const FILTER_FIELD_OPTIONS: {
 type OperatorOption = { value: FilterOperator; label: string };
 export type FieldConfig = {
 	operators: OperatorOption[];
-	valueType: "string" | "boolean" | "number" | "none";
+	valueType: "string" | "boolean" | "plan" | "none";
 };
-
-const STRING_OPERATORS: OperatorOption[] = [
-	{ value: "is", label: "is" },
-	{ value: "is_not", label: "is not" },
-	{ value: "in", label: "in" },
-	{ value: "not_in", label: "not in" },
-	{ value: "regex", label: "regex" },
-	{ value: "starts_with", label: "starts with" },
-];
-
-// Plan adds "has none" — selects customers with no active plans at all
-// (compiles to the `$none` quantifier, not a per-plan matcher).
-const PLAN_OPERATORS: OperatorOption[] = [
-	...STRING_OPERATORS,
-	{ value: "none", label: "has none" },
-];
 
 const STRING_MATCH_OPERATORS: OperatorOption[] = [
 	{ value: "is", label: "is" },
@@ -80,15 +58,11 @@ const STRING_MATCH_OPERATORS: OperatorOption[] = [
 	{ value: "not_in", label: "not in" },
 ];
 
-const NUMBER_OPERATORS: OperatorOption[] = [
-	{ value: "is", label: "is" },
-	{ value: "is_not", label: "is not" },
-	{ value: "gt", label: ">" },
-	{ value: "gte", label: "≥" },
-	{ value: "lt", label: "<" },
-	{ value: "lte", label: "≤" },
-	{ value: "in", label: "in" },
-	{ value: "not_in", label: "not in" },
+// Plan adds "has none" — selects customers with no active plans at all
+// (compiles to the `$none` quantifier, not a per-plan matcher).
+const PLAN_OPERATORS: OperatorOption[] = [
+	...STRING_MATCH_OPERATORS,
+	{ value: "none", label: "has none" },
 ];
 
 const BOOLEAN_ONLY: FieldConfig = {
@@ -106,8 +80,7 @@ const NULLABLE_ONLY: FieldConfig = {
 
 export const FIELD_CONFIGS: Record<FilterField, FieldConfig> = {
 	customer_id: { operators: STRING_MATCH_OPERATORS, valueType: "string" },
-	plan_id: { operators: PLAN_OPERATORS, valueType: "string" },
-	version: { operators: NUMBER_OPERATORS, valueType: "number" },
+	plan_id: { operators: PLAN_OPERATORS, valueType: "plan" },
 	custom: BOOLEAN_ONLY,
 	paid: BOOLEAN_ONLY,
 	recurring: BOOLEAN_ONLY,
@@ -151,100 +124,7 @@ function stringMatcherToRule(
 	return { field, operator: "is", values: [] };
 }
 
-/**
- * Convert a NumberMatcher to one OR MORE FilterRules. A combined matcher like
- * `{ $gte: 2, $lte: 4 }` emits two rules (a "≥ 2" rule and a "≤ 4" rule) so
- * neither constraint is silently dropped. `groupsToPlanFilter` re-merges them
- * by field on save.
- */
-export function numberMatcherToRules(
-	field: FilterField,
-	matcher: NumberMatcher | undefined,
-): FilterRule[] {
-	if (matcher === undefined) return [];
-	if (matcher === null) return [{ field, operator: "is", values: [] }];
-	if (typeof matcher === "number")
-		return [{ field, operator: "is", values: [String(matcher)] }];
-
-	const rules: FilterRule[] = [];
-	if (matcher.$eq !== undefined) {
-		if (matcher.$eq === null) rules.push({ field, operator: "is", values: [] });
-		else rules.push({ field, operator: "is", values: [String(matcher.$eq)] });
-	}
-	if (matcher.$ne !== undefined && matcher.$ne !== null)
-		rules.push({ field, operator: "is_not", values: [String(matcher.$ne)] });
-	if (matcher.$in !== undefined)
-		rules.push({ field, operator: "in", values: matcher.$in.map(String) });
-	if (matcher.$nin !== undefined)
-		rules.push({ field, operator: "not_in", values: matcher.$nin.map(String) });
-	if (matcher.$gt !== undefined)
-		rules.push({ field, operator: "gt", values: [String(matcher.$gt)] });
-	if (matcher.$gte !== undefined)
-		rules.push({ field, operator: "gte", values: [String(matcher.$gte)] });
-	if (matcher.$lt !== undefined)
-		rules.push({ field, operator: "lt", values: [String(matcher.$lt)] });
-	if (matcher.$lte !== undefined)
-		rules.push({ field, operator: "lte", values: [String(matcher.$lte)] });
-	return rules;
-}
-
-/**
- * Convert a single FilterRule into a NumberMatcher fragment that can be
- * merged with other fragments for the same field. An empty `"is"` rule round-
- * trips from `version: null` and must preserve the explicit null match.
- */
-function ruleToNumberMatcherFragment(
-	rule: FilterRule,
-): Record<string, unknown> | null {
-	const nums = rule.values
-		.map((v) => Number.parseFloat(v))
-		.filter((n) => !Number.isNaN(n));
-	if (nums.length === 0) {
-		if (rule.operator === "is") return { $eq: null };
-		return null;
-	}
-	const first = nums[0];
-	switch (rule.operator) {
-		case "is":
-			return nums.length > 1 ? { $in: nums } : { $eq: first };
-		case "is_not":
-			return { $ne: first };
-		case "in":
-			return { $in: nums };
-		case "not_in":
-			return { $nin: nums };
-		case "gt":
-			return { $gt: first };
-		case "gte":
-			return { $gte: first };
-		case "lt":
-			return { $lt: first };
-		case "lte":
-			return { $lte: first };
-		default:
-			return { $eq: first };
-	}
-}
-
-export function mergeNumberFragments(
-	fragments: Record<string, unknown>[],
-): NumberMatcher | undefined {
-	if (fragments.length === 0) return undefined;
-	if (fragments.length === 1) {
-		const fragment = fragments[0];
-		const keys = Object.keys(fragment);
-		if (keys.length === 1 && "$eq" in fragment) {
-			// Simplify single-eq fragments back to bare value (matches the
-			// canonical "bare = $eq" convention) — handles version: 1 → 1
-			// and version: null → null.
-			return fragment.$eq as NumberMatcher;
-		}
-		return fragment as NumberMatcher;
-	}
-	return Object.assign({}, ...fragments) as NumberMatcher;
-}
-
-function ruleToStringMatcher(rule: FilterRule): StringMatcher {
+export function ruleToStringMatcher(rule: FilterRule): StringMatcher {
 	if (
 		rule.operator === "in" ||
 		(rule.operator === "is" && rule.values.length > 1)
@@ -280,13 +160,111 @@ function nullableToRule(field: FilterField, value: unknown): FilterRule | null {
 	return { field, operator: "exists", values: [] };
 }
 
+// Plan selections are encoded as value keys: "<planId>" (any version) or
+// "<planId>:<version>" (a specific version). Version is therefore always bound
+// to its plan — there is no standalone version field.
+const PLAN_KEY_SEPARATOR = ":";
+
+export type PlanSelection = { planId: string; version?: number };
+
+export function parsePlanKey(key: string): PlanSelection {
+	const separatorIndex = key.lastIndexOf(PLAN_KEY_SEPARATOR);
+	if (separatorIndex === -1) return { planId: key };
+	const version = Number.parseInt(key.slice(separatorIndex + 1), 10);
+	if (Number.isNaN(version)) return { planId: key };
+	return { planId: key.slice(0, separatorIndex), version };
+}
+
+export function makePlanKey({ planId, version }: PlanSelection): string {
+	return version === undefined
+		? planId
+		: `${planId}${PLAN_KEY_SEPARATOR}${version}`;
+}
+
+function selectionToFilter({ planId, version }: PlanSelection): PlanFilter {
+	return version === undefined
+		? { plan_id: planId }
+		: { plan_id: planId, version };
+}
+
+/**
+ * Plan-selection value keys → the PlanFilter for one quantifier. Version-less
+ * keys collapse to `plan_id` / `$in`; any pinned version forces an `$or` of
+ * `{ plan_id, version }` branches (each compiles to a single bound EXISTS).
+ */
+export function planKeysToFilter(keys: string[]): PlanFilter {
+	const selections = keys.map(parsePlanKey);
+	if (selections.every((s) => s.version === undefined)) {
+		const ids = selections.map((s) => s.planId);
+		return { plan_id: ids.length === 1 ? ids[0] : { $in: ids } };
+	}
+	if (selections.length === 1) return selectionToFilter(selections[0]);
+	return { $or: selections.map(selectionToFilter) };
+}
+
+const PLAN_SELECTION_KEYS = new Set(["plan_id", "version"]);
+
+function planIdsFromMatcher(
+	matcher: StringMatcher | undefined,
+): string[] | null {
+	if (typeof matcher === "string") return [matcher];
+	if (matcher && typeof matcher === "object") {
+		if (matcher.$eq) return [matcher.$eq];
+		if (matcher.$in) return matcher.$in;
+	}
+	return null;
+}
+
+/** A PlanFilter that is purely a plan selection (`plan_id` and an optional bare
+ *  `version`) → its value keys, else null. */
+function pureSelectionKeys(filter: PlanFilter): string[] | null {
+	if (filter.plan_id === undefined) return null;
+	if (Object.keys(filter).some((key) => !PLAN_SELECTION_KEYS.has(key)))
+		return null;
+	const ids = planIdsFromMatcher(filter.plan_id);
+	if (ids === null) return null;
+	const version =
+		typeof filter.version === "number" ? filter.version : undefined;
+	return ids.map((planId) => makePlanKey({ planId, version }));
+}
+
+/**
+ * Decode a quantifier's PlanFilter to plan-selection keys, or null when it
+ * isn't a plan selection (a non-plan field, or a legacy `$or` of full filters
+ * — those are handled by `planFilterToGroups`).
+ */
+export function planFilterToPlanKeys(filter: PlanFilter): string[] | null {
+	if (filter.$or) {
+		if (Object.keys(filter).some((key) => key !== "$or")) return null;
+		const keys: string[] = [];
+		for (const branch of filter.$or) {
+			const branchKeys = pureSelectionKeys(branch);
+			if (branchKeys === null) return null;
+			keys.push(...branchKeys);
+		}
+		return keys;
+	}
+	return pureSelectionKeys(filter);
+}
+
+function planKeysToRule(keys: string[]): FilterRule {
+	return {
+		field: "plan_id",
+		operator: keys.length > 1 ? "in" : "is",
+		values: keys,
+	};
+}
+
 export function planFilterToGroups(filter: PlanFilter): FilterGroupData[] {
+	// A pure plan selection is a single plan row (version folded into the keys).
+	const planKeys = planFilterToPlanKeys(filter);
+	if (planKeys !== null)
+		return [{ rules: planKeys.length > 0 ? [planKeysToRule(planKeys)] : [] }];
+
 	const mainRules: FilterRule[] = [];
 
 	const planIdRule = stringMatcherToRule("plan_id", filter.plan_id);
 	if (planIdRule) mainRules.push(planIdRule);
-
-	mainRules.push(...numberMatcherToRules("version", filter.version));
 
 	if (filter.custom !== undefined)
 		mainRules.push(booleanRule("custom", filter.custom));
@@ -319,6 +297,7 @@ export function planFilterToGroups(filter: PlanFilter): FilterGroupData[] {
 	const groups: FilterGroupData[] =
 		mainRules.length > 0 ? [{ rules: mainRules }] : [];
 
+	// Legacy `$or` of full filters — each branch is its own OR-group.
 	if (filter.$or) {
 		for (const orFilter of filter.$or) {
 			const orGroups = planFilterToGroups(orFilter);
@@ -327,69 +306,6 @@ export function planFilterToGroups(filter: PlanFilter): FilterGroupData[] {
 	}
 
 	return groups.length > 0 ? groups : [{ rules: [] }];
-}
-
-function groupToPlanFilter(group: FilterGroupData): PlanFilter {
-	const filter: PlanFilter = {};
-	let hasItemFields = false;
-	const itemInner: Record<string, unknown> = {};
-	const versionFragments: Record<string, unknown>[] = [];
-	const hasStringValue = (rule: FilterRule) =>
-		rule.values.some((value) => value.trim().length > 0);
-
-	for (const rule of group.rules) {
-		switch (rule.field) {
-			case "plan_id":
-				if (!hasStringValue(rule)) break;
-				filter.plan_id = ruleToStringMatcher(rule);
-				break;
-			case "version": {
-				const fragment = ruleToNumberMatcherFragment(rule);
-				if (fragment) versionFragments.push(fragment);
-				break;
-			}
-			case "custom":
-				filter.custom = rule.values[0] === "true";
-				break;
-			case "paid":
-				filter.paid = rule.values[0] === "true";
-				break;
-			case "recurring":
-				filter.recurring = rule.values[0] === "true";
-				break;
-			case "price":
-				filter.price = rule.operator === "exists" ? { $ne: null } : null;
-				break;
-			case "item_feature_id":
-				if (!hasStringValue(rule)) break;
-				hasItemFields = true;
-				itemInner.feature_id = ruleToStringMatcher(rule);
-				break;
-			case "item_unlimited":
-				hasItemFields = true;
-				itemInner.unlimited = rule.values[0] === "true";
-				break;
-		}
-	}
-
-	if (hasItemFields) {
-		filter.item = itemInner as PlanFilter["item"];
-	}
-
-	const versionMatcher = mergeNumberFragments(versionFragments);
-	if (versionMatcher !== undefined) filter.version = versionMatcher;
-
-	return filter;
-}
-
-export function groupsToPlanFilter(groups: FilterGroupData[]): PlanFilter {
-	const branches = groups
-		.map(groupToPlanFilter)
-		.filter((filter) => Object.keys(filter).length > 0);
-
-	if (branches.length === 0) return {};
-	if (branches.length === 1) return branches[0];
-	return { $or: branches };
 }
 
 export function customerIdToStrings(

--- a/vite/src/views/migrations/migration/filters/planVersion.test.ts
+++ b/vite/src/views/migrations/migration/filters/planVersion.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+import type { MigrationFilter } from "@autumn/shared";
+import { buildGroups, groupsToMigrationFilter } from "./FilterForm";
+import {
+	type FilterGroupData,
+	type FilterRule,
+	planFilterToPlanKeys,
+	planKeysToFilter,
+} from "./filterRowTypes";
+
+const group = (...rules: FilterRule[]): FilterGroupData[] => [{ rules }];
+const planOf = (filter: MigrationFilter) => filter.customer?.plan;
+
+// A specific version is bound to its plan in one quantifier — "pro:2" means
+// "has Pro at version 2", never "has Pro AND has something at version 2".
+test("a version-pinned plan key encodes to plan_id + version", () => {
+	const filter = groupsToMigrationFilter(
+		group({ field: "plan_id", operator: "is", values: ["pro:2"] }),
+		{},
+	);
+	expect(planOf(filter)).toEqual({ plan_id: "pro", version: 2 });
+});
+
+test("a whole-plan key (no version) stays version-less", () => {
+	expect(planKeysToFilter(["pro"])).toEqual({ plan_id: "pro" });
+});
+
+test("mixed whole + pinned keys encode to a plan-level $or", () => {
+	const filter = groupsToMigrationFilter(
+		group({ field: "plan_id", operator: "in", values: ["free", "pro:2"] }),
+		{},
+	);
+	expect(planOf(filter)).toEqual({
+		$or: [{ plan_id: "free" }, { plan_id: "pro", version: 2 }],
+	});
+});
+
+test("version-less keys collapse to a $in", () => {
+	expect(planKeysToFilter(["free", "pro"])).toEqual({
+		plan_id: { $in: ["free", "pro"] },
+	});
+});
+
+test("plan_id + version decodes back to a single pinned key", () => {
+	expect(planFilterToPlanKeys({ plan_id: "pro", version: 2 })).toEqual([
+		"pro:2",
+	]);
+});
+
+test("$or of plan matchers decodes back to mixed keys", () => {
+	expect(
+		planFilterToPlanKeys({
+			$or: [{ plan_id: "free" }, { plan_id: "pro", version: 2 }],
+		}),
+	).toEqual(["free", "pro:2"]);
+});
+
+test("a non-selection plan filter is not treated as plan keys", () => {
+	expect(planFilterToPlanKeys({ paid: true })).toBeNull();
+	expect(planFilterToPlanKeys({ item: { feature_id: "credits" } })).toBeNull();
+});
+
+test("version-pinned selection round-trips through the UI", () => {
+	const filter: MigrationFilter = {
+		customer: { plan: { plan_id: "pro", version: 2 } },
+	};
+	const rules = buildGroups(filter).flatMap((g) => g.rules);
+	expect(rules).toEqual([
+		{ field: "plan_id", operator: "is", values: ["pro:2"] },
+	]);
+});
+
+test("mixed $or selection round-trips to one plan row", () => {
+	const filter: MigrationFilter = {
+		customer: {
+			plan: { $or: [{ plan_id: "free" }, { plan_id: "pro", version: 2 }] },
+		},
+	};
+	const rules = buildGroups(filter).flatMap((g) => g.rules);
+	expect(rules).toEqual([
+		{ field: "plan_id", operator: "in", values: ["free", "pro:2"] },
+	]);
+});

--- a/vite/src/views/migrations/migration/filters/planVersion.test.ts
+++ b/vite/src/views/migrations/migration/filters/planVersion.test.ts
@@ -60,6 +60,25 @@ test("a non-selection plan filter is not treated as plan keys", () => {
 	expect(planFilterToPlanKeys({ item: { feature_id: "credits" } })).toBeNull();
 });
 
+// `version: { $eq: N }` is the object form of a single pinned version and must
+// fold into the key — dropping it would broaden the migration's scope on save.
+test("an $eq version matcher decodes to a pinned key", () => {
+	expect(planFilterToPlanKeys({ plan_id: "pro", version: { $eq: 2 } })).toEqual(
+		["pro:2"],
+	);
+});
+
+// A version range/set can't be carried by a plan key; it must not masquerade as
+// a clean "any version" selection.
+test("a non-foldable version matcher is not treated as plan keys", () => {
+	expect(
+		planFilterToPlanKeys({ plan_id: "pro", version: { $gte: 2 } }),
+	).toBeNull();
+	expect(
+		planFilterToPlanKeys({ plan_id: "pro", version: { $in: [2, 3] } }),
+	).toBeNull();
+});
+
 test("version-pinned selection round-trips through the UI", () => {
 	const filter: MigrationFilter = {
 		customer: { plan: { plan_id: "pro", version: 2 } },

--- a/vite/src/views/migrations/migration/migrationGuards.test.ts
+++ b/vite/src/views/migrations/migration/migrationGuards.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import type { Operations } from "@autumn/shared";
+import { hasActiveFilter } from "./FilterStep";
+import { toOperationsPayload } from "./useMigrationEditorForm";
+
+// `hasActiveFilter` gates the customer preview. It must recognize the
+// customer-level `$and`/`$or` shapes — not just the legacy single `plan` — or
+// multi-condition filters silently render no preview.
+test("hasActiveFilter is false for an empty or default-only filter", () => {
+	expect(hasActiveFilter({})).toBe(false);
+	expect(hasActiveFilter({ plan: { plan_id: "" } })).toBe(false);
+});
+
+test("hasActiveFilter is true for a single plan / customer_id condition", () => {
+	expect(hasActiveFilter({ plan: { plan_id: "free" } })).toBe(true);
+	expect(hasActiveFilter({ customer_id: "cus_1" })).toBe(true);
+});
+
+test("hasActiveFilter is true for $and / $or compositions", () => {
+	expect(
+		hasActiveFilter({
+			$and: [{ plan: { plan_id: "free" } }, { plan: { plan_id: "pro" } }],
+		}),
+	).toBe(true);
+	expect(
+		hasActiveFilter({
+			$or: [{ plan: { plan_id: "free" } }, { plan: { plan_id: "pro" } }],
+		}),
+	).toBe(true);
+});
+
+// A filter-only draft (no operations yet) must persist: an empty operations
+// block is sent as null, since the `{}` shape fails the server's resource-block
+// check. A non-empty (even mid-edit) block is kept so editing isn't lost.
+const op = {
+	type: "add_plan",
+	plan_filter: { plan_id: "pro" },
+	plan_id: "pro",
+} as unknown as NonNullable<Operations["customer"]>[number];
+
+test("toOperationsPayload sends an empty operations block as null", () => {
+	expect(toOperationsPayload({})).toBeNull();
+	expect(toOperationsPayload({ customer: [] })).toBeNull();
+});
+
+test("toOperationsPayload keeps a non-empty operations block", () => {
+	const operations: Operations = { customer: [op] };
+	expect(toOperationsPayload(operations)).toBe(operations);
+});

--- a/vite/src/views/migrations/migration/shared/PlanVersionPicker.tsx
+++ b/vite/src/views/migrations/migration/shared/PlanVersionPicker.tsx
@@ -194,8 +194,9 @@ export function PlanVersionPicker({
 													}}
 												>
 													<Checkbox
-														checked={
-															isWhole(plan.id) || isVersion(plan.id, version)
+														checked={isVersion(plan.id, version)}
+														indeterminate={
+															isWhole(plan.id) && !isVersion(plan.id, version)
 														}
 														className="border-border"
 													/>

--- a/vite/src/views/migrations/migration/shared/PlanVersionPicker.tsx
+++ b/vite/src/views/migrations/migration/shared/PlanVersionPicker.tsx
@@ -1,0 +1,215 @@
+import { PackageIcon, XIcon } from "@phosphor-icons/react";
+import { Checkbox } from "@/components/v2/checkboxes/Checkbox";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
+} from "@/components/v2/dropdowns/DropdownMenu";
+import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import { cn } from "@/lib/utils";
+import { getVersionCounts } from "@/utils/productUtils";
+import { makePlanKey, parsePlanKey } from "../filters/filterRowTypes";
+
+const MAX_VISIBLE_CHIPS = 3;
+
+/**
+ * Multi-select plan picker. A selection is either a whole plan (any version,
+ * key `"<id>"`) or a specific version (key `"<id>:<v>"`). Whole-plan and
+ * specific-version picks are mutually exclusive per plan.
+ */
+export function PlanVersionPicker({
+	values,
+	onChange,
+	className,
+	defaultOpen = false,
+}: {
+	values: string[];
+	onChange: (next: string[]) => void;
+	className?: string;
+	defaultOpen?: boolean;
+}) {
+	const { products } = useProductsQuery();
+	const versionCounts = getVersionCounts(products);
+
+	const uniquePlans = products.filter(
+		(plan, index) => products.findIndex((p) => p.id === plan.id) === index,
+	);
+	const nameById = new Map(uniquePlans.map((plan) => [plan.id, plan.name]));
+
+	const isWhole = (planId: string) => values.includes(planId);
+	const isVersion = (planId: string, version: number) =>
+		values.includes(makePlanKey({ planId, version }));
+
+	const toggleWhole = (planId: string) => {
+		if (isWhole(planId)) {
+			onChange(values.filter((key) => key !== planId));
+			return;
+		}
+		// Whole plan supersedes any pinned versions of the same plan.
+		const cleared = values.filter((key) => parsePlanKey(key).planId !== planId);
+		onChange([...cleared, planId]);
+	};
+
+	const toggleVersion = (planId: string, version: number) => {
+		const key = makePlanKey({ planId, version });
+		if (values.includes(key)) {
+			onChange(values.filter((existing) => existing !== key));
+			return;
+		}
+		// A specific version supersedes the whole-plan pick.
+		onChange([...values.filter((existing) => existing !== planId), key]);
+	};
+
+	const removeKey = (key: string) =>
+		onChange(values.filter((existing) => existing !== key));
+
+	const chipLabel = (key: string) => {
+		const { planId, version } = parsePlanKey(key);
+		const name = nameById.get(planId) ?? planId;
+		return version === undefined ? name : `${name} v${version}`;
+	};
+
+	return (
+		<div className={cn("min-w-0", className)}>
+			<DropdownMenu defaultOpen={defaultOpen}>
+				<DropdownMenuTrigger className="flex h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl px-3 input-base input-state-open-tiny text-sm">
+					{values.length === 0 ? (
+						<span className="text-tertiary-foreground">Select plans...</span>
+					) : (
+						<>
+							{values.slice(0, MAX_VISIBLE_CHIPS).map((key) => (
+								<span
+									className="flex h-4.5 max-w-48 shrink-0 items-center gap-0.5 rounded border border-border bg-accent px-1 text-[10px] text-foreground"
+									key={key}
+								>
+									<span className="shrink-0 [&_svg]:size-3">
+										<PackageIcon
+											className="text-tertiary-foreground"
+											size={12}
+											weight="duotone"
+										/>
+									</span>
+									<span className="truncate">{chipLabel(key)}</span>
+									<span
+										className="ml-0.5 cursor-pointer text-tertiary-foreground hover:text-destructive"
+										onClick={(e) => {
+											e.stopPropagation();
+											removeKey(key);
+										}}
+										onPointerDown={(e) => e.stopPropagation()}
+									>
+										<XIcon size={10} />
+									</span>
+								</span>
+							))}
+							{values.length > MAX_VISIBLE_CHIPS && (
+								<span className="shrink-0 px-1 text-sm text-tertiary-foreground">
+									+{values.length - MAX_VISIBLE_CHIPS}
+								</span>
+							)}
+						</>
+					)}
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="start" className="w-64">
+					{uniquePlans.length === 0 ? (
+						<div className="px-2 py-3 text-center text-sm text-tertiary-foreground">
+							No plans found
+						</div>
+					) : (
+						<div className="max-h-72 overflow-y-auto">
+							{uniquePlans.map((plan) => {
+								const versionCount = versionCounts?.[plan.id] || 1;
+								if (versionCount === 1)
+									return (
+										<DropdownMenuItem
+											className="flex cursor-pointer items-center gap-2 font-medium"
+											closeOnClick={false}
+											key={plan.id}
+											onClick={(e) => {
+												e.preventDefault();
+												toggleWhole(plan.id);
+											}}
+										>
+											<Checkbox
+												checked={isWhole(plan.id)}
+												className="border-border"
+											/>
+											<span className="truncate">{plan.name}</span>
+										</DropdownMenuItem>
+									);
+
+								const versions = Array.from(
+									{ length: versionCount },
+									(_, i) => i + 1,
+								);
+								const anyVersionPinned = versions.some((version) =>
+									isVersion(plan.id, version),
+								);
+
+								return (
+									<DropdownMenuSub key={plan.id}>
+										<DropdownMenuSubTrigger
+											className="flex cursor-pointer items-center gap-2 font-medium"
+											onClick={(e) => {
+												e.preventDefault();
+												toggleWhole(plan.id);
+											}}
+										>
+											<Checkbox
+												checked={isWhole(plan.id)}
+												className="border-border"
+												indeterminate={anyVersionPinned && !isWhole(plan.id)}
+											/>
+											<span className="truncate">{plan.name}</span>
+										</DropdownMenuSubTrigger>
+										<DropdownMenuSubContent>
+											<DropdownMenuItem
+												className="flex cursor-pointer items-center gap-2 font-medium"
+												closeOnClick={false}
+												onClick={(e) => {
+													e.preventDefault();
+													toggleWhole(plan.id);
+												}}
+											>
+												<Checkbox
+													checked={isWhole(plan.id)}
+													className="border-border"
+												/>
+												All versions
+											</DropdownMenuItem>
+											<DropdownMenuSeparator />
+											{versions.map((version) => (
+												<DropdownMenuItem
+													className="flex cursor-pointer items-center gap-2 text-sm"
+													closeOnClick={false}
+													key={`${plan.id}:${version}`}
+													onClick={(e) => {
+														e.preventDefault();
+														toggleVersion(plan.id, version);
+													}}
+												>
+													<Checkbox
+														checked={
+															isWhole(plan.id) || isVersion(plan.id, version)
+														}
+														className="border-border"
+													/>
+													v{version}
+												</DropdownMenuItem>
+											))}
+										</DropdownMenuSubContent>
+									</DropdownMenuSub>
+								);
+							})}
+						</div>
+					)}
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/vite/src/views/migrations/migration/shared/RunSummaryRows.tsx
+++ b/vite/src/views/migrations/migration/shared/RunSummaryRows.tsx
@@ -1,6 +1,7 @@
 import type { Operations } from "@autumn/shared";
 import { GearIcon } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
+import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
 import { AutumnMark, StripeMark } from "./BillingScopeMarks";
 import { getOperationsSummaryText } from "./operationUtils";
 
@@ -41,6 +42,11 @@ export function RunSummaryRows({
 					</>
 				)}
 			</div>
+			{!noBillingChanges && (
+				<InfoBox variant="warning">
+					Customer subscriptions will be updated with this change.
+				</InfoBox>
+			)}
 		</div>
 	);
 }

--- a/vite/src/views/migrations/migration/useMigrationEditorForm.ts
+++ b/vite/src/views/migrations/migration/useMigrationEditorForm.ts
@@ -17,6 +17,15 @@ const FRIENDLY_MESSAGES: Record<string, string> = {
 		"Add at least one operation",
 };
 
+/**
+ * Persist filter-only drafts: an operations block with no entries is sent as
+ * `null`, since the empty `{}` shape fails the server's resource-block check. A
+ * non-empty (even mid-edit) block is kept so in-progress operations aren't lost.
+ */
+export function toOperationsPayload(operations: Operations): Operations | null {
+	return (operations.customer?.length ?? 0) === 0 ? null : operations;
+}
+
 function humanizeValidationError(raw: string): string {
 	const stripped = raw.replace(/^\[Validation Errors\]\s*/, "");
 	const segments = stripped.split(";").map((s) => s.trim());
@@ -52,7 +61,7 @@ export function useMigrationEditorForm({
 					id: migration.id,
 					updates: {
 						filter: value.filter,
-						operations: value.operations,
+						operations: toOperationsPayload(value.operations),
 						no_billing_changes: value.noBillingChanges,
 					},
 				});
@@ -79,7 +88,7 @@ export function useMigrationEditorForm({
 						id: migration.id,
 						updates: {
 							filter,
-							operations,
+							operations: toOperationsPayload(operations),
 							no_billing_changes: noBillingChanges,
 						},
 					});

--- a/vite/src/views/products/plan/components/EditPlanHeader.tsx
+++ b/vite/src/views/products/plan/components/EditPlanHeader.tsx
@@ -70,8 +70,7 @@ export const EditPlanHeader = () => {
 			.filter(([version, counts]) => {
 				const v = Number(version);
 				if (v >= numVersions) return false;
-				const nonCustomActive = (counts.active ?? 0) - (counts.custom ?? 0);
-				return nonCustomActive > 0;
+				return (counts.active ?? 0) > 0;
 			})
 			.map(([version]) => Number(version));
 	}, [numVersions, versionCounts]);
@@ -154,6 +153,7 @@ export const EditPlanHeader = () => {
 				productId={product.id}
 				latestVersion={numVersions}
 				migratableVersions={migratableVersions}
+				pastVersions={pastVersionsWithCustomers}
 				versionCounts={versionCounts}
 			/>
 			<div className="flex flex-col gap-2 p-4 pb-3  border-none shadow-none w-full max-w-5xl mx-auto pt-4 sm:pt-8 px-4 sm:px-12">
@@ -246,7 +246,7 @@ export const EditPlanHeader = () => {
 					</div>
 
 					<div className="flex flex-row gap-2 items-center">
-						{migratableVersions.length > 0 && !isCusPlanEditor && (
+						{pastVersionsWithCustomers.length > 0 && !isCusPlanEditor && (
 							<IconButton
 								variant="secondary"
 								size="mini"

--- a/vite/src/views/products/plan/components/SaveChangesBar.tsx
+++ b/vite/src/views/products/plan/components/SaveChangesBar.tsx
@@ -37,7 +37,8 @@ export const SaveChangesBar = ({
 	const [saving, setSaving] = useState(false);
 
 	const { invalidate: invalidateProducts } = useProductsQuery();
-	const { refetch: queryRefetch } = useProductQuery();
+	const { refetch: queryRefetch, invalidate: invalidateProduct } =
+		useProductQuery();
 	const { counts, isLoading: isCountsLoading } = useProductCountsQuery(
 		product.version ? { version: product.version } : {},
 	);
@@ -89,7 +90,7 @@ export const SaveChangesBar = ({
 			version: product.version,
 			onSuccess: async () => {
 				await queryRefetch();
-				invalidateProducts();
+				await Promise.all([invalidateProduct(), invalidateProducts()]);
 			},
 		});
 

--- a/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
+++ b/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
@@ -42,6 +42,7 @@ interface MigrateCustomersDialogProps {
 	productId: string;
 	latestVersion: number;
 	migratableVersions: number[];
+	pastVersions: number[];
 	versionCounts: Record<
 		number,
 		{ active: number; canceled: number; custom: number; trialing: number }
@@ -150,6 +151,7 @@ export function MigrateCustomersDialog({
 	productId,
 	latestVersion,
 	migratableVersions,
+	pastVersions,
 	versionCounts,
 }: MigrateCustomersDialogProps) {
 	const navigate = useNavigate();
@@ -173,8 +175,9 @@ export function MigrateCustomersDialog({
 			? (versionProducts.get(effectiveVersion) ?? null)
 			: null;
 
+	const sortedCandidateVersions = [...pastVersions].sort((a, b) => b - a);
 	const versionSelectItems = Object.fromEntries(
-		migratableVersions.map((v) => [String(v), `Version ${v}`]),
+		sortedCandidateVersions.map((v) => [String(v), `Version ${v}`]),
 	);
 
 	const handleCreate = async () => {
@@ -198,7 +201,9 @@ export function MigrateCustomersDialog({
 		}
 	};
 
-	if (migratableVersions.length === 0) return null;
+	if (pastVersions.length === 0) return null;
+
+	const hasMigratableVersions = migratableVersions.length > 0;
 
 	return (
 		<Dialog
@@ -258,17 +263,28 @@ export function MigrateCustomersDialog({
 										<SelectValue placeholder="Select version" />
 									</SelectTrigger>
 									<SelectContent>
-										{migratableVersions.map((version) => {
+										{sortedCandidateVersions.map((version) => {
+											const hasDiff = migratableVersions.includes(version);
 											const count =
 												(versionCounts[version]?.active ?? 0) -
 												(versionCounts[version]?.custom ?? 0);
 											return (
-												<SelectItem key={version} value={String(version)}>
+												<SelectItem
+													key={version}
+													value={String(version)}
+													disabled={!hasDiff}
+												>
 													<div className="flex items-center justify-between w-full gap-3">
 														<span>Version {version}</span>
-														<IconBadge variant="muted" icon={<UserIcon />}>
-															{count}
-														</IconBadge>
+														{hasDiff ? (
+															<IconBadge variant="muted" icon={<UserIcon />}>
+																{count}
+															</IconBadge>
+														) : (
+															<span className="text-xs text-muted-foreground">
+																No diff
+															</span>
+														)}
 													</div>
 												</SelectItem>
 											);
@@ -303,10 +319,10 @@ export function MigrateCustomersDialog({
 						metaShortcut="enter"
 						onClick={handleCreate}
 						isLoading={isCreating}
-						disabled={isCreating}
+						disabled={isCreating || !hasMigratableVersions}
 						className="w-full"
 					>
-						Preview Migration
+						{hasMigratableVersions ? "Preview Migration" : "No changes to migrate"}
 					</ShortcutButton>
 				</DialogFooter>
 			</DialogContent>

--- a/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
+++ b/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
@@ -256,7 +256,9 @@ export function MigrateCustomersDialog({
 										if (val === "all") {
 											setScope("all");
 										} else {
-											setScope(selectedVersion);
+											// effectiveVersion is what the dropdown shows; selectedVersion
+											// may still be null before the user touches it.
+											setScope(effectiveVersion ?? "all");
 										}
 									}}
 								>

--- a/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
+++ b/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
@@ -32,6 +32,7 @@ import { getBackendErr, navigateTo } from "@/utils/genUtils";
 import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
 import {
 	buildVersionMigrationDraft,
+	planHasPricingChange,
 	type VersionMigrateScope,
 } from "./buildMigrationDraft";
 import { getPlanPriceChange, hasPlanMigrationDiff } from "./planMigrationDiff";
@@ -169,6 +170,35 @@ export function MigrateCustomersDialog({
 
 	const versionProducts = useVersionProducts(productId, migratableVersions);
 	const latestProduct = useLatestProduct(productId, latestVersion);
+	const { features = [] } = useFeaturesQuery();
+
+	const hasPricingChange = useMemo(() => {
+		if (!latestProduct) return false;
+		const versionsToCheck =
+			scope === "all"
+				? migratableVersions
+				: effectiveVersion !== null
+					? [effectiveVersion]
+					: [];
+		return versionsToCheck.some((version) => {
+			const fromProduct = versionProducts.get(version);
+			return (
+				!!fromProduct &&
+				planHasPricingChange({
+					baseProduct: fromProduct,
+					product: latestProduct,
+					features,
+				})
+			);
+		});
+	}, [
+		scope,
+		migratableVersions,
+		effectiveVersion,
+		versionProducts,
+		latestProduct,
+		features,
+	]);
 
 	const selectedFromProduct =
 		effectiveVersion !== null
@@ -188,6 +218,7 @@ export function MigrateCustomersDialog({
 			latestVersion,
 			scope,
 			pastVersions: migratableVersions,
+			hasPricingChange,
 		});
 
 		try {
@@ -309,6 +340,14 @@ export function MigrateCustomersDialog({
 							<InfoBox variant="info">
 								Customers on custom plans will not be migrated.
 							</InfoBox>
+
+							{hasPricingChange && (
+								<InfoBox variant="warning">
+									{scope === "all"
+										? "Some of these versions have pricing changes. Migrated customers will move to the new prices from their next billing cycle."
+										: "This version has pricing changes. Migrated customers will move to the new prices from their next billing cycle."}
+								</InfoBox>
+							)}
 						</div>
 					</DialogDescription>
 				</div>

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -84,7 +84,12 @@ export default function PlanChangeDialog({
 	const baseProduct = useProductStore((s) => s.baseProduct);
 	const setBaseProduct = useProductStore((s) => s.setBaseProduct);
 	const { features = [] } = useFeaturesQuery();
-	const { refetch, numVersions, versionCounts } = useProductQuery();
+	const {
+		refetch,
+		invalidate: invalidateProduct,
+		numVersions,
+		versionCounts,
+	} = useProductQuery();
 	const { setQueryStates } = useProductQueryState();
 	const { invalidate: invalidateProducts } = useProductsQuery();
 	const { createMigration, invalidate: invalidateMigrations } =
@@ -142,7 +147,7 @@ export default function PlanChangeDialog({
 	const syncToLatestVersion = async () => {
 		await setQueryStates({ version: null });
 		await refetch();
-		invalidateProducts();
+		await Promise.all([invalidateProduct(), invalidateProducts()]);
 	};
 
 	const markSaved = () => {
@@ -184,6 +189,7 @@ export default function PlanChangeDialog({
 					resetState();
 					void refetch();
 				}
+				void invalidateProduct();
 				void invalidateProducts();
 			} catch (error) {
 				toast.error(getBackendErr(error, "Failed to update plan"));
@@ -231,6 +237,7 @@ export default function PlanChangeDialog({
 			setOpen(false);
 			resetState();
 			void refetch();
+			void invalidateProduct();
 			void invalidateProducts();
 			return;
 		}
@@ -260,6 +267,7 @@ export default function PlanChangeDialog({
 			resetState();
 			navigateTo(`/migrations/${migration.id}?step=live&run=true`, navigate);
 			void refetch();
+			void invalidateProduct();
 			void invalidateProducts();
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to create migration"));

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -153,7 +153,16 @@ export function planHasPricingChange({
 	const diff = diffPlanV1({ from, to });
 	if (diff.price !== undefined) return true;
 	if (diff.add_items?.some((item) => item.price != null)) return true;
-	return diff.remove_items?.some((item) => item.billing_method != null) ?? false;
+	// Remove filters can omit billing_method even when priced, so check the
+	// source items by feature_id rather than the lossy filter.
+	const removedFeatureIds = new Set(
+		diff.remove_items?.map((item) => item.feature_id) ?? [],
+	);
+	return (
+		from.items?.some(
+			(item) => item.price != null && removedFeatureIds.has(item.feature_id),
+		) ?? false
+	);
 }
 
 function getMigratablePlanDiff(

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -137,6 +137,25 @@ function diffHasBillingChanges(diff: DiffedCustomizePlanV1): boolean {
 	return false;
 }
 
+// Unlike `diffHasBillingChanges`, also flags pure removals of priced items so
+// the migration UI can warn about any change to what customers are billed.
+export function planHasPricingChange({
+	baseProduct,
+	product,
+	features,
+}: {
+	baseProduct: FrontendProduct;
+	product: FrontendProduct;
+	features: Feature[];
+}): boolean {
+	const from = frontendProductToApiPlanV1(baseProduct, features);
+	const to = frontendProductToApiPlanV1(product, features);
+	const diff = diffPlanV1({ from, to });
+	if (diff.price !== undefined) return true;
+	if (diff.add_items?.some((item) => item.price != null)) return true;
+	return diff.remove_items?.some((item) => item.billing_method != null) ?? false;
+}
+
 function getMigratablePlanDiff(
 	diff: DiffedCustomizePlanV1,
 ): DiffedCustomizePlanV1 {
@@ -161,12 +180,14 @@ export function buildVersionMigrationDraft({
 	latestVersion,
 	scope,
 	pastVersions,
+	hasPricingChange,
 	includeCustom = false,
 }: {
 	productId: string;
 	latestVersion: number;
 	scope: VersionMigrateScope;
 	pastVersions: number[];
+	hasPricingChange: boolean;
 	includeCustom?: boolean;
 }): MigrationDraft {
 	const versions = scope === "all" ? pastVersions : [scope];
@@ -201,7 +222,7 @@ export function buildVersionMigrationDraft({
 		id: `${productId}-${suffix}-to-v${latestVersion}-${migrationUid()}`,
 		filter,
 		operations,
-		no_billing_changes: true,
+		no_billing_changes: !hasPricingChange,
 	};
 }
 


### PR DESCRIPTION
## Overview

Builds out the plan-version migration flow and the underlying migration-filter compiler. Customers on past plan versions can now be migrated to the latest version from the plan editor, with clear visibility into whether a migration changes what they're billed.

## What changed

### Migration filters & compiler
- Added filter **composition**, **negation**, and **plan-version targeting** to the customer filter DSL, with compiler support in `parseCustomerFilter` and new unit/integration tests (`composition`, `negation`, `planVersion`, `composition-filter`).
- Reworked the filter UI (`FilterForm`, `FilterRow`, `FilterGroup`, `filterRowTypes`) and added a reusable `PlanVersionPicker`.

### Migrate-customers dialog (plan editor)
- The **Migrate customers** button now shows whenever a past version has active customers (previously hidden when all customers were on custom plans).
- The version dropdown lists **all** past versions with customers; versions with no plan diff render as disabled **"No diff"** entries.
- Added a pricing-change detector (`planHasPricingChange`) built on `diffPlanV1` that flags base-price changes **and** feature-item-level price add/change/removal (the existing `diffHasBillingChanges` missed pure removals).

### Billing-change correctness
- `buildVersionMigrationDraft` no longer hardcodes `no_billing_changes: true`. It now derives the flag from whether the selected scope has a pricing change, so a version migration with price changes actually pushes the update to Stripe (`proration_behavior: 'none'` → customers move to the new price next billing cycle, no immediate charge). The runtime `assertStripePlanNoCharges` guard remains the safety net.
- Added a scope-aware warning in the migrate dialog when prices differ.
- Added a prominent warning box in the shared `RunSummaryRows` (shown in both the bulk Run Migration dialog and the per-customer run sheet) when billing changes apply to Stripe: *"Customer subscriptions will be updated with this change."*

### Misc
- Dashboard usage limits enriched with live usage and entity-scoped support.
- Plan editor stays in sync after save; product cache refresh.
- `knip.json` updated for colocated tests.

## Reviewer notes
- The `no_billing_changes` change makes the `assertStripePlanNoCharges` path reachable for version migrations for the first time. Edge cases (a matched customer with no live Stripe subscription, or a change that would force an immediate proration charge) will now surface that guard's error at run time instead of silently no-op'ing. An integration test covering a price-change version migration (happy path + no-subscription case) would be worth adding as a follow-up.
- `planHasPricingChange` detects priced removals via `billing_method` on the remove filter, since `PlanItemFilter` doesn't retain the full price — worth confirming `billing_method` is always set for priced items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Built the plan-version migration flow with a richer customer filter ($and/$or, $none, and version targeting) and clear billing-change visibility. Also fixed version-targeting round-trips and migrate-dialog scope, improved priced-removal detection, added live usage to usage-limit pills, and kept the plan editor in sync after saves.

- **New Features**
  - Migration filters: added customer-level `$and`/`$or` and `$none`; version targeting via a multi-select Plan picker. Version pins fold into plan keys (e.g. "pro:2") and round-trip cleanly; mixed whole-plan + pinned versions compile to plan-level `$or`.
  - Migrate Customers dialog: shows whenever any past version has customers; lists all past versions and disables “No diff” entries; sets scope from the effective version; detects pricing changes and shows scope-aware warnings; `no_billing_changes` now derives from the selected scope so Stripe updates are scheduled for next cycle. Run summary shows a Stripe update warning.
  - Usage limits: server overlays live usage for customer and entities; dashboard can view/edit entity-scoped usage limits.
  - Plan editor: keeps the working copy in sync after in-place saves; invalidates both single-product and list caches.

- **Bug Fixes**
  - Correct negation: “plan is not …” compiles to `$none` so multi-plan customers don’t leak; composition `$and`/`$or` recognized across preview and guards; empty `$and`/`$or` rejected.
  - Version targeting: removed standalone version field; fixed migrate-dialog “specific version” scope so it never sends null; plan version filters round-trip via plan keys.
  - Billing-change detection: now catches priced item removals by comparing removed feature_ids to priced source items.
  - Tooling: updated `knip.json` to include colocated `src/**/*.test.{ts,tsx}` files.

<sup>Written for commit 097efd11e7b255f2058c2a622826bbccdc98fdfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Builds out the plan-version migration flow end-to-end: a reworked filter compiler with `$and`/`$or` composition and negation, a revamped Migrate Customers dialog that surfaces all past versions, and a corrected `no_billing_changes` flag that now triggers Stripe subscription updates when prices actually change.

- **Improvements** — `CustomerFilterSchema` made recursive with `$and`/`$or` composition; `parseCustomerFilter` emits independent `EXISTS` quantifiers; `planFilterToGroups`/`groupsToMigrationFilter` fully reworked to round-trip all new shapes; `PlanVersionPicker` added for version-pinned plan selection; `useProductSync` keeps the working copy in sync after an in-place save without clobbering unsaved edits.
- **Bug fixes** — `no_billing_changes` no longer hardcoded `true` in `buildVersionMigrationDraft`; `EditPlanHeader` migrate button now visible for any past version with active customers (not just non-custom); entity-scoped usage limits now visible and editable in the dashboard; live Redis usage counters returned in the dashboard customer response.
- **API changes** — `handleGetCustomer` response now overlays `ApiUsageLimit[]` (with `usage`) on both the customer and entity `usage_limits` fields; `CusService.updateEntity` extended to accept `usage_limits`.
</details>


<h3>Confidence Score: 3/5</h3>

Two paths in the versioned migration flow can produce incorrect outcomes: the `billing_method` check in `planHasPricingChange` may silently skip Stripe updates for priced item removals, and the "specific version" radio group can set `scope` to `null`, generating a migration filter that targets all customers rather than the selected version.

The `no_billing_changes` flag is now derived rather than hardcoded for the first time, making the correctness of `planHasPricingChange` consequential. The PR author explicitly called out the `billing_method` gap as unresolved. Separately, switching to "specific" scope before touching the version dropdown leaves `scope` as `null`, which would create a wrong-scoped migration. The filter compiler, `PlanVersionPicker`, `useProductSync`, and the server-side usage-limit enrichment all look solid.

`buildMigrationDraft.ts` (priced-removal detection) and `MigrateCustomersDialog.tsx` (scope null state on radio switch) warrant a second look before the version-migration path goes live.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/buildMigrationDraft.ts | New `planHasPricingChange` function and `no_billing_changes` derivation; priced-removal detection via `billing_method` may silently miss items where `billing_method` is undefined, causing Stripe to be skipped. |
| vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx | Expanded to show all past versions with customers (not just migratable); `scope` state can be set to `null` when user switches to "specific" before selecting a version, producing a migration filter with `version: null`. |
| shared/api/migrations/compiler/filterToIr/scopes/parseCustomerFilter.ts | Adds `$and`/`$or` composition with `$or`-empty guard; `$and` with an empty array is silently treated as no-op (tautology), which is semantically valid. |
| shared/api/migrations/filters/customerFilter.ts | Schema made recursive via `z.lazy` to support `$and`/`$or`; explicit `CustomerFilter` type replaces inferred type, correctly reflecting the new composition shape. |
| vite/src/views/migrations/migration/filters/FilterForm.tsx | Major rework: negation now emits customer-level `$none` quantifiers, multi-row groups produce `$and`, multiple groups produce `$or`; round-trip tests cover all paths. |
| vite/src/views/migrations/migration/filters/filterRowTypes.ts | Replaced version number operators with plan-key encoding (`planId:version`); removed `NumberMatcher` path; `parsePlanKey` correctly uses `lastIndexOf` for colon-containing plan IDs. |
| vite/src/views/migrations/migration/shared/PlanVersionPicker.tsx | New multi-select plan picker with whole-plan and version-pinned selections; whole-plan and specific-version picks are correctly made mutually exclusive per plan. |
| server/src/internal/customers/cusUtils/cusResponseUtils/getCusUsageLimitsWithUsage.ts | New utility that rehydrates Redis-backed usage counters for both the customer and all entities with caps, correctly fetching each scope via `getOrSetCachedFullSubject`. |
| server/src/internal/customers/internalHandlers/handleGetCustomer.ts | Enriches the dashboard customer response with live usage data for both the customer and entity-scoped usage limits; falls back gracefully when no caps exist. |
| vite/src/hooks/stores/useProductSync.ts | Adds `editorIsClean` check so the working copy is reset after an in-place save; the `isProductUpdated` guard prevents re-entry on subsequent effect runs triggered by `currentProduct` changes. |
| vite/src/views/customers2/components/CustomerBillingControlsSection.tsx | Extends entity-scoped display to usage limits; type annotation on the `usageLimits` map callback is still `DbUsageLimit` even though entities now return `ApiUsageLimit[]` after decoration. |
| vite/src/views/migrations/migration/shared/RunSummaryRows.tsx | Adds a warning InfoBox when `noBillingChanges` is false, surfacing Stripe subscription update behaviour to the operator. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MigrateCustomersDialog\nselect scope & version] --> B{hasPricingChange?}
    B -- Yes --> C[no_billing_changes: false]
    B -- No --> D[no_billing_changes: true]
    C --> E[buildVersionMigrationDraft\ncreate MigrationDraft]
    D --> E
    E --> F[createMigration API]
    F --> G[/migrations/:id?step=live&run=true/]

    G --> H[RunSummaryRows\nshow billing-change warning]
    H --> I{no_billing_changes?}
    I -- false --> J[⚠️ InfoBox: subscriptions updated]
    I -- true --> K[no warning shown]

    subgraph planHasPricingChange
        L[diffPlanV1: from to] --> M{diff.price changed?}
        M -- Yes --> N[return true]
        M -- No --> O{add_items with price?}
        O -- Yes --> N
        O -- No --> P{remove_items with billing_method not null?}
        P -- Yes --> N
        P -- No --> Q[return false]
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx`, line 255-260 ([link](https://github.com/useautumn/autumn/blob/91679ddc898bc89d6dc168668323cdf3ad66fbbb/vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx#L255-L260)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`scope` can be `null` when the user switches to "specific" before selecting a version**

   When a user clicks "Migrate a specific version" and `selectedVersion` is still `null` (initial state), `setScope(selectedVersion)` sets `scope` to `null` — `null` is not a valid `VersionMigrateScope`. If the user then clicks "Preview Migration" without first interacting with the dropdown, `handleCreate` passes `scope: null` to `buildVersionMigrationDraft`, which executes `[null]` as the versions array and produces a filter with `version: null`, targeting all customers on the plan regardless of version.

   The displayed version in the select is driven by `effectiveVersion` (which correctly falls back to `migratableVersions[0]`), so the UI looks correct but the migration is for the wrong scope. Fix by initialising `selectedVersion` from `migratableVersions[0]` or by guarding with `setScope(selectedVersion ?? migratableVersions[0])`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx
   Line: 255-260

   Comment:
   **`scope` can be `null` when the user switches to "specific" before selecting a version**

   When a user clicks "Migrate a specific version" and `selectedVersion` is still `null` (initial state), `setScope(selectedVersion)` sets `scope` to `null` — `null` is not a valid `VersionMigrateScope`. If the user then clicks "Preview Migration" without first interacting with the dropdown, `handleCreate` passes `scope: null` to `buildVersionMigrationDraft`, which executes `[null]` as the versions array and produces a filter with `version: null`, targeting all customers on the plan regardless of version.

   The displayed version in the select is driven by `effectiveVersion` (which correctly falls back to `migratableVersions[0]`), so the UI looks correct but the migration is for the wrong scope. Fix by initialising `selectedVersion` from `migratableVersions[0]` or by guarding with `setScope(selectedVersion ?? migratableVersions[0])`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
vite/src/views/products/plan/versioning/buildMigrationDraft.ts:156
**Priced-removal detection may silently return false**

`buildRemoveFilter` (in `diffPlanV1.ts`) only sets `filter.billing_method` when `item.price?.billing_method !== undefined`. If a priced item reaches `diffPlanV1` with `price` present but `billing_method === undefined` (the match-key fallback uses `?? ""`, confirming this is possible), the remove filter has no `billing_method` field, this check returns `false`, and `no_billing_changes: true` is set — so the Stripe subscription is never updated for that removal.

The PR author flagged this in the reviewer notes; it's worth verifying (and adding a guard) before this path goes to production, since `buildVersionMigrationDraft` now derives the flag from this function for the first time.

### Issue 2 of 3
vite/src/views/products/plan/versioning/MigrateCustomersDialog.tsx:255-260
**`scope` can be `null` when the user switches to "specific" before selecting a version**

When a user clicks "Migrate a specific version" and `selectedVersion` is still `null` (initial state), `setScope(selectedVersion)` sets `scope` to `null` — `null` is not a valid `VersionMigrateScope`. If the user then clicks "Preview Migration" without first interacting with the dropdown, `handleCreate` passes `scope: null` to `buildVersionMigrationDraft`, which executes `[null]` as the versions array and produces a filter with `version: null`, targeting all customers on the plan regardless of version.

The displayed version in the select is driven by `effectiveVersion` (which correctly falls back to `migratableVersions[0]`), so the UI looks correct but the migration is for the wrong scope. Fix by initialising `selectedVersion` from `migratableVersions[0]` or by guarding with `setScope(selectedVersion ?? migratableVersions[0])`.

### Issue 3 of 3
vite/src/views/customers2/components/CustomerBillingControlsSection.tsx:293-297
**Type annotation out of date after entity usage-limit decoration**

The map callback annotates `item` as `DbUsageLimit`, but entity usage limits are now decorated with live `usage` data by `getCusUsageLimitsWithUsage` and returned as `ApiUsageLimit[]`. The `UsageLimitRow` component was updated to accept `ApiUsageLimit`, so the annotation here is incorrect. It works at runtime because `ApiUsageLimit` is a superset of `DbUsageLimit`, but the explicit cast silently discards the `usage` field from the type checker's perspective, undermining the usage-display feature for entity-scoped limits.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Warn when plan version migrations change..."](https://github.com/useautumn/autumn/commit/91679ddc898bc89d6dc168668323cdf3ad66fbbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37207837)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->