### PR TITLE
fix: 🐛 cli auth for the last time

### DIFF
--- a/packages/auth/src/oauth/leafOAuth.ts
+++ b/packages/auth/src/oauth/leafOAuth.ts
@@ -1,5 +1,8 @@
 import { LEAF_OAUTH_SCOPES } from "@autumn/shared/leafOAuthScopes";
-import { OPENID_SCOPES } from "@autumn/shared/scopeDefinitions";
+import {
+	LEGACY_SCOPE_ALIASES,
+	OPENID_SCOPES,
+} from "@autumn/shared/scopeDefinitions";
 
 const leafScopeSet = new Set<string>(LEAF_OAUTH_SCOPES);
 const oauthPassthroughScopeSet = new Set<string>(["offline_access"]);
@@ -11,8 +14,12 @@ export const getDefaultOAuthScopes = (requestedScopes?: string[] | null) => {
 			? requestedScopes
 			: [...LEAF_OAUTH_SCOPES, ...oauthPassthroughScopeSet];
 
+	// Issued scopes must echo the client's request verbatim (better-auth
+	// rejects rewrites), so legacy CRUDL aliases are used for filtering only.
 	return [...new Set(requested)].filter(
-		(scope) => leafScopeSet.has(scope) || oauthPassthroughScopeSet.has(scope),
+		(scope) =>
+			leafScopeSet.has(LEGACY_SCOPE_ALIASES[scope] ?? scope) ||
+			oauthPassthroughScopeSet.has(scope),
 	);
 };
 

--- a/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
+++ b/server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts
@@ -1,4 +1,10 @@
-import { AppEnv, ErrCode, RecaseError, Scopes } from "@autumn/shared";
+import {
+	AppEnv,
+	ErrCode,
+	LEGACY_SCOPE_ALIASES,
+	RecaseError,
+	Scopes,
+} from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { isMcpOAuthClientId } from "@/internal/auth/oauth/mcpOAuthScopes.js";
 import {
@@ -84,7 +90,15 @@ export const handleCreateOAuthApiKeys = createRoute({
 				statusCode: 401,
 			});
 		}
