### PR TITLE
fix preview attach tax discounts

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
@@ -44,9 +44,9 @@ const allocateAmountOffDiscounts = ({
 		return diff === 0 ? a.index - b.index : diff;
 	});
 
-	for (const allocation of byRemainder) {
+	for (const { index } of byRemainder) {
 		if (remaining <= 0) break;
-		allocation.minorUnits += 1;
+		allocations[index].minorUnits += 1;
 		remaining -= 1;
 	}
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts
@@ -1,14 +1,62 @@
 import {
+	atmnToStripeAmount,
 	type LineItem,
 	type LineItemDiscount,
 	type StripeDiscountWithCoupon,
 	stripeToAtmnAmount,
-	sumValues,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
 import { addDiscountTagToDescription } from "./addDiscountTagToDescription";
 import { discountAppliesToLineItem } from "./discountAppliesToLineItem";
 import { getBackdatedDiscountCycleCount } from "./getBackdatedDiscountCycleCount";
+
+const allocateAmountOffDiscounts = ({
+	lineItems,
+	amountOffMinorUnits,
+	currency,
+}: {
+	lineItems: LineItem[];
+	amountOffMinorUnits: number;
+	currency: string;
+}) => {
+	const weightedItems = lineItems
+		.map((item, index) => ({
+			item,
+			index,
+			weight: atmnToStripeAmount({ amount: Math.abs(item.amount), currency }),
+		}))
+		.filter((item) => item.weight > 0);
+
+	const totalWeight = weightedItems.reduce((sum, item) => sum + item.weight, 0);
+	if (totalWeight === 0) return new Map<LineItem, number>();
+
+	const allocations = weightedItems.map(({ item, index, weight }) => {
+		const exact = new Decimal(amountOffMinorUnits).times(weight).div(totalWeight);
+		const minorUnits = exact.floor().toNumber();
+		return { item, index, minorUnits, remainder: exact.minus(minorUnits) };
+	});
+
+	let remaining =
+		amountOffMinorUnits -
+		allocations.reduce((sum, allocation) => sum + allocation.minorUnits, 0);
+	const byRemainder = [...allocations].sort((a, b) => {
+		const diff = b.remainder.comparedTo(a.remainder);
+		return diff === 0 ? a.index - b.index : diff;
+	});
+
+	for (const allocation of byRemainder) {
+		if (remaining <= 0) break;
+		allocation.minorUnits += 1;
+		remaining -= 1;
+	}
+
+	return new Map(
+		allocations.map(({ item, minorUnits }) => [
+			item,
+			stripeToAtmnAmount({ amount: minorUnits, currency }),
+		]),
+	);
+};
 
 /**
  * Applies an amount_off discount to line items.
@@ -32,11 +80,7 @@ export const applyAmountOffDiscountToLineItems = ({
 		return lineItems;
 	}
 
-	// Convert from Stripe cents to Autumn dollars
-	const baseDiscountAmountOff = stripeToAtmnAmount({
-		amount: amountOffCents,
-		currency: coupon.currency ?? "usd",
-	});
+	const currency = coupon.currency ?? "usd";
 
 	// Filter to applicable CHARGE line items only
 	// Discounts reduce what the customer pays, so only apply to charges
@@ -53,23 +97,12 @@ export const applyAmountOffDiscountToLineItems = ({
 	);
 	if (eligibleCycleCount <= 0) return lineItems;
 
-	const discountAmountOff = baseDiscountAmountOff;
-
 	// Build a map of line item -> discount amount
-	const discountMap = new Map<LineItem, number>();
-
-	// Distribute discount proportionally across charge items
-	const total = sumValues(
-		applicableChargeItems.map((item) => Math.abs(item.amount)),
-	);
-
-	if (total === 0) return lineItems;
-
-	for (const item of applicableChargeItems) {
-		const proportion = new Decimal(Math.abs(item.amount)).dividedBy(total);
-		const itemDiscount = proportion.times(discountAmountOff).round().toNumber();
-		discountMap.set(item, itemDiscount);
-	}
+	const discountMap = allocateAmountOffDiscounts({
+		lineItems: applicableChargeItems,
+		amountOffMinorUnits: amountOffCents,
+		currency,
+	});
 
 	// Apply discounts to line items
 	return lineItems.map((item) => {

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts
@@ -27,10 +27,8 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
  *    existing Stripe customer; Stripe's location waterfall needs it)
  *  - no `chargeImmediately` line items at all
  *
- * When the net taxable subtotal is `<= 0` (proration credits exceed new
- * charges), we short-circuit with `{ status: "complete", ...zeros }` —
- * Stripe Tax rejects non-positive line amounts and produces no tax on
- * net-credit invoices anyway, so this matches actual billing.
+ * When the net taxable subtotal is negative, Stripe Tax is called with the
+ * absolute amount and the result is negated to preview tax-credit invoices.
  *
  * Net-subtotal collapsing: we sum positive and negative `chargeImmediately`
  * line items into a single Stripe Tax line. Stripe Tax requires positive
@@ -98,10 +96,7 @@ export const computeStripeTaxPreviewForNetSubtotal = async ({
 	const currency = orgToCurrency({ org: ctx.org });
 	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
 
-	// No tax owed when net subtotal is zero or negative (credit exceeds
-	// charge). Stripe Tax rejects non-positive line amounts anyway, and
-	// a credit invoice produces no tax in actual billing.
-	if (netSubtotal <= 0) {
+	if (netSubtotal === 0) {
 		return {
 			total: 0,
 			amount_inclusive: 0,
@@ -110,6 +105,8 @@ export const computeStripeTaxPreviewForNetSubtotal = async ({
 			status: "complete",
 		};
 	}
+	const taxSign = netSubtotal < 0 ? -1 : 1;
+	const taxableSubtotal = Math.abs(netSubtotal);
 
 	try {
 		const calc = await stripeCli.tax.calculations.create({
@@ -118,7 +115,7 @@ export const computeStripeTaxPreviewForNetSubtotal = async ({
 			line_items: [
 				{
 					amount: atmnToStripeAmount({
-						amount: netSubtotal,
+						amount: taxableSubtotal,
 						currency,
 					}),
 					reference: "preview_net_subtotal",
@@ -128,19 +125,23 @@ export const computeStripeTaxPreviewForNetSubtotal = async ({
 		});
 
 		return {
-			total: stripeToAtmnAmount({
-				amount:
-					(calc.tax_amount_exclusive ?? 0) + (calc.tax_amount_inclusive ?? 0),
-				currency,
-			}),
-			amount_inclusive: stripeToAtmnAmount({
-				amount: calc.tax_amount_inclusive ?? 0,
-				currency,
-			}),
-			amount_exclusive: stripeToAtmnAmount({
-				amount: calc.tax_amount_exclusive ?? 0,
-				currency,
-			}),
+			total:
+				stripeToAtmnAmount({
+					amount:
+						(calc.tax_amount_exclusive ?? 0) +
+						(calc.tax_amount_inclusive ?? 0),
+					currency,
+				}) * taxSign,
+			amount_inclusive:
+				stripeToAtmnAmount({
+					amount: calc.tax_amount_inclusive ?? 0,
+					currency,
+				}) * taxSign,
+			amount_exclusive:
+				stripeToAtmnAmount({
+					amount: calc.tax_amount_exclusive ?? 0,
+					currency,
+				}) * taxSign,
 			currency,
 			status: "complete",
 		};

--- a/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
@@ -113,7 +113,7 @@ export const computeTaxRateIdPreviewFromTaxableMinorUnits = ({
 		0,
 	);
 
-	if (totalTaxableMinorUnits <= 0) {
+	if (totalTaxableMinorUnits === 0) {
 		return {
 			total: 0,
 			amount_inclusive: 0,
@@ -149,7 +149,7 @@ export const computeTaxRateIdPreviewFromTaxableMinorUnits = ({
 	);
 
 	const taxAmount = stripeToAtmnAmount({
-		amount: Math.max(taxMinorUnits, 0),
+		amount: taxMinorUnits,
 		currency,
 	});
 

--- a/server/tests/integration/billing/tax/automatic-tax-preview-attach-prorated-credit.test.ts
+++ b/server/tests/integration/billing/tax/automatic-tax-preview-attach-prorated-credit.test.ts
@@ -12,13 +12,13 @@
  * Red-failure mode (current behavior):
  *  - Case 1 (upgrade with credit): preview.tax.total ~ positiveSum * rate
  *    (inflated, ignores negative proration credit)
- *  - Case 2 (downgrade, net <= 0): preview.tax.total > 0
- *    (Stripe still gets called with the positive line and taxes it)
+ *  - Case 2 (downgrade, net < 0): preview.tax.total === 0
+ *    (tax credit omitted from the preview)
  *  - Case 3 (all-positive new attach): correct
  *
  * Green-success criteria (after fix):
  *  - Case 1: preview.tax.total ~ netSubtotal * rate
- *  - Case 2: preview.tax.total === 0, status === "complete"
+ *  - Case 2: preview.tax.total ~ netSubtotal * rate (negative)
  *  - Case 3: unchanged (no regression)
  *
  * Architecture (per fetch-build-execute):
@@ -123,7 +123,7 @@ test.concurrent(`${chalk.yellowBright(
 }, 300_000);
 
 test.concurrent(`${chalk.yellowBright(
-	"automatic-tax-preview-attach-prorated-credit (downgrade, credit exceeds new charge): preview tax is zero with status complete",
+	"automatic-tax-preview-attach-prorated-credit (downgrade, credit exceeds new charge): preview returns negative tax credit",
 )}`, async () => {
 	const customerId = "tax-preview-prorated-credit-downgrade";
 	const proProd = products.pro({ id: "pro", items: [] });
@@ -154,8 +154,8 @@ test.concurrent(`${chalk.yellowBright(
 	//   Pro prorated charge:        ~ +$16.67 (25 days x $20 / 30)
 	//   Unused Premium credit:      ~ -$41.67 (25 days x $50 / 30)
 	//   netSubtotal:                ~ -$25.00  (credit exceeds charge)
-	// Bug: tax = positiveSum * rate ~ 16.67 * 0.10 = ~$1.67
-	// Fix: tax = 0 (skip Stripe call, no tax owed on net-credit invoice)
+	// Bug: tax = 0, omitting the tax credit from the preview
+	// Fix: tax = netSubtotal * rate = ~$-2.50
 	const preview = (await autumnV2_2.billing.previewAttach({
 		customer_id: customerId,
 		plan_id: `pro_${customerId}`,
@@ -179,9 +179,17 @@ test.concurrent(`${chalk.yellowBright(
 	const positiveLines = preview.line_items.filter((li) => li.total > 0);
 	expect(positiveLines.length).toBeGreaterThan(0);
 
-	// Core assertion: no tax when net subtotal is non-positive.
-	expect(preview.tax?.total).toBe(0);
-	expect(preview.tax?.amount_exclusive).toBe(0);
+	const expectedTax = immediateLineItemsTotal * AU_GST_RATE;
+
+	// Core assertion: tax mirrors the negative net subtotal.
+	expect(preview.tax?.total).toBeGreaterThanOrEqual(expectedTax - 0.05);
+	expect(preview.tax?.total).toBeLessThanOrEqual(expectedTax + 0.05);
+	expect(preview.tax?.amount_exclusive).toBeGreaterThanOrEqual(
+		expectedTax - 0.05,
+	);
+	expect(preview.tax?.amount_exclusive).toBeLessThanOrEqual(
+		expectedTax + 0.05,
+	);
 	expect(preview.tax?.amount_inclusive).toBe(0);
 }, 300_000);
 

--- a/server/tests/integration/billing/tax/preview-attach-discount-tax.test.ts
+++ b/server/tests/integration/billing/tax/preview-attach-discount-tax.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for billing.preview_attach discount precision and downgrade tax credits.
+ *
+ * Red-failure mode (current behavior):
+ *  - A 3620-cent coupon appears as 36; downgrade tax credits appear as 0.
+ *
+ * Green-success criteria (after fix):
+ *  - The preview preserves coupon cents and includes negative tax credits.
+ */
+
+import { expect, test } from "bun:test";
+import type { AttachParamsV1, AttachPreviewResponse } from "@autumn/shared";
+import { createAmountCoupon } from "@tests/integration/billing/utils/discounts/discountTestUtils";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { createStripeCli } from "@/external/connect/createStripeCli";
+
+test.concurrent(
+	`${chalk.yellowBright("preview_attach fixed amount discount: preserves cents")}`,
+	async () => {
+		const customerId = "preview-attach-fixed-discount-cents";
+		const planId = "fixed-discount-cents-plan";
+		const plan = products.base({
+			id: planId,
+			items: [items.monthlyPrice({ price: 155 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [],
+		});
+
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		const coupon = await createAmountCoupon({
+			stripeCli,
+			amountOffCents: 3620,
+		});
+
+		const preview = await autumnV2_2.billing.previewAttach<AttachParamsV1>({
+			customer_id: customerId,
+			plan_id: `${planId}_${customerId}`,
+			redirect_mode: "never",
+			discounts: [{ reward_id: coupon.id }],
+		});
+
+		const lineItem = preview.line_items[0];
+
+		expect(preview.line_items).toHaveLength(1);
+		expect(lineItem.discounts).toHaveLength(1);
+		expect(lineItem.discounts[0].amount_off).toBe(36.2);
+		expect(lineItem.total).toBe(118.8);
+	},
+	300_000,
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview_attach downgrade tax: includes negative tax on credit invoice")}`,
+	async () => {
+		const customerId = "preview-attach-downgrade-negative-tax";
+		const proId = "pro-negative-tax";
+		const premiumId = "premium-negative-tax";
+		const pro = products.pro({ id: proId, items: [] });
+		const premium = products.premium({
+			id: premiumId,
+			items: [],
+		});
+
+		const { autumnV2_2, ctx, testClockId } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: true }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
+		});
+
+		const taxRate = await ctx.stripeCli.taxRates.create({
+			display_name: "Preview Attach Downgrade Negative Tax",
+			percentage: 20,
+			inclusive: false,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: `${premiumId}_${customerId}`,
+			redirect_mode: "never",
+			tax_rate_id: taxRate.id,
+		});
+
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			numberOfDays: 5,
+			waitForSeconds: 15,
+		});
+
+		const preview = (await autumnV2_2.billing.previewAttach<AttachParamsV1>({
+			customer_id: customerId,
+			plan_id: `${proId}_${customerId}`,
+			redirect_mode: "never",
+			plan_schedule: "immediate",
+			tax_rate_id: taxRate.id,
+		})) as AttachPreviewResponse;
+
+		const lineItemsTotal = preview.line_items.reduce(
+			(sum, item) => sum + item.total,
+			0,
+		);
+		const expectedTax = Math.round(lineItemsTotal * 0.2 * 100) / 100;
+
+		expect(lineItemsTotal).toBeLessThan(0);
+		expect(preview.tax).toBeDefined();
+		expect(preview.tax?.total).toBe(expectedTax);
+		expect(preview.tax?.amount_exclusive).toBe(expectedTax);
+		expect(preview.total).toBe(
+			Math.round((lineItemsTotal + expectedTax) * 100) / 100,
+		);
+	},
+	300_000,
+);

