### PR TITLE
Feat/ignore past due preserve subscription

### DIFF
--- a/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
+++ b/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
@@ -129,6 +129,8 @@ export const isStripeSubscriptionPastDueTransition = ({
 	stripeSubscription?: Stripe.Subscription;
 	previousAttributes?: { status?: Stripe.Subscription.Status };
 }) => {
-	const wasPastDue = previousAttributes?.status === "past_due";
-	return !wasPastDue && isStripeSubscriptionPastDue(stripeSubscription);
+	// previousAttributes only contains fields that changed; status present means
+	// it changed in this event, so reaching past_due is a real transition.
+	const statusChanged = !!previousAttributes && "status" in previousAttributes;
+	return statusChanged && isStripeSubscriptionPastDue(stripeSubscription);
 };

--- a/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
+++ b/server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts
@@ -120,3 +120,15 @@ export const isStripeSubscriptionPastDue = (
 
 	return stripeSubscription.status === "past_due";
 };
+
+/** True only on the event where the subscription just entered past_due. */
+export const isStripeSubscriptionPastDueTransition = ({
+	stripeSubscription,
+	previousAttributes,
+}: {
+	stripeSubscription?: Stripe.Subscription;
+	previousAttributes?: { status?: Stripe.Subscription.Status };
+}) => {
+	const wasPastDue = previousAttributes?.status === "past_due";
+	return !wasPastDue && isStripeSubscriptionPastDue(stripeSubscription);
+};

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts
@@ -5,6 +5,7 @@ import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhoo
 import { emitBillingChangeWebhook, logCustomerProductUpdates } from "../common";
 import { setupStripeSubscriptionUpdatedContext } from "./setupStripeSubscriptionUpdatedContext.js";
 import { handleCancelOnPastDue } from "./tasks/handleCancelOnPastDue.js";
+import { handleIgnorePastDue } from "./tasks/handleIgnorePastDue.js";
 import { handleSchedulePhaseChanges } from "./tasks/handleSchedulePhaseChanges/handleSchedulePhaseChanges.js";
 import { handleStripeSubscriptionRenewed } from "./tasks/handleStripeSubscriptionRenewed/handleStripeSubscriptionRenewed.js";
 import { handleStripeSubscriptionTrialEnded } from "./tasks/handleStripeSubscriptionTrialEnded/handleStripeSubscriptionTrialEnded.js";
