### PR TITLE
chore: pin mastra packages + enforce frozen lockfile in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           bun-version: 1.3.10
       
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
       
       - name: Run TypeScript type check
         run: |

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -22,7 +22,7 @@ jobs:
           bun-version: 1.3.10
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run Knip
         run: bun knip

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -110,7 +110,7 @@ jobs:
           echo "Updated npm version: $(npm --version)"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Install Speakeasy CLI
         if: inputs.install-speakeasy

--- a/.github/workflows/server-typecheck.yml
+++ b/.github/workflows/server-typecheck.yml
@@ -42,7 +42,7 @@ jobs:
           bun-version: 1.3.10
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run TypeScript type check
         run: cd server && bun ts

--- a/.github/workflows/server-unit-tests.yml
+++ b/.github/workflows/server-unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run unit tests
         run: bun test --isolate tests/unit

--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         if: needs.changes.outputs.schema == 'true'
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Validate schema
         if: needs.changes.outputs.schema == 'true'

--- a/.github/workflows/vite-build.yml
+++ b/.github/workflows/vite-build.yml
@@ -44,7 +44,7 @@ jobs:
           bun-version: 1.3.10
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run TypeScript type check
         run: cd vite && bunx tsc --noEmit

--- a/.github/workflows/vite-unit-tests.yml
+++ b/.github/workflows/vite-unit-tests.yml
@@ -44,7 +44,7 @@ jobs:
           bun-version: 1.3.10
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run unit tests
         run: bun test tests/

