### PR TITLE
chore: atmn release CI — unit tests only + version seed

### DIFF
--- a/.github/workflows/atmn-publish.yml
+++ b/.github/workflows/atmn-publish.yml
@@ -35,5 +35,7 @@ jobs:
       contents: write
     with:
       package-dir: packages/atmn
+      # atmn's default `test` script is sandbox integration tests; release CI runs unit only
+      test-command: bun -F atmn test:unit
       version-bump: ${{ github.event_name == 'workflow_dispatch' && inputs.version-bump || '' }}
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}

--- a/packages/atmn/package.json
+++ b/packages/atmn/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "atmn",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"license": "MIT",
 	"bin": {
 		"atmn": "dist/cli.js"

--- a/packages/atmn/package.json
+++ b/packages/atmn/package.json
@@ -34,6 +34,7 @@
 		"dev": "nodemon -e ts,tsx --watch src --ignore dist --exec \"bun run bun.config.ts\"",
 		"dev:bun": "bun run dev.ts",
 		"test": "bun test",
+		"test:unit": "bun test test/codegen",
 		"test:watch": "bun test --watch",
 		"test2": "prettier --check . && xo && ava",
 		"test-cli": "node --trace-deprecation -- ./dist/cli.js"


### PR DESCRIPTION
Follow-up to the `atmn` publish action (already merged to dev).

## Changes
- **`atmn-publish.yml`**: override `test-command` to `bun -F atmn test:unit`. The package's default `test` script runs sandbox integration tests requiring `UNIT_TEST_AUTUMN_SECRET_KEY`, which isn't available in release CI. Release CI now runs unit tests only.
- **`packages/atmn/package.json`**:
  - Add `test:unit` script (`bun test test/codegen`) — the only sandbox-free tests.
  - Bump version `1.1.8 → 1.1.9`. There's no `atmn-v*` git tag, so the workflow's version calc falls back to package.json; `1.1.8` already exists on npm and 409s. Seeding `1.1.9` lets the first CI publish succeed and create the `atmn-v1.1.9` tag.

## Verification
Dry-run dispatch on this branch ([run](https://github.com/useautumn/autumn/actions/runs/27507728906)): build ✓, typecheck ✓, unit tests ✓ (6 pass), tarball built ✓. Only failed at the publish step on the expected `cannot publish over 1.1.8` — fixed by this version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `atmn` release CI to run unit tests only by overriding the workflow test command and adding a `test:unit` script, skipping sandbox integration tests that require secrets. Bumps `atmn` to `1.1.9` to seed the first CI publish and avoid the existing `1.1.8` on npm.

<sup>Written for commit 52a93a3f17fd1b9eb7b941aee7feeecd9402bcca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Wires up the `atmn` release CI so it runs only unit tests and can publish successfully for the first time. The default `test` script requires a sandbox secret unavailable in release CI; this PR overrides it with a new `test:unit` script that runs only `test/codegen`. The version is bumped from `1.1.8` to `1.1.9` because no `atmn-v*` git tag exists yet and `1.1.8` is already on npm, so the seeded version lets the first publish succeed before the tag-based versioning takes over.

- **Improvements**: Added `test:unit` script in `packages/atmn/package.json` and `test-command` override in `atmn-publish.yml` to isolate sandbox-free codegen tests for CI.
- **Improvements**: Bumped version to `1.1.9` as a one-time seed so the tag-less fallback path in the reusable workflow can publish without hitting a 409 conflict on the already-published `1.1.8`.
</details>

<h3>Confidence Score: 5/5</h3>

Straightforward CI configuration change with no runtime code modifications; safe to merge.

Both changes are small and self-contained: a new `test:unit` script that correctly narrows the test run to the only sandbox-free tests, and a one-time version seed that unblocks the first publish. The reusable workflow's `eval "$COMMAND"` path already handles the override correctly, as confirmed by the dry-run linked in the PR description.

No files require special attention. Once `1.1.9` is published and the `atmn-v1.1.9` tag is created, the package.json version seed becomes irrelevant for future releases.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/atmn-publish.yml | Adds `test-command: bun -F atmn test:unit` override so release CI skips sandbox integration tests that require unavailable secrets. |
| packages/atmn/package.json | Adds `test:unit` script targeting only `test/codegen` (sandbox-free) and bumps version 1.1.8→1.1.9 to unblock the first publish after the no-tag fallback would otherwise 409. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub (push to main)
    participant WF as atmn-publish.yml
    participant RW as npm-publish.yml (reusable)
    participant BUN as Bun
    participant NPM as npm registry

    GH->>WF: "push to main (packages/atmn/**)"
    WF->>RW: "call with package-dir=packages/atmn, test-command=bun -F atmn test:unit"
    RW->>RW: "resolve package name & tag prefix (atmn)"
    RW->>RW: determine version bump from commit msg
    RW->>RW: "no atmn-v* tag found, use package.json (1.1.9)"
    RW->>BUN: eval bun -F atmn test:unit
    BUN->>BUN: run test/codegen only (sandbox-free)
    BUN-->>RW: 6 tests pass
    RW->>BUN: bun -F atmn build
    BUN-->>RW: build success
    RW->>NPM: npm publish --provenance
    NPM-->>RW: "published atmn@1.1.9"
    RW->>GH: git tag atmn-v1.1.9 (future runs use tag-based versioning)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: seed atmn release at 1.1.9 for firs..."](https://github.com/useautumn/autumn/commit/52a93a3f17fd1b9eb7b941aee7feeecd9402bcca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37505022)</sub>

<!-- /greptile_comment -->