### PR TITLE
fix(trials): scope free-trial dedup by entity so each entity gets its own trial

### DIFF
--- a/server/src/internal/billing/v2/setup/trialContext/applyProductTrialConfig.ts
+++ b/server/src/internal/billing/v2/setup/trialContext/applyProductTrialConfig.ts
@@ -53,6 +53,7 @@ export const applyProductTrialConfig = async ({
 		productId: fullProduct.id,
 		fingerprint: fullCustomer.fingerprint,
 		internalCustomerId: fullCustomer.internal_id,
+		internalEntityId: fullCustomer.entity?.internal_id,
 		multipleAllowed: multipleTrialsAllowed,
 	});
 

--- a/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getPricesAndEnts.ts
+++ b/server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getPricesAndEnts.ts
@@ -55,6 +55,7 @@ export const getPricesAndEnts = async ({
 				freeTrial: freeTrialProduct.free_trial,
 				fingerprint: customer.fingerprint,
 				internalCustomerId: customer.internal_id,
+				internalEntityId: customer.entity?.internal_id,
 				multipleAllowed: org.config.multiple_trials,
 				productId: freeTrialProduct.id,
 			});
@@ -114,6 +115,7 @@ export const getPricesAndEnts = async ({
 		freeTrial: freeTrial,
 		fingerprint: customer.fingerprint,
 		internalCustomerId: customer.internal_id,
+		internalEntityId: customer.entity?.internal_id,
 		multipleAllowed: org.config.multiple_trials,
 		productId: product.id,
 	});

--- a/server/src/internal/customers/attach/attachUtils/attachParams/checkToAttachParams.ts
+++ b/server/src/internal/customers/attach/attachUtils/attachParams/checkToAttachParams.ts
@@ -28,6 +28,7 @@ export const checkToAttachParams = async ({
 		freeTrial: product.free_trial,
 		fingerprint: customer.fingerprint,
 		internalCustomerId: customer.internal_id,
+		internalEntityId: customer.entity?.internal_id,
 		multipleAllowed: org.config.multiple_trials,
 		productId: product.id,
 	});

--- a/server/src/internal/customers/cusProducts/CusProductService.ts
+++ b/server/src/internal/customers/cusProducts/CusProductService.ts
@@ -567,11 +567,13 @@ export class CusProductService {
 		productId,
 		internalCustomerId,
 		fingerprint,
+		internalEntityId,
 	}: {
 		db: DrizzleCli;
 		productId: string;
 		internalCustomerId: string;
 		fingerprint?: string;
+		internalEntityId?: string;
 	}) {
 		const data = await db
 			.select()
@@ -592,6 +594,11 @@ export class CusProductService {
 					),
 					eq(products.id, productId),
 					isNotNull(customerProducts.free_trial_id),
+					// Entity-scoped attach: each entity has its own trial history,
+					// so a customer-level or sibling-entity trial must not dedup it.
+					internalEntityId
+						? eq(customerProducts.internal_entity_id, internalEntityId)
+						: undefined,
 				),
 			);
 

--- a/server/src/internal/customers/cusProducts/CusProductService.ts
+++ b/server/src/internal/customers/cusProducts/CusProductService.ts
@@ -588,17 +588,22 @@ export class CusProductService {
 			)
 			.where(
 				and(
-					or(
-						fingerprint ? eq(customers.fingerprint, fingerprint) : undefined,
-						eq(customers.internal_id, internalCustomerId),
-					),
 					eq(products.id, productId),
 					isNotNull(customerProducts.free_trial_id),
-					// Entity-scoped attach: each entity has its own trial history,
-					// so a customer-level or sibling-entity trial must not dedup it.
-					internalEntityId
-						? eq(customerProducts.internal_entity_id, internalEntityId)
-						: undefined,
+					or(
+						// Cross-customer fingerprint dedup (unique_fingerprint abuse
+						// prevention) must match other customers regardless of entity,
+						// so it stays unscoped.
+						fingerprint ? eq(customers.fingerprint, fingerprint) : undefined,
+						// Same-customer dedup is scoped to the entity when entity-scoped,
+						// so each entity gets its own trial.
+						and(
+							eq(customers.internal_id, internalCustomerId),
+							internalEntityId
+								? eq(customerProducts.internal_entity_id, internalEntityId)
+								: undefined,
+						),
+					),
 				),
 			);
 

