### PR TITLE
fix: point atmn repository.url at useautumn/autumn

### DIFF
--- a/packages/atmn/package.json
+++ b/packages/atmn/package.json
@@ -7,7 +7,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/useautumn/typescript"
+		"url": "git+https://github.com/useautumn/autumn.git",
+		"directory": "packages/atmn"
 	},
 	"homepage": "https://docs.useautumn.com/api-reference/cli/getting-started",
 	"main": "dist/compose/index.js",


### PR DESCRIPTION
Last blocker for the atmn npm release.

npm provenance validates that `package.json` `repository.url` matches the repo the build ran in. atmn's was stale, pointing at the old `useautumn/typescript` repo:

```
npm error 422 Failed to validate repository information:
package.json "repository.url" is "git+https://github.com/useautumn/typescript.git",
expected to match "https://github.com/useautumn/autumn" from provenance
```

Updated to `useautumn/autumn` + `directory: packages/atmn`, matching the gateway/autumn-js convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed npm publish provenance for `atmn` by pointing repository info to the `useautumn/autumn` repo. Set `repository.url` to `git+https://github.com/useautumn/autumn.git` and `repository.directory` to `packages/atmn`, unblocking the release.

<sup>Written for commit bf008c6af6f3d59d50323e11e73d6942dcd6e99e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the `repository.url` field in `packages/atmn/package.json` so npm provenance checks pass during the `atmn` CLI package release. The previous value pointed at the old `useautumn/typescript` repo, causing a 422 validation error from the npm registry.

- **[Bug fixes]** Updates `repository.url` from `https://github.com/useautumn/typescript` to `git+https://github.com/useautumn/autumn.git`, adding the correct `git+` prefix and `.git` suffix required by npm provenance.
- **[Improvements]** Adds `directory: packages/atmn` to the repository object, precisely identifying the sub-package location within the monorepo.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single metadata field correction with no runtime logic changes.

The change updates one JSON field to unblock an npm publish. The new URL format (`git+https://...git`) is correct for npm provenance, and the added `directory` field accurately reflects the package's monorepo location. No code logic, exports, or dependencies are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/package.json | Corrects stale `repository.url` from `useautumn/typescript` to `useautumn/autumn` and adds `directory: packages/atmn` to satisfy npm provenance validation |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as CI Build
    participant npm as npm Registry
    participant GH as GitHub (provenance)

    CI->>npm: publish atmn package
    npm->>GH: validate provenance
    GH-->>npm: "repo = useautumn/autumn"
    npm->>npm: compare with package.json repository.url
    alt Before fix (useautumn/typescript)
        npm-->>CI: 422 Failed to validate repository information
    else After fix (useautumn/autumn)
        npm-->>CI: 200 Published successfully
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: point atmn repository.url at useaut..."](https://github.com/useautumn/autumn/commit/bf008c6af6f3d59d50323e11e73d6942dcd6e99e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37505958)</sub>

<!-- /greptile_comment -->