### PR TITLE
chore: add gateway tests

### DIFF
--- a/packages/gateway/tests/integration/openrouter.test.ts
+++ b/packages/gateway/tests/integration/openrouter.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Live integration tests: real OpenRouter calls through the withAutumn
+ * wrapper, asserting provider usage semantics that the unit suite can only
+ * assume:
+ *
+ * - both OpenAI and Anthropic models report OpenAI-style INCLUSIVE totals
+ *   (prompt_tokens contains cached + cache-write tokens)
+ * - our exclusive pools re-price to OpenRouter's own reported cost using
+ *   upstream per-token rates — proving the pool split is billing-correct
+ * - Anthropic prompt caching (cache_control) lands in cache_write_tokens /
+ *   cached_tokens and our subtraction yields the right text-input count
+ *
+ * Requires OPENROUTER_API_KEY (skipped otherwise) and spends ~$0.05/run.
+ *   bun run test:integration
+ */
+import { describe, expect, test } from "bun:test";
+import { OpenRouter } from "@openrouter/sdk";
+import { withAutumn } from "../../src/openrouter/index.js";
+import type { TrackTokensParams } from "../../src/shared/track.js";
+
+const API_KEY = process.env.OPENROUTER_API_KEY;
+
+// $ per million tokens, upstream (no markup) — used to re-derive
+// OpenRouter's reported cost from our exclusive pools.
+const RATES: Record<
+	string,
+	{ input: number; output: number; cacheRead?: number; cacheWrite?: number }
+> = {
+	"openai/gpt-4o-mini": { input: 0.15, output: 0.6 },
+	"anthropic/claude-3.5-haiku": {
+		input: 0.8,
+		output: 4,
+		cacheRead: 0.08,
+		cacheWrite: 1,
+	},
+};
+
+const priceOf = (pools: TrackTokensParams, model: string) => {
+	const rate = RATES[model];
+	if (!rate) {
+		throw new Error(`no rates for ${model}`);
+	}
+	return (
+		(pools.inputTokens * rate.input +
+			pools.outputTokens * rate.output +
+			pools.cacheReadTokens * (rate.cacheRead ?? rate.input) +
+			pools.cacheWriteTokens * (rate.cacheWrite ?? rate.input)) /
+		1_000_000
+	);
+};
+
+const createCapture = () => {
+	const calls: TrackTokensParams[] = [];
+	return {
+		calls,
+		autumn: {
+			trackTokens: async (params: TrackTokensParams) => {
+				calls.push(params);
+			},
+		},
+	};
+};
+
+const wrap = (calls: ReturnType<typeof createCapture>) =>
+	withAutumn({
+		autumn: calls.autumn,
+		openRouter: new OpenRouter({ apiKey: API_KEY ?? "" }),
+		customerId: "cus_integration_test",
+	});
+
+type ChatResult = {
+	usage?: {
+		promptTokens?: number;
+		completionTokens?: number;
+		cost?: number | null;
+		costDetails?: { upstreamInferenceCost?: number | null } | null;
+		promptTokensDetails?: {
+			cachedTokens?: number | null;
+			cacheWriteTokens?: number | null;
+		} | null;
+	} | null;
+};
+
+describe.skipIf(!API_KEY)("live OpenRouter usage semantics", () => {
+	for (const model of ["openai/gpt-4o-mini", "anthropic/claude-3.5-haiku"]) {
+		test(`${model}: pools conserve totals and re-price to OpenRouter's cost`, async () => {
+			const capture = createCapture();
+			const result = (await wrap(capture).chat.send({
+				chatRequest: {
+					model,
+					messages: [{ role: "user", content: "Reply with exactly: ok" }],
+					maxTokens: 20,
+				},
+			})) as ChatResult;
+
+			expect(capture.calls).toHaveLength(1);
+			const pools = capture.calls[0] as TrackTokensParams;
+			const usage = result.usage;
+
+			// Conservation: exclusive pools re-sum to the inclusive totals
+			expect(
+				pools.inputTokens +
+					pools.cacheReadTokens +
+					pools.cacheWriteTokens +
+					(pools.audioInputTokens ?? 0),
+			).toBe(usage?.promptTokens ?? -1);
+			expect(pools.outputTokens + pools.reasoningTokens).toBe(
+				usage?.completionTokens ?? -1,
+			);
+
+			// Pricing: pools × upstream rates ≈ OpenRouter's own upstream cost
+			const upstream = usage?.costDetails?.upstreamInferenceCost;
+			if (upstream) {
+				const derived = priceOf(pools, model);
+				expect(Math.abs(derived - upstream) / upstream).toBeLessThan(0.02);
+			}
+		}, 60_000);
+	}
+
+	test("anthropic cache_control: write then read, totals stay inclusive", async () => {
+		const model = "anthropic/claude-3.5-haiku";
+		// ~13k-token prefix, above the model's minimum cacheable size. The
+		// nonce makes it unique per run so the first call always writes cache
+		// instead of hitting a still-warm entry from a previous run.
+		const prefix = `Run ${crypto.randomUUID()}. ${Array.from(
+			{ length: 400 },
+			(_, i) =>
+				`Clause ${i}: the party of the first part shall deliver widgets to the party of the second part subject to schedule ${i % 7} annex ${i % 3}.`,
+		).join(" ")}`;
+
+		const send = async () => {
+			const capture = createCapture();
+			const result = (await wrap(capture).chat.send({
+				chatRequest: {
+					model,
+					messages: [
+						{
+							role: "system",
+							content: [
+								{
+									type: "text",
+									text: prefix,
+									cacheControl: { type: "ephemeral" },
+								},
+							],
+						},
+						{ role: "user", content: "Say ok" },
+					],
+					maxTokens: 20,
+				},
+			})) as ChatResult;
+			return { pools: capture.calls[0] as TrackTokensParams, result };
+		};
+
+		const first = await send();
+		const second = await send();
+
+		const wrote = first.pools.cacheWriteTokens;
+		const read = second.pools.cacheReadTokens;
+		expect(wrote).toBeGreaterThan(1_000);
+		expect(read).toBeGreaterThan(1_000);
+
+		// Inclusive totals: after subtracting the cache pools, the remaining
+		// text input is tiny (just the user turn + wrappers), NOT the prefix
+		// again. If OpenRouter ever switched Anthropic to exclusive totals,
+		// inputTokens here would jump by the full prefix size.
+		expect(first.pools.inputTokens).toBeLessThan(100);
+		expect(second.pools.inputTokens).toBeLessThan(100);
+
+		// And the split re-prices to OpenRouter's reported upstream cost
+		for (const { pools, result } of [first, second]) {
+			const upstream = result.usage?.costDetails?.upstreamInferenceCost;
+			if (upstream) {
+				const derived = priceOf(pools, model);
+				expect(Math.abs(derived - upstream) / upstream).toBeLessThan(0.02);
+			}
+		}
+	}, 120_000);
+});

