### PR TITLE
feat: support boolean feature grants in rewards

### DIFF
--- a/server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts
@@ -36,6 +36,7 @@ export const handleCreateCoupon = createRoute({
 			reward: rewardData,
 			orgId: org.id,
 			env,
+			features: ctx.features,
 		});
 
 		if (getRewardCat(newReward) === RewardCategory.Discount) {

--- a/server/src/internal/rewards/actions/redeemPromoCode.ts
+++ b/server/src/internal/rewards/actions/redeemPromoCode.ts
@@ -3,6 +3,7 @@ import {
 	type CustomerEntitlement,
 	type Entitlement,
 	ErrCode,
+	FeatureType,
 	findFeatureByInternalId,
 	RecaseError,
 	RewardType,
@@ -144,8 +145,9 @@ export const redeemPromoCode = async ({
 			continue;
 		}
 
+		const isBoolean = feature.type === FeatureType.Boolean;
 		const allowance = rewardEnt.allowance;
-		if (!allowance || allowance <= 0) {
+		if (!isBoolean && (!allowance || allowance <= 0)) {
 			throw new RecaseError({
 				message: `Reward entitlement for feature "${feature.id}" must have a positive allowance`,
 				code: ErrCode.InvalidReward,
@@ -170,7 +172,7 @@ export const redeemPromoCode = async ({
 				params: {
 					customer_id: customerId,
 					feature_id: feature.id,
-					included_grant: allowance,
+					included_grant: isBoolean ? undefined : (allowance ?? undefined),
 					expires_at: expiresAt,
 					balance_id: `reward_${code}_${new Date().toISOString().slice(0, 10).replace(/-/g, "_")}`,
 				},

--- a/server/src/internal/rewards/repos/rewardEntitlementRows.ts
+++ b/server/src/internal/rewards/repos/rewardEntitlementRows.ts
@@ -23,6 +23,9 @@ export const rewardToEntitlementRows = ({
 
 	return entitlements.map((entitlement) => {
 		const expiry = "expiry" in entitlement ? entitlement.expiry : undefined;
+		// Boolean grants carry no allowance
+		const hasAllowance =
+			entitlement.allowance != null && entitlement.allowance > 0;
 
 		return {
 			id:
@@ -37,8 +40,8 @@ export const rewardToEntitlementRows = ({
 			internal_product_id: null,
 			internal_reward_id: reward.internal_id,
 			is_custom: false,
-			allowance_type: AllowanceType.Fixed,
-			allowance: entitlement.allowance ?? null,
+			allowance_type: hasAllowance ? AllowanceType.Fixed : AllowanceType.None,
+			allowance: hasAllowance ? entitlement.allowance : null,
 			interval: null,
 			interval_count: 1,
 			carry_from_previous: false,

--- a/server/src/internal/rewards/rewardUtils.ts
+++ b/server/src/internal/rewards/rewardUtils.ts
@@ -3,6 +3,9 @@ import {
 	type CreateRewardProgram,
 	DiscountConfigSchema,
 	ErrCode,
+	type Feature,
+	FeatureType,
+	findFeatureByInternalId,
 	isFixedPrice,
 	notNullish,
 	type Price,
@@ -27,11 +30,13 @@ export const constructReward = ({
 	reward,
 	orgId,
 	env,
+	features = [],
 }: {
 	internalId?: string;
 	reward: CreateReward;
 	orgId: string;
 	env: string;
+	features?: Feature[];
 }) => {
 	if (!reward.id || !reward.name) {
 		throw new RecaseError({
@@ -61,7 +66,13 @@ export const constructReward = ({
 					code: ErrCode.InvalidReward,
 				});
 			}
-			if (!ent.allowance || ent.allowance <= 0) {
+			const feature = findFeatureByInternalId({
+				features,
+				internalId: ent.internal_feature_id,
+			});
+			// Boolean features grant on/off access, so they carry no allowance
+			const isBoolean = feature?.type === FeatureType.Boolean;
+			if (!isBoolean && (!ent.allowance || ent.allowance <= 0)) {
 				throw new RecaseError({
 					message: "Each entitlement must have a positive allowance",
 					code: ErrCode.InvalidReward,

--- a/server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts
+++ b/server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts
@@ -254,3 +254,26 @@ test(`${chalk.yellowBright("feature-grant-6: add customer coupon requires promo 
 	expect(messagesAfterMatch.allowed).toBe(true);
 	expect(messagesAfterMatch.balance).toBe(10);
 });
+
+test(`${chalk.yellowBright("feature-grant-7: redeem boolean feature grant (on/off, no allowance)")}`, async () => {
+	const customerId = "feature-grant-7";
+
+	const { autumnV1 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.featureGrant({
+				entitlements: [{ feature_id: TestFeature.Dashboard }],
+				promoCodes: [{ code: "DASHBOARD" }],
+			}),
+		],
+		actions: [s.rewards.redeem({ code: "DASHBOARD" })],
+	});
+
+	const check = await autumnV1.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Dashboard,
+	});
+
+	expect(check.allowed).toBe(true);
+});

--- a/server/tests/utils/testInitUtils/initScenario.ts
+++ b/server/tests/utils/testInitUtils/initScenario.ts
@@ -74,7 +74,8 @@ type RewardConfig = {
 
 type FeatureGrantEntitlement = {
 	feature_id: string;
-	allowance: number;
+	// Optional: boolean features grant on/off access with no allowance
+	allowance?: number;
 	expiry?: { duration: EntitlementDuration; length: number };
 };
 

--- a/shared/models/rewardModels/rewardModels/rewardModels.ts
+++ b/shared/models/rewardModels/rewardModels/rewardModels.ts
@@ -16,7 +16,8 @@ const PromoCodeSchema = z.object({
 
 const RewardEntitlementSchema = z.object({
 	internal_feature_id: z.string().min(1),
-	allowance: z.number().positive(),
+	// Optional: boolean features grant on/off access with no allowance
+	allowance: z.number().positive().optional(),
 	expiry: EntitlementExpirySchema.optional(),
 });
 

--- a/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
@@ -1,3 +1,4 @@
+import { FeatureType } from "@autumn/shared";
 import type { AxiosError } from "axios";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -85,9 +86,13 @@ export function CreateRewardSheet({
 			)
 				return false;
 			if (
-				reward.featureGrantEntitlements.some(
-					(e) => !e.allowance || e.allowance <= 0,
-				)
+				reward.featureGrantEntitlements.some((e) => {
+					// Boolean features grant on/off access with no allowance
+					const isBoolean =
+						features.find((f) => f.id === e.feature_id)?.type ===
+						FeatureType.Boolean;
+					return !isBoolean && (!e.allowance || e.allowance <= 0);
+				})
 			)
 				return false;
 			if (

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -37,11 +37,15 @@ export function FeatureGrantRewardConfig({
 }: FeatureGrantRewardConfigProps) {
 	const { features } = useFeaturesQuery();
 
-	// Keep existing metered filtering, but allow credit systems too
 	const availableGrantTargets = features.filter(
 		(f) =>
-			f.type === FeatureType.Metered || f.type === FeatureType.CreditSystem,
+			f.type === FeatureType.Metered ||
+			f.type === FeatureType.CreditSystem ||
+			f.type === FeatureType.Boolean,
 	);
+
+	const isBooleanFeature = (featureId: string) =>
+		features.find((f) => f.id === featureId)?.type === FeatureType.Boolean;
 
 	const entitlements = reward.featureGrantEntitlements;
 	const getGlobalMaxRedemption = (
@@ -320,22 +324,24 @@ export function FeatureGrantRewardConfig({
 										/>
 									</div>
 
-									{/* Allowance */}
-									<div>
-										<FormLabel>Balance Grant</FormLabel>
-										<Input
-											type="number"
-											value={ent.allowance || ""}
-											onChange={(e) =>
-												updateEntitlement({
-													index,
-													updates: { allowance: Number(e.target.value) },
-												})
-											}
-											placeholder="0"
-											className="w-full [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-										/>
-									</div>
+									{/* Allowance (boolean features grant on/off access, no balance) */}
+									{!isBooleanFeature(ent.feature_id) && (
+										<div>
+											<FormLabel>Balance Grant</FormLabel>
+											<Input
+												type="number"
+												value={ent.allowance || ""}
+												onChange={(e) =>
+													updateEntitlement({
+														index,
+														updates: { allowance: Number(e.target.value) },
+													})
+												}
+												placeholder="0"
+												className="w-full [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+											/>
+										</div>
+									)}
 
 									{/* Expiry */}
 									<div>

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -222,7 +222,7 @@ export function FeatureGrantRewardConfig({
 					<AnimatePresence initial={false}>
 						{entitlements.map((ent, index) => (
 							<motion.div
-								key={`${ent.feature_id || "new"}-${index}`}
+								key={index}
 								initial={{ opacity: 0, scaleY: 0.95, originY: 0 }}
 								animate={{ opacity: 1, scaleY: 1 }}
 								exit={{ opacity: 0, scaleY: 0.95 }}

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -4,7 +4,6 @@ import { CheckIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { cloneElement, isValidElement } from "react";
 import { Button } from "@/components/v2/buttons/Button";
-import { TextCheckbox } from "@/components/v2/checkboxes/TextCheckbox";
 import { FormLabel } from "@/components/v2/form/FormLabel";
 import { Input } from "@/components/v2/inputs/Input";
 import { SearchableSelect } from "@/components/v2/selects/SearchableSelect";
@@ -24,7 +23,6 @@ import type {
 	FrontendReward,
 	FrontendRewardEntitlement,
 } from "../../types/frontendReward";
-import { FirstTimeTransactionTooltip } from "./FirstTimeTransactionTooltip";
 
 interface FeatureGrantRewardConfigProps {
 	reward: FrontendReward;
@@ -111,25 +109,6 @@ export function FeatureGrantRewardConfig({
 		updated[index] = {
 			...rest,
 			global_max_redemption: value,
-		};
-		setReward({ ...reward, promo_codes: updated });
-	};
-
-	const updateFirstTimeTransaction = ({
-		index,
-		value,
-	}: {
-		index: number;
-		value: boolean;
-	}) => {
-		const updated = [...(reward.promo_codes || [])];
-		const promoCode = updated[index] ?? { code: "" };
-		const globalMaxRedemption = getGlobalMaxRedemption(promoCode);
-		const { max_redemptions: _maxRedemptions, ...rest } = promoCode;
-		updated[index] = {
-			...rest,
-			global_max_redemption: globalMaxRedemption,
-			first_time_transaction: value,
 		};
 		setReward({ ...reward, promo_codes: updated });
 	};
@@ -224,20 +203,6 @@ export function FeatureGrantRewardConfig({
 										<TrashIcon size={14} />
 									</button>
 								)}
-							</div>
-							<div className="flex items-center gap-1.5">
-								<TextCheckbox
-									checked={promoCode.first_time_transaction ?? false}
-									onCheckedChange={(checked) =>
-										updateFirstTimeTransaction({
-											index,
-											value: checked === true,
-										})
-									}
-								>
-									Limit to first-time customers
-								</TextCheckbox>
-								<FirstTimeTransactionTooltip />
 							</div>
 						</div>
 					))}

--- a/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
@@ -1,4 +1,4 @@
-import type { Reward } from "@autumn/shared";
+import { FeatureType, type Reward } from "@autumn/shared";
 import type { AxiosError } from "axios";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -87,9 +87,13 @@ export function UpdateRewardSheet({
 			)
 				return false;
 			if (
-				reward.featureGrantEntitlements.some(
-					(e) => !e.allowance || e.allowance <= 0,
-				)
+				reward.featureGrantEntitlements.some((e) => {
+					// Boolean features grant on/off access with no allowance
+					const isBoolean =
+						features.find((f) => f.id === e.feature_id)?.type ===
+						FeatureType.Boolean;
+					return !isBoolean && (!e.allowance || e.allowance <= 0);
+				})
 			)
 				return false;
 			if (

--- a/vite/src/views/products/rewards/types/frontendReward.ts
+++ b/vite/src/views/products/rewards/types/frontendReward.ts
@@ -21,7 +21,8 @@ export enum FrontendDiscountType {
 /** Frontend entitlement config for feature grant rewards */
 export interface FrontendRewardEntitlement {
 	feature_id: string;
-	allowance: number;
+	// Optional: boolean features grant on/off access with no allowance
+	allowance?: number;
 	expiry?: {
 		duration: EntitlementDuration;
 		length: number;

--- a/vite/src/views/products/rewards/utils/rewardMappers.ts
+++ b/vite/src/views/products/rewards/utils/rewardMappers.ts
@@ -102,9 +102,10 @@ export function mapFrontendToApiReward({
 			const feature = features
 				? findFeatureById({ features, featureId: e.feature_id })
 				: undefined;
+			const hasAllowance = e.allowance != null && e.allowance > 0;
 			return {
 				internal_feature_id: feature?.internal_id ?? e.feature_id,
-				allowance: e.allowance,
+				allowance: hasAllowance ? e.allowance : undefined,
 				expiry: e.expiry,
 			};
 		});


### PR DESCRIPTION
## Summary

Boolean features can now be granted via feature-grant reward promo codes. The underlying balance-creation path already supported booleans (`ValidateCreateBalanceParamsSchema` handles `FeatureType.Boolean` — no `included_grant`, no `reset`), so this primarily lifts the "positive allowance required" guards and skips `included_grant` for boolean features end-to-end.

### Backend
- `RewardEntitlementSchema.allowance` is now optional (boolean grants carry no allowance)
- `redeemPromoCode` skips the positive-allowance check and omits `included_grant` for boolean features
- `constructReward` is now feature-aware (takes `features`) and only requires an allowance for non-boolean features
- Stored reward entitlement rows use `allowance_type: None` + null allowance for boolean grants

### Frontend
- Boolean features now appear in the feature-grant selector; the "Balance Grant" input hides for them
- Create/Update reward form validation no longer requires an allowance for boolean grants
- Removed the "Limit to first-time customers" promo-code option from feature grants (it only applies to coupons)
- Fixed a stray fade animation: the entitlement card is now keyed by index, so selecting a feature no longer remounts it

### Tests
- Added `feature-grant-7` integration test redeeming a boolean grant (no allowance)

## Test plan
- [ ] `bun ts` passes (server + vite)
- [ ] Manual: create a feature-grant reward with a boolean feature, redeem the code, confirm `/check` returns `allowed: true`
- [ ] Manual: confirm metered/credit grants still require a positive allowance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable granting boolean features via feature‑grant promo codes. Removes the allowance requirement and skips included_grant for booleans in redemption, storage, and the dashboard.

- **New Features**
  - Backend: allowance is optional for entitlements; boolean grants redeem without a positive allowance and omit included_grant; rows persist with `allowance_type: None`.
  - Frontend: boolean features appear in the selector; hides “Balance Grant” for booleans; create/update forms allow booleans without an allowance; removed “Limit to first-time customers” from feature grants.
  - Tests: added an integration test redeeming a boolean grant.

- **Bug Fixes**
  - Prevent entitlement card flicker by keying rows by index instead of feature_id.

<sup>Written for commit 2d541eac28223f6ed18dfb527d105d03cad017c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends feature-grant promo code rewards to support boolean (on/off) features, which carry no numeric allowance. The change is well-scoped: backend validation guards, the balance-creation path, stored row format, and frontend form validation are all updated consistently.

- **Improvements**: Boolean features are now selectable in the feature-grant reward UI; the Balance Grant input hides automatically, and form validation skips the positive-allowance requirement for boolean types.
- **Bug fixes**: The entitlement card animation no longer remounts when a feature is selected (key changed from `feature_id-index` to `index`); `allowance_type` is now stored as `None` (not `Fixed`) for boolean grants.
- **API changes**: `RewardEntitlementSchema.allowance` is now optional; `constructReward` accepts `features` so it can distinguish boolean from metered entitlements at creation time; `redeemPromoCode` omits `included_grant` for boolean features.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; boolean grants flow correctly end-to-end with no data-loss or correctness risk. The two nits are cosmetic/API-surface issues.

The core paths — creation, storage, redemption, and `/check` — are all handled correctly and covered by the new integration test. The two minor issues (redeemPromoCode returning `balance: 0` for boolean grants instead of `null`, and mapApiToFrontendReward hydrating boolean allowances as `0` instead of `undefined`) are API/type inconsistencies that don't affect functional correctness but could confuse consumers or future maintainers.

`rewardMappers.ts` (the `allowance ?? 0` hydration) and the `entitlements_granted` response shape in `redeemPromoCode.ts`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/rewards/actions/redeemPromoCode.ts | Core redemption logic correctly skips the allowance check and omits `included_grant` for boolean features; the only nit is the response returns `balance: 0` for boolean grants instead of `null`. |
| server/src/internal/rewards/rewardUtils.ts | `constructReward` now accepts `features` and correctly gates the positive-allowance check on `feature?.type === FeatureType.Boolean`; default `features = []` is safe because all non-FeatureGrant paths skip the entitlement loop entirely. |
| server/src/internal/rewards/repos/rewardEntitlementRows.ts | Correctly switches `allowance_type` from `Fixed` to `None` and nulls the allowance for boolean grants using a simple `hasAllowance` guard; no feature-type lookup needed here since allowance presence is sufficient. |
| shared/models/rewardModels/rewardModels/rewardModels.ts | Makes `allowance` optional on `RewardEntitlementSchema`; correct schema change to allow boolean grants with no numeric balance. |
| vite/src/views/products/rewards/utils/rewardMappers.ts | `mapFrontendToApiReward` correctly strips zero/null allowances before sending; `mapApiToFrontendReward` still uses `?? 0` which is inconsistent with the newly-optional `FrontendRewardEntitlement.allowance` type. |
| vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx | Adds boolean features to the selector, hides the Balance Grant input for boolean features, removes the first-time-customer checkbox, and fixes the motion key to prevent spurious remounts on feature selection. |
| vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx | Validation now correctly bypasses the positive-allowance requirement for boolean features. |
| vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx | Same validation fix as `CreateRewardSheet`; mirrors the boolean-allowance bypass correctly. |
| server/tests/integration/rewards/rewards-redeem-feature-grant.test.ts | Adds `feature-grant-7` integration test verifying end-to-end boolean grant redemption; covers the happy path of creating a boolean feature grant reward, redeeming it, and confirming `/check` returns `allowed: true`. |
| server/tests/utils/testInitUtils/initScenario.ts | Makes `allowance` optional in `FeatureGrantEntitlement`, correctly allowing boolean feature grants with no numeric allowance in test setup. |
| vite/src/views/products/rewards/types/frontendReward.ts | Makes `allowance` optional on `FrontendRewardEntitlement` to match the new boolean-grant model. |
| server/src/internal/api/rewards/handlers/rewards/handleCreateCoupon.ts | Now threads `ctx.features` into `constructReward` so boolean-feature validation works correctly at creation time. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant FE as Frontend
    participant API as handleCreateCoupon
    participant CU as constructReward
    participant RR as rewardRepo
    participant RP as redeemPromoCode
    participant PB as prepareNewBalanceForInsertion

    FE->>API: POST /rewards (FeatureGrant, boolean feature, no allowance)
    API->>CU: "constructReward({ reward, features })"
    CU-->>CU: "findFeatureByInternalId → isBoolean=true"
    CU-->>CU: skip positive-allowance guard
    CU-->>API: new Reward
    API->>RR: insert(reward)

    FE->>RP: "POST /redeem { code, customer_id }"
    RP->>RR: getByCode(code)
    RR-->>RP: "reward with entitlements (allowance=null)"
    RP-->>RP: "feature.type === Boolean → isBoolean=true"
    RP-->>RP: skip allowance check
    RP->>PB: "prepareNewBalance({ included_grant: undefined })"
    PB-->>RP: newEntitlement (AllowanceType.None)
    RP-->>FE: "{ balance: 0 }  ← returns 0 for boolean grants"
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `vite/src/views/products/rewards/utils/rewardMappers.ts`, line 156-159 ([link](https://github.com/useautumn/autumn/blob/2d541eac28223f6ed18dfb527d105d03cad017c1/vite/src/views/products/rewards/utils/rewardMappers.ts#L156-L159)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`allowance ?? 0` doesn't match the updated optional type**

   `FrontendRewardEntitlement.allowance` is now typed as `number | undefined`, yet `mapApiToFrontendReward` still maps it with `e.allowance ?? 0`, so boolean-feature entitlements (where the stored allowance is `null`) are always hydrated as `0` in the frontend state. The type declaration becomes misleading, and in `UpdateRewardSheet` the validation predicate (`!isBoolean && (!e.allowance || e.allowance <= 0)`) would silently fail if `features` hasn't loaded yet when submit is clicked — `isBoolean` would evaluate to `false` for every feature, and `!0` would cause validation to block the submit even for legitimate boolean grants. Using `e.allowance ?? undefined` keeps the state consistent with the type.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vite/src/views/products/rewards/utils/rewardMappers.ts
   Line: 156-159

   Comment:
   **`allowance ?? 0` doesn't match the updated optional type**

   `FrontendRewardEntitlement.allowance` is now typed as `number | undefined`, yet `mapApiToFrontendReward` still maps it with `e.allowance ?? 0`, so boolean-feature entitlements (where the stored allowance is `null`) are always hydrated as `0` in the frontend state. The type declaration becomes misleading, and in `UpdateRewardSheet` the validation predicate (`!isBoolean && (!e.allowance || e.allowance <= 0)`) would silently fail if `features` hasn't loaded yet when submit is clicked — `isBoolean` would evaluate to `false` for every feature, and `!0` would cause validation to block the submit even for legitimate boolean grants. Using `e.allowance ?? undefined` keeps the state consistent with the type.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `server/src/internal/rewards/actions/redeemPromoCode.ts`, line 242-245 ([link](https://github.com/useautumn/autumn/blob/2d541eac28223f6ed18dfb527d105d03cad017c1/server/src/internal/rewards/actions/redeemPromoCode.ts#L242-L245)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Boolean feature grants report `balance: 0` in the API response**

   For boolean feature grants the stored `allowance` is `null`, so `ent.allowance ?? 0` always returns `0`. API callers receive `{ feature_id: "...", balance: 0 }`, which is indistinguishable from "no balance granted" and could mislead consumers into thinking the redemption failed or produced nothing. Using `null` makes it clear that the concept of a numeric balance doesn't apply to this entitlement.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/rewards/actions/redeemPromoCode.ts
   Line: 242-245

   Comment:
   **Boolean feature grants report `balance: 0` in the API response**

   For boolean feature grants the stored `allowance` is `null`, so `ent.allowance ?? 0` always returns `0`. API callers receive `{ feature_id: "...", balance: 0 }`, which is indistinguishable from "no balance granted" and could mislead consumers into thinking the redemption failed or produced nothing. Using `null` makes it clear that the concept of a numeric balance doesn't apply to this entitlement.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
vite/src/views/products/rewards/utils/rewardMappers.ts:156-159
**`allowance ?? 0` doesn't match the updated optional type**

`FrontendRewardEntitlement.allowance` is now typed as `number | undefined`, yet `mapApiToFrontendReward` still maps it with `e.allowance ?? 0`, so boolean-feature entitlements (where the stored allowance is `null`) are always hydrated as `0` in the frontend state. The type declaration becomes misleading, and in `UpdateRewardSheet` the validation predicate (`!isBoolean && (!e.allowance || e.allowance <= 0)`) would silently fail if `features` hasn't loaded yet when submit is clicked — `isBoolean` would evaluate to `false` for every feature, and `!0` would cause validation to block the submit even for legitimate boolean grants. Using `e.allowance ?? undefined` keeps the state consistent with the type.

### Issue 2 of 2
server/src/internal/rewards/actions/redeemPromoCode.ts:242-245
**Boolean feature grants report `balance: 0` in the API response**

For boolean feature grants the stored `allowance` is `null`, so `ent.allowance ?? 0` always returns `0`. API callers receive `{ feature_id: "...", balance: 0 }`, which is indistinguishable from "no balance granted" and could mislead consumers into thinking the redemption failed or produced nothing. Using `null` makes it clear that the concept of a numeric balance doesn't apply to this entitlement.

```suggestion
			return {
				feature_id: feature?.id ?? ent.internal_feature_id,
				balance: ent.allowance ?? null,
			};
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop feature-grant card remounting ..."](https://github.com/useautumn/autumn/commit/2d541eac28223f6ed18dfb527d105d03cad017c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37503729)</sub>

<!-- /greptile_comment -->