### PR TITLE
feat: per-range granularity options; add weekly to 30d, no grey-out

### DIFF
--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -38,10 +38,12 @@ const INTERVAL_LABELS: Record<string, string> = {
 // Billing-cycle ranges, hidden when the customer has no billing cycle.
 const BILLING_CYCLE_INTERVALS = new Set(["1bc", "3bc"]);
 
+type Granularity = "hour" | "day" | "week" | "month";
+
 // Selectable granularities per range, in display order; the first is the
 // default. A single entry means the range has no choice, so the granularity
 // section is hidden for it.
-const INTERVAL_GRANULARITIES: Record<string, string[]> = {
+const INTERVAL_GRANULARITIES: Record<string, Granularity[]> = {
 	"24h": ["hour"],
 	"7d": ["day"],
 	"30d": ["day", "week"],
@@ -50,7 +52,7 @@ const INTERVAL_GRANULARITIES: Record<string, string[]> = {
 	"3bc": ["day", "week", "month"],
 };
 
-const GRANULARITY_LABELS: Record<string, string> = {
+const GRANULARITY_LABELS: Record<Granularity, string> = {
 	hour: "by hour",
 	day: "by day",
 	week: "by week",
@@ -58,9 +60,9 @@ const GRANULARITY_LABELS: Record<string, string> = {
 };
 
 const CUSTOM_INTERVAL = "custom";
-const DEFAULT_GRANULARITIES = ["day"];
+const DEFAULT_GRANULARITIES: Granularity[] = ["day"];
 
-const granularitiesFor = (interval: string): string[] =>
+const granularitiesFor = (interval: string): Granularity[] =>
 	INTERVAL_GRANULARITIES[interval] ?? DEFAULT_GRANULARITIES;
 
 // The bin size in effect for a range: the viewer's choice when it's valid for
@@ -71,10 +73,10 @@ const getEffectiveBinSize = ({
 }: {
 	interval: string;
 	binSize?: string | null;
-}): string => {
+}): Granularity => {
 	const granularities = granularitiesFor(interval);
-	return binSize && granularities.includes(binSize)
-		? binSize
+	return binSize && granularities.some((g) => g === binSize)
+		? (binSize as Granularity)
 		: granularities[0];
 };
 
@@ -84,7 +86,7 @@ const getDisplayLabel = ({
 	customRange,
 }: {
 	interval: string;
-	binSize: string;
+	binSize: Granularity;
 	customRange?: DateRange;
 }): string => {
 	if (interval === CUSTOM_INTERVAL) {

--- a/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
+++ b/vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx
@@ -25,40 +25,46 @@ import { SelectEntityDropdown } from "./SelectEntityDropdown";
 import { SelectFeatureDropdown } from "./SelectFeatureDropdown";
 import { SelectGroupByDropdown } from "./SelectGroupByDropdown";
 
-// Intervals with a single fixed granularity (no day/week/month choice).
-const SIMPLE_INTERVALS: Record<string, string> = {
+// Time ranges shown in the dropdown, in display order.
+const INTERVAL_LABELS: Record<string, string> = {
 	"24h": "Last 24 hours",
 	"7d": "Last 7 days",
 	"30d": "Last 30 days",
 	"1bc": "Current billing cycle",
-};
-
-// Intervals that let the viewer choose the bin size (day/week/month).
-const BIN_SIZE_INTERVALS: Record<string, string> = {
 	"90d": "Last 90 days",
 	"3bc": "Latest 3 billing cycles",
 };
 
-const ALL_INTERVALS: Record<string, string> = {
-	...SIMPLE_INTERVALS,
-	...BIN_SIZE_INTERVALS,
+// Billing-cycle ranges, hidden when the customer has no billing cycle.
+const BILLING_CYCLE_INTERVALS = new Set(["1bc", "3bc"]);
+
+// Selectable granularities per range, in display order; the first is the
+// default. A single entry means the range has no choice, so the granularity
+// section is hidden for it.
+const INTERVAL_GRANULARITIES: Record<string, string[]> = {
+	"24h": ["hour"],
+	"7d": ["day"],
+	"30d": ["day", "week"],
+	"1bc": ["day"],
+	"90d": ["day", "week", "month"],
+	"3bc": ["day", "week", "month"],
 };
 
-// Granularities offered in the bottom section, in display order.
 const GRANULARITY_LABELS: Record<string, string> = {
+	hour: "by hour",
 	day: "by day",
 	week: "by week",
 	month: "by month",
 };
 
-const DEFAULT_BIN_SIZE = "day";
 const CUSTOM_INTERVAL = "custom";
+const DEFAULT_GRANULARITIES = ["day"];
 
-const supportsBinSizeChoice = (interval: string): boolean =>
-	Boolean(BIN_SIZE_INTERVALS[interval]);
+const granularitiesFor = (interval: string): string[] =>
+	INTERVAL_GRANULARITIES[interval] ?? DEFAULT_GRANULARITIES;
 
-// The bin size actually in effect for an interval — fixed for simple/custom
-// ranges, viewer-chosen for the multi-granularity ones.
+// The bin size in effect for a range: the viewer's choice when it's valid for
+// the range, otherwise the range's default (first) granularity.
 const getEffectiveBinSize = ({
 	interval,
 	binSize,
@@ -66,13 +72,10 @@ const getEffectiveBinSize = ({
 	interval: string;
 	binSize?: string | null;
 }): string => {
-	if (interval === "24h") {
-		return "hour";
-	}
-	if (supportsBinSizeChoice(interval)) {
-		return binSize && GRANULARITY_LABELS[binSize] ? binSize : DEFAULT_BIN_SIZE;
-	}
-	return DEFAULT_BIN_SIZE;
+	const granularities = granularitiesFor(interval);
+	return binSize && granularities.includes(binSize)
+		? binSize
+		: granularities[0];
 };
 
 const getDisplayLabel = ({
@@ -90,10 +93,12 @@ const getDisplayLabel = ({
 		}
 		return "Custom range";
 	}
-	if (supportsBinSizeChoice(interval) && binSize !== DEFAULT_BIN_SIZE) {
-		return `${ALL_INTERVALS[interval]} (${GRANULARITY_LABELS[binSize]})`;
+	const granularities = granularitiesFor(interval);
+	const label = INTERVAL_LABELS[interval];
+	if (granularities.length > 1 && binSize !== granularities[0]) {
+		return `${label} (${GRANULARITY_LABELS[binSize]})`;
 	}
-	return ALL_INTERVALS[interval];
+	return label;
 };
 
 export const QueryTopbar = () => {
@@ -104,11 +109,12 @@ export const QueryTopbar = () => {
 	);
 
 	const { interval: selectedInterval, start, end } = queryStates;
+	const granularities = granularitiesFor(selectedInterval);
 	const effectiveBinSize = getEffectiveBinSize({
 		interval: selectedInterval,
 		binSize: queryStates.bin_size,
 	});
-	const binSizeChoiceEnabled = supportsBinSizeChoice(selectedInterval);
+	const showGranularity = granularities.length > 1;
 	const customRange =
 		selectedInterval === CUSTOM_INTERVAL && start && end
 			? { from: new Date(start), to: new Date(end) }
@@ -137,17 +143,16 @@ export const QueryTopbar = () => {
 		}
 		setQueryStates({
 			interval: CUSTOM_INTERVAL,
-			bin_size: DEFAULT_BIN_SIZE,
+			bin_size: granularitiesFor(CUSTOM_INTERVAL)[0],
 			start: range.from.getTime(),
 			end: endOfDay(range.to).getTime(),
 		});
 	};
 
 	const shouldShowBillingCycleOptions = !bcExclusionFlag && customer;
-	const visibleIntervals = Object.keys(ALL_INTERVALS).filter((interval) =>
-		shouldShowBillingCycleOptions
-			? true
-			: interval !== "1bc" && interval !== "3bc",
+	const visibleIntervals = Object.keys(INTERVAL_LABELS).filter(
+		(interval) =>
+			shouldShowBillingCycleOptions || !BILLING_CYCLE_INTERVALS.has(interval),
 	);
 
 	return (
@@ -182,7 +187,7 @@ export const QueryTopbar = () => {
 							onClick={() => handleIntervalSelect(interval)}
 							className="flex items-center justify-between"
 						>
-							{ALL_INTERVALS[interval]}
+							{INTERVAL_LABELS[interval]}
 							{selectedInterval === interval && (
 								<Check className="ml-2 h-3 w-3 text-tertiary-foreground" />
 							)}
@@ -219,24 +224,27 @@ export const QueryTopbar = () => {
 						</DropdownMenuSubContent>
 					</DropdownMenuSub>
 
-					<DropdownMenuSeparator />
-					<DropdownMenuGroup>
-						<DropdownMenuLabel>Granularity</DropdownMenuLabel>
-						{Object.entries(GRANULARITY_LABELS).map(([binSize, label]) => (
-							<DropdownMenuItem
-								key={binSize}
-								disabled={!binSizeChoiceEnabled}
-								closeOnClick={false}
-								onClick={() => handleBinSizeSelect(binSize)}
-								className="flex items-center justify-between"
-							>
-								{label}
-								{effectiveBinSize === binSize && (
-									<Check className="ml-2 h-3 w-3 text-tertiary-foreground" />
-								)}
-							</DropdownMenuItem>
-						))}
-					</DropdownMenuGroup>
+					{showGranularity && (
+						<>
+							<DropdownMenuSeparator />
+							<DropdownMenuGroup>
+								<DropdownMenuLabel>Granularity</DropdownMenuLabel>
+								{granularities.map((binSize) => (
+									<DropdownMenuItem
+										key={binSize}
+										closeOnClick={false}
+										onClick={() => handleBinSizeSelect(binSize)}
+										className="flex items-center justify-between"
+									>
+										{GRANULARITY_LABELS[binSize]}
+										{effectiveBinSize === binSize && (
+											<Check className="ml-2 h-3 w-3 text-tertiary-foreground" />
+										)}
+									</DropdownMenuItem>
+								))}
+							</DropdownMenuGroup>
+						</>
+					)}
 				</DropdownMenuContent>
 			</DropdownMenu>
 			<SelectFeatureDropdown />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added per-range granularity options to the analytics top bar. 30d now supports weekly; the picker only shows valid choices, and granularity types are now compile-time safe.

- **New Features**
  - Introduced per-range granularity map (`INTERVAL_GRANULARITIES`), linked to `GRANULARITY_LABELS` via a shared `Granularity` union; `30d` adds `week`, and each range defaults to its first allowed option.
  - Granularity UI appears only when a range has multiple options; otherwise it’s hidden.
  - Interval label shows the chosen granularity when it differs from the default; custom/invalid choices fall back to the range default.
  - Billing-cycle intervals (`1bc`, `3bc`) are hidden when no billing cycle is available or the exclusion flag is set.

<sup>Written for commit 7dfd18895a928eb9ddf11cbd2fb1c93c2423dcb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces two separate interval maps (`SIMPLE_INTERVALS` / `BIN_SIZE_INTERVALS`) with a single `INTERVAL_LABELS` map and a new `INTERVAL_GRANULARITIES` lookup that lists each range's valid granularities in priority order. The main user-visible changes are that "week" becomes selectable for the 30-day range, and the granularity section is now hidden entirely for single-granularity intervals rather than being shown with greyed-out items.

- **[Improvements]** Unified interval/granularity data model: `INTERVAL_GRANULARITIES` drives both which options appear in the UI and which bin size is effective, eliminating the need to keep two separate sets in sync.
- **[Improvements]** Granularity section is conditionally hidden (`showGranularity = granularities.length > 1`) instead of rendering disabled items, improving clarity for ranges like \"24h\" and \"7d\".
- **[Improvements]** \"week\" granularity is now offered for the 30-day range; existing saved `bin_size=week` + `interval=30d` URL states will now resolve to \"week\" instead of silently falling back to \"day\".
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the refactoring is self-contained in one UI component and the logic is correct across all interval/granularity combinations.

The rewrite is clean and the control flow is correct for every interval/granularity combination. The one thing worth a follow-up is that GRANULARITY_LABELS is typed as a plain string record, so adding a new granularity to INTERVAL_GRANULARITIES without a matching label entry would silently produce "undefined" in the dropdown button label at runtime.

Only QueryTopbar.tsx changed; worth a quick check when new granularity keys are added in the future.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx | Refactors interval/granularity data model into a single lookup table and adds "week" as a granularity option for the 30-day range; hides the granularity section entirely for single-option intervals instead of greying them out. Logic is correct; one minor type-safety gap exists in the display-label builder. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens dropdown] --> B[Select time range]
    B --> C{granularitiesFor interval}
    C -->|length === 1| D[Hide granularity section]
    C -->|length > 1| E[Show granularity options]
    E --> F[User selects granularity]
    F --> G[handleBinSizeSelect\nsetQueryStates bin_size]
    B --> H[handleIntervalSelect]
    H --> I[getEffectiveBinSize\npreserve choice if valid\notherwise use default]
    I --> J[setQueryStates interval + bin_size]
    A --> K[Select custom range]
    K --> L[handleCustomRangeSelect]
    L --> M[bin_size = granularitiesFor custom 0\n= day]
    J --> N[getDisplayLabel\nshows granularity suffix\nonly when non-default]
    G --> N
    M --> N
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
vite/src/views/customers/customer/analytics/components/QueryTopbar.tsx:98-99
**Silent `undefined` in display label for unknown granularities**

`GRANULARITY_LABELS` is typed as `Record<string, string>`, so TypeScript won't warn when a key is missing — the lookup silently returns `undefined` at runtime. If someone later adds a new granularity key to `INTERVAL_GRANULARITIES` (e.g. `"quarter"`) without a matching entry in `GRANULARITY_LABELS`, the button label would render as `"Last 30 days (undefined)"`. Narrowing both maps to a shared `const` union type (e.g. `type Granularity = "hour" | "day" | "week" | "month"`) would surface this mistake at compile time.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: per-range granularity options; add..."](https://github.com/useautumn/autumn/commit/7087c854017555e45d860b95af276114d199a299) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37244031)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->