--- a/server/tests/unit/billing/stripe/discounts/apply-amount-off-discount-to-line-items.spec.ts
+++ b/server/tests/unit/billing/stripe/discounts/apply-amount-off-discount-to-line-items.spec.ts
@@ -97,12 +97,12 @@ describe(chalk.yellowBright("applyAmountOffDiscountToLineItems"), () => {
 					discount,
 				});
 
-				// First item: 75/100 * 30 = 22.5 → 23 (rounded)
-				// Second item: 25/100 * 30 = 7.5 → 8 (rounded)
-				expect(result[0].discounts[0].amountOff).toBe(23);
-				expect(result[0].amountAfterDiscounts).toBe(52); // 75 - 23
-				expect(result[1].discounts[0].amountOff).toBe(8);
-				expect(result[1].amountAfterDiscounts).toBe(17); // 25 - 8
+				// First item: 75/100 * 30 = 22.5
+				// Second item: 25/100 * 30 = 7.5
+				expect(result[0].discounts[0].amountOff).toBe(22.5);
+				expect(result[0].amountAfterDiscounts).toBe(52.5);
+				expect(result[1].discounts[0].amountOff).toBe(7.5);
+				expect(result[1].amountAfterDiscounts).toBe(17.5);
 			});
 		},
 	);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes preview_attach tax and fixed-amount discount precision. Amount-off coupons now preserve cents, and downgrade previews return negative tax credits instead of zero.

