### PR TITLE
fix: patch migrations no longer skip custom products

### DIFF
--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -265,11 +265,13 @@ export function buildMigrationDraft({
 	const planFilter = includeCustom
 		? basePlanFilter
 		: { ...basePlanFilter, custom: false };
-	const updatePlanOp = (custom: boolean): UpdatePlanOp => ({
+	// Patch op (no version bump): never scope by `custom` so it applies to
+	// both custom and non-custom products the filter selected.
+	const updatePlanOp: UpdatePlanOp = {
 		type: "update_plan",
-		plan_filter: { ...basePlanFilter, custom },
+		plan_filter: basePlanFilter,
 		...(customize ? { customize } : {}),
-	});
+	};
 
 	const filter: MigrationFilter = {
 		customer: { plan: planFilter },
@@ -282,9 +284,7 @@ export function buildMigrationDraft({
 		id: `${baseProduct.id}-${suffix}-${migrationUid()}`,
 		filter,
 		operations: {
-			customer: includeCustom
-				? [updatePlanOp(false), updatePlanOp(true)]
-				: [updatePlanOp(false)],
+			customer: [updatePlanOp],
 		},
 		no_billing_changes: diffHasBillingChanges(migrationDiff) === false,
 	};

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -265,8 +265,6 @@ export function buildMigrationDraft({
 	const planFilter = includeCustom
 		? basePlanFilter
 		: { ...basePlanFilter, custom: false };
-	// Patch op (no version bump): never scope by `custom` so it applies to
-	// both custom and non-custom products the filter selected.
 	const updatePlanOp: UpdatePlanOp = {
 		type: "update_plan",
 		plan_filter: basePlanFilter,

--- a/vite/tests/views/products/plan/versioning/build-migration-draft.test.ts
+++ b/vite/tests/views/products/plan/versioning/build-migration-draft.test.ts
@@ -70,13 +70,11 @@ describe("buildMigrationDraft", () => {
 			scope: "this_version",
 		});
 
-		// Filter still excludes custom customers by default...
 		expect(draft.filter.customer?.plan).toMatchObject({
 			plan_id: "pro",
 			version: 2,
 			custom: false,
 		});
-		// ...but the patch op never scopes by `custom`.
 		expect(firstUpdatePlan(draft).plan_filter).toEqual({
 			plan_id: "pro",
 			version: 2,

--- a/vite/tests/views/products/plan/versioning/build-migration-draft.test.ts
+++ b/vite/tests/views/products/plan/versioning/build-migration-draft.test.ts
@@ -62,7 +62,7 @@ const firstUpdatePlan = (draft: MigrationDraft): UpdatePlanOp => {
 };
 
 describe("buildMigrationDraft", () => {
-	test("excludes custom plans by default", () => {
+	test("excludes custom customers via the filter but patches both", () => {
 		const draft = buildMigrationDraft({
 			baseProduct,
 			editedProduct: { ...baseProduct, name: "Pro updated" },
@@ -70,15 +70,16 @@ describe("buildMigrationDraft", () => {
 			scope: "this_version",
 		});
 
+		// Filter still excludes custom customers by default...
 		expect(draft.filter.customer?.plan).toMatchObject({
 			plan_id: "pro",
 			version: 2,
 			custom: false,
 		});
-		expect(firstUpdatePlan(draft).plan_filter).toMatchObject({
+		// ...but the patch op never scopes by `custom`.
+		expect(firstUpdatePlan(draft).plan_filter).toEqual({
 			plan_id: "pro",
 			version: 2,
-			custom: false,
 		});
 	});
 
@@ -99,17 +100,11 @@ describe("buildMigrationDraft", () => {
 			{
 				plan_id: "pro",
 				version: 2,
-				custom: false,
-			},
-			{
-				plan_id: "pro",
-				version: 2,
-				custom: true,
 			},
 		]);
 	});
 
-	test("keeps custom targeting explicit for version reset migrations", () => {
+	test("patch op is never scoped by custom regardless of includeCustom", () => {
 		const draft = buildMigrationDraft({
 			baseProduct,
 			editedProduct: baseProduct,
@@ -122,17 +117,11 @@ describe("buildMigrationDraft", () => {
 			{
 				plan_id: "pro",
 				version: 2,
-				custom: false,
-			},
-			{
-				plan_id: "pro",
-				version: 2,
-				custom: true,
 			},
 		]);
 	});
 
-	test("keeps a single operation when custom plans are excluded", () => {
+	test("keeps a single unscoped operation when custom customers are excluded", () => {
 		const draft = buildMigrationDraft({
 			baseProduct,
 			editedProduct: baseProduct,
@@ -144,7 +133,6 @@ describe("buildMigrationDraft", () => {
 		expect(firstUpdatePlan(draft).plan_filter).toEqual({
 			plan_id: "pro",
 			version: 2,
-			custom: false,
 		});
 	});
 


### PR DESCRIPTION
## Problem

The `enterprise-update-all-q4z` migration (add `AUDIT_LOGS` to all Enterprise customers) silently **skipped every customer on a custom Enterprise product** — even though the Filter selected all 321 of them.

### Root cause

`buildMigrationDraft` (the customize/**patch** flow in the plan dashboard) hard-codes `plan_filter.custom: false` into the `update_plan` op whenever `includeCustom` is off (the default). At run time, `migrateCustomer` matches the op's `plan_filter` against each customer's products:

```ts
status: matchedCustomerProducts === 0 ? "skipped" : "succeeded"
```

A custom product (`is_custom === true`) fails the `custom: false` predicate → 0 matched → **skipped, no effect**.

This contradicts the server-side guards, which only inject `custom: false` for **version-bump** ops (`preProcessMigrationOperations` / `preProcessMigrationFilter`, both gated on `hasVersionBumpUpdatePlan`). A patch should never silently exclude custom products.

The Filter tab and the op's `plan_filter` carry `custom` independently, so removing the condition from the Filter left the op's `custom: false` stale — selecting custom customers the op then refused to touch.

## Fix

In `buildMigrationDraft` (patch flow only), omit `custom` from the op's `plan_filter` so it matches both custom and non-custom products. The **customer filter** still excludes custom by default (unchanged). `buildVersionMigrationDraft` (version bumps) is intentionally left as-is.

## Test

Updated `build-migration-draft.test.ts` to assert the patch op's `plan_filter` is never scoped by `custom`. All pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes patch migrations that skipped customers on custom products by removing `custom` from the `update_plan` op’s `plan_filter` and collapsing dual ops into one. Aligns with server guards so migrations like `enterprise-update-all-q4z` apply to both custom and non-custom plans.

- **Bug Fixes**
  - Patch flow: `update_plan.plan_filter` now uses the base filter (no `custom`); `includeCustom` now creates a single unscoped op.
  - Defaults preserved: the customer filter still excludes custom by default; version-bump migrations keep explicit `custom`; tests updated to assert this behavior.

<sup>Written for commit 3180832001fb72a5a731e4261f735c0b99a6b62d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a silent skip affecting customers on custom Enterprise products during patch migrations by removing the erroneous `custom` predicate from the patch op's `plan_filter` in `buildMigrationDraft`. The customer-level filter still controls which customers are included; the op itself no longer double-gates on `is_custom`, so it correctly applies to every product the filter selected.

- **Bug fixes**: `buildMigrationDraft` no longer injects `custom: false` (or `custom: true`) into `update_plan` ops — `basePlanFilter` (plan_id + optional version) is used directly, matching both custom and non-custom products that passed the customer filter.
- **Bug fixes**: The two-op generation for `includeCustom=true` is collapsed into a single unscoped op, eliminating the redundancy that masked the underlying mismatch.
- **Improvements**: `buildVersionMigrationDraft` (version-bump path) is intentionally left unchanged, preserving explicit `custom` scoping required for bumping custom vs non-custom products to the new version separately.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow and well-tested, touching only the patch migration path without affecting the version-bump path.

The fix surgically removes a `custom` predicate that was incorrectly placed on the op's `plan_filter` in the patch flow. The customer-level filter retains its `custom: false` guard when `includeCustom` is off, so the blast radius is limited to customers already selected by the filter. `buildVersionMigrationDraft` is untouched. Tests cover both the default and `includeCustom=true` cases and use `toEqual` (not `toMatchObject`) for the op filter, making the assertions tight.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/buildMigrationDraft.ts | Removes the erroneous `custom` scoping from the patch op's `plan_filter`; customer-level filter still controls inclusion, but the op itself now matches any product the filter selects. |
| vite/tests/views/products/plan/versioning/build-migration-draft.test.ts | Tests updated to assert the patch op's `plan_filter` never carries a `custom` predicate, and that the `buildVersionMigrationDraft` path (version bumps) still uses explicit `custom` scoping. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Plan Dashboard
    participant BMD as buildMigrationDraft
    participant Runner as migrateCustomer
    participant P as Customer Product

    UI->>BMD: "buildMigrationDraft({ includeCustom=false })"
    Note over BMD: planFilter = { plan_id, version, custom: false }<br/>(customer-level filter — unchanged)
    Note over BMD: BEFORE: updatePlanOp.plan_filter = { plan_id, version, custom: false }<br/>AFTER: updatePlanOp.plan_filter = { plan_id, version } (basePlanFilter only)
    BMD-->>UI: MigrationDraft (single op)

    UI->>Runner: run migration
    Runner->>Runner: apply filter → select customers (custom: false)
    Runner->>P: match op.plan_filter against customer products
    Note over P: BEFORE: is_custom=true ✗ custom:false → 0 matches → skipped<br/>AFTER: no custom predicate → matches regardless of is_custom → succeeded
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Plan Dashboard
    participant BMD as buildMigrationDraft
    participant Runner as migrateCustomer
    participant P as Customer Product

    UI->>BMD: "buildMigrationDraft({ includeCustom=false })"
    Note over BMD: planFilter = { plan_id, version, custom: false }<br/>(customer-level filter — unchanged)
    Note over BMD: BEFORE: updatePlanOp.plan_filter = { plan_id, version, custom: false }<br/>AFTER: updatePlanOp.plan_filter = { plan_id, version } (basePlanFilter only)
    BMD-->>UI: MigrationDraft (single op)

    UI->>Runner: run migration
    Runner->>Runner: apply filter → select customers (custom: false)
    Runner->>P: match op.plan_filter against customer products
    Note over P: BEFORE: is_custom=true ✗ custom:false → 0 matches → skipped<br/>AFTER: no custom predicate → matches regardless of is_custom → succeeded
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: patch migrations no longer skip cus..."](https://github.com/useautumn/autumn/commit/b99425a2f60c5d5554bd73f3d85fd833960f09d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37855834)</sub>

<!-- /greptile_comment -->