### PR TITLE
fix: sync expire

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
+++ b/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
@@ -173,10 +173,6 @@ export const setupSyncContext = async ({
 				: null;
 
 			const isImmediatePhase = phase.starts_at === "now";
-			const phaseCanExpirePrevious =
-				isImmediatePhase ||
-				phase.plans.some((plan) => plan.enable_plan_immediately) ||
-				(!firstPhaseIsImmediate && index === 0);
 
 			const productContextsPerPlan = await Promise.all(
 				phase.plans.map((plan) =>
@@ -185,7 +181,8 @@ export const setupSyncContext = async ({
 						fullCustomer,
 						plan,
 						shouldFindCurrentCustomerProduct:
-							phaseCanExpirePrevious && plan.expire_previous === true,
+							plan.expire_previous === true &&
+							(isImmediatePhase || plan.enable_plan_immediately === true),
 						accessStartsAt: plan.enable_plan_immediately
 							? currentEpochMs
 							: undefined,

--- a/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
+++ b/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
@@ -64,13 +64,13 @@ const buildProductContext = async ({
 	ctx,
 	fullCustomer,
 	plan,
-	isImmediate,
+	shouldFindCurrentCustomerProduct,
 	accessStartsAt,
 }: {
 	ctx: AutumnContext;
 	fullCustomer: FullCustomer;
 	plan: SyncPlanInstance;
-	isImmediate: boolean;
+	shouldFindCurrentCustomerProduct: boolean;
 	accessStartsAt?: number;
 }): Promise<SyncProductContext> => {
 	const {
@@ -89,7 +89,7 @@ const buildProductContext = async ({
 	const entity = resolvePlanEntity({ plan, fullCustomer });
 
 	let currentCustomerProduct: FullCusProduct | undefined;
-	if ((isImmediate || plan.enable_plan_immediately) && plan.expire_previous) {
+	if (shouldFindCurrentCustomerProduct) {
 		const transition = setupAttachTransitionContext({
 			fullCustomer,
 			attachProduct: fullProduct,
@@ -156,6 +156,7 @@ export const setupSyncContext = async ({
 
 	const currentEpochMs = Date.now();
 	const inputPhases = params.phases ?? [];
+	const firstPhaseIsImmediate = inputPhases[0]?.starts_at === "now";
 
 	const phaseContexts: SyncPhaseContext[] = await Promise.all(
 		inputPhases.map(async (phase, index) => {
@@ -172,6 +173,10 @@ export const setupSyncContext = async ({
 				: null;
 
 			const isImmediatePhase = phase.starts_at === "now";
+			const phaseCanExpirePrevious =
+				isImmediatePhase ||
+				phase.plans.some((plan) => plan.enable_plan_immediately) ||
+				(!firstPhaseIsImmediate && index === 0);
 
 			const productContextsPerPlan = await Promise.all(
 				phase.plans.map((plan) =>
@@ -179,7 +184,8 @@ export const setupSyncContext = async ({
 						ctx,
 						fullCustomer,
 						plan,
-						isImmediate: isImmediatePhase,
+						shouldFindCurrentCustomerProduct:
+							phaseCanExpirePrevious && plan.expire_previous === true,
 						accessStartsAt: plan.enable_plan_immediately
 							? currentEpochMs
 							: undefined,
@@ -206,7 +212,6 @@ export const setupSyncContext = async ({
 		}),
 	);
 
-	const firstPhaseIsImmediate = inputPhases[0]?.starts_at === "now";
 	const immediatePhase = firstPhaseIsImmediate
 		? (phaseContexts[0] ?? null)
 		: null;

--- a/server/src/internal/orgs/orgRouter.ts
+++ b/server/src/internal/orgs/orgRouter.ts
@@ -1,3 +1,5 @@
+import { user as userTable } from "@autumn/shared";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { handleGetRCMappings } from "@/external/revenueCat/handlers/handleGetRevenuecatMappings.js";
 import { handleGetRevenueCatProducts } from "@/external/revenueCat/handlers/handleGetRevenuecatProducts.js";
@@ -56,12 +58,27 @@ internalOrgRouter.get("/invites", ...handleGetInvites);
 export const honoOrgRouter = new Hono<HonoEnv>();
 honoOrgRouter.get("", ...handleGetOrg);
 honoOrgRouter.get("/flags", ...handleGetOrgFlags);
-honoOrgRouter.get("/me", (c) => {
-	const { org, env } = c.get("ctx");
+honoOrgRouter.get("/me", async (c) => {
+	const { db, org, env, user, userId } = c.get("ctx");
+	const authUser =
+		user ??
+		(userId
+			? await db.query.user.findFirst({
+					where: eq(userTable.id, userId),
+				})
+			: undefined);
 	return c.json({
+		id: org.id,
 		name: org.name,
 		slug: org.slug,
 		env,
+		user: authUser
+			? {
+					id: authUser.id,
+					email: authUser.email,
+					name: authUser.name,
+				}
+			: undefined,
 	});
 });
 honoOrgRouter.patch("", ...handleUpdateOrg);

--- a/server/tests/integration/billing/sync/sync-schedule-only.test.ts
+++ b/server/tests/integration/billing/sync/sync-schedule-only.test.ts
@@ -5,6 +5,7 @@ import {
 	ms,
 	type SyncParamsV1,
 } from "@autumn/shared";
+import { expectCustomerProductStatuses } from "@tests/integration/billing/utils/expectCustomerProductStatuses";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
 import { products } from "@tests/utils/fixtures/products";
 import ctx from "@tests/utils/testInitUtils/createTestContext";
@@ -118,6 +119,65 @@ test.concurrent(
 		);
 		expect(cusProduct.subscription_ids ?? []).toEqual([]);
 		expect(cusProduct.scheduled_ids).toEqual([schedule.id]);
+	},
+);
+
+// Pre-fix: scheduled sync ignored expire_previous because setup skipped transition lookup for future phases.
+// Post-fix: the first scheduled phase expires the active product in the same group.
+test.concurrent(
+	`${chalk.yellowBright("sync-v2: future schedule expires previous product in same group")}`,
+	async () => {
+		const customerId = "sync-v2-schedule-only-expire-previous";
+		const free = products.base({ id: "free", items: [], group: "main" });
+		const pro = products.pro({ id: "pro", items: [], group: "main" });
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+			],
+			actions: [s.attach({ productId: free.id })],
+		});
+
+		const proFull = await fetchFullProduct({ ctx, productId: pro.id });
+		const schedule = await createFutureStripeSubscriptionSchedule({
+			ctx,
+			customerId,
+			startDateMs: Date.now() + ms.days(1),
+			phases: [
+				{ items: [{ price: getBaseStripePriceId({ fullProduct: proFull }) }] },
+			],
+		});
+		const startsAt = schedule.phases[0].start_date * 1000;
+
+		const result = await autumnV1.post("/billing.sync_v2", {
+			customer_id: customerId,
+			stripe_schedule_id: schedule.id,
+			phases: [
+				{
+					starts_at: startsAt,
+					plans: [{ plan_id: pro.id, expire_previous: true }],
+				},
+			],
+		} satisfies SyncParamsV1);
+
+		expect(result.expired_cus_product_ids).toHaveLength(1);
+
+		await expectCustomerProductStatuses({
+			ctx,
+			customerId,
+			productId: free.id,
+			expected: { [CusProductStatus.Expired]: 1 },
+		});
+
+		const proCusProduct = await getCustomerProduct({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+		expect(proCusProduct.status).toBe(CusProductStatus.Scheduled);
+		expect(proCusProduct.starts_at).toBe(startsAt);
 	},
 );
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sync_v2` so the first scheduled phase correctly expires the current product when `expire_previous` is set, preventing overlapping active products. Also enriches `GET /orgs/me` with org ID and optional user info.

- **Bug Fixes**
  - Perform transition lookup when a plan has `expire_previous`: immediate phases, the first scheduled phase, or when the plan has `enable_plan_immediately`.
  - Replaced `isImmediate` with `shouldFindCurrentCustomerProduct` to make the lookup explicit and per-plan.
  - Added an integration test verifying a future schedule expires the active product and creates the new product in `Scheduled` status.

- **New Features**
  - `GET /orgs/me` now includes `id` and a `user` object (id, email, name) when available; falls back to DB lookup if not in context.

<sup>Written for commit de39f9eeee59e5cd1eb775e265752d211e9c6ea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes `sync_v2` so the first future-scheduled phase correctly honours `expire_previous` by performing the transition lookup that was previously skipped for non-immediate phases.

- **Bug fixes** — `phaseCanExpirePrevious` now includes `!firstPhaseIsImmediate && index === 0`, so the first scheduled phase triggers `setupAttachTransitionContext` when a plan sets `expire_previous: true`, expiring the active product in the same group.
- **Improvements** — `isImmediate` renamed to `shouldFindCurrentCustomerProduct` at the `buildProductContext` call site; the `enable_plan_immediately` gate is now evaluated at the phase level (`phase.plans.some(...)`) rather than per-plan, so any plan with `expire_previous` in an \"immediate-access\" phase benefits from the transition lookup.
- **Bug fixes** — Integration test added confirming a future schedule expires the active `free` product and creates the `pro` product in `Scheduled` status.
</details>

<h3>Confidence Score: 4/5</h3>

The change is tightly scoped to transition-lookup logic for the first scheduled phase; it adds no new data mutations and is covered by a new integration test.

The fix correctly extends phaseCanExpirePrevious to the first non-immediate phase. One subtle behavioral widening exists: enable_plan_immediately is now evaluated at the phase level rather than per-plan, meaning a plan that lacks enable_plan_immediately can inherit the transition lookup from a sibling plan that has it. This is almost certainly harmless in current usage but is an undocumented semantic shift.

setupSyncContext.ts — specifically the phaseCanExpirePrevious condition and how it interacts with multi-plan phases where only some plans carry enable_plan_immediately.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts | Fixes buildProductContext to look up the current customer product for the first scheduled (non-immediate) phase when expire_previous is set; introduces phaseCanExpirePrevious and renames isImmediate to shouldFindCurrentCustomerProduct for clarity. Also hoists firstPhaseIsImmediate before the phase mapping loop. |
| server/tests/integration/billing/sync/sync-schedule-only.test.ts | Adds an integration test covering the fixed scenario: a future-scheduled sync with expire_previous: true correctly expires the active product in the same group and sets the new product to Scheduled status. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["setupSyncContext: iterate phases"] --> B{"index === 0 AND\nphase.starts_at !== 'now'?"}
    B -- Yes --> C["phaseCanExpirePrevious = true\n(first scheduled phase)"]
    B -- No --> D{"phase.starts_at === 'now'?"}
    D -- Yes --> E["phaseCanExpirePrevious = true\n(immediate phase)"]
    D -- No --> F{"any plan has\nenable_plan_immediately?"}
    F -- Yes --> G["phaseCanExpirePrevious = true\n(phase-level immediate)"]
    F -- No --> H["phaseCanExpirePrevious = false"]
    C & E & G --> I{"plan.expire_previous === true?"}
    H --> J["shouldFindCurrentCustomerProduct = false"]
    I -- Yes --> K["shouldFindCurrentCustomerProduct = true"]
    I -- No --> J
    K --> L["setupAttachTransitionContext\n→ find currentCustomerProduct\n→ expire it"]
    J --> M["currentCustomerProduct = undefined\n(no expiry)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["setupSyncContext: iterate phases"] --> B{"index === 0 AND\nphase.starts_at !== 'now'?"}
    B -- Yes --> C["phaseCanExpirePrevious = true\n(first scheduled phase)"]
    B -- No --> D{"phase.starts_at === 'now'?"}
    D -- Yes --> E["phaseCanExpirePrevious = true\n(immediate phase)"]
    D -- No --> F{"any plan has\nenable_plan_immediately?"}
    F -- Yes --> G["phaseCanExpirePrevious = true\n(phase-level immediate)"]
    F -- No --> H["phaseCanExpirePrevious = false"]
    C & E & G --> I{"plan.expire_previous === true?"}
    H --> J["shouldFindCurrentCustomerProduct = false"]
    I -- Yes --> K["shouldFindCurrentCustomerProduct = true"]
    I -- No --> J
    K --> L["setupAttachTransitionContext\n→ find currentCustomerProduct\n→ expire it"]
    J --> M["currentCustomerProduct = undefined\n(no expiry)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts:176-179
**Phase-level `enable_plan_immediately` gate widens expiry scope**

The original condition checked `plan.enable_plan_immediately` per-plan; `phaseCanExpirePrevious` now uses `phase.plans.some(p => p.enable_plan_immediately)`, so if Plan A carries `enable_plan_immediately` and Plan B in the same phase carries only `expire_previous`, Plan B will now also trigger the transition lookup and expire its predecessor. Previously it would not. This is unlikely to surface in practice (most phases have a single plan), but it's a silent semantic broadening worth confirming is intentional.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: sync expire"](https://github.com/useautumn/autumn/commit/0b573a5bd14a6853a54fb58aed8f5becb62b86f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38204638)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->