--- a/packages/gateway/tests/unit/openrouter-usage.test.ts
+++ b/packages/gateway/tests/unit/openrouter-usage.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeOpenRouterUsage } from "../../src/openrouter/usage.js";
+
+const MODEL = "openrouter/openai/gpt-test";
+
+// OpenRouter usage arrives in four dialects: chat completions vs responses
+// API, each as SDK camelCase or raw snake_case. All four must normalize to
+// identical exclusive pools.
+describe("normalizeOpenRouterUsage shape matrix", () => {
+	const expected = {
+		inputTokens: 82, // 100 − 15 (cached) − 2 (cache write) − 1 (audio)
+		outputTokens: 37, // 40 − 3 (reasoning)
+		cacheReadTokens: 15,
+		cacheWriteTokens: 2,
+		reasoningTokens: 3,
+		audioInputTokens: 1,
+	};
+
+	test("chat completions, SDK camelCase", () => {
+		expect(
+			normalizeOpenRouterUsage(
+				{
+					promptTokens: 100,
+					completionTokens: 40,
+					promptTokensDetails: {
+						cachedTokens: 15,
+						cacheWriteTokens: 2,
+						audioTokens: 1,
+					},
+					completionTokensDetails: { reasoningTokens: 3 },
+				},
+				MODEL,
+			),
+		).toEqual(expected);
+	});
+
+	test("chat completions, raw snake_case", () => {
+		expect(
+			normalizeOpenRouterUsage(
+				{
+					prompt_tokens: 100,
+					completion_tokens: 40,
+					prompt_tokens_details: {
+						cached_tokens: 15,
+						cache_write_tokens: 2,
+						audio_tokens: 1,
+					},
+					completion_tokens_details: { reasoning_tokens: 3 },
+				},
+				MODEL,
+			),
+		).toEqual(expected);
+	});
+
+	test("responses API, SDK camelCase", () => {
+		expect(
+			normalizeOpenRouterUsage(
+				{
+					inputTokens: 100,
+					outputTokens: 40,
+					inputTokensDetails: {
+						cachedTokens: 15,
+						cacheWriteTokens: 2,
+						audioTokens: 1,
+					},
+					outputTokensDetails: { reasoningTokens: 3 },
+				},
+				MODEL,
+			),
+		).toEqual(expected);
+	});
+
+	test("responses API, raw snake_case", () => {
+		expect(
+			normalizeOpenRouterUsage(
+				{
+					input_tokens: 100,
+					output_tokens: 40,
+					input_tokens_details: {
+						cached_tokens: 15,
+						cache_write_tokens: 2,
+						audio_tokens: 1,
+					},
+					output_tokens_details: { reasoning_tokens: 3 },
+				},
+				MODEL,
+			),
+		).toEqual(expected);
+	});
+});
+
+describe("normalizeOpenRouterUsage edge cases", () => {
+	test("chat naming wins over responses naming when both are present", () => {
+		const pools = normalizeOpenRouterUsage(
+			{ promptTokens: 100, inputTokens: 999, completionTokens: 40 },
+			MODEL,
+		);
+		expect(pools.inputTokens).toBe(100);
+	});
+
+	test("missing details default to zero pools", () => {
+		expect(
+			normalizeOpenRouterUsage(
+				{ promptTokens: 10, completionTokens: 5 },
+				MODEL,
+			),
+		).toEqual({
+			inputTokens: 10,
+			outputTokens: 5,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			reasoningTokens: 0,
+			audioInputTokens: 0,
+		});
+	});
+
+	test("null detail objects are tolerated", () => {
+		const pools = normalizeOpenRouterUsage(
+			{
+				prompt_tokens: 10,
+				completion_tokens: 5,
+				prompt_tokens_details: null,
+				completion_tokens_details: null,
+			},
+			MODEL,
+		);
+		expect(pools.inputTokens).toBe(10);
+		expect(pools.outputTokens).toBe(5);
+	});
+
+	test("zero usage normalizes without throwing", () => {
+		const pools = normalizeOpenRouterUsage(
+			{ prompt_tokens: 0, completion_tokens: 0 },
+			MODEL,
+		);
+		expect(pools.inputTokens).toBe(0);
+		expect(pools.outputTokens).toBe(0);
+	});
+
+	test("cost is billing metadata, not a token pool", () => {
+		const pools = normalizeOpenRouterUsage(
+			{ promptTokens: 10, completionTokens: 5, cost: 0.42 },
+			MODEL,
+		);
+		expect(Object.values(pools).every((v) => typeof v === "number")).toBe(
+			true,
+		);
+		expect(pools.inputTokens).toBe(10);
+	});
+
+	test("missing prompt count throws naming Input and the model", () => {
+		expect(() =>
+			normalizeOpenRouterUsage({ completionTokens: 5 }, MODEL),
+		).toThrow(/Input token usage.*gpt-test/);
+	});
+
+	test("missing completion count throws naming Output", () => {
+		expect(() =>
+			normalizeOpenRouterUsage({ promptTokens: 5 }, MODEL),
+		).toThrow(/Output token usage/);
+	});
+
+	test("cached-heavy prompt: cache read dominates, text input clamps cleanly", () => {
+		// 95% cache hit — common for agent loops re-sending big system prompts
+		expect(
+			normalizeOpenRouterUsage(
+				{
+					prompt_tokens: 10_000,
+					completion_tokens: 200,
+					prompt_tokens_details: { cached_tokens: 9_500 },
+				},
+				MODEL,
+			),
+		).toMatchObject({
+			inputTokens: 500,
+			cacheReadTokens: 9_500,
+		});
+	});
+});

