### PR TITLE
fix: multi-entity granted amount undercounts to one entity in balance sub-rows

### DIFF
--- a/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx
@@ -7,7 +7,6 @@ import {
 	cusEntsToBalance,
 	cusEntsToGrantedBalance,
 	cusEntsToPrepaidQuantity,
-	cusEntToPrepaidQuantity,
 	getRolloverFields,
 	isFreeCustomerEntitlement,
 	isPrepaidCustomerEntitlement,
@@ -120,20 +119,15 @@ function getIndividualEntValues({
 		cusEnts: [ent],
 		sumAcrossEntities: nullish(entityId),
 	});
-	void grantedBalance;
-	void prepaidAllowance;
 
 	const rolloverBalance =
 		getRolloverFields({ cusEnt: ent, entityId: entityId ?? undefined })
 			?.balance ?? 0;
 
 	const quantity = ent.customer_product?.quantity || 1;
-	const allowance =
-		(ent.entitlement.allowance ?? 0) * quantity +
-		(entityId && ent.entities?.[entityId]
-			? (ent.entities[entityId].adjustment ?? ent.adjustment ?? 0)
-			: (ent.adjustment ?? 0)) +
-		cusEntToPrepaidQuantity({ cusEnt: ent });
+	// grantedBalance/prepaidAllowance already account for per-entity multiplication
+	// at customer level; the manual sum here dropped it, undercounting to one entity.
+	const allowance = grantedBalance + prepaidAllowance;
 	return { balance, allowance, quantity, rolloverBalance };
 }
 


### PR DESCRIPTION
## What

Fixes the per-feature **granted** total showing "as if there was 1 entity" for entity-scoped features with multiple entities, in the customer balance table sub-rows.

## Root cause

`getIndividualEntValues` (used by `SubRowUsageCell` / `SubRowBarCell` in `CustomerBalanceTableColumns.tsx`) computed the correct, entity-aware grant via `cusEntsToGrantedBalance` + `cusEntsToPrepaidQuantity`, then `void`'d both results and re-derived `allowance` from a hand-rolled formula:

```ts
const allowance =
  (ent.entitlement.allowance ?? 0) * quantity + adjustment + cusEntToPrepaidQuantity({ cusEnt: ent });
```

That formula omits the per-entity multiplication that `getSummedEntityBalances` applies at the customer level. So for an entity-scoped feature (`entity_feature_id` set) the sub-row showed **one entity's** allowance while its `balance` was summed across **all** entities — an inconsistent display (e.g. `380 / 200`).

## Fix

Use the already-correct shared-util results and drop the manual formula:

```ts
const allowance = grantedBalance + prepaidAllowance;
```

Removed the now-unused `cusEntToPrepaidQuantity` import.

## Verification

Ran the `@autumn/shared` balance utils against real data (entity-scoped `ai_credits`, allowance 200, 2 entities + a 100 top-up):

| | before | after |
|---|---|---|
| team sub-row (customer level) | 380 / **200** | 380 / **400** ✅ |
| team sub-row (entity selected) | — | 190 / 200 ✅ |
| top-up sub-row | 100 / 100 | 100 / 100 ✅ |

The collapsed **parent** row was already correct (it goes through `useFeatureUsageBalance` → `cusEntsToGrantedBalance`, which multiplies by entity count); only the sub-row breakdown was affected.

Frontend typecheck (`bun ts`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes undercounted granted totals in customer balance sub-rows for entity-scoped features. Sub-rows now reflect totals across all entities, matching the parent row and actual usage.

- **Bug Fixes**
  - Use computed `grantedBalance + prepaidAllowance` from shared utils instead of a manual formula that dropped per-entity multiplication.
  - Remove unused `cusEntToPrepaidQuantity` import.

<sup>Written for commit ca325f9fd0cb697056da24cd9bfb7724603e7d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a display bug in the customer balance table where sub-rows for entity-scoped features showed the granted allowance for only one entity instead of the full multi-entity total.

- **Bug fixes**: `getIndividualEntValues` was computing `allowance` via a hand-rolled formula that omitted the per-entity multiplier applied by `cusEntsToAllowance` (`.mul(entityCount)`), causing the sub-row to show `380 / 200` instead of `380 / 400` for a 2-entity setup. The fix replaces the manual formula with the already-correct `grantedBalance + prepaidAllowance` values that were previously computed but discarded with `void`.
- **Improvements**: Removes the now-unused `cusEntToPrepaidQuantity` (single-entitlement variant) import, leaving only the array-based `cusEntsToPrepaidQuantity`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line display fix that replaces a hand-rolled computation with shared utilities that were already being called and whose results were being discarded.

The old manual formula simply omitted the entity-count multiplication that `cusEntsToAllowance` already performs via `.mul(entityCount)`. The replacement `grantedBalance + prepaidAllowance` re-uses results from `cusEntsToGrantedBalance` and `cusEntsToPrepaidQuantity` that were already computed in the same function (previously voided), so the logic is well-tested at the utility layer. No new state, network calls, or side effects are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/table/customer-balance/CustomerBalanceTableColumns.tsx | Drops the manual allowance formula in `getIndividualEntValues` and uses the pre-computed `grantedBalance + prepaidAllowance` values that already apply the entity-count multiplier; removes the now-unused `cusEntToPrepaidQuantity` import. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SR as SubRowUsageCell / SubRowBarCell
    participant GIV as getIndividualEntValues
    participant GB as cusEntsToGrantedBalance
    participant PA as cusEntsToPrepaidQuantity
    participant AL as cusEntsToAllowance

    SR->>GIV: ent, entityId
    GIV->>GB: "cusEnts=[ent], entityId"
    GB->>AL: "cusEnts=[ent], entityId"
    AL-->>GB: allowance × quantity × entityCount
    GB-->>GIV: grantedBalance (entity-aware)
    GIV->>PA: "cusEnts=[ent], sumAcrossEntities=nullish(entityId)"
    PA-->>GIV: prepaidAllowance (entity-aware)
    Note over GIV: allowance = grantedBalance + prepaidAllowance
    GIV-->>SR: "{ balance, allowance, quantity, rolloverBalance }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 sub-row granted undercounts to o..."](https://github.com/useautumn/autumn/commit/ca325f9fd0cb697056da24cd9bfb7724603e7d2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37676068)</sub>

<!-- /greptile_comment -->