### PR TITLE
feat(balances): add next_reset_at param to create balance

### DIFF
--- a/apps/docs/mintlify/api-reference/balances/createBalance.mdx
+++ b/apps/docs/mintlify/api-reference/balances/createBalance.mdx
@@ -61,6 +61,10 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
   Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset.
 </DynamicParamField>
 
+<DynamicParamField body="next_reset_at" type="number">
+  Unix timestamp (milliseconds) for the first reset boundary, allowing a custom (e.g. shorter) first period. Requires 'reset', and must occur before 'expires_at' if both are provided. Subsequent resets advance by one reset interval from this boundary.
+</DynamicParamField>
+
 <DynamicParamField body="balance_id" type="string">
   A unique identifier for this balance. Use this to target the balance in future update / delete calls.
 </DynamicParamField>

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -15934,6 +15934,13 @@ paths:
                   type: number
                   description: Unix timestamp (milliseconds) when the balance expires. Mutually
                     exclusive with reset.
+                next_reset_at:
+                  type: number
+                  description: Unix timestamp (milliseconds) for the first reset boundary,
+                    allowing a custom (e.g. shorter) first period. Requires
+                    'reset', and must occur before 'expires_at' if both are
+                    provided. Subsequent resets advance by one reset interval
+                    from this boundary.
                 balance_id:
                   type: string
                   description: A unique identifier for this balance. Use this to target the
@@ -18830,6 +18837,7 @@ paths:
                   enum:
                     - day
                     - hour
+                    - week
                     - month
                   type: string
                   default: day

--- a/others/python-sdk/src/autumn_sdk/balances.py
+++ b/others/python-sdk/src/autumn_sdk/balances.py
@@ -24,6 +24,7 @@ class Balances(BaseSDK):
             Union[models.CreateBalanceRollover, models.CreateBalanceRolloverTypedDict]
         ] = None,
         expires_at: Optional[float] = None,
+        next_reset_at: Optional[float] = None,
         balance_id: Optional[str] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
@@ -40,6 +41,7 @@ class Balances(BaseSDK):
         :param reset: Reset configuration for the balance. If not provided, the balance is a one-time grant that never resets.
         :param rollover: Rollover configuration for the balance.
         :param expires_at: Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset.
+        :param next_reset_at: Unix timestamp (milliseconds) for the first reset boundary, allowing a custom (e.g. shorter) first period. Requires 'reset', and must occur before 'expires_at' if both are provided. Subsequent resets advance by one reset interval from this boundary.
         :param balance_id: A unique identifier for this balance. Use this to target the balance in future update / delete calls.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
@@ -67,6 +69,7 @@ class Balances(BaseSDK):
                 rollover, Optional[models.CreateBalanceRollover]
             ),
             expires_at=expires_at,
+            next_reset_at=next_reset_at,
             balance_id=balance_id,
         )
 
@@ -144,6 +147,7 @@ class Balances(BaseSDK):
             Union[models.CreateBalanceRollover, models.CreateBalanceRolloverTypedDict]
         ] = None,
         expires_at: Optional[float] = None,
+        next_reset_at: Optional[float] = None,
         balance_id: Optional[str] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
@@ -160,6 +164,7 @@ class Balances(BaseSDK):
         :param reset: Reset configuration for the balance. If not provided, the balance is a one-time grant that never resets.
         :param rollover: Rollover configuration for the balance.
         :param expires_at: Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset.
+        :param next_reset_at: Unix timestamp (milliseconds) for the first reset boundary, allowing a custom (e.g. shorter) first period. Requires 'reset', and must occur before 'expires_at' if both are provided. Subsequent resets advance by one reset interval from this boundary.
         :param balance_id: A unique identifier for this balance. Use this to target the balance in future update / delete calls.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
@@ -187,6 +192,7 @@ class Balances(BaseSDK):
                 rollover, Optional[models.CreateBalanceRollover]
             ),
             expires_at=expires_at,
+            next_reset_at=next_reset_at,
             balance_id=balance_id,
         )
 

--- a/others/python-sdk/src/autumn_sdk/models/createbalanceop.py
+++ b/others/python-sdk/src/autumn_sdk/models/createbalanceop.py
@@ -161,6 +161,8 @@ class CreateBalanceParamsTypedDict(TypedDict):
     r"""Rollover configuration for the balance."""
     expires_at: NotRequired[float]
     r"""Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset."""