--- a/packages/gateway/tests/unit/usage.test.ts
+++ b/packages/gateway/tests/unit/usage.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import {
+	poolsFromParts,
+	type TokenParts,
+	type TokenPools,
+} from "../../src/shared/usage.js";
+
+const MODEL = "openrouter/openai/gpt-test";
+
+const poolSum = (pools: TokenPools) =>
+	pools.inputTokens +
+	pools.cacheReadTokens +
+	pools.cacheWriteTokens +
+	(pools.audioInputTokens ?? 0);
+
+describe("poolsFromParts", () => {
+	test("subtracts every detail pool out of the inclusive input total", () => {
+		expect(
+			poolsFromParts(
+				{
+					totalInput: 100,
+					totalOutput: 50,
+					cacheRead: 20,
+					cacheWrite: 5,
+					audioInput: 10,
+					reasoning: 30,
+				},
+				MODEL,
+			),
+		).toEqual({
+			inputTokens: 65, // 100 − 20 − 5 − 10
+			outputTokens: 20, // 50 − 30
+			cacheReadTokens: 20,
+			cacheWriteTokens: 5,
+			reasoningTokens: 30,
+			audioInputTokens: 10,
+		});
+	});
+
+	test("conservation: exclusive pools always re-sum to the inclusive totals", () => {
+		const fixtures: TokenParts[] = [
+			{ totalInput: 1, totalOutput: 1 },
+			{ totalInput: 1234, totalOutput: 567, cacheRead: 1000 },
+			{ totalInput: 50, totalOutput: 50, cacheRead: 25, cacheWrite: 25 },
+			{
+				totalInput: 9_999_999,
+				totalOutput: 1_000_000,
+				cacheRead: 123_456,
+				cacheWrite: 7,
+				audioInput: 88,
+				reasoning: 999_999,
+			},
+		];
+		for (const parts of fixtures) {
+			const pools = poolsFromParts(parts, MODEL);
+			expect(poolSum(pools)).toBe(parts.totalInput ?? 0);
+			expect(pools.outputTokens + pools.reasoningTokens).toBe(
+				parts.totalOutput ?? 0,
+			);
+		}
+	});
+
+	test("exclusive text counts win over totals — no double subtraction", () => {
+		expect(
+			poolsFromParts(
+				{
+					textInput: 70,
+					totalInput: 100,
+					textOutput: 40,
+					totalOutput: 50,
+					cacheRead: 30,
+					reasoning: 10,
+				},
+				MODEL,
+			),
+		).toMatchObject({ inputTokens: 70, outputTokens: 40 });
+	});
+
+	test("zero usage is valid, not missing", () => {
+		expect(poolsFromParts({ totalInput: 0, totalOutput: 0 }, MODEL)).toEqual({
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+			reasoningTokens: 0,
+		});
+	});
+
+	test("details exceeding totals clamp to zero, never negative", () => {
+		const pools = poolsFromParts(
+			{
+				totalInput: 10,
+				totalOutput: 5,
+				cacheRead: 8,
+				cacheWrite: 8,
+				audioInput: 8,
+				reasoning: 9,
+			},
+			MODEL,
+		);
+		expect(pools.inputTokens).toBe(0);
+		expect(pools.outputTokens).toBe(0);
+		// Detail pools still report what the provider claimed
+		expect(pools.cacheReadTokens).toBe(8);
+		expect(pools.reasoningTokens).toBe(9);
+	});
+
+	test("missing input total throws naming the pool and model", () => {
+		expect(() => poolsFromParts({ totalOutput: 5 }, MODEL)).toThrow(
+			/Input token usage.*gpt-test/,
+		);
+	});
+
+	test("missing output total throws naming the pool and model", () => {
+		expect(() => poolsFromParts({ totalInput: 5 }, MODEL)).toThrow(
+			/Output token usage.*gpt-test/,
+		);
+	});
+
+	test("null totals are treated as missing", () => {
+		expect(() =>
+			poolsFromParts({ totalInput: null, totalOutput: 5 }, MODEL),
+		).toThrow(/Input/);
+	});
+
+	test("audio pool key only exists when the provider reports one", () => {
+		const withoutAudio = poolsFromParts(
+			{ totalInput: 10, totalOutput: 5 },
+			MODEL,
+		);
+		expect("audioInputTokens" in withoutAudio).toBe(false);
+
+		const withZeroAudio = poolsFromParts(
+			{ totalInput: 10, totalOutput: 5, audioInput: 0 },
+			MODEL,
+		);
+		expect(withZeroAudio.audioInputTokens).toBe(0);
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add unit and live integration tests for `gateway` OpenRouter usage accounting, verifying correct token pool splits, Anthropic cache read/write behavior, and upstream cost parity. Also covers normalization across chat vs responses APIs and camelCase vs snake_case shapes.

- **Migration**
  - Integration tests require `OPENROUTER_API_KEY`; run with: bun run test:integration
  - Tests make real calls and may cost ~ $0.05 per run

<sup>Written for commit c66ce0aa8a5667f4fad6b7720c05e2442affaea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a two-tier test suite for the gateway package's OpenRouter token-usage pipeline: unit tests that exercise `poolsFromParts` and `normalizeOpenRouterUsage` in isolation, and live integration tests (skipped without `OPENROUTER_API_KEY`) that validate inclusive-to-exclusive pool splitting and cost-derivation against real API responses for both OpenAI and Anthropic models.

- **Improvements** — Unit tests cover all four OpenRouter wire dialects (chat completions vs. responses API × camelCase vs. snake_case), clamping behaviour, conservation invariants, and every error path; the integration suite adds an Anthropic prompt-caching scenario that verifies cache-write → cache-read semantics end-to-end.
- **Improvements** — Integration tests are correctly guarded with `describe.skipIf(!API_KEY)` so they never run in CI without a key, and each uses a per-run nonce to guarantee a fresh cache write on the first Anthropic call.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — these are purely additive test files with no production code changes.

The unit tests are thorough and correctly reflect the implementation. The one notable gap is in the integration test's RATES table: openai/gpt-4o-mini has no cacheRead entry, so priceOf falls back to the full input rate when cached tokens appear, which would over-price those tokens by 2× and could silently fail the 2% tolerance assertion in environments where prompt caching activates.

packages/gateway/tests/integration/openrouter.test.ts — the RATES table for gpt-4o-mini should include the cache-read rate.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/gateway/tests/unit/usage.test.ts | Unit tests for poolsFromParts — covers conservation, clamping, exclusive-wins-over-inclusive, conditional audioInputTokens key presence, and all error paths. Logic matches the implementation exactly. |
| packages/gateway/tests/unit/openrouter-usage.test.ts | Unit tests for normalizeOpenRouterUsage — covers all four wire dialects (chat/responses × camelCase/snake_case), null tolerance, naming priority, and error paths. Expected values align with the implementation. |
| packages/gateway/tests/integration/openrouter.test.ts | Live integration tests for OpenRouter usage semantics; skipped without OPENROUTER_API_KEY. Missing cacheRead rate for openai/gpt-4o-mini could cause the 2% pricing tolerance to fail if cached tokens are returned for that model. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OpenRouter API response] --> B{Wire shape?}
    B -->|chat completions camelCase| C[promptTokens / completionTokens]
    B -->|chat completions snake_case| D[prompt_tokens / completion_tokens]
    B -->|responses API camelCase| E[inputTokens / outputTokens]
    B -->|responses API snake_case| F[input_tokens / output_tokens]
    C & D & E & F --> G[normalizeOpenRouterUsage]
    G --> H[promptTotal + promptDetails]
    H --> I[poolsFromParts]
    I --> J{textInput/Output explicit?}
    J -->|yes| K[use directly — no double subtraction]
    J -->|no| L[totalInput − cacheRead − cacheWrite − audioInput]
    K & L --> M[clamp to zero if negative]
    M --> N[TokenPools exclusive]
    N --> O[trackTokens call captured in integration test]
    O --> P{upstream cost present?}
    P -->|yes| Q[priceOf pools × RATES ≈ upstream within 2%]
    P -->|no| R[skip pricing assertion]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/gateway/tests/integration/openrouter.test.ts:29
Missing `cacheRead` rate for gpt-4o-mini in `RATES`. GPT-4o-mini's cached input tokens are billed at $0.075/M (half the regular input rate of $0.15/M). When `rate.cacheRead` is absent, `priceOf` falls back to `rate.input`, doubling the derived cost for any cached tokens — easily blowing past the 2% tolerance guard. Prompt caching for OpenAI models is automatic and can activate once a shared prefix exceeds 1024 tokens across repeated calls, so this is reachable without any code change to the test.

```suggestion
	"openai/gpt-4o-mini": { input: 0.15, output: 0.6, cacheRead: 0.075 },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add gateway tests"](https://github.com/useautumn/autumn/commit/c66ce0aa8a5667f4fad6b7720c05e2442affaea6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37582022)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->