--- a/server/src/internal/products/free-trials/freeTrialUtils.ts
+++ b/server/src/internal/products/free-trials/freeTrialUtils.ts
@@ -88,6 +88,7 @@ export const getFreeTrialAfterFingerprint = async ({
 	productId,
 	fingerprint,
 	internalCustomerId,
+	internalEntityId,
 	multipleAllowed,
 }: {
 	db: DrizzleCli;
@@ -95,6 +96,7 @@ export const getFreeTrialAfterFingerprint = async ({
 	productId: string;
 	fingerprint: string | null | undefined;
 	internalCustomerId: string;
+	internalEntityId?: string;
 	multipleAllowed: boolean;
 }): Promise<FreeTrial | null> => {
 	if (!freeTrial) return null;
@@ -109,6 +111,7 @@ export const getFreeTrialAfterFingerprint = async ({
 		db,
 		productId,
 		internalCustomerId,
+		internalEntityId,
 		fingerprint: uniqueFreeTrial.unique_fingerprint ? fingerprint! : undefined,
 	});
 

--- a/server/src/internal/products/pricecn/pricecnUtils.ts
+++ b/server/src/internal/products/pricecn/pricecnUtils.ts
@@ -410,6 +410,7 @@ export const toPricecnProduct = async ({
 			freeTrial: fullProduct.free_trial,
 			fingerprint: fullCus.fingerprint,
 			internalCustomerId: fullCus.internal_id,
+			internalEntityId: fullCus.entity?.internal_id,
 			multipleAllowed: org.config.multiple_trials,
 			productId: product.id,
 		});

--- a/server/src/internal/products/productUtils/productResponseUtils/buildCustomerEligibility.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/buildCustomerEligibility.ts
@@ -116,6 +116,7 @@ export const buildCustomerEligibility = async ({
 			freeTrial: fullProduct.free_trial,
 			fingerprint: fullCus.fingerprint,
 			internalCustomerId: fullCus.internal_id,
+			internalEntityId,
 			multipleAllowed: false,
 			productId: fullProduct.id,
 		});

--- a/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
@@ -101,6 +101,7 @@ const getFreeTrialResponse = async ({
 			freeTrial: product.free_trial,
 			fingerprint: fullCus.fingerprint,
 			internalCustomerId: fullCus.internal_id,
+			internalEntityId: fullCus.entity?.internal_id,
 			multipleAllowed: false,
 			productId: product.id,
 		});

--- a/server/tests/integration/billing/free-trials/entity-scoped-trials.test.ts
+++ b/server/tests/integration/billing/free-trials/entity-scoped-trials.test.ts
@@ -19,7 +19,12 @@
  */
 
 import { expect, test } from "bun:test";
-import { ALL_STATUSES, CusProductStatus, type FullCusProduct } from "@autumn/shared";
+import {
+	ALL_STATUSES,
+	CusProductStatus,
+	FreeTrialDuration,
+	type FullCusProduct,
+} from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
@@ -184,6 +189,56 @@ test.concurrent(
 		expect(
 			reTrial?.free_trial_id,
 			"An entity that already trialed must not be re-granted a trial",
+		).toBeNull();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity-trials: unique_fingerprint still dedups across entities (device-level)")}`,
+	async () => {
+		const customerId = "entity-scoped-trials-fingerprint";
+		const trial = products.base({
+			id: "trial-fp",
+			items: trialItems,
+			freeTrial: {
+				length: 30,
+				duration: FreeTrialDuration.Day,
+				cardRequired: false,
+				uniqueFingerprint: true,
+			},
+		});
+
+		const { entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({
+					testClock: false,
+					data: { fingerprint: "device-shared-fp" },
+				}),
+				s.products({ list: [trial] }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: trial.id, entityIndex: 0 }),
+				s.billing.attach({ productId: trial.id, entityIndex: 1 }),
+			],
+		});
+
+		const first = await activeTrialForEntity({
+			customerId,
+			entityId: entities[0].id,
+		});
+		const second = await activeTrialForEntity({
+			customerId,
+			entityId: entities[1].id,
+		});
+
+		expect(first?.free_trial_id, "First entity should trial").not.toBeNull();
+		// unique_fingerprint is device-level abuse prevention, so it must keep
+		// deduping across entities even though entity scoping is now applied.
+		expect(
+			second?.free_trial_id,
+			"unique_fingerprint must still dedup across entities",
 		).toBeNull();
 	},
 );

