### PR TITLE
docs: ground lakehouse balance docs in ETL/getApi source

### DIFF
--- a/apps/docs/mintlify/docs.json
+++ b/apps/docs/mintlify/docs.json
@@ -146,6 +146,7 @@
 							"documentation/lakehouse/overview",
 							"documentation/lakehouse/connecting",
 							"documentation/lakehouse/schema",
+							"documentation/lakehouse/balance-semantics",
 							"documentation/lakehouse/querying"
 						]
 					}

--- a/apps/docs/mintlify/documentation/lakehouse/balance-semantics.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/balance-semantics.mdx
@@ -1,0 +1,107 @@
+---
+title: "Balance semantics"
+sidebarTitle: "Balance semantics"
+description: "What v2_3_balances and v2_3_breakdowns actually mean — and how to reconstruct the figures the API and dashboard show."
+---
+
+{/*
+  MAINTAINER SOURCE TRACE — every claim on this page is grounded in code, not in the prose docs.
+  When the implementation changes, update this page against these files:
+  - ETL reshape (the warehouse tables ARE this computation, materialized):
+      terraform/risingwave-etl/sql/03_v2.3_mvs_balances.sql  (api_2_3.breakdowns, api_2_3.balances)
+  - API read path the ETL mirrors:
+      server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/getApiBalanceV2.ts
+      server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/getApiBalancesV2.ts
+  - Active-status / expiry / dedup filter applied by the API but NOT by the ETL:
+      shared/utils/fullSubjectUtils/fullSubjectToCustomerEntitlements.ts
+      shared/utils/orgUtils/convertOrgUtils.ts                 (orgToInStatuses)
+  - Per-column math:
+      shared/utils/cusEntUtils/balanceUtils/cusEntsToUsage.ts  (usage = granted + prepaid − balance)
+      shared/utils/cusEntUtils/balanceUtils.ts                 (cusEntToCurrentBalance — floors at 0)
+      shared/utils/cusEntUtils/overageUtils/cusEntToInvoiceOverage.ts  (overage = max(0, −balance))
+      shared/utils/cusEntUtils/sortCusEntsForDeduction.ts      (shortest-interval-first deduction)
+*/}
+
+<Warning>
+  **Available on request** — The Autumn Lakehouse is provisioned per customer. Contact us at [hey@useautumn.com](mailto:hey@useautumn.com) to get access.
+</Warning>
+
+`v2_3_balances` and `v2_3_breakdowns` look like a tidy relational schema, but they aren't one. They are **denormalized snapshots of Autumn's read-time balance computation** — the same computation behind `GET /customers/:id` and the dashboard. Read them as columns named after their source values rather than as a schema you can do naive arithmetic on, and the surprises below disappear.
+
+If you only take one thing from this page: **the warehouse keeps every entitlement row, the API does not.** To reproduce an API or dashboard figure you must re-apply the filter the API applies — active products, non-expired entitlements, current cycle.
+
+## The model in one paragraph
+
+For each feature, the API gathers a customer's **active** `customer_entitlement` rows, computes a small set of values per row (`included_grant`, `prepaid_grant`, `remaining`, `usage`, `overage`), and sums them into one balance. The ETL materializes exactly this: `v2_3_breakdowns` is one row **per entitlement per scope** (the per-row values), and `v2_3_balances` is the `GROUP BY customer × feature × scope` sum over it. The only — but decisive — difference is that the ETL aggregates over **all** entitlement rows in your database, while the API first filters to the active, current set.
+
+## Why your numbers look inflated
+
+`v2_3_breakdowns` is built from a plain join over `customer_entitlements` with **no status, expiry, or cycle filter**. Every entitlement row your account has ever held is in there:
+
+- superseded / cancelled product **versions**,
+- past reset **cycles** that already rolled over,
+- pre-seeded **future** cycles.
+
+The API, by contrast, keeps only entitlements whose product is **active** (status `active`, or `past_due` if your org enables `include_past_due`) and whose `expires_at` is in the future, then dedups and sums.
+
+So a single `v2_3_balances` row can sum *many lifetimes* of `usage` for one customer × feature. This is **not** because `usage` is a lifetime accumulator — each entitlement's `usage` is its own current value. It's because the row aggregates over entitlements the API would have thrown away. A pooled balance that reads `granted = 53,000`, `usage = 3,408,161`, `remaining = +10,312` is not a corrupted row — it is dozens of historical entitlements summed together. Filter to the active, current-cycle set and it reconciles.
+
+## Per-column meaning
+
+These are the values the ETL writes, verbatim from the read-time math.
+
+| Column (both tables unless noted) | Definition |
+|---|---|
+| `included_grant` *(breakdowns)* | `allowance + adjustment`, scaled by product quantity / entity count |
+| `prepaid_grant` *(breakdowns)* | prepaid quantity × billing units (0 unless a prepaid price is linked) |
+| `granted` *(balances)* | `Σ(included_grant + prepaid_grant)` + rollover-granted |
+| `usage` | `included_grant + prepaid_grant − balance` per row (signed balance); summed, then `+ rollover_usage − unused` |
+| `remaining` | `max(0, balance)` per row — **floored at 0** — summed, then `+ rollover_balance + unused` |
+| `overage` | **not stored** — see below |
+
+Two consequences fall straight out of these definitions:
+
+1. **`remaining` is floored.** Each entitlement contributes `max(0, balance)`, never a negative. You cannot recover how far a balance went negative from `remaining` — that information lives only in `usage`.
+2. **`usage` carries the sign.** Because `usage = granted − balance` (per row), `usage − granted = −balance`. When a balance goes negative (overage), `usage` exceeds `granted` by exactly that amount. This is the hook used to reconstruct overage.
+
+### `granted`, `remaining`, `usage` are not a closed triple
+
+`remaining ≠ granted − usage`. They diverge for three independent reasons, all by design:
+
+- **Manual "Set Balance"** writes `balance` directly, decoupling it from `granted`. Set a balance below zero and `usage` (= `granted − balance`) inflates past `granted` with no real consumption behind it — the "spurious negative balance / huge usage" artifact.
+- **Rollover and unused** terms are layered into `granted`/`remaining`/`usage` separately (rollover-granted, rollover-balance, rollover-usage, unused), and don't cancel.
+- **The flooring** of `remaining` (above) breaks the identity whenever any entitlement is in overage.
+
+Treat each column as the named sum it is, not as a term in an equation.
+
+## Overage is derived, not stored
+
+There is **no overage column** on `v2_3_balances` or `v2_3_breakdowns`. The dashboard's overage figure is computed at read time: per entitlement, `overage = max(0, −balance)`, summed. That is identical to `max(0, usage − (included_grant + prepaid_grant))` per breakdown row, since `usage − granted = −balance`.
+
+So the faithful warehouse reconstruction is:
+
+```text
+overage = Σ  max(0, usage − included_grant − prepaid_grant)
+          over active, current-cycle breakdown rows
+```
+
+**Floor per row, then sum.** Flooring at the customer level instead lets a surplus on one entitlement cancel an overage on another, which the API never does. (`overage` is only meaningful where a usage-based price exists — a feature with no overage-allowed price never goes negative.)
+
+## The active + current-cycle filter
+
+This is the filter the API applies and the warehouse does not. Re-apply it before any balance, usage, or overage query.
+
+1. **Active product only.** Keep breakdown rows whose `internal_product_id` matches an active subscription (`v2_3_subscriptions.status = 'active'`). If your org enables `include_past_due`, also keep `past_due`. One-off entitlements (`reset_interval = 'one_off'`) are always live.
+2. **Current cycle only.** An entitlement carries one row per reset cycle it has lived through. The current cycle is the one whose reset is the **earliest still in the future**: per `(internal_customer_id, internal_product_id)`, `min(reset_resets_at)` where `reset_resets_at > now`. `one_off` rows have no cycle and are always kept.
+3. **Pooled vs per-entity.** Keep `coalesce(entity_id, '') = ''` for customer-level (pooled) totals. Customers with `config.disable_pooled_balance` set track per-entity instead — for those, sum the per-entity rows rather than the pooled row. See [Querying → Pooled vs per-entity](/documentation/lakehouse/querying#pooled-vs-per-entity-rows).
+4. **Not expired.** Drop rows whose `expires_at` is in the past.
+
+A ready-to-run query that applies all of this and reproduces the dashboard's overage leaderboard is in [Querying → Current-period billable overage](/documentation/lakehouse/querying#current-period-billable-overage).
+
+## Deduction order (why monthly drains before lifetime)
+
+When usage is recorded, Autumn deducts from entitlements **shortest-reset-interval-first** (a daily grant drains before a monthly, which drains before a lifetime/`one_off`), after a few higher-priority rules — entity-scoped before pooled when tracking an entity, unlimited first, prepaid before pay-per-use. This is why, when a customer has both a monthly grant and a lifetime grant for the same feature, the monthly empties first and overage lands on whichever pool is drained last. It matters for analytics because it determines **which** breakdown row shows the overage, not just the total.
+
+## Footgun: `IS NULL` throws on these tables
+
+On the Iceberg balances/breakdowns/flags tables, `WHERE entity_id IS NULL` raises `NOT_FOUND_COLUMN_IN_BLOCK` (it reaches for an unmaterialized `entity_id.null` subcolumn). Use `coalesce(entity_id, '') = ''` instead, everywhere you'd reach for `IS NULL`. See [Querying → Pooled vs per-entity](/documentation/lakehouse/querying#pooled-vs-per-entity-rows).

--- a/apps/docs/mintlify/documentation/lakehouse/querying.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/querying.mdx
@@ -10,6 +10,22 @@ description: "How to address tables, convert types, join, and avoid footguns."
 
 Throughout this page, replace `<catalog>` and `<namespace>` with the names Autumn assigned you.
 
+## Find your catalog and namespace
+
+Autumn sends you both names when your Lakehouse is provisioned (see [Connecting](/documentation/lakehouse/connecting)). If you need to rediscover them in ClickHouse Cloud, the catalog mounts as a database — list databases to find it:
+
+<Tabs>
+<Tab title="ClickHouse">
+
+```sql
+SHOW DATABASES;
+```
+
+The catalog appears as one of the listed databases. Your tables then live under `` `<catalog>`.`<namespace>.v2_3_<object>` `` (the `<namespace>.v2_3_<object>` part is a single literal table name — see below).
+
+</Tab>
+</Tabs>
+
 ## Identifier syntax
 
 <Tabs>
@@ -21,7 +37,7 @@ The Glue catalog mounts as a database. The whole `<namespace>.v2_3_<object>` is 
 SELECT * FROM `<catalog>`.`<namespace>.v2_3_features` LIMIT 10;
 ```
 
-A common mistake is `` `<catalog>.<namespace>`.`v2_3_features` `` — that won't resolve, because `<namespace>.v2_3_features` is a single identifier, not `database.table`.
+A common mistake is `` `<catalog>.<namespace>`.`v2_3_features` `` — that won't resolve, because `<namespace>.v2_3_features` is a single identifier, not `database.table`. The single-quoted `'<namespace>.v2_3_features'` form does not resolve in ClickHouse Cloud either — use backticks on both parts.
 
 </Tab>
 {/*
@@ -93,6 +109,19 @@ FROM `<project>.<dataset>.v2_3_events`;
 */}
 </Tabs>
 
+## Nullable columns: don't use `IS NULL`
+
+<Warning>
+  On the Iceberg tables, `WHERE col IS NULL` raises `NOT_FOUND_COLUMN_IN_BLOCK` — the engine reaches for an unmaterialized `col.null` subcolumn that doesn't exist. This bites hardest on `entity_id` (the pooled-vs-entity discriminator). Use **`coalesce(col, '') = ''`** for "is null" and **`coalesce(col, '') != ''`** for "is not null".
+</Warning>
+
+```sql
+-- ✗ throws NOT_FOUND_COLUMN_IN_BLOCK
+WHERE entity_id IS NULL
+-- ✓ pooled (customer-level) rows
+WHERE coalesce(entity_id, '') = ''
+```
+
 ## Examples
 
 ### Fetch one customer
@@ -161,7 +190,11 @@ WHERE s.status = 'active';
 
 ### A customer's balances for a feature
 
-Use the pooled (customer-level) rows where `entity_id IS NULL`.
+Use the pooled (customer-level) rows where `coalesce(entity_id, '') = ''`.
+
+<Warning>
+  This returns the **raw** aggregated row, which sums over *every* entitlement — including superseded versions and past cycles — so `granted`/`remaining`/`usage` will not match the API for customers with history. To reproduce the API/dashboard figure, apply the active + current-cycle filter from [Balance semantics](/documentation/lakehouse/balance-semantics). For overage specifically, use [the reference query below](#current-period-billable-overage).
+</Warning>
 
 <Tabs>
 <Tab title="ClickHouse">
@@ -171,7 +204,7 @@ SELECT feature_id, granted, remaining, usage
 FROM `<catalog>`.`<namespace>.v2_3_balances`
 WHERE customer_id = 'cus_123'
   AND feature_id = 'AI_CREDITS'
-  AND entity_id IS NULL;
+  AND coalesce(entity_id, '') = '';
 ```
 
 </Tab>
@@ -188,6 +221,89 @@ WHERE customer_id = 'cus_123'
 
 </Tab>
 */}