+    next_reset_at: NotRequired[float]
+    r"""Unix timestamp (milliseconds) for the first reset boundary, allowing a custom (e.g. shorter) first period. Requires 'reset', and must occur before 'expires_at' if both are provided. Subsequent resets advance by one reset interval from this boundary."""
     balance_id: NotRequired[str]
     r"""A unique identifier for this balance. Use this to target the balance in future update / delete calls."""
 
@@ -190,6 +192,9 @@ class CreateBalanceParams(BaseModel):
     expires_at: Optional[float] = None
     r"""Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset."""
 
+    next_reset_at: Optional[float] = None
+    r"""Unix timestamp (milliseconds) for the first reset boundary, allowing a custom (e.g. shorter) first period. Requires 'reset', and must occur before 'expires_at' if both are provided. Subsequent resets advance by one reset interval from this boundary."""
+
     balance_id: Optional[str] = None
     r"""A unique identifier for this balance. Use this to target the balance in future update / delete calls."""
 
@@ -203,6 +208,7 @@ class CreateBalanceParams(BaseModel):
                 "reset",
                 "rollover",
                 "expires_at",
+                "next_reset_at",
                 "balance_id",
             ]
         )

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -15247,6 +15247,13 @@ paths:
                   type: number
                   description: Unix timestamp (milliseconds) when the balance expires. Mutually
                     exclusive with reset.
+                next_reset_at:
+                  type: number
+                  description: Unix timestamp (milliseconds) for the first reset boundary,
+                    allowing a custom (e.g. shorter) first period. Requires
+                    'reset', and must occur before 'expires_at' if both are
+                    provided. Subsequent resets advance by one reset interval
+                    from this boundary.
                 balance_id:
                   type: string
                   description: A unique identifier for this balance. Use this to target the
@@ -17902,6 +17909,7 @@ paths:
                   enum:
                     - day
                     - hour
+                    - week
                     - month
                   type: string
                   default: day

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -9519,7 +9519,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1781265695558,"plans":[{"planId":"trial_plan"}]},{"startsAt":1782475295558,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1781546357840,"plans":[{"planId":"trial_plan"}]},{"startsAt":1782755957840,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -16040,6 +16040,13 @@ paths:
                   type: number
                   description: Unix timestamp (milliseconds) when the balance expires. Mutually
                     exclusive with reset.
+                next_reset_at:
+                  type: number
+                  description: Unix timestamp (milliseconds) for the first reset boundary,
+                    allowing a custom (e.g. shorter) first period. Requires
+                    'reset', and must occur before 'expires_at' if both are
+                    provided. Subsequent resets advance by one reset interval
+                    from this boundary.
                 balance_id:
                   type: string
                   description: A unique identifier for this balance. Use this to target the
@@ -18836,6 +18843,7 @@ paths:
                   enum:
                     - day
                     - hour
+                    - week
                     - month
                   type: string
                   default: day

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -8799,7 +8799,7 @@ paths:
         @example
         ```typescript
         // Schedule a transition from a trial plan to a paid plan
-        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1781265695558,"plans":[{"planId":"trial_plan"}]},{"startsAt":1782475295558,"plans":[{"planId":"pro_plan"}]}] });
+        const response = await client.billing.createSchedule({ customerId: "cus_123", phases: [{"startsAt":1781546357840,"plans":[{"planId":"trial_plan"}]},{"startsAt":1782755957840,"plans":[{"planId":"pro_plan"}]}] });
         ```
 
         @param customerId - The ID of the customer to create the schedule for.
@@ -14663,6 +14663,9 @@ paths:
                 expires_at:
                   type: number
                   description: Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset.
+                next_reset_at:
+                  type: number
+                  description: Unix timestamp (milliseconds) for the first reset boundary, allowing a custom (e.g. shorter) first period. Requires 'reset', and must occur before 'expires_at' if both are provided. Subsequent resets advance by one reset interval from this boundary.
                 balance_id:
                   type: string
                   description: A unique identifier for this balance. Use this to target the balance in future update / delete calls.
@@ -17178,6 +17181,7 @@ paths:
                   enum:
                     - day
                     - hour
+                    - week
                     - month
                   type: string
                   default: day

--- a/packages/sdk/src/models/create-balance-op.ts
+++ b/packages/sdk/src/models/create-balance-op.ts
@@ -97,6 +97,10 @@ export type CreateBalanceParams = {
    */
   expiresAt?: number | undefined;
   /**
+   * Unix timestamp (milliseconds) for the first reset boundary, allowing a custom (e.g. shorter) first period. Requires 'reset', and must occur before 'expires_at' if both are provided. Subsequent resets advance by one reset interval from this boundary.
+   */
+  nextResetAt?: number | undefined;
+  /**
    * A unique identifier for this balance. Use this to target the balance in future update / delete calls.
    */
   balanceId?: string | undefined;
@@ -193,6 +197,7 @@ export type CreateBalanceParams$Outbound = {
   reset?: CreateBalanceReset$Outbound | undefined;
   rollover?: CreateBalanceRollover$Outbound | undefined;
   expires_at?: number | undefined;
+  next_reset_at?: number | undefined;
   balance_id?: string | undefined;
 };
 
@@ -210,6 +215,7 @@ export const CreateBalanceParams$outboundSchema: z.ZodMiniType<
     reset: z.optional(z.lazy(() => CreateBalanceReset$outboundSchema)),
     rollover: z.optional(z.lazy(() => CreateBalanceRollover$outboundSchema)),
     expiresAt: z.optional(z.number()),
+    nextResetAt: z.optional(z.number()),
     balanceId: z.optional(z.string()),
   }),
   z.transform((v) => {
@@ -219,6 +225,7 @@ export const CreateBalanceParams$outboundSchema: z.ZodMiniType<
       entityId: "entity_id",
       includedGrant: "included_grant",
       expiresAt: "expires_at",
+      nextResetAt: "next_reset_at",
       balanceId: "balance_id",
     });
   }),