-		const apiKeyScopes = requestedScopes ?? tokenRecord.scopes;
+		// Tokens may carry legacy CRUDL scopes (old CLI); store modern R/W on keys.
+		const apiKeyScopes = [
+			...new Set(
+				(requestedScopes ?? tokenRecord.scopes).map(
+					(scope) => LEGACY_SCOPE_ALIASES[scope] ?? scope,
+				),
+			),
+		];
+
 		if (await isMcpOAuthClientId({ clientId, ctx })) {
 			throw new RecaseError({
 				message: "MCP OAuth clients must use OAuth access tokens directly",

--- a/server/tests/unit/auth/registerMcpOAuthClient.test.ts
+++ b/server/tests/unit/auth/registerMcpOAuthClient.test.ts
@@ -64,6 +64,33 @@ describe("getRequestedScopesForMcpClient", () => {
 		]);
 	});
 
+	test("keeps legacy CRUDL scopes (old CLI) whose alias is leaf-allowed, verbatim", () => {
+		expect(
+			getDefaultOAuthScopes([
+				"customers:create",
+				"customers:read",
+				"customers:list",
+				"customers:update",
+				"customers:delete",
+				"features:create",
+				"features:read",
+				"plans:update",
+				"apiKeys:create",
+				"organisation:read",
+			]),
+		).toEqual([
+			"customers:create",
+			"customers:read",
+			"customers:list",
+			"customers:update",
+			"customers:delete",
+			"features:create",
+			"features:read",
+			"plans:update",
+			"organisation:read",
+		]);
+	});
+
 	test("strips OAuth protocol scopes from resource scopes", () => {
 		expect(
 			getOAuthResourceScopes([


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CLI authentication by accepting legacy CRUDL OAuth scopes from older CLIs and normalizing them when creating API keys. Tokens now echo the client's requested scopes verbatim to avoid auth failures.

- **Bug Fixes**
  - OAuth: filter requested scopes using `LEGACY_SCOPE_ALIASES` while issuing tokens with the original scopes unchanged.
  - CLI API keys: map legacy CRUDL scopes to modern read/write equivalents before persisting; deduplicate scopes.
  - Tests: add coverage to ensure legacy scopes are accepted when allowed.

<sup>Written for commit 6e09f4dba1e31db180a36e0571368300fb418209. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes CLI OAuth authentication by teaching the scope pipeline to tolerate the legacy CRUDL scope strings (`customers:create`, `plans:update`, etc.) emitted by old CLI versions that pre-date the modern R/W scope model.

- **Bug fixes** — `getDefaultOAuthScopes` now uses `LEGACY_SCOPE_ALIASES` for filtering so that a legacy scope whose modern equivalent is in `LEAF_OAUTH_SCOPES` is accepted verbatim (required by better-auth, which rejects rewrites on the issued scope list).
- **Bug fixes** — `handleCreateOAuthApiKeys` normalizes any legacy CRUDL scopes on an OAuth token to their modern R/W equivalents before writing them to the API key, so stored keys always carry canonical scope strings regardless of which CLI version completed the OAuth flow.
- **Improvements** — A unit test is added to `registerMcpOAuthClient.test.ts` covering the verbatim-pass-through of legacy CRUDL scopes through `getDefaultOAuthScopes`, confirming that scopes mapping to non-leaf modern equivalents (e.g., `apiKeys:create` → `apiKeys:write`, not in `LEAF_OAUTH_SCOPES`) are correctly filtered out.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are well-scoped to the legacy CLI compatibility path and do not alter the MCP or modern-scope flows.

The core logic in both files is correct: getDefaultOAuthScopes correctly preserves verbatim legacy scopes while filtering against their modern aliases, and handleCreateOAuthApiKeys correctly normalizes them before storage. The one gap worth noting is that the normalization of a partial legacy write verb silently broadens to the full write scope on the API key — intentional for old-CLI tokens but undocumented. Test coverage also lacks an assertion for org-write legacy scopes being filtered out at the leaf boundary.

handleCreateOAuthApiKeys.ts merits a second look on the implicit scope widening during normalization; registerMcpOAuthClient.test.ts would benefit from an added test for org write legacy scopes being rejected.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/auth/src/oauth/leafOAuth.ts | Modified getDefaultOAuthScopes to accept legacy CRUDL scopes by checking aliases against leafScopeSet while preserving scope strings verbatim in the output for better-auth compatibility. Logic is correct. |
| server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts | Normalizes legacy CRUDL scopes from OAuth tokens to modern R/W equivalents before storing them on API keys. Implicit widening of partial verb grants warrants a comment, but behavior is intentional for the old-CLI migration path. |
| server/tests/unit/auth/registerMcpOAuthClient.test.ts | Adds a test covering legacy CRUDL scope acceptance in getDefaultOAuthScopes. Misses coverage for org-write legacy scopes being filtered out (since organisation:write is absent from LEAF_OAUTH_SCOPES). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as Old CLI
    participant Auth as /authorize
    participant Token as OAuth Token
    participant Handler as POST /cli/api-keys
    participant Key as API Key Store

    CLI->>Auth: "scope=customers:create customers:list"
    Auth->>Auth: "getDefaultOAuthScopes(legacy scopes)<br/>LEGACY_SCOPE_ALIASES[scope] lookup modern equiv<br/>keep verbatim if equiv is in LEAF_OAUTH_SCOPES"
    Auth-->>Token: issued scopes: [customers:create, customers:list]

    CLI->>Handler: Bearer token
    Handler->>Handler: getOAuthAccessTokenRecord(token)
    Handler->>Handler: "map legacy scopes via LEGACY_SCOPE_ALIASES<br/>customers:create → customers:write<br/>customers:list → customers:read"
    Handler->>Handler: deduplicate with Set
    Handler->>Key: store apiKeyScopes: [customers:write, customers:read]
    Handler-->>CLI: "{sandbox_key, prod_key, scopes}"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tests/unit/auth/registerMcpOAuthClient.test.ts:67-92
**Missing test coverage for org write legacy scopes**

`organisation:create`, `organisation:update`, and `organisation:delete` alias to `organisation:write` which is NOT in `LEAF_OAUTH_SCOPES`. A test asserting those scopes are filtered out would make the allowlist boundary explicit and prevent a future expansion of `LEAF_OAUTH_SCOPES` from silently granting org-write access to old CLI tokens.

### Issue 2 of 2
server/src/internal/dev/cli/handlers/handleCreateOAuthApiKeys.ts:93-100
**Scope widening on API key creation is implicit**

A token carrying `customers:create` (write, but not `customers:update` or `customers:delete`) is normalized to `customers:write` on the resulting API key, which also grants update and delete. For the common old-CLI path this is intentional because the old CLI always requested all CRUDL verbs together, but a token that was deliberately scoped to a single verb (e.g., read-only `customers:list`) correctly becomes `customers:read`, so the asymmetry is also correct. The concern is that a partial write grant (`customers:create` only) silently escalates to full write on the API key. A comment or assertion that old-CLI tokens always carry the full CRUDL set would clarify intent and guard against future callers that send partial verb subsets.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 cli auth for the last time"](https://github.com/useautumn/autumn/commit/6e09f4dba1e31db180a36e0571368300fb418209) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37349100)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->