- **Bug Fixes**
  - Allocate fixed-amount discounts in minor units with weighted distribution and deterministic remainder handling; preserves cents (e.g., 3620¢ => 36.20) and accurate per-line totals.
  - Attach tax preview: if net subtotal is negative, call Stripe Tax on the absolute amount and negate the result; return zeros only when net is exactly 0.
  - Tax-rate preview mirrors this and allows negative tax amounts.

- **Refactors**
  - Extracted `allocateAmountOffDiscounts` helper operating in Stripe minor units; sorts by remainder with index tiebreak for deterministic allocation.

<sup>Written for commit c48729458d65c97f6f8314ec1ccdd9289edadc0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs in the billing preview attach flow: fractional-cent coupon amounts being silently truncated during proportional discount allocation, and downgrade scenarios with net-negative subtotals returning zero tax instead of a negative tax credit.

- **Bug fixes** — `applyAmountOffDiscountToLineItems` now allocates discounts in Stripe minor units (cents) using a largest-remainder algorithm before converting back to Autumn amounts, so a 3620-cent coupon is correctly preserved as $36.20 rather than rounded to $36.
- **Bug fixes** — `computeAttachTaxPreview` and `computeAttachTaxRateIdPreview` now allow negative net subtotals through: the Stripe Tax path calls the API with `Math.abs(netSubtotal)` and negates the result, while the tax-rate-ID path removes the `Math.max(..., 0)` floor so per-line negative contributions sum to a negative tax credit.
- **Improvements** — New integration test (`preview-attach-discount-tax.test.ts`) and updated assertions in the prorated-credit integration test cover both fixed scenarios end-to-end.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the two independent fixes are well-scoped and each is covered by new or updated tests.

