### PR TITLE
feat(stripe): keep ignore_past_due subscriptions alive on past_due

### DIFF
--- a/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
+++ b/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
@@ -120,3 +120,15 @@ export const isStripeSubscriptionPastDue = (
 
 	return stripeSubscription.status === "past_due";
 };
+
+/** True only on the event where the subscription just entered past_due. */
+export const isStripeSubscriptionPastDueTransition = ({
+	stripeSubscription,
+	previousAttributes,
+}: {
+	stripeSubscription?: Stripe.Subscription;
+	previousAttributes?: { status?: Stripe.Subscription.Status };
+}) => {
+	const wasPastDue = previousAttributes?.status === "past_due";
+	return !wasPastDue && isStripeSubscriptionPastDue(stripeSubscription);
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
@@ -5,6 +5,7 @@ import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhoo
 import { emitBillingChangeWebhook, logCustomerProductUpdates } from "../common";
 import { setupStripeSubscriptionUpdatedContext } from "./setupStripeSubscriptionUpdatedContext.js";
 import { handleCancelOnPastDue } from "./tasks/handleCancelOnPastDue.js";
+import { handleIgnorePastDue } from "./tasks/handleIgnorePastDue.js";
 import { handleSchedulePhaseChanges } from "./tasks/handleSchedulePhaseChanges/handleSchedulePhaseChanges.js";
 import { handleStripeSubscriptionRenewed } from "./tasks/handleStripeSubscriptionRenewed/handleStripeSubscriptionRenewed.js";
 import { handleStripeSubscriptionTrialEnded } from "./tasks/handleStripeSubscriptionTrialEnded/handleStripeSubscriptionTrialEnded.js";
@@ -61,6 +62,12 @@ export const handleStripeSubscriptionUpdated = async ({
 
 	// 5. Handle cancel_on_past_due org setting
 	await handleCancelOnPastDue({
+		ctx,
+		subscriptionUpdatedContext,
+	});
+
+	// 5b. Keep ignore_past_due plans alive instead of letting Stripe cancel them
+	await handleIgnorePastDue({
 		ctx,
 		subscriptionUpdatedContext,
 	});

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts
@@ -1,26 +1,8 @@
 import { createStripeCli } from "@/external/connect/createStripeCli";
-import type { ExpandedStripeSubscription } from "@/external/stripe/subscriptions/operations/getExpandedStripeSubscription";
+import { isStripeSubscriptionPastDueTransition } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
 import { stripeSubscriptionToLatestInvoice } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
-import type {
-	StripeSubscriptionUpdatedContext,
-	SubscriptionPreviousAttributes,
-} from "../stripeSubscriptionUpdatedContext";
-
-/**
- * Detects if a subscription.updated event represents a transition to past_due.
- */
-const isStripeSubscriptionPastDueEvent = ({
-	stripeSubscription,
-	previousAttributes,
-}: {
-	stripeSubscription: ExpandedStripeSubscription;
-	previousAttributes: SubscriptionPreviousAttributes;
-}): boolean => {
-	const wasPastDue = previousAttributes.status === "past_due";
-	const isPastDue = stripeSubscription.status === "past_due";
-	return !wasPastDue && isPastDue;
-};
+import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
 
 /**
  * Handles the cancel_on_past_due org setting.
@@ -40,11 +22,13 @@ export const handleCancelOnPastDue = async ({
 	if (!org.config.cancel_on_past_due) return;
 
 	// Only proceed if subscription just transitioned to past_due
-	const isPastDueEvent = isStripeSubscriptionPastDueEvent({
-		stripeSubscription,
-		previousAttributes,
-	});
-	if (!isPastDueEvent) return;
+	if (
+		!isStripeSubscriptionPastDueTransition({
+			stripeSubscription,
+			previousAttributes,
+		})
+	)
+		return;
 
 	const stripeCli = createStripeCli({ org, env });
 

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts
@@ -1,0 +1,69 @@
+import { isCustomerProductOnStripeSubscription } from "@autumn/shared";
+import { isStripeSubscriptionPastDueTransition } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
+import { stripeSubscriptionToLatestInvoice } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
+import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
+
+// Long window so the now-manual invoice doesn't immediately read as overdue.
+const SEND_INVOICE_DAYS_UNTIL_DUE = 365;
+
+/**
+ * Keeps an `ignore_past_due` plan's subscription alive when it goes past_due:
+ * removes the open invoice from Stripe's auto-dunning and switches the sub to
+ * send_invoice so Stripe's retry/cancel flow never tears it down.
+ */
+export const handleIgnorePastDue = async ({
+	ctx,
+	subscriptionUpdatedContext,
+}: {
+	ctx: StripeWebhookContext;
+	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
+}): Promise<void> => {
+	const { stripeCli, logger } = ctx;
+	const { stripeSubscription, previousAttributes, customerProducts } =
+		subscriptionUpdatedContext;
+
+	if (
+		!isStripeSubscriptionPastDueTransition({
+			stripeSubscription,
+			previousAttributes,
+		})
+	)
+		return;
+
+	const ignorePastDue = customerProducts.some(
+		(customerProduct) =>
+			isCustomerProductOnStripeSubscription({
+				customerProduct,
+				stripeSubscriptionId: stripeSubscription.id,
+			}) && customerProduct.product.config?.ignore_past_due,
+	);
+	if (!ignorePastDue) return;
+
+	try {
+		const latestInvoice = await stripeSubscriptionToLatestInvoice({
+			stripeSubscription,
+			stripeCli,
+		});
+
+		if (latestInvoice?.status === "open" && latestInvoice.id) {
+			await stripeCli.invoices.update(latestInvoice.id, {
+				auto_advance: false,
+			});
+		}
+
+		await stripeCli.subscriptions.update(stripeSubscription.id, {
+			collection_method: "send_invoice",
+			days_until_due: SEND_INVOICE_DAYS_UNTIL_DUE,
+		});
+
+		logger.info(
+			`[sub.updated] ignore_past_due: kept subscription ${stripeSubscription.id} alive (send_invoice, invoice auto_advance off)`,
+		);
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		logger.error(
+			`[sub.updated] ignore_past_due: failed to preserve subscription ${stripeSubscription.id}: ${errorMessage}`,
+		);
+	}
+};


### PR DESCRIPTION
## Summary

Cherry-picked from `feat/ignore-past-due-preserve-subscription` onto `main`.

When a subscription enters `past_due` and a plan on it has `ignore_past_due`, this:
- Removes the open invoice from Stripe's auto-dunning (`auto_advance: false`)
- Switches the sub to `send_invoice` so Stripe's retry/cancel flow doesn't tear it down
- Extracts the shared past-due-transition classifier

## Files
- `classifyStripeSubscriptionUtils.ts` — shared past-due-transition classifier
- `handleStripeSubscriptionUpdated.ts` — dispatch to the new handler
- `handleCancelOnPastDue.ts` — use the shared classifier
- `handleIgnorePastDue.ts` — new handler (preserves the subscription)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps subscriptions with `ignore_past_due` alive when they enter `past_due`. Disables auto-dunning on the latest open invoice and switches the subscription to `send_invoice` with a long due period to avoid Stripe auto-cancel.

- **New Features**
  - Added `handleIgnorePastDue` to preserve subs on `past_due` when a plan has `ignore_past_due`.
  - Sets invoice `auto_advance: false` and subscription `collection_method: "send_invoice"` with `days_until_due: 365`.

- **Refactors**
  - Extracted `isStripeSubscriptionPastDueTransition` to a shared util.
  - Updated `handleCancelOnPastDue` to use the shared transition check.

<sup>Written for commit d64a2bc8f07bf076595b624c817a3ac0b432fcd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a new `handleIgnorePastDue` webhook task that keeps a subscription alive when it enters `past_due` and at least one of its products has `ignore_past_due: true`. It disables Stripe's auto-dunning on the open invoice and switches the subscription to `send_invoice` collection so Stripe's retry/cancel flow never tears it down. The shared past-due transition classifier is extracted from `handleCancelOnPastDue` so both handlers can reuse it.

- **Improvements**: New `handleIgnorePastDue` handler prevents Stripe from auto-canceling subscriptions whose products opt-in to `ignore_past_due`, by disabling invoice `auto_advance` and switching to `send_invoice` collection mode.
- **Improvements**: `isStripeSubscriptionPastDueTransition` is extracted as a shared utility, eliminating the duplicated inline classifier that was previously inside `handleCancelOnPastDue`.
- **Bug fixes**: The two past-due handlers (`handleCancelOnPastDue` and `handleIgnorePastDue`) run unconditionally in sequence and can conflict — when `cancel_on_past_due: true` at the org level and `ignore_past_due: true` on the product, the cancel always wins silently and the preservation intent is lost.
</details>


<h3>Confidence Score: 3/5</h3>

The new handler introduces a real conflict with the existing cancel-on-past-due path: when both `cancel_on_past_due` (org-level) and `ignore_past_due` (product-level) are active simultaneously, the cancellation always fires first and the preservation step silently fails. Additionally, because switching to `send_invoice` triggers a follow-up Stripe webhook that the transition detector misreads as a fresh past_due entry, both handlers will re-execute unnecessarily on that second event.

The conflict between the two handlers can cause a subscription to be silently canceled even when the product explicitly opts in to `ignore_past_due`, and the follow-up event loop means the handler fires twice on every activation. Both issues affect the core billing flow and could produce incorrect subscription states in production without any visible error signal.

`handleStripeSubscriptionUpdated.ts` and `handleIgnorePastDue.ts` — the dispatch ordering and the transition-detection logic are where both issues manifest.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts | Extracts the past-due transition classifier into a shared utility; the function itself is logically correct but cannot distinguish 'status just changed to past_due' from 'status was already past_due and an unrelated field changed', which creates false positives on follow-up events. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts | Wires in the new `handleIgnorePastDue` as step 5b, but the two past-due handlers (5 and 5b) run unconditionally and can conflict when both `cancel_on_past_due` and `ignore_past_due` are active on the same subscription. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts | Refactored to use the shared `isStripeSubscriptionPastDueTransition` classifier; behavior is functionally identical to the original and the change is clean. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts | New handler that preserves `ignore_past_due` subscriptions by disabling auto-advance and switching to `send_invoice`; the subscription update it makes triggers a follow-up Stripe webhook that the transition detector misidentifies as another past_due entry, causing the handler to re-execute unnecessarily. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Stripe
    participant H as handleStripeSubscriptionUpdated
    participant C as handleCancelOnPastDue
    participant I as handleIgnorePastDue

    S->>H: subscription.updated (active → past_due)
    H->>C: step 5 — handleCancelOnPastDue
    alt "cancel_on_past_due=true AND ignore_past_due=true (conflict)"
        C->>S: subscriptions.cancel()
        C->>S: invoices.voidInvoice()
        H->>I: step 5b — handleIgnorePastDue (subscription already canceled!)
        I->>S: invoices.update() ← error caught silently
        I->>S: subscriptions.update() ← error caught silently
        Note over I: ignore_past_due intent silently violated
    else "cancel_on_past_due=false, ignore_past_due=true (normal path)"
        H->>I: step 5b — handleIgnorePastDue
        I->>S: invoices.update(auto_advance: false)
        I->>S: "subscriptions.update(send_invoice, days_until_due=365)"
        S-->>H: subscription.updated (collection_method changed, status still past_due)
        Note over H: previousAttributes has no status field
        Note over H: isStripeSubscriptionPastDueTransition → true (false positive)
        H->>C: "handleCancelOnPastDue (exits early, cancel_on_past_due=false)"
        H->>I: handleIgnorePastDue fires again (redundant API calls)
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts`, line 64-73 ([link](https://github.com/useautumn/autumn/blob/d64a2bc8f07bf076595b624c817a3ac0b432fcd5/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts#L64-L73)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **No mutual exclusion between `handleCancelOnPastDue` and `handleIgnorePastDue`**

   `handleCancelOnPastDue` (step 5) always runs before `handleIgnorePastDue` (step 5b) with no awareness of each other. If an org has `cancel_on_past_due: true` and the subscription's product has `ignore_past_due: true`, step 5 will call `stripeCli.subscriptions.cancel()` and the subscription is gone before step 5b even runs. `handleIgnorePastDue` will then hit a Stripe error, which its `try/catch` silently swallows. The subscription ends up canceled rather than preserved, with no warning that the `ignore_past_due` intent was violated.

   `handleCancelOnPastDue` should skip if any product on the subscription has `ignore_past_due: true`, or `handleIgnorePastDue` should run first and signal via the shared `subscriptionUpdatedContext` that the subscription should not be canceled.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
   Line: 64-73

   Comment:
   **No mutual exclusion between `handleCancelOnPastDue` and `handleIgnorePastDue`**

   `handleCancelOnPastDue` (step 5) always runs before `handleIgnorePastDue` (step 5b) with no awareness of each other. If an org has `cancel_on_past_due: true` and the subscription's product has `ignore_past_due: true`, step 5 will call `stripeCli.subscriptions.cancel()` and the subscription is gone before step 5b even runs. `handleIgnorePastDue` will then hit a Stripe error, which its `try/catch` silently swallows. The subscription ends up canceled rather than preserved, with no warning that the `ignore_past_due` intent was violated.

   `handleCancelOnPastDue` should skip if any product on the subscription has `ignore_past_due: true`, or `handleIgnorePastDue` should run first and signal via the shared `subscriptionUpdatedContext` that the subscription should not be canceled.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts:64-73
**No mutual exclusion between `handleCancelOnPastDue` and `handleIgnorePastDue`**

`handleCancelOnPastDue` (step 5) always runs before `handleIgnorePastDue` (step 5b) with no awareness of each other. If an org has `cancel_on_past_due: true` and the subscription's product has `ignore_past_due: true`, step 5 will call `stripeCli.subscriptions.cancel()` and the subscription is gone before step 5b even runs. `handleIgnorePastDue` will then hit a Stripe error, which its `try/catch` silently swallows. The subscription ends up canceled rather than preserved, with no warning that the `ignore_past_due` intent was violated.

`handleCancelOnPastDue` should skip if any product on the subscription has `ignore_past_due: true`, or `handleIgnorePastDue` should run first and signal via the shared `subscriptionUpdatedContext` that the subscription should not be canceled.

### Issue 2 of 2
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts:26-41
**False positive on the follow-up `subscription.updated` event caused by this handler's own update**

`isStripeSubscriptionPastDueTransition` detects a new past_due event by checking `previousAttributes?.status !== "past_due"`. Stripe's `previousAttributes` only includes _changed_ fields, so when `handleIgnorePastDue` updates `collection_method` to `"send_invoice"`, Stripe fires a second `subscription.updated` event where `previousAttributes.status` is absent (the status didn't change). In that second event `wasPastDue` evaluates to `false`, and since the subscription is still `past_due`, the function returns `true` — a false positive. `handleIgnorePastDue` fires a second time, making redundant Stripe API calls. More critically, if `cancel_on_past_due` is later enabled on the org, `handleCancelOnPastDue` would also fire on that follow-up event and cancel the subscription that was just preserved.

The guard should check whether `"status"` is explicitly present in `previousAttributes` (i.e. the status field actually changed) rather than inferring intent from `previousAttributes.status === "past_due"`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(stripe): keep ignore\_past\_due subsc..."](https://github.com/useautumn/autumn/commit/d64a2bc8f07bf076595b624c817a3ac0b432fcd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37615345)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->