### PR TITLE
fix: wrap analytics granularity label in DropdownMenuGroup

### DIFF
--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -8,6 +8,7 @@ import { IconButton } from "@/components/v2/buttons/IconButton";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
+	DropdownMenuGroup,
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
@@ -219,21 +220,23 @@ export const QueryTopbar = () => {
 					</DropdownMenuSub>
 
 					<DropdownMenuSeparator />
-					<DropdownMenuLabel>Granularity</DropdownMenuLabel>
-					{Object.entries(GRANULARITY_LABELS).map(([binSize, label]) => (
-						<DropdownMenuItem
-							key={binSize}
-							disabled={!binSizeChoiceEnabled}
-							closeOnClick={false}
-							onClick={() => handleBinSizeSelect(binSize)}
-							className="flex items-center justify-between"
-						>
-							{label}
-							{effectiveBinSize === binSize && (
-								<Check className="ml-2 h-3 w-3 text-tertiary-foreground" />
-							)}
-						</DropdownMenuItem>
-					))}
+					<DropdownMenuGroup>
+						<DropdownMenuLabel>Granularity</DropdownMenuLabel>
+						{Object.entries(GRANULARITY_LABELS).map(([binSize, label]) => (
+							<DropdownMenuItem
+								key={binSize}
+								disabled={!binSizeChoiceEnabled}
+								closeOnClick={false}
+								onClick={() => handleBinSizeSelect(binSize)}
+								className="flex items-center justify-between"
+							>
+								{label}
+								{effectiveBinSize === binSize && (
+									<Check className="ml-2 h-3 w-3 text-tertiary-foreground" />
+								)}
+							</DropdownMenuItem>
+						))}
+					</DropdownMenuGroup>
 				</DropdownMenuContent>
 			</DropdownMenu>
 			<SelectFeatureDropdown />


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Wrapped the analytics Granularity label and options in `DropdownMenuGroup` to correctly group them in the dropdown. This fixes keyboard navigation and accessibility semantics without changing selection behavior.

<sup>Written for commit eac0d923253090992153ab6637a7243d9ebe0b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the dropdown menu in the analytics query topbar by wrapping the "Granularity" label and its associated items in a `DropdownMenuGroup`, giving them proper semantic grouping consistent with how Radix UI / shadcn dropdown components are structured.

- **[Bug fixes]** Wraps `DropdownMenuLabel` ("Granularity") and its `DropdownMenuItem` list in a `DropdownMenuGroup`, matching the intended usage of the component and ensuring correct ARIA role semantics for the group.
</details>

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal structural fix with no logic changes — it only wraps existing elements in a grouping component.

The change adds an import and wraps the Granularity section's label and items in a DropdownMenuGroup. No business logic, state management, or rendering behavior is affected — only the semantic hierarchy of the dropdown is improved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx | Adds DropdownMenuGroup import and wraps the Granularity label + items in a DropdownMenuGroup for correct semantic structure; no logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant Trigger as DropdownMenuTrigger
    participant Content as DropdownMenuContent
    participant IntervalItems as Interval Items
    participant Sub as Custom Range Sub
    participant Group as DropdownMenuGroup (Granularity)

    User->>Trigger: Click
    Trigger->>Content: Open dropdown
    Content->>IntervalItems: Render interval options
    User->>IntervalItems: Select interval
    IntervalItems-->>Content: handleIntervalSelect()
    Content->>Sub: Render Custom Range submenu
    User->>Sub: "Expand & pick date range"
    Sub-->>Content: handleCustomRangeSelect()
    Content->>Group: Render Granularity section
    Note over Group: DropdownMenuLabel + DropdownMenuItems now wrapped in DropdownMenuGroup
    User->>Group: Select granularity (day/week/month)
    Group-->>Content: handleBinSizeSelect()
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: wrap analytics granularity label in..."](https://github.com/useautumn/autumn/commit/eac0d923253090992153ab6637a7243d9ebe0b5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37235213)</sub>

<!-- /greptile_comment -->