--- a/server/tests/integration/billing/free-trials/entity-scoped-trials.test.ts
+++ b/server/tests/integration/billing/free-trials/entity-scoped-trials.test.ts
@@ -1,0 +1,189 @@
+/**
+ * TDD: free trials must be deduplicated per-entity, not per-customer.
+ *
+ * Catalog (anonymised from a real sandbox customer): a no-price "trial" plan
+ * with a 30-day free trial (card_required: false, unique_fingerprint: false)
+ * and two metered items. "users" is the entity feature (seats).
+ *
+ * Red-failure mode (current behavior):
+ *  - getByFingerprint dedups on (customer, product) ignoring internal_entity_id.
+ *  - Only the FIRST entity to attach the trial gets free_trial_id / trial_ends_at.
+ *    Every later entity resolves "not trialing -> no trial".
+ *  - A customer-level trial also burns the first entity's trial.
+ *
+ * Green-success criteria (after fix):
+ *  - Each entity gets exactly one trial of its own.
+ *  - A customer-level trial does NOT burn an entity's trial.
+ *  - Once an entity has trialed, re-attaching the trial plan to that same
+ *    entity does NOT re-grant (historical per-entity dedup).
+ */
+
+import { expect, test } from "bun:test";
+import { ALL_STATUSES, CusProductStatus, type FullCusProduct } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService.js";
+
+const trialItems = [
+	items.monthlyCredits({ includedUsage: 25 }),
+	items.unlimitedMessages(),
+];
+
+const activeTrialForEntity = async ({
+	customerId,
+	entityId,
+}: {
+	customerId: string;
+	entityId: string;
+}): Promise<FullCusProduct | undefined> => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		inStatuses: ALL_STATUSES,
+	});
+
+	return fullCustomer.customer_products.find(
+		(cp) =>
+			cp.entity_id === entityId && cp.status === CusProductStatus.Active,
+	);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("entity-trials: each entity gets its own free trial")}`,
+	async () => {
+		const customerId = "entity-scoped-trials-each";
+		const trial = products.baseWithTrial({
+			id: "trial",
+			items: trialItems,
+			trialDays: 30,
+			cardRequired: false,
+		});
+
+		const { entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [trial] }),
+				s.entities({ count: 3, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.billing.attach({ productId: trial.id, entityIndex: 0 }),
+				s.billing.attach({ productId: trial.id, entityIndex: 1 }),
+				s.billing.attach({ productId: trial.id, entityIndex: 2 }),
+			],
+		});
+
+		for (const entity of entities) {
+			const trialProduct = await activeTrialForEntity({
+				customerId,
+				entityId: entity.id,
+			});
+
+			expect(
+				trialProduct,
+				`No active trial product for ${entity.id}`,
+			).toBeDefined();
+			expect(
+				trialProduct?.free_trial_id,
+				`Entity ${entity.id} should have a free trial granted`,
+			).not.toBeNull();
+			expect(
+				trialProduct?.trial_ends_at,
+				`Entity ${entity.id} should have a trial end date`,
+			).not.toBeNull();
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity-trials: customer-level trial does NOT burn an entity's trial")}`,
+	async () => {
+		const customerId = "entity-scoped-trials-customer-level";
+		const trial = products.baseWithTrial({
+			id: "trial",
+			items: trialItems,
+			trialDays: 30,
+			cardRequired: false,
+		});
+
+		const { entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [trial] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [
+				// Customer-level (no entity) trial first...
+				s.billing.attach({ productId: trial.id }),
+				// ...then an entity attaches the same trial.
+				s.billing.attach({ productId: trial.id, entityIndex: 0 }),
+			],
+		});
+
+		const trialProduct = await activeTrialForEntity({
+			customerId,
+			entityId: entities[0].id,
+		});
+
+		expect(trialProduct, "No active trial product for entity").toBeDefined();
+		expect(
+			trialProduct?.free_trial_id,
+			"A customer-level trial must not burn the entity's trial",
+		).not.toBeNull();
+		expect(trialProduct?.trial_ends_at).not.toBeNull();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("entity-trials: an entity that already trialed does not re-trial")}`,
+	async () => {
+		const customerId = "entity-scoped-trials-no-retrial";
+		const trial = products.baseWithTrial({
+			id: "trial",
+			items: trialItems,
+			trialDays: 30,
+			cardRequired: false,
+		});
+
+		const { entities, autumnV1, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [trial] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [s.billing.attach({ productId: trial.id, entityIndex: 0 })],
+		});
+
+		const entityId = entities[0].id;
+
+		const firstTrial = await activeTrialForEntity({ customerId, entityId });
+		expect(firstTrial?.free_trial_id, "First attach should trial").not.toBeNull();
+		const productId = firstTrial!.product.id;
+
+		// Free trial off, then back: cancel immediately and re-attach the same plan.
+		await autumnV1.cancel({
+			customer_id: customerId,
+			product_id: productId,
+			entity_id: entityId,
+			cancel_immediately: true,
+		});
+		await autumnV2_3.billing.attach({
+			customer_id: customerId,
+			plan_id: productId,
+			entity_id: entityId,
+		});
+
+		const reTrial = await activeTrialForEntity({ customerId, entityId });
+		expect(reTrial, "No active trial product for entity").toBeDefined();
+		expect(
+			reTrial?.free_trial_id,
+			"An entity that already trialed must not be re-granted a trial",
+		).toBeNull();
+	},
+);


### PR DESCRIPTION
## Problem

When a product with a free trial is attached to a customer **per entity**, only the **first** entity gets the free trial. Every subsequent entity resolves `trialTransition: "not trialing -> no trial"` (no `free_trial_id` / `trial_ends_at`) — so new entities silently lose their trial window.

Observed on a real sandbox customer: the `trial` plan attached to 3 entities, but only entity #1 carried `free_trial_id` + `trial_ends_at`.

## Root cause

`CusProductService.getByFingerprint` deduplicates trial eligibility at the `(customer, product)` level and ignores `internal_entity_id`. The first entity's trial writes a `customer_products` row with a `free_trial_id`; the next entity-scoped attach finds that row and concludes the trial is already used.

`internal_entity_id` already exists on `customer_products` (populated on every entity-scoped attach, FK + index) — the dedup query simply never applied it, unlike its sibling `getExistingCusProducts`.

## Fix

Scope the trial-dedup lookup by entity:

- `getByFingerprint` — optional `internalEntityId`; when present, `AND internal_entity_id = $entity`. Customer-level attaches (no entity) keep prior behavior.
- `getFreeTrialAfterFingerprint` — threads `internalEntityId` through.
- Call sites pass `…entity?.internal_id`: `applyProductTrialConfig` (v2 attach), `getPricesAndEnts` ×2 (v1 attach), `buildCustomerEligibility` (eligibility/preview).

Behavior guaranteed:

1. **One trial per entity** — entity-scoped dedup.
2. **A customer-level trial does NOT burn an entity's trial** — the entity filter matches only same-entity rows, so a `NULL`-entity (customer-level) row never blocks an entity.
3. **No re-trial on downgrade-back** — the lookup has no status filter, so an entity's expired/canceled trial row still blocks (verified by a cancel→reattach guard).

No schema change / migration — uses the existing `internal_entity_id` column.

## Tests

New regression test `server/tests/integration/billing/free-trials/entity-scoped-trials.test.ts` (3 cases, all green): each entity trials independently; customer-level trial doesn't burn an entity's; an already-trialed entity isn't re-granted.

Regression sweep of the trial suites shows **no new failures** — pre-existing failures (Stripe proration/timing in `trial-entity-upgrade`/`trial-override-*`, and the `defaultTrial` default-group isolation collisions) reproduce identically on baseline with the fix stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes free-trial deduplication so trials are granted per entity instead of per customer. Keeps device-level `unique_fingerprint` dedup intact across entities and customers.

- **Bug Fixes**
  - Scoped trial dedup in `CusProductService.getByFingerprint` by `internal_entity_id` for same-customer matches; fingerprint branch stays unscoped to preserve cross-entity/customer dedup.
  - Threaded `internalEntityId` through `getFreeTrialAfterFingerprint` and new call sites used in previews: `checkToAttachParams`, `getProductResponse`, `toPricecnProduct` (in addition to `applyProductTrialConfig`, `getPricesAndEnts`, `buildCustomerEligibility`).
  - Guarantees: one trial per entity, customer-level trial doesn’t burn an entity’s trial, no re-trial for the same entity after cancel/downgrade, and `unique_fingerprint` still blocks second attaches on the same device.
  - Added `entity-scoped-trials` integration tests (now covers 4 cases, including fingerprint dedup); no schema or migration changes.

<sup>Written for commit ded6f2d97e500cc2e83e55499424507764450439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Scopes free-trial deduplication by `internal_entity_id` so each entity on a customer gets its own independent trial window, fixing a bug where only the first entity to attach a trial product received `free_trial_id`/`trial_ends_at`. The optional entity filter is wired through `getByFingerprint` → `getFreeTrialAfterFingerprint` and applied at all four attach/eligibility call sites.

- **Bug fixes / Improvements**: `CusProductService.getByFingerprint` gains an optional `internalEntityId` parameter; when provided it appends `AND internal_entity_id = $entity` so sibling-entity trial rows don't block one another, while customer-level attaches (no entity) retain prior behaviour.
- **Bug fixes**: `getFreeTrialAfterFingerprint`, `applyProductTrialConfig`, `getPricesAndEnts` (×2), and `buildCustomerEligibility` all pass `entity?.internal_id` through, ensuring the fix covers both v1 and v2 attach paths as well as eligibility previews.
- **Improvements**: New integration test file covers three regression cases — per-entity trial isolation, customer-level trial not burning an entity's trial, and no re-trial after cancel+reattach.
</details>

<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped and correctly fixes per-entity trial isolation without touching the schema or any unrelated billing paths.

All attach paths and the eligibility preview are updated consistently, and the new tests exercise all three documented guarantees. The one thing worth a second look: when unique_fingerprint=true, the new entity filter means the fingerprint OR branch can never match rows from other customers (their internal_entity_id values are different DB surrogates), so cross-customer fingerprint-based trial dedup is silently bypassed for entity-scoped attaches.

server/src/internal/customers/cusProducts/CusProductService.ts — the getByFingerprint query interaction between the fingerprint OR clause and the new entity filter.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/CusProductService.ts | Adds optional internalEntityId to getByFingerprint; Drizzle safely ignores the undefined branch. Cross-customer unique_fingerprint dedup is bypassed for entity-scoped attaches (narrow edge case). |
| server/src/internal/products/free-trials/freeTrialUtils.ts | Threads internalEntityId through to getByFingerprint; no logic changes, clean pass-through. |
| server/src/internal/billing/v2/setup/trialContext/applyProductTrialConfig.ts | Passes entity?.internal_id to getFreeTrialAfterFingerprint; one-line addition, consistent with other call sites. |
| server/src/internal/customers/attach/attachUtils/attachParams/attachParamsUtils/getPricesAndEnts.ts | Adds internalEntityId at two call sites in the v1 attach path; mirrors the v2 call site correctly. |
| server/src/internal/products/productUtils/productResponseUtils/buildCustomerEligibility.ts | Passes pre-existing internalEntityId (already used for findActiveCustomerProductById) to getFreeTrialAfterFingerprint; consistent change. |
| server/tests/integration/billing/free-trials/entity-scoped-trials.test.ts | New integration tests cover all three documented guarantees (per-entity trial, customer-level doesn't burn entity trial, no re-trial after cancel). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["attach product to entity"] --> B["getFreeTrialAfterFingerprint\n(freeTrial, internalEntityId)"]
    B --> C{"multipleAllowed?"}
    C -- yes --> D["return freeTrial ✓"]
    C -- no --> E["getByFingerprint\n(productId, customerId, fingerprint?, entityId?)"]
    E --> F{"internalEntityId\npresent?"}
    F -- yes --> G["WHERE ... AND\ninternal_entity_id = entityId"]
    F -- no --> H["WHERE ...\n(no entity filter)"]
    G --> I{"any row with\nfree_trial_id IS NOT NULL?"}
    H --> I
    I -- yes --> J["return null\n(no trial granted)"]
    I -- no --> K["return freeTrial ✓\n(trial granted)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["attach product to entity"] --> B["getFreeTrialAfterFingerprint\n(freeTrial, internalEntityId)"]
    B --> C{"multipleAllowed?"}
    C -- yes --> D["return freeTrial ✓"]
    C -- no --> E["getByFingerprint\n(productId, customerId, fingerprint?, entityId?)"]
    E --> F{"internalEntityId\npresent?"}
    F -- yes --> G["WHERE ... AND\ninternal_entity_id = entityId"]
    F -- no --> H["WHERE ...\n(no entity filter)"]
    G --> I{"any row with\nfree_trial_id IS NOT NULL?"}
    H --> I
    I -- yes --> J["return null\n(no trial granted)"]
    I -- no --> K["return freeTrial ✓\n(trial granted)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/customers/cusProducts/CusProductService.ts:599-602
**Cross-customer fingerprint dedup silently bypassed for entity attaches**

When `unique_fingerprint=true` is set on a free trial, the `or(fingerprint = $fp, customer = $id)` clause is intended to block re-trials across multiple customer accounts that share the same browser/device fingerprint. After this change, when `internalEntityId` is present, the query additionally requires `internal_entity_id = $entityId`. Because `internal_entity_id` is a globally-unique DB surrogate, entity rows from *other* customers will never match — so the fingerprint branch of the `or` condition becomes effectively dead for entity-scoped attaches. A user who creates two separate customer accounts (same fingerprint) and attaches an entity-scoped trial on each can now receive two trials for the same product, bypassing the `unique_fingerprint` abuse-prevention gate.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trials): 🐛 scope free-trial dedup b..."](https://github.com/useautumn/autumn/commit/bc2d196d44856cc707d783fbcbf0468892128383) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37974626)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->