@@ -61,6 +62,12 @@ export const handleStripeSubscriptionUpdated = async ({
 
 	// 5. Handle cancel_on_past_due org setting
 	await handleCancelOnPastDue({
+		ctx,
+		subscriptionUpdatedContext,
+	});
+
+	// 5b. Keep ignore_past_due plans alive instead of letting Stripe cancel them
+	await handleIgnorePastDue({
 		ctx,
 		subscriptionUpdatedContext,
 	});

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts
@@ -1,26 +1,8 @@
 import { createStripeCli } from "@/external/connect/createStripeCli";
-import type { ExpandedStripeSubscription } from "@/external/stripe/subscriptions/operations/getExpandedStripeSubscription";
+import { isStripeSubscriptionPastDueTransition } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
 import { stripeSubscriptionToLatestInvoice } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
 import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
-import type {
-	StripeSubscriptionUpdatedContext,
-	SubscriptionPreviousAttributes,
-} from "../stripeSubscriptionUpdatedContext";
-
-/**
- * Detects if a subscription.updated event represents a transition to past_due.
- */
-const isStripeSubscriptionPastDueEvent = ({
-	stripeSubscription,
-	previousAttributes,
-}: {
-	stripeSubscription: ExpandedStripeSubscription;
-	previousAttributes: SubscriptionPreviousAttributes;
-}): boolean => {
-	const wasPastDue = previousAttributes.status === "past_due";
-	const isPastDue = stripeSubscription.status === "past_due";
-	return !wasPastDue && isPastDue;
-};
+import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
 
 /**
  * Handles the cancel_on_past_due org setting.
@@ -40,11 +22,13 @@ export const handleCancelOnPastDue = async ({
 	if (!org.config.cancel_on_past_due) return;
 
 	// Only proceed if subscription just transitioned to past_due
-	const isPastDueEvent = isStripeSubscriptionPastDueEvent({
-		stripeSubscription,
-		previousAttributes,
-	});
-	if (!isPastDueEvent) return;
+	if (
+		!isStripeSubscriptionPastDueTransition({
+			stripeSubscription,
+			previousAttributes,
+		})
+	)
+		return;
 
 	const stripeCli = createStripeCli({ org, env });
 

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts
@@ -1,3 +1,4 @@
+import { isCustomerProductOnStripeSubscription } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { isStripeSubscriptionPastDueTransition } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
 import { stripeSubscriptionToLatestInvoice } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
@@ -16,7 +17,8 @@ export const handleCancelOnPastDue = async ({
 	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
 }): Promise<void> => {
 	const { org, env, logger } = ctx;
-	const { stripeSubscription, previousAttributes } = subscriptionUpdatedContext;
+	const { stripeSubscription, previousAttributes, customerProducts } =
+		subscriptionUpdatedContext;
 
 	// Only proceed if org has cancel_on_past_due enabled
 	if (!org.config.cancel_on_past_due) return;
@@ -29,6 +31,21 @@ export const handleCancelOnPastDue = async ({
 		})
 	)
 		return;
+
+	// ignore_past_due preserves the subscription, so it wins over cancellation.
+	const ignorePastDue = customerProducts.some(
+		(customerProduct) =>
+			isCustomerProductOnStripeSubscription({
+				customerProduct,
+				stripeSubscriptionId: stripeSubscription.id,
+			}) && customerProduct.product.config?.ignore_past_due,
+	);
+	if (ignorePastDue) {
+		logger.info(
+			`subscription.updated (past_due): skipping cancel for ${stripeSubscription.id}, ignore_past_due is set`,
+		);
+		return;
+	}
 
 	const stripeCli = createStripeCli({ org, env });
 

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts
@@ -1,0 +1,69 @@
+import { isCustomerProductOnStripeSubscription } from "@autumn/shared";
+import { isStripeSubscriptionPastDueTransition } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
+import { stripeSubscriptionToLatestInvoice } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
+import type { StripeWebhookContext } from "@/external/stripe/webhookMiddlewares/stripeWebhookContext";
+import type { StripeSubscriptionUpdatedContext } from "../stripeSubscriptionUpdatedContext";
+
+// Long window so the now-manual invoice doesn't immediately read as overdue.
+const SEND_INVOICE_DAYS_UNTIL_DUE = 365;
+
+/**
+ * Keeps an `ignore_past_due` plan's subscription alive when it goes past_due:
+ * removes the open invoice from Stripe's auto-dunning and switches the sub to
+ * send_invoice so Stripe's retry/cancel flow never tears it down.
+ */
+export const handleIgnorePastDue = async ({
+	ctx,
+	subscriptionUpdatedContext,
+}: {
+	ctx: StripeWebhookContext;
+	subscriptionUpdatedContext: StripeSubscriptionUpdatedContext;
+}): Promise<void> => {
+	const { stripeCli, logger } = ctx;
+	const { stripeSubscription, previousAttributes, customerProducts } =
+		subscriptionUpdatedContext;
+
+	if (
+		!isStripeSubscriptionPastDueTransition({
+			stripeSubscription,
+			previousAttributes,
+		})
+	)
+		return;
+
+	const ignorePastDue = customerProducts.some(
+		(customerProduct) =>
+			isCustomerProductOnStripeSubscription({
+				customerProduct,
+				stripeSubscriptionId: stripeSubscription.id,
+			}) && customerProduct.product.config?.ignore_past_due,
+	);
+	if (!ignorePastDue) return;
+
+	try {
+		const latestInvoice = await stripeSubscriptionToLatestInvoice({
+			stripeSubscription,
+			stripeCli,
+		});
+
+		if (latestInvoice?.status === "open" && latestInvoice.id) {
+			await stripeCli.invoices.update(latestInvoice.id, {
+				auto_advance: false,
+			});
+		}
+
+		await stripeCli.subscriptions.update(stripeSubscription.id, {
+			collection_method: "send_invoice",
+			days_until_due: SEND_INVOICE_DAYS_UNTIL_DUE,
+		});
+
+		logger.info(
+			`[sub.updated] ignore_past_due: kept subscription ${stripeSubscription.id} alive (send_invoice, invoice auto_advance off)`,
+		);
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		logger.error(
+			`[sub.updated] ignore_past_due: failed to preserve subscription ${stripeSubscription.id}: ${errorMessage}`,
+		);
+	}
+};


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves subscriptions with `ignore_past_due` when they transition to `past_due` by turning off invoice auto-dunning and switching to manual invoicing, so Stripe won’t cancel them. Also updates `cancel_on_past_due` to skip cancellation for these subscriptions.

- **New Features**
  - Added `handleIgnorePastDue` to detect `past_due` transitions and, when an `ignore_past_due` plan is present, set `collection_method: send_invoice`, `days_until_due: 365`, and disable invoice `auto_advance`.
  - Updated `handleCancelOnPastDue` to check for `ignore_past_due` and avoid canceling those subscriptions.
  - Extracted `isStripeSubscriptionPastDueTransition` utility for shared past_due transition detection.

<sup>Written for commit 506560be5839ec71f53f8bec442523902a2e0069. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an `ignore_past_due` product-level feature that keeps a subscription alive when it enters `past_due` status, instead of allowing Stripe's dunning to cancel it. It also extracts a shared `isStripeSubscriptionPastDueTransition` utility that correctly detects the status transition (fixing a subtle edge-case in the old inline check).

- **[Improvements]** New `isStripeSubscriptionPastDueTransition` utility uses `\"status\" in previousAttributes` (key presence) instead of comparing the value, correctly ignoring non-status-change events where the old check would have misfired.
- **[Bug fixes]** `handleCancelOnPastDue` now short-circuits when `ignore_past_due` is set on any attached product, so product-level intent wins over the org-level `cancel_on_past_due` flag.
- **[Improvements]** New `handleIgnorePastDue` handler disables invoice `auto_advance` and switches the subscription to `send_invoice` with a 365-day due window, preventing Stripe from ever tearing down the subscription through automated dunning.
</details>

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge; the new handler correctly prevents infinite loops and the cancel-vs-preserve priority is wired up properly, but a transient Stripe API error in handleIgnorePastDue will silently leave the subscription exposed to dunning cancellation.

The core feature logic — detecting the past_due transition, checking the product flag, and updating both the invoice and the subscription — is sound. The interaction between handleCancelOnPastDue and handleIgnorePastDue is correctly ordered and guarded. The main risk is in the error-handling path: swallowing Stripe API errors in handleIgnorePastDue means a failed preservation attempt goes undetected and the subscription can still be torn down by Stripe's dunning without any retry opportunity.

handleIgnorePastDue.ts — the catch block that absorbs all Stripe API failures deserves a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts | New handler that switches a past_due subscription to send_invoice mode and disables invoice auto_advance; catches all Stripe API errors silently, meaning a transient failure leaves the subscription unprotected from Stripe's dunning cancellation. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleCancelOnPastDue.ts | Refactored to use the shared isStripeSubscriptionPastDueTransition utility and adds an early-return guard when ignore_past_due is set on any product attached to the subscription. |
| server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts | New isStripeSubscriptionPastDueTransition utility correctly gates on key presence in previousAttributes, fixing a subtle edge-case bug in the old inline check; parameter types are wider than needed. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/handleStripeSubscriptionUpdated.ts | Inserts handleIgnorePastDue after handleCancelOnPastDue; ordering is correct since handleCancelOnPastDue now short-circuits for ignore_past_due plans before handleIgnorePastDue runs. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Stripe
    participant Handler as handleStripeSubscriptionUpdated
    participant CancelTask as handleCancelOnPastDue
    participant IgnoreTask as handleIgnorePastDue

    Stripe->>Handler: subscription.updated (status → past_due)
    Handler->>CancelTask: run
    CancelTask->>CancelTask: isStripeSubscriptionPastDueTransition?
    alt org.cancel_on_past_due AND no ignore_past_due
        CancelTask->>Stripe: subscriptions.cancel + invoices.voidInvoice
    else ignore_past_due set on product
        CancelTask-->>Handler: return early (skip cancel)
    end
    Handler->>IgnoreTask: run
    IgnoreTask->>IgnoreTask: isStripeSubscriptionPastDueTransition?
    alt ignore_past_due set on product
        IgnoreTask->>Stripe: invoices.update (auto_advance: false)
        IgnoreTask->>Stripe: subscriptions.update (send_invoice, days_until_due: 365)
        Stripe-->>Handler: subscription.updated (collection_method changed)
        Note over Handler: Second event: no status change in previousAttributes → early exit for both tasks
    else no ignore_past_due
        IgnoreTask-->>Handler: return early
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Stripe
    participant Handler as handleStripeSubscriptionUpdated
    participant CancelTask as handleCancelOnPastDue
    participant IgnoreTask as handleIgnorePastDue

    Stripe->>Handler: subscription.updated (status → past_due)
    Handler->>CancelTask: run
    CancelTask->>CancelTask: isStripeSubscriptionPastDueTransition?
    alt org.cancel_on_past_due AND no ignore_past_due
        CancelTask->>Stripe: subscriptions.cancel + invoices.voidInvoice
    else ignore_past_due set on product
        CancelTask-->>Handler: return early (skip cancel)
    end
    Handler->>IgnoreTask: run
    IgnoreTask->>IgnoreTask: isStripeSubscriptionPastDueTransition?
    alt ignore_past_due set on product
        IgnoreTask->>Stripe: invoices.update (auto_advance: false)
        IgnoreTask->>Stripe: subscriptions.update (send_invoice, days_until_due: 365)
        Stripe-->>Handler: subscription.updated (collection_method changed)
        Note over Handler: Second event: no status change in previousAttributes → early exit for both tasks
    else no ignore_past_due
        IgnoreTask-->>Handler: return early
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleIgnorePastDue.ts:63-68
**Silent failure leaves subscription unprotected**

If either the `invoices.update` (auto_advance off) or the critical `subscriptions.update` (switch to send_invoice) call throws, the error is caught and logged but the webhook still returns 200 OK to Stripe. Stripe will not retry the event, so Stripe's default dunning remains active and will eventually cancel the subscription despite `ignore_past_due` being set. This is the "unsafe" direction for this feature — a transient Stripe API hiccup silently defeats subscription preservation. `handleCancelOnPastDue` has the same pattern, but a failure there leaves the subscription alive (the safe direction); here the failure leads to the opposite of the intended outcome.

### Issue 2 of 2
server/src/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils.ts:125-131
The `previousAttributes` and `stripeSubscription` parameters accept `undefined`, but all callers within the webhook handler always have non-undefined values per `StripeSubscriptionUpdatedContext`. Tightening these types would make the contract clearer and prevent accidental `false` returns from undefined inputs going unnoticed.

```suggestion
export const isStripeSubscriptionPastDueTransition = ({
	stripeSubscription,
	previousAttributes,
}: {
	stripeSubscription: Stripe.Subscription;
	previousAttributes: { status?: Stripe.Subscription.Status };
}) => {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(stripe): respect ignore\_past\_due wh..."](https://github.com/useautumn/autumn/commit/506560be5839ec71f53f8bec442523902a2e0069) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38123014)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->