### PR TITLE
fix: publish npm packages on github-hosted runner for provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -68,7 +68,8 @@ on:
 jobs:
   publish:
     name: Build and Publish
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted: npm --provenance rejects self-hosted/Blacksmith runners
+    runs-on: ubuntu-latest
 
     permissions:
       id-token: write


### PR DESCRIPTION
## Problem
The shared `npm-publish.yml` runs on `blacksmith-4vcpu-ubuntu-2404` (self-hosted). npm's `--provenance` flag rejects this:

```
npm error 422 Error verifying sigstore provenance bundle:
Unsupported GitHub Actions runner environment: "self-hosted".
Only "github-hosted" runners are supported when publishing with provenance.
```

Surfaced while bringing up the new `atmn` release pipeline. gateway/sdk last published on Blacksmith on 2026-06-12, but npm appears to have tightened provenance verification since — so they'd hit this on their next publish too.

## Fix
Switch the reusable publish job to `ubuntu-latest` (GitHub-hosted), which npm accepts for provenance attestation. Affects all three callers (atmn, gateway, autumn-js) equally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the shared publish workflow to GitHub-hosted `ubuntu-latest` to satisfy `npm --provenance` requirements; self-hosted/Blacksmith runners were rejected with a 422 provenance verification error. This unblocks publishing for all callers of the reusable workflow (`atmn`, `gateway`, `autumn-js`).

<sup>Written for commit 49ff51dbc456e8f256b12e6484e38c6a76980c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Switches the reusable `npm-publish.yml` job from the Blacksmith self-hosted runner (`blacksmith-4vcpu-ubuntu-2404`) to `ubuntu-latest` so that `npm publish --provenance` can obtain a valid OIDC sigstore bundle; npm rejects provenance attestations from self-hosted environments.

- **Bug fixes** — Changes `runs-on` to `ubuntu-latest`, unblocking provenance publishing for all three callers (`atmn`, `gateway`, `autumn-js`); the existing `id-token: write` permission already satisfies the OIDC requirement.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is the runner label, and GitHub-hosted runners are required for npm provenance to work correctly.

One-line runner change that directly resolves the npm provenance rejection. The workflow's id-token: write permission was already in place, so the fix is complete as written. No logic, secrets handling, or publish steps were altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-publish.yml | Switches runner from Blacksmith self-hosted to ubuntu-latest (GitHub-hosted) so npm --provenance can issue a valid OIDC sigstore bundle; no other logic changed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller workflow<br/>(atmn / gateway / autumn-js)
    participant Job as publish job<br/>(ubuntu-latest)
    participant npm as npm registry
    participant Sigstore as Sigstore / OIDC

    Caller->>Job: workflow_call (package-dir, version-bump, …)
    Job->>Job: Resolve package, bump version
    Job->>Job: bun install → pre-build → build → typecheck → test
    Job->>Sigstore: Request OIDC token (id-token: write)
    Sigstore-->>Job: JWT token
    Job->>npm: npm publish --provenance --access public
    npm->>Sigstore: Verify sigstore bundle (GitHub-hosted runner ✓)
    Sigstore-->>npm: Bundle valid
    npm-->>Job: 200 Published
    Job->>Job: git tag + push
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: publish on github-hosted runner for..."](https://github.com/useautumn/autumn/commit/49ff51dbc456e8f256b12e6484e38c6a76980c3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37505745)</sub>

<!-- /greptile_comment -->