### PR TITLE
fix: copy entity ID and allow duplicate plans in sync editor

### DIFF
--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -288,8 +288,14 @@ export function SubscriptionDetailSheet() {
 						<InfoRow
 							icon={<HashIcon size={16} weight="duotone" />}
 							label="Entity ID"
-							value={entity.id || entity.internal_id}
-							mono
+							value={
+								<CopyButton
+									text={entity.id || entity.internal_id}
+									size="mini"
+									className="text-tertiary-foreground"
+									innerClassName={ID_CHIP_INNER_CLASS}
+								/>
+							}
 						/>
 					</div>
 				</SheetSection>

--- a/vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx
+++ b/vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx
@@ -461,9 +461,6 @@ export function SubscriptionEditorView({
 
 				{phaseSections.map((section, phaseIndex) => {
 					const phasePlans = draftPlansByPhase[phaseIndex] ?? [];
-					const usedPlanIds = new Set(
-						phasePlans.map((p) => p.plan_id).filter(Boolean) as string[],
-					);
 
 					return (
 						<div
@@ -505,13 +502,6 @@ export function SubscriptionEditorView({
 										key={plan._key}
 										plan={plan}
 										products={products ?? []}
-										usedPlanIds={
-											new Set(
-												Array.from(usedPlanIds).filter(
-													(id) => id !== plan.plan_id,
-												),
-											)
-										}
 										entities={entities}
 										onChange={(next) =>
 											handlePlanChange(phaseIndex, planIndex, next)

--- a/vite/src/views/customers2/components/sync-stripe-v2/SyncPlanRow.tsx
+++ b/vite/src/views/customers2/components/sync-stripe-v2/SyncPlanRow.tsx
@@ -113,7 +113,6 @@ const EntityScopeSubRow = ({
 export function SyncPlanRow({
 	plan,
 	products,
-	usedPlanIds,
 	entities,
 	onChange,
 	onRemove,
@@ -121,7 +120,6 @@ export function SyncPlanRow({
 }: {
 	plan: DraftPlan;
 	products: ProductV2[];
-	usedPlanIds: Set<string>;
 	entities: Entity[];
 	onChange: (plan: DraftPlan) => void;
 	onRemove: () => void;
@@ -145,14 +143,8 @@ export function SyncPlanRow({
 				options={availableProducts}
 				getOptionValue={(product) => product.id}
 				getOptionLabel={(product) => product.name}
-				getOptionDisabled={(product) => usedPlanIds.has(product.id)}
 				renderOption={(product) => (
-					<>
-						<span className="flex-1 truncate min-w-0">{product.name}</span>
-						{usedPlanIds.has(product.id) && (
-							<span className="text-xs text-subtle shrink-0">Already added</span>
-						)}
-					</>
+					<span className="flex-1 truncate min-w-0">{product.name}</span>
 				)}
 				placeholder="Select plan…"
 				searchable


### PR DESCRIPTION
## Summary

- Add a copy button for entity IDs in the subscription detail sheet
- Allow selecting the same plan multiple times in the Stripe sync subscription editor by removing the duplicate-plan restriction

## Test plan

- [ ] Open a subscription detail sheet for an entity-scoped subscription and verify the entity ID is copyable
- [ ] In the Stripe sync subscription editor, add the same plan twice in a phase and confirm both rows can be configured independently

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a copy button for entity IDs in the subscription detail sheet and enabled selecting the same plan multiple times in the Stripe sync subscription editor.

- **New Features**
  - Entity ID is now copyable via a mini copy button in the subscription detail sheet.
  - Removed the duplicate-plan restriction in the Stripe sync editor: plans can be added multiple times per phase, with no disabled options or “Already added” labels.

<sup>Written for commit c17287d481a9d2a040c622eeb7b60878e6cfdde6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a copy button for entity IDs in the subscription detail sheet and removes the restriction that prevented selecting the same plan more than once in the Stripe sync subscription editor.

- **[Improvements]** Entity ID field in `SubscriptionDetailSheet` is now rendered as a `CopyButton`, using the existing `ID_CHIP_INNER_CLASS` and `CopyButton` component already used elsewhere in the file for consistent UX.
- **[Bug fixes]** The `usedPlanIds` deduplication logic and the `getOptionDisabled`/`renderOption` \"Already added\" hint have been removed from `SubscriptionEditorView` and `SyncPlanRow`, allowing the same plan to be added to a phase multiple times (e.g., with different entity scopes).
</details>

<h3>Confidence Score: 5/5</h3>

Both changes are small and focused — the copy button wires into existing infrastructure, and the duplicate-plan removal is a clean deletion with no leftover references.

All three files touch UI-only concerns. The CopyButton addition reuses established patterns already present in the file. The duplicate-plan guard removal is a deliberate product decision backed by a clear test plan; the deleted code has no remaining callers.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx | Replaces plain string Entity ID value with a CopyButton; imports and constants are already in place. |
| vite/src/views/customers2/components/sync-stripe-v2/SubscriptionEditorView.tsx | Removes usedPlanIds set computation and prop forwarding to SyncPlanRow; clean deletion with no leftover references. |
| vite/src/views/customers2/components/sync-stripe-v2/SyncPlanRow.tsx | Removes usedPlanIds prop, getOptionDisabled, and the "Already added" label from renderOption; simplifies renderOption to a single span. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant SubscriptionEditorView
    participant SyncPlanRow
    participant SearchableSelect

    User->>SubscriptionEditorView: Add plan row
    SubscriptionEditorView->>SyncPlanRow: plan, products, entities
    Note over SubscriptionEditorView,SyncPlanRow: usedPlanIds no longer computed or passed
    User->>SyncPlanRow: Open plan selector
    SyncPlanRow->>SearchableSelect: "options=availableProducts"
    Note over SearchableSelect: No options disabled (duplicate plans allowed)
    User->>SearchableSelect: Select plan (even if already used)
    SearchableSelect-->>SyncPlanRow: onChange(plan)
    SyncPlanRow-->>SubscriptionEditorView: handlePlanChange(phaseIndex, planIndex, next)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant SubscriptionEditorView
    participant SyncPlanRow
    participant SearchableSelect

    User->>SubscriptionEditorView: Add plan row
    SubscriptionEditorView->>SyncPlanRow: plan, products, entities
    Note over SubscriptionEditorView,SyncPlanRow: usedPlanIds no longer computed or passed
    User->>SyncPlanRow: Open plan selector
    SyncPlanRow->>SearchableSelect: "options=availableProducts"
    Note over SearchableSelect: No options disabled (duplicate plans allowed)
    User->>SearchableSelect: Select plan (even if already used)
    SearchableSelect-->>SyncPlanRow: onChange(plan)
    SyncPlanRow-->>SubscriptionEditorView: handlePlanChange(phaseIndex, planIndex, next)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: copy entity ID and allow duplicate ..."](https://github.com/useautumn/autumn/commit/c17287d481a9d2a040c622eeb7b60878e6cfdde6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38027606)</sub>

<!-- /greptile_comment -->