The discount-allocation rewrite correctly moves all arithmetic to minor units and the largest-remainder distribution is mathematically sound. The negative-tax paths in both tax helpers are a straightforward sign-flip or floor-removal with no edge cases that break existing positive-subtotal behavior. The one area worth a double-check before merging is whether `stripeToAtmnAmount` in `computeAttachTaxRateIdPreview` cleanly handles negative integer inputs, as it is being called with a negative value for the first time in this path.

computeAttachTaxRateIdPreview.ts — confirm `stripeToAtmnAmount` handles negative minor-unit values correctly

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts | Replaces dollar-level proportional allocation with a minor-unit largest-remainder algorithm, fixing the cents-precision bug where e.g. a 3620-cent coupon was rounded to $36 instead of $36.20. Logic is sound; minor implicit mutation of shared object references in the LR pass warrants a comment. |
| server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxPreview.ts | Replaces the `<= 0` short-circuit with an abs-value + sign flip so that Stripe Tax is called for negative subtotals and the preview returns a negative tax credit instead of zero. Change is correct: the absolute amount is always positive for Stripe, and `taxSign` is applied uniformly to all three result fields. |
| server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts | Removes the `<= 0` guard and the `Math.max(..., 0)` clamp so negative-subtotal tax rate calculations return a negative credit amount. The per-line `taxableMinorUnitsToTaxMinorUnits` correctly propagates negative values; relies on `stripeToAtmnAmount` handling negative inputs. |
| server/tests/integration/billing/tax/preview-attach-discount-tax.test.ts | New integration test covering both the cents-precision fix (3620-cent coupon preserved as $36.20) and negative tax credits on downgrade scenarios. Tolerance and assertion values look correct. |
| server/tests/integration/billing/tax/automatic-tax-preview-attach-prorated-credit.test.ts | Test updated from 'tax = 0 on downgrade' to 'tax is approximately netSubtotal x rate (negative)' with a ±$0.05 tolerance band, consistent with the new behavior. |
| server/tests/unit/billing/stripe/discounts/apply-amount-off-discount-to-line-items.spec.ts | Expectations updated from rounded integers (23/8) to exact minor-unit results (22.5/7.5), which are the correct values produced by the new cents-level allocation. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[previewAttach request] --> B[Build line items with discounts]
    B --> C{amount_off coupon?}
    C -- Yes --> D[allocateAmountOffDiscounts\nwork in minor units\nlargest-remainder]
    D --> E[Convert back:\nstripeToAtmnAmount per item]
    C -- No --> F[Line items unchanged]
    E --> F
    F --> G[Compute netSubtotal\nsum chargeImmediately lines]
    G --> H{Tax method?}
    H -- Stripe Tax --> I{netSubtotal}
    I -- === 0 --> J[Return zeros]
    I -- < 0 --> K[Call Stripe Tax with\nMath.abs netSubtotal\ntaxSign = -1]
    I -- > 0 --> L[Call Stripe Tax normally\ntaxSign = +1]
    K --> M[Multiply result by taxSign\nnegative tax credit]
    L --> M
    H -- Tax Rate ID --> N{totalTaxableMinorUnits}
    N -- === 0 --> O[Return zeros]
    N -- < 0 or > 0 --> P[Per-line tax computation\nno Math.max floor\nnegative values allowed]
    P --> Q[stripeToAtmnAmount\nnegative-safe]
    M --> R[PreviewTax returned]
    O --> R
    Q --> R
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts`, line 140-154 ([link](https://github.com/useautumn/autumn/blob/017a133f89eaf2c1a134346afd387755aae4add0/server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts#L140-L154)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Negative tax flows directly into `stripeToAtmnAmount`**

   With the removal of `Math.max(taxMinorUnits, 0)`, `taxMinorUnits` can now be negative when the proration credit lines dominate (each calls `taxableMinorUnitsToTaxMinorUnits` with a negative value and these sum to a negative total). `stripeToAtmnAmount` is being called with a negative integer here for the first time in this path. As long as its implementation is a plain division (e.g. `cents / 100`) this is fine — but it is an implicit assumption worth a quick verification, since other call sites in this file only ever passed non-negative values before this PR.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts
   Line: 140-154

   Comment:
   **Negative tax flows directly into `stripeToAtmnAmount`**

   With the removal of `Math.max(taxMinorUnits, 0)`, `taxMinorUnits` can now be negative when the proration credit lines dominate (each calls `taxableMinorUnitsToTaxMinorUnits` with a negative value and these sum to a negative total). `stripeToAtmnAmount` is being called with a negative integer here for the first time in this path. As long as its implementation is a plain division (e.g. `cents / 100`) this is fine — but it is an implicit assumption worth a quick verification, since other call sites in this file only ever passed non-negative values before this PR.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/internal/billing/v2/utils/billingPlan/preview/tax/computeAttachTaxRateIdPreview.ts:140-154
**Negative tax flows directly into `stripeToAtmnAmount`**

With the removal of `Math.max(taxMinorUnits, 0)`, `taxMinorUnits` can now be negative when the proration credit lines dominate (each calls `taxableMinorUnitsToTaxMinorUnits` with a negative value and these sum to a negative total). `stripeToAtmnAmount` is being called with a negative integer here for the first time in this path. As long as its implementation is a plain division (e.g. `cents / 100`) this is fine — but it is an implicit assumption worth a quick verification, since other call sites in this file only ever passed non-negative values before this PR.

### Issue 2 of 2
server/src/internal/billing/v2/providers/stripe/utils/discounts/applyAmountOffDiscountToLineItems.ts:39-51
**Implicit shared-reference mutation in the largest-remainder pass**

`byRemainder` is a sorted shallow copy of `allocations`, so the objects in both arrays are the same references. The `allocation.minorUnits += 1` mutation inside the loop modifies each element in-place, which is why the final `allocations.map(...)` sees the incremented values. This is correct, but the implicit aliasing is non-obvious — a future reader could reasonably assume `byRemainder` and `allocations` are independent and introduce a re-sort or early reassignment that would silently break the distribution. A brief comment noting the intentional shared-reference design would help.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;dev&#39; into preview-attach-t..."](https://github.com/useautumn/autumn/commit/017a133f89eaf2c1a134346afd387755aae4add0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37625898)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->