### PR TITLE
Immediate invoice void on past-due cancel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: fix-health-check-redis-disabled-detection feat/track-rate-limit-redis feat/events-hourly-rollup fix/analytics-tz-bucket-offset uw-1-storage fix/usage-limit-ai-credit-dimension feat/analytics-week-bin
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: feat/past-due-cancel-immediate-void
 
 jobs:
   checks:

--- a/server/src/external/stripe/invoices/operations/voidOpenInvoicesForStripeSubscription.ts
+++ b/server/src/external/stripe/invoices/operations/voidOpenInvoicesForStripeSubscription.ts
@@ -4,12 +4,8 @@ import { invoiceActions } from "@/internal/invoices/actions";
 
 const VOIDABLE_STATUSES: Stripe.Invoice.Status[] = ["open", "uncollectible"];
 
-/**
- * Void every open/uncollectible invoice on a Stripe subscription, then mirror the new status
- * into Autumn's invoice records. Per-invoice failures are tolerated (the subscription.deleted
- * webhook can race this for the same invoices, and Stripe rejects voiding an already-voided one)
- * but are counted and returned so the caller can surface a partial failure.
- */
+// Per-invoice failures are tolerated + counted: the subscription.deleted webhook can race the
+// same invoices, and Stripe rejects voiding an already-voided one.
 export const voidOpenInvoicesForStripeSubscription = async ({
 	ctx,
 	stripeCli,

--- a/server/src/external/stripe/invoices/operations/voidOpenInvoicesForStripeSubscription.ts
+++ b/server/src/external/stripe/invoices/operations/voidOpenInvoicesForStripeSubscription.ts
@@ -1,0 +1,73 @@
+import type { Stripe } from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { invoiceActions } from "@/internal/invoices/actions";
+
+const VOIDABLE_STATUSES: Stripe.Invoice.Status[] = ["open", "uncollectible"];
+
+/**
+ * Void every open/uncollectible invoice on a Stripe subscription, then mirror the new status
+ * into Autumn's invoice records. Per-invoice failures are tolerated (the subscription.deleted
+ * webhook can race this for the same invoices, and Stripe rejects voiding an already-voided one)
+ * but are counted and returned so the caller can surface a partial failure.
+ */
+export const voidOpenInvoicesForStripeSubscription = async ({
+	ctx,
+	stripeCli,
+	customerId,
+	stripeCustomerId,
+	subscriptionId,
+}: {
+	ctx: AutumnContext;
+	stripeCli: Stripe;
+	customerId: string;
+	stripeCustomerId: string;
+	subscriptionId: string;
+}): Promise<{ voided: number; failed: number }> => {
+	const { logger } = ctx;
+
+	const voidableInvoices: Stripe.Invoice[] = [];
+	let startingAfter: string | undefined;
+
+	while (true) {
+		const page = await stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			subscription: subscriptionId,
+			limit: 100,
+			starting_after: startingAfter,
+		});
+
+		for (const invoice of page.data) {
+			if (VOIDABLE_STATUSES.includes(invoice.status ?? "draft")) {
+				voidableInvoices.push(invoice);
+			}
+		}
+
+		if (!page.has_more) break;
+		startingAfter = page.data[page.data.length - 1]?.id;
+		if (!startingAfter) break;
+	}
+
+	let failed = 0;
+	await Promise.all(
+		voidableInvoices.map(async (invoice) => {
+			try {
+				const voidedInvoice = await stripeCli.invoices.voidInvoice(invoice.id);
+				await invoiceActions.updateFromStripe({
+					ctx,
+					customerId,
+					stripeInvoice: voidedInvoice,
+				});
+				logger.info(
+					`[voidOpenInvoicesForStripeSubscription] Voided invoice ${invoice.id}`,
+				);
+			} catch (error) {
+				failed++;
+				logger.warn(
+					`[voidOpenInvoicesForStripeSubscription] Failed to void invoice ${invoice.id}: ${error}`,
+				);
+			}
+		}),
+	);
+
+	return { voided: voidableInvoices.length - failed, failed };
+};

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -17,7 +17,7 @@ import { setupAnchorResetRefund } from "@/internal/billing/v2/setup/setupAnchorR
 import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
 import {
 	setupCancelAction,
-	shouldForcePastDueImmediateCancel,
+	shouldSuppressUnpaidCycleCredit,
 } from "@/internal/billing/v2/setup/setupCancelMode";
 import { setupFeatureQuantitiesContext } from "@/internal/billing/v2/setup/setupFeatureQuantitiesContext";
 import { setupFullCustomerContext } from "@/internal/billing/v2/setup/setupFullCustomerContext";
@@ -180,9 +180,10 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		customerProduct,
 	});
 
-	// A past_due cancel forced to immediate must not refund the unpaid cycle.
-	const forcePastDueImmediate = shouldForcePastDueImmediateCancel({
-		params,
+	// A past_due immediate cancel (resolved from end-of-cycle OR requested directly) must not
+	// credit the unpaid cycle — the open invoice is voided instead.
+	const suppressUnpaidCycleCredit = shouldSuppressUnpaidCycleCredit({
+		cancelAction,
 		org: ctx.org,
 		customerProduct,
 	});
@@ -235,7 +236,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		billingCycleAnchorMs,
 		resetCycleAnchorMs,
 		requestedBillingCycleAnchor: params.billing_cycle_anchor,
-		requestedProrationBehavior: forcePastDueImmediate
+		requestedProrationBehavior: suppressUnpaidCycleCredit
 			? "none"
 			: setupIgnoreProrationBehavior({ intent })
 				? undefined

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -15,7 +15,10 @@ import { fetchStoredLineItemsForSubscriptionBilling } from "@/internal/billing/v
 import { setupAdjustableQuantities } from "@/internal/billing/v2/setup/setupAdjustableQuantities";
 import { setupAnchorResetRefund } from "@/internal/billing/v2/setup/setupAnchorResetRefund";
 import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
-import { setupCancelAction } from "@/internal/billing/v2/setup/setupCancelMode";
+import {
+	setupCancelAction,
+	shouldForcePastDueImmediateCancel,
+} from "@/internal/billing/v2/setup/setupCancelMode";
 import { setupFeatureQuantitiesContext } from "@/internal/billing/v2/setup/setupFeatureQuantitiesContext";
 import { setupFullCustomerContext } from "@/internal/billing/v2/setup/setupFullCustomerContext";
 import { setupIgnoreProrationBehavior } from "@/internal/billing/v2/setup/setupIgnoreProrationBehavior";
@@ -171,7 +174,18 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		customerProduct,
 	});
 
