### PR TITLE
feat(stripe): keep ignore_past_due subscriptions alive on past_due

### DIFF
--- a/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
+++ b/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
@@ -120,3 +120,15 @@ export const isStripeSubscriptionPastDue = (
 
 	return stripeSubscription.status === "past_due";
 };
+
+/** True only on the event where the subscription just entered past_due. */
+export const isStripeSubscriptionPastDueTransition = ({
+	stripeSubscription,
+	previousAttributes,
+}: {
+	stripeSubscription?: Stripe.Subscription;
+	previousAttributes?: { status?: Stripe.Subscription.Status };
+}) => {
+	const wasPastDue = previousAttributes?.status === "past_due";
+	return !wasPastDue && isStripeSubscriptionPastDue(stripeSubscription);
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
@@ -5,6 +5,7 @@ import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhoo
 import { emitBillingChangeWebhook, logCustomerProductUpdates } from "../common";
 import { setupStripeSubscriptionUpdatedContext } from "./setupStripeSubscriptionUpdatedContext.js";
 import { handleCancelOnPastDue } from "./tasks/handleCancelOnPastDue.js";
+import { handleIgnorePastDue } from "./tasks/handleIgnorePastDue.js";
 import { handleSchedulePhaseChanges } from "./tasks/handleSchedulePhaseChanges/handleSchedulePhaseChanges.js";
 import { handleStripeSubscriptionRenewed } from "./tasks/handleStripeSubscriptionRenewed/handleStripeSubscriptionRenewed.js";
 import { handleStripeSubscriptionTrialEnded } from "./tasks/handleStripeSubscriptionTrialEnded/handleStripeSubscriptionTrialEnded.js";
@@ -61,6 +62,12 @@ export const handleStripeSubscriptionUpdated = async ({
 
 	// 5. Handle cancel_on_past_due org setting
 	await handleCancelOnPastDue({
+		ctx,
+		subscriptionUpdatedContext,
+	});
+
+	// 5b. Keep ignore_past_due plans alive instead of letting Stripe cancel them
+	await handleIgnorePastDue({
 		ctx,
 		subscriptionUpdatedContext,
 	});

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts
@@ -1,26 +1,8 @@
 import { createStripeCli } from "@/external/connect/createStripeCli";
-import type { ExpandedStripeSubscription } from "@/external/stripe/subscriptions/operations/getExpandedStripeSubscription";
+import { isStripeSubscriptionPastDueTransition } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
 import { stripeSubscriptionToLatestInvoice } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
-import type {
-	StripeSubscriptionUpdatedContext,
-	SubscriptionPreviousAttributes,
-} from "../stripeSubscriptionUpdatedContext";
-
-/**
- * Detects if a subscription.updated event represents a transition to past_due.
- */
-const isStripeSubscriptionPastDueEvent = ({
-	stripeSubscription,
-	previousAttributes,
-}: {
-	stripeSubscription: ExpandedStripeSubscription;
-	previousAttributes: SubscriptionPreviousAttributes;
-}): boolean => {
-	const wasPastDue = previousAttributes.status === "past_due";
-	const isPastDue = stripeSubscription.status === "past_due";
-	return !wasPastDue && isPastDue;
-};
+import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
 
 /**
  * Handles the cancel_on_past_due org setting.
@@ -40,11 +22,13 @@ export const handleCancelOnPastDue = async ({
 	if (!org.config.cancel_on_past_due) return;
 
 	// Only proceed if subscription just transitioned to past_due
-	const isPastDueEvent = isStripeSubscriptionPastDueEvent({
-		stripeSubscription,
-		previousAttributes,
-	});
-	if (!isPastDueEvent) return;
+	if (
+		!isStripeSubscriptionPastDueTransition({
+			stripeSubscription,
+			previousAttributes,
+		})
+	)
+		return;
 
 	const stripeCli = createStripeCli({ org, env });
 

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts
@@ -1,0 +1,69 @@
+import { isCustomerProductOnStripeSubscription } from "@autumn/shared";
+import { isStripeSubscriptionPastDueTransition } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
+import { stripeSubscriptionToLatestInvoice } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
+import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
+
+// Long window so the now-manual invoice doesn't immediately read as overdue.
+const SEND_INVOICE_DAYS_UNTIL_DUE = 365;
+
+/**
+ * Keeps an `ignore_past_due` plan's subscription alive when it goes past_due:
+ * removes the open invoice from Stripe's auto-dunning and switches the sub to
+ * send_invoice so Stripe's retry/cancel flow never tears it down.
+ */
+export const handleIgnorePastDue = async ({
+	ctx,
+	subscriptionUpdatedContext,
+}: {
+	ctx: StripeWebhookContext;
+	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
+}): Promise<void> => {
+	const { stripeCli, logger } = ctx;
+	const { stripeSubscription, previousAttributes, customerProducts } =
+		subscriptionUpdatedContext;
+
+	if (
+		!isStripeSubscriptionPastDueTransition({
+			stripeSubscription,
+			previousAttributes,
+		})
+	)
+		return;
+
+	const ignorePastDue = customerProducts.some(
+		(customerProduct) =>
+			isCustomerProductOnStripeSubscription({
+				customerProduct,
+				stripeSubscriptionId: stripeSubscription.id,
+			}) && customerProduct.product.config?.ignore_past_due,
+	);
+	if (!ignorePastDue) return;
+
+	try {
+		const latestInvoice = await stripeSubscriptionToLatestInvoice({
+			stripeSubscription,
+			stripeCli,
+		});
+
+		if (latestInvoice?.status === "open" && latestInvoice.id) {
+			await stripeCli.invoices.update(latestInvoice.id, {
+				auto_advance: false,
+			});
+		}
+
+		await stripeCli.subscriptions.update(stripeSubscription.id, {
+			collection_method: "send_invoice",
+			days_until_due: SEND_INVOICE_DAYS_UNTIL_DUE,
+		});
+
+		logger.info(
+			`[sub.updated] ignore_past_due: kept subscription ${stripeSubscription.id} alive (send_invoice, invoice auto_advance off)`,
+		);
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		logger.error(
+			`[sub.updated] ignore_past_due: failed to preserve subscription ${stripeSubscription.id}: ${errorMessage}`,
+		);
+	}
+};


### PR DESCRIPTION
When a subscription enters past_due and a plan on it has ignore_past_due, remove the open invoice from Stripe's auto-dunning (auto_advance: false) and switch the sub to send_invoice so Stripe's retry/cancel flow doesn't tear it down. Extract the shared past-due-transition classifier.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps subscriptions with an `ignore_past_due` plan alive when they first enter `past_due` by disabling Stripe auto-dunning and switching to manual invoicing. This prevents Stripe’s retry/cancel flow from tearing down these subscriptions.

- **New Features**
  - Added `handleIgnorePastDue` to run on the past_due transition when any plan has `ignore_past_due`.
  - Sets the latest open invoice `auto_advance=false`.
  - Updates the subscription to `collection_method=send_invoice` with `days_until_due=365`.

- **Refactors**
  - Extracted `isStripeSubscriptionPastDueTransition` for shared use.
  - Updated `handleCancelOnPastDue` to use the new transition classifier.
  - Wired `handleIgnorePastDue` into `handleStripeSubscriptionUpdated`.

<sup>Written for commit 5ffe610c7de49ea978fd406b069b9e957210e64a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `handleIgnorePastDue`, a new webhook task that prevents Stripe from auto-canceling subscriptions when a plan has `ignore_past_due` set — it removes the open invoice from Stripe's auto-dunning (`auto_advance: false`) and switches the subscription to `send_invoice` with a 365-day due window. It also extracts the shared past-due-transition classifier (`isStripeSubscriptionPastDueTransition`) out of `handleCancelOnPastDue` and into `classifyStripeSubscriptionUtils`.

- **[Improvements]** Extracted `isStripeSubscriptionPastDueTransition` into a shared utility used by both `handleCancelOnPastDue` and the new `handleIgnorePastDue`, removing duplicate logic.
- **[Bug fixes / Improvements]** Added `handleIgnorePastDue` to the `subscription.updated` pipeline to keep `ignore_past_due` subscriptions alive when they enter `past_due` by switching to `send_invoice` and disabling the invoice's auto-dunning.
- **[API changes]** `handleIgnorePastDue` now calls two new Stripe API mutations (`invoices.update` and `subscriptions.update`) on every `past_due` transition for a qualifying subscription.
</details>


<h3>Confidence Score: 3/5</h3>

The new `handleIgnorePastDue` task is correct in isolation, but its placement after `handleCancelOnPastDue` means the org-level cancel flag silently overrides the product-level ignore flag when both are active — the subscription gets canceled and the error from the subsequent update is swallowed.

The core logic of `handleIgnorePastDue` is sound and the `isStripeSubscriptionPastDueTransition` refactor is clean. The concern is the interaction between the two past-due handlers: if an org has `cancel_on_past_due` enabled and a product has `ignore_past_due`, the subscription is canceled in step 5 and `handleIgnorePastDue` fails silently in step 5b, defeating its purpose with no observable signal to the operator.

`handleStripeSubscriptionUpdated.ts` (task ordering) and `handleIgnorePastDue.ts` (Stripe call ordering and missing guard against `cancel_on_past_due`).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts | Extracts `isStripeSubscriptionPastDueTransition` into a shared utility with optional parameters; clean refactor, no logic changes. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts | Inserts `handleIgnorePastDue` at step 5b, after `handleCancelOnPastDue`; ordering causes `cancel_on_past_due` to silently override `ignore_past_due` when both are active. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts | Replaces the local `isStripeSubscriptionPastDueEvent` with the shared `isStripeSubscriptionPastDueTransition`; functionally identical. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts | New handler that switches past_due subscriptions with `ignore_past_due` to `send_invoice` and disables auto-dunning; invoice update before subscription update risks partial failure leaving sub on `charge_automatically`. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Handler as handleStripeSubscriptionUpdated
    participant CancelTask as handleCancelOnPastDue
    participant IgnoreTask as handleIgnorePastDue
    participant StripeCli as Stripe API

    Stripe->>Handler: customer.subscription.updated (status→past_due)
    Handler->>CancelTask: step 5 (if cancel_on_past_due)
    alt "org.cancel_on_past_due = true"
        CancelTask->>StripeCli: subscriptions.cancel()
        CancelTask->>StripeCli: invoices.voidInvoice()
    end
    Handler->>IgnoreTask: step 5b (if product.ignore_past_due)
    alt "product.ignore_past_due = true"
        IgnoreTask->>StripeCli: invoices.update(auto_advance: false)
        IgnoreTask->>StripeCli: subscriptions.update(send_invoice, days_until_due: 365)
        Note over IgnoreTask,StripeCli: Fails silently if subscription was already canceled in step 5
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts`, line 63-73 ([link](https://github.com/useautumn/autumn/blob/5ffe610c7de49ea978fd406b069b9e957210e64a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts#L63-L73)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`cancel_on_past_due` silently wins over `ignore_past_due`**

   `handleCancelOnPastDue` (step 5) runs before `handleIgnorePastDue` (step 5b). If an org has `cancel_on_past_due = true` and one of their products has `ignore_past_due = true`, `handleCancelOnPastDue` calls `stripeCli.subscriptions.cancel()` first. When `handleIgnorePastDue` runs immediately after, Stripe returns an error (can't update a canceled subscription), which is silently swallowed by the `try/catch`. The subscription ends up canceled despite the product-level `ignore_past_due` intent, with no warning surfaced to the caller. Either `handleIgnorePastDue` should guard against `org.config.cancel_on_past_due`, or `handleCancelOnPastDue` should skip subscriptions that have an `ignore_past_due` product.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
   Line: 63-73

   Comment:
   **`cancel_on_past_due` silently wins over `ignore_past_due`**

   `handleCancelOnPastDue` (step 5) runs before `handleIgnorePastDue` (step 5b). If an org has `cancel_on_past_due = true` and one of their products has `ignore_past_due = true`, `handleCancelOnPastDue` calls `stripeCli.subscriptions.cancel()` first. When `handleIgnorePastDue` runs immediately after, Stripe returns an error (can't update a canceled subscription), which is silently swallowed by the `try/catch`. The subscription ends up canceled despite the product-level `ignore_past_due` intent, with no warning surfaced to the caller. Either `handleIgnorePastDue` should guard against `org.config.cancel_on_past_due`, or `handleCancelOnPastDue` should skip subscriptions that have an `ignore_past_due` product.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts:63-73
**`cancel_on_past_due` silently wins over `ignore_past_due`**

`handleCancelOnPastDue` (step 5) runs before `handleIgnorePastDue` (step 5b). If an org has `cancel_on_past_due = true` and one of their products has `ignore_past_due = true`, `handleCancelOnPastDue` calls `stripeCli.subscriptions.cancel()` first. When `handleIgnorePastDue` runs immediately after, Stripe returns an error (can't update a canceled subscription), which is silently swallowed by the `try/catch`. The subscription ends up canceled despite the product-level `ignore_past_due` intent, with no warning surfaced to the caller. Either `handleIgnorePastDue` should guard against `org.config.cancel_on_past_due`, or `handleCancelOnPastDue` should skip subscriptions that have an `ignore_past_due` product.

### Issue 2 of 2
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts:49-58
The subscription update (`collection_method: send_invoice`) is the critical guard that stops Stripe from ever tearing down the subscription. If the invoice update succeeds but the subscription update then throws (network timeout, Stripe error, etc.), the invoice is removed from auto-dunning but the subscription is still on `charge_automatically` — Stripe can still cancel it. Reversing the order ensures the most important protection is applied first.

```suggestion
		await stripeCli.subscriptions.update(stripeSubscription.id, {
			collection_method: "send_invoice",
			days_until_due: SEND_INVOICE_DAYS_UNTIL_DUE,
		});

		if (latestInvoice?.status === "open" && latestInvoice.id) {
			await stripeCli.invoices.update(latestInvoice.id, {
				auto_advance: false,
			});
		}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(stripe): keep ignore\_past\_due subsc..."](https://github.com/useautumn/autumn/commit/5ffe610c7de49ea978fd406b069b9e957210e64a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37611202)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->