--- a/bun.lock
+++ b/bun.lock
@@ -697,6 +697,11 @@
   "overrides": {
     "@better-auth/passkey": "1.6.5",
     "@isaacs/brace-expansion": "5.0.1",
+    "@mastra/braintrust": "1.1.3",
+    "@mastra/core": "1.42.0",
+    "@mastra/mcp": "1.10.0",
+    "@mastra/observability": "1.14.1",
+    "@mastra/schema-compat": "1.2.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@smithy/config-resolver": "^4.4.0",
     "@types/pg": "8.20.0",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,11 +41,10 @@ COPY packages/stripe-sync/package.json packages/stripe-sync/
 # install step doesn't fail before the real source is copied.
 RUN mkdir -p scripts && touch scripts/preload-env.ts
 
-# Install the full workspace because runtime source imports cross package boundaries.
-# --no-save keeps this image layer from mutating bun.lock.
+# Install the full workspace (runtime source imports cross package boundaries).
+# --frozen-lockfile pins bun.lock exactly; --ignore-scripts blocks postinstall hooks.
 RUN --mount=type=cache,target=/root/.bun/install/cache \
-	bun install --ignore-scripts --no-save \
-		--minimum-release-age 0
+	bun install --ignore-scripts --frozen-lockfile
 
 FROM oven/bun:1.3.10
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
 	},
 	"overrides": {
 		"@better-auth/passkey": "1.6.5",
+		"@mastra/braintrust": "1.1.3",
+		"@mastra/core": "1.42.0",
+		"@mastra/mcp": "1.10.0",
+		"@mastra/observability": "1.14.1",
+		"@mastra/schema-compat": "1.2.11",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@isaacs/brace-expansion": "5.0.1",
 		"fast-xml-parser": "5.3.4",
@@ -67,6 +72,11 @@
 	"resolutions": {
 		"@better-auth/core": "1.6.5",
 		"@better-auth/passkey": "1.6.5",
+		"@mastra/braintrust": "1.1.3",
+		"@mastra/core": "1.42.0",
+		"@mastra/mcp": "1.10.0",
+		"@mastra/observability": "1.14.1",
+		"@mastra/schema-compat": "1.2.11",
 		"better-auth": "1.6.5",
 		"@modelcontextprotocol/sdk": "1.29.0",
 		"@isaacs/brace-expansion": "5.0.1",


### PR DESCRIPTION
## Why
Hardening after the **2026-06-17 Mastra / `easy-day-js` npm compromise** — a hijacked publisher (`ehindero`) republished 32 `@mastra/*` versions trojanized to drop a remote payload via an `easy-day-js@1.11.22` postinstall dropper.

**We were never compromised** (lockfile predated the attack; prod images last built ~8h before the malicious packages existed; the Dockerfile uses `--ignore-scripts`). This PR closes the gaps that *could* have let it in on a future build.

## Changes
- **Pin Mastra packages** (`overrides` + `resolutions`) to the safe versions `dev` already resolves — `core@1.42.0`, `mcp@1.10.0`, `schema-compat@1.2.11`, `observability@1.14.1`, `braintrust@1.1.3`. Blocks the malicious `.1` bumps from floating in via caret ranges. Resolution is unchanged (verified).
- **`bun install --frozen-lockfile`** in the prod `Dockerfile` and all 8 workflows — installs `bun.lock` byte-for-byte and fails on drift.
- **Remove `--minimum-release-age 0`** from the Dockerfile. It was masking build failures caused by the *non-frozen* install re-resolving against the 3-day age gate. Frozen installs skip resolution, so the gate no longer conflicts and the prod build now inherits the 3-day quarantine. (Verified: `bun install --frozen-lockfile` passes with the gate active.)

`--ignore-scripts` is retained — it's what neutralized the dropper for this incident.

## ⚠️ Heads-up for the team
`--frozen-lockfile` will now **fail CI** if a `package.json` change is pushed without regenerating `bun.lock`. That's intended (it's the integrity guarantee), but it changes the workflow: after editing deps, run `bun install` and commit the updated `bun.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `@mastra/*` dependencies to safe versions and enforces `bun install --frozen-lockfile` across CI and Docker. Hardens the supply chain and prevents unexpected version drift.

- **Dependencies**
  - Pin via `overrides` + `resolutions`: `@mastra/core@1.42.0`, `@mastra/mcp@1.10.0`, `@mastra/schema-compat@1.2.11`, `@mastra/observability@1.14.1`, `@mastra/braintrust@1.1.3`.
  - Use `bun install --frozen-lockfile` in Dockerfile and all workflows.
  - Remove `--minimum-release-age 0`; builds inherit the 3-day age gate.
  - Keep `--ignore-scripts` to block postinstall hooks.

- **Migration**
  - After changing deps, run `bun install` and commit `bun.lock` or CI will fail.

<sup>Written for commit bbbb26e1f52511f1db9593b061aedbdece6343d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the supply chain after the 2026-06-17 Mastra/`easy-day-js` npm compromise by pinning five `@mastra/*` packages via `overrides`/`resolutions` and enforcing `--frozen-lockfile` across all CI workflows and the production Dockerfile. It also removes the `--minimum-release-age 0` override from the Dockerfile, restoring the default 3-day quarantine now that frozen installs skip resolution.

- **[Improvements]** `bun install --frozen-lockfile` added to all 8 GitHub Actions workflows and the prod Dockerfile, ensuring installs are always byte-for-byte identical to the committed `bun.lock`.
- **[Improvements]** Five `@mastra/*` packages pinned to exact safe versions in both `overrides` and `resolutions`, blocking malicious floating bumps from being pulled in via caret ranges.
- **[Improvements]** `--minimum-release-age 0` removed from the Dockerfile; `--no-save` dropped as it is now redundant with `--frozen-lockfile`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes tighten the install pipeline without altering runtime behaviour.

Every change is purely additive hardening: the lockfile was already pinned to the safe Mastra versions before this PR, the bun.lock is copied into the Docker image before the install step so frozen installs work correctly, and the overrides/resolutions entries follow the existing pattern exactly. No runtime code is touched.

No files require special attention. The Dockerfile comment on line 14 could be extended to note that bun.lock must also be regenerated when a workspace is added, but this is a minor omission already covered by the PR description.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Replaces `--no-save --minimum-release-age 0` with `--frozen-lockfile`; `bun.lock` is correctly copied before the install step on line 18, so frozen install will work as intended. |
| package.json | Adds five `@mastra/*` exact-version pins to both `overrides` and `resolutions`, consistent with the existing dual-field pattern used for other packages. |
| bun.lock | Only the metadata `overrides` section is updated; no resolved package versions change, confirming the lockfile already had these exact Mastra versions pinned. |
| .github/workflows/build.yml | Single-line change adding `--frozen-lockfile` to `bun install`; no issues. |
| .github/workflows/npm-publish.yml | Frozen install added; dependency install precedes any publish steps, so lockfile drift is not a risk here. |
| .github/workflows/server-unit-tests.yml | Single-line change adding `--frozen-lockfile`; no issues. |
| .github/workflows/vite-unit-tests.yml | Single-line change adding `--frozen-lockfile`; no issues. |
| .github/workflows/knip.yml | Single-line change adding `--frozen-lockfile`; no issues. |
| .github/workflows/server-typecheck.yml | Single-line change adding `--frozen-lockfile`; no issues. |
| .github/workflows/validate-schema.yml | Single-line change adding `--frozen-lockfile`; no issues. |
| .github/workflows/vite-build.yml | Single-line change adding `--frozen-lockfile`; no issues. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer pushes package.json change] --> B{bun.lock regenerated?}
    B -- No --> C[CI: bun install --frozen-lockfile]
    C --> D[❌ Fails — lockfile drift detected]
    B -- Yes --> E[CI: bun install --frozen-lockfile]
    E --> F[✅ Installs exact locked versions]
    F --> G{Any @mastra/* caret range resolves to new version?}
    G -- Yes, malicious bump --> H[overrides/resolutions block it]
    H --> I[✅ Safe pinned version installed]
    G -- No drift --> I

    subgraph Docker Build
        J[COPY bun.lock + package.json] --> K[bun install --ignore-scripts --frozen-lockfile]
        K --> L[✅ 3-day quarantine gate active]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Developer pushes package.json change] --> B{bun.lock regenerated?}
    B -- No --> C[CI: bun install --frozen-lockfile]
    C --> D[❌ Fails — lockfile drift detected]
    B -- Yes --> E[CI: bun install --frozen-lockfile]
    E --> F[✅ Installs exact locked versions]
    F --> G{Any @mastra/* caret range resolves to new version?}
    G -- Yes, malicious bump --> H[overrides/resolutions block it]
    H --> I[✅ Safe pinned version installed]
    G -- No drift --> I

    subgraph Docker Build
        J[COPY bun.lock + package.json] --> K[bun install --ignore-scripts --frozen-lockfile]
        K --> L[✅ 3-day quarantine gate active]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: pin mastra packages + enforce fro..."](https://github.com/useautumn/autumn/commit/bbbb26e1f52511f1db9593b061aedbdece6343d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38100943)</sub>

<!-- /greptile_comment -->