### PR TITLE
chore: atmn release action

### DIFF
--- a/.github/workflows/atmn-publish.yml
+++ b/.github/workflows/atmn-publish.yml
@@ -1,0 +1,39 @@
+name: ATMN Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/atmn/**"
+
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run (no actual publish)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      version-bump:
+        description: "Version bump type (for manual triggers)"
+        required: false
+        default: "patch"
+        type: choice
+        options:
+          - "patch"
+          - "minor"
+          - "major"
+
+jobs:
+  publish:
+    uses: ./.github/workflows/npm-publish.yml
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      package-dir: packages/atmn
+      version-bump: ${{ github.event_name == 'workflow_dispatch' && inputs.version-bump || '' }}
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub Actions workflow to publish the `packages/atmn` package via the shared `npm-publish.yml`. Automates releases on `main` and supports manual runs with dry-run and version bump options.

- **New Features**
  - Auto-publish on `main` changes under `packages/atmn/**`
  - Manual `workflow_dispatch` with `dry-run` and `version-bump` (patch/minor/major)
  - Reuses `npm-publish.yml` with `package-dir: packages/atmn` and `id-token`/`contents` write permissions

<sup>Written for commit 2e4130e93cb972026e5b8c6114e5de37ae76bab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a GitHub Actions publish workflow for the `atmn` CLI package (`packages/atmn`), following the same pattern already established by `gateway-publish.yml` and `sdk-publish.yml`. The workflow delegates to the shared `npm-publish.yml` reusable workflow with no custom overrides needed, relying on the default build/typecheck/test script detection.

- **Improvements**: New `atmn-publish.yml` triggers on pushes to `main` that touch `packages/atmn/**` and supports manual dispatch with `dry-run` and `version-bump` inputs, matching the established publish workflow pattern across the repo.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a new workflow file that mirrors an already-working pattern used by gateway-publish.yml, with no changes to existing logic.

The new workflow is a minimal, faithful copy of the established gateway-publish.yml pattern. It correctly wires package-dir, version-bump, and dry-run inputs to the shared reusable workflow, and the packages/atmn package already has build, ts, and test scripts that the reusable workflow will discover automatically.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/atmn-publish.yml | New publish workflow for the packages/atmn package, mirroring the existing gateway-publish.yml pattern and delegating to the shared npm-publish.yml reusable workflow. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Event
    participant AW as atmn-publish.yml
    participant NP as npm-publish.yml (reusable)
    participant NPM as npm Registry

    GH->>AW: "push to main (packages/atmn/**)"
    Note over AW: OR workflow_dispatch
    AW->>NP: uses: ./.github/workflows/npm-publish.yml
    Note over NP: package-dir=packages/atmn
    NP->>NP: "Resolve package name & tag-prefix"
    NP->>NP: Determine version bump (commit msgs or explicit input)
    alt "bump != skip"
        NP->>NP: "Calculate next version from git tags (atmn-v*)"
        NP->>NP: Update package.json version
        NP->>NP: Build (bun -F atmn build)
        NP->>NP: TypeScript check (bun -F atmn ts)
        NP->>NP: Run tests (bun -F atmn test)
        alt "dry-run == true"
            NP->>NPM: npm publish --dry-run
        else
            NP->>NPM: npm publish --provenance --access public
            NP->>GH: "git tag atmn-v{version}"
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: atmn release action"](https://github.com/useautumn/autumn/commit/2e4130e93cb972026e5b8c6114e5de37ae76bab4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37504488)</sub>

<!-- /greptile_comment -->