### PR TITLE
fix: claude oauth

### DIFF
--- a/packages/auth/src/oauth/leafOAuth.ts
+++ b/packages/auth/src/oauth/leafOAuth.ts
@@ -1,15 +1,20 @@
 import { LEAF_OAUTH_SCOPES } from "@autumn/shared/leafOAuthScopes";
-import type { ScopeString } from "@autumn/shared/scopeDefinitions";
+import { OPENID_SCOPES } from "@autumn/shared/scopeDefinitions";
 
 const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
+const oauthPassthroughScopeSet = new Set<string>(["offline_access"]);
+const oauthProtocolScopeSet = new Set<string>(OPENID_SCOPES);
 
 export const getDefaultOAuthScopes = (requestedScopes?: string[] | null) => {
 	const requested =
 		requestedScopes && requestedScopes.length > 0
 			? requestedScopes
-			: [...LEAF_OAUTH_SCOPES];
+			: [...LEAF_OAUTH_SCOPES, ...oauthPassthroughScopeSet];
 
-	return [...new Set(requested)].filter((scope): scope is ScopeString =>
-		leafScopeSet.has(scope),
+	return [...new Set(requested)].filter(
+		(scope) => leafScopeSet.has(scope) || oauthPassthroughScopeSet.has(scope),
 	);
 };
+
+export const getOAuthResourceScopes = <T extends string>(scopes: readonly T[]) =>
+	scopes.filter((scope) => !oauthProtocolScopeSet.has(scope));

--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -1,5 +1,6 @@
 import { prefixOAuthToken } from "@autumn/auth";
 import {
+	getOAuthResourceScopes,
 	getResourceFromOAuthTokenRequest,
 	returnsOAuthAccessTokenForClientId,
 } from "@autumn/auth/oauth";
@@ -123,7 +124,10 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 	const accessToken = getString(tokenPayload.access_token);
 	if (!accessToken) return response;
 
-	const requestedScopes = scopesFromOAuthScopeString(tokenPayload.scope);
+	const parsedRequestedScopes = scopesFromOAuthScopeString(tokenPayload.scope);
+	const requestedScopes = parsedRequestedScopes
+		? getOAuthResourceScopes(parsedRequestedScopes)
+		: null;
 	let apiKeyResult: Awaited<ReturnType<typeof getExternalOAuthApiKeyForToken>>;
 	try {
 		const tokenRecord = await getOAuthAccessTokenRecord({
@@ -142,15 +146,15 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 		const issuedScopes = await getOAuthConsentScopeGrant({
 			db,
 			organizationId: tokenRecord.referenceId,
-			requestedScopes: tokenRecord.scopes,
+			requestedScopes: parsedRequestedScopes ?? tokenRecord.scopes,
 			userId: tokenRecord.userId,
 		});
-		tokenRecord.scopes = issuedScopes;
+		tokenRecord.scopes = getOAuthResourceScopes(issuedScopes);
 		if (tokenRecord.id) {
 			await oauthAccessTokenRepo.updateScopes({
 				db,
 				id: tokenRecord.id,
-				scopes: issuedScopes,
+				scopes: tokenRecord.scopes,
 			});
 		}
 		if (tokenRecord.refreshId) {

--- a/server/src/internal/auth/oauth/oauthConsentScopes.ts
+++ b/server/src/internal/auth/oauth/oauthConsentScopes.ts
@@ -1,4 +1,7 @@
-import { getDefaultOAuthScopes } from "@autumn/auth/oauth";
+import {
+	getDefaultOAuthScopes,
+	getOAuthResourceScopes,
+} from "@autumn/auth/oauth";
 import { ErrCode, isScopeSubset, RecaseError } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { getScopesForUserInOrg } from "@/utils/authUtils/customSessionScopes.js";
@@ -21,14 +24,21 @@ export const getOAuthConsentScopeGrant = async ({
 		organizationId,
 	});
 
-	const grant = finalRequestedScopes.filter((scope) =>
+	const resourceScopes = getOAuthResourceScopes(finalRequestedScopes);
+	const resourceGrant = resourceScopes.filter((scope) =>
 		isScopeSubset([scope], userScopes),
 	);
-	if (grant.length > 0) return grant;
+	if (resourceGrant.length === 0) {
+		throw new RecaseError({
+			message: "No requested scopes can be granted to this OAuth client",
+			code: ErrCode.InsufficientScopes,
+			statusCode: 403,
+		});
+	}
 
-	throw new RecaseError({
-		message: "No requested scopes can be granted to this OAuth client",
-		code: ErrCode.InsufficientScopes,
-		statusCode: 403,
-	});
+	const grantedResourceScopes = new Set(resourceGrant);
+	return finalRequestedScopes.filter(
+		(scope) =>
+			!resourceScopes.includes(scope) || grantedResourceScopes.has(scope),
+	);
 };

--- a/server/tests/unit/auth/registerMcpOAuthClient.test.ts
+++ b/server/tests/unit/auth/registerMcpOAuthClient.test.ts
@@ -1,45 +1,77 @@
 import { describe, expect, test } from "bun:test";
-import { getDefaultOAuthScopes } from "@autumn/auth/oauth";
+import {
+	getDefaultOAuthScopes,
+	getOAuthResourceScopes,
+} from "@autumn/auth/oauth";
 import { LEAF_OAUTH_SCOPES } from "@autumn/shared";
 import { Scopes } from "@autumn/shared/scopeDefinitions";
 import { getRequestedScopesForMcpClient } from "@/internal/auth/actions/registerMcpOAuthClient.js";
 
+const OFFLINE_ACCESS_SCOPE = "offline_access";
+const DEFAULT_MCP_SCOPES = [...LEAF_OAUTH_SCOPES, OFFLINE_ACCESS_SCOPE];
+
 describe("getRequestedScopesForMcpClient", () => {
-	test("defaults Slack MCP clients to Leaf OAuth scopes", () => {
+	test("defaults Slack MCP clients to Leaf scopes plus offline access", () => {
 		expect(
 			getRequestedScopesForMcpClient({ clientType: "slack", scope: undefined }),
-		).toEqual([...LEAF_OAUTH_SCOPES]);
+		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("defaults Codex MCP clients to Leaf OAuth scopes", () => {
+	test("defaults Codex MCP clients to Leaf scopes plus offline access", () => {
 		expect(
 			getRequestedScopesForMcpClient({ clientType: "codex", scope: undefined }),
-		).toEqual([...LEAF_OAUTH_SCOPES]);
+		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("defaults dynamic MCP clients to Leaf OAuth scopes", () => {
+	test("defaults dynamic MCP clients to Leaf scopes plus offline access", () => {
 		expect(
 			getRequestedScopesForMcpClient({
 				clientType: "dynamic",
 				scope: undefined,
 			}),
-		).toEqual([...LEAF_OAUTH_SCOPES]);
+		).toEqual(DEFAULT_MCP_SCOPES);
 	});
 
-	test("caps explicit requested scopes to Leaf scopes", () => {
+	test("caps explicit requested scopes to Leaf scopes plus offline access", () => {
 		expect(
 			getRequestedScopesForMcpClient({
 				clientType: "slack",
-				scope: `${Scopes.Customers.Read} ${Scopes.Plans.Write} ${Scopes.ApiKeys.Write} invalid`,
+				scope: `${Scopes.Customers.Read} ${Scopes.Plans.Write} ${Scopes.ApiKeys.Write} ${OFFLINE_ACCESS_SCOPE} invalid`,
 			}),
-		).toEqual([Scopes.Customers.Read, Scopes.Plans.Write]);
+		).toEqual([
+			Scopes.Customers.Read,
+			Scopes.Plans.Write,
+			OFFLINE_ACCESS_SCOPE,
+		]);
 	});
 
-	test("caps OAuth grants to Leaf scopes", () => {
+	test("preserves offline access in default OAuth scopes", () => {
+		expect(getDefaultOAuthScopes()).toEqual(DEFAULT_MCP_SCOPES);
+	});
+
+	test("caps OAuth grants to Leaf scopes plus offline access", () => {
 		expect(
 			getDefaultOAuthScopes([
 				Scopes.Customers.Read,
 				Scopes.ApiKeys.Write,
+				Scopes.Analytics.Read,
+				OFFLINE_ACCESS_SCOPE,
+			]),
+		).toEqual([
+			Scopes.Customers.Read,
+			Scopes.Analytics.Read,
+			OFFLINE_ACCESS_SCOPE,
+		]);
+	});
+
+	test("strips OAuth protocol scopes from resource scopes", () => {
+		expect(
+			getOAuthResourceScopes([
+				Scopes.Customers.Read,
+				OFFLINE_ACCESS_SCOPE,
+				"openid",
+				"profile",
+				"email",
 				Scopes.Analytics.Read,
 			]),
 		).toEqual([Scopes.Customers.Read, Scopes.Analytics.Read]);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes OAuth scope handling for Claude/OIDC clients by adding offline_access to defaults and excluding OIDC protocol scopes from consent checks and stored tokens. Prevents invalid consent failures and ensures only resource scopes are persisted.

- **Bug Fixes**
  - Added offline_access to default MCP and OAuth scopes; capped explicit requests to Leaf scopes plus offline_access.
  - Introduced resource-scope filtering to strip OIDC protocol scopes (e.g., openid, profile, email) from consent evaluation and token storage.
  - Updated consent logic to require at least one grantable resource scope and pass through protocol scopes unmodified.
  - Persist only granted resource scopes to access/refresh token records; expanded unit tests to cover these cases.

<sup>Written for commit 2de53a5d890eb4e817a0ab01f551930d24a3c1b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Claude MCP OAuth flow by ensuring the `offline_access` scope (required by Claude to receive a refresh token) is correctly handled throughout the authorization pipeline instead of being silently dropped or causing an `InsufficientScopes` error.

- **Bug fixes** — `getOAuthConsentScopeGrant` now separates OIDC protocol scopes (openid, profile, email, offline_access) from resource scopes. Protocol scopes pass through automatically whenever at least one resource scope is granted, rather than being tested against `userScopes` (where they would always fail).
- **Bug fixes / Improvements** — `getDefaultOAuthScopes` now includes `offline_access` in the default and passthrough filter, and a new `getOAuthResourceScopes` helper makes the protocol-vs-resource split reusable across token handling code.
- **Improvements** — Token handling in `handleOAuthTokenWithApiKey` is now more precise: resource-only scopes drive access-token DB writes and token lookup, while full scopes (including `offline_access`) are persisted to the refresh-token record.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are well-scoped, well-tested, and the OAuth token response still carries the refresh_token field untouched so clients can use it regardless of the scope field.

The scope-grant rewrite is the most sensitive part of the change — the passthrough rule for protocol scopes is correct given current set definitions, but relies on oauthPassthroughScopeSet and OPENID_SCOPES staying aligned.

oauthConsentScopes.ts and handleOAuthTokenWithApiKey.ts deserve a second read to confirm protocol-scope passthrough does not inadvertently grant unintended scopes if the two scope sets ever diverge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/auth/src/oauth/leafOAuth.ts | Adds `getOAuthResourceScopes` to strip OIDC protocol scopes, and extends `getDefaultOAuthScopes` to include `offline_access` in defaults and passthrough filter. |
| server/src/internal/auth/oauth/oauthConsentScopes.ts | Refactors grant logic to separate resource scopes from protocol scopes; protocol scopes (like `offline_access`) now pass through automatically when any resource scope is granted. |
| server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts | Separates resource scopes from full scopes in token handling: resource scopes drive token lookup and access-token DB record, while full scopes (including `offline_access`) drive the refresh-token DB record. |
| server/tests/unit/auth/registerMcpOAuthClient.test.ts | Updated tests to assert `offline_access` is now included in default scopes and explicitly verifies protocol-scope stripping via `getOAuthResourceScopes`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Claude MCP Client
    participant H as handleOAuthTokenWithApiKey
    participant G as getOAuthConsentScopeGrant
    participant DB as Database

    C->>H: POST /token (scope: "customers:read offline_access openid")
    H->>H: "parsedRequestedScopes = [customers:read, offline_access, openid]"
    H->>H: "requestedScopes = getOAuthResourceScopes(parsed) → [customers:read]"
    H->>DB: "getOAuthAccessTokenRecord(requestedScopes=[customers:read])"
    DB-->>H: "tokenRecord {scopes, userId, ...}"
    H->>G: "getOAuthConsentScopeGrant(requestedScopes=parsedRequestedScopes)"
    G->>G: "finalRequestedScopes = getDefaultOAuthScopes(...) → [customers:read, offline_access]"
    G->>G: "resourceScopes = getOAuthResourceScopes(final) → [customers:read]"
    G->>G: "resourceGrant = [customers:read] (user has permission)"
    G->>G: Return granted resources ∪ protocol passthrough → [customers:read, offline_access]
    G-->>H: "issuedScopes = [customers:read, offline_access]"
    H->>H: "tokenRecord.scopes = getOAuthResourceScopes(issued) → [customers:read]"
    H->>DB: updateScopes(accessToken, [customers:read])
    H->>DB: updateScopes(refreshToken, [customers:read, offline_access])
    H-->>C: "{access_token, scope: "customers:read", refresh_token}"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/auth/oauth/oauthConsentScopes.ts:39-43
Minor inefficiency: `resourceScopes` is an array, so each `resourceScopes.includes(scope)` call in the final `filter` is O(n). Converting it to a `Set` first (which `grantedResourceScopes` already is) makes the lookup O(1). The lists are small today, but this path is exercised on every token exchange.

```suggestion
	const resourceScopeSet = new Set(resourceScopes);
	const grantedResourceScopes = new Set(resourceGrant);
	return finalRequestedScopes.filter(
		(scope) =>
			!resourceScopeSet.has(scope) || grantedResourceScopes.has(scope),
	);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: claude oauth"](https://github.com/useautumn/autumn/commit/2de53a5d890eb4e817a0ab01f551930d24a3c1b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37295649)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->