-	const cancelAction = setupCancelAction({ params });
+	const cancelAction = setupCancelAction({
+		params,
+		org: ctx.org,
+		customerProduct,
+	});
+
+	// A past_due cancel forced to immediate must not refund the unpaid cycle.
+	const forcePastDueImmediate = shouldForcePastDueImmediateCancel({
+		params,
+		org: ctx.org,
+		customerProduct,
+	});
 
 	let checkoutMode = setupAttachCheckoutMode({
 		paymentMethod,
@@ -221,9 +235,11 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		billingCycleAnchorMs,
 		resetCycleAnchorMs,
 		requestedBillingCycleAnchor: params.billing_cycle_anchor,
-		requestedProrationBehavior: setupIgnoreProrationBehavior({ intent })
-			? undefined
-			: params.proration_behavior,
+		requestedProrationBehavior: forcePastDueImmediate
+			? "none"
+			: setupIgnoreProrationBehavior({ intent })
+				? undefined
+				: params.proration_behavior,
 
 		invoiceMode,
 		featureQuantities,

--- a/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/updateSubscription.ts
@@ -10,6 +10,7 @@ import { handleUpdateSubscriptionErrors } from "@/internal/billing/v2/actions/up
 import { logUpdateSubscriptionContext } from "@/internal/billing/v2/actions/updateSubscription/logs/logUpdateSubscriptionContext";
 import { setupUpdateSubscriptionBillingContext } from "@/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext";
 import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan";
+import { voidInvoicesOnImmediateCancel } from "@/internal/billing/v2/execute/voidInvoicesOnImmediateCancel";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
 import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
@@ -112,6 +113,13 @@ export async function updateSubscription({
 		ctx,
 		billingContext,
 		billingPlan,
+	});
+
+	await voidInvoicesOnImmediateCancel({
+		ctx,
+		billingContext,
+		billingPlan,
+		billingResult,
 	});
 
 	logStripeBillingResult({ ctx, result: billingResult.stripe });

--- a/server/src/internal/billing/v2/execute/voidInvoicesOnImmediateCancel.ts
+++ b/server/src/internal/billing/v2/execute/voidInvoicesOnImmediateCancel.ts
@@ -7,8 +7,7 @@ import { createStripeCli } from "@/external/connect/createStripeCli";
 import { voidOpenInvoicesForStripeSubscription } from "@/external/stripe/invoices/operations/voidOpenInvoicesForStripeSubscription";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
-// Void-on-cancel must run inline for Autumn-initiated immediate cancels: the sub:<id> lock makes
-// the subscription.deleted webhook (which normally does the voiding) skip itself for our cancels.
+// Inline because the sub:<id> lock makes the subscription.deleted webhook skip its own void.
 export const voidInvoicesOnImmediateCancel = async ({
 	ctx,
 	billingContext,
@@ -24,9 +23,8 @@ export const voidInvoicesOnImmediateCancel = async ({
 	if (billingContext.cancelAction !== "cancel_immediately") return;
 	if (billingResult.stripe.deferred) return;
 
-	// Only void when the whole Stripe subscription was actually cancelled — a partial item
-	// removal (e.g. cancelling one product while an add-on stays live on the same subscription)
-	// produces an "update" action, and voiding the surviving product's open invoices would be wrong.
+	// Only when the whole sub was cancelled; a partial item removal (add-on survives) is an
+	// "update", and voiding the surviving product's invoices would be wrong.
 	if (billingPlan.stripe.subscriptionAction?.type !== "cancel") return;
 
 	const { stripeSubscription, stripeCustomer, fullCustomer } = billingContext;

--- a/server/src/internal/billing/v2/execute/voidInvoicesOnImmediateCancel.ts
+++ b/server/src/internal/billing/v2/execute/voidInvoicesOnImmediateCancel.ts
@@ -1,0 +1,49 @@
+import type {
+	BillingPlan,
+	BillingResult,
+	UpdateSubscriptionBillingContext,
+} from "@autumn/shared";
+import { createStripeCli } from "@/external/connect/createStripeCli";
+import { voidOpenInvoicesForStripeSubscription } from "@/external/stripe/invoices/operations/voidOpenInvoicesForStripeSubscription";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+// Void-on-cancel must run inline for Autumn-initiated immediate cancels: the sub:<id> lock makes
+// the subscription.deleted webhook (which normally does the voiding) skip itself for our cancels.
+export const voidInvoicesOnImmediateCancel = async ({
+	ctx,
+	billingContext,
+	billingPlan,
+	billingResult,
+}: {
+	ctx: AutumnContext;
+	billingContext: UpdateSubscriptionBillingContext;
+	billingPlan: BillingPlan;
+	billingResult: BillingResult;
+}): Promise<void> => {
+	if (!ctx.org.config.void_invoices_on_subscription_deletion) return;
+	if (billingContext.cancelAction !== "cancel_immediately") return;
+	if (billingResult.stripe.deferred) return;
+
+	// Only void when the whole Stripe subscription was actually cancelled — a partial item
+	// removal (e.g. cancelling one product while an add-on stays live on the same subscription)
+	// produces an "update" action, and voiding the surviving product's open invoices would be wrong.
+	if (billingPlan.stripe.subscriptionAction?.type !== "cancel") return;
+
+	const { stripeSubscription, stripeCustomer, fullCustomer } = billingContext;
+	if (!stripeSubscription || !stripeCustomer) return;
+
+	const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+	const { failed } = await voidOpenInvoicesForStripeSubscription({
+		ctx,
+		stripeCli,
+		customerId: fullCustomer.id ?? fullCustomer.internal_id,
+		stripeCustomerId: stripeCustomer.id,
+		subscriptionId: stripeSubscription.id,
+	});
+
+	if (failed > 0) {
+		ctx.logger.error(
+			`[voidInvoicesOnImmediateCancel] ${failed} invoice(s) failed to void for subscription ${stripeSubscription.id}; they may still be open in Stripe`,
+		);
+	}
+};

--- a/server/src/internal/billing/v2/setup/setupCancelMode.ts
+++ b/server/src/internal/billing/v2/setup/setupCancelMode.ts
@@ -1,19 +1,37 @@
-import type { CancelAction, UpdateSubscriptionV1Params } from "@autumn/shared";
+import type {
+	CancelAction,
+	FullCusProduct,
+	Organization,
+	UpdateSubscriptionV1Params,
+} from "@autumn/shared";
+import { CusProductStatus } from "@autumn/shared";
 
-/**
- * Setup cancel action from params
- * @param params - The params
- * cancel_action param maps directly to internal cancel action
- * - cancel_action: "cancel_immediately" means cancel immediately
- * - cancel_action: "cancel_end_of_cycle" means cancel at end of cycle
- * - cancel_action: "uncancel" means remove scheduled cancellation
- * - cancel_action: undefined means no cancel operation
- * @returns The cancel action
- */
-export const setupCancelAction = ({
+// Void-on-cancel orgs cancel a past_due end-of-cycle request immediately: the customer is in a
+// cycle they never paid for, so there is no paid period to honor. The unpaid invoice is voided
+// downstream (voidInvoicesOnImmediateCancel) and proration credits are suppressed by the caller
+// (no refund is owed for a cycle that was never paid).
+export const shouldForcePastDueImmediateCancel = ({
 	params,
+	org,
+	customerProduct,
 }: {
 	params: UpdateSubscriptionV1Params;
-}): CancelAction | undefined => {
-	return params.cancel_action;
-};
+	org: Organization;
+	customerProduct?: FullCusProduct;
+}): boolean =>
+	params.cancel_action === "cancel_end_of_cycle" &&
+	org.config.void_invoices_on_subscription_deletion &&
+	customerProduct?.status === CusProductStatus.PastDue;
+
+export const setupCancelAction = ({
+	params,
+	org,
+	customerProduct,
+}: {
+	params: UpdateSubscriptionV1Params;
+	org: Organization;
+	customerProduct?: FullCusProduct;
+}): CancelAction | undefined =>
+	shouldForcePastDueImmediateCancel({ params, org, customerProduct })
+		? "cancel_immediately"
+		: params.cancel_action;

--- a/server/src/internal/billing/v2/setup/setupCancelMode.ts
+++ b/server/src/internal/billing/v2/setup/setupCancelMode.ts
@@ -6,11 +6,8 @@ import type {
 } from "@autumn/shared";
 import { CusProductStatus } from "@autumn/shared";
 
-// Void-on-cancel orgs cancel a past_due end-of-cycle request immediately: the customer is in a
-// cycle they never paid for, so there is no paid period to honor. The unpaid invoice is voided
-// downstream (voidInvoicesOnImmediateCancel) and proration credits are suppressed by the caller
-// (no refund is owed for a cycle that was never paid).
-export const shouldForcePastDueImmediateCancel = ({
+// past_due end-of-cycle resolves to immediate: no paid period left to honor.
+const shouldForcePastDueImmediateCancel = ({
 	params,
 	org,
 	customerProduct,
@@ -35,3 +32,17 @@ export const setupCancelAction = ({
 	shouldForcePastDueImmediateCancel({ params, org, customerProduct })
 		? "cancel_immediately"
 		: params.cancel_action;
+
+// No refund for a past_due immediate cancel: the customer never paid the cycle being voided.
+export const shouldSuppressUnpaidCycleCredit = ({
+	cancelAction,
+	org,
+	customerProduct,
+}: {
+	cancelAction: CancelAction | undefined;
+	org: Organization;
+	customerProduct?: FullCusProduct;
+}): boolean =>
+	cancelAction === "cancel_immediately" &&
+	org.config.void_invoices_on_subscription_deletion &&
+	customerProduct?.status === CusProductStatus.PastDue;

--- a/server/src/internal/customers/cancel/handleCancelV2.ts
+++ b/server/src/internal/customers/cancel/handleCancelV2.ts
@@ -1,11 +1,12 @@
-import { Scopes } from "@autumn/shared";
 import type { UpdateSubscriptionV1Params } from "@autumn/shared";
+import { Scopes } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler";
 import { computeUpdateSubscriptionPlan } from "@/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan";
 import { handleUpdateSubscriptionErrors } from "@/internal/billing/v2/actions/updateSubscription/errors/handleUpdateSubscriptionErrors";
 import { logUpdateSubscriptionContext } from "@/internal/billing/v2/actions/updateSubscription/logs/logUpdateSubscriptionContext";
 import { setupUpdateSubscriptionBillingContext } from "@/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext";
 import { executeBillingPlan } from "@/internal/billing/v2/execute/executeBillingPlan";
+import { voidInvoicesOnImmediateCancel } from "@/internal/billing/v2/execute/voidInvoicesOnImmediateCancel";
 import { evaluateStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/actionBuilders/evaluateStripeBillingPlan";
 import { logStripeBillingPlan } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingPlan";
 import { logStripeBillingResult } from "@/internal/billing/v2/providers/stripe/logs/logStripeBillingResult";
@@ -96,6 +97,13 @@ export const handleCancelV2 = createRoute({
 				autumn: autumnBillingPlan,
 				stripe: stripeBillingPlan,
 			},
+		});
+
+		await voidInvoicesOnImmediateCancel({
+			ctx,
+			billingContext,
+			billingPlan,
+			billingResult,
 		});
 
 		logStripeBillingResult({ ctx, result: billingResult.stripe });

--- a/server/tests/integration/billing/update-subscription/cancel/end-of-cycle/cancel-end-of-cycle-past-due-void-edge.test.ts
+++ b/server/tests/integration/billing/update-subscription/cancel/end-of-cycle/cancel-end-of-cycle-past-due-void-edge.test.ts
@@ -1,0 +1,524 @@
+// Edge/adversarial coverage for void-on-cancel of past_due customers (companion to the PRIMARY +
+// control cases): no unpaid-cycle credit across entry points, no shared-sub collateral void,
+// void-correctness. Cases mutate shared org.config -> serial via withVoidFlag.
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { driveProductPastDue } from "@tests/integration/billing/utils/driveProductPastDue";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectNoStripeSubscription } from "@tests/integration/billing/utils/expectNoStripeSubscription";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import type { Stripe } from "stripe";
+import { OrgService } from "@/internal/orgs/OrgService";
+import { timeout } from "@/utils/genUtils";
+
+type ScenarioCtx = Awaited<ReturnType<typeof initScenario>>["ctx"];
+
+const withVoidFlag = async ({
+	ctx,
+	enabled,
+	fn,
+}: {
+	ctx: ScenarioCtx;
+	enabled: boolean;
+	fn: () => Promise<void>;
+}): Promise<void> => {
+	const originalConfig = ctx.org.config;
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: {
+				...ctx.org.config,
+				void_invoices_on_subscription_deletion: enabled,
+			},
+		},
+	});
+	try {
+		await fn();
+	} finally {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: { config: originalConfig },
+		});
+	}
+};
+
+// A past_due cancel must never credit the customer for the cycle they never paid:
+// no negative-total invoice anywhere, and a zero Stripe customer balance.
+const expectNoCredit = async ({
+	ctx,
+	stripeCustomerId,
+}: {
+	ctx: ScenarioCtx;
+	stripeCustomerId: string | undefined;
+}): Promise<void> => {
+	const allInvoices = await ctx.stripeCli.invoices.list({
+		customer: stripeCustomerId,
+	});
+	expect(allInvoices.data.filter((inv) => (inv.total ?? 0) < 0).length).toBe(0);
+	const stripeCustomer = (await ctx.stripeCli.customers.retrieve(
+		stripeCustomerId!,
+	)) as Stripe.Customer;
+	expect(stripeCustomer.balance).toBe(0);
+};
+
+const expectInvoicesVoided = async ({
+	ctx,
+	stripeCustomerId,
+	subscriptionId,
+}: {
+	ctx: ScenarioCtx;
+	stripeCustomerId: string | undefined;
+	subscriptionId: string;
+}): Promise<void> => {
+	const invoices = await ctx.stripeCli.invoices.list({
+		customer: stripeCustomerId,
+		subscription: subscriptionId,
+	});
+	expect(invoices.data.filter((inv) => inv.status === "open").length).toBe(0);
+	expect(
+		invoices.data.filter((inv) => inv.status === "void").length,
+	).toBeGreaterThan(0);
+};
+
+const buildProductSet = () => {
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+	return { free, pro };
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// #1 (no-credit): the proration suppression must hold across every entry point/input
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("edge: billing.update past_due + explicit proration_behavior=prorate_immediately -> immediate, void, NO credit")}`, async () => {
+	const customerId = "qa-eoc-prorate-override";
+	const { free, pro } = buildProductSet();
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await withVoidFlag({
+		ctx,
+		enabled: true,
+		fn: async () => {
+			const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+				ctx,
+				testClockId: testClockId!,
+				customerId,
+				productId: pro.id,
+			});
+			// Caller explicitly asks to prorate — the past_due resolution must still force "none".
+			await autumnV1.subscriptions.update({
+				customer_id: customerId,
+				product_id: pro.id,
+				cancel_action: "cancel_end_of_cycle",
+				proration_behavior: "prorate_immediately",
+			});
+			await timeout(3000);
+
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer,
+				notPresent: [pro.id],
+				active: [free.id],
+			});
+			await expectNoStripeSubscription({
+				db: ctx.db,
+				customerId,
+				org: ctx.org,
+				env: ctx.env,
+			});
+			await expectInvoicesVoided({ ctx, stripeCustomerId, subscriptionId });
+			await expectNoCredit({ ctx, stripeCustomerId });
+		},
+	});
+});
+
+test(`${chalk.yellowBright("edge: /billing/cancel past_due + prorate=true -> immediate, void, NO credit")}`, async () => {
+	const customerId = "qa-cancel-endpoint-prorate";
+	const { free, pro } = buildProductSet();
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await withVoidFlag({
+		ctx,
+		enabled: true,
+		fn: async () => {
+			const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+				ctx,
+				testClockId: testClockId!,
+				customerId,
+				productId: pro.id,
+			});
+			// Legacy /billing/cancel hardcodes proration_behavior="prorate_immediately".
+			await autumnV1.cancel({
+				customer_id: customerId,
+				product_id: pro.id,
+				cancel_immediately: false,
+				prorate: true,
+			});
+			await timeout(3000);
+
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer,
+				notPresent: [pro.id],
+				active: [free.id],
+			});
+			await expectNoStripeSubscription({
+				db: ctx.db,
+				customerId,
+				org: ctx.org,
+				env: ctx.env,
+			});
+			await expectInvoicesVoided({ ctx, stripeCustomerId, subscriptionId });
+			await expectNoCredit({ ctx, stripeCustomerId });
+		},
+	});
+});
+
+test(`${chalk.yellowBright("edge: explicit cancel_immediately on past_due -> immediate, void, NO credit")}`, async () => {
+	const customerId = "qa-explicit-immediate";
+	const { free, pro } = buildProductSet();
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await withVoidFlag({
+		ctx,
+		enabled: true,
+		fn: async () => {
+			const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+				ctx,
+				testClockId: testClockId!,
+				customerId,
+				productId: pro.id,
+			});
+			await autumnV1.subscriptions.update({
+				customer_id: customerId,
+				product_id: pro.id,
+				cancel_action: "cancel_immediately",
+			});
+			await timeout(3000);
+
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer,
+				notPresent: [pro.id],
+				active: [free.id],
+			});
+			await expectInvoicesVoided({ ctx, stripeCustomerId, subscriptionId });
+			await expectNoCredit({ ctx, stripeCustomerId });
+		},
+	});
+});
+
+test(`${chalk.yellowBright("edge: refund_last_payment=full on unpaid past_due -> NO credit")}`, async () => {
+	const customerId = "qa-refund-last-payment";
+	const { free, pro } = buildProductSet();
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await withVoidFlag({
+		ctx,
+		enabled: true,
+		fn: async () => {
+			const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+				ctx,
+				testClockId: testClockId!,
+				customerId,
+				productId: pro.id,
+			});
+			// refund_last_payment requires cancel_immediately. The unpaid cycle has no collected
+			// payment to refund, so this must still net no credit.
+			await autumnV1.subscriptions.update({
+				customer_id: customerId,
+				product_id: pro.id,
+				cancel_action: "cancel_immediately",
+				refund_last_payment: "full",
+			});
+			await timeout(3000);
+
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer,
+				notPresent: [pro.id],
+				active: [free.id],
+			});
+			await expectInvoicesVoided({ ctx, stripeCustomerId, subscriptionId });
+			await expectNoCredit({ ctx, stripeCustomerId });
+		},
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// #2 (shared-sub collateral): only void when the WHOLE subscription is cancelled
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("edge: shared sub - cancelling past_due main does NOT void surviving add-on's invoice")}`, async () => {
+	const customerId = "qa-shared-sub-addon";
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+	const addon = products.recurringAddOn({ id: "addon", items: [messagesItem] });
+
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({
+				list: [free, pro, addon],
+				customerIdsToDelete: [customerId],
+			}),
+		],
+		// Add-on attaches onto the SAME Stripe subscription as pro (no new_billing_subscription).
+		actions: [
+			s.attach({ productId: pro.id }),
+			s.attach({ productId: addon.id }),
+		],
+	});
+
+	await withVoidFlag({
+		ctx,
+		enabled: true,
+		fn: async () => {
+			const customerBefore =
+				await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			const stripeCustomerId = customerBefore.stripe_id;
+			// Precondition: a single shared Stripe subscription carrying both products' items.
+			const subs = await ctx.stripeCli.subscriptions.list({
+				customer: stripeCustomerId!,
+			});
+			expect(subs.data.length).toBe(1);
+			expect(subs.data[0].items.data.length).toBeGreaterThanOrEqual(2);
+			const subscriptionId = subs.data[0].id;
+
+			// Force ONLY the main product past_due; the add-on stays on the live subscription.
+			await driveProductPastDue({
+				ctx,
+				testClockId: testClockId!,
+				customerId,
+				productId: pro.id,
+			});
+
+			await autumnV1.subscriptions.update({
+				customer_id: customerId,
+				product_id: pro.id,
+				cancel_action: "cancel_end_of_cycle",
+			});
+			await timeout(3000);
+
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			// Main gone; add-on survives -> the Stripe op was an "update", not a whole-sub cancel.
+			await expectCustomerProducts({ customer, notPresent: [pro.id] });
+			expect(customer.products.some((p) => p.id === addon.id)).toBe(true);
+
+			const subsAfter = await ctx.stripeCli.subscriptions.list({
+				customer: stripeCustomerId!,
+			});
+			expect(subsAfter.data.length).toBeGreaterThan(0);
+
+			// The shared sub's open invoice must NOT be voided (it covers the surviving add-on).
+			const invoices = await ctx.stripeCli.invoices.list({
+				customer: stripeCustomerId!,
+				subscription: subscriptionId,
+			});
+			expect(invoices.data.filter((inv) => inv.status === "void").length).toBe(
+				0,
+			);
+			await expectNoCredit({ ctx, stripeCustomerId: stripeCustomerId! });
+		},
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Void-correctness: open/uncollectible voided, paid untouched
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("edge: uncollectible invoice is voided on the inline cancel path")}`, async () => {
+	const customerId = "qa-uncollectible";
+	const { free, pro } = buildProductSet();
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await withVoidFlag({
+		ctx,
+		enabled: true,
+		fn: async () => {
+			const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+				ctx,
+				testClockId: testClockId!,
+				customerId,
+				productId: pro.id,
+			});
+			const before = await ctx.stripeCli.invoices.list({
+				customer: stripeCustomerId,
+				subscription: subscriptionId,
+			});
+			const open = before.data.find((inv) => inv.status === "open");
+			expect(open).toBeDefined();
+			const uncollectible = await ctx.stripeCli.invoices.markUncollectible(
+				open!.id,
+			);
+			expect(uncollectible.status).toBe("uncollectible");
+
+			await autumnV1.subscriptions.update({
+				customer_id: customerId,
+				product_id: pro.id,
+				cancel_action: "cancel_end_of_cycle",
+			});
+			await timeout(3000);
+
+			const after = await ctx.stripeCli.invoices.retrieve(uncollectible.id);
+			expect(after.status).toBe("void");
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			await expectCustomerProducts({
+				customer,
+				notPresent: [pro.id],
+				active: [free.id],
+			});
+		},
+	});
+});
+
+test(`${chalk.yellowBright("edge: paid invoice untouched, only the open invoice voided")}`, async () => {
+	const customerId = "qa-paid-untouched";
+	const { free, pro } = buildProductSet();
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await withVoidFlag({
+		ctx,
+		enabled: true,
+		fn: async () => {
+			// Initial attach invoice is paid (success card); driveProductPastDue then fails the renewal.
+			const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+				ctx,
+				testClockId: testClockId!,
+				customerId,
+				productId: pro.id,
+			});
+			await autumnV1.subscriptions.update({
+				customer_id: customerId,
+				product_id: pro.id,
+				cancel_action: "cancel_end_of_cycle",
+			});
+			await timeout(3000);
+
+			const invoices = await ctx.stripeCli.invoices.list({
+				customer: stripeCustomerId,
+				subscription: subscriptionId,
+			});
+			expect(invoices.data.filter((inv) => inv.status === "paid").length).toBe(
+				1,
+			);
+			expect(invoices.data.filter((inv) => inv.status === "open").length).toBe(
+				0,
+			);
+			expect(invoices.data.filter((inv) => inv.status === "void").length).toBe(
+				1,
+			);
+		},
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Gating: an omitted cancel_action must not resolve to immediate or void
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("edge: omitted cancel_action on past_due does not resolve/void")}`, async () => {
+	const customerId = "qa-no-cancel-action";
+	const { free, pro } = buildProductSet();
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	await withVoidFlag({
+		ctx,
+		enabled: true,
+		fn: async () => {
+			const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+				ctx,
+				testClockId: testClockId!,
+				customerId,
+				productId: pro.id,
+			});
+			// No cancel_action: nothing to cancel, no resolution, no void. recalculate_balances
+			// is a no-op billing-relevant field so the request has something to act on.
+			await autumnV1.subscriptions.update({
+				customer_id: customerId,
+				product_id: pro.id,
+				recalculate_balances: { enabled: true },
+			});
+			await timeout(3000);
+
+			// pro still present (not removed), open invoice still open, nothing voided.
+			const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+			expect(customer.products.some((p) => p.id === pro.id)).toBe(true);
+			const invoices = await ctx.stripeCli.invoices.list({
+				customer: stripeCustomerId,
+				subscription: subscriptionId,
+			});
+			expect(
+				invoices.data.filter((inv) => inv.status === "open").length,
+			).toBeGreaterThan(0);
+			expect(invoices.data.filter((inv) => inv.status === "void").length).toBe(
+				0,
+			);
+		},
+	});
+});

--- a/server/tests/integration/billing/update-subscription/cancel/end-of-cycle/cancel-end-of-cycle-past-due-void.test.ts
+++ b/server/tests/integration/billing/update-subscription/cancel/end-of-cycle/cancel-end-of-cycle-past-due-void.test.ts
@@ -1,0 +1,400 @@
+/**
+ * TDD (feature) for: void-on-cancel orgs cancel past_due customers immediately.
+ *
+ * Contract under test:
+ *   New behavior:
+ *     - flag void_invoices_on_subscription_deletion ON + product past_due + cancel_action "cancel_end_of_cycle"
+ *       -> resolves to an IMMEDIATE cancel: product removed now, default/free active now (not scheduled).
+ *   Side effects:
+ *     - that immediate cancel voids the subscription's open/uncollectible invoices INLINE
+ *       (the Autumn cancel sets the sub:<id> lock, so the subscription.deleted webhook is skipped).
+ *   Gating (unchanged behavior, control cases):
+ *     - flag OFF + past_due + cancel_end_of_cycle -> still scheduled-cancel, open invoice NOT voided.
+ *     - flag ON + NOT past_due + cancel_end_of_cycle -> normal end-of-cycle (canceling + free scheduled).
+ *
+ * Pre-impl red: the PRIMARY test fails because cancel_end_of_cycle on a past_due sub today
+ *   schedules the cancel (pro stays, free not active) and never voids the open invoice on the
+ *   Autumn-initiated path.
+ *
+ * past_due setup: attach with a good card, swap the SUBSCRIPTION's default_payment_method to a
+ * failing card and advance the test clock so the renewal charge fails (produces a real open
+ * invoice in Stripe). The customer_product.status is then flipped to past_due directly in
+ * Postgres (+ cache bust) rather than waiting on the subscription.updated webhook -- there is no
+ * public API to set past_due, and the webhook sync is the flakiest part of a local run. This
+ * mirrors balances/cron/past-due-reset.test.ts. What we're actually testing is the cancel
+ * behavior, not the past_due sync.
+ *
+ * These tests mutate shared org.config, so they run serially (plain `test`) and restore in `finally`.
+ */
+
+import { expect, test } from "bun:test";
+import type { Stripe } from "stripe";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { CusProductStatus, customerProducts } from "@autumn/shared";
+import {
+	expectCustomerProducts,
+	expectProductActive,
+	expectProductCanceling,
+	expectProductPastDue,
+	expectProductScheduled,
+} from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectNoStripeSubscription } from "@tests/integration/billing/utils/expectNoStripeSubscription";
+import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { attachFailedPaymentMethod } from "@/external/stripe/stripeCusUtils";
+import { CusService } from "@/internal/customers/CusService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+import { OrgService } from "@/internal/orgs/OrgService";
+import { timeout } from "@/utils/genUtils";
+
+/**
+ * Fail the renewal to create a real open invoice, then force the product into past_due
+ * directly in Postgres (no webhook dependency). Returns the Stripe customer + subscription ids.
+ */
+const driveProductPastDue = async ({
+	ctx,
+	testClockId,
+	customerId,
+	productId,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	testClockId: string;
+	customerId: string;
+	productId: string;
+}) => {
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId,
+	});
+
+	const customer = await CusService.get({
+		db: ctx.db,
+		idOrInternalId: customerId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+	await attachFailedPaymentMethod({
+		stripeCli: ctx.stripeCli,
+		customer: customer!,
+	});
+
+	const paymentMethods = await ctx.stripeCli.paymentMethods.list({
+		customer: customer!.processor?.id,
+	});
+	await ctx.stripeCli.subscriptions.update(subscriptionId, {
+		default_payment_method: paymentMethods.data[0].id,
+	});
+
+	await advanceToNextInvoice({ stripeCli: ctx.stripeCli, testClockId });
+	await timeout(4000);
+
+	// Flip the customer_product to past_due directly (no public API; webhook sync is unreliable
+	// locally), then bust the cache so the HTTP server re-reads it from Postgres.
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const customerProduct = fullCustomer.customer_products.find(
+		(cp) => cp.product.id === productId,
+	);
+	await ctx.db
+		.update(customerProducts)
+		.set({ status: CusProductStatus.PastDue })
+		.where(eq(customerProducts.id, customerProduct!.id));
+	await deleteCachedFullCustomer({ ctx, customerId });
+
+	return { subscriptionId, stripeCustomerId: customer!.processor?.id };
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PRIMARY (pre-impl RED): flag on + past_due + cancel_end_of_cycle -> immediate + void
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("cancel eoc past_due: flag on -> cancels immediately and voids open invoice")}`, async () => {
+	const customerId = "cancel-pastdue-void-immediate";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const originalOrgConfig = ctx.org.config;
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: {
+				...ctx.org.config,
+				void_invoices_on_subscription_deletion: true,
+			},
+		},
+	});
+
+	try {
+		const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+			ctx,
+			testClockId: testClockId!,
+			customerId,
+			productId: pro.id,
+		});
+
+		// Precondition: product is past_due with an open (unpaid) invoice
+		const customerBeforeCancel =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductPastDue({
+			customer: customerBeforeCancel,
+			productId: pro.id,
+		});
+
+		const invoicesBeforeCancel = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			subscription: subscriptionId,
+		});
+		expect(
+			invoicesBeforeCancel.data.filter((inv) => inv.status === "open").length,
+		).toBeGreaterThan(0);
+
+		// ── Action: cancel_end_of_cycle on a past_due sub with the flag on ──
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_end_of_cycle",
+		});
+
+		// Read-consistency wait for the inline void (NOT a webhook wait).
+		await timeout(3000);
+
+		// ── Contract assertion 1: immediate downgrade (not scheduled) ──
+		const customerAfterCancel =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer: customerAfterCancel,
+			notPresent: [pro.id],
+			active: [free.id],
+		});
+
+		// ── Contract assertion 2: Stripe subscription cancelled now ──
+		await expectNoStripeSubscription({
+			db: ctx.db,
+			customerId,
+			org: ctx.org,
+			env: ctx.env,
+		});
+
+		// ── Contract assertion 3: open invoice voided inline ──
+		const invoicesAfterCancel = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			subscription: subscriptionId,
+		});
+		expect(
+			invoicesAfterCancel.data.filter((inv) => inv.status === "open").length,
+		).toBe(0);
+		expect(
+			invoicesAfterCancel.data.filter((inv) => inv.status === "void").length,
+		).toBeGreaterThan(0);
+
+		// ── Contract assertion 4: no proration credit issued for the unpaid cycle ──
+		// The customer never paid this cycle, so cancelling must not refund/credit them.
+		const allInvoices = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+		});
+		expect(
+			allInvoices.data.filter((inv) => (inv.total ?? 0) < 0).length,
+		).toBe(0);
+		const stripeCustomer = (await ctx.stripeCli.customers.retrieve(
+			stripeCustomerId!,
+		)) as Stripe.Customer;
+		expect(stripeCustomer.balance).toBe(0);
+	} finally {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: { config: originalOrgConfig },
+		});
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CONTROL A: flag OFF + past_due + cancel_end_of_cycle -> unchanged (no immediate, no void)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("cancel eoc past_due: flag off -> stays scheduled, invoice not voided")}`, async () => {
+	const customerId = "cancel-pastdue-void-flag-off";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+
+	const { autumnV1, ctx, testClockId } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: true, paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const originalOrgConfig = ctx.org.config;
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: {
+				...ctx.org.config,
+				void_invoices_on_subscription_deletion: false,
+			},
+		},
+	});
+
+	try {
+		const { subscriptionId, stripeCustomerId } = await driveProductPastDue({
+			ctx,
+			testClockId: testClockId!,
+			customerId,
+			productId: pro.id,
+		});
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_end_of_cycle",
+		});
+
+		await timeout(3000);
+
+		// Not immediately removed: a Stripe subscription still exists (cancel scheduled at period end)
+		const subsAfterCancel = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+		});
+		expect(subsAfterCancel.data.length).toBeGreaterThan(0);
+
+		// Open invoice is NOT voided when the flag is off
+		const invoicesAfterCancel = await ctx.stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			subscription: subscriptionId,
+		});
+		expect(
+			invoicesAfterCancel.data.filter((inv) => inv.status === "open").length,
+		).toBeGreaterThan(0);
+		expect(
+			invoicesAfterCancel.data.filter((inv) => inv.status === "void").length,
+		).toBe(0);
+	} finally {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: { config: originalOrgConfig },
+		});
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CONTROL B: flag ON + NOT past_due + cancel_end_of_cycle -> normal end-of-cycle
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("cancel eoc not past_due: flag on -> normal end-of-cycle (no immediate)")}`, async () => {
+	const customerId = "cancel-pastdue-void-not-pastdue";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [free, pro], customerIdsToDelete: [customerId] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const originalOrgConfig = ctx.org.config;
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: {
+				...ctx.org.config,
+				void_invoices_on_subscription_deletion: true,
+			},
+		},
+	});
+
+	try {
+		const customerAfterAttach =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({
+			customer: customerAfterAttach,
+			productId: pro.id,
+		});
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: pro.id,
+			cancel_action: "cancel_end_of_cycle",
+		});
+
+		// Active (paid) sub: flag must NOT force immediate; normal end-of-cycle applies.
+		const customerAfterCancel =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductCanceling({
+			customer: customerAfterCancel,
+			productId: pro.id,
+		});
+		await expectProductScheduled({
+			customer: customerAfterCancel,
+			productId: free.id,
+		});
+
+		// Side-effect contract: a paid, non-past_due cancel must NOT void any invoice.
+		const customer = await CusService.get({
+			db: ctx.db,
+			idOrInternalId: customerId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		const subscriptionId = await getSubscriptionId({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+		const invoices = await ctx.stripeCli.invoices.list({
+			customer: customer!.processor?.id,
+			subscription: subscriptionId,
+		});
+		expect(invoices.data.filter((inv) => inv.status === "void").length).toBe(0);
+	} finally {
+		await OrgService.update({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			updates: { config: originalOrgConfig },
+		});
+	}
+});

--- a/server/tests/integration/billing/update-subscription/cancel/end-of-cycle/cancel-end-of-cycle-past-due-void.test.ts
+++ b/server/tests/integration/billing/update-subscription/cancel/end-of-cycle/cancel-end-of-cycle-past-due-void.test.ts
@@ -3,7 +3,7 @@
 
 import { expect, test } from "bun:test";
 import type { ApiCustomerV3 } from "@autumn/shared";
-import { CusProductStatus, customerProducts } from "@autumn/shared";
+import { driveProductPastDue } from "@tests/integration/billing/utils/driveProductPastDue";
 import {
 	expectCustomerProducts,
 	expectProductActive,
@@ -15,77 +15,12 @@ import { expectNoStripeSubscription } from "@tests/integration/billing/utils/exp
 import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
-import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
-import { eq } from "drizzle-orm";
 import type { Stripe } from "stripe";
-import { attachFailedPaymentMethod } from "@/external/stripe/stripeCusUtils";
 import { CusService } from "@/internal/customers/CusService";
-import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
 import { OrgService } from "@/internal/orgs/OrgService";
 import { timeout } from "@/utils/genUtils";
-
-/**
- * Fail the renewal to create a real open invoice, then force the product into past_due
- * directly in Postgres (no webhook dependency). Returns the Stripe customer + subscription ids.
- */
-const driveProductPastDue = async ({
-	ctx,
-	testClockId,
-	customerId,
-	productId,
-}: {
-	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
-	testClockId: string;
-	customerId: string;
-	productId: string;
-}) => {
-	const subscriptionId = await getSubscriptionId({
-		ctx,
-		customerId,
-		productId,
-	});
-
-	const customer = await CusService.get({
-		db: ctx.db,
-		idOrInternalId: customerId,
-		orgId: ctx.org.id,
-		env: ctx.env,
-	});
-
-	await attachFailedPaymentMethod({
-		stripeCli: ctx.stripeCli,
-		customer: customer!,
-	});
-
-	const paymentMethods = await ctx.stripeCli.paymentMethods.list({
-		customer: customer!.processor?.id,
-	});
-	await ctx.stripeCli.subscriptions.update(subscriptionId, {
-		default_payment_method: paymentMethods.data[0].id,
-	});
-
-	await advanceToNextInvoice({ stripeCli: ctx.stripeCli, testClockId });
-	await timeout(4000);
-
-	// Flip the customer_product to past_due directly (no public API; webhook sync is unreliable
-	// locally), then bust the cache so the HTTP server re-reads it from Postgres.
-	const fullCustomer = await CusService.getFull({
-		ctx,
-		idOrInternalId: customerId,
-	});
-	const customerProduct = fullCustomer.customer_products.find(
-		(cp) => cp.product.id === productId,
-	);
-	await ctx.db
-		.update(customerProducts)
-		.set({ status: CusProductStatus.PastDue })
-		.where(eq(customerProducts.id, customerProduct!.id));
-	await deleteCachedFullCustomer({ ctx, customerId });
-
-	return { subscriptionId, stripeCustomerId: customer!.processor?.id };
-};
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // PRIMARY (pre-impl RED): flag on + past_due + cancel_end_of_cycle -> immediate + void

--- a/server/tests/integration/billing/update-subscription/cancel/end-of-cycle/cancel-end-of-cycle-past-due-void.test.ts
+++ b/server/tests/integration/billing/update-subscription/cancel/end-of-cycle/cancel-end-of-cycle-past-due-void.test.ts
@@ -1,34 +1,7 @@
-/**
- * TDD (feature) for: void-on-cancel orgs cancel past_due customers immediately.
- *
- * Contract under test:
- *   New behavior:
- *     - flag void_invoices_on_subscription_deletion ON + product past_due + cancel_action "cancel_end_of_cycle"
- *       -> resolves to an IMMEDIATE cancel: product removed now, default/free active now (not scheduled).
- *   Side effects:
- *     - that immediate cancel voids the subscription's open/uncollectible invoices INLINE
- *       (the Autumn cancel sets the sub:<id> lock, so the subscription.deleted webhook is skipped).
- *   Gating (unchanged behavior, control cases):
- *     - flag OFF + past_due + cancel_end_of_cycle -> still scheduled-cancel, open invoice NOT voided.
- *     - flag ON + NOT past_due + cancel_end_of_cycle -> normal end-of-cycle (canceling + free scheduled).
- *
- * Pre-impl red: the PRIMARY test fails because cancel_end_of_cycle on a past_due sub today
- *   schedules the cancel (pro stays, free not active) and never voids the open invoice on the
- *   Autumn-initiated path.
- *
- * past_due setup: attach with a good card, swap the SUBSCRIPTION's default_payment_method to a
- * failing card and advance the test clock so the renewal charge fails (produces a real open
- * invoice in Stripe). The customer_product.status is then flipped to past_due directly in
- * Postgres (+ cache bust) rather than waiting on the subscription.updated webhook -- there is no
- * public API to set past_due, and the webhook sync is the flakiest part of a local run. This
- * mirrors balances/cron/past-due-reset.test.ts. What we're actually testing is the cancel
- * behavior, not the past_due sync.
- *
- * These tests mutate shared org.config, so they run serially (plain `test`) and restore in `finally`.
- */
+// void-on-cancel: flag ON + past_due + cancel_end_of_cycle -> immediate cancel + voided invoice.
+// PRIMARY + 2 controls (flag off; not past_due). Serial (shared org.config, restored in finally).
 
 import { expect, test } from "bun:test";
-import type { Stripe } from "stripe";
 import type { ApiCustomerV3 } from "@autumn/shared";
 import { CusProductStatus, customerProducts } from "@autumn/shared";
 import {
@@ -46,6 +19,7 @@ import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUti
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { eq } from "drizzle-orm";
+import type { Stripe } from "stripe";
 import { attachFailedPaymentMethod } from "@/external/stripe/stripeCusUtils";
 import { CusService } from "@/internal/customers/CusService";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
@@ -217,9 +191,9 @@ test(`${chalk.yellowBright("cancel eoc past_due: flag on -> cancels immediately 
 		const allInvoices = await ctx.stripeCli.invoices.list({
 			customer: stripeCustomerId,
 		});
-		expect(
-			allInvoices.data.filter((inv) => (inv.total ?? 0) < 0).length,
-		).toBe(0);
+		expect(allInvoices.data.filter((inv) => (inv.total ?? 0) < 0).length).toBe(
+			0,
+		);
 		const stripeCustomer = (await ctx.stripeCli.customers.retrieve(
 			stripeCustomerId!,
 		)) as Stripe.Customer;

--- a/server/tests/integration/billing/utils/driveProductPastDue.ts
+++ b/server/tests/integration/billing/utils/driveProductPastDue.ts
@@ -1,0 +1,71 @@
+import { CusProductStatus, customerProducts } from "@autumn/shared";
+import { getSubscriptionId } from "@tests/integration/billing/utils/stripe/getSubscriptionId";
+import { advanceToNextInvoice } from "@tests/utils/testAttachUtils/testAttachUtils";
+import type { initScenario } from "@tests/utils/testInitUtils/initScenario";
+import { eq } from "drizzle-orm";
+import { attachFailedPaymentMethod } from "@/external/stripe/stripeCusUtils";
+import { CusService } from "@/internal/customers/CusService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+import { timeout } from "@/utils/genUtils";
+
+type ScenarioCtx = Awaited<ReturnType<typeof initScenario>>["ctx"];
+
+// Fails the renewal (real open invoice), then forces only this product to past_due in Postgres
+// (webhook sync is unreliable locally; mirrors balances/cron/past-due-reset.test.ts).
+export const driveProductPastDue = async ({
+	ctx,
+	testClockId,
+	customerId,
+	productId,
+}: {
+	ctx: ScenarioCtx;
+	testClockId: string;
+	customerId: string;
+	productId: string;
+}): Promise<{
+	subscriptionId: string;
+	stripeCustomerId: string | undefined;
+}> => {
+	const subscriptionId = await getSubscriptionId({
+		ctx,
+		customerId,
+		productId,
+	});
+
+	const customer = await CusService.get({
+		db: ctx.db,
+		idOrInternalId: customerId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+	await attachFailedPaymentMethod({
+		stripeCli: ctx.stripeCli,
+		customer: customer!,
+	});
+
+	const paymentMethods = await ctx.stripeCli.paymentMethods.list({
+		customer: customer!.processor?.id,
+	});
+	await ctx.stripeCli.subscriptions.update(subscriptionId, {
+		default_payment_method: paymentMethods.data[0].id,
+	});
+
+	await advanceToNextInvoice({ stripeCli: ctx.stripeCli, testClockId });
+	await timeout(4000);
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const customerProduct = fullCustomer.customer_products.find(
+		(cp) => cp.product.id === productId,
+	);
+	await ctx.db
+		.update(customerProducts)
+		.set({ status: CusProductStatus.PastDue })
+		.where(eq(customerProducts.id, customerProduct!.id));
+	await deleteCachedFullCustomer({ ctx, customerId });
+
+	return { subscriptionId, stripeCustomerId: customer!.processor?.id };
+};

--- a/server/tests/unit/billing/stripe/invoices/void-open-invoices-for-subscription.spec.ts
+++ b/server/tests/unit/billing/stripe/invoices/void-open-invoices-for-subscription.spec.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import chalk from "chalk";
+import type Stripe from "stripe";
+
+const updateFromStripeCalls: string[] = [];
+
+mock.module("@/internal/invoices/actions", () => ({
+	invoiceActions: {
+		updateFromStripe: async ({
+			stripeInvoice,
+		}: {
+			stripeInvoice: Stripe.Invoice;
+		}) => {
+			updateFromStripeCalls.push(stripeInvoice.id);
+		},
+	},
+}));
+
+const { voidOpenInvoicesForStripeSubscription } = await import(
+	"@/external/stripe/invoices/operations/voidOpenInvoicesForStripeSubscription"
+);
+
+const ctx = {
+	logger: { info: () => {}, warn: () => {}, error: () => {} },
+} as never;
+
+const inv = (id: string, status: Stripe.Invoice.Status) =>
+	({ id, status }) as Stripe.Invoice;
+
+type Page = { data: Stripe.Invoice[]; has_more: boolean };
+
+const fakeStripe = ({
+	pages,
+	failVoidIds = [],
+}: {
+	pages: Page[];
+	failVoidIds?: string[];
+}) => {
+	const listCalls: Stripe.InvoiceListParams[] = [];
+	const voided: string[] = [];
+	let pageIndex = 0;
+
+	const stripeCli = {
+		invoices: {
+			list: async (params: Stripe.InvoiceListParams) => {
+				listCalls.push(params);
+				return pages[pageIndex++] ?? { data: [], has_more: false };
+			},
+			voidInvoice: async (id: string) => {
+				if (failVoidIds.includes(id)) throw new Error(`cannot void ${id}`);
+				voided.push(id);
+				return inv(id, "void");
+			},
+		},
+	} as unknown as Stripe;
+
+	return { stripeCli, listCalls, voided };
+};
+
+const run = (stripeCli: Stripe) =>
+	voidOpenInvoicesForStripeSubscription({
+		ctx,
+		stripeCli,
+		customerId: "cus_internal",
+		stripeCustomerId: "cus_stripe",
+		subscriptionId: "sub_123",
+	});
+
+describe(chalk.yellowBright("voidOpenInvoicesForStripeSubscription"), () => {
+	beforeEach(() => {
+		updateFromStripeCalls.length = 0;
+	});
+
+	test("voids only open/uncollectible invoices, leaving paid/draft untouched", async () => {
+		const { stripeCli, voided } = fakeStripe({
+			pages: [
+				{
+					data: [
+						inv("inv_open", "open"),
+						inv("inv_paid", "paid"),
+						inv("inv_uncollectible", "uncollectible"),
+						inv("inv_draft", "draft"),
+					],
+					has_more: false,
+				},
+			],
+		});
+
+		const result = await run(stripeCli);
+
+		expect(result).toEqual({ voided: 2, failed: 0 });
+		expect(voided.sort()).toEqual(["inv_open", "inv_uncollectible"]);
+		expect(updateFromStripeCalls.sort()).toEqual([
+			"inv_open",
+			"inv_uncollectible",
+		]);
+	});
+
+	test("partial void failure is counted, not thrown; success still records", async () => {
+		const { stripeCli, voided } = fakeStripe({
+			pages: [
+				{
+					data: [
+						inv("inv_a", "open"),
+						inv("inv_b", "uncollectible"),
+						inv("inv_c", "open"),
+					],
+					has_more: false,
+				},
+			],
+			failVoidIds: ["inv_b"],
+		});
+
+		const result = await run(stripeCli);
+
+		expect(result).toEqual({ voided: 2, failed: 1 });
+		expect(voided.sort()).toEqual(["inv_a", "inv_c"]);
+		// The failed invoice never reaches the DB sync.
+		expect(updateFromStripeCalls).not.toContain("inv_b");
+		expect(updateFromStripeCalls.sort()).toEqual(["inv_a", "inv_c"]);
+	});
+
+	test("paginates past 100 invoices, threading starting_after by last id", async () => {
+		const firstPage = Array.from({ length: 100 }, (_, i) =>
+			inv(`inv_p1_${i}`, "open"),
+		);
+		const secondPage = Array.from({ length: 30 }, (_, i) =>
+			inv(`inv_p2_${i}`, "open"),
+		);
+
+		const { stripeCli, listCalls, voided } = fakeStripe({
+			pages: [
+				{ data: firstPage, has_more: true },
+				{ data: secondPage, has_more: false },
+			],
+		});
+
+		const result = await run(stripeCli);
+
+		expect(result).toEqual({ voided: 130, failed: 0 });
+		expect(voided).toHaveLength(130);
+		expect(listCalls).toHaveLength(2);
+		expect(listCalls[0]?.starting_after).toBeUndefined();
+		expect(listCalls[1]?.starting_after).toBe("inv_p1_99");
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Past-due end-of-cycle cancellations now cancel immediately and void the unpaid invoice when the org flag is enabled. We also suppress proration credits so customers don’t get credit for cycles they didn’t pay.

- **New Features**
  - Past-due `cancel_end_of_cycle` is forced to `cancel_immediately` when `org.config.void_invoices_on_subscription_deletion` is true.
  - Added `voidOpenInvoicesForStripeSubscription`: lists invoices and voids only `open`/`uncollectible`; paid invoices are untouched; partial failures are tolerated and synced via `invoiceActions.updateFromStripe`.
  - Voiding runs inline in both update and cancel flows, only when the whole subscription is cancelled (not on partial item removals), and only for non-deferred Stripe actions.
  - Suppressed proration credits for past-due immediate cancels by enforcing `proration_behavior: "none"` even if the caller requests proration.
  - Added unit and integration tests covering flag gating, shared-subscription behavior, pagination, and failure handling.

- **Refactors**
  - Deduplicated test helper `driveProductPastDue`; both suites now import `@tests/integration/billing/utils/driveProductPastDue`.

<sup>Written for commit 97b77f5593dba536623c2c643ed8efafbce9a12e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes past-due `cancel_end_of_cycle` requests behave as immediate cancellations and void the unpaid invoice when `org.config.void_invoices_on_subscription_deletion` is enabled, preventing customers from receiving proration credit for cycles they never paid.

- **[Improvements]** `setupCancelAction` now forces `cancel_immediately` for past-due products when the void flag is on, and `shouldSuppressUnpaidCycleCredit` overrides `proration_behavior` to `"none"` to block any credit for the unpaid cycle.
- **[Improvements]** New `voidInvoicesOnImmediateCancel` orchestrator (called in both `handleCancelV2` and `updateSubscription`) gates on the void flag, cancel action, deferred state, and whole-subscription cancellation before calling the new `voidOpenInvoicesForStripeSubscription` utility, which paginates and voids `open`/`uncollectible` invoices with per-invoice failure tolerance.
- **[Improvements]** Shared `driveProductPastDue` test helper extracted and imported by both new integration test suites; unit tests cover status filtering, failure counting, and pagination; edge-case integration tests cover explicit proration override, shared-sub collateral protection, uncollectible invoices, and omitted `cancel_action` gating.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — core cancellation logic is well-guarded and the billing path changes are small and correctly placed.

All new code paths are tightly gated (flag, cancel action, deferred state, whole-subscription cancel). Proration suppression and invoice voiding are both independently correct. The void runs after the subscription is already cancelled, and per-invoice failure tolerance handles the webhook race cleanly. Tests are thorough. The only change worth noting before merge is the staging allowlist replacement rather than addition.

.github/workflows/build.yml — the STAGING_DEPLOY_BRANCH_ALLOWLIST was replaced entirely rather than extended.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/execute/voidInvoicesOnImmediateCancel.ts | New orchestrator called after executeBillingPlan; gates on flag, cancel_immediately action, non-deferred Stripe result, and full subscription cancel (not partial item removal) before invoking voidOpenInvoicesForStripeSubscription. |
| server/src/external/stripe/invoices/operations/voidOpenInvoicesForStripeSubscription.ts | New utility that paginates and voids open/uncollectible invoices for a subscription; per-invoice error tolerance, correct pagination, and DB sync via invoiceActions.updateFromStripe. |
| server/src/internal/billing/v2/setup/setupCancelMode.ts | Adds two exported helpers: shouldForcePastDueImmediateCancel (rewrites cancel_end_of_cycle → cancel_immediately for past-due with void flag) and shouldSuppressUnpaidCycleCredit (returns true to force proration_behavior="none" in that scenario). |
| server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts | Wires org and customerProduct into setupCancelAction and computes suppressUnpaidCycleCredit to override requestedProrationBehavior to "none", correctly ordered before the return value is assembled. |
| server/src/internal/customers/cancel/handleCancelV2.ts | Adds voidInvoicesOnImmediateCancel call in the same position as updateSubscription.ts — after executeBillingPlan and before logging the result. |
| .github/workflows/build.yml | Replaces the entire STAGING_DEPLOY_BRANCH_ALLOWLIST (7 branches) with only the current feature branch, removing all previously listed branches from staging access. |

</details>

<sub>Reviews (2): Last reviewed commit: ["dedupe driveProductPastDue"](https://github.com/useautumn/autumn/commit/97b77f5593dba536623c2c643ed8efafbce9a12e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37677154)</sub>

<!-- /greptile_comment -->