### PR TITLE
fix: 🐛 events backfiller overlap

### DIFF
--- a/apps/docs/mintlify/docs.json
+++ b/apps/docs/mintlify/docs.json
@@ -146,6 +146,8 @@
 							"documentation/lakehouse/overview",
 							"documentation/lakehouse/connecting",
 							"documentation/lakehouse/schema",
+							"documentation/lakehouse/balance-semantics",
+							"documentation/lakehouse/working-with-invoices",
 							"documentation/lakehouse/querying"
 						]
 					}

--- a/apps/docs/mintlify/documentation/lakehouse/balance-semantics.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/balance-semantics.mdx
@@ -1,0 +1,123 @@
+---
+title: "Working with balances"
+sidebarTitle: "Working with balances"
+description: "What v2_3_balances and v2_3_breakdowns actually mean — and how to reconstruct the figures the API and dashboard show."
+---
+
+{/*
+  MAINTAINER SOURCE TRACE — every claim on this page is grounded in code, not in the prose docs.
+  When the implementation changes, update this page against these files:
+  - ETL reshape (the warehouse tables ARE this computation, materialized):
+      terraform/risingwave-etl/sql/03_v2.3_mvs_balances.sql  (api_2_3.breakdowns, api_2_3.balances)
+  - API read path the ETL mirrors:
+      server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/getApiBalanceV2.ts
+      server/src/internal/customers/cusUtils/getApiCustomerV2/getApiBalance/getApiBalancesV2.ts
+  - Active-status / expiry / dedup filter applied by the API but NOT by the ETL:
+      shared/utils/fullSubjectUtils/fullSubjectToCustomerEntitlements.ts
+      shared/utils/orgUtils/convertOrgUtils.ts                 (orgToInStatuses)
+  - Per-column math:
+      shared/utils/cusEntUtils/balanceUtils/cusEntsToUsage.ts  (usage = granted + prepaid - balance)
+      shared/utils/cusEntUtils/balanceUtils.ts                 (cusEntToCurrentBalance — floors at 0)
+      shared/utils/cusEntUtils/overageUtils/cusEntToInvoiceOverage.ts  (BILLABLE overage = per-row max(0, -balance))
+      shared/utils/cusEntUtils/sortCusEntsForDeduction.ts      (shortest-interval-first deduction)
+  - Two overages, do not conflate:
+      BILLABLE  = Σ cusEntToInvoiceOverage  (floor each row, then sum) — what gets invoiced.
+      DISPLAYED = max(0, balances.usage - balances.granted)  (sum first, then floor once) — the
+                  balance-header / dashboard figure, from getApiBalanceV2's top-level totals.
+      They differ by undrawn grants; the dashboard shows DISPLAYED.
+*/}
+
+<Warning>
+  **Available on request** — The Autumn Lakehouse is provisioned per customer. Contact us at [hey@useautumn.com](mailto:hey@useautumn.com) to get access.
+</Warning>
+
+`v2_3_balances` and `v2_3_breakdowns` look like a tidy relational schema, but they aren't one. They are **denormalized snapshots of Autumn's read-time balance computation** — the same computation behind `GET /customers/:id` and the dashboard. Read them as columns named after their source values rather than as a schema you can do naive arithmetic on, and the surprises below disappear.
+
+If you only take one thing from this page: **the warehouse keeps every entitlement row, the API does not.** To reproduce an API or dashboard figure you must re-apply the filter the API applies — active products, non-expired entitlements, current cycle.
+
+## The model in one paragraph
+
+For each feature, the API gathers a customer's **active** `customer_entitlement` rows, computes a small set of values per row (`included_grant`, `prepaid_grant`, `remaining`, `usage`, `overage`), and sums them into one balance. The ETL materializes exactly this: `v2_3_breakdowns` is one row **per entitlement per scope** (the per-row values), and `v2_3_balances` is the `GROUP BY customer × feature × scope` sum over it. The only — but decisive — difference is that the ETL aggregates over **all** entitlement rows in your database, while the API first filters to the active, current set.
+
+## Why your numbers look inflated
+
+`v2_3_breakdowns` is built from a plain join over `customer_entitlements` with **no status, expiry, or cycle filter**. Every entitlement row your account has ever held is in there:
+
+- superseded / cancelled product **versions**,
+- past reset **cycles** that already rolled over,
+- pre-seeded **future** cycles.
+
+The API, by contrast, keeps only entitlements whose product is **active** (status `active`, or `past_due` if your org enables `include_past_due`) and whose `expires_at` is in the future, then dedups and sums.
+
+So a single `v2_3_balances` row can sum *many lifetimes* of `usage` for one customer × feature. This is **not** because `usage` is a lifetime accumulator — each entitlement's `usage` is its own current value. It's because the row aggregates over entitlements the API would have thrown away. A pooled balance that reads `granted = 53,000`, `usage = 3,408,161`, `remaining = +10,312` is not a corrupted row — it is dozens of historical entitlements summed together. Filter to the active, current-cycle set and it reconciles.
+
+## Per-column meaning
+
+These are the values the ETL writes, verbatim from the read-time math.
+
+| Column (both tables unless noted) | Definition |
+|---|---|
+| `included_grant` *(breakdowns)* | `allowance + adjustment`, scaled by product quantity / entity count |
+| `prepaid_grant` *(breakdowns)* | prepaid quantity × billing units (0 unless a prepaid price is linked) |
+| `granted` *(balances)* | `Σ(included_grant + prepaid_grant)` + rollover-granted |
+| `usage` | `included_grant + prepaid_grant - balance` per row (signed balance); summed, then `+ rollover_usage - unused` |
+| `remaining` | `max(0, balance)` per row — **floored at 0** — summed, then `+ rollover_balance + unused` |
+| `overage` | **not stored** — see below |
+
+Two consequences fall straight out of these definitions:
+
+1. **`remaining` is floored.** Each entitlement contributes `max(0, balance)`, never a negative. You cannot recover how far a balance went negative from `remaining` — that information lives only in `usage`.
+2. **`usage` carries the sign.** Because `usage = granted - balance` (per row), `usage - granted = -balance`. When a balance goes negative (overage), `usage` exceeds `granted` by exactly that amount. This is the hook used to reconstruct overage.
+
+### `granted`, `remaining`, `usage` are not a closed triple
+
+`remaining ≠ granted - usage`. They diverge for three independent reasons, all by design:
+
+- **Manual "Set Balance"** writes `balance` directly, decoupling it from `granted`. Set a balance below zero and `usage` (= `granted - balance`) inflates past `granted` with no real consumption behind it — the "spurious negative balance / huge usage" artifact.
+- **Rollover and unused** terms are layered into `granted`/`remaining`/`usage` separately (rollover-granted, rollover-balance, rollover-usage, unused), and don't cancel.
+- **The flooring** of `remaining` (above) breaks the identity whenever any entitlement is in overage.
+
+Treat each column as the named sum it is, not as a term in an equation.
+
+## Overage is derived, not stored — and there are two of them
+
+There is **no overage column** on `v2_3_balances` or `v2_3_breakdowns`. Overage is computed at read time, and there are **two distinct figures** that are easy to conflate. They use the same per-row quantity (`usage - granted = -balance`) but floor at different points, so they give different answers.
+
+**Billable overage** — what Autumn invoices. Per entitlement, `max(0, -balance)`, **floored per row, then summed**. Equivalently `Σ max(0, usage - included_grant - prepaid_grant)`. An undrawn grant on one entitlement never reduces the bill on another. This is `cusEntToInvoiceOverage`.
+
+```text
+billable_overage = Σ  max(0, usage - included_grant - prepaid_grant)   -- floor each row, then sum
+```
+
+**Displayed overage** — what the balance header and dashboard show. The **feature-level net**, summed first and floored once: `max(0, Σusage - Σgranted)`. Because `balances.usage` and `balances.granted` already net per-entitlement surpluses against deficits, an undrawn grant on one entitlement **does** offset an overage on another.
+
+```text
+displayed_overage = max(0, Σusage - Σgranted)   -- sum first, then floor once
+```
+
+<Warning>
+  **These two diverge by exactly the undrawn grants** (`Σ max(0, granted - usage)`), and the difference can be large. For one real customer, billable overage was ≈ `824k` while displayed (dashboard) overage was ≈ `715k` — a ≈ `110k` gap of unused allowance and lifetime grants that offset the deficit in the net but not in the per-row floor. The absolute figures drift each cycle; the gap structure does not. The dashboard balance header shows **displayed** — decide which one you mean before you report it, and label it.
+</Warning>
+
+Either way, overage is only meaningful where a usage-based / overage-allowed price exists — a capped feature never goes negative.
+
+The leaderboard query in [Querying → Current-period overage](/documentation/lakehouse/querying#current-period-overage) computes the **displayed** net (to match the dashboard) and shows the billable variant alongside.
+
+## The active + current-cycle filter
+
+This is the filter the API applies and the warehouse does not. Re-apply it before any balance, usage, or overage query.
+
+1. **Active product only.** Keep breakdown rows whose `internal_product_id` matches an active subscription (`v2_3_subscriptions.status = 'active'`). If your org enables `include_past_due`, also keep `past_due`. One-off entitlements (`reset_interval = 'one_off'`) are always live.
+2. **Current cycle only.** An entitlement carries one row per reset cycle it has lived through. The current cycle is the one whose reset is the **earliest still in the future**: per `(internal_customer_id, internal_product_id)`, `min(reset_resets_at)` where `reset_resets_at > now`. `one_off` rows have no cycle and are always kept.
+3. **Pooled vs per-entity.** Keep `coalesce(entity_id, '') = ''` for customer-level (pooled) totals. Customers with `config.disable_pooled_balance` set track per-entity instead — for those, sum the per-entity rows rather than the pooled row. See [Querying → Pooled vs per-entity](/documentation/lakehouse/querying#pooled-vs-per-entity-rows).
+4. **Not expired.** Drop rows whose `expires_at` is in the past.
+
+A ready-to-run query that applies all of this and reproduces the dashboard's overage leaderboard is in [Querying → Current-period overage](/documentation/lakehouse/querying#current-period-overage).
+
+## Deduction order (why monthly drains before lifetime)
+
+When usage is recorded, Autumn deducts from entitlements **shortest-reset-interval-first** (a daily grant drains before a monthly, which drains before a lifetime/`one_off`), after a few higher-priority rules — entity-scoped before pooled when tracking an entity, unlimited first, prepaid before pay-per-use. This is why, when a customer has both a monthly grant and a lifetime grant for the same feature, the monthly empties first and overage lands on whichever pool is drained last. It matters for analytics because it determines **which** breakdown row shows the overage, not just the total.
+
+## Footgun: `IS NULL` throws on these tables
+
+On the Iceberg balances/breakdowns/flags tables, `WHERE entity_id IS NULL` raises `NOT_FOUND_COLUMN_IN_BLOCK` (it reaches for an unmaterialized `entity_id.null` subcolumn). Use `coalesce(entity_id, '') = ''` instead, everywhere you'd reach for `IS NULL`. See [Querying → Pooled vs per-entity](/documentation/lakehouse/querying#pooled-vs-per-entity-rows).

--- a/apps/docs/mintlify/documentation/lakehouse/overview.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/overview.mdx
@@ -12,7 +12,7 @@ The Autumn Lakehouse mirrors your entire Autumn dataset — customers, plans, su
 
 It's built for analytics: BI dashboards, revenue and usage reporting, cohort analysis, and joining Autumn's billing data against your own product data — all in SQL, against the full history.
 
-Every object is delivered as a table named `v2_3_<object>` (for example `v2_3_customers`, `v2_3_subscriptions`, `v2_3_events`) inside a namespace Autumn assigns you.
+Every object is delivered as a table named `v2_3_<object>` (for example `v2_3_customers`, `v2_3_subscriptions`) inside a namespace Autumn assigns you. The usage event log is the one exception — it's immutable and unversioned, delivered as `events` (not `v2_3_events`).
 
 ## How it works
 

--- a/apps/docs/mintlify/documentation/lakehouse/querying.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/querying.mdx
@@ -10,6 +10,22 @@ description: "How to address tables, convert types, join, and avoid footguns."
 
 Throughout this page, replace `<catalog>` and `<namespace>` with the names Autumn assigned you.
 
+## Find your catalog and namespace
+
+Autumn sends you both names when your Lakehouse is provisioned (see [Connecting](/documentation/lakehouse/connecting)). If you need to rediscover them in ClickHouse Cloud, the catalog mounts as a database — list databases to find it:
+
+<Tabs>
+<Tab title="ClickHouse">
+
+```sql
+SHOW DATABASES;
+```
+
+The catalog appears as one of the listed databases. Your tables then live under `` `<catalog>`.`<namespace>.v2_3_<object>` `` (the `<namespace>.v2_3_<object>` part is a single literal table name — see below).
+
+</Tab>
+</Tabs>
+
 ## Identifier syntax
 
 <Tabs>
@@ -21,7 +37,7 @@ The Glue catalog mounts as a database. The whole `<namespace>.v2_3_<object>` is 
 SELECT * FROM `<catalog>`.`<namespace>.v2_3_features` LIMIT 10;
 ```
 
-A common mistake is `` `<catalog>.<namespace>`.`v2_3_features` `` — that won't resolve, because `<namespace>.v2_3_features` is a single identifier, not `database.table`.
+A common mistake is `` `<catalog>.<namespace>`.`v2_3_features` `` — that won't resolve, because `<namespace>.v2_3_features` is a single identifier, not `database.table`. The single-quoted `'<namespace>.v2_3_features'` form does not resolve in ClickHouse Cloud either — use backticks on both parts.
 
 </Tab>
 {/*
@@ -39,7 +55,7 @@ SELECT * FROM `<project>.<dataset>.v2_3_features` LIMIT 10;
 
 ## Timestamps
 
-All `number (epoch ms)` columns (`created_at`, `started_at`, `expires_at`, `current_period_*`, `*_resets_at`, …) are epoch-milliseconds. Convert before use. The only native timestamp is `v2_3_events.timestamp`.
+All `number (epoch ms)` columns (`created_at`, `started_at`, `expires_at`, `current_period_*`, `*_resets_at`, …) are epoch-milliseconds. Convert before use. The only native timestamp is `events.timestamp` (the unversioned `events` table — see [Schema → Events](/documentation/lakehouse/schema#events)).
 
 <Tabs>
 <Tab title="ClickHouse">
@@ -51,7 +67,7 @@ SELECT
 FROM `<catalog>`.`<namespace>.v2_3_customers`;
 ```
 
-`fromUnixTimestamp64Milli(toInt64(created_at))` also works and preserves millisecond precision. `v2_3_events.timestamp` is already a `DateTime` — use it directly.
+`fromUnixTimestamp64Milli(toInt64(created_at))` also works and preserves millisecond precision. `events.timestamp` is already a `DateTime` — use it directly.
 
 </Tab>
 {/*
@@ -77,7 +93,7 @@ FROM `<project>.<dataset>.v2_3_customers`;
 
 ```sql
 SELECT JSONExtractString(properties, 'subtype') AS subtype
-FROM `<catalog>`.`<namespace>.v2_3_events`;
+FROM `<catalog>`.`<namespace>.events`;
 ```
 
 </Tab>
@@ -86,12 +102,25 @@ FROM `<catalog>`.`<namespace>.v2_3_events`;
 
 ```sql
 SELECT JSON_VALUE(properties, '$.subtype') AS subtype
-FROM `<project>.<dataset>.v2_3_events`;
+FROM `<project>.<dataset>.events`;
 ```
 
 </Tab>
 */}
 </Tabs>
+
+## Nullable columns: don't use `IS NULL`
+
+<Warning>
+  On the Iceberg tables, `WHERE col IS NULL` raises `NOT_FOUND_COLUMN_IN_BLOCK` — the engine reaches for an unmaterialized `col.null` subcolumn that doesn't exist. This bites hardest on `entity_id` (the pooled-vs-entity discriminator). Use **`coalesce(col, '') = ''`** for "is null" and **`coalesce(col, '') != ''`** for "is not null".
+</Warning>
+
+```sql
+-- ✗ throws NOT_FOUND_COLUMN_IN_BLOCK
+WHERE entity_id IS NULL
+-- ✓ pooled (customer-level) rows
+WHERE coalesce(entity_id, '') = ''
+```
 
 ## Examples
 
@@ -161,7 +190,11 @@ WHERE s.status = 'active';
 
 ### A customer's balances for a feature
 
-Use the pooled (customer-level) rows where `entity_id IS NULL`.
+Use the pooled (customer-level) rows where `coalesce(entity_id, '') = ''`.
+
+<Warning>
+  This returns the **raw** aggregated row, which sums over *every* entitlement — including superseded versions and past cycles — so `granted`/`remaining`/`usage` will not match the API for customers with history. To reproduce the API/dashboard figure, apply the active + current-cycle filter from [Working with balances](/documentation/lakehouse/balance-semantics). For overage specifically, use [the reference query below](#current-period-overage).
+</Warning>
 
 <Tabs>
 <Tab title="ClickHouse">
@@ -171,7 +204,7 @@ SELECT feature_id, granted, remaining, usage
 FROM `<catalog>`.`<namespace>.v2_3_balances`
 WHERE customer_id = 'cus_123'
   AND feature_id = 'AI_CREDITS'
-  AND entity_id IS NULL;
+  AND coalesce(entity_id, '') = '';
 ```
 
 </Tab>
@@ -188,6 +221,96 @@ WHERE customer_id = 'cus_123'
 
 </Tab>
 */}
+</Tabs>
+
+### Current-period overage
+
+Overage is **derived, not stored**, and there are **two figures** — pick deliberately (see [Working with balances → Overage](/documentation/lakehouse/balance-semantics#overage-is-derived-not-stored-and-there-are-two-of-them)):
+
+- **Displayed** (`max(0, Σusage − Σgranted)` — sum first, floor once): what the **balance header / dashboard** shows. This query computes this one, so it reproduces the dashboard to within sync-lag drift.
+- **Billable** (`Σ max(0, usage − granted)` — floor per row, then sum): what Autumn **invoices** (`cusEntToInvoiceOverage`). To get it, swap the `overage` expression as noted in the query.
+
+Both reconstruct from `v2_3_breakdowns` over the same row set: rows whose product is an **active** subscription (plus always-live `one_off` rows), restricted to each entitlement's **current cycle** (earliest upcoming reset).
+
+<Note>
+  Swap in your `<catalog>` / `<namespace>` and the feature id. Known simplifications: it omits `rollover` / `unused` terms (zero for most customers, non-zero in general) and is pooled-only (`coalesce(entity_id,'') = ''`), so per-entity overage under `config.disable_pooled_balance` is not counted. For those customers, sum the per-entity rows instead.
+</Note>
+
+<Tabs>
+<Tab title="ClickHouse">
+<Expandable title="ClickHouse">
+
+```sql
+WITH
+  active_prod AS (
+    SELECT DISTINCT internal_customer_id, internal_product_id
+    FROM `<catalog>`.`<namespace>.v2_3_subscriptions`
+    WHERE env = 'live' AND status = 'active'
+  ),
+  bd AS (
+    SELECT
+      b.internal_customer_id AS icid,
+      b.internal_product_id  AS ipid,
+      b.reset_interval       AS ri,
+      toInt64(b.reset_resets_at) AS rra,
+      (b.included_grant + b.prepaid_grant) AS granted,
+      b.usage AS usage
+    FROM `<catalog>`.`<namespace>.v2_3_breakdowns` AS b
+    WHERE b.env = 'live'
+      AND b.feature_id = 'AI_CREDITS'
+      AND coalesce(b.entity_id, '') = ''
+      AND (
+        b.reset_interval = 'one_off'
+        OR (b.internal_customer_id, b.internal_product_id)
+             IN (SELECT internal_customer_id, internal_product_id FROM active_prod)
+      )
+  ),
+  cur_cycle AS (
+    SELECT icid, ipid, min(rra) AS cur_reset
+    FROM bd
+    WHERE ri != 'one_off' AND rra > toUnixTimestamp(now()) * 1000
+    GROUP BY icid, ipid
+  ),
+  per_customer AS (
+    SELECT
+      bd.icid AS icid,
+      sum(bd.granted) AS granted,
+      sum(bd.usage)   AS usage,
+      -- DISPLAYED overage (matches the dashboard): sum first, floor once.
+      greatest(0, sum(bd.usage) - sum(bd.granted)) AS overage
+      -- For BILLABLE overage (what Autumn invoices) instead, floor per row, then sum:
+      --   sum(greatest(0, bd.usage - bd.granted)) AS overage
+    FROM bd
+    LEFT JOIN cur_cycle AS cc ON cc.icid = bd.icid AND cc.ipid = bd.ipid
+    WHERE bd.ri = 'one_off' OR bd.rra = cc.cur_reset
+    GROUP BY bd.icid
+    HAVING overage > 0
+    ORDER BY overage DESC
+    LIMIT 10
+  ),
+  active_subs AS (
+    SELECT s.internal_customer_id AS icid, groupArray(coalesce(p.name, s.plan_id)) AS subscriptions
+    FROM `<catalog>`.`<namespace>.v2_3_subscriptions` AS s
+    LEFT JOIN `<catalog>`.`<namespace>.v2_3_plans` AS p ON p.internal_id = s.internal_product_id
+    WHERE s.env = 'live' AND s.status = 'active'
+    GROUP BY s.internal_customer_id
+  )
+SELECT
+  c.customer_id AS customer_id,
+  nullIf(c.name, '')  AS name,
+  nullIf(c.email, '') AS email,
+  pc.granted AS granted,
+  pc.usage   AS usage,
+  pc.overage AS overage,
+  s.subscriptions AS subscriptions
+FROM per_customer AS pc
+INNER JOIN `<catalog>`.`<namespace>.v2_3_customers` AS c ON c.internal_id = pc.icid
+LEFT JOIN active_subs AS s ON s.icid = pc.icid
+ORDER BY pc.overage DESC;
+```
+
+</Expandable>
+</Tab>
 </Tabs>
 
 ### Invoice totals by status
@@ -244,7 +367,7 @@ SELECT
   toStartOfDay(timestamp) AS day,
   JSONExtractString(properties, 'subtype') AS subtype,
   count() AS events
-FROM `<catalog>`.`<namespace>.v2_3_events`
+FROM `<catalog>`.`<namespace>.events`
 WHERE timestamp > now() - INTERVAL 30 DAY
 GROUP BY day, subtype
 ORDER BY day;
@@ -259,7 +382,7 @@ SELECT
   TIMESTAMP_TRUNC(timestamp, DAY) AS day,
   JSON_VALUE(properties, '$.subtype') AS subtype,
   COUNT(*) AS events
-FROM `<project>.<dataset>.v2_3_events`
+FROM `<project>.<dataset>.events`
 WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
 GROUP BY day, subtype
 ORDER BY day;
@@ -273,6 +396,10 @@ ORDER BY day;
 This rebuilds the **entire** `GET /customers/:id` response — scalars, subscriptions, purchases, balances (with per-plan breakdowns), flags, and invoices — from the warehouse in a single query, returned as one JSON object. It's the most useful query if you want the API's customer view without calling the API.
 
 ClickHouse-specific (uses `groupArray`, `Tuple`/`Map` casts, and the `JSON` type — ClickHouse 24.8+). Customer-level (pooled) balances and flags use `entity_id = ''`; per-entity rows are excluded from the customer envelope. `FORMAT PrettyJSONEachRow` emits one pretty-printed JSON object.
+
+<Warning>
+  This mirrors the **shape** of the API response, but the `balances` / `breakdown` values are the raw aggregated rows — they sum over superseded versions and past cycles, so they will not match `GET /customers/:id` for customers with billing history. To match the API, restrict the balances/breakdowns subqueries to active, current-cycle rows per [Working with balances → The active + current-cycle filter](/documentation/lakehouse/balance-semantics#the-active-current-cycle-filter).
+</Warning>
 <Tabs>
 <Tab title="ClickHouse">
 <Expandable title="ClickHouse">
@@ -462,10 +589,16 @@ So:
 
 `v2_3_balances`, `v2_3_breakdowns`, and `v2_3_flags` contain two kinds of row:
 
-- **Pooled** (customer-level) — `entity_id IS NULL`.
+- **Pooled** (customer-level) — `entity_id` is null.
 - **Per-entity** — `entity_id` is set.
 
-For customer-level totals, filter `entity_id IS NULL` to avoid double counting. To analyze a specific entity, filter on its `entity_id` (or `internal_entity_id`).
+For customer-level totals, keep the pooled rows with `coalesce(entity_id, '') = ''` to avoid double counting. To analyze a specific entity, filter on its `entity_id` (or `internal_entity_id`).
+
+<Warning>
+  Write `coalesce(entity_id, '') = ''`, **not** `entity_id IS NULL` — `IS NULL` throws on these Iceberg columns (see [Nullable columns](#nullable-columns-dont-use-is-null)).
+</Warning>
+
+Customers with `config.disable_pooled_balance` track per-entity rather than pooled — for them, sum the per-entity rows instead of reading the pooled row. See [Working with balances](/documentation/lakehouse/balance-semantics) for what the aggregated values mean and the active + current-cycle filter you need before trusting them.
 
 ### Freshness
 

--- a/apps/docs/mintlify/documentation/lakehouse/schema.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/schema.mdx
@@ -8,7 +8,7 @@ description: "Every Lakehouse table and column, with the keys to join on."
   **Available on request** — The Autumn Lakehouse is provisioned per customer. Contact us at [hey@useautumn.com](mailto:hey@useautumn.com) to get access.
 </Warning>
 
-Every object is delivered as a table named `v2_3_<object>`. Tables are grouped below by lane.
+Every object is delivered as a table named `v2_3_<object>`, grouped below by lane. The **one exception is events**: the event log is immutable and unversioned, delivered as `events` (not `v2_3_events`) — see [Events](#events).
 
 ## Type legend
 
@@ -38,7 +38,7 @@ Types below are **engine-neutral**. How each engine surfaces them:
 | `timestamp` | `Nullable(DateTime64)` |
 
 <Info>
-  - **Timestamps are epoch-milliseconds** (`number (epoch ms)`), not native datetimes — convert before use. See [Querying → Timestamps](/documentation/lakehouse/querying#timestamps). The one exception is `v2_3_events.timestamp`, which is a real `timestamp`.
+  - **Timestamps are epoch-milliseconds** (`number (epoch ms)`), not native datetimes — convert before use. See [Querying → Timestamps](/documentation/lakehouse/querying#timestamps). The one exception is `events.timestamp`, which is a real `timestamp`.
   - **JSON columns are stored as strings** — parse them with `JSONExtract*` (ClickHouse).
 </Info>
 
@@ -47,7 +47,7 @@ Types below are **engine-neutral**. How each engine surfaces them:
 - ⭐ marks the **stable, immutable key** for a table — join and filter on this.
 - 🔗 marks a **stable foreign key** (`internal_customer_id`, `internal_feature_id`, `internal_product_id`, `internal_entity_id`, `internal_reward_id`) — join to the matching `internal_id`.
 - External ids (`customer_id`, `plan_id`, `feature_id`, `entity_id`, `id`, …) are **mutable** — convenient for display, but don't rely on them as stable keys. See [Querying → Use internal ids](/documentation/lakehouse/querying#use-internal-ids-not-external-ids).
-- `org_id` is your tenant id (constant across your tables); `env` is `sandbox` or `production`.
+- `org_id` is your tenant id (constant across your tables); `env` is `sandbox` or `live` (**not** `production` — filtering `env = 'production'` silently returns zero rows).
 
 ---
 
@@ -63,7 +63,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `internal_id` | string | ⭐ stable key |
 | `feature_id` | string | external id (e.g. `AI_CREDITS`), mutable |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `name` | string | |
 | `type` | string | feature type |
 | `display` | json (string) | display config |
@@ -77,7 +77,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `internal_id` | string | ⭐ stable key — one row **per plan version** |
 | `plan_id` | string | external id, mutable, shared across versions |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `name` | string | |
 | `description` | string | |
 | `group` | string | |
@@ -105,7 +105,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `plan_id` | string | external plan id |
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `feature_id` | string | external feature id |
 | `internal_feature_id` | string | 🔗 → `v2_3_features.internal_id` |
 | `included` | number | allowance (`0` if unlimited) |
@@ -134,7 +134,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `internal_id` | string | ⭐ stable key |
 | `id` | string | external id, mutable |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `name` | string | |
 | `type` | string | percentage_discount / fixed_discount / free_product |
 | `created_at` | number (epoch ms) | |
@@ -156,7 +156,7 @@ Your pricing model: features, plans, plan items, rewards, and referral programs.
 | `internal_id` | string | ⭐ stable key |
 | `id` | string | external id, mutable |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `created_at` | number (epoch ms) | |
 | `reward_id` | string | external reward id |
 | `internal_reward_id` | string | 🔗 → `v2_3_rewards.internal_id` |
@@ -184,7 +184,7 @@ Who your plans apply to: customers and entities (sub-customers).
 | `internal_id` | string | ⭐ stable key |
 | `customer_id` | string | external id, mutable (may be null) |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `name` | string | |
 | `email` | string | |
 | `created_at` | number (epoch ms) | |
@@ -204,7 +204,7 @@ Who your plans apply to: customers and entities (sub-customers).
 | `internal_id` | string | ⭐ stable key |
 | `id` | string | external id, mutable |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `customer_id` | string | parent customer external id |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
 | `feature_id` | string | entity feature scope (external) |
@@ -232,7 +232,7 @@ Active customer–product relationships: recurring subscriptions and one-off pur
 | `customer_id` | string | external customer id |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `plan_id` | string | external plan id |
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
 | `add_on` | boolean | |
@@ -259,7 +259,7 @@ Active customer–product relationships: recurring subscriptions and one-off pur
 | `customer_id` | string | external customer id |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `plan_id` | string | external plan id |
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
 | `expires_at` | number (epoch ms) | null if no expiry |
@@ -277,8 +277,12 @@ Active customer–product relationships: recurring subscriptions and one-off pur
 
 Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 
+<Warning>
+  **These tables do not behave like a clean relational schema.** They are denormalized snapshots of Autumn's read-time balance computation, and they include **every** `customer_entitlement` row — across superseded product versions and past reset cycles — with **no active-status or current-cycle filter**. A naive `SELECT ... FROM v2_3_balances` therefore double- and triple-counts. Before you query balances, breakdowns, or overage, read **[Working with balances](/documentation/lakehouse/balance-semantics)** — it explains what each column means, why `usage`/`granted`/`remaining` don't form a closed arithmetic triple, where overage comes from (it is **not** stored), and the active + current-cycle filter you must apply.
+</Warning>
+
 <Note>
-  Balances, breakdowns, and flags carry both **pooled** (customer-level) rows — where `entity_id` is null — and **per-entity** rows. Filter on `entity_id IS NULL` for customer-level totals to avoid double counting. See [Querying → Pooled vs per-entity](/documentation/lakehouse/querying#pooled-vs-per-entity-rows).
+  Balances, breakdowns, and flags carry both **pooled** (customer-level) rows — where `entity_id` is null — and **per-entity** rows. For customer-level totals, keep only the pooled rows with `coalesce(entity_id, '') = ''` to avoid double counting. (Use `coalesce`, **not** `entity_id IS NULL` — `IS NULL` throws on these Iceberg columns; see [Querying → Pooled vs per-entity](/documentation/lakehouse/querying#pooled-vs-per-entity-rows).)
 </Note>
 
 <AccordionGroup>
@@ -293,17 +297,21 @@ Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 | `feature_id` | string | external feature id |
 | `internal_entity_id` | string | 🔗 → `v2_3_entities.internal_id` (null = pooled) |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `unlimited` | boolean | |
-| `granted` | number | total granted (incl. rollover) |
-| `remaining` | number | total remaining (incl. rollover) |
-| `usage` | number | total usage |
+| `granted` | number | Σ(`included_grant` + `prepaid_grant`) + rollover-granted, over **all** entitlements in the group |
+| `remaining` | number | Σ(floored per-entitlement balance) + rollover-balance + unused — **floored at 0**, never negative |
+| `usage` | number | Σ(per-entitlement `usage`) + rollover-usage − unused. **Not** `granted − remaining`; see below |
 | `overage_allowed` | boolean | |
 | `max_purchase` | number | null if unbounded |
 | `reset_interval` | string | single interval or `multiple` |
 | `reset_interval_count` | number | null if `multiple` or count 1 |
 | `reset_resets_at` | number (epoch ms) | earliest reset across entitlements |
 | `next_reset_at` | number (epoch ms) | earliest next reset |
+
+<Warning>
+  `granted` / `remaining` / `usage` are **not** a closed arithmetic triple — `remaining ≠ granted − usage`. Each is aggregated **over every entitlement row for this customer × feature × scope**, including superseded product versions and past cycles, so a single row routinely sums many lifetimes of usage. `remaining` is floored per-entitlement, manual "Set Balance" decouples balance from grant, and rollover/unused are layered in. **There is no overage column** — it is derived. Always read [Working with balances](/documentation/lakehouse/balance-semantics) and apply the active + current-cycle filter before trusting these numbers.
+</Warning>
 
 </Accordion>
 <Accordion title="v2_3_breakdowns — per-entitlement balance detail">
@@ -320,14 +328,14 @@ Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 | `internal_feature_id` | string | 🔗 → `v2_3_features.internal_id` |
 | `plan_id` | string | external plan id |
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
-| `included_grant` | number | allowance grant |
+| `included_grant` | number | allowance grant (allowance + adjustment) |
 | `prepaid_grant` | number | prepaid grant |
-| `remaining` | number | |
-| `usage` | number | |
+| `remaining` | number | floored balance — `max(0, balance)`, **never negative** |
+| `usage` | number | `included_grant` + `prepaid_grant` − raw (signed) balance |
 | `unlimited` | boolean | |
-| `reset_interval` | string | null for continuous-use |
+| `reset_interval` | string | null for continuous-use; `one_off` for lifetime grants |
 | `reset_interval_count` | number | null if count 1 |
-| `reset_resets_at` | number (epoch ms) | next reset |
+| `reset_resets_at` | number (epoch ms) | next reset for **this** entitlement (use to pick the current cycle) |
 | `price_amount` | number | single-tier only |
 | `price_billing_method` | string | prepaid / usage_based |
 | `price_billing_units` | number | default 1 |
@@ -336,7 +344,11 @@ Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 | `price_tiers` | json (string) | multi-tier array |
 | `expires_at` | number (epoch ms) | null if no expiry |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
+
+<Warning>
+  **`v2_3_breakdowns` has no `status` / `is_active` / `is_current` column** and mixes rows from superseded/cancelled product versions, past reset cycles, and pre-seeded future cycles. To get the rows the API would use, join `internal_product_id` to active subscription status and pick the current cycle (earliest upcoming `reset_resets_at`); `one_off` rows are always live. See [Working with balances → The active + current-cycle filter](/documentation/lakehouse/balance-semantics#the-active-current-cycle-filter).
+</Warning>
 
 </Accordion>
 <Accordion title="v2_3_flags — boolean feature flags">
@@ -355,7 +367,7 @@ Feature balances, their per-entitlement breakdowns, and boolean feature flags.
 | `internal_product_id` | string | 🔗 → `v2_3_plans.internal_id` |
 | `expires_at` | number (epoch ms) | null if no expiry |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 
 </Accordion>
 </AccordionGroup>
@@ -373,7 +385,7 @@ Invoices and their line items.
 |---|---|---|
 | `id` | string | ⭐ stable key (invoice id) |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `customer_id` | string | external customer id |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
 | `entity_id` | string | external entity id (null = customer-scoped) |
@@ -398,7 +410,7 @@ Invoices and their line items.
 |---|---|---|
 | `id` | string | ⭐ stable key (line item id) |
 | `org_id` | string | your tenant id |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `invoice_id` | string | 🔗 → `v2_3_invoices.id` |
 | `customer_id` | string | external customer id |
 | `description` | string | |
@@ -426,8 +438,12 @@ Invoices and their line items.
 
 The append-only usage event log. This is the highest-volume table and is **append-only** (no updates).
 
+<Warning>
+  **The events table is `events`, not `v2_3_events`.** Events are immutable and **unversioned** — they are *not* subject to the `v2_3` schema versioning that every other object uses. Address it as `` `<catalog>`.`<namespace>.events` ``. Querying `v2_3_events` returns `Unknown table expression identifier` because that table does not exist.
+</Warning>
+
 <AccordionGroup>
-<Accordion title="v2_3_events — usage event log">
+<Accordion title="events — usage event log">
 
 | Column | Type | Notes |
 |---|---|---|
@@ -435,7 +451,7 @@ The append-only usage event log. This is the highest-volume table and is **appen
 | `org_id` | string | your tenant id |
 | `org_slug` | string | |
 | `internal_customer_id` | string | 🔗 → `v2_3_customers.internal_id` |
-| `env` | string | `sandbox` / `production` |
+| `env` | string | `sandbox` / `live` |
 | `created_at` | number (epoch ms) | when Autumn recorded the event |
 | `timestamp` | timestamp | event time — a **real timestamp**, use directly |
 | `event_name` | string | |
@@ -452,5 +468,5 @@ The append-only usage event log. This is the highest-volume table and is **appen
 </AccordionGroup>
 
 <Note>
-  Unlike every other table, `v2_3_events.timestamp` is a native `timestamp` — no epoch-ms conversion needed. `created_at` is still epoch-ms.
+  Unlike every other table, `events.timestamp` is a native `timestamp` — no epoch-ms conversion needed. `created_at` is still epoch-ms.
 </Note>

--- a/apps/docs/mintlify/documentation/lakehouse/working-with-invoices.mdx
+++ b/apps/docs/mintlify/documentation/lakehouse/working-with-invoices.mdx
@@ -1,0 +1,108 @@
+---
+title: "Working with invoices"
+sidebarTitle: "Working with invoices"
+description: "Revenue, MRR, and paying-customer metrics — the rows to drop and the column that actually carries truth."
+---
+
+{/*
+  MAINTAINER SOURCE TRACE — ground every recipe here in code, not prose.
+  - ETL reshape (warehouse columns are passed through verbatim from the billing tables):
+      terraform/risingwave-etl/sql/03_v2.3_mvs_invoices.sql   (api_2_3.invoices, api_2_3.invoice_line_items)
+      terraform/risingwave-etl/sql/03_v2.3_mvs_states.sql      (api_2_3.subscriptions / purchases)
+      terraform/risingwave-etl/sql/03_v2.3_mvs_catalog.sql     (api_2_3.plans price_* columns)
+  - API builders the columns mirror:
+      server/src/internal/invoices/invoiceUtils.ts                                   (invoicesToResponse)
+      server/src/internal/customers/cusUtils/getApiCustomerV2/getApiSubscription/getApiSubscriptionsV2.ts
+  Note: invoices carry no org_id/env of their own — both are joined from the customer in the ETL.
+  Plan-header price (v2_3_plans.price_amount) is the base list price; custom/enterprise pricing is
+  set per subscription and is NOT on the plan header, so plan-header MRR undercounts those accounts.
+*/}
+
+<Warning>
+  **Available on request** — The Autumn Lakehouse is provisioned per customer. Contact us at [hey@useautumn.com](mailto:hey@useautumn.com) to get access.
+</Warning>
+
+The same lesson as [Working with balances](/documentation/lakehouse/balance-semantics) applies across the rest of the schema: **the warehouse stores inputs; the business number is a derivation that drops rows.** Columns are named like a clean OLTP table, but realized revenue, MRR, and paying-customer counts each require knowing which rows to exclude and which column actually carries truth. The traps below all surfaced from running realistic BI queries against live data.
+
+## Revenue: `total` is not realized revenue
+
+`sum(total)` over invoices **overstates** what you collected — typically by low double digits — because `total` is the **gross, pre-refund** amount and includes discounts, proration, and partially-paid invoices. Realized revenue is what cleared, net of refunds:
+
+```text
+realized_revenue = Σ amount_paid − Σ refunded_amount   over status = 'paid'
+```
+
+Three traps around it:
+
+- **Amounts are in the currency's major unit (dollars), not Stripe cents.** Sanity-check one known invoice before scaling — porting Stripe intuition will put you off by 100×.
+- **`void` invoices carry real-looking totals** and must be excluded. Filter `status = 'paid'`, not merely non-null.
+- **`paid` includes negative totals** (credit notes / refunds modeled as negative invoices) — expected, and correctly handled by the `amount_paid − refunded_amount` form.
+
+```sql
+SELECT
+  sum(amount_paid) - sum(refunded_amount) AS net_revenue,
+  sum(total)                              AS gross_total_do_not_use
+FROM `<catalog>`.`<namespace>.v2_3_invoices`
+WHERE env = 'live' AND status = 'paid';
+```
+
+## Paying customers: `status = 'active'` is not "paying"
+
+Active subscriptions include your entire **free** base and everyone **mid-trial**. A naive `count()` of active rows can overstate paying customers by orders of magnitude. A paying customer has an active, **priced**, **non-trial** base subscription — and you must dedup, because one customer holds several subscription rows (versions + add-ons).
+
+```sql
+SELECT uniqExact(s.internal_customer_id) AS paying_customers
+FROM `<catalog>`.`<namespace>.v2_3_subscriptions` AS s
+INNER JOIN `<catalog>`.`<namespace>.v2_3_plans` AS p
+  ON p.internal_id = s.internal_product_id
+WHERE s.env = 'live'
+  AND s.status = 'active'
+  AND s.add_on = false
+  AND coalesce(p.price_amount, 0) > 0
+  AND coalesce(s.trial_ends_at, 0) <= toUnixTimestamp(now()) * 1000;  -- not currently in trial
+```
+
+<Note>
+  Row count ≠ customer count: subscription rows exceed distinct customers because of plan versions, duplicate base rows, and add-ons. Anything customer-level needs `uniqExact(internal_customer_id)`, never `count()`.
+</Note>
+
+## MRR: six footguns, and an honest floor
+
+MRR is the densest seam in the schema. Building it from `v2_3_subscriptions` × `v2_3_plans` hits six independent traps:
+
+1. **Plan versioning is live.** A plan has many internal versions sharing one external `plan_id`. Filtering or joining on `plan_id` silently fans out across versions — join on `internal_product_id → v2_3_plans.internal_id`.
+2. **`plans.price_amount` is hollow exactly where the money is.** For custom / enterprise / usage-priced plans the recurring amount is set **per subscription**, not on the plan header, so the header price is null or zero. Plan-header MRR therefore **systematically undercounts your largest accounts**.
+3. **`status = 'active'` includes free and trial** — exclude price-0 / null-interval plans and in-trial subs (as above).
+4. **Intervals are mixed.** `month` and `year` plans share the same `price_amount` column; summing across them is meaningless. Normalize yearly to monthly (`year → /12`).
+5. **Row count ≠ customer count** — see the dedup note above.
+6. **Add-ons are separate priced rows** (`add_on = true`, e.g. SSO, extra credits). Fold them into MRR, but never treat them as base plans or you double-count.
+
+For an **accurate** figure, derive recurring revenue from invoices / `v2_3_invoice_line_items` (the line items carry the real billed amounts, including custom pricing) rather than the plan header. The query below is a deliberate **floor for self-serve tiers only** — it is correct for plans whose price lives on the header and silently omits custom/enterprise accounts:
+
+```sql
+-- CAVEAT: undercounts. plans.price_amount is null/0 for custom/enterprise/usage plans,
+-- so this covers self-serve tiers only. For true MRR, derive recurring amounts from invoices.
+SELECT
+  sum(
+    multiIf(
+      p.price_interval = 'year',  p.price_amount / 12,
+      p.price_interval = 'month', p.price_amount,
+      0
+    ) * s.quantity
+  ) AS approx_self_serve_mrr
+FROM `<catalog>`.`<namespace>.v2_3_subscriptions` AS s
+INNER JOIN `<catalog>`.`<namespace>.v2_3_plans` AS p
+  ON p.internal_id = s.internal_product_id
+WHERE s.env = 'live'
+  AND s.status = 'active'
+  AND coalesce(p.price_amount, 0) > 0
+  AND coalesce(s.trial_ends_at, 0) <= toUnixTimestamp(now()) * 1000;
+```
+
+## Cross-reference: which overage?
+
+Overage (on the balances side) has the same "two figures" hazard as revenue here — **billable** (what you invoice) vs **displayed** (what the dashboard header shows) diverge by undrawn grants. If a report combines revenue and overage, make sure both pages agree on which overage you mean. See [Working with balances → Overage](/documentation/lakehouse/balance-semantics#overage-is-derived-not-stored-and-there-are-two-of-them).
+
+<Note>
+  All queries here use `env = 'live'` (**not** `production`) and the `` `<catalog>`.`<namespace>.v2_3_…` `` addressing form. Join on `internal_*` ids — external ids are mutable and versioned. See [Querying](/documentation/lakehouse/querying) for the addressing and `IS NULL` footguns.
+</Note>

--- a/server/tinybird/pipes/events_sink_s3.pipe
+++ b/server/tinybird/pipes/events_sink_s3.pipe
@@ -20,8 +20,8 @@ SQL >
         deductions
     FROM events_by_org_ts
     WHERE ({{String(org_id, '')}} = '' OR org_id = {{String(org_id, '')}})
-      AND timestamp >= subtractHours(now(), {{Int32(start_hours_ago, 3)}})
-      AND timestamp <  subtractHours(now(), {{Int32(end_hours_ago, 0)}})
+      AND timestamp >= if({{String(start_ts, '')}} = '', subtractHours(now(), {{Int32(start_hours_ago, 2)}}), parseDateTimeBestEffortOrZero({{String(start_ts, '')}}))
+      AND timestamp <  if({{String(end_ts, '')}} = '', subtractHours(now(), {{Int32(end_hours_ago, 1)}}), parseDateTimeBestEffortOrZero({{String(end_ts, '')}}))
 
 TYPE sink
 EXPORT_CONNECTION_NAME "events_s3"
@@ -30,4 +30,4 @@ EXPORT_FILE_TEMPLATE "org_id={org_id}/year={timestamp, '%Y'}/month={timestamp, '
 EXPORT_SCHEDULE "0 * * * *"
 EXPORT_FORMAT "parquet"
 EXPORT_COMPRESSION "zstd"
-EXPORT_STRATEGY "replace"
+EXPORT_STRATEGY "create_new"

--- a/server/tinybird/scripts/backfill_events_s3.sh
+++ b/server/tinybird/scripts/backfill_events_s3.sh
@@ -51,7 +51,6 @@ mstart() { local v; v=$(mspec "$1"); date -u -v"$v" -v1d -v0H -v0M -v0S +%s 2>/d
 mlabel() { local v; v=$(mspec "$1"); date -u -v"$v" +%Y%m 2>/dev/null || date -u -d "$(date -u +%Y-%m-01) $(( -$1 )) month" +%Y%m; }
 isots()  { date -u -r "$1" "+%Y-%m-%d %H:%M:%S" 2>/dev/null || date -u -d "@$1" "+%Y-%m-%d %H:%M:%S"; }
 ts2epoch() { date -u -j -f '%Y-%m-%d %H:%M:%S' "$1" +%s 2>/dev/null || date -u -d "$1" +%s; }
-hago()   { local d=$(( (NOW - $1) / 3600 )); (( d < 0 )) && d=0; echo "$d"; }
 FLOOR_EPOCH=$(ts2epoch "$FLOOR_DATE 00:00:00")
 POP_END_EPOCH=$(ts2epoch "$POP_END_TS")
 
@@ -119,15 +118,21 @@ scan_density() {  # parallel pruned counts → DENSITY, sorted per-org newest→
   log "density: $(wc -l < "$DENSITY" | tr -d ' ')/$n months have data"
 }
 
-plan_chunks() {  # DENSITY → CHUNKS: split each month into ceil(rows/TARGET_ROWS) equal time windows
+plan_chunks() {  # DENSITY → CHUNKS: split each month into ceil(rows/TARGET_ROWS) windows, every boundary hour-aligned
   : > "$CHUNKS"
   while read -r o ym s e rows; do
+    s=$(( s - s % 3600 )); e=$(( e - e % 3600 ))   # hour-align unit bounds; drops the in-progress hour (cron exports settled hours)
+    (( e <= s )) && continue
     local n=$(( (rows + TARGET_ROWS - 1) / TARGET_ROWS )); (( n < 1 )) && n=1
     local span=$(( e - s )) w est i a b
     w=$(( span / n )); est=$(( rows / n ))
+    b=$e
     for (( i=0; i<n; i++ )); do
-      b=$(( e - i*w )); a=$(( e - (i+1)*w )); (( i == n-1 )) && a=$s   # oldest chunk hits exact month start
+      a=$(( e - (i+1)*w )); (( i == n-1 )) && a=$s   # oldest chunk hits exact (aligned) month start
+      a=$(( a - a % 3600 )); (( a < s )) && a=$s     # hour-align so no two chunks share a clock-hour (one S3 file per org/day/hour)
+      (( a >= b )) && continue                       # rounding collapsed this window — fold into the next chunk
       echo "$o $a $b $est $ym" >> "$CHUNKS"
+      b=$a                                           # contiguous: next chunk ends where this one started
     done
   done < "$DENSITY"
 }
@@ -136,18 +141,20 @@ CHUNK_FLOOR=${CHUNK_FLOOR:-3600}   # min chunk window (s) before declaring a win
 run_chunk() {  # $1=org $2=a_epoch $3=b_epoch $4=est_rows $5=ym → 0 ok / 1 fail. Splits on OOM and retries.
   local key="$1:$2:$3"
   grep -qxF "$key" "$DONE" 2>/dev/null && return 0   # already exported (resume / sub-chunk dedup)
-  local out sa ea; sa=$(hago "$2"); ea=$(hago "$3")
-  out=$(tb --cloud sink run "$SINK" --param org_id="$1" --param start_hours_ago="$sa" --param end_hours_ago="$ea" --wait 2>&1)
+  local out
+  out=$(tb --cloud sink run "$SINK" --param org_id="$1" --param start_ts="$(isots "$2")" --param end_ts="$(isots "$3")" --wait 2>&1)
   if grep -q "Data exported" <<<"$out"; then
     echo "$key" >> "$DONE"; echo "$5 $4" >> "$PROGRESS"; return 0
   fi
   if grep -qiE "MEMORY_LIMIT|Timeout exceeded" <<<"$out" && (( $3 - $2 > CHUNK_FLOOR )); then
-    local mid=$(( $2 + ($3 - $2)/2 ))
-    log "      ↳ too big $(isots "$2")→$(isots "$3") (~$(( $4/1000 ))k) — split & retry"
-    if run_chunk "$1" "$2" "$mid" "$(( $4/2 ))" "$5" && run_chunk "$1" "$mid" "$3" "$(( $4/2 ))" "$5"; then
-      echo "$key" >> "$DONE"; return 0   # both halves landed → mark parent done so resume skips it
+    local mid=$(( ( ($2 + ($3 - $2)/2) / 3600 ) * 3600 ))   # hour-align the split so the two halves never share a clock-hour
+    if (( mid > $2 && mid < $3 )); then
+      log "      ↳ too big $(isots "$2")→$(isots "$3") (~$(( $4/1000 ))k) — split & retry"
+      if run_chunk "$1" "$2" "$mid" "$(( $4/2 ))" "$5" && run_chunk "$1" "$mid" "$3" "$(( $4/2 ))" "$5"; then
+        echo "$key" >> "$DONE"; return 0   # both halves landed → mark parent done so resume skips it
+      fi
+      return 1
     fi
-    return 1
   fi
   if grep -qiE "MEMORY_LIMIT|Timeout exceeded" <<<"$out"; then
     echo "org=$1 $(isots "$2")→$(isots "$3") rows=$4 reason=toobig_at_floor" >> "$FAILED"


### PR DESCRIPTION
- **fix: 🐛 events backfiller overlap**
- **feat: 🎸 better docs**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlapping S3 exports in the Tinybird events backfiller by hour-aligning chunks and using absolute timestamps. Also ships deeper Lakehouse docs on balances, querying, invoices, and the unversioned `events` table.

- **Bug Fixes**
  - `server/tinybird/pipes/events_sink_s3.pipe`
    - Accept `start_ts`/`end_ts` (ISO) with fallback to `start_hours_ago`/`end_hours_ago`.
    - Shift defaults to avoid the in-progress hour (`start_hours_ago=2`, `end_hours_ago=1`).
    - Change `EXPORT_STRATEGY` to `create_new` to prevent replacement collisions.
  - `server/tinybird/scripts/backfill_events_s3.sh`
    - Plan chunks with start/end aligned to whole hours; contiguous windows with no overlap.
    - Split oversized windows on an hour boundary to avoid shared clock-hours.
    - Drive the sink with absolute ISO timestamps to match the pipe’s new params.
    - Skip already-exported windows via a done-file to ensure idempotent resumes.

- **New Features**
  - Add “Working with balances” and “Working with invoices” docs; linked in `apps/docs/mintlify/docs.json`.
  - Clarify that the usage log is `events` (not `v2_3_events`); update examples and schema notes.
  - Document `env = 'live'`, epoch-ms handling, and the `IS NULL` footgun (use `coalesce(entity_id, '') = ''`).
  - Add a reference overage query (displayed vs billable) and callouts on active + current-cycle filtering.

<sup>Written for commit 676e3dffa16b16673411fb5910c66285c4521e8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/1969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the events backfiller overlap bug and adds two new Lakehouse documentation pages. The root cause was `EXPORT_STRATEGY = replace` combined with a 3-hour cron window: consecutive hourly exports overlapped and the later run would silently overwrite the earlier export's S3 files.

- **Bug fixes**: `EXPORT_STRATEGY` changed from `replace` to `create_new`; cron defaults narrowed to a non-overlapping 1-hour settled window (`[now-2h, now-1h]`); backfill script switched from hours-ago integers to exact ISO timestamps and now hour-aligns all chunk boundaries so no two chunks share a clock-hour (matching the S3 file template).
- **Improvements**: Two new Lakehouse docs pages — \"Working with balances\" and \"Working with invoices\" — plus corrections throughout schema and querying docs (`env = 'production'` → `env = 'live'`, `v2_3_events` → `events`, `entity_id IS NULL` → `coalesce(entity_id, '') = ''`).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge. The core change correctly eliminates the overwrite regression by combining a non-overlapping cron window with `create_new`; no existing exported data is at risk.

The backfill and pipe changes are mechanically sound — hour-alignment, explicit timestamp params, and the `create_new` strategy all work together correctly. Two observations worth acknowledging before running large backfills: `parseDateTimeBestEffortOrZero` returns epoch zero on a malformed `start_ts`/`end_ts`, and concurrent cron + backfill over overlapping date ranges will accumulate duplicate Parquet files that downstream readers must deduplicate on event `id`.

The two Tinybird files (`events_sink_s3.pipe` and `backfill_events_s3.sh`) carry the substantive logic change and deserve a final read before deploying the updated pipe to production.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tinybird/pipes/events_sink_s3.pipe | Core bug fix: switches EXPORT_STRATEGY from `replace` to `create_new` and replaces the hours-ago integer params with explicit ISO timestamp params, eliminating the cron overlap that was overwriting previously-exported data. Default cron window narrowed from 3 h to a non-overlapping 1 h settled window. |
| server/tinybird/scripts/backfill_events_s3.sh | Chunk planning now hour-aligns all boundaries so no two chunks share a clock-hour (matching the S3 file template). Removed hago() helper; run_chunk now passes exact ISO timestamps instead of hours-ago integers. OOM split also hour-aligns its midpoint and guards against collapsed halves. |
| apps/docs/mintlify/documentation/lakehouse/balance-semantics.mdx | New page explaining why v2_3_balances/breakdowns appear inflated (no active/current-cycle filter), the two distinct overage definitions (billable vs displayed), and the exact filter to reproduce API figures. |
| apps/docs/mintlify/documentation/lakehouse/working-with-invoices.mdx | New page documenting revenue/MRR/paying-customer query patterns, including the amount_paid vs total distinction, the IS NULL footgun, and six MRR footguns around plan versioning and custom pricing. |
| apps/docs/mintlify/documentation/lakehouse/schema.mdx | Corrects `env` values from `production` → `live` across all tables, renames v2_3_events accordion to `events`, enriches balance/breakdown column descriptions, and adds warnings about the denormalized schema. |
| apps/docs/mintlify/documentation/lakehouse/querying.mdx | Updates all `v2_3_events` references to `events`, replaces `entity_id IS NULL` with `coalesce(entity_id, '') = ''` throughout, adds a catalog/namespace discovery section, and adds a complete current-period overage reference query. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron as Tinybird Cron (0 * * * *)
    participant Sink as events_sink_s3 pipe
    participant S3 as S3 Bucket
    participant Script as backfill_events_s3.sh

    Note over Cron,S3: OLD behaviour (replace strategy, 3-hour window)
    Cron->>Sink: run [now-3h, now)
    Sink->>S3: REPLACE ev_07, ev_08, ev_09
    Note right of S3: Run at 10:00 writes hours 7-9
    Cron->>Sink: run [now-3h, now)
    Sink->>S3: REPLACE ev_08, ev_09, ev_10
    Note right of S3: Run at 11:00 OVERWRITES hours 8-9 - overlap bug

    Note over Cron,S3: NEW behaviour (create_new strategy, 1-hour settled window)
    Cron->>Sink: run [now-2h, now-1h)
    Sink->>S3: CREATE ev_08 (new file)
    Note right of S3: Run at 10:00 writes only hour 8 (settled)
    Cron->>Sink: run [now-2h, now-1h)
    Sink->>S3: CREATE ev_09 (new file)
    Note right of S3: Run at 11:00 writes only hour 9 - no overlap

    Note over Script,S3: Backfill (explicit ISO timestamps, hour-aligned chunks)
    Script->>Script: plan_chunks(): hour-align all boundaries
    Script->>Sink: "start_ts=2024-05-01 00:00:00 end_ts=2024-05-01 01:00:00"
    Sink->>S3: CREATE ev_00 (historical hour)
    Script->>Script: "echo key >> .backfill_done (idempotency)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron as Tinybird Cron (0 * * * *)
    participant Sink as events_sink_s3 pipe
    participant S3 as S3 Bucket
    participant Script as backfill_events_s3.sh

    Note over Cron,S3: OLD behaviour (replace strategy, 3-hour window)
    Cron->>Sink: run [now-3h, now)
    Sink->>S3: REPLACE ev_07, ev_08, ev_09
    Note right of S3: Run at 10:00 writes hours 7-9
    Cron->>Sink: run [now-3h, now)
    Sink->>S3: REPLACE ev_08, ev_09, ev_10
    Note right of S3: Run at 11:00 OVERWRITES hours 8-9 - overlap bug

    Note over Cron,S3: NEW behaviour (create_new strategy, 1-hour settled window)
    Cron->>Sink: run [now-2h, now-1h)
    Sink->>S3: CREATE ev_08 (new file)
    Note right of S3: Run at 10:00 writes only hour 8 (settled)
    Cron->>Sink: run [now-2h, now-1h)
    Sink->>S3: CREATE ev_09 (new file)
    Note right of S3: Run at 11:00 writes only hour 9 - no overlap

    Note over Script,S3: Backfill (explicit ISO timestamps, hour-aligned chunks)
    Script->>Script: plan_chunks(): hour-align all boundaries
    Script->>Sink: "start_ts=2024-05-01 00:00:00 end_ts=2024-05-01 01:00:00"
    Sink->>S3: CREATE ev_00 (historical hour)
    Script->>Script: "echo key >> .backfill_done (idempotency)"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server/tinybird/pipes/events_sink_s3.pipe:23-24
**Silent epoch-zero on invalid timestamp input**

`parseDateTimeBestEffortOrZero` returns `1970-01-01 00:00:00` when it cannot parse its input. If `start_ts` or `end_ts` is passed as a non-empty but malformed string (e.g. from a direct API call outside the backfill script), the `timestamp >= 1970-01-01` predicate becomes effectively a no-op and the sink would attempt to export the entire event history. Consider using `parseDateTime64BestEffort` (which throws on failure) or documenting that callers must pass a parseable string — the `OrZero` variant is safe here only because `isots()` always produces valid ISO timestamps.

### Issue 2 of 2
server/tinybird/pipes/events_sink_s3.pipe:33
**`create_new` accumulates duplicate Parquet files when cron and backfill overlap**

Switching from `replace` to `create_new` fixes the overwrite regression, but introduces a new tradeoff: if the scheduled cron (exporting `[now-2h, now-1h]`) runs concurrently with a backfill that covers a recent month, both will write separate files to the same S3 prefix (`ev_{timestamp, '%H'}`). The `.backfill_done` dedup only prevents the backfill from re-running the same chunk — it does not prevent the cron from also exporting the same clock-hour. Any downstream reader that scans all files in a directory without deduplication on event `id` would double-count those events. This is acceptable for purely-historical backfills (`FLOOR_DATE = 2024-04-01`), but worth documenting as a constraint so operators know not to run a backfill over the cron's live window.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 better docs"](https://github.com/useautumn/autumn/commit/676e3dffa16b16673411fb5910c66285c4521e8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38368714)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->