+</Tabs>
+
+### Current-period billable overage
+
+Overage is **derived, not stored** (see [Balance semantics → Overage](/documentation/lakehouse/balance-semantics#overage-is-derived-not-stored)). This query reconstructs the dashboard's overage leaderboard from `v2_3_breakdowns`: it keeps only rows whose product is an **active** subscription (plus always-live `one_off` rows), picks each entitlement's **current cycle** (earliest upcoming reset), floors overage **per row** (`max(0, usage − granted)`), then sums per customer. It reproduces the dashboard figure to within sync-lag drift.
+
+<Note>
+  Swap in your `<catalog>` / `<namespace>` and the feature id. Known simplifications: it omits `rollover` / `unused` terms (zero for most customers, non-zero in general) and is pooled-only (`coalesce(entity_id,'') = ''`), so per-entity overage under `config.disable_pooled_balance` is not counted. For those customers, sum the per-entity rows instead.
+</Note>
+
+<Tabs>
+<Tab title="ClickHouse">
+<Expandable title="ClickHouse">
+
+```sql
+WITH
+  active_prod AS (
+    SELECT DISTINCT internal_customer_id, internal_product_id
+    FROM `<catalog>`.`<namespace>.v2_3_subscriptions`
+    WHERE env = 'live' AND status = 'active'
+  ),
+  bd AS (
+    SELECT
+      b.internal_customer_id AS icid,
+      b.internal_product_id  AS ipid,
+      b.reset_interval       AS ri,
+      toInt64(b.reset_resets_at) AS rra,
+      (b.included_grant + b.prepaid_grant) AS granted,
+      b.usage AS usage
+    FROM `<catalog>`.`<namespace>.v2_3_breakdowns` AS b
+    WHERE b.env = 'live'
+      AND b.feature_id = 'AI_CREDITS'
+      AND coalesce(b.entity_id, '') = ''
+      AND (
+        b.reset_interval = 'one_off'
+        OR (b.internal_customer_id, b.internal_product_id)
+             IN (SELECT internal_customer_id, internal_product_id FROM active_prod)
+      )
+  ),
+  cur_cycle AS (
+    SELECT icid, ipid, min(rra) AS cur_reset
+    FROM bd
+    WHERE ri != 'one_off' AND rra > toUnixTimestamp(now()) * 1000
+    GROUP BY icid, ipid
+  ),
+  per_customer AS (
+    SELECT
+      bd.icid AS icid,
+      sum(bd.granted) AS granted,
+      sum(bd.usage)   AS usage,
+      -- floor overage PER ROW, then sum (matches the API's per-entitlement max(0, −balance))
+      sum(greatest(0, bd.usage - bd.granted)) AS overage
+    FROM bd
+    LEFT JOIN cur_cycle AS cc ON cc.icid = bd.icid AND cc.ipid = bd.ipid
+    WHERE bd.ri = 'one_off' OR bd.rra = cc.cur_reset
+    GROUP BY bd.icid
+    HAVING overage > 0
+    ORDER BY overage DESC
+    LIMIT 10
+  ),
+  active_subs AS (
+    SELECT s.internal_customer_id AS icid, groupArray(coalesce(p.name, s.plan_id)) AS subscriptions
+    FROM `<catalog>`.`<namespace>.v2_3_subscriptions` AS s
+    LEFT JOIN `<catalog>`.`<namespace>.v2_3_plans` AS p ON p.internal_id = s.internal_product_id
+    WHERE s.env = 'live' AND s.status = 'active'
+    GROUP BY s.internal_customer_id
+  )
+SELECT
+  c.customer_id AS customer_id,
+  nullIf(c.name, '')  AS name,
+  nullIf(c.email, '') AS email,
+  pc.granted AS granted,
+  pc.usage   AS usage,
+  pc.overage AS overage,
+  s.subscriptions AS subscriptions
+FROM per_customer AS pc
+INNER JOIN `<catalog>`.`<namespace>.v2_3_customers` AS c ON c.internal_id = pc.icid
+LEFT JOIN active_subs AS s ON s.icid = pc.icid
+ORDER BY pc.overage DESC;
+```
+
+</Expandable>
+</Tab>
 </Tabs>
 
 ### Invoice totals by status
@@ -273,6 +389,10 @@ ORDER BY day;
 This rebuilds the **entire** `GET /customers/:id` response — scalars, subscriptions, purchases, balances (with per-plan breakdowns), flags, and invoices — from the warehouse in a single query, returned as one JSON object. It's the most useful query if you want the API's customer view without calling the API.
 
 ClickHouse-specific (uses `groupArray`, `Tuple`/`Map` casts, and the `JSON` type — ClickHouse 24.8+). Customer-level (pooled) balances and flags use `entity_id = ''`; per-entity rows are excluded from the customer envelope. `FORMAT PrettyJSONEachRow` emits one pretty-printed JSON object.
+
+<Warning>
+  This mirrors the **shape** of the API response, but the `balances` / `breakdown` values are the raw aggregated rows — they sum over superseded versions and past cycles, so they will not match `GET /customers/:id` for customers with billing history. To match the API, restrict the balances/breakdowns subqueries to active, current-cycle rows per [Balance semantics → The active + current-cycle filter](/documentation/lakehouse/balance-semantics#the-active-current-cycle-filter).
+</Warning>
 <Tabs>
 <Tab title="ClickHouse">
 <Expandable title="ClickHouse">
@@ -462,10 +582,16 @@ So:
 
 `v2_3_balances`, `v2_3_breakdowns`, and `v2_3_flags` contain two kinds of row:
 
-- **Pooled** (customer-level) — `entity_id IS NULL`.
+- **Pooled** (customer-level) — `entity_id` is null.
 - **Per-entity** — `entity_id` is set.
 
-For customer-level totals, filter `entity_id IS NULL` to avoid double counting. To analyze a specific entity, filter on its `entity_id` (or `internal_entity_id`).
+For customer-level totals, keep the pooled rows with `coalesce(entity_id, '') = ''` to avoid double counting. To analyze a specific entity, filter on its `entity_id` (or `internal_entity_id`).
+
+<Warning>
+  Write `coalesce(entity_id, '') = ''`, **not** `entity_id IS NULL` — `IS NULL` throws on these Iceberg columns (see [Nullable columns](#nullable-columns-dont-use-is-null)).
+</Warning>
+
+Customers with `config.disable_pooled_balance` track per-entity rather than pooled — for them, sum the per-entity rows instead of reading the pooled row. See [Balance semantics](/documentation/lakehouse/balance-semantics) for what the aggregated values mean and the active + current-cycle filter you need before trusting them.
 
 ### Freshness
 

--- a/apps/docs/mintlify/documentation/lakehouse/schema.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/schema.mdx
@@ -47,7 +47,7 @@ Types below are **engine-neutral**. How each engine surfaces them:
 - ⭐ marks the **stable, immutable key** for a table — join and filter on this.
 - 🔗 marks a **stable foreign key** (`internal_customer_id`, `internal_feature_id`, `internal_product_id`, `internal_entity_id`, `internal_reward_id`) — join to the matching `internal_id`.
 - External ids (`customer_id`, `plan_id`, `feature_id`, `entity_id`, `id`, …) are **mutable** — convenient for display, but don't rely on them as stable keys. See [Querying → Use internal ids](/documentation/lakehouse/querying#use-internal-ids-not-external-ids).
-- `org_id` is your tenant id (constant across your tables); `env` is `sandbox` or `production`.
+- `org_id` is your tenant id (constant across your tables); `env` is `sandbox` or `live` (**not** `production` — filtering `env = 'production'` silently returns zero rows).
 
 ---
 
@@ -63,7 +63,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `internal_id` | string | ⭐ stable key |
 | `feature_id` | string | external id (e.g. `AI_CREDITS`), mutable |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `name` | string | |
 | `type` | string | feature type |
 | `display` | json (string) | display config |
@@ -77,7 +77,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `internal_id` | string | ⭐ stable key — one row **per plan version** |
 | `plan_id` | string | external id, mutable, shared across versions |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `name` | string | |
 | `description` | string | |
 | `group` | string | |
@@ -105,7 +105,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `plan_id` | string | external plan id |
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `feature_id` | string | external feature id |
 | `internal_feature_id` | string | 🔗 → `v2_3_features.internal_id` |
 | `included` | number | allowance (`0` if unlimited) |
@@ -134,7 +134,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `internal_id` | string | ⭐ stable key |
 | `id` | string | external id, mutable |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `name` | string | |
 | `type` | string | percentage_discount / fixed_discount / free_product |
 | `created_at` | number (epoch ms) | |
@@ -156,7 +156,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `internal_id` | string | ⭐ stable key |
 | `id` | string | external id, mutable |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `created_at` | number (epoch ms) | |
 | `reward_id` | string | external reward id |
 | `internal_reward_id` | string | 🔗 → `v2_3_rewards.internal_id` |
@@ -184,7 +184,7 @@ Who your plans apply to: customers and entities (sub-customers).
 | `internal_id` | string | ⭐ stable key |
 | `customer_id` | string | external id, mutable (may be null) |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `name` | string | |
 | `email` | string | |
 | `created_at` | number (epoch ms) | |
@@ -204,7 +204,7 @@ Who your plans apply to: customers and entities (sub-customers).
 | `internal_id` | string | ⭐ stable key |
 | `id` | string | external id, mutable |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `customer_id` | string | parent customer external id |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
 | `feature_id` | string | entity feature scope (external) |
@@ -232,7 +232,7 @@ Active customer–product relationships: recurring subscriptions and one-off pur
 | `customer_id` | string | external customer id |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `plan_id` | string | external plan id |
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
 | `add_on` | boolean | |
@@ -259,7 +259,7 @@ Active customer–product relationships: recurring subscriptions and one-off pur
 | `customer_id` | string | external customer id |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `plan_id` | string | external plan id |
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
 | `expires_at` | number (epoch ms) | null if no expiry |
@@ -277,8 +277,12 @@ Active customer–product relationships: recurring subscriptions and one-off pur
 
 Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 
+<Warning>
+  **These tables do not behave like a clean relational schema.** They are denormalized snapshots of Autumn's read-time balance computation, and they include **every** `customer_entitlement` row — across superseded product versions and past reset cycles — with **no active-status or current-cycle filter**. A naive `SELECT ... FROM v2_3_balances` therefore double- and triple-counts. Before you query balances, breakdowns, or overage, read **[Balance semantics](/documentation/lakehouse/balance-semantics)** — it explains what each column means, why `usage`/`granted`/`remaining` don't form a closed arithmetic triple, where overage comes from (it is **not** stored), and the active + current-cycle filter you must apply.
+</Warning>
+
 <Note>
-  Balances, breakdowns, and flags carry both **pooled** (customer-level) rows — where `entity_id` is null — and **per-entity** rows. Filter on `entity_id IS NULL` for customer-level totals to avoid double counting. See [Querying → Pooled vs per-entity](/documentation/lakehouse/querying#pooled-vs-per-entity-rows).
+  Balances, breakdowns, and flags carry both **pooled** (customer-level) rows — where `entity_id` is null — and **per-entity** rows. For customer-level totals, keep only the pooled rows with `coalesce(entity_id, '') = ''` to avoid double counting. (Use `coalesce`, **not** `entity_id IS NULL` — `IS NULL` throws on these Iceberg columns; see [Querying → Pooled vs per-entity](/documentation/lakehouse/querying#pooled-vs-per-entity-rows).)
 </Note>
 
 <AccordionGroup>
@@ -293,17 +297,21 @@ Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 | `feature_id` | string | external feature id |
 | `internal_entity_id` | string | 🔗 → `v2_3_entities.internal_id` (null = pooled) |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `unlimited` | boolean | |
-| `granted` | number | total granted (incl. rollover) |
-| `remaining` | number | total remaining (incl. rollover) |
-| `usage` | number | total usage |
+| `granted` | number | Σ(`included_grant` + `prepaid_grant`) + rollover-granted, over **all** entitlements in the group |
+| `remaining` | number | Σ(floored per-entitlement balance) + rollover-balance + unused — **floored at 0**, never negative |
+| `usage` | number | Σ(per-entitlement `usage`) + rollover-usage − unused. **Not** `granted − remaining`; see below |
 | `overage_allowed` | boolean | |
 | `max_purchase` | number | null if unbounded |
 | `reset_interval` | string | single interval or `multiple` |
 | `reset_interval_count` | number | null if `multiple` or count 1 |
 | `reset_resets_at` | number (epoch ms) | earliest reset across entitlements |
 | `next_reset_at` | number (epoch ms) | earliest next reset |
+
+<Warning>
+  `granted` / `remaining` / `usage` are **not** a closed arithmetic triple — `remaining ≠ granted − usage`. Each is aggregated **over every entitlement row for this customer × feature × scope**, including superseded product versions and past cycles, so a single row routinely sums many lifetimes of usage. `remaining` is floored per-entitlement, manual "Set Balance" decouples balance from grant, and rollover/unused are layered in. **There is no overage column** — it is derived. Always read [Balance semantics](/documentation/lakehouse/balance-semantics) and apply the active + current-cycle filter before trusting these numbers.
+</Warning>
 
 </Accordion>
 <Accordion title="v2_3_breakdowns — per-entitlement balance detail">
@@ -320,14 +328,14 @@ Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 | `internal_feature_id` | string | 🔗 → `v2_3_features.internal_id` |
 | `plan_id` | string | external plan id |
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
-| `included_grant` | number | allowance grant |
+| `included_grant` | number | allowance grant (allowance + adjustment) |
 | `prepaid_grant` | number | prepaid grant |
-| `remaining` | number | |
-| `usage` | number | |
+| `remaining` | number | floored balance — `max(0, balance)`, **never negative** |
+| `usage` | number | `included_grant` + `prepaid_grant` − raw (signed) balance |
 | `unlimited` | boolean | |
-| `reset_interval` | string | null for continuous-use |
+| `reset_interval` | string | null for continuous-use; `one_off` for lifetime grants |
 | `reset_interval_count` | number | null if count 1 |
-| `reset_resets_at` | number (epoch ms) | next reset |
+| `reset_resets_at` | number (epoch ms) | next reset for **this** entitlement (use to pick the current cycle) |
 | `price_amount` | number | single-tier only |
 | `price_billing_method` | string | prepaid / usage_based |
 | `price_billing_units` | number | default 1 |
@@ -336,7 +344,11 @@ Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 | `price_tiers` | json (string) | multi-tier array |
 | `expires_at` | number (epoch ms) | null if no expiry |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
+
+<Warning>
+  **`v2_3_breakdowns` has no `status` / `is_active` / `is_current` column** and mixes rows from superseded/cancelled product versions, past reset cycles, and pre-seeded future cycles. To get the rows the API would use, join `internal_product_id` to active subscription status and pick the current cycle (earliest upcoming `reset_resets_at`); `one_off` rows are always live. See [Balance semantics → The active + current-cycle filter](/documentation/lakehouse/balance-semantics#the-active-current-cycle-filter).
+</Warning>
 
 </Accordion>
 <Accordion title="v2_3_flags — boolean feature flags">
@@ -355,7 +367,7 @@ Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
 | `expires_at` | number (epoch ms) | null if no expiry |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 
 </Accordion>
 </AccordionGroup>
@@ -373,7 +385,7 @@ Invoices and their line items.
 |---|---|---|
 | `id` | string | ⭐ stable key (invoice id) |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `customer_id` | string | external customer id |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
 | `entity_id` | string | external entity id (null = customer-scoped) |
@@ -398,7 +410,7 @@ Invoices and their line items.
 |---|---|---|
 | `id` | string | ⭐ stable key (line item id) |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `invoice_id` | string | 🔗 → `v2_3_invoices.id` |
 | `customer_id` | string | external customer id |
 | `description` | string | |
@@ -435,7 +447,7 @@ The append-only usage event log. This is the highest-volume table and is **appen
 | `org_id` | string | your tenant id |
 | `org_slug` | string | |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `created_at` | number (epoch ms) | when Autumn recorded the event |
 | `timestamp` | timestamp | event time — a **real timestamp**, use directly |
 | `event_name` | string | |


### PR DESCRIPTION
## Why

A session trying to reconstruct the dashboard's overage figure from the Lakehouse warehouse hit repeated dead ends because the docs described a clean relational schema, while the tables are denormalized snapshots of Autumn's read-time balance computation. Every wrong turn traced back to a doc claim contradicted by the source.

This PR re-grounds the docs in the **actual source of truth**:
- the RisingWave ETL MVs that build the tables — `terraform/risingwave-etl/sql/03_v2.3_mvs_balances.sql` (`api_2_3.breakdowns`, `api_2_3.balances`)
- the API read path they mirror — `getApiBalanceV2` / `getApiBalancesV2`
- the per-column helpers (`cusEntsToUsage`, `cusEntToCurrentBalance`, `cusEntToInvoiceOverage`, `sortCusEntsForDeduction`, `orgToInStatuses`, `fullSubjectToCustomerEntitlements`)

## Key correction

The ETL joins **all** `customer_entitlements` with **no active-status / expiry / current-cycle filter**, while the API filters to active products + non-expired entitlements. That — not a "lifetime accumulator" — is why `v2_3_balances.usage`/`granted` look inflated. (The original investigation's "usage is cumulative" model was itself imprecise; `usage` is per-entitlement current, the row just aggregates stale entitlements.)

## Changes

- **New page** `balance-semantics.mdx`: what each column means, why `granted`/`remaining`/`usage` aren't a closed triple, the active + current-cycle filter, overage-is-derived, deduction order, and the `IS NULL` footgun. Includes a maintainer-only source-trace comment.
- **schema.mdx**: `env` → `sandbox`/`live` (was `production`); corrected `balances`/`breakdowns` column notes; warnings on the multi-period/version nature and missing status column; `coalesce` instead of `IS NULL`.
- **querying.mdx**: catalog/namespace discovery step; global `IS NULL` → `coalesce` guidance; fixed the pooled example and prose; caveat on the full-customer reconstruct example; **validated "current-period billable overage" reference query** (floors overage per row, applies active + current-cycle filter).
- **docs.json**: register the new page.

Verified against source: `AppEnv.Live = "live"`; `cusEntToCurrentBalance` floors at `max(0, balance)` (matches MV `GREATEST(0, balance)`); `usage − granted = −balance` so `overage = max(0, usage − granted)` per row reproduces `cusEntToInvoiceOverage`.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-grounded Lakehouse balance docs in the actual computation (RisingWave `api_2_3` MVs and the `getApiBalanceV2` read path). Clarifies that warehouse tables aggregate all entitlements while the API filters to active products and the current cycle, and adds a validated overage query.

- **New Features**
  - Added `balance-semantics.mdx`: defines each column, explains floored `remaining`, derived overage, and the active + current-cycle filter; notes deduction order.
  - Added a reference “current-period billable overage” query that floors per row and matches the dashboard.
  - Registered the new page in `apps/docs/mintlify/docs.json`.

- **Bug Fixes**
  - Fixed `env` enum docs to `sandbox`/`live` (was `production`).
  - Replaced `IS NULL` guidance with `coalesce(col, '') = ''` for Iceberg tables.
  - Updated `schema.mdx` and `querying.mdx` with warnings on denormalized balances/breakdowns, corrected column notes, and pooled vs per-entity caveats.
  - Added catalog/namespace discovery (`SHOW DATABASES`) and clarified ClickHouse identifier syntax.

<sup>Written for commit 3520bbfec31151422b5194fcef15fba4a807e1bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This docs-only PR re-grounds the Lakehouse balance documentation in the actual ETL and API source, correcting the `env` value (`'production'` → `'live'`), adding a new `balance-semantics.mdx` page explaining why naive queries produce inflated numbers, and updating `querying.mdx` with a reference overage query and `coalesce`-based IS NULL workarounds.

- **Improvements**: New `balance-semantics.mdx` explains the denormalized ETL structure, per-column math sourced from `getApiBalanceV2.ts`/`cusEntsToUsage.ts`, the active+current-cycle filter, derived overage, deduction order, and the `IS NULL` footgun — all with inline source-file citations for maintainability.
- **Bug fixes**: `env = 'production'` silently returned zero rows for every table across all schemas; corrected to `'live'` in `schema.mdx` and the overage reference query. `IS NULL` on Iceberg columns replaced with `coalesce(col, '') = ''` throughout.
- **Improvements**: Reference "Current-period billable overage" query added to `querying.mdx`; the query implements the active-product and current-cycle filters but is missing the `expires_at > now()` guard (step 4 of the filter the new page defines) and the `past_due` subscription status variant.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the missing expires_at guard in the reference overage query; all other changes are corrections to previously wrong or misleading docs.

The env='production' → 'live' fix and IS NULL → coalesce changes are clearly correct and grounded in source. The new balance-semantics page is thorough and internally consistent with the API code. The one concrete defect is in querying.mdx: the reference overage query omits the expires_at filter that the same PR documents as a required step — expired one_off entitlements are unconditionally included and will inflate the computed overage. The past_due omission is a minor undocumented gap for a subset of orgs.

querying.mdx — the reference overage SQL query needs an expires_at guard and a note about the past_due status variant

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/docs/mintlify/documentation/lakehouse/balance-semantics.mdx | New page grounding balance column semantics in the ETL and API source; explanations of the inflated-numbers footgun, per-column definitions, closed-triple violation, derived overage, active+current-cycle filter, deduction order, and IS NULL warning are all consistent with the referenced source files. |
| apps/docs/mintlify/documentation/lakehouse/querying.mdx | Adds catalog-discovery step, IS NULL → coalesce fix, and the reference overage query; the query omits the expires_at filter (step 4 of the filter described in balance-semantics) and the past_due status variant, causing inflated overage for expired one_off entitlements and orgs with include_past_due enabled. |
| apps/docs/mintlify/documentation/lakehouse/schema.mdx | Corrects env values from 'production' to 'live' across all tables, adds precise column definitions for granted/remaining/usage, and adds warnings about the denormalized nature of the balances tables and the missing status column on breakdowns. |
| apps/docs/mintlify/docs.json | Registers the new balance-semantics page in the lakehouse sidebar between schema and querying. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["v2_3_breakdowns\n(all entitlements, no filter)"] --> B{Apply active+current-cycle filter}
    B -->|Step 1: active product| C["active_prod CTE\nstatus = 'active'\n(+ past_due if org enables it)"]
    B -->|Step 2: current cycle| D["cur_cycle CTE\nmin(reset_resets_at) > now()"]
    B -->|Step 3: pooled rows| E["coalesce(entity_id,'') = ''"]
    B -->|Step 4: not expired ⚠️| F["coalesce(expires_at, 9999999999999)\n> now() — MISSING in query"]
    C & D & E & F --> G["Filtered breakdown rows"]
    G --> H["sum(greatest(0, usage - granted))\nper row → overage"]
    H --> I["Matches dashboard figure\n(within sync-lag drift)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["v2_3_breakdowns\n(all entitlements, no filter)"] --> B{Apply active+current-cycle filter}
    B -->|Step 1: active product| C["active_prod CTE\nstatus = 'active'\n(+ past_due if org enables it)"]
    B -->|Step 2: current cycle| D["cur_cycle CTE\nmin(reset_resets_at) > now()"]
    B -->|Step 3: pooled rows| E["coalesce(entity_id,'') = ''"]
    B -->|Step 4: not expired ⚠️| F["coalesce(expires_at, 9999999999999)\n> now() — MISSING in query"]
    C & D & E & F --> G["Filtered breakdown rows"]
    G --> H["sum(greatest(0, usage - granted))\nper row → overage"]
    H --> I["Matches dashboard figure\n(within sync-lag drift)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/docs/mintlify/documentation/lakehouse/querying.mdx:254-261
The `bd` CTE omits the `expires_at > now()` filter that `balance-semantics.mdx` explicitly requires as step 4 of the active + current-cycle filter. Without it, expired `one_off` entitlements (which have no `reset_resets_at`-based cycle guard and are unconditionally kept by `bd.ri = 'one_off'`) are included in the overage sum. The query note lists known simplifications (rollover/unused, pooled-only) but doesn't mention this one, so readers trusting the query get inflated numbers. Because `IS NULL` throws on these Iceberg columns, use `coalesce` to treat NULL `expires_at` as "no expiry".

```suggestion
    WHERE b.env = 'live'
      AND b.feature_id = 'AI_CREDITS'
      AND coalesce(b.entity_id, '') = ''
      AND coalesce(b.expires_at, 9999999999999) > toUnixTimestamp(now()) * 1000
      AND (
        b.reset_interval = 'one_off'
        OR (b.internal_customer_id, b.internal_product_id)
             IN (SELECT internal_customer_id, internal_product_id FROM active_prod)
      )
```

### Issue 2 of 2
apps/docs/mintlify/documentation/lakehouse/querying.mdx:243
`balance-semantics.mdx` states that orgs with `include_past_due` enabled should also keep `past_due` subscriptions. The `active_prod` CTE only matches `status = 'active'`, so those orgs' past-due subscriptions are excluded and their overage is undercounted. The existing note lists known simplifications but doesn't mention this gap, so affected orgs would silently get wrong numbers.

```suggestion
    WHERE env = 'live' AND status IN ('active') -- add 'past_due' if your org has include_past_due enabled
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: 📝 ground lakehouse balance docs i..."](https://github.com/useautumn/autumn/commit/3520bbfec31151422b5194fcef15fba4a807e1bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38265038)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->