--- a/server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts
+++ b/server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts
@@ -78,6 +78,13 @@ export const prepareNewBalanceForInsertion = async ({
 		newCustomerEntitlement.next_reset_at = null;
 	}
 
+	// Apply an explicit first reset boundary if provided. This overrides the
+	// derived next_reset_at (and the null set above when expires_at is present),
+	// allowing a custom first period that resets up until expiry.
+	if (params.next_reset_at) {
+		newCustomerEntitlement.next_reset_at = params.next_reset_at;
+	}
+
 	if (params.balance_id) {
 		newCustomerEntitlement.external_id = params.balance_id;
 	}

--- a/server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts
+++ b/server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts
@@ -81,7 +81,7 @@ export const prepareNewBalanceForInsertion = async ({
 	// Apply an explicit first reset boundary if provided. This overrides the
 	// derived next_reset_at (and the null set above when expires_at is present),
 	// allowing a custom first period that resets up until expiry.
-	if (params.next_reset_at) {
+	if (params.next_reset_at !== undefined) {
 		newCustomerEntitlement.next_reset_at = params.next_reset_at;
 	}
 

--- a/server/src/internal/balances/createBalance/validateCreateBalance.ts
+++ b/server/src/internal/balances/createBalance/validateCreateBalance.ts
@@ -80,15 +80,26 @@ export const validateCreateBalanceParams = async ({
 	}
 
 	// An explicit next_reset_at only makes sense for a resetting balance.
-	if (params.next_reset_at && !params.reset?.interval) {
+	if (params.next_reset_at !== undefined && !params.reset?.interval) {
 		throw new RecaseError({
 			message: `next_reset_at requires a reset interval to be provided`,
 		});
 	}
 
+	// An explicit first reset boundary must be in the future — a past value would
+	// immediately fire a lazy reset and cycle the balance the caller just created.
+	if (
+		params.next_reset_at !== undefined &&
+		params.next_reset_at <= Date.now()
+	) {
+		throw new RecaseError({
+			message: `next_reset_at must be in the future`,
+		});
+	}
+
 	// The first reset must happen before the balance expires.
 	if (
-		params.next_reset_at &&
+		params.next_reset_at !== undefined &&
 		params.expires_at &&
 		params.next_reset_at >= params.expires_at
 	) {

--- a/server/src/internal/balances/createBalance/validateCreateBalance.ts
+++ b/server/src/internal/balances/createBalance/validateCreateBalance.ts
@@ -79,6 +79,24 @@ export const validateCreateBalanceParams = async ({
 		}
 	}
 
+	// An explicit next_reset_at only makes sense for a resetting balance.
+	if (params.next_reset_at && !params.reset?.interval) {
+		throw new RecaseError({
+			message: `next_reset_at requires a reset interval to be provided`,
+		});
+	}
+
+	// The first reset must happen before the balance expires.
+	if (
+		params.next_reset_at &&
+		params.expires_at &&
+		params.next_reset_at >= params.expires_at
+	) {
+		throw new RecaseError({
+			message: `next_reset_at (${new Date(params.next_reset_at).toISOString()}) must occur before expires_at (${new Date(params.expires_at).toISOString()})`,
+		});
+	}
+
 	if (params.balance_id) {
 		await validateBalanceIdUnique({
 			ctx,

--- a/server/tests/integration/balances/create/create-balance-next-reset-at.test.ts
+++ b/server/tests/integration/balances/create/create-balance-next-reset-at.test.ts
@@ -1,0 +1,207 @@
+/**
+ * TDD feature test for `next_reset_at` as a create-balance parameter.
+ *
+ * Contract under test:
+ *   New field on POST /balances/create:
+ *     - next_reset_at?: number (unix ms) — explicit timestamp for the FIRST reset
+ *       boundary, allowing a custom (e.g. short) first period. Requires `reset`.
+ *   New behaviors:
+ *     - create with reset + next_reset_at -> the cusEnt's next_reset_at equals the
+ *       provided value verbatim (NOT the derived `now + interval`).
+ *     - deduction does not move next_reset_at.
+ *     - when next_reset_at passes, the balance refills AND the next boundary is
+ *       anchored on the prior boundary + one interval (NOT `now + interval`),
+ *       i.e. periods stay aligned to the custom first boundary.
+ *   New validation:
+ *     - next_reset_at without `reset` -> rejected.
+ *     - next_reset_at >= expires_at -> rejected (next reset must precede expiry).
+ *
+ * Pre-impl red:
+ *   - `next_reset_at` is not in CreateBalanceParamsV0Schema, so zod strips it and
+ *     prepareNewBalanceForInsertion derives next_reset_at = now + interval. The
+ *     verbatim-equality assertion fails.
+ *   - No validation exists, so both rejection assertions fail (calls succeed).
+ *
+ * Post-impl green:
+ *   - Schema accepts next_reset_at; prepareNewBalanceForInsertion applies it;
+ *     validateCreateBalanceParams enforces the two rules.
+ *
+ * Clock note: a create-balance cusEnt is a "free" (price-less) entitlement, so it
+ * resets via the LAZY path (next_reset_at < Date.now() on read) — the Stripe test
+ * clock does not drive it. We simulate the boundary passing with
+ * `expireCusEntForReset` (stamps next_reset_at into the past across PG + both Redis
+ * caches); the next read fires the lazy reset.
+ */
+
+import { expect, test } from "bun:test";
+import { type CheckResponseV2, ResetInterval } from "@autumn/shared";
+import { UTCDate } from "@date-fns/utc";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expireCusEntForReset } from "@tests/utils/cusProductUtils/resetTestUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { add } from "date-fns";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const checkBalance = async (autumn: AutumnInt, customerId: string) => {
+	const res = (await autumn.check({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	})) as unknown as CheckResponseV2;
+	return res.balance?.current_balance;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Happy path: create (t0) -> deduct (t1) -> reset (t5)
+//   t0: 50/50, next_reset = t5 (custom short first period), interval = 1 month
+//   t1: use 10 -> 40/50, next_reset still t5
+//   t5: boundary passes -> 50/50, next_reset = t5 + 1 month  (~t15)
+// ─────────────────────────────────────────────────────────────────────────────
+test.concurrent(
+	`${chalk.yellowBright("create-balance next_reset_at: custom first period, reset re-anchors on boundary + interval")}`,
+	async () => {
+		const customerId = "create-balance-nra-happy";
+
+		const { autumnV1, autumnV2, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		// ── t0: create loose balance with explicit next_reset_at ────────────────
+		// "5t" first period: 10 days out — deliberately shorter than the 1-month
+		// ("10t") interval, which is only possible via the new param.
+		const customNextResetAt = Date.now() + 10 * DAY_MS;
+
+		await autumnV1.post("/balances/create", {
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: 50,
+			reset: { interval: ResetInterval.Month },
+			next_reset_at: customNextResetAt,
+		});
+
+		// Contract: next_reset_at honored verbatim (pre-fix: derived ~now+1month)
+		const t0Balance = await checkBalance(autumnV2, customerId);
+		expect(t0Balance).toBe(50);
+
+		const t0CusEnt = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(t0CusEnt).toBeDefined();
+		expect(t0CusEnt!.next_reset_at).toBe(customNextResetAt);
+
+		// ── t1: use 10 -> 40/50, boundary unchanged ─────────────────────────────
+		await autumnV1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 10,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		const t1Balance = await checkBalance(autumnV2, customerId);
+		expect(t1Balance).toBe(40);
+
+		const t1CusEnt = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(t1CusEnt!.next_reset_at).toBe(customNextResetAt);
+
+		// ── t5: simulate the boundary passing ───────────────────────────────────
+		// Stamp the boundary 5 days in the past so the re-anchored next boundary
+		// (pastBoundary + 1 month) lands measurably BEFORE `now + 1 month`,
+		// making "anchored on boundary, not on now" a real assertion.
+		const pastBoundary = Date.now() - 5 * DAY_MS;
+		await expireCusEntForReset({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			pastTimeMs: pastBoundary,
+		});
+
+		// Read triggers lazy reset -> balance refills to 50
+		const t5Balance = await checkBalance(autumnV2, customerId);
+		expect(t5Balance).toBe(50);
+
+		const t5CusEnt = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(t5CusEnt!.next_reset_at).toBeGreaterThan(Date.now());
+
+		// Anchored on the prior boundary + one interval (≈ t15)…
+		const expectedNext = add(new UTCDate(pastBoundary), {
+			months: 1,
+		}).getTime();
+		expect(Math.abs(t5CusEnt!.next_reset_at! - expectedNext)).toBeLessThan(
+			DAY_MS,
+		);
+		// …and provably NOT `now + interval` (which would be ~5 days later).
+		const nowPlusInterval = add(new UTCDate(), { months: 1 }).getTime();
+		expect(t5CusEnt!.next_reset_at!).toBeLessThan(nowPlusInterval - 3 * DAY_MS);
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation: next_reset_at requires a reset
+// ─────────────────────────────────────────────────────────────────────────────
+test.concurrent(
+	`${chalk.yellowBright("create-balance next_reset_at: rejected without a reset interval")}`,
+	async () => {
+		const customerId = "create-balance-nra-no-reset";
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await expect(
+			autumnV1.post("/balances/create", {
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				included_grant: 50,
+				// no `reset`
+				next_reset_at: Date.now() + 10 * DAY_MS,
+			}),
+		).rejects.toThrow();
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation: next_reset_at must precede expires_at
+// ─────────────────────────────────────────────────────────────────────────────
+test.concurrent(
+	`${chalk.yellowBright("create-balance next_reset_at: rejected when it occurs at/after expires_at")}`,
+	async () => {
+		const customerId = "create-balance-nra-after-expiry";
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		const nextResetAt = Date.now() + 20 * DAY_MS;
+		const expiresAt = Date.now() + 10 * DAY_MS; // expiry BEFORE next reset -> invalid
+
+		await expect(
+			autumnV1.post("/balances/create", {
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				included_grant: 50,
+				reset: { interval: ResetInterval.Month },
+				next_reset_at: nextResetAt,
+				expires_at: expiresAt,
+			}),
+		).rejects.toThrow();
+	},
+);

--- a/server/tests/integration/balances/create/create-balance-next-reset-at.test.ts
+++ b/server/tests/integration/balances/create/create-balance-next-reset-at.test.ts
@@ -14,6 +14,7 @@
  *       i.e. periods stay aligned to the custom first boundary.
  *   New validation:
  *     - next_reset_at without `reset` -> rejected.
+ *     - next_reset_at in the past -> rejected (would immediately cycle the balance).
  *     - next_reset_at >= expires_at -> rejected (next reset must precede expiry).
  *
  * Pre-impl red:
@@ -171,6 +172,32 @@ test.concurrent(
 				included_grant: 50,
 				// no `reset`
 				next_reset_at: Date.now() + 10 * DAY_MS,
+			}),
+		).rejects.toThrow();
+	},
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation: next_reset_at must be in the future
+// ─────────────────────────────────────────────────────────────────────────────
+test.concurrent(
+	`${chalk.yellowBright("create-balance next_reset_at: rejected when in the past")}`,
+	async () => {
+		const customerId = "create-balance-nra-past";
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		await expect(
+			autumnV1.post("/balances/create", {
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				included_grant: 50,
+				reset: { interval: ResetInterval.Month },
+				next_reset_at: Date.now() - 10 * DAY_MS, // already elapsed
 			}),
 		).rejects.toThrow();
 	},

--- a/shared/api/balances/create/createBalanceParams.ts
+++ b/shared/api/balances/create/createBalanceParams.ts
@@ -43,6 +43,11 @@ export const ExtCreateBalanceParamsSchema = BalanceParamsBaseSchema.extend({
 			"Unix timestamp (milliseconds) when the balance expires. Mutually exclusive with reset.",
 	}),
 
+	next_reset_at: z.number().optional().meta({
+		description:
+			"Unix timestamp (milliseconds) for the first reset boundary, allowing a custom (e.g. shorter) first period. Requires 'reset', and must occur before 'expires_at' if both are provided. Subsequent resets advance by one reset interval from this boundary.",
+	}),
+
 	balance_id: z.string().optional().meta({
 		description:
 			"A unique identifier for this balance. Use this to target the balance in future update / delete calls.",

--- a/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
@@ -69,6 +69,7 @@ export function BalanceCreateSheet() {
 	const [resetInterval, setResetInterval] = useState<string>("");
 	const [oneOff, setOneOff] = useState(false);
 	const [expiresAt, setExpiresAt] = useState<number | null>(null);
+	const [nextResetAt, setNextResetAt] = useState<number | null>(null);
 	const [rollover, setRollover] = useState<RolloverConfig | null>(null);
 
 	// Rollover requires a recurring reset interval. If the interval goes away
@@ -111,6 +112,10 @@ export function BalanceCreateSheet() {
 		if (!nextIsMetered || nextIsContUse) {
 			setRollover(null);
 		}
+		// next_reset_at only applies to a resetting (metered) balance.
+		if (!nextIsMetered) {
+			setNextResetAt(null);
+		}
 	};
 
 	const handleCreate = async () => {
@@ -151,6 +156,21 @@ export function BalanceCreateSheet() {
 
 		if (expiresAt) {
 			params.expires_at = expiresAt;
+		}
+
+		// next_reset_at sets a custom first reset boundary. It requires a recurring
+		// reset, must be in the future, and must precede expires_at — match the
+		// server-side validation so we fail fast with a clear message.
+		if (nextResetAt && hasRecurringReset) {
+			if (nextResetAt <= Date.now()) {
+				toast.error("Next reset must be in the future");
+				return;
+			}
+			if (expiresAt && nextResetAt >= expiresAt) {
+				toast.error("Next reset must be before the expiry date");
+				return;
+			}
+			params.next_reset_at = nextResetAt;
 		}
 
 		setIsCreating(true);
@@ -227,6 +247,7 @@ export function BalanceCreateSheet() {
 													setResetInterval("");
 													setOneOff(false);
 													setRollover(null);
+													setNextResetAt(null);
 												}
 											}}
 											className="py-1 w-26 text-subtle gap-2"
@@ -271,6 +292,7 @@ export function BalanceCreateSheet() {
 												if (checked) {
 													setResetInterval("");
 													setRollover(null);
+													setNextResetAt(null);
 												}
 											}}
 											className="py-1 w-26 text-subtle gap-2 justify-start"
@@ -278,6 +300,18 @@ export function BalanceCreateSheet() {
 											One-off
 										</IconCheckbox>
 									</div>
+								</div>
+							)}
+
+							{isMetered && hasRecurringReset && (
+								<div className="flex flex-col shrink-0 w-full">
+									<FormLabel>Next Reset At</FormLabel>
+									<DateInputUnix
+										unixDate={nextResetAt}
+										setUnixDate={setNextResetAt}
+										withTime
+										use24Hour
+									/>
 								</div>
 							)}
 


### PR DESCRIPTION
## What

Adds an optional `next_reset_at` parameter to `POST /balances/create`, letting callers set an explicit first reset boundary — enabling a custom (e.g. shorter) first period while subsequent periods stay aligned to the reset interval.

## Changes
- **Schema** (`shared/.../createBalanceParams.ts`): new `next_reset_at?: number` (unix ms) field.
- **Behavior** (`prepareNewBalanceForInsertion.ts`): applies the explicit boundary to the new cusEnt, overriding the derived `now + interval`.
- **Validation** (`validateCreateBalance.ts`): `next_reset_at` requires a `reset` interval, and must occur before `expires_at`.
- **Generated**: regenerated docs MDX, OpenAPI spec, and create-balance SDK models for the new param.

## Behavior

A create-balance cusEnt is a *free* (price-less) entitlement, so it resets via the lazy path. On reset, the next boundary re-anchors on the prior boundary + one interval (period alignment preserved).

## Test

`server/tests/integration/balances/create/create-balance-next-reset-at.test.ts` (TDD, written red → green):
- t0 create with explicit `next_reset_at` → balance full, boundary honored verbatim.
- t1 deduct → boundary unchanged.
- t5 boundary passes (simulated via `expireCusEntForReset`) → refills, next boundary = prior boundary + 1 interval (provably not `now + interval`).
- Both validation rejections.

3/3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `next_reset_at` to `POST /balances/create` so you can set the first reset boundary (e.g., a shorter initial period) while future resets stay aligned to the interval. Includes stronger validation, dashboard support, and updates to OpenAPI, SDKs, and docs.

- **New Features**
  - New param: `next_reset_at` (unix ms) sets the first reset boundary and overrides the derived `now + interval`.
  - Reset behavior: after the first reset, the next boundary advances by one interval from the prior boundary (not from now).
  - Validation: requires a `reset` interval, must be in the future, and must be before `expires_at` when both are set.
  - Ecosystem updates: OpenAPI, `packages/sdk`, `others/python-sdk`, and docs updated; dashboard Balance Create sheet now includes a “Next Reset At” field with client-side checks to match server rules.

- **Bug Fixes**
  - Reject past `next_reset_at` to prevent an immediate lazy reset after creation.
  - Apply `next_reset_at` when provided using `!== undefined` to avoid dropping epoch-like values.

<sup>Written for commit b398fe287899c56c0ca523ea1aa71471ded27a51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an optional `next_reset_at` parameter to `POST /balances/create`, letting callers pin the first reset boundary to an explicit timestamp rather than accepting the derived `now + interval`. Subsequent resets re-anchor on that boundary plus one interval, preserving period alignment.

- **API changes**: New `next_reset_at?: number` (unix ms) field in schema, OpenAPI specs, TS SDK, and Python SDK; two new validation rules enforce it requires a `reset` interval and must precede `expires_at`.
- **Improvements**: `prepareNewBalanceForInsertion` applies the explicit boundary after expiry handling so it cleanly overrides both the derived and nulled-out values.
- **Improvements**: Integration test covers the full lifecycle — creation, deduction, lazy reset re-anchoring, and both validation rejections.
</details>


<h3>Confidence Score: 3/5</h3>

The core create/insert path works correctly for the common case, but two gaps in the validation layer can produce wrong behavior or incorrect rejections for callers using the rollover+expires_at+next_reset_at combination, or for a past-timestamp input.

The rollover expiry check compares `now + interval` against `expires_at` without considering the explicit `next_reset_at` boundary, so valid requests where `next_reset_at < expires_at < now + interval` are rejected incorrectly. Separately, there is no guard preventing a `next_reset_at` in the past, which causes the lazy reset to fire on the very first check call — silently cycling the balance before the caller has had a chance to use it.

`server/src/internal/balances/createBalance/validateCreateBalance.ts` needs the rollover check updated to use `params.next_reset_at` when present, and a forward-looking guard added for `next_reset_at`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/createBalance/validateCreateBalance.ts | Two new validation blocks added for next_reset_at; rollover expiry check doesn't account for the new param, and no guard prevents a past next_reset_at from being accepted |
| server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts | Applies next_reset_at to the cusEnt after expiry handling; truthy guard instead of !== undefined is a minor correctness gap |
| shared/api/balances/create/createBalanceParams.ts | Adds next_reset_at as an optional number field to both the external and internal schemas; no issues found |
| server/tests/integration/balances/create/create-balance-next-reset-at.test.ts | New integration test covering happy-path boundary honoring, deduction stability, lazy reset re-anchoring, and both validation rejection cases |
| packages/sdk/src/models/create-balance-op.ts | Adds nextResetAt to the TS SDK model with correct camelCase-to-snake_case outbound mapping |
| others/python-sdk/src/autumn_sdk/balances.py | Adds next_reset_at parameter to both sync and async create methods with correct forwarding |
| others/python-sdk/src/autumn_sdk/models/createbalanceop.py | Adds next_reset_at to both the TypedDict and Pydantic model with correct field ordering in the serialization list |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant API as POST /balances/create
    participant Validate as validateCreateBalance
    participant Prepare as prepareNewBalanceForInsertion
    participant DB as Database

    Caller->>API: "{ feature_id, included_grant, reset, next_reset_at }"
    API->>Validate: validateCreateBalanceParams()
    Note over Validate: ① next_reset_at requires reset.interval
    Note over Validate: ② next_reset_at < expires_at
    Note over Validate: ③ rollover check uses now+interval (not next_reset_at) ⚠️
    Validate-->>API: ok
    API->>Prepare: prepareNewBalanceForInsertion()
    Note over Prepare: initCustomerEntitlement → sets next_reset_at = now + interval
    Note over Prepare: if expires_at → next_reset_at = null
    Note over Prepare: if params.next_reset_at → override next_reset_at
    Prepare-->>API: "{ newEntitlement, newCusEnt }"
    API->>DB: "insert cusEnt (next_reset_at = params.next_reset_at)"
    DB-->>Caller: 200 OK

    Note over Caller,DB: Later — lazy reset path
    Caller->>API: GET /check
    API->>DB: read cusEnt
    Note over DB: next_reset_at < now → lazy reset fires
    Note over DB: new next_reset_at = prior_boundary + interval
    DB-->>Caller: balance refilled
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/balances/createBalance/validateCreateBalance.ts`, line 63-80 ([link](https://github.com/useautumn/autumn/blob/da2a69fe205db4e4c0f5f5c10da7d8e503fa394e/server/src/internal/balances/createBalance/validateCreateBalance.ts#L63-L80)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Rollover expiry check ignores explicit `next_reset_at`**

   The rollover guard computes `nextResetAt` via `getNextResetAt()` (i.e. `now + interval`), but when `next_reset_at` is supplied the actual first-cycle boundary is `params.next_reset_at`, not `now + interval`. If a caller passes `rollover + reset + expires_at + next_reset_at` where `next_reset_at < expires_at < now + interval`, `getNextResetAt()` returns a value beyond `expires_at` and the request is rejected with "expires_at occurs before the next rollover event" — even though the explicit boundary proves the rollover *would* complete before expiry. The comparison on line 75 should prefer `params.next_reset_at` when it is present: `(params.next_reset_at ?? nextResetAt) > params.expires_at`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/balances/createBalance/validateCreateBalance.ts
   Line: 63-80

   Comment:
   **Rollover expiry check ignores explicit `next_reset_at`**

   The rollover guard computes `nextResetAt` via `getNextResetAt()` (i.e. `now + interval`), but when `next_reset_at` is supplied the actual first-cycle boundary is `params.next_reset_at`, not `now + interval`. If a caller passes `rollover + reset + expires_at + next_reset_at` where `next_reset_at < expires_at < now + interval`, `getNextResetAt()` returns a value beyond `expires_at` and the request is rejected with "expires_at occurs before the next rollover event" — even though the explicit boundary proves the rollover *would* complete before expiry. The comparison on line 75 should prefer `params.next_reset_at` when it is present: `(params.next_reset_at ?? nextResetAt) > params.expires_at`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
server/src/internal/balances/createBalance/validateCreateBalance.ts:63-80
**Rollover expiry check ignores explicit `next_reset_at`**

The rollover guard computes `nextResetAt` via `getNextResetAt()` (i.e. `now + interval`), but when `next_reset_at` is supplied the actual first-cycle boundary is `params.next_reset_at`, not `now + interval`. If a caller passes `rollover + reset + expires_at + next_reset_at` where `next_reset_at < expires_at < now + interval`, `getNextResetAt()` returns a value beyond `expires_at` and the request is rejected with "expires_at occurs before the next rollover event" — even though the explicit boundary proves the rollover *would* complete before expiry. The comparison on line 75 should prefer `params.next_reset_at` when it is present: `(params.next_reset_at ?? nextResetAt) > params.expires_at`.

### Issue 2 of 3
server/src/internal/balances/createBalance/validateCreateBalance.ts:82-83
**No validation that `next_reset_at` is in the future**

A caller can supply a `next_reset_at` in the past. Because balance resets follow the lazy path, the very first `check` after creation will see `next_reset_at < Date.now()`, fire the reset, and re-anchor the boundary to `past_boundary + interval`. The balance the caller just created with a specific grant immediately cycles — the "first period" they intended has already elapsed before the balance exists. Adding a forward-looking guard here prevents this silent data issue.

```suggestion
	// An explicit next_reset_at only makes sense for a resetting balance.
	if (params.next_reset_at !== undefined && params.next_reset_at <= Date.now()) {
		throw new RecaseError({
			message: `next_reset_at must be in the future`,
		});
	}

	if (params.next_reset_at && !params.reset?.interval) {
```

### Issue 3 of 3
server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts:84-86
**Truthy guard silently drops `next_reset_at: 0`**

`if (params.next_reset_at)` evaluates to `false` when the value is `0` (Unix epoch). While epoch-time is not a meaningful reset boundary in practice, the explicit intent check `!== undefined` is more correct for a numeric timestamp and avoids the subtle footgun if the field ever takes a falsy-but-valid value.

```suggestion
	if (params.next_reset_at !== undefined) {
		newCustomerEntitlement.next_reset_at = params.next_reset_at;
	}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(balances): 🎸 add next\_reset\_at par..."](https://github.com/useautumn/autumn/commit/da2a69fe205db4e4c0f5f5c10da7d8e503